### PR TITLE
P1-1282 - improve wincher integration on multisite

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -79,8 +79,8 @@
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_coding_standards"
 		],
 		"check-cs-thresholds": [
-			"@putenv YOASTCS_THRESHOLD_ERRORS=245",
-			"@putenv YOASTCS_THRESHOLD_WARNINGS=218",
+			"@putenv YOASTCS_THRESHOLD_ERRORS=243",
+			"@putenv YOASTCS_THRESHOLD_WARNINGS=219",
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_cs_thresholds"
 		],
 		"check-cs": [

--- a/composer.json
+++ b/composer.json
@@ -79,8 +79,8 @@
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_coding_standards"
 		],
 		"check-cs-thresholds": [
-			"@putenv YOASTCS_THRESHOLD_ERRORS=248",
-			"@putenv YOASTCS_THRESHOLD_WARNINGS=219",
+			"@putenv YOASTCS_THRESHOLD_ERRORS=245",
+			"@putenv YOASTCS_THRESHOLD_WARNINGS=218",
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_cs_thresholds"
 		],
 		"check-cs": [

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -77,7 +77,7 @@ class WPSEO_Upgrade {
 			'17.7.1-RC0' => 'upgrade_1771',
 			'17.9-RC0'   => 'upgrade_179',
 			'18.3-RC3'   => 'upgrade_183',
-			'18.6-RC0'   => 'upgrade_185',
+			'18.6-RC0'   => 'upgrade_186',
 		];
 
 		array_walk( $routines, [ $this, 'run_upgrade_routine' ], $version );
@@ -874,7 +874,7 @@ class WPSEO_Upgrade {
 	/**
 	 * Performs the 18.5 upgrade routine.
 	 */
-	private function upgrade_185() {
+	private function upgrade_186() {
 		if ( is_multisite() ) {
 			WPSEO_Options::set( 'allow_wincher_integration_active', false );
 		}

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -872,7 +872,7 @@ class WPSEO_Upgrade {
 	}
 
 	/**
-	 * Performs the 18.5 upgrade routine.
+	 * Performs the 18.6 upgrade routine.
 	 */
 	private function upgrade_186() {
 		if ( is_multisite() ) {

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -77,6 +77,7 @@ class WPSEO_Upgrade {
 			'17.7.1-RC0' => 'upgrade_1771',
 			'17.9-RC0'   => 'upgrade_179',
 			'18.3-RC3'   => 'upgrade_183',
+			'18.6-RC0'   => 'upgrade_185',
 		];
 
 		array_walk( $routines, [ $this, 'run_upgrade_routine' ], $version );
@@ -868,6 +869,15 @@ class WPSEO_Upgrade {
 	 */
 	private function upgrade_183() {
 		$this->delete_post_meta( 'yoast-structured-data-blocks-images-cache' );
+	}
+
+	/**
+	 * Performs the 18.5 upgrade routine.
+	 */
+	private function upgrade_185() {
+		if ( is_multisite() ) {
+			WPSEO_Options::set( 'allow_wincher_integration_active', false );
+		}
 	}
 
 	/**

--- a/inc/options/class-wpseo-option-ms.php
+++ b/inc/options/class-wpseo-option-ms.php
@@ -100,7 +100,7 @@ class WPSEO_Option_MS extends WPSEO_Option {
 			"{$allow_prefix}enable_enhanced_slack_sharing"  => true,
 			"{$allow_prefix}semrush_integration_active"     => true,
 			"{$allow_prefix}zapier_integration_active"      => true,
-			"{$allow_prefix}wincher_integration_active"     => true,
+			"{$allow_prefix}wincher_integration_active"     => false,
 		];
 
 		if ( is_multisite() ) {

--- a/src/helpers/wincher-helper.php
+++ b/src/helpers/wincher-helper.php
@@ -32,11 +32,20 @@ class Wincher_Helper {
 	/**
 	 * Checks if the integration is active for the current user.
 	 *
+	 * @return bool Whether the integration is active.
+	 */
+	public function is_active() {
+		return ! $this->is_disabled() && $this->options->get( 'wincher_integration_active', true );
+	}
+
+	/**
+	 * Checks if the integration should be disabled for the current user.
+	 *
 	 * @param bool $return_conditional If the conditional class name that was unmet should be returned.
 	 *
 	 * @return bool|string Whether the integration is active.
 	 */
-	public function is_active( $return_conditional = false ) {
+	public function is_disabled( $return_conditional = false ) {
 		$conditional = new Non_Multisite_Conditional();
 
 		if ( ! $conditional->is_met() ) {
@@ -45,14 +54,14 @@ class Wincher_Helper {
 				return ( new \ReflectionClass( $conditional ) )->getShortName();
 			}
 
-			return false;
+			return true;
 		}
 
 		if ( ! \current_user_can( 'publish_posts' ) && ! \current_user_can( 'publish_pages' ) ) {
-			return false;
+			return true;
 		}
 
-		return (bool) $this->options->get( 'wincher_integration_active', true );
+		return false;
 	}
 
 	/**

--- a/src/helpers/wincher-helper.php
+++ b/src/helpers/wincher-helper.php
@@ -35,7 +35,7 @@ class Wincher_Helper {
 	 * @return bool Whether the integration is active.
 	 */
 	public function is_active() {
-		return ! $this->is_disabled() && $this->options->get( 'wincher_integration_active', true );
+		return ! $this->is_disabled() && (bool) $this->options->get( 'wincher_integration_active', true );
 	}
 
 	/**

--- a/src/helpers/wincher-helper.php
+++ b/src/helpers/wincher-helper.php
@@ -30,38 +30,22 @@ class Wincher_Helper {
 	}
 
 	/**
-	 * Checks if the integration is active for the current user.
+	 * Checks if the integration should be active for the current user.
 	 *
 	 * @return bool Whether the integration is active.
 	 */
 	public function is_active() {
-		return ! $this->is_disabled() && (bool) $this->options->get( 'wincher_integration_active', true );
-	}
-
-	/**
-	 * Checks if the integration should be disabled for the current user.
-	 *
-	 * @param bool $return_conditional If the conditional class name that was unmet should be returned.
-	 *
-	 * @return bool|string Whether the integration is active.
-	 */
-	public function is_disabled( $return_conditional = false ) {
 		$conditional = new Non_Multisite_Conditional();
 
 		if ( ! $conditional->is_met() ) {
-
-			if ( $return_conditional === true ) {
-				return ( new \ReflectionClass( $conditional ) )->getShortName();
-			}
-
-			return true;
+			return false;
 		}
 
 		if ( ! \current_user_can( 'publish_posts' ) && ! \current_user_can( 'publish_pages' ) ) {
-			return true;
+			return false;
 		}
 
-		return false;
+		return (bool) $this->options->get( 'wincher_integration_active', true );
 	}
 
 	/**

--- a/src/helpers/wincher-helper.php
+++ b/src/helpers/wincher-helper.php
@@ -30,55 +30,29 @@ class Wincher_Helper {
 	}
 
 	/**
-	 * Returns if conditionals are met. If not, the integration should be disabled.
+	 * Checks if the integration is active for the current user.
 	 *
 	 * @param bool $return_conditional If the conditional class name that was unmet should be returned.
 	 *
-	 * @return bool|string Returns if the integration should be disabled.
+	 * @return bool|string Whether the integration is active.
 	 */
-	public function integration_is_disabled( $return_conditional = false ) {
-		$conditionals = [ new Non_Multisite_Conditional() ];
+	public function is_active( $return_conditional = false ) {
+		$conditional = new Non_Multisite_Conditional();
 
-		foreach ( $conditionals as $conditional ) {
-			if ( ! $conditional->is_met() ) {
+		if ( ! $conditional->is_met() ) {
 
-				if ( $return_conditional === true ) {
-					return ( new \ReflectionClass( $conditional ) )->getShortName();
-				}
-
-				return true;
+			if ( $return_conditional === true ) {
+				return ( new \ReflectionClass( $conditional ) )->getShortName();
 			}
-		}
 
-		return false;
-	}
-
-	/**
-	 * Returns if the Wincher integration toggle is turned on.
-	 *
-	 * @return bool Returns if the integration toggle is set to true if conditionals are met.
-	 */
-	public function integration_is_active() {
-		if ( $this->integration_is_disabled() ) {
 			return false;
 		}
 
-		return $this->options->get( 'wincher_integration_active', true );
-	}
-
-	/**
-	 * Return if Wincher should be active for this post editor page.
-	 *
-	 * @return bool Returns if Wincher should be active.
-	 */
-	public function is_active() {
-		$is_wincher_active = $this->integration_is_active();
-
-		if ( ! $is_wincher_active ) {
+		if ( ! \current_user_can( 'publish_posts' ) && ! \current_user_can( 'publish_pages' ) ) {
 			return false;
 		}
 
-		return true;
+		return (bool) $this->options->get( 'wincher_integration_active', true );
 	}
 
 	/**

--- a/src/integrations/third-party/wincher.php
+++ b/src/integrations/third-party/wincher.php
@@ -78,7 +78,7 @@ class Wincher implements Integration_Interface {
 					'Wincher'
 				),
 				'order'    => 11,
-				'disabled' => ( $this->wincher->is_disabled() ),
+				'disabled' => \is_multisite(),
 			];
 		}
 
@@ -98,27 +98,20 @@ class Wincher implements Integration_Interface {
 				require \WPSEO_PATH . 'admin/views/tabs/metas/paper-content/integrations/wincher.php';
 			}
 
-			if ( $integration->disabled ) {
-
-				$conditional = $this->wincher->is_disabled( true );
-
-				if ( $conditional === 'Non_Multisite_Conditional' ) {
-					$this->get_disabled_note();
-				}
+			if ( \is_multisite() ) {
+				$this->get_disabled_note();
 			}
 		}
 	}
 
 	/**
-	 * Adds the disabled note when the network integration toggle is disabled.
+	 * Adds the disabled note to the network integration toggle.
 	 *
 	 * @param Yoast_Feature_Toggle $integration The integration toggle class.
 	 */
 	public function after_network_integration_toggle( $integration ) {
 		if ( $integration->setting === 'wincher_integration_active' ) {
-			if ( $integration->disabled ) {
-				$this->get_disabled_note();
-			}
+			$this->get_disabled_note();
 		}
 	}
 
@@ -128,10 +121,10 @@ class Wincher implements Integration_Interface {
 	 * @return void
 	 */
 	protected function get_disabled_note() {
-		echo '<p>' , \sprintf(
-			/* translators: %s expands to Wincher */
+		echo '<p>', \sprintf(
+		/* translators: %s expands to Wincher */
 			\esc_html__( 'Currently, the %s integration is not available for multisites.', 'wordpress-seo' ),
 			'Wincher'
-		) , '</p>';
+		), '</p>';
 	}
 }

--- a/src/integrations/third-party/wincher.php
+++ b/src/integrations/third-party/wincher.php
@@ -118,6 +118,8 @@ class Wincher implements Integration_Interface {
 	/**
 	 * Outputs the disabled note.
 	 *
+	 * @codeCoverageIgnore
+	 *
 	 * @return void
 	 */
 	protected function get_disabled_note() {

--- a/src/integrations/third-party/wincher.php
+++ b/src/integrations/third-party/wincher.php
@@ -122,7 +122,11 @@ class Wincher implements Integration_Interface {
 		}
 	}
 
-	/** The disabled note */
+	/**
+	 * Outputs the disabled note.
+	 *
+	 * @return void
+	 */
 	protected function get_disabled_note() {
 		echo '<p>' , \sprintf(
 			/* translators: %s expands to Wincher */

--- a/src/integrations/third-party/wincher.php
+++ b/src/integrations/third-party/wincher.php
@@ -78,7 +78,7 @@ class Wincher implements Integration_Interface {
 					'Wincher'
 				),
 				'order'    => 11,
-				'disabled' => ( ! $this->wincher->is_active() ),
+				'disabled' => ( $this->wincher->is_disabled() ),
 			];
 		}
 
@@ -100,10 +100,10 @@ class Wincher implements Integration_Interface {
 
 			if ( $integration->disabled ) {
 
-				$conditional = $this->wincher->is_active( true );
+				$conditional = $this->wincher->is_disabled( true );
 
 				if ( $conditional === 'Non_Multisite_Conditional' ) {
-					echo $this->get_disabled_note();
+					$this->get_disabled_note();
 				}
 			}
 		}
@@ -117,17 +117,17 @@ class Wincher implements Integration_Interface {
 	public function after_network_integration_toggle( $integration ) {
 		if ( $integration->setting === 'wincher_integration_active' ) {
 			if ( $integration->disabled ) {
-				echo $this->get_disabled_note();
+				$this->get_disabled_note();
 			}
 		}
 	}
 
 	/** The disabled note */
 	protected function get_disabled_note() {
-		return '<p>' . \sprintf(
+		echo '<p>' . \sprintf(
 			/* translators: %s expands to Wincher */
-				\esc_html__( 'Currently, the %s integration is not available for multisites.', 'wordpress-seo' ),
-				'Wincher'
-			) . '</p>';
+			\esc_html__( 'Currently, the %s integration is not available for multisites.', 'wordpress-seo' ),
+			'Wincher'
+		) . '</p>';
 	}
 }

--- a/src/integrations/third-party/wincher.php
+++ b/src/integrations/third-party/wincher.php
@@ -40,11 +40,6 @@ class Wincher implements Integration_Interface {
 		\add_filter( 'wpseo_integration_toggles', [ $this, 'add_integration_toggle' ] );
 
 		/**
-		 * Update the default wincher_integration_active depending on the integration is disabled or not.
-		 */
-		\add_filter( 'wpseo_option_wpseo_defaults', [ $this, 'default_values' ] );
-
-		/**
 		 * Called in dashboard/integrations.php to put additional content after the toggle.
 		 */
 		\add_action( 'Yoast\WP\SEO\admin_integration_after', [ $this, 'after_integration_toggle' ] );
@@ -65,7 +60,7 @@ class Wincher implements Integration_Interface {
 	}
 
 	/**
-	 * Adds the Wincher integration toggle to the array.
+	 * Adds the Wincher integration toggle to the $integration_toggles array.
 	 *
 	 * @param array $integration_toggles The integration toggles array.
 	 *
@@ -83,7 +78,7 @@ class Wincher implements Integration_Interface {
 					'Wincher'
 				),
 				'order'    => 11,
-				'disabled' => $this->wincher->integration_is_disabled(),
+				'disabled' => ( ! $this->wincher->is_active() ),
 			];
 		}
 
@@ -91,59 +86,48 @@ class Wincher implements Integration_Interface {
 	}
 
 	/**
-	 * Set the default Wincher integration option value depending on the integration is disabled or not.
-	 *
-	 * @param array $defaults Array containing default wpseo options.
-	 *
-	 * @return array
-	 */
-	public function default_values( $defaults ) {
-		if ( $this->wincher->integration_is_disabled() ) {
-			$defaults['wincher_integration_active'] = false;
-		}
-
-		return $defaults;
-	}
-
-	/**
-	 * Add an explainer when the integration toggle is disabled.
+	 * Adds the disabled note when the integration toggle is disabled.
 	 *
 	 * @param Yoast_Feature_Toggle $integration The integration toggle class.
 	 */
 	public function after_integration_toggle( $integration ) {
 		if ( $integration->setting === 'wincher_integration_active' ) {
 
-			require \WPSEO_PATH . 'admin/views/tabs/metas/paper-content/integrations/wincher.php';
+			// Check if 'WPSEO_PATH' is defined else the relevant unittest will require the file.
+			if ( defined( 'WPSEO_PATH' ) ) {
+				require \WPSEO_PATH . 'admin/views/tabs/metas/paper-content/integrations/wincher.php';
+			}
 
 			if ( $integration->disabled ) {
 
-				$conditional = $this->wincher->integration_is_disabled( true );
+				$conditional = $this->wincher->is_active( true );
 
 				if ( $conditional === 'Non_Multisite_Conditional' ) {
-					echo '<p>' . \sprintf(
-						/* translators: %s expands to Wincher */
-							\esc_html__( 'Currently, the %s integration is not available for multisites.', 'wordpress-seo' ),
-							'Wincher'
-						) . '</p>';
+					echo $this->get_disabled_note();
 				}
 			}
 		}
 	}
 
 	/**
-	 * Add an explainer when the network integration toggle is disabled.
+	 * Adds the disabled note when the network integration toggle is disabled.
 	 *
 	 * @param Yoast_Feature_Toggle $integration The integration toggle class.
 	 */
 	public function after_network_integration_toggle( $integration ) {
 		if ( $integration->setting === 'wincher_integration_active' ) {
 			if ( $integration->disabled ) {
-				echo '<p>' . \sprintf(
-					/* translators: %s expands to Wincher */
-						\esc_html__( 'Currently, the %s integration is not available for multisites.', 'wordpress-seo' ),
-						'Wincher'
-					) . '</p>';
+				echo $this->get_disabled_note();
 			}
 		}
+	}
+
+	/** The disabled note */
+	protected function get_disabled_note() {
+		return '<p>' . \sprintf(
+			/* translators: %s expands to Wincher */
+				\esc_html__( 'Currently, the %s integration is not available for multisites.', 'wordpress-seo' ),
+				'Wincher'
+			) . '</p>';
 	}
 }

--- a/src/integrations/third-party/wincher.php
+++ b/src/integrations/third-party/wincher.php
@@ -124,10 +124,10 @@ class Wincher implements Integration_Interface {
 
 	/** The disabled note */
 	protected function get_disabled_note() {
-		echo '<p>' . \sprintf(
+		echo '<p>' , \sprintf(
 			/* translators: %s expands to Wincher */
 			\esc_html__( 'Currently, the %s integration is not available for multisites.', 'wordpress-seo' ),
 			'Wincher'
-		) . '</p>';
+		) , '</p>';
 	}
 }

--- a/tests/unit/helpers/wincher-helper-test.php
+++ b/tests/unit/helpers/wincher-helper-test.php
@@ -81,7 +81,7 @@ class Wincher_Helper_Test extends TestCase {
 	 * @covers ::is_active
 	 */
 	public function test_is_active() {
-		$this->instance->expects( 'is_disabled' )->andReturnFalse();
+		Monkey\Functions\expect( 'current_user_can' )->andReturn( true );
 
 		$this->options->expects( 'get' )->andReturn( true );
 
@@ -89,55 +89,29 @@ class Wincher_Helper_Test extends TestCase {
 	}
 
 	/**
-	 * Test return if conditionals are met.
+	 * Test return if conditionals are unmet.
 	 *
-	 * @covers ::is_disabled
+	 * @covers ::is_active
 	 */
-	public function test_is_disabled() {
-		Monkey\Functions\expect( 'current_user_can' )->andReturn( true );
-
-		$this->assertFalse( $this->instance->is_disabled() );
-	}
-
-	/**
-	 * Test return conditional if conditionals are unmet.
-	 *
-	 * @covers ::is_disabled
-	 */
-	public function test_is_disabled_unmet() {
+	public function test_is_active_unmet() {
 		Monkey\Functions\stubs(
 			[
 				'is_multisite' => true,
 			]
 		);
 
-		$this->assertTrue( $this->instance->is_disabled() );
-	}
-
-	/**
-	 * Test return conditional if conditionals are unmet.
-	 *
-	 * @covers ::is_disabled
-	 */
-	public function test_is_disabled_unmet_conditional_return() {
-		Monkey\Functions\stubs(
-			[
-				'is_multisite' => true,
-			]
-		);
-
-		$this->assertEquals( 'Non_Multisite_Conditional', $this->instance->is_disabled( true ) );
+		$this->assertFalse( $this->instance->is_active() );
 	}
 
 	/**
 	 * Test return if capabilities are unmet.
 	 *
-	 * @covers ::is_disabled
+	 * @covers ::is_active
 	 */
-	public function test_is_disabled_unmet_capabilities() {
+	public function test_is_active_unmet_capabilities() {
 		Monkey\Functions\expect( 'current_user_can' )->andReturn( false );
 
-		$this->assertTrue( $this->instance->is_disabled() );
+		$this->assertFalse( $this->instance->is_active() );
 	}
 
 	/**

--- a/tests/unit/helpers/wincher-helper-test.php
+++ b/tests/unit/helpers/wincher-helper-test.php
@@ -7,6 +7,7 @@ use Mockery;
 use Yoast\WP\SEO\Config\Wincher_Client;
 use Yoast\WP\SEO\Exceptions\OAuth\Authentication_Failed_Exception;
 use Yoast\WP\SEO\Exceptions\OAuth\Tokens\Empty_Token_Exception;
+use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Wincher_Helper;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 use Yoast\WP\SEO\Values\OAuth\OAuth_Token;
@@ -21,11 +22,18 @@ use Yoast\WP\SEO\Values\OAuth\OAuth_Token;
 class Wincher_Helper_Test extends TestCase {
 
 	/**
-	 * The instance under test.
+	 * The instance to test.
 	 *
 	 * @var Wincher_Helper
 	 */
 	protected $instance;
+
+	/**
+	 * Holds the Options Page helper instance.
+	 *
+	 * @var Options_Helper
+	 */
+	protected $options;
 
 	/**
 	 * The token mock.
@@ -47,9 +55,24 @@ class Wincher_Helper_Test extends TestCase {
 	public function set_up() {
 		parent::set_up();
 
-		$this->instance                        = new Wincher_Helper();
+		$this->options                         = Mockery::mock( Options_Helper::class );
+		$this->instance                        = Mockery::mock( Wincher_Helper::class, [ $this->options ] )
+			->makePartial();
 		$this->token                           = Mockery::mock( OAuth_Token::class );
 		$this->authentication_failed_exception = Mockery::mock( Authentication_Failed_Exception::class );
+	}
+
+	/**
+	 * Tests if given dependencies are set as expected.
+	 *
+	 * @covers ::__construct
+	 */
+	public function test_constructor() {
+		$this->assertInstanceOf( Wincher_Helper::class, $this->instance );
+		$this->assertInstanceOf(
+			Options_Helper::class,
+			$this->getPropertyValue( $this->instance, 'options' )
+		);
 	}
 
 	/**
@@ -97,7 +120,8 @@ class Wincher_Helper_Test extends TestCase {
 	}
 
 	/**
-	 * Tests retrieval of the login status when the user is not logged in when an authentication failed exception is thrown.
+	 * Tests retrieval of the login status when the user is not logged in when an authentication failed exception is
+	 * thrown.
 	 *
 	 * @covers ::login_status
 	 */
@@ -114,7 +138,6 @@ class Wincher_Helper_Test extends TestCase {
 				'classes' => $classes,
 			]
 		);
-
 		$this->assertFalse( $this->instance->login_status() );
 	}
 

--- a/tests/unit/helpers/wincher-helper-test.php
+++ b/tests/unit/helpers/wincher-helper-test.php
@@ -76,11 +76,46 @@ class Wincher_Helper_Test extends TestCase {
 	}
 
 	/**
+	 * Test return if conditionals are met.
+	 *
+	 * @covers ::integration_is_disabled
+	 */
+	public function test_integration_is_disabled() {
+		$this->assertFalse( $this->instance->integration_is_disabled() );
+	}
+
+	/**
+	 * Test return if conditionals are not met.
+	 *
+	 * @covers ::integration_is_disabled
+	 */
+	public function test_integration_is_disabled_unmet() {
+		Monkey\Functions\stubs( [
+			'is_multisite' => true,
+		] );
+
+		$this->assertTrue( $this->instance->integration_is_disabled( ) );
+	}
+
+	/**
+	 * Test return conditional if conditionals are not met.
+	 *
+	 * @covers ::integration_is_disabled
+	 */
+	public function test_integration_is_disabled_unmet_conditional_return() {
+		Monkey\Functions\stubs( [
+			'is_multisite' => true,
+		] );
+
+		$this->assertEquals( 'Non_Multisite_Conditional', $this->instance->integration_is_disabled( true ) );
+	}
+
+	/**
 	 * Tests retrieval of the login status.
 	 *
 	 * @covers ::login_status
 	 */
-	public function test_get_login_status() {
+	public function test_login_status() {
 		$wincher_client = Mockery::mock( Wincher_Client::class );
 		$wincher_client->expects( 'get_tokens' )->once()->andReturn( $this->token );
 		$wincher_client->expects( 'has_valid_tokens' )->once()->andReturnTrue();
@@ -102,7 +137,7 @@ class Wincher_Helper_Test extends TestCase {
 	 *
 	 * @covers ::login_status
 	 */
-	public function test_get_login_status_not_logged_in() {
+	public function test_login_status_not_logged_in() {
 		$wincher_client = Mockery::mock( Wincher_Client::class );
 		$wincher_client->expects( 'get_tokens' )->once()->andReturnNull();
 		$wincher_client->expects( 'has_valid_tokens' )->once()->andReturnFalse();
@@ -125,7 +160,7 @@ class Wincher_Helper_Test extends TestCase {
 	 *
 	 * @covers ::login_status
 	 */
-	public function test_get_login_status_not_logged_in_on_authentication_exception() {
+	public function test_login_status_not_logged_in_on_authentication_exception() {
 		$wincher_client = Mockery::mock( Wincher_Client::class );
 		$wincher_client->expects( 'get_tokens' )->once()->andThrow( $this->authentication_failed_exception );
 		$wincher_client->expects( 'has_valid_tokens' )->never();
@@ -146,7 +181,7 @@ class Wincher_Helper_Test extends TestCase {
 	 *
 	 * @covers ::login_status
 	 */
-	public function test_get_login_status_not_logged_in_on_empty_token_exception() {
+	public function test_login_status_not_logged_in_on_empty_token_exception() {
 		$wincher_client = Mockery::mock( Wincher_Client::class );
 		$wincher_client->expects( 'get_tokens' )->once()->andThrow( Empty_Token_Exception::class );
 		$wincher_client->expects( 'has_valid_tokens' )->never();

--- a/tests/unit/helpers/wincher-helper-test.php
+++ b/tests/unit/helpers/wincher-helper-test.php
@@ -76,12 +76,12 @@ class Wincher_Helper_Test extends TestCase {
 	}
 
 	/**
-	 * Test return if conditionals are met.
+	 * Test return option.
 	 *
 	 * @covers ::is_active
 	 */
 	public function test_is_active() {
-		Monkey\Functions\expect( 'current_user_can' )->andReturn( true );
+		$this->instance->expects( 'is_disabled' )->andReturnFalse();
 
 		$this->options->expects( 'get' )->andReturn( true );
 
@@ -89,40 +89,55 @@ class Wincher_Helper_Test extends TestCase {
 	}
 
 	/**
-	 * Test return conditional if conditionals are unmet.
+	 * Test return if conditionals are met.
 	 *
-	 * @covers ::is_active
+	 * @covers ::is_disabled
 	 */
-	public function test_is_active_unmet() {
-		Monkey\Functions\stubs( [
-			'is_multisite' => true,
-		] );
+	public function test_is_disabled() {
+		Monkey\Functions\expect( 'current_user_can' )->andReturn( true );
 
-		$this->assertFalse( $this->instance->is_active() );
+		$this->assertFalse( $this->instance->is_disabled() );
 	}
 
 	/**
 	 * Test return conditional if conditionals are unmet.
 	 *
-	 * @covers ::is_active
+	 * @covers ::is_disabled
 	 */
-	public function test_is_active_unmet_conditional_return() {
-		Monkey\Functions\stubs( [
-			'is_multisite' => true,
-		] );
+	public function test_is_disabled_unmet() {
+		Monkey\Functions\stubs(
+			[
+				'is_multisite' => true,
+			]
+		);
 
-		$this->assertEquals( 'Non_Multisite_Conditional', $this->instance->is_active( true ) );
+		$this->assertTrue( $this->instance->is_disabled() );
+	}
+
+	/**
+	 * Test return conditional if conditionals are unmet.
+	 *
+	 * @covers ::is_disabled
+	 */
+	public function test_is_disabled_unmet_conditional_return() {
+		Monkey\Functions\stubs(
+			[
+				'is_multisite' => true,
+			]
+		);
+
+		$this->assertEquals( 'Non_Multisite_Conditional', $this->instance->is_disabled( true ) );
 	}
 
 	/**
 	 * Test return if capabilities are unmet.
 	 *
-	 * @covers ::is_active
+	 * @covers ::is_disabled
 	 */
-	public function test_is_active_unmet_capabilities() {
+	public function test_is_disabled_unmet_capabilities() {
 		Monkey\Functions\expect( 'current_user_can' )->andReturn( false );
 
-		$this->assertFalse( $this->instance->is_active() );
+		$this->assertTrue( $this->instance->is_disabled() );
 	}
 
 	/**

--- a/tests/unit/helpers/wincher-helper-test.php
+++ b/tests/unit/helpers/wincher-helper-test.php
@@ -24,14 +24,14 @@ class Wincher_Helper_Test extends TestCase {
 	/**
 	 * The instance to test.
 	 *
-	 * @var Wincher_Helper
+	 * @var Wincher_Helper|Mockery\Mock
 	 */
 	protected $instance;
 
 	/**
 	 * Holds the Options Page helper instance.
 	 *
-	 * @var Options_Helper
+	 * @var Options_Helper|Mockery\Mock
 	 */
 	protected $options;
 
@@ -78,36 +78,51 @@ class Wincher_Helper_Test extends TestCase {
 	/**
 	 * Test return if conditionals are met.
 	 *
-	 * @covers ::integration_is_disabled
+	 * @covers ::is_active
 	 */
-	public function test_integration_is_disabled() {
-		$this->assertFalse( $this->instance->integration_is_disabled() );
+	public function test_is_active() {
+		Monkey\Functions\expect( 'current_user_can' )->andReturn( true );
+
+		$this->options->expects( 'get' )->andReturn( true );
+
+		$this->assertTrue( $this->instance->is_active() );
 	}
 
 	/**
-	 * Test return if conditionals are not met.
+	 * Test return conditional if conditionals are unmet.
 	 *
-	 * @covers ::integration_is_disabled
+	 * @covers ::is_active
 	 */
-	public function test_integration_is_disabled_unmet() {
+	public function test_is_active_unmet() {
 		Monkey\Functions\stubs( [
 			'is_multisite' => true,
 		] );
 
-		$this->assertTrue( $this->instance->integration_is_disabled( ) );
+		$this->assertFalse( $this->instance->is_active() );
 	}
 
 	/**
-	 * Test return conditional if conditionals are not met.
+	 * Test return conditional if conditionals are unmet.
 	 *
-	 * @covers ::integration_is_disabled
+	 * @covers ::is_active
 	 */
-	public function test_integration_is_disabled_unmet_conditional_return() {
+	public function test_is_active_unmet_conditional_return() {
 		Monkey\Functions\stubs( [
 			'is_multisite' => true,
 		] );
 
-		$this->assertEquals( 'Non_Multisite_Conditional', $this->instance->integration_is_disabled( true ) );
+		$this->assertEquals( 'Non_Multisite_Conditional', $this->instance->is_active( true ) );
+	}
+
+	/**
+	 * Test return if capabilities are unmet.
+	 *
+	 * @covers ::is_active
+	 */
+	public function test_is_active_unmet_capabilities() {
+		Monkey\Functions\expect( 'current_user_can' )->andReturn( false );
+
+		$this->assertFalse( $this->instance->is_active() );
 	}
 
 	/**

--- a/tests/unit/integrations/third-party/wincher-test.php
+++ b/tests/unit/integrations/third-party/wincher-test.php
@@ -83,7 +83,7 @@ class Wincher_Test extends TestCase {
 		$this->instance->register_hooks();
 
 		$this->assertNotFalse( Monkey\Filters\has( 'wpseo_integration_toggles', [ $this->instance, 'add_integration_toggle' ] ) );
-		$this->assertNotFalse( Monkey\Actions\has( 'Yoast\WP\SEO\admin_integration_after', [ $this->instance, 'after_integration_toggle'	] ) );
+		$this->assertNotFalse( Monkey\Actions\has( 'Yoast\WP\SEO\admin_integration_after', [ $this->instance, 'after_integration_toggle' ] ) );
 	}
 
 	/**
@@ -177,6 +177,11 @@ class Wincher_Test extends TestCase {
 		$this->instance->after_network_integration_toggle( $wincher_integration_toggle );
 	}
 
+	/**
+	 * The integration toggles to test with.
+	 *
+	 * @return array The integration toggles.
+	 */
 	private function get_integration_toggles() {
 		return [
 			(object) [

--- a/tests/unit/integrations/third-party/wincher-test.php
+++ b/tests/unit/integrations/third-party/wincher-test.php
@@ -83,7 +83,6 @@ class Wincher_Test extends TestCase {
 		$this->instance->register_hooks();
 
 		$this->assertNotFalse( Monkey\Filters\has( 'wpseo_integration_toggles', [ $this->instance, 'add_integration_toggle' ] ) );
-
 		$this->assertNotFalse( Monkey\Actions\has( 'Yoast\WP\SEO\admin_integration_after', [ $this->instance, 'after_integration_toggle'	] ) );
 	}
 

--- a/tests/unit/integrations/third-party/wincher-test.php
+++ b/tests/unit/integrations/third-party/wincher-test.php
@@ -94,7 +94,7 @@ class Wincher_Test extends TestCase {
 	public function test_add_integration_toggle() {
 		Monkey\Functions\stubTranslationFunctions();
 
-		$this->wincher->expects( 'is_active' )->once()->andReturnTrue();
+		$this->wincher->expects( 'is_disabled' )->once()->andReturnFalse();
 
 		$result = $this->instance->add_integration_toggle(
 			[
@@ -137,7 +137,7 @@ class Wincher_Test extends TestCase {
 			'disabled' => true,
 		];
 
-		$this->wincher->expects( 'is_active' )->once()->andReturn( 'Non_Multisite_Conditional' );
+		$this->wincher->expects( 'is_disabled' )->once()->andReturn( 'Non_Multisite_Conditional' );
 		$this->instance->expects( 'get_disabled_note' )->once();
 
 		$this->instance->after_integration_toggle( $wincher_integration_toggle );
@@ -166,6 +166,6 @@ class Wincher_Test extends TestCase {
 	 * @covers ::get_disabled_note
 	 */
 	public function test_get_disabled_note() {
-		$this->assertContains( 'Currently, the Wincher integration is not available for multisites.', $this->instance->get_disabled_note() );
+		$this->expectOutputString( '<p>Currently, the Wincher integration is not available for multisites.</p>', $this->instance->get_disabled_note() );
 	}
 }

--- a/tests/unit/integrations/third-party/wincher-test.php
+++ b/tests/unit/integrations/third-party/wincher-test.php
@@ -45,7 +45,6 @@ class Wincher_Test extends TestCase {
 		$this->instance = Mockery::mock( Wincher::class, [ $this->wincher ] )
 			->makePartial()
 			->shouldAllowMockingProtectedMethods();
-
 	}
 
 	/**
@@ -83,15 +82,9 @@ class Wincher_Test extends TestCase {
 	public function test_register_hooks() {
 		$this->instance->register_hooks();
 
-		$this->assertNotFalse( Monkey\Filters\has( 'wpseo_integration_toggles', [
-			$this->instance,
-			'add_integration_toggle',
-		] ) );
+		$this->assertNotFalse( Monkey\Filters\has( 'wpseo_integration_toggles', [ $this->instance, 'add_integration_toggle' ] ) );
 
-		$this->assertNotFalse( Monkey\Actions\has( 'Yoast\WP\SEO\admin_integration_after', [
-			$this->instance,
-			'after_integration_toggle',
-		] ) );
+		$this->assertNotFalse( Monkey\Actions\has( 'Yoast\WP\SEO\admin_integration_after', [ $this->instance, 'after_integration_toggle'	] ) );
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The Wincher integration is not available on multisite. The integrations (tab) on Yoast SEO didn’t show the Wincher toggle and that made it very confusing.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds a disabled Wincher integration toggle to the Network admin/Multisite `integrations` tab.

## Relevant technical choices:

* Added a `upgrade routine` to set the Wincher toggle to 'Disable/Off' on Multisites/Network admin
  * Else it was possible that the toggle was disabled and still showed 'Allow Control/On'

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Testing using a multisite:
  * Click on `SEO -> General`  in the WordPress sidebar
  * Navigate to the `Integrations` tab
  * Verify the `Wincher integration` toggle is disabled and has the value 'Off'
  * Verify the copy reads: `Currently, the Wincher integration is not available for multisites.`
* Testing using the Network Admin:
  * Click on `SEO -> General`  in the WordPress sidebar
  * Navigate to the `Integrations` tab
  * Verify the `Wincher integration` toggle is disabled and has the value 'Disabled'
  * Verify the copy reads: `Currently, the Wincher integration is not available for multisites.`
* Testing using a `non multisite site`:
  * Click on `SEO -> General`  in the WordPress sidebar
  * Navigate to the `Integrations` tab
  * Verify the `Wincher integration` toggle is 'toggleable'
* Testing the `upgrade routine`
  * Access the multisite database and navigate to the '`*_sitemeta` table > `wpseo_ms` row'
  * Find and replace:
    * `s:32:"allow_wincher_integration_active";b:0;`  
    `s:32:"allow_wincher_integration_active";b:1;`
  * Go to the `Network Admin` dashboard
  * Click on `SEO -> General`  in the WordPress sidebar
  * Navigate to the `Integrations` tab
  * Verify the `Wincher integration` toggle is disabled and has the value `Allow Control`
  * Go to the dashboard of a multisite
  * Get the yoast-test-helper plugin
  * Go to tools>yoast-test-helper
  * Set the DB version to 18.6.
  * See that an upgrade routine is called.
  * Go to the `Network Admin` dashboard
  * Click on `SEO -> General`  in the WordPress sidebar
  * Navigate to the `Integrations` tab
  * Verify the `Wincher integration` toggle is disabled and has the value `Disable`
  * Verify in the database the `allow_wincher_integration_active` is set to **0**
* Testing the `upgrade routine` (**for when the code is in the RC**)
  * Have 18.5 
  * Access the multisite database and navigate to the '`*_sitemeta` table > `wpseo_ms` row'
  * Find and replace:
    * `s:32:"allow_wincher_integration_active";b:0;`  
    `s:32:"allow_wincher_integration_active";b:1;`
  * Go to the `Network Admin` dashboard
  * Click on `SEO -> General`  in the WordPress sidebar
  * Navigate to the `Integrations` tab
  * Verify the `Wincher integration` toggle is disabled and has the value `Allow Control`
  * Upgrade to 18.6
  * Go to the `Network Admin` dashboard
  * Click on `SEO -> General`  in the WordPress sidebar
  * Navigate to the `Integrations` tab
  * Verify the `Wincher integration` toggle is disabled and has the value `Disable`
  * Verify in the database the `allow_wincher_integration_active` is set to **0**

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* 

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [x] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes P1-1282
