### PR TITLE
Fix sitemap numbering and redirect wrongly numbered sitemaps

### DIFF
--- a/inc/sitemaps/class-author-sitemap-provider.php
+++ b/inc/sitemaps/class-author-sitemap-provider.php
@@ -65,23 +65,18 @@ class WPSEO_Author_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 		}
 
 		$index      = [];
-		$page       = 1;
 		$user_pages = array_chunk( $users, $max_entries );
 
-		if ( count( $user_pages ) === 1 ) {
-			$page = '';
-		}
+		foreach ( $user_pages as $page_counter => $users_page ) {
 
-		foreach ( $user_pages as $users_page ) {
+			$current_page = ( $page_counter === 0 ) ? '' : ( $page_counter + 1 );
 
 			$user_id = array_shift( $users_page ); // Time descending, first user on page is most recently updated.
 			$user    = get_user_by( 'id', $user_id );
 			$index[] = [
-				'loc'     => WPSEO_Sitemaps_Router::get_base_url( 'author-sitemap' . $page . '.xml' ),
+				'loc'     => WPSEO_Sitemaps_Router::get_base_url( 'author-sitemap' . $current_page . '.xml' ),
 				'lastmod' => ( $user->_yoast_wpseo_profile_updated ) ? YoastSEO()->helpers->date->format_timestamp( $user->_yoast_wpseo_profile_updated ) : null,
 			];
-
-			++$page;
 		}
 
 		return $index;

--- a/inc/sitemaps/class-post-type-sitemap-provider.php
+++ b/inc/sitemaps/class-post-type-sitemap-provider.php
@@ -129,7 +129,7 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 
 			for ( $page_counter = 0; $page_counter < $max_pages; $page_counter++ ) {
 
-				$current_page = ( $max_pages > 1 ) ? ( $page_counter + 1 ) : '';
+				$current_page = ( $page_counter === 0 ) ? '' : ( $page_counter + 1 );
 				$date         = false;
 
 				if ( empty( $current_page ) || $current_page === $max_pages ) {

--- a/inc/sitemaps/class-sitemaps.php
+++ b/inc/sitemaps/class-sitemaps.php
@@ -251,6 +251,11 @@ class WPSEO_Sitemaps {
 			return;
 		}
 
+		if ( get_query_var( 'sitemap_n' ) === '1' || get_query_var( 'sitemap_n' ) === '0' ) {
+			wp_safe_redirect( home_url( "/$type-sitemap.xml" ), 301, 'Yoast SEO' );
+			exit;
+		}
+
 		$this->set_n( get_query_var( 'sitemap_n' ) );
 
 		if ( ! $this->get_sitemap_from_cache( $type, $this->current_page ) ) {

--- a/inc/sitemaps/class-taxonomy-sitemap-provider.php
+++ b/inc/sitemaps/class-taxonomy-sitemap-provider.php
@@ -123,7 +123,7 @@ class WPSEO_Taxonomy_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 
 			for ( $page_counter = 0; $page_counter < $max_pages; $page_counter++ ) {
 
-				$current_page = ( $max_pages > 1 ) ? ( $page_counter + 1 ) : '';
+				$current_page = ( $page_counter === 0 ) ? '' : ( $page_counter + 1 );
 
 				if ( ! is_array( $tax->object_type ) || count( $tax->object_type ) === 0 ) {
 					continue;

--- a/tests/integration/sitemaps/test-class-wpseo-author-sitemap-provider.php
+++ b/tests/integration/sitemaps/test-class-wpseo-author-sitemap-provider.php
@@ -164,9 +164,6 @@ class WPSEO_Author_Sitemap_Provider_Test extends WPSEO_UnitTestCase {
 		// Fetches the global sitemap.
 		set_query_var( 'sitemap', 'author' );
 
-		// Sets the page to the second one, which should not contain an entry, and should not exist.
-		set_query_var( 'sitemap_n', '1' );
-
 		// Loads the sitemap.
 		$sitemaps = new WPSEO_Sitemaps_Double();
 		$sitemaps->redirect( $GLOBALS['wp_the_query'] );

--- a/tests/integration/sitemaps/test-class-wpseo-post-type-sitemap-provider.php
+++ b/tests/integration/sitemaps/test-class-wpseo-post-type-sitemap-provider.php
@@ -63,7 +63,7 @@ class WPSEO_Post_Type_Sitemap_Provider_Test extends WPSEO_UnitTestCase {
 		$this->factory->post->create();
 
 		$index_links = self::$class_instance->get_index_links( 1 );
-		$this->assertContains( 'http://example.org/post-sitemap1.xml', $index_links[0] );
+		$this->assertContains( 'http://example.org/post-sitemap.xml', $index_links[0] );
 		$this->assertContains( 'http://example.org/post-sitemap2.xml', $index_links[1] );
 	}
 

--- a/tests/integration/sitemaps/test-class-wpseo-taxonomy-sitemap-provider.php
+++ b/tests/integration/sitemaps/test-class-wpseo-taxonomy-sitemap-provider.php
@@ -50,7 +50,7 @@ class WPSEO_Taxonomy_Sitemap_Provider_Test extends WPSEO_UnitTestCase {
 		$post2_id     = $this->factory->post->create();
 		wp_set_post_categories( $post2_id, $category2_id );
 		$index_links = self::$class_instance->get_index_links( 1 );
-		$this->assertContains( 'http://example.org/category-sitemap1.xml', $index_links[0] );
+		$this->assertContains( 'http://example.org/category-sitemap.xml', $index_links[0] );
 		$this->assertContains( 'http://example.org/category-sitemap2.xml', $index_links[1] );
 	}
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Makes our sitemap numbering consistent.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an issue where sitemap locations would change once the number of entries exceeded that of the first page.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Set your number of posts for your sitemap suitably low using the `wpseo_sitemap_entries_per_page` filter:
```
add_filter( 'wpseo_sitemap_entries_per_page', function () { return 10; } );
```
* Go to your sitemap index.
* The first sitemap entry for each content type should not have a number.
* If you visit, for example, /post-sitemap1.xml, you should be redirect to the sitemap without a number.
* See the issue for full details.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Sitemap indexes and the first page sitemap of each content type.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes https://yoast.atlassian.net/browse/IM-467
