### PR TITLE
Add a filter to allow changing the priority of head tags

### DIFF
--- a/src/integrations/front-end-integration.php
+++ b/src/integrations/front-end-integration.php
@@ -217,7 +217,7 @@ class Front_End_Integration implements Integration_Interface {
 	 * to avoid duplicate and/or mismatched metadata.
 	 */
 	public function register_hooks() {
-		\add_action( 'wp_head', [ $this, 'call_wpseo_head' ], 1 );
+		\add_action( 'wp_head', [ $this, 'call_wpseo_head' ], \apply_filters( 'wpseo_head_priority', 1 ) );
 		// Filter the title for compatibility with other plugins and themes.
 		\add_filter( 'wp_title', [ $this, 'filter_title' ], 15 );
 		// Filter the title for compatibility with block-based themes.


### PR DESCRIPTION
## Context
* Performance is currently an area of significant focus within WordPress.
* Performance of websites can be significantly improved by optimally ordering items in the `<head>` element.
* See for example https://paper.dropbox.com/doc/Performance-Optimization-Strategy-in-2022-Addk8wccr1TuhKqzLW09b#:uid=776675799262198432449914&h2=1.-Cleaning-up-and-reordering-
* This PR adds a filter so that the priority of the head tags added by the Yoast SEO plugin can be changed from the default value of 1.
* See issue https://github.com/Yoast/wordpress-seo/issues/16421 for details.

## Summary

This PR can be summarized in the following changelog entry:

* Added the wpseo_head_priority filter to allow changing the priority of items added to the head.

## Relevant technical choices:

* Keep the default priority of 1 and allow it to be overridden by a filter, so there is no backwards compatibilty issue.
* Ideally the priority of the `<title>` tag should be able to be set separately from the `<meta>` tags, but I'm not sure if this is possible, so this PR does not cover that.

## Test instructions

The following code will set the priority to 999, so the items added will be at or near the end of the head element:

```
add_filter( 'wpseo_head_priority', 'my_wpseo_head_priority' );

function my_wpseo_head_priority( int $priority ): int {

    $priority = 999;

    return $priority;

}
```

### Test instructions for QA when the code is in the RC

* [ ] QA should use the same steps as above.

QA can test this PR by following these steps:

*

## Impact check

This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes #16421
