### PR TITLE
Wincher: store PKCE code as transient instead of cookie

### DIFF
--- a/src/config/wincher-client.php
+++ b/src/config/wincher-client.php
@@ -25,7 +25,7 @@ class Wincher_Client extends OAuth_Client {
 	/**
 	 * Name of the temporary PKCE cookie.
 	 */
-	const PKCE_COOKIE_NAME = 'yoast_wincher_pkce';
+	const PKCE_TRANSIENT_NAME = 'yoast_wincher_pkce';
 
 	/**
 	 * The WP_Remote_Handler instance.
@@ -86,10 +86,9 @@ class Wincher_Client extends OAuth_Client {
 
 		$pkce_code = $this->provider->getPkceCode();
 
-		// Store a session cookie with the PKCE code that we need in order to
+		// Store a transient value with the PKCE code that we need in order to
 		// exchange the returned code for a token after authorization.
-		$secure = ! empty( $_SERVER['HTTPS'] );
-		\setcookie( self::PKCE_COOKIE_NAME, $pkce_code, 0, '/', '', $secure, true );
+		\set_transient( self::PKCE_TRANSIENT_NAME, $pkce_code, \DAY_IN_SECONDS );
 
 		return $url;
 	}
@@ -104,7 +103,7 @@ class Wincher_Client extends OAuth_Client {
 	 * @throws Authentication_Failed_Exception Exception thrown if authentication has failed.
 	 */
 	public function request_tokens( $code ) {
-		$pkce_code = ! empty( $_COOKIE[ self::PKCE_COOKIE_NAME ] ) ? \sanitize_text_field( \wp_unslash( $_COOKIE[ self::PKCE_COOKIE_NAME ] ) ) : null;
+		$pkce_code = \get_transient( self::PKCE_TRANSIENT_NAME );
 		if ( $pkce_code ) {
 			$this->provider->setPkceCode( $pkce_code );
 		}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

Currently the connection flow relies on setting a cookie in order to store the PKCE-code needed to exchange the code for a token. This seems to fail on certain installation that are behind a misconfigured cache (for instance Cloudflare). Cloudflare seems to strip the Set-Cookie header and cache the response to /authorization-url if the caching settings are too aggressive.

This PR aims to fix this problem by storing the PKCE  code as a transient in the DB instead.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the Wincher connection flow would fail on certain installations.

## Relevant technical choices:

* Use set_transient instead of setcookie.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Make sure you have deleted all the cookies for the test website
* Ensure that Wincher connection flow still works.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes #
