### PR TITLE
Make sure the wpseo_breadcrumb_links filter returns an array

### DIFF
--- a/src/generators/breadcrumbs-generator.php
+++ b/src/generators/breadcrumbs-generator.php
@@ -176,7 +176,7 @@ class Breadcrumbs_Generator implements Generator_Interface {
 		/**
 		 * Filter: 'wpseo_breadcrumb_links' - Allow the developer to filter the Yoast SEO breadcrumb links, add to them, change order, etc.
 		 *
-		 * @api array $crumbs The crumbs array.
+		 * @param array $crumbs The crumbs array.
 		 */
 		$filtered_crumbs = \apply_filters( 'wpseo_breadcrumb_links', $crumbs );
 

--- a/src/generators/breadcrumbs-generator.php
+++ b/src/generators/breadcrumbs-generator.php
@@ -182,12 +182,13 @@ class Breadcrumbs_Generator implements Generator_Interface {
 
 		// Basic check to make sure the filtered crumbs are in an array.
 		if ( ! is_array( $filtered_crumbs ) ) {
-			_doing_it_wrong( 
-				'add_filter(\'wpseo_breadcrumb_links\')', 
+			_doing_it_wrong(
+				'add_filter(\'wpseo_breadcrumb_links\')',
 				'The `wpseo_breadcrumb_links` filter should return a multi-dimensional array.',
-				'wordpress-seo 18.5'
+				'wordpress-seo v18.5'
 			);
-		} else {
+		}
+		else {
 			$crumbs = $filtered_crumbs;
 		}
 

--- a/src/generators/breadcrumbs-generator.php
+++ b/src/generators/breadcrumbs-generator.php
@@ -185,7 +185,7 @@ class Breadcrumbs_Generator implements Generator_Interface {
 			\_doing_it_wrong(
 				'Filter: \'wpseo_breadcrumb_links\'',
 				'The `wpseo_breadcrumb_links` filter should return a multi-dimensional array.',
-				'YoastSEO v18.5'
+				'YoastSEO v20.0'
 			);
 		}
 		else {

--- a/src/generators/breadcrumbs-generator.php
+++ b/src/generators/breadcrumbs-generator.php
@@ -178,7 +178,18 @@ class Breadcrumbs_Generator implements Generator_Interface {
 		 *
 		 * @api array $crumbs The crumbs array.
 		 */
-		$crumbs = \apply_filters( 'wpseo_breadcrumb_links', $crumbs );
+		$filtered_crumbs = \apply_filters( 'wpseo_breadcrumb_links', $crumbs );
+
+		// Basic check to make sure the filtered crumbs are in an array.
+		if ( ! is_array( $filtered_crumbs ) ) {
+			_doing_it_wrong( 
+				'add_filter(\'wpseo_breadcrumb_links\')', 
+				'The `wpseo_breadcrumb_links` filter should return a multi-dimensional array.',
+				'wordpress-seo 18.5'
+			);
+		} else {
+			$crumbs = $filtered_crumbs;
+		}
 
 		$filter_callback = static function( $link_info, $index ) use ( $crumbs ) {
 			/**

--- a/src/generators/breadcrumbs-generator.php
+++ b/src/generators/breadcrumbs-generator.php
@@ -181,8 +181,8 @@ class Breadcrumbs_Generator implements Generator_Interface {
 		$filtered_crumbs = \apply_filters( 'wpseo_breadcrumb_links', $crumbs );
 
 		// Basic check to make sure the filtered crumbs are in an array.
-		if ( ! is_array( $filtered_crumbs ) ) {
-			_doing_it_wrong(
+		if ( ! \is_array( $filtered_crumbs ) ) {
+			\_doing_it_wrong(
 				'Filter: \'wpseo_breadcrumb_links\'',
 				'The `wpseo_breadcrumb_links` filter should return a multi-dimensional array.',
 				'YoastSEO v18.5'

--- a/src/generators/breadcrumbs-generator.php
+++ b/src/generators/breadcrumbs-generator.php
@@ -185,7 +185,7 @@ class Breadcrumbs_Generator implements Generator_Interface {
 			_doing_it_wrong(
 				'add_filter(\'wpseo_breadcrumb_links\')',
 				'The `wpseo_breadcrumb_links` filter should return a multi-dimensional array.',
-				'wordpress-seo v18.5'
+				'YoastSEO v18.5'
 			);
 		}
 		else {

--- a/src/generators/breadcrumbs-generator.php
+++ b/src/generators/breadcrumbs-generator.php
@@ -183,7 +183,7 @@ class Breadcrumbs_Generator implements Generator_Interface {
 		// Basic check to make sure the filtered crumbs are in an array.
 		if ( ! is_array( $filtered_crumbs ) ) {
 			_doing_it_wrong(
-				'add_filter(\'wpseo_breadcrumb_links\')',
+				'Filter: \'wpseo_breadcrumb_links\'',
 				'The `wpseo_breadcrumb_links` filter should return a multi-dimensional array.',
 				'YoastSEO v18.5'
 			);


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* If `wpseo_breadcrumb_links` is used wrongly, it may cause fatal errors on PHP 8.0+ since our code expects it to return an array.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where a fatal error would be thrown when using the `wpseo_breadcrumb_links` filter in the wrong way on PHP 8.0+

## Relevant technical choices:

* First usage of the `_doing_it_wrong` method in our plugin. This prints a PHP notice to the PHP error logs when `WP_DEBUG` is enabled.
* Take care to change the version number in the code of this PR if this is not released in 18.5

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

You will need to keep an eye on your logs (this can be done with Query Monitor)
- on PHP 8.0+, add the following to your functions.php:
```php
add_filter('wpseo_breadcrumb_links', 'change_breadcrumbs');

function change_breadcrumbs( $crumbs ) {
	return 'string';
}
```
- Without this PR, when loading a page, it should throw a fatal error.
- With this PR, no fatal error will be thrown and a notice will be printed to the logs.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes https://github.com/Yoast/wordpress-seo/issues/18216
