### PR TITLE
Excludes links that are identical to the page link in the Competing links assessment

### DIFF
--- a/packages/yoastseo/spec/languageProcessing/researches/getLinkStatisticsSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/getLinkStatisticsSpec.js
@@ -105,8 +105,8 @@ describe( "Tests a string for anchors and its attributes", function() {
 
 	it( "should not detect the keyword in link texts identical to the page URL", function() {
 		const attributes = {
-			keyword: "link",
-			url: "",
+			keyword: "focuskeyphrase",
+			url: "http://yoast.com/",
 			permalink: "yoast.com",
 		};
 
@@ -121,8 +121,8 @@ describe( "Tests a string for anchors and its attributes", function() {
 
 	it( "should not detect the keyword in link texts that have a scheme and are identical to the page URL", function() {
 		const attributes = {
-			keyword: "link",
-			url: "",
+			keyword: "focuskeyword",
+			url: "http://yoast.com/",
 			permalink: "http://yoast.com",
 		};
 

--- a/packages/yoastseo/spec/languageProcessing/researches/getLinkStatisticsSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/getLinkStatisticsSpec.js
@@ -15,7 +15,7 @@ describe( "Tests a string for anchors and its attributes", function() {
 	const paperAttributes = {
 		keyword: "link",
 		url: "http://yoast.com",
-		siteUrlOrDomain: "http://yoast.com",
+		permalink: "http://yoast.com",
 	};
 
 	it( "should detect internal links", function() {
@@ -103,11 +103,27 @@ describe( "Tests a string for anchors and its attributes", function() {
 		expect( foundLinks.keyword.totalKeyword ).toBe( 0 );
 	} );
 
-	it( "should not detect the keyword in link text which links to itself, when the siteUrlOrDomain is a domain", function() {
+	it( "should not detect the keyword in link texts identical to the page URL", function() {
 		const attributes = {
-			keyword: "focuskeyword",
-			url: "http://yoast.com/this-page/",
-			siteUrlOrDomain: "yoast.com",
+			keyword: "link",
+			url: "",
+			permalink: "yoast.com",
+		};
+
+		const mockPaper = new Paper( "string <a href='http://yoast.com/'>focuskeyword</a>", attributes );
+		const researcher = new EnglishResearcher( mockPaper );
+		researcher.addResearchData( "morphology", morphologyData );
+		foundLinks = linkCount( mockPaper, researcher );
+		expect( foundLinks.total ).toBe( 1 );
+		expect( foundLinks.internalTotal ).toBe( 1 );
+		expect( foundLinks.keyword.totalKeyword ).toBe( 0 );
+	} );
+
+	it( "should not detect the keyword in link texts that have a scheme and are identical to the page URL", function() {
+		const attributes = {
+			keyword: "link",
+			url: "",
+			permalink: "http://yoast.com",
 		};
 
 		const mockPaper = new Paper( "string <a href='http://yoast.com/'>focuskeyword</a>", attributes );

--- a/packages/yoastseo/spec/languageProcessing/researches/getLinkStatisticsSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/getLinkStatisticsSpec.js
@@ -103,30 +103,14 @@ describe( "Tests a string for anchors and its attributes", function() {
 		expect( foundLinks.keyword.totalKeyword ).toBe( 0 );
 	} );
 
-	it( "should not detect the keyword in link texts identical to the page URL", function() {
+	it( "should not detect the keyword in link text which links to itself also when the permalink is set to a domain, not a full URL", function() {
 		const attributes = {
 			keyword: "focuskeyphrase",
 			url: "http://yoast.com/",
 			permalink: "yoast.com",
 		};
 
-		const mockPaper = new Paper( "string <a href='http://yoast.com/'>focuskeyword</a>", attributes );
-		const researcher = new EnglishResearcher( mockPaper );
-		researcher.addResearchData( "morphology", morphologyData );
-		foundLinks = linkCount( mockPaper, researcher );
-		expect( foundLinks.total ).toBe( 1 );
-		expect( foundLinks.internalTotal ).toBe( 1 );
-		expect( foundLinks.keyword.totalKeyword ).toBe( 0 );
-	} );
-
-	it( "should not detect the keyword in link texts that have a scheme and are identical to the page URL", function() {
-		const attributes = {
-			keyword: "focuskeyword",
-			url: "http://yoast.com/",
-			permalink: "http://yoast.com",
-		};
-
-		const mockPaper = new Paper( "string <a href='http://yoast.com/'>focuskeyword</a>", attributes );
+		const mockPaper = new Paper( "string <a href='http://yoast.com/'>focuskeyphrase</a>", attributes );
 		const researcher = new EnglishResearcher( mockPaper );
 		researcher.addResearchData( "morphology", morphologyData );
 		foundLinks = linkCount( mockPaper, researcher );

--- a/packages/yoastseo/spec/languageProcessing/researches/getLinkStatisticsSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/getLinkStatisticsSpec.js
@@ -15,7 +15,7 @@ describe( "Tests a string for anchors and its attributes", function() {
 	const paperAttributes = {
 		keyword: "link",
 		url: "http://yoast.com",
-		permalink: "http://yoast.com",
+		siteUrlOrDomain: "http://yoast.com",
 	};
 
 	it( "should detect internal links", function() {
@@ -44,7 +44,7 @@ describe( "Tests a string for anchors and its attributes", function() {
 		const attributes = {
 			keyword: "test",
 			url: "http://yoast.com",
-			permalink: "http://yoast.com",
+			siteUrlOrDomain: "http://yoast.com",
 		};
 
 		const mockPaper = new Paper( "string <a href='http://yoast.com/some-other-page/'>link</a>", attributes );
@@ -59,7 +59,7 @@ describe( "Tests a string for anchors and its attributes", function() {
 		const attributes = {
 			keyword: "focuskeyword",
 			url: "http://yoast.com",
-			permalink: "http://yoast.com",
+			siteUrlOrDomain: "http://yoast.com",
 		};
 
 		const mockPaper = new Paper( "string <a href='http://yoast.com/some-other-page/'>focuskeyword</a>", attributes );
@@ -75,7 +75,7 @@ describe( "Tests a string for anchors and its attributes", function() {
 		const attributes = {
 			keyword: "focuskeyword",
 			url: "http://yoast.com",
-			permalink: "http://yoast.com",
+			siteUrlOrDomain: "http://yoast.com",
 		};
 
 		const mockPaper = new Paper( "string <a href='http://example.com/some-page/'>focuskeyword</a>", attributes );
@@ -91,10 +91,26 @@ describe( "Tests a string for anchors and its attributes", function() {
 		const attributes = {
 			keyword: "focuskeyword",
 			url: "http://yoast.com/this-page/",
-			permalink: "http://yoast.com/this-page/",
+			siteUrlOrDomain: "http://yoast.com/this-page/",
 		};
 
 		const mockPaper = new Paper( "string <a href='http://yoast.com/this-page/'>focuskeyword</a>", attributes );
+		const researcher = new EnglishResearcher( mockPaper );
+		researcher.addResearchData( "morphology", morphologyData );
+		foundLinks = linkCount( mockPaper, researcher );
+		expect( foundLinks.total ).toBe( 1 );
+		expect( foundLinks.internalTotal ).toBe( 1 );
+		expect( foundLinks.keyword.totalKeyword ).toBe( 0 );
+	} );
+
+	it( "should not detect the keyword in link text which links to itself, when the siteUrlOrDomain is a domain", function() {
+		const attributes = {
+			keyword: "focuskeyword",
+			url: "http://yoast.com/this-page/",
+			siteUrlOrDomain: "yoast.com",
+		};
+
+		const mockPaper = new Paper( "string <a href='http://yoast.com/'>focuskeyword</a>", attributes );
 		const researcher = new EnglishResearcher( mockPaper );
 		researcher.addResearchData( "morphology", morphologyData );
 		foundLinks = linkCount( mockPaper, researcher );
@@ -107,7 +123,7 @@ describe( "Tests a string for anchors and its attributes", function() {
 		const attributes = {
 			keyword: "focuskeyword",
 			url: "http://yoast.com/this-page/",
-			permalink: "http://yoast.com/this-page/",
+			siteUrlOrDomain: "http://yoast.com/this-page/",
 		};
 
 		const mockPaper = new Paper( "string <a href='#some-fragment'>focuskeyword</a>", attributes );
@@ -263,7 +279,7 @@ describe( "Tests a string for anchors and its attributes", function() {
 		const attributes = {
 			keyword: "keyword",
 			url: "http://example.org",
-			permalink: "http://example.org",
+			siteUrlOrDomain: "http://example.org",
 		};
 		let mockPaper = new Paper( "hello", attributes );
 		const researcher = new EnglishResearcher( mockPaper );
@@ -326,7 +342,7 @@ describe( "Tests a string for anchors and its attributes", function() {
 		const attributes = {
 			keyword: "keyword",
 			url: "http://example.org/keyword",
-			permalink: "http://example.org/keyword",
+			siteUrlOrDomain: "http://example.org/keyword",
 		};
 
 		const mockPaper = new Paper( "hello, here is a link with my <a href='http://example.org/keyword'>Keyword</a>", attributes );
@@ -357,7 +373,7 @@ describe( "Tests a string for anchors and its attributes", function() {
 		const attributes = {
 			keyword: "keyword",
 			url: "http://example.org/keyword#top",
-			permalink: "http://example.org/keyword#top",
+			siteUrlOrDomain: "http://example.org/keyword#top",
 		};
 
 		const mockPaper = new Paper( "hello, here is a link with my <a href='http://example.org/keyword'>Keyword</a>", attributes );
@@ -388,7 +404,7 @@ describe( "Tests a string for anchors and its attributes", function() {
 		const attributes = {
 			keyword: "keyword",
 			url: "http://example.org/keyword",
-			permalink: "http://example.org/keyword",
+			siteUrlOrDomain: "http://example.org/keyword",
 		};
 
 		const mockPaper = new Paper( "hello, here is a link with my <a href='http://example.org/keyword#top'>resume</a>", attributes );
@@ -419,7 +435,7 @@ describe( "Tests a string for anchors and its attributes", function() {
 		const attributes = {
 			keyword: "keyword",
 			url: "http://example.org/keyword",
-			permalink: "http://example.org/keyword",
+			siteUrlOrDomain: "http://example.org/keyword",
 		};
 
 		const mockPaper = new Paper( "hello, here is a link with my <a href='http://example.com/keyword#top'>resume</a>", attributes );
@@ -450,7 +466,7 @@ describe( "Tests a string for anchors and its attributes", function() {
 		const attributes = {
 			keyword: "keyword",
 			url: "http://example.org/keyword#top",
-			permalink: "http://example.org/keyword#top",
+			siteUrlOrDomain: "http://example.org/keyword#top",
 		};
 
 		const mockPaper = new Paper( "hello, here is a link with my <a href='http://example.com/keyword#top'>keyword</a>", attributes );
@@ -481,7 +497,7 @@ describe( "Tests a string for anchors and its attributes", function() {
 		const attributes = {
 			keyword: "",
 			url: "http://example.org/keyword#top",
-			permalink: "http://example.org/keyword#top",
+			siteUrlOrDomain: "http://example.org/keyword#top",
 		};
 
 		const mockPaper = new Paper( "hello, here is a link with my <a href='http://example.com/keyword#top'>keyword</a>", attributes );
@@ -512,7 +528,7 @@ describe( "Tests a string for anchors and its attributes", function() {
 		const attributes = {
 			keyword: "keyword",
 			url: "http://example.org/keyword",
-			permalink: "http://example.org/keyword",
+			siteUrlOrDomain: "http://example.org/keyword",
 		};
 
 		const mockPaper = new Paper( "hello, here is a link with my <a href='http://example.com/keyword'>keywords</a>", attributes );
@@ -530,7 +546,7 @@ describe( "Tests a string for anchors and its attributes", function() {
 		const attributes = {
 			keyword: "key word and key phrase",
 			url: "http://example.org/keyword",
-			permalink: "http://example.org/keyword",
+			siteUrlOrDomain: "http://example.org/keyword",
 		};
 
 		const mockPaper = new Paper( "hello, here is a link with my <a href='http://example.com/keyword'>keys wording phrased</a>", attributes );
@@ -549,7 +565,7 @@ describe( "Tests a string for anchors and its attributes", function() {
 			keyword: "key word and key phrase",
 			synonyms: "interesting article, and another exciting paper",
 			url: "http://example.org/keyword",
-			permalink: "http://example.org/keyword",
+			siteUrlOrDomain: "http://example.org/keyword",
 		};
 
 		const mockPaper = new Paper( "hello, here is a link with my <a href='http://example.com/keyword'>keys wording phrased</a>" +
@@ -574,7 +590,7 @@ describe( "Tests a string for anchors and its attributes", function() {
 			keyword: "key word and key phrase",
 			synonyms: "interesting article, and another exciting paper",
 			url: "http://example.org/keyword",
-			permalink: "http://example.org/keyword",
+			siteUrlOrDomain: "http://example.org/keyword",
 		};
 
 		const mockPaper = new Paper( "hello, here is a link with my <a href='http://example.com/keyword'>keys wording </a>" +
@@ -597,7 +613,7 @@ describe( "Tests a string for anchors and its attributes", function() {
 			keyword: "سوار در طبیعت",
 			synonyms: "",
 			url: "http://example.org/keyword",
-			permalink: "http://example.org/keyword",
+			siteUrlOrDomain: "http://example.org/keyword",
 			locale: "fa_IR",
 		};
 
@@ -618,7 +634,7 @@ describe( "Tests a string for anchors and its attributes", function() {
 			keyword: "fast",
 			synonyms: "",
 			url: "http://example.org/keyword",
-			permalink: "http://example.org/keyword",
+			siteUrlOrDomain: "http://example.org/keyword",
 		};
 
 		const mockPaper = new Paper( "hello, here is a link with my <a href='http://example.com/keyword'>fast one </a>" +
@@ -640,7 +656,7 @@ describe( "a test for anchors and its attributes when the exact match of a keyph
 		const attributes = {
 			keyword: "\"walking in nature\"",
 			url: "http://example.org/keyword",
-			permalink: "http://example.org/keyword",
+			siteUrlOrDomain: "http://example.org/keyword",
 		};
 
 		const mockPaper = new Paper( "hello, here is a link with my <a href='http://example.com/keyword'>walking in nature</a>", attributes );
@@ -658,7 +674,7 @@ describe( "a test for anchors and its attributes when the exact match of a keyph
 		const attributes = {
 			keyword: "\"walking in nature\"",
 			url: "http://example.org/keyword",
-			permalink: "http://example.org/keyword",
+			siteUrlOrDomain: "http://example.org/keyword",
 		};
 
 		const mockPaper = new Paper( "hello, here is a link with my <a href='http://example.com/keyword'>" +
@@ -677,7 +693,7 @@ describe( "a test for anchors and its attributes when the exact match of a keyph
 		const attributes = {
 			keyword: "\"walking in nature\"",
 			url: "http://example.org/keyword",
-			permalink: "http://example.org/keyword",
+			siteUrlOrDomain: "http://example.org/keyword",
 		};
 
 		const mockPaper = new Paper( "hello, here is a link with my <a href='http://example.com/keyword'>" +
@@ -696,7 +712,7 @@ describe( "a test for anchors and its attributes when the exact match of a keyph
 		const attributes = {
 			keyword: "\"walking in nature\"",
 			url: "http://example.org/keyword",
-			permalink: "http://example.org/keyword",
+			siteUrlOrDomain: "http://example.org/keyword",
 		};
 
 		const mockPaper = new Paper( "hello, here is a link with my <a href='http://example.com/keyword'>" +
@@ -717,7 +733,7 @@ describe( "a test for anchors and its attributes when the exact match of a keyph
 			keyword: "something and tortie",
 			synonyms: "\"cats and dogs\", tortoiseshell",
 			url: "http://yoast.com",
-			permalink: "http://yoast.com",
+			siteUrlOrDomain: "http://yoast.com",
 		};
 		const mockPaper = new Paper( "A text with a <a href='http://yoast.com'>link</a>, <a href='http://example.com'>cats and dogs</a>",
 			paperAttributes );
@@ -740,7 +756,7 @@ describe( "a test for anchors and its attributes when the exact match of a keyph
 		const paperAttributes = {
 			keyword: "「読ん一冊の本」",
 			url: "http://yoast.com",
-			permalink: "http://yoast.com",
+			siteUrlOrDomain: "http://yoast.com",
 		};
 		const mockPaper = new Paper( "言葉 <a href='http://yoast.com'>リンク</a>, <a href='http://example.com'>読ん一冊の本</a>", paperAttributes );
 		const researcher = new JapaneseResearcher( mockPaper );
@@ -754,7 +770,7 @@ describe( "a test for anchors and its attributes when the exact match of a keyph
 		const paperAttributes = {
 			keyword: "「読ん一冊の本」",
 			url: "http://yoast.com",
-			permalink: "http://yoast.com",
+			siteUrlOrDomain: "http://yoast.com",
 		};
 		const mockPaper = new Paper( "言葉 <a href='http://yoast.com'>リンク</a>, <a href='http://example.com'>から読ん一冊の本</a>", paperAttributes );
 		const researcher = new JapaneseResearcher( mockPaper );
@@ -768,7 +784,7 @@ describe( "a test for anchors and its attributes when the exact match of a keyph
 		const paperAttributes = {
 			keyword: "「読ん一冊の本」",
 			url: "http://yoast.com",
-			permalink: "http://yoast.com",
+			siteUrlOrDomain: "http://yoast.com",
 		};
 		const mockPaper = new Paper( "言葉 <a href='http://yoast.com'>リンク</a>, <a href='http://example.com'>猫から読ん一冊の本</a>", paperAttributes );
 		const researcher = new JapaneseResearcher( mockPaper );
@@ -783,7 +799,7 @@ describe( "a test for anchors and its attributes when the exact match of a keyph
 			keyword: "言葉",
 			synonyms: "「小さく花の刺繍」",
 			url: "http://yoast.com",
-			permalink: "http://yoast.com",
+			siteUrlOrDomain: "http://yoast.com",
 		};
 		const mockPaper = new Paper( "言葉 <a href='http://yoast.com'>リンク</a>, <a href='http://example.com'>小さく花の刺繍</a>", paperAttributes );
 		const researcher = new JapaneseResearcher( mockPaper );
@@ -809,7 +825,7 @@ describe( "a test for anchors and its attributes in languages that have a custom
 		let paperAttributes = {
 			keyword: "リンク",
 			url: "http://yoast.com",
-			permalink: "http://yoast.com",
+			siteUrlOrDomain: "http://yoast.com",
 		};
 
 		it( "should detect internal links", function() {
@@ -859,7 +875,7 @@ describe( "a test for anchors and its attributes in languages that have a custom
 			paperAttributes = {
 				keyword: "読ん一冊の本",
 				url: "http://yoast.com",
-				permalink: "http://yoast.com",
+				siteUrlOrDomain: "http://yoast.com",
 			};
 			const mockPaper = new Paper( "言葉 <a href='http://yoast.com'>リンク</a>, <a href='http://example.com'>猫と読ん一冊の本</a>", paperAttributes );
 			const researcher = new JapaneseResearcher( mockPaper );
@@ -876,7 +892,7 @@ describe( "a test for anchors and its attributes in languages that have a custom
 			paperAttributes = {
 				keyword: "から小さい花の刺繍",
 				url: "http://yoast.com",
-				permalink: "http://yoast.com",
+				siteUrlOrDomain: "http://yoast.com",
 			};
 			const mockPaper = new Paper( "言葉 <a href='http://yoast.com'>リンク</a>, <a href='http://example.com'>小さい花の刺繍</a>", paperAttributes );
 			const researcher = new JapaneseResearcher( mockPaper );
@@ -894,7 +910,7 @@ describe( "a test for anchors and its attributes in languages that have a custom
 			paperAttributes = {
 				keyword: "から小さく花の刺繍",
 				url: "http://yoast.com",
-				permalink: "http://yoast.com",
+				siteUrlOrDomain: "http://yoast.com",
 			};
 			const mockPaper = new Paper( "言葉 <a href='http://yoast.com'>リンク</a>, <a href='http://example.com'>小さい花の刺繍</a>", paperAttributes );
 			const researcher = new JapaneseResearcher( mockPaper );
@@ -912,7 +928,7 @@ describe( "a test for anchors and its attributes in languages that have a custom
 				keyword: "から小さく花の刺繍",
 				synonyms: "猫用のフード, 猫用食品",
 				url: "http://yoast.com",
-				permalink: "http://yoast.com",
+				siteUrlOrDomain: "http://yoast.com",
 			};
 			const mockPaper = new Paper( "言葉 <a href='http://yoast.com'>リンク</a>, <a href='http://example.com'>小さく花の刺繍</a>" +
 				" <a href='http://example.com'>から猫用のフード</a>", paperAttributes );
@@ -938,7 +954,7 @@ describe( "a test for anchors and its attributes in languages that have a custom
 			const paperAttributes = {
 				keyword: "読ん一冊の本",
 				url: "http://yoast.com",
-				permalink: "http://yoast.com",
+				siteUrlOrDomain: "http://yoast.com",
 			};
 			const mockPaper = new Paper( "言葉 <a href='http://yoast.com'>リンク</a>, <a href='http://example.com'>猫と読ん一冊の本</a>", paperAttributes );
 			const researcher = new JapaneseResearcher( mockPaper );
@@ -956,7 +972,7 @@ describe( "a test for anchors and its attributes in languages that have a custom
 			const paperAttributes = {
 				keyword: "から小さい花の刺繍",
 				url: "http://yoast.com",
-				permalink: "http://yoast.com",
+				siteUrlOrDomain: "http://yoast.com",
 			};
 			const mockPaper = new Paper( "言葉 <a href='http://yoast.com'>リンク</a>, <a href='http://example.com'>小さい花の刺繍</a>", paperAttributes );
 			const researcher = new JapaneseResearcher( mockPaper );
@@ -975,7 +991,7 @@ describe( "a test for anchors and its attributes in languages that have a custom
 			const paperAttributes = {
 				keyword: "から小さく花の刺繍",
 				url: "http://yoast.com",
-				permalink: "http://yoast.com",
+				siteUrlOrDomain: "http://yoast.com",
 			};
 			const mockPaper = new Paper( "言葉 <a href='http://yoast.com'>リンク</a>, <a href='http://example.com'>小さい花の刺繍</a>" +
 				" <a href='http://example.com'>小さける花の刺繍</a>", paperAttributes );
@@ -999,7 +1015,7 @@ describe( "a test for anchors and its attributes in languages that have a custom
 				keyword: "猫用食品",
 				synonyms: "小さく花の刺繍",
 				url: "http://yoast.com",
-				permalink: "http://yoast.com",
+				siteUrlOrDomain: "http://yoast.com",
 			};
 			const mockPaper = new Paper( "言葉 <a href='http://yoast.com'>リンク</a>," +
 				" <a href='http://example.com'>から小さい花の刺繍</a>", paperAttributes );
@@ -1022,7 +1038,7 @@ describe( "a test for anchors and its attributes in languages that have a custom
 				keyword: "「小さく花の刺繍」",
 				synonyms: "something, something else",
 				url: "http://yoast.com",
-				permalink: "http://yoast.com",
+				siteUrlOrDomain: "http://yoast.com",
 			};
 			const mockPaper = new Paper( "言葉 <a href='http://yoast.com'>リンク</a>, <a href='http://example.com'>小さい花の刺繍</a>", paperAttributes );
 			const researcher = new JapaneseResearcher( mockPaper );

--- a/packages/yoastseo/spec/languageProcessing/researches/getLinkStatisticsSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/getLinkStatisticsSpec.js
@@ -14,7 +14,6 @@ let foundLinks;
 describe( "Tests a string for anchors and its attributes", function() {
 	const paperAttributes = {
 		keyword: "link",
-		url: "http://yoast.com",
 		permalink: "http://yoast.com",
 	};
 
@@ -43,7 +42,6 @@ describe( "Tests a string for anchors and its attributes", function() {
 	it( "should detect no keyword in link text", function() {
 		const attributes = {
 			keyword: "test",
-			url: "http://yoast.com",
 			permalink: "http://yoast.com",
 		};
 
@@ -58,7 +56,6 @@ describe( "Tests a string for anchors and its attributes", function() {
 	it( "should detect the keyword in internal link text", function() {
 		const attributes = {
 			keyword: "focuskeyword",
-			url: "http://yoast.com",
 			permalink: "http://yoast.com",
 		};
 
@@ -74,7 +71,6 @@ describe( "Tests a string for anchors and its attributes", function() {
 	it( "should detect the keyword in external link text", function() {
 		const attributes = {
 			keyword: "focuskeyword",
-			url: "http://yoast.com",
 			permalink: "http://yoast.com",
 		};
 
@@ -90,7 +86,7 @@ describe( "Tests a string for anchors and its attributes", function() {
 	it( "should not detect the keyword in link text which links to itself", function() {
 		const attributes = {
 			keyword: "focuskeyword",
-			url: "http://yoast.com/this-page/",
+			url: "this-page",
 			permalink: "http://yoast.com/this-page/",
 		};
 
@@ -106,11 +102,11 @@ describe( "Tests a string for anchors and its attributes", function() {
 	it( "should not detect the keyword in link text which links to itself also when the permalink is set to a domain, not a full URL", function() {
 		const attributes = {
 			keyword: "focuskeyphrase",
-			url: "http://yoast.com/",
+			url: "this-page",
 			permalink: "yoast.com",
 		};
 
-		const mockPaper = new Paper( "string <a href='http://yoast.com/'>focuskeyphrase</a>", attributes );
+		const mockPaper = new Paper( "string <a href='http://yoast.com/this-page/'>focuskeyphrase</a>", attributes );
 		const researcher = new EnglishResearcher( mockPaper );
 		researcher.addResearchData( "morphology", morphologyData );
 		foundLinks = linkCount( mockPaper, researcher );
@@ -122,7 +118,7 @@ describe( "Tests a string for anchors and its attributes", function() {
 	it( "should not detect the keyword in link text which links to a fragment on the same page", function() {
 		const attributes = {
 			keyword: "focuskeyword",
-			url: "http://yoast.com/this-page/",
+			url: "this-page",
 			permalink: "http://yoast.com/this-page/",
 		};
 
@@ -278,7 +274,6 @@ describe( "Tests a string for anchors and its attributes", function() {
 	it( "should return all special types", function() {
 		const attributes = {
 			keyword: "keyword",
-			url: "http://example.org",
 			permalink: "http://example.org",
 		};
 		let mockPaper = new Paper( "hello", attributes );
@@ -341,7 +336,7 @@ describe( "Tests a string for anchors and its attributes", function() {
 	it( "should ignore the keyword in an url when referencing to the current url", function() {
 		const attributes = {
 			keyword: "keyword",
-			url: "http://example.org/keyword",
+			url: "keyword",
 			permalink: "http://example.org/keyword",
 		};
 
@@ -372,7 +367,7 @@ describe( "Tests a string for anchors and its attributes", function() {
 	it( "should ignore the keyword in an url when referencing to the current url with a hash", function() {
 		const attributes = {
 			keyword: "keyword",
-			url: "http://example.org/keyword#top",
+			url: "keyword#top",
 			permalink: "http://example.org/keyword#top",
 		};
 
@@ -403,7 +398,7 @@ describe( "Tests a string for anchors and its attributes", function() {
 	it( "should ignore the keyword in an url with a hash when referencing to the current url", function() {
 		const attributes = {
 			keyword: "keyword",
-			url: "http://example.org/keyword",
+			url: "keyword",
 			permalink: "http://example.org/keyword",
 		};
 
@@ -434,7 +429,7 @@ describe( "Tests a string for anchors and its attributes", function() {
 	it( "should match the keyword in an url with a hash", function() {
 		const attributes = {
 			keyword: "keyword",
-			url: "http://example.org/keyword",
+			url: "keyword",
 			permalink: "http://example.org/keyword",
 		};
 
@@ -465,7 +460,7 @@ describe( "Tests a string for anchors and its attributes", function() {
 	it( "should match the keyword in an url with a hash in the current url", function() {
 		const attributes = {
 			keyword: "keyword",
-			url: "http://example.org/keyword#top",
+			url: "keyword#top",
 			permalink: "http://example.org/keyword#top",
 		};
 
@@ -496,7 +491,7 @@ describe( "Tests a string for anchors and its attributes", function() {
 	it( "should match without a keyword", function() {
 		const attributes = {
 			keyword: "",
-			url: "http://example.org/keyword#top",
+			url: "keyword#top",
 			permalink: "http://example.org/keyword#top",
 		};
 
@@ -527,7 +522,7 @@ describe( "Tests a string for anchors and its attributes", function() {
 	it( "should match different keyword forms in a url ", function() {
 		const attributes = {
 			keyword: "keyword",
-			url: "http://example.org/keyword",
+			url: "keyword",
 			permalink: "http://example.org/keyword",
 		};
 
@@ -545,7 +540,7 @@ describe( "Tests a string for anchors and its attributes", function() {
 	it( "should match all words from keyphrase in the link text and vice versa ", function() {
 		const attributes = {
 			keyword: "key word and key phrase",
-			url: "http://example.org/keyword",
+			url: "keyword",
 			permalink: "http://example.org/keyword",
 		};
 
@@ -564,7 +559,7 @@ describe( "Tests a string for anchors and its attributes", function() {
 		const attributes = {
 			keyword: "key word and key phrase",
 			synonyms: "interesting article, and another exciting paper",
-			url: "http://example.org/keyword",
+			url: "keyword",
 			permalink: "http://example.org/keyword",
 		};
 
@@ -589,7 +584,7 @@ describe( "Tests a string for anchors and its attributes", function() {
 		const attributes = {
 			keyword: "key word and key phrase",
 			synonyms: "interesting article, and another exciting paper",
-			url: "http://example.org/keyword",
+			url: "keyword",
 			permalink: "http://example.org/keyword",
 		};
 
@@ -612,7 +607,7 @@ describe( "Tests a string for anchors and its attributes", function() {
 		const attributes = {
 			keyword: "سوار در طبیعت",
 			synonyms: "",
-			url: "http://example.org/keyword",
+			url: "keyword",
 			permalink: "http://example.org/keyword",
 			locale: "fa_IR",
 		};
@@ -633,7 +628,7 @@ describe( "Tests a string for anchors and its attributes", function() {
 		const attributes = {
 			keyword: "fast",
 			synonyms: "",
-			url: "http://example.org/keyword",
+			url: "keyword",
 			permalink: "http://example.org/keyword",
 		};
 
@@ -655,7 +650,7 @@ describe( "a test for anchors and its attributes when the exact match of a keyph
 	it( "should match all words from keyphrase in the link text and vice versa when the keyphrase is enclosed in double quotes", function() {
 		const attributes = {
 			keyword: "\"walking in nature\"",
-			url: "http://example.org/keyword",
+			url: "keyword",
 			permalink: "http://example.org/keyword",
 		};
 
@@ -673,7 +668,7 @@ describe( "a test for anchors and its attributes when the exact match of a keyph
 		"and the keyphrase is preceded by a function word in the anchor text", function() {
 		const attributes = {
 			keyword: "\"walking in nature\"",
-			url: "http://example.org/keyword",
+			url: "keyword",
 			permalink: "http://example.org/keyword",
 		};
 
@@ -692,7 +687,7 @@ describe( "a test for anchors and its attributes when the exact match of a keyph
 		"and the keyphrase is followed by a content word in the anchor text", function() {
 		const attributes = {
 			keyword: "\"walking in nature\"",
-			url: "http://example.org/keyword",
+			url: "keyword",
 			permalink: "http://example.org/keyword",
 		};
 
@@ -711,7 +706,7 @@ describe( "a test for anchors and its attributes when the exact match of a keyph
 		"and the keyphrase appears in a different form in the anchor text", function() {
 		const attributes = {
 			keyword: "\"walking in nature\"",
-			url: "http://example.org/keyword",
+			url: "keyword",
 			permalink: "http://example.org/keyword",
 		};
 
@@ -732,7 +727,6 @@ describe( "a test for anchors and its attributes when the exact match of a keyph
 		const paperAttributes = {
 			keyword: "something and tortie",
 			synonyms: "\"cats and dogs\", tortoiseshell",
-			url: "http://yoast.com",
 			permalink: "http://yoast.com",
 		};
 		const mockPaper = new Paper( "A text with a <a href='http://yoast.com'>link</a>, <a href='http://example.com'>cats and dogs</a>",
@@ -755,7 +749,6 @@ describe( "a test for anchors and its attributes when the exact match of a keyph
 	it( "checks the keyphrase in the anchor text when the keyphrase is enclosed in double quotes", function() {
 		const paperAttributes = {
 			keyword: "「読ん一冊の本」",
-			url: "http://yoast.com",
 			permalink: "http://yoast.com",
 		};
 		const mockPaper = new Paper( "言葉 <a href='http://yoast.com'>リンク</a>, <a href='http://example.com'>読ん一冊の本</a>", paperAttributes );
@@ -769,7 +762,6 @@ describe( "a test for anchors and its attributes when the exact match of a keyph
 		"and the keyphrase is preceded by a function word in the anchor text", function() {
 		const paperAttributes = {
 			keyword: "「読ん一冊の本」",
-			url: "http://yoast.com",
 			permalink: "http://yoast.com",
 		};
 		const mockPaper = new Paper( "言葉 <a href='http://yoast.com'>リンク</a>, <a href='http://example.com'>から読ん一冊の本</a>", paperAttributes );
@@ -783,7 +775,6 @@ describe( "a test for anchors and its attributes when the exact match of a keyph
 		"and the keyphrase is preceded by a function word and a content word in the anchor text", function() {
 		const paperAttributes = {
 			keyword: "「読ん一冊の本」",
-			url: "http://yoast.com",
 			permalink: "http://yoast.com",
 		};
 		const mockPaper = new Paper( "言葉 <a href='http://yoast.com'>リンク</a>, <a href='http://example.com'>猫から読ん一冊の本</a>", paperAttributes );
@@ -798,7 +789,6 @@ describe( "a test for anchors and its attributes when the exact match of a keyph
 		const paperAttributes = {
 			keyword: "言葉",
 			synonyms: "「小さく花の刺繍」",
-			url: "http://yoast.com",
 			permalink: "http://yoast.com",
 		};
 		const mockPaper = new Paper( "言葉 <a href='http://yoast.com'>リンク</a>, <a href='http://example.com'>小さく花の刺繍</a>", paperAttributes );
@@ -824,7 +814,6 @@ describe( "a test for anchors and its attributes in languages that have a custom
 	describe( "a test for when the morphology data is not available", () => {
 		let paperAttributes = {
 			keyword: "リンク",
-			url: "http://yoast.com",
 			permalink: "http://yoast.com",
 		};
 
@@ -874,7 +863,6 @@ describe( "a test for anchors and its attributes in languages that have a custom
 		it( "assesses the anchor text where not all content words in the text are present in the keyphrse", function() {
 			paperAttributes = {
 				keyword: "読ん一冊の本",
-				url: "http://yoast.com",
 				permalink: "http://yoast.com",
 			};
 			const mockPaper = new Paper( "言葉 <a href='http://yoast.com'>リンク</a>, <a href='http://example.com'>猫と読ん一冊の本</a>", paperAttributes );
@@ -891,7 +879,6 @@ describe( "a test for anchors and its attributes in languages that have a custom
 		it( "assesses the anchor text where all content words in the text present in the keyphrase", function() {
 			paperAttributes = {
 				keyword: "から小さい花の刺繍",
-				url: "http://yoast.com",
 				permalink: "http://yoast.com",
 			};
 			const mockPaper = new Paper( "言葉 <a href='http://yoast.com'>リンク</a>, <a href='http://example.com'>小さい花の刺繍</a>", paperAttributes );
@@ -909,7 +896,6 @@ describe( "a test for anchors and its attributes in languages that have a custom
 		it( "assesses the anchor text where all content words in the text present in the keyphrase, but in a different form", function() {
 			paperAttributes = {
 				keyword: "から小さく花の刺繍",
-				url: "http://yoast.com",
 				permalink: "http://yoast.com",
 			};
 			const mockPaper = new Paper( "言葉 <a href='http://yoast.com'>リンク</a>, <a href='http://example.com'>小さい花の刺繍</a>", paperAttributes );
@@ -927,7 +913,6 @@ describe( "a test for anchors and its attributes in languages that have a custom
 			paperAttributes = {
 				keyword: "から小さく花の刺繍",
 				synonyms: "猫用のフード, 猫用食品",
-				url: "http://yoast.com",
 				permalink: "http://yoast.com",
 			};
 			const mockPaper = new Paper( "言葉 <a href='http://yoast.com'>リンク</a>, <a href='http://example.com'>小さく花の刺繍</a>" +
@@ -953,7 +938,6 @@ describe( "a test for anchors and its attributes in languages that have a custom
 		it( "assesses the anchor text where not all content words in the text present in the keyphrse", function() {
 			const paperAttributes = {
 				keyword: "読ん一冊の本",
-				url: "http://yoast.com",
 				permalink: "http://yoast.com",
 			};
 			const mockPaper = new Paper( "言葉 <a href='http://yoast.com'>リンク</a>, <a href='http://example.com'>猫と読ん一冊の本</a>", paperAttributes );
@@ -971,7 +955,6 @@ describe( "a test for anchors and its attributes in languages that have a custom
 		it( "assesses the anchor text where all content words in the text present in the keyphrase", function() {
 			const paperAttributes = {
 				keyword: "から小さい花の刺繍",
-				url: "http://yoast.com",
 				permalink: "http://yoast.com",
 			};
 			const mockPaper = new Paper( "言葉 <a href='http://yoast.com'>リンク</a>, <a href='http://example.com'>小さい花の刺繍</a>", paperAttributes );
@@ -990,7 +973,6 @@ describe( "a test for anchors and its attributes in languages that have a custom
 		it( "assesses the anchor text where all content words in the text present in the keyphrase, but in a different form", function() {
 			const paperAttributes = {
 				keyword: "から小さく花の刺繍",
-				url: "http://yoast.com",
 				permalink: "http://yoast.com",
 			};
 			const mockPaper = new Paper( "言葉 <a href='http://yoast.com'>リンク</a>, <a href='http://example.com'>小さい花の刺繍</a>" +
@@ -1014,7 +996,6 @@ describe( "a test for anchors and its attributes in languages that have a custom
 			const paperAttributes = {
 				keyword: "猫用食品",
 				synonyms: "小さく花の刺繍",
-				url: "http://yoast.com",
 				permalink: "http://yoast.com",
 			};
 			const mockPaper = new Paper( "言葉 <a href='http://yoast.com'>リンク</a>," +
@@ -1037,7 +1018,6 @@ describe( "a test for anchors and its attributes in languages that have a custom
 			const paperAttributes = {
 				keyword: "「小さく花の刺繍」",
 				synonyms: "something, something else",
-				url: "http://yoast.com",
 				permalink: "http://yoast.com",
 			};
 			const mockPaper = new Paper( "言葉 <a href='http://yoast.com'>リンク</a>, <a href='http://example.com'>小さい花の刺繍</a>", paperAttributes );
@@ -1048,4 +1028,3 @@ describe( "a test for anchors and its attributes in languages that have a custom
 		} );
 	} );
 } );
-

--- a/packages/yoastseo/spec/languageProcessing/researches/getLinkStatisticsSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/getLinkStatisticsSpec.js
@@ -44,7 +44,7 @@ describe( "Tests a string for anchors and its attributes", function() {
 		const attributes = {
 			keyword: "test",
 			url: "http://yoast.com",
-			siteUrlOrDomain: "http://yoast.com",
+			permalink: "http://yoast.com",
 		};
 
 		const mockPaper = new Paper( "string <a href='http://yoast.com/some-other-page/'>link</a>", attributes );
@@ -59,7 +59,7 @@ describe( "Tests a string for anchors and its attributes", function() {
 		const attributes = {
 			keyword: "focuskeyword",
 			url: "http://yoast.com",
-			siteUrlOrDomain: "http://yoast.com",
+			permalink: "http://yoast.com",
 		};
 
 		const mockPaper = new Paper( "string <a href='http://yoast.com/some-other-page/'>focuskeyword</a>", attributes );
@@ -75,7 +75,7 @@ describe( "Tests a string for anchors and its attributes", function() {
 		const attributes = {
 			keyword: "focuskeyword",
 			url: "http://yoast.com",
-			siteUrlOrDomain: "http://yoast.com",
+			permalink: "http://yoast.com",
 		};
 
 		const mockPaper = new Paper( "string <a href='http://example.com/some-page/'>focuskeyword</a>", attributes );
@@ -91,7 +91,7 @@ describe( "Tests a string for anchors and its attributes", function() {
 		const attributes = {
 			keyword: "focuskeyword",
 			url: "http://yoast.com/this-page/",
-			siteUrlOrDomain: "http://yoast.com/this-page/",
+			permalink: "http://yoast.com/this-page/",
 		};
 
 		const mockPaper = new Paper( "string <a href='http://yoast.com/this-page/'>focuskeyword</a>", attributes );
@@ -139,7 +139,7 @@ describe( "Tests a string for anchors and its attributes", function() {
 		const attributes = {
 			keyword: "focuskeyword",
 			url: "http://yoast.com/this-page/",
-			siteUrlOrDomain: "http://yoast.com/this-page/",
+			permalink: "http://yoast.com/this-page/",
 		};
 
 		const mockPaper = new Paper( "string <a href='#some-fragment'>focuskeyword</a>", attributes );
@@ -295,7 +295,7 @@ describe( "Tests a string for anchors and its attributes", function() {
 		const attributes = {
 			keyword: "keyword",
 			url: "http://example.org",
-			siteUrlOrDomain: "http://example.org",
+			permalink: "http://example.org",
 		};
 		let mockPaper = new Paper( "hello", attributes );
 		const researcher = new EnglishResearcher( mockPaper );
@@ -358,7 +358,7 @@ describe( "Tests a string for anchors and its attributes", function() {
 		const attributes = {
 			keyword: "keyword",
 			url: "http://example.org/keyword",
-			siteUrlOrDomain: "http://example.org/keyword",
+			permalink: "http://example.org/keyword",
 		};
 
 		const mockPaper = new Paper( "hello, here is a link with my <a href='http://example.org/keyword'>Keyword</a>", attributes );
@@ -389,7 +389,7 @@ describe( "Tests a string for anchors and its attributes", function() {
 		const attributes = {
 			keyword: "keyword",
 			url: "http://example.org/keyword#top",
-			siteUrlOrDomain: "http://example.org/keyword#top",
+			permalink: "http://example.org/keyword#top",
 		};
 
 		const mockPaper = new Paper( "hello, here is a link with my <a href='http://example.org/keyword'>Keyword</a>", attributes );
@@ -420,7 +420,7 @@ describe( "Tests a string for anchors and its attributes", function() {
 		const attributes = {
 			keyword: "keyword",
 			url: "http://example.org/keyword",
-			siteUrlOrDomain: "http://example.org/keyword",
+			permalink: "http://example.org/keyword",
 		};
 
 		const mockPaper = new Paper( "hello, here is a link with my <a href='http://example.org/keyword#top'>resume</a>", attributes );
@@ -451,7 +451,7 @@ describe( "Tests a string for anchors and its attributes", function() {
 		const attributes = {
 			keyword: "keyword",
 			url: "http://example.org/keyword",
-			siteUrlOrDomain: "http://example.org/keyword",
+			permalink: "http://example.org/keyword",
 		};
 
 		const mockPaper = new Paper( "hello, here is a link with my <a href='http://example.com/keyword#top'>resume</a>", attributes );
@@ -482,7 +482,7 @@ describe( "Tests a string for anchors and its attributes", function() {
 		const attributes = {
 			keyword: "keyword",
 			url: "http://example.org/keyword#top",
-			siteUrlOrDomain: "http://example.org/keyword#top",
+			permalink: "http://example.org/keyword#top",
 		};
 
 		const mockPaper = new Paper( "hello, here is a link with my <a href='http://example.com/keyword#top'>keyword</a>", attributes );
@@ -513,7 +513,7 @@ describe( "Tests a string for anchors and its attributes", function() {
 		const attributes = {
 			keyword: "",
 			url: "http://example.org/keyword#top",
-			siteUrlOrDomain: "http://example.org/keyword#top",
+			permalink: "http://example.org/keyword#top",
 		};
 
 		const mockPaper = new Paper( "hello, here is a link with my <a href='http://example.com/keyword#top'>keyword</a>", attributes );
@@ -544,7 +544,7 @@ describe( "Tests a string for anchors and its attributes", function() {
 		const attributes = {
 			keyword: "keyword",
 			url: "http://example.org/keyword",
-			siteUrlOrDomain: "http://example.org/keyword",
+			permalink: "http://example.org/keyword",
 		};
 
 		const mockPaper = new Paper( "hello, here is a link with my <a href='http://example.com/keyword'>keywords</a>", attributes );
@@ -562,7 +562,7 @@ describe( "Tests a string for anchors and its attributes", function() {
 		const attributes = {
 			keyword: "key word and key phrase",
 			url: "http://example.org/keyword",
-			siteUrlOrDomain: "http://example.org/keyword",
+			permalink: "http://example.org/keyword",
 		};
 
 		const mockPaper = new Paper( "hello, here is a link with my <a href='http://example.com/keyword'>keys wording phrased</a>", attributes );
@@ -581,7 +581,7 @@ describe( "Tests a string for anchors and its attributes", function() {
 			keyword: "key word and key phrase",
 			synonyms: "interesting article, and another exciting paper",
 			url: "http://example.org/keyword",
-			siteUrlOrDomain: "http://example.org/keyword",
+			permalink: "http://example.org/keyword",
 		};
 
 		const mockPaper = new Paper( "hello, here is a link with my <a href='http://example.com/keyword'>keys wording phrased</a>" +
@@ -606,7 +606,7 @@ describe( "Tests a string for anchors and its attributes", function() {
 			keyword: "key word and key phrase",
 			synonyms: "interesting article, and another exciting paper",
 			url: "http://example.org/keyword",
-			siteUrlOrDomain: "http://example.org/keyword",
+			permalink: "http://example.org/keyword",
 		};
 
 		const mockPaper = new Paper( "hello, here is a link with my <a href='http://example.com/keyword'>keys wording </a>" +
@@ -629,7 +629,7 @@ describe( "Tests a string for anchors and its attributes", function() {
 			keyword: "سوار در طبیعت",
 			synonyms: "",
 			url: "http://example.org/keyword",
-			siteUrlOrDomain: "http://example.org/keyword",
+			permalink: "http://example.org/keyword",
 			locale: "fa_IR",
 		};
 
@@ -650,7 +650,7 @@ describe( "Tests a string for anchors and its attributes", function() {
 			keyword: "fast",
 			synonyms: "",
 			url: "http://example.org/keyword",
-			siteUrlOrDomain: "http://example.org/keyword",
+			permalink: "http://example.org/keyword",
 		};
 
 		const mockPaper = new Paper( "hello, here is a link with my <a href='http://example.com/keyword'>fast one </a>" +
@@ -672,7 +672,7 @@ describe( "a test for anchors and its attributes when the exact match of a keyph
 		const attributes = {
 			keyword: "\"walking in nature\"",
 			url: "http://example.org/keyword",
-			siteUrlOrDomain: "http://example.org/keyword",
+			permalink: "http://example.org/keyword",
 		};
 
 		const mockPaper = new Paper( "hello, here is a link with my <a href='http://example.com/keyword'>walking in nature</a>", attributes );
@@ -690,7 +690,7 @@ describe( "a test for anchors and its attributes when the exact match of a keyph
 		const attributes = {
 			keyword: "\"walking in nature\"",
 			url: "http://example.org/keyword",
-			siteUrlOrDomain: "http://example.org/keyword",
+			permalink: "http://example.org/keyword",
 		};
 
 		const mockPaper = new Paper( "hello, here is a link with my <a href='http://example.com/keyword'>" +
@@ -709,7 +709,7 @@ describe( "a test for anchors and its attributes when the exact match of a keyph
 		const attributes = {
 			keyword: "\"walking in nature\"",
 			url: "http://example.org/keyword",
-			siteUrlOrDomain: "http://example.org/keyword",
+			permalink: "http://example.org/keyword",
 		};
 
 		const mockPaper = new Paper( "hello, here is a link with my <a href='http://example.com/keyword'>" +
@@ -728,7 +728,7 @@ describe( "a test for anchors and its attributes when the exact match of a keyph
 		const attributes = {
 			keyword: "\"walking in nature\"",
 			url: "http://example.org/keyword",
-			siteUrlOrDomain: "http://example.org/keyword",
+			permalink: "http://example.org/keyword",
 		};
 
 		const mockPaper = new Paper( "hello, here is a link with my <a href='http://example.com/keyword'>" +
@@ -749,7 +749,7 @@ describe( "a test for anchors and its attributes when the exact match of a keyph
 			keyword: "something and tortie",
 			synonyms: "\"cats and dogs\", tortoiseshell",
 			url: "http://yoast.com",
-			siteUrlOrDomain: "http://yoast.com",
+			permalink: "http://yoast.com",
 		};
 		const mockPaper = new Paper( "A text with a <a href='http://yoast.com'>link</a>, <a href='http://example.com'>cats and dogs</a>",
 			paperAttributes );
@@ -772,7 +772,7 @@ describe( "a test for anchors and its attributes when the exact match of a keyph
 		const paperAttributes = {
 			keyword: "「読ん一冊の本」",
 			url: "http://yoast.com",
-			siteUrlOrDomain: "http://yoast.com",
+			permalink: "http://yoast.com",
 		};
 		const mockPaper = new Paper( "言葉 <a href='http://yoast.com'>リンク</a>, <a href='http://example.com'>読ん一冊の本</a>", paperAttributes );
 		const researcher = new JapaneseResearcher( mockPaper );
@@ -786,7 +786,7 @@ describe( "a test for anchors and its attributes when the exact match of a keyph
 		const paperAttributes = {
 			keyword: "「読ん一冊の本」",
 			url: "http://yoast.com",
-			siteUrlOrDomain: "http://yoast.com",
+			permalink: "http://yoast.com",
 		};
 		const mockPaper = new Paper( "言葉 <a href='http://yoast.com'>リンク</a>, <a href='http://example.com'>から読ん一冊の本</a>", paperAttributes );
 		const researcher = new JapaneseResearcher( mockPaper );
@@ -800,7 +800,7 @@ describe( "a test for anchors and its attributes when the exact match of a keyph
 		const paperAttributes = {
 			keyword: "「読ん一冊の本」",
 			url: "http://yoast.com",
-			siteUrlOrDomain: "http://yoast.com",
+			permalink: "http://yoast.com",
 		};
 		const mockPaper = new Paper( "言葉 <a href='http://yoast.com'>リンク</a>, <a href='http://example.com'>猫から読ん一冊の本</a>", paperAttributes );
 		const researcher = new JapaneseResearcher( mockPaper );
@@ -815,7 +815,7 @@ describe( "a test for anchors and its attributes when the exact match of a keyph
 			keyword: "言葉",
 			synonyms: "「小さく花の刺繍」",
 			url: "http://yoast.com",
-			siteUrlOrDomain: "http://yoast.com",
+			permalink: "http://yoast.com",
 		};
 		const mockPaper = new Paper( "言葉 <a href='http://yoast.com'>リンク</a>, <a href='http://example.com'>小さく花の刺繍</a>", paperAttributes );
 		const researcher = new JapaneseResearcher( mockPaper );
@@ -841,7 +841,7 @@ describe( "a test for anchors and its attributes in languages that have a custom
 		let paperAttributes = {
 			keyword: "リンク",
 			url: "http://yoast.com",
-			siteUrlOrDomain: "http://yoast.com",
+			permalink: "http://yoast.com",
 		};
 
 		it( "should detect internal links", function() {
@@ -891,7 +891,7 @@ describe( "a test for anchors and its attributes in languages that have a custom
 			paperAttributes = {
 				keyword: "読ん一冊の本",
 				url: "http://yoast.com",
-				siteUrlOrDomain: "http://yoast.com",
+				permalink: "http://yoast.com",
 			};
 			const mockPaper = new Paper( "言葉 <a href='http://yoast.com'>リンク</a>, <a href='http://example.com'>猫と読ん一冊の本</a>", paperAttributes );
 			const researcher = new JapaneseResearcher( mockPaper );
@@ -908,7 +908,7 @@ describe( "a test for anchors and its attributes in languages that have a custom
 			paperAttributes = {
 				keyword: "から小さい花の刺繍",
 				url: "http://yoast.com",
-				siteUrlOrDomain: "http://yoast.com",
+				permalink: "http://yoast.com",
 			};
 			const mockPaper = new Paper( "言葉 <a href='http://yoast.com'>リンク</a>, <a href='http://example.com'>小さい花の刺繍</a>", paperAttributes );
 			const researcher = new JapaneseResearcher( mockPaper );
@@ -926,7 +926,7 @@ describe( "a test for anchors and its attributes in languages that have a custom
 			paperAttributes = {
 				keyword: "から小さく花の刺繍",
 				url: "http://yoast.com",
-				siteUrlOrDomain: "http://yoast.com",
+				permalink: "http://yoast.com",
 			};
 			const mockPaper = new Paper( "言葉 <a href='http://yoast.com'>リンク</a>, <a href='http://example.com'>小さい花の刺繍</a>", paperAttributes );
 			const researcher = new JapaneseResearcher( mockPaper );
@@ -944,7 +944,7 @@ describe( "a test for anchors and its attributes in languages that have a custom
 				keyword: "から小さく花の刺繍",
 				synonyms: "猫用のフード, 猫用食品",
 				url: "http://yoast.com",
-				siteUrlOrDomain: "http://yoast.com",
+				permalink: "http://yoast.com",
 			};
 			const mockPaper = new Paper( "言葉 <a href='http://yoast.com'>リンク</a>, <a href='http://example.com'>小さく花の刺繍</a>" +
 				" <a href='http://example.com'>から猫用のフード</a>", paperAttributes );
@@ -970,7 +970,7 @@ describe( "a test for anchors and its attributes in languages that have a custom
 			const paperAttributes = {
 				keyword: "読ん一冊の本",
 				url: "http://yoast.com",
-				siteUrlOrDomain: "http://yoast.com",
+				permalink: "http://yoast.com",
 			};
 			const mockPaper = new Paper( "言葉 <a href='http://yoast.com'>リンク</a>, <a href='http://example.com'>猫と読ん一冊の本</a>", paperAttributes );
 			const researcher = new JapaneseResearcher( mockPaper );
@@ -988,7 +988,7 @@ describe( "a test for anchors and its attributes in languages that have a custom
 			const paperAttributes = {
 				keyword: "から小さい花の刺繍",
 				url: "http://yoast.com",
-				siteUrlOrDomain: "http://yoast.com",
+				permalink: "http://yoast.com",
 			};
 			const mockPaper = new Paper( "言葉 <a href='http://yoast.com'>リンク</a>, <a href='http://example.com'>小さい花の刺繍</a>", paperAttributes );
 			const researcher = new JapaneseResearcher( mockPaper );
@@ -1007,7 +1007,7 @@ describe( "a test for anchors and its attributes in languages that have a custom
 			const paperAttributes = {
 				keyword: "から小さく花の刺繍",
 				url: "http://yoast.com",
-				siteUrlOrDomain: "http://yoast.com",
+				permalink: "http://yoast.com",
 			};
 			const mockPaper = new Paper( "言葉 <a href='http://yoast.com'>リンク</a>, <a href='http://example.com'>小さい花の刺繍</a>" +
 				" <a href='http://example.com'>小さける花の刺繍</a>", paperAttributes );
@@ -1031,7 +1031,7 @@ describe( "a test for anchors and its attributes in languages that have a custom
 				keyword: "猫用食品",
 				synonyms: "小さく花の刺繍",
 				url: "http://yoast.com",
-				siteUrlOrDomain: "http://yoast.com",
+				permalink: "http://yoast.com",
 			};
 			const mockPaper = new Paper( "言葉 <a href='http://yoast.com'>リンク</a>," +
 				" <a href='http://example.com'>から小さい花の刺繍</a>", paperAttributes );
@@ -1054,7 +1054,7 @@ describe( "a test for anchors and its attributes in languages that have a custom
 				keyword: "「小さく花の刺繍」",
 				synonyms: "something, something else",
 				url: "http://yoast.com",
-				siteUrlOrDomain: "http://yoast.com",
+				permalink: "http://yoast.com",
 			};
 			const mockPaper = new Paper( "言葉 <a href='http://yoast.com'>リンク</a>, <a href='http://example.com'>小さい花の刺繍</a>", paperAttributes );
 			const researcher = new JapaneseResearcher( mockPaper );

--- a/packages/yoastseo/src/languageProcessing/researches/getLinkStatistics.js
+++ b/packages/yoastseo/src/languageProcessing/researches/getLinkStatistics.js
@@ -17,19 +17,18 @@ let functionWords = [];
 /**
  * Checks whether the link is pointing at itself.
  *
- * @param {Paper} paper The paper to research.
+ * @param {string} slug      	 	  The slug.
  * @param {string} anchor      	 	  The link anchor.
  * @param {string} siteUrlOrDomain    The site URL or domain of the paper.
  *
  * @returns {boolean} Whether the anchor is pointing at itself.
  */
-const linkToSelf = function( paper, anchor, siteUrlOrDomain ) {
+const linkToSelf = function( slug, anchor, siteUrlOrDomain ) {
 	const anchorLink = urlHelper.getFromAnchorTag( anchor );
 	// Relative fragment links always point to the page itself.
 	if ( urlHelper.isRelativeFragmentURL( anchorLink ) ) {
 		return true;
 	}
-	const slug = paper.getUrl();
 	if ( ! siteUrlOrDomain.startsWith( "https://" || "http://" ) ) {
 		siteUrlOrDomain = ( "http://" + siteUrlOrDomain + slug ) && ( "https://" + siteUrlOrDomain + slug );
 	}
@@ -39,14 +38,15 @@ const linkToSelf = function( paper, anchor, siteUrlOrDomain ) {
 /**
  * Filters anchors that are not pointing at itself.
  *
+ * @param {string}  slug      	 	  The slug.
  * @param {Array}   anchors     	  An array with all anchors from the paper.
  * @param {string}  siteUrlOrDomain   The site URL or domain of the paper.
  *
  * @returns {Array} The array of all anchors that are not pointing at the paper itself.
  */
-const filterAnchorsLinkingToSelf = function( anchors, siteUrlOrDomain ) {
+const filterAnchorsLinkingToSelf = function( slug, anchors, siteUrlOrDomain ) {
 	const anchorsLinkingToSelf = anchors.map( function( anchor ) {
-		return linkToSelf( anchor, siteUrlOrDomain );
+		return linkToSelf( slug, anchor, siteUrlOrDomain );
 	} );
 
 	anchors = anchors.filter( function( anchor, index ) {
@@ -155,6 +155,7 @@ const keywordInAnchor = function( paper, researcher, anchors, siteUrlOrDomain ) 
 		getWordsCustomHelper: researcher.getHelper( "getWordsCustomHelper" ),
 	};
 	const result = { totalKeyword: 0, matchedAnchors: [] };
+	const slug = paper.getUrl();
 
 	const keyword = paper.getKeyword();
 	const originalTopics = parseSynonyms( paper.getSynonyms() );

--- a/packages/yoastseo/src/languageProcessing/researches/getLinkStatistics.js
+++ b/packages/yoastseo/src/languageProcessing/researches/getLinkStatistics.js
@@ -29,10 +29,15 @@ const linkToSelf = function( slug, anchor, siteUrlOrDomain ) {
 	if ( urlHelper.isRelativeFragmentURL( anchorLink ) ) {
 		return true;
 	}
-	if ( ! siteUrlOrDomain.startsWith( "https://" || "http://" ) ) {
-		siteUrlOrDomain = ( "http://" + siteUrlOrDomain + slug ) && ( "https://" + siteUrlOrDomain + slug );
+	console.log( siteUrlOrDomain );
+	if ( ! new RegExp( "^(https://|http://)" ).test( siteUrlOrDomain ) && siteUrlOrDomain !== "" ) {
+		console.log( siteUrlOrDomain );
+		siteUrlOrDomain = [ "http://" + siteUrlOrDomain + slug, "https://" + siteUrlOrDomain + slug ];
+		console.log( siteUrlOrDomain );
+	} else {
+		siteUrlOrDomain = [ siteUrlOrDomain ];
 	}
-	return urlHelper.areEqual( anchorLink, siteUrlOrDomain );
+	return siteUrlOrDomain.some( element => urlHelper.areEqual( anchorLink, element ) );
 };
 
 /**

--- a/packages/yoastseo/src/languageProcessing/researches/getLinkStatistics.js
+++ b/packages/yoastseo/src/languageProcessing/researches/getLinkStatistics.js
@@ -11,25 +11,29 @@ import parseSynonyms from "../helpers/sanitize/parseSynonyms";
 import urlHelper from "../helpers/url/url.js";
 import filterWordsFromArray from "../helpers/word/filterWordsFromArray";
 import getWords from "../helpers/word/getWords";
+import parseSlug from "../helpers/url/parseSlug";
 
 let functionWords = [];
 
 /**
  * Checks whether the link is pointing at itself.
  *
+ * @param {Paper} paper The paper to research.
  * @param {string} anchor      	 	  The link anchor.
  * @param {string} siteUrlOrDomain    The site URL or domain of the paper.
  *
  * @returns {boolean} Whether the anchor is pointing at itself.
  */
-const linkToSelf = function( anchor, siteUrlOrDomain ) {
+const linkToSelf = function( paper, anchor, siteUrlOrDomain ) {
 	const anchorLink = urlHelper.getFromAnchorTag( anchor );
-
 	// Relative fragment links always point to the page itself.
 	if ( urlHelper.isRelativeFragmentURL( anchorLink ) ) {
 		return true;
 	}
-
+	const slug = paper.getUrl();
+	if ( ! siteUrlOrDomain.startsWith( "https://" || "http://" ) ) {
+		siteUrlOrDomain = ( "http://" + siteUrlOrDomain + slug ) && ( "https://" + siteUrlOrDomain + slug );
+	}
 	return urlHelper.areEqual( anchorLink, siteUrlOrDomain );
 };
 

--- a/packages/yoastseo/src/languageProcessing/researches/getLinkStatistics.js
+++ b/packages/yoastseo/src/languageProcessing/researches/getLinkStatistics.js
@@ -29,11 +29,9 @@ const linkToSelf = function( slug, anchor, siteUrlOrDomain ) {
 	if ( urlHelper.isRelativeFragmentURL( anchorLink ) ) {
 		return true;
 	}
-	console.log( siteUrlOrDomain );
+	// If siteUrlOrDomain is a domain, create URLs out of it in order to compare them with the anchor URL.
 	if ( ! new RegExp( "^(https://|http://)" ).test( siteUrlOrDomain ) && siteUrlOrDomain !== "" ) {
-		console.log( siteUrlOrDomain );
 		siteUrlOrDomain = [ "http://" + siteUrlOrDomain + slug, "https://" + siteUrlOrDomain + slug ];
-		console.log( siteUrlOrDomain );
 	} else {
 		siteUrlOrDomain = [ siteUrlOrDomain ];
 	}

--- a/packages/yoastseo/src/languageProcessing/researches/getLinkStatistics.js
+++ b/packages/yoastseo/src/languageProcessing/researches/getLinkStatistics.js
@@ -167,7 +167,7 @@ const keywordInAnchor = function( paper, researcher, anchors, siteUrlOrDomain ) 
 	}
 
 	// Filter out anchors that point at the paper itself.
-	anchors = filterAnchorsLinkingToSelf( anchors, siteUrlOrDomain );
+	anchors = filterAnchorsLinkingToSelf( slug, anchors, siteUrlOrDomain );
 	if ( anchors.length === 0 ) {
 		return result;
 	}

--- a/packages/yoastseo/src/languageProcessing/researches/getLinkStatistics.js
+++ b/packages/yoastseo/src/languageProcessing/researches/getLinkStatistics.js
@@ -11,7 +11,6 @@ import parseSynonyms from "../helpers/sanitize/parseSynonyms";
 import urlHelper from "../helpers/url/url.js";
 import filterWordsFromArray from "../helpers/word/filterWordsFromArray";
 import getWords from "../helpers/word/getWords";
-import parseSlug from "../helpers/url/parseSlug";
 
 let functionWords = [];
 

--- a/packages/yoastseo/src/languageProcessing/researches/getLinkStatistics.js
+++ b/packages/yoastseo/src/languageProcessing/researches/getLinkStatistics.js
@@ -31,7 +31,7 @@ const linkToSelf = function( slug, anchor, siteUrlOrDomain ) {
 	}
 	// If siteUrlOrDomain is a domain, create URLs out of it in order to compare them with the anchor URL.
 	if ( ! new RegExp( "^(https://|http://)" ).test( siteUrlOrDomain ) && siteUrlOrDomain !== "" ) {
-		siteUrlOrDomain = [ "http://" + siteUrlOrDomain + slug, "https://" + siteUrlOrDomain + slug ];
+		siteUrlOrDomain = [ "http://" + siteUrlOrDomain + "/" + slug, "https://" + siteUrlOrDomain + "/" + slug ];
 	} else {
 		siteUrlOrDomain = [ siteUrlOrDomain ];
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* In the Link keyphrase (aka Text competing links) assessment, we want to filter out links that point to the page itself. This includes relative fragment URLs (starting with # ), and links that are identical to the page URL (e.g. if my page URL is [`https://example.com/cats`](`https://examples.com/cats`) and the link is also [`https://example.com/cats`](`https://examples.com/cats`). In Shopify the relative fragment URLs were filtered out correctly, but not links identical to the page URL. They are expected to be filtered out as well.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [shopify-seo] Fixes a bug where links that are identical to the page link are not excluded in the Link keyphrase assessment.
* [yoastseo] Adds a step to create a URL from a domain for when a domain instead of a URL is passed to the `linkToSelf` helper function.

## Relevant technical choices:

* The ideal option would be to always pass the actual URL to the function, but we haven’t found a way to access the URL that uses the primary domain in Shopify so far. That's why we create a URL from the siteUrlOrDomain variable when it is a domain.
* The `url` attribute of the Paper is (confusingly) actually a slug. We have edited the `getLinkStatisticsSpec` file to set the `url` attribute to the slug (or remove it if slug if there is no slug).

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

**In Shopify**
* Go to a Page 
* Add a keyphrase
* Add the keyphrase to the text
* Add a link to the keyphrase text that is equal to the URL of the page your are on (i.e. the URL that shows in the Google preview)
* Confirm that Link keyphrase assessment does not show up
* Change the slug in the link so it's different from the slug of your page
* Confirm that the Link keyphrase assessment returns a red bullet
* Repeat in blogpost

**In Yoast SEO Free** (regression testing)
* Create a new post
* Add a keyphrase
* Add the keyphrase to the text
* Add a link to the keyphrase text that is equal to the URL of the page your are on (i.e. the URL that shows in the Google preview)
* Confirm that the Link keyphrase assessment does not show up
* Change the slug in the link so it's different from the slug of the current page
* Confirm that the Link keyphrase assessment returns a red bullet


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [x] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #https://yoast.atlassian.net/jira/software/c/projects/LINGO/boards/99?modal=detail&selectedIssue=LINGO-1377
