### PR TITLE
WordProof: removes unnecessary log function

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -159,16 +159,16 @@
         },
         {
             "name": "wordproof/wordpress-sdk",
-            "version": "1.2.15",
+            "version": "1.2.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wordproof/wordpress-sdk.git",
-                "reference": "2dd9b6eba15e07896630d21619b4e5ab56598282"
+                "reference": "b8ed1266c7ea79604029e501dc0093e9b07ea602"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wordproof/wordpress-sdk/zipball/2dd9b6eba15e07896630d21619b4e5ab56598282",
-                "reference": "2dd9b6eba15e07896630d21619b4e5ab56598282",
+                "url": "https://api.github.com/repos/wordproof/wordpress-sdk/zipball/b8ed1266c7ea79604029e501dc0093e9b07ea602",
+                "reference": "b8ed1266c7ea79604029e501dc0093e9b07ea602",
                 "shasum": ""
             },
             "require": {
@@ -204,9 +204,9 @@
             "description": "WordPress SDK",
             "support": {
                 "issues": "https://github.com/wordproof/wordpress-sdk/issues",
-                "source": "https://github.com/wordproof/wordpress-sdk/tree/1.2.15"
+                "source": "https://github.com/wordproof/wordpress-sdk/tree/1.2.16"
             },
-            "time": "2022-03-17T04:46:49+00:00"
+            "time": "2022-03-18T07:11:31+00:00"
         },
         {
             "name": "yoast/i18n-module",


### PR DESCRIPTION
## Context

* A one-line WordProof SDK change to remove a leftover log function.

## Summary

This PR can be summarized in the following changelog entry:

* Removes a log function that would prevent the saving of WordProof settings in some cases.

## Relevant technical choices:

* Update the SDK

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Authenticate with WordProof
* Timestamp a page
* The certificate link should only contain the shield.
* Update the certificate link text (WordProof Settings -> Go to My WordProof -> Change the text and press save)
* Check if this text is used on the timestamped privacy page for the certificate link.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Setting WordProof settings

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes #
