### PR TITLE
Dupp 329 person add tailwind input boxes and route for social profile ur ls for the selected user

### DIFF
--- a/packages/js/src/workouts/components/ConfigurationWorkout.js
+++ b/packages/js/src/workouts/components/ConfigurationWorkout.js
@@ -125,6 +125,14 @@ function configurationWorkoutReducer( state, action ) {
 			newState.personId = action.payload.value;
 			newState.personName = action.payload.label;
 			return newState;
+		case "CHANGE_PERSON_SOCIAL_PROFILE":
+			newState = handleStepEdit( newState, 3 );
+			newState.personSocialProfiles[ action.payload.socialMedium ] = action.payload.value;
+			return newState;
+		case "INIT_PERSON_SOCIAL_PROFILES":
+			newState = handleStepEdit( newState, 3 );
+			newState.personSocialProfiles = action.payload.socialProfiles;
+			return newState;
 		case "CHANGE_SOCIAL_PROFILE":
 			newState = handleStepEdit( newState, 3 );
 			newState.socialProfiles[ action.payload.socialMedium ] = action.payload.value;
@@ -213,18 +221,44 @@ async function updateSocialProfiles( state ) {
 		/* eslint-disable camelcase */
 		facebook_site: state.socialProfiles.facebookUrl,
 		twitter_site: state.socialProfiles.twitterUsername,
-		instagram_url: state.socialProfiles.instagramUrl,
-		linkedin_url: state.socialProfiles.linkedinUrl,
-		myspace_url: state.socialProfiles.myspaceUrl,
-		pinterest_url: state.socialProfiles.pinterestUrl,
-		youtube_url: state.socialProfiles.youtubeUrl,
-		wikipedia_url: state.socialProfiles.wikipediaUrl,
 		other_social_urls: state.socialProfiles.otherSocialUrls,
 		/* eslint-enable camelcase */
 	};
 
 	const response = await apiFetch( {
 		path: "yoast/v1/workouts/social_profiles",
+		method: "POST",
+		data: socialProfiles,
+	} );
+	return await response.json;
+}
+
+/**
+ * Updates the person social profiles in the database.
+ *
+ * @param {Object} state The state to save.
+ *
+ * @returns {Promise|bool} A promise, or false if the call fails.
+ */
+async function updatePersonSocialProfiles( state ) {
+	const socialProfiles = {
+		/* eslint-disable camelcase */
+		person_id: state.personId,
+		facebook: state.personSocialProfiles.facebook,
+		instagram: state.personSocialProfiles.instagram,
+		linkedin: state.personSocialProfiles.linkedin,
+		myspace: state.personSocialProfiles.myspace,
+		pinterest: state.personSocialProfiles.pinterest,
+		soundcloud: state.personSocialProfiles.soundcloud,
+		tumblr: state.personSocialProfiles.tumblr,
+		twitter: state.personSocialProfiles.twitter,
+		youtube: state.personSocialProfiles.youtube,
+		wikipedia: state.personSocialProfiles.wikipedia,
+		/* eslint-enable camelcase */
+	};
+
+	const response = await apiFetch( {
+		path: "yoast/v1/workouts/person_social_profiles",
 		method: "POST",
 		data: socialProfiles,
 	} );
@@ -512,6 +546,27 @@ export function ConfigurationWorkout( { finishSteps, reviseStep, toggleWorkout, 
 	 * @returns {void}
 	 */
 	function updateOnFinishSocialProfiles() {
+		if ( state.companyOrPerson === "person" ) {
+			return updatePersonSocialProfiles( state )
+				.then( () => setStepIsSaved( 3 ) )
+				.then( () => {
+					setErrorFields( [] );
+					finishSteps( "configuration", [ steps.socialProfiles ] );
+					scrollToStep( 4 );
+				} )
+				.then( () => {
+					return true;
+				} )
+				.catch(
+					( e ) => {
+						if ( e.failures ) {
+							setErrorFields( e.failures );
+						}
+						return false;
+					}
+				);
+		}
+
 		return updateSocialProfiles( state )
 			.then( () => setStepIsSaved( 3 ) )
 			.then( () => {

--- a/packages/js/src/workouts/components/ConfigurationWorkout.js
+++ b/packages/js/src/workouts/components/ConfigurationWorkout.js
@@ -133,6 +133,10 @@ function configurationWorkoutReducer( state, action ) {
 			newState = handleStepEdit( newState, 3 );
 			newState.personSocialProfiles = action.payload.socialProfiles;
 			return newState;
+		case "SET_CAN_EDIT_USER":
+			newState = handleStepEdit( newState, 2 );
+			newState.canEditUser = action.payload.value === true ? 1 : 0;
+			return newState;
 		case "CHANGE_SOCIAL_PROFILE":
 			newState = handleStepEdit( newState, 3 );
 			newState.socialProfiles[ action.payload.socialMedium ] = action.payload.value;
@@ -243,7 +247,7 @@ async function updateSocialProfiles( state ) {
 async function updatePersonSocialProfiles( state ) {
 	const socialProfiles = {
 		/* eslint-disable camelcase */
-		person_id: state.personId,
+		user_id: state.personId,
 		facebook: state.personSocialProfiles.facebook,
 		instagram: state.personSocialProfiles.instagram,
 		linkedin: state.personSocialProfiles.linkedin,
@@ -256,7 +260,6 @@ async function updatePersonSocialProfiles( state ) {
 		wikipedia: state.personSocialProfiles.wikipedia,
 		/* eslint-enable camelcase */
 	};
-
 	const response = await apiFetch( {
 		path: "yoast/v1/workouts/person_social_profiles",
 		method: "POST",
@@ -547,6 +550,9 @@ export function ConfigurationWorkout( { finishSteps, reviseStep, toggleWorkout, 
 	 */
 	function updateOnFinishSocialProfiles() {
 		if ( state.companyOrPerson === "person" ) {
+			if ( ! state.canEditUser ) {
+				return true;
+			}
 			return updatePersonSocialProfiles( state )
 				.then( () => setStepIsSaved( 3 ) )
 				.then( () => {
@@ -562,6 +568,7 @@ export function ConfigurationWorkout( { finishSteps, reviseStep, toggleWorkout, 
 						if ( e.failures ) {
 							setErrorFields( e.failures );
 						}
+						console.error( e );
 						return false;
 					}
 				);

--- a/packages/js/src/workouts/tailwind-components/steps/site-representation/person-section.js
+++ b/packages/js/src/workouts/tailwind-components/steps/site-representation/person-section.js
@@ -1,3 +1,4 @@
+import apiFetch from "@wordpress/api-fetch";
 import { useCallback, createInterpolateElement, Fragment } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
 import PropTypes from "prop-types";
@@ -10,13 +11,15 @@ import ImageSelect from "../../base/image-select";
 /**
  * The Person section.
  *
- * @param {function} dispatch     The function to update the container's state.
- * @param {string}   imageUrl     The image URL.
- * @param {integer}  personId     The ID of the user.
- * @param {bool}     isDisabled   A flag to disable the field.
+ * @param {Object}   props             The props object.
+ * @param {function} props.dispatch    The function to update the container's state.
+ * @param {string}   props.imageUrl    The image URL.
+ * @param {integer}  props.personId    The ID of the user.
+ * @param {Boolean}  props.canEditUser Wether the current user can edit the selected person's profile.
+
  * @returns {WPElement} The person section.
  */
-export function PersonSection( { dispatch, imageUrl, person } ) {
+export function PersonSection( { dispatch, imageUrl, person, canEditUser } ) {
 	const openImageSelect = useCallback( () => {
 		openMedia( ( selectedImage ) => {
 			dispatch( { type: "SET_PERSON_LOGO", payload: { ...selectedImage } } );
@@ -30,31 +33,60 @@ export function PersonSection( { dispatch, imageUrl, person } ) {
 	const onUserChange = useCallback(
 		( selectedPerson ) => {
 			dispatch( { type: "SET_PERSON", payload: selectedPerson } );
+			apiFetch( {
+				path: `yoast/v1/workouts/check_capability?user_id=${ selectedPerson.value  }`,
+			} ).then( response => {
+				dispatch( { type: "SET_CAN_EDIT_USER", payload: { value: response.success } } );
+			} ).catch(
+				( e ) => {
+					console.error( e.message  );
+				}
+			);
 		},
 		[ dispatch ]
 	);
 
-	const userMessage = createInterpolateElement(
-		sprintf(
-			// translators: %1$s is replaced by the selected user's name, and %2$s and %3$s are opening and closing anchor tags.
-			__(
-				"You have selected the user %1$s as the person this site represents. This user profile information will now be used in search results. %2$sUpdate this profile to make sure the information is correct%3$s.",
-				"wordpress-seo"
+	const userMessage = canEditUser
+		? createInterpolateElement(
+			sprintf(
+				// translators: %1$s is replaced by the selected user's name, and %2$s and %3$s are opening and closing anchor tags.
+				__(
+					"You have selected the user %1$s as the person this site represents. This user profile information will now be used in search results. %2$sUpdate this profile to make sure the information is correct%3$s.",
+					"wordpress-seo"
+				),
+				`<b>${ person.name }</b>`,
+				"<a>",
+				"</a>"
 			),
-			`<b>${ person.name }</b>`,
-			"<a>",
-			"</a>"
-		),
-		{
-			b: <b />,
-			// eslint-disable-next-line jsx-a11y/anchor-has-content
-			a: <a
-				id="yoast-configuration-workout-user-selector-user-link"
-				href={ window.wpseoScriptData.searchAppearance.userEditUrl.replace( "{user_id}", person.id ) }
-				target="_blank" rel="noopener noreferrer"
-			/>,
-		}
-	);
+			{
+				b: <b />,
+				// eslint-disable-next-line jsx-a11y/anchor-has-content
+				a: <a
+					id="yoast-configuration-workout-user-selector-user-link"
+					href={ window.wpseoScriptData.searchAppearance.userEditUrl.replace( "{user_id}", person.id ) }
+					target="_blank" rel="noopener noreferrer"
+				/>,
+			}
+		)
+		:  createInterpolateElement(
+			sprintf(
+				// translators: %1$s is replaced by the selected user's name, and %2$s and %3$s are opening and closing anchor tags.
+				__(
+					"You have selected the user %1$s as the person this site represents. This user profile information will now be used in search results. You're not allowed to update this user profile, so please ask this user or an admin to make sure the information is correct..",
+					"wordpress-seo"
+				),
+				`<b>${ person.name }</b>`
+			),
+			{
+				b: <b />,
+				// eslint-disable-next-line jsx-a11y/anchor-has-content
+				a: <a
+					id="yoast-configuration-workout-user-selector-user-link"
+					href={ window.wpseoScriptData.searchAppearance.userEditUrl.replace( "{user_id}", person.id ) }
+					target="_blank" rel="noopener noreferrer"
+				/>,
+			}
+		);
 
 	return (
 		<Fragment>
@@ -93,6 +125,7 @@ PersonSection.propTypes = {
 		id: PropTypes.number,
 		name: PropTypes.string,
 	} ),
+	canEditUser: PropTypes.bool.isRequired,
 };
 
 PersonSection.defaultProps = {

--- a/packages/js/src/workouts/tailwind-components/steps/site-representation/site-representation-step.js
+++ b/packages/js/src/workouts/tailwind-components/steps/site-representation/site-representation-step.js
@@ -89,6 +89,7 @@ export default function SiteRepresentationStep( { onOrganizationOrPersonChange, 
 						id: state.personId,
 						name: state.personName,
 					} }
+					canEditUser={ !! state.canEditUser }
 				/> }
 			</div>
 		</ReactAnimateHeight>

--- a/packages/js/src/workouts/tailwind-components/steps/social-profiles/social-field-array.js
+++ b/packages/js/src/workouts/tailwind-components/steps/social-profiles/social-field-array.js
@@ -1,16 +1,22 @@
 import { TrashIcon } from "@heroicons/react/outline";
 import { PlusIcon } from "@heroicons/react/solid";
+import { useCallback } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
 import { PropTypes } from "prop-types";
-import { useCallback } from "@wordpress/element";
 
 /**
  * The FieldArray component.
  *
- * @param {array} data The array data.
- * @param {Node} addButtonChildren Children for the add item button.
+ * @param {Object}     props                 The props object
+ * @param {array}      props.items           The array containing the organization's social profiles.
+ * @param {function}   props.onAddProfile    Function to call when a new field is added to the field array.
+ * @param {function}   props.onRemoveProfile Function to call when a field is removed from the field array.
+ * @param {function}   props.onChangeProfile Function to call when a the content of a field is edited.
+ * @param {array}      props.errorFields     The array containing the names of the fields with an invalid value.
+ * @param {Node}       addButtonChildren     Children for the add item button.
+ * @param {Component}  fieldType             The component to render each item with.
  *
- * @returns {Component} The FieldArray component.
+ * @returns {WPElement} The FieldArray component.
  */
 const SocialFieldArray = ( { items, onAddProfile, onRemoveProfile, onChangeProfile, errorFields, addButtonChildren, fieldType: Component } ) => {
 	const handleRemove = useCallback( ( event ) => {
@@ -41,7 +47,7 @@ const SocialFieldArray = ( { items, onAddProfile, onRemoveProfile, onChangeProfi
 							data-index={ index }
 							onClick={ handleRemove }
 						>
-							<span className="yst-sr-only">{ __( "Delete item", "admin-ui" ) }</span>
+							<span className="yst-sr-only">{ __( "Delete item", "wordpress-seo" ) }</span>
 							<TrashIcon className="yst-relative yst--top-0.5 yst-w-5 yst-h-5" />
 						</button>
 					</div>

--- a/packages/js/src/workouts/tailwind-components/steps/social-profiles/social-input-section.js
+++ b/packages/js/src/workouts/tailwind-components/steps/social-profiles/social-input-section.js
@@ -9,12 +9,14 @@ import SocialInput from "./social-input";
 /**
  * A wrapper that combines all the SocialInputs. Intended for use in the configuration workout.
  *
- * @param {Object} props The props object.
- * @param {function} dispatch                     A dispatch function to communicate with the Stepper store.
- * @param {Object}   state                        The Stepper store.
+ * @param {Object}   props                The props object.
+ * @param {Object}   props.socialProfiles An associative array containing { socialmedium : url } pairs.
+ * @param {array}    props.errorFields    The array containing the names of the fields with an invalid value.
+ * @param {function} props.dispatch       A dispatch function to communicate with the Stepper store.
+ *
  * @returns {WPElement} The SocialInputSection.
  */
-export default function SocialInputSection( { socialProfiles, errorFields, dispatch, isDisabled } ) {
+export default function SocialInputSection( { socialProfiles, errorFields, dispatch } ) {
 	const onChangeHandler = useCallback(
 		( newValue, socialMedium ) => {
 			dispatch( { type: "CHANGE_SOCIAL_PROFILE", payload: { socialMedium, value: newValue } } );
@@ -50,7 +52,6 @@ export default function SocialInputSection( { socialProfiles, errorFields, dispa
 				value={ socialProfiles.facebookUrl }
 				socialMedium="facebookUrl"
 				onChange={ onChangeHandler }
-				isDisabled={ isDisabled }
 				error={ {
 					message: [ __( "Could not save this value. Please check the URL.", "wordpress-seo" ) ],
 					isVisible: errorFields.includes( "facebook_site" ),
@@ -63,7 +64,6 @@ export default function SocialInputSection( { socialProfiles, errorFields, dispa
 				value={ socialProfiles.twitterUsername }
 				socialMedium="twitterUsername"
 				onChange={ onChangeHandler }
-				isDisabled={ isDisabled }
 				error={ {
 					message: [ __( "Could not save this value. Please check the URL or username.", "wordpress-seo" ) ],
 					isVisible: errorFields.includes( "twitter_site" ),
@@ -71,11 +71,11 @@ export default function SocialInputSection( { socialProfiles, errorFields, dispa
 			/>
 
 			<SocialFieldArray
-				fieldType={ SocialInput }
 				items={ socialProfiles.otherSocialUrls }
 				onAddProfile={ onAddProfileHandler }
 				onRemoveProfile={ onRemoveProfileHandler }
 				onChangeProfile={ onChangeOthersHandler }
+				fieldType={ SocialInput }
 			/>
 		</div>
 	);
@@ -86,10 +86,8 @@ SocialInputSection.propTypes = {
 	socialProfiles: PropTypes.object.isRequired,
 	dispatch: PropTypes.func.isRequired,
 	errorFields: PropTypes.array,
-	isDisabled: PropTypes.bool,
 };
 
 SocialInputSection.defaultProps = {
 	errorFields: [],
-	isDisabled: false,
 };

--- a/packages/js/src/workouts/tailwind-components/steps/social-profiles/social-input.js
+++ b/packages/js/src/workouts/tailwind-components/steps/social-profiles/social-input.js
@@ -1,15 +1,18 @@
-import PropTypes from "prop-types";
 import { useCallback } from "@wordpress/element";
+import PropTypes from "prop-types";
 
 import TextInput from "../../base/text-input";
 
 /**
  * A wrapped TextInput for the social inputs
  *
- * @param {function} dispatch     The function to update the container's state.
- * @param {string}   socialMedium The social medium this fields refers to.
- * @param {bool}     isDisabled   A flag to disable the field.
- * @param {object}   restProps    The other props.
+ * @param {Object}   props              The props object.
+ * @param {string}   props.id           The id to associate to the text field element.
+ * @param {function} props.onChange     The function to update the container's state.
+ * @param {string}   props.socialMedium The social medium this fields refers to.
+ * @param {bool}     props.isDisabled   A flag to disable the field.
+ * @param {object}   props.restProps    The other props.
+ *
  * @returns {WPElement} A wrapped TextInput for the social inputs.
  */
 export default function SocialInput( { id, onChange, socialMedium, isDisabled, ...restProps } ) {

--- a/packages/js/src/workouts/tailwind-components/steps/social-profiles/social-profiles-step.js
+++ b/packages/js/src/workouts/tailwind-components/steps/social-profiles/social-profiles-step.js
@@ -33,15 +33,15 @@ export default function SocialProfilesStep( { state, dispatch, setErrorFields } 
 	}
 
 	return <Fragment>
-		<Fragment>
-			<p>{
-				__(
-					"We need a little more help from you! Add your Facebook and Twitter profile so we can optimize the metadata for those platforms too.",
-					"wordpress-seo"
-				)
-			}</p>
-			<SocialInputPersonSection personId={ state.personId } />
-		</Fragment>
+		<p>{
+			__(
+				"We need a little more help from you! Add your Facebook and Twitter profile so we can optimize the metadata for those platforms too.",
+				"wordpress-seo"
+			)
+		}</p>
+		<SocialInputPersonSection
+			personId={ state.personId }
+		/>
 	</Fragment>;
 }
 

--- a/packages/js/src/workouts/tailwind-components/steps/social-profiles/social-profiles-step.js
+++ b/packages/js/src/workouts/tailwind-components/steps/social-profiles/social-profiles-step.js
@@ -40,6 +40,9 @@ export default function SocialProfilesStep( { state, dispatch, setErrorFields } 
 			)
 		}</p>
 		<SocialInputPersonSection
+			socialProfiles={ state.personSocialProfiles }
+			dispatch={ dispatch }
+			canEditUser={ !! state.canEditUser }
 			personId={ state.personId }
 		/>
 	</Fragment>;

--- a/packages/js/src/workouts/tailwind-components/steps/social-profiles/social-profiles-step.js
+++ b/packages/js/src/workouts/tailwind-components/steps/social-profiles/social-profiles-step.js
@@ -10,7 +10,10 @@ import SocialInputPersonSection from "./social-input-person-section.js";
 /**
  * Social profiles step component
  *
- * @param {Object} props The props object.
+ * @param {Object}   props                The props object.
+ * @param {Object}   props.state          The container's state
+ * @param {function} props.dispatch       The function to update the container's state.
+ * @param {function} props.setErrorFields The function to keep track of which text fields are not valid
  *
  * @returns {WPElement} The social profiles step.
  */

--- a/src/actions/configuration/configuration-workout-action.php
+++ b/src/actions/configuration/configuration-workout-action.php
@@ -33,6 +33,23 @@ class Configuration_Workout_Action {
 	];
 
 	/**
+	 * The fields for the person social profiles payload.
+	 */
+	const PERSON_SOCIAL_PROFILES_FIELDS = [
+		'facebook',
+		'twitter',
+		'instagram',
+		'linkedin',
+		'myspace',
+		'pinterest',
+		'soundcloud',
+		'tumblr',
+		'twitter',
+		'youtube',
+		'wikipedia',
+	];
+
+	/**
 	 * The Options_Helper instance.
 	 *
 	 * @var Options_Helper
@@ -131,6 +148,66 @@ class Configuration_Workout_Action {
 			'status'   => 500,
 			'error'    => 'Could not save some options in the database',
 			'failures' => $failures,
+		];
+	}
+
+	/**
+	 * Stores the values for the social profiles.
+	 *
+	 * @param array $params The values to store.
+	 *
+	 * @return object The response object.
+	 */
+	public function set_person_social_profiles( $params ) {
+		$failures = [];
+
+		foreach ( self::PERSON_SOCIAL_PROFILES_FIELDS as $field_name ) {
+			if ( isset( $params[ $field_name ] ) ) {
+				$result = $this->options_helper->set( $field_name, $params[ $field_name ] );
+				if ( ! $result ) {
+						$failures[] = $field_name;
+				}
+			}
+		}
+
+		if ( \count( $failures ) === 0 ) {
+			return (object) [
+				'success' => true,
+				'status'  => 200,
+			];
+		}
+		return (object) [
+			'success'  => false,
+			'status'   => 500,
+			'error'    => 'Could not save some options in the database',
+			'failures' => $failures,
+		];
+	}
+
+    /**
+	 * Gets the values for the social profiles.
+	 *
+	 * @param array $params the person id.
+	 *
+	 * @return object The response object.
+	 */
+	public function get_person_social_profiles( $person_id ) {
+		$social_profiles = [];
+		if (\current_user_can( 'edit_user', $person_id)) {
+			foreach ( self::PERSON_SOCIAL_PROFILES_FIELDS as $field_name ) {
+				$social_profiles[$field_name] = \get_user_meta($person_id, $field_name, true);
+			}
+			return (object) [
+				'success' => true,
+				'status'  => 200,
+				'social_profiles' => $social_profiles,
+			];
+		}
+
+		return (object) [
+			'success' => false,
+			'status'  => 500,
+			'error'    => 'The current user has not the permission to edit the selected user',
 		];
 	}
 

--- a/src/actions/configuration/configuration-workout-action.php
+++ b/src/actions/configuration/configuration-workout-action.php
@@ -3,6 +3,7 @@
 namespace Yoast\WP\SEO\Actions\Configuration;
 
 use Yoast\WP\SEO\Helpers\Options_Helper;
+use Yoast\WP\SEO\Integrations\Admin\Configuration_workout_helper;
 
 /**
  * Class Configuration_Workout_Action.
@@ -35,6 +36,7 @@ class Configuration_Workout_Action {
 	/**
 	 * The fields for the person social profiles payload.
 	 */
+	// To be removed
 	const PERSON_SOCIAL_PROFILES_FIELDS = [
 		'facebook',
 		'twitter',
@@ -160,13 +162,10 @@ class Configuration_Workout_Action {
 	 */
 	public function set_person_social_profiles( $params ) {
 		$failures = [];
-
-		foreach ( self::PERSON_SOCIAL_PROFILES_FIELDS as $field_name ) {
+        // Validation to be added
+		foreach ( Configuration_workout_helper::$person_social_profiles as $field_name ) {
 			if ( isset( $params[ $field_name ] ) ) {
-				$result = $this->options_helper->set( $field_name, $params[ $field_name ] );
-				if ( ! $result ) {
-						$failures[] = $field_name;
-				}
+				\update_user_meta( $params['person_id'], $field_name, $params[ $field_name ] );
 			}
 		}
 
@@ -184,30 +183,22 @@ class Configuration_Workout_Action {
 		];
 	}
 
-    /**
+	/**
 	 * Gets the values for the social profiles.
 	 *
-	 * @param array $params the person id.
+	 * @param int $person_id the person id.
 	 *
 	 * @return object The response object.
 	 */
 	public function get_person_social_profiles( $person_id ) {
 		$social_profiles = [];
-		if (\current_user_can( 'edit_user', $person_id)) {
-			foreach ( self::PERSON_SOCIAL_PROFILES_FIELDS as $field_name ) {
-				$social_profiles[$field_name] = \get_user_meta($person_id, $field_name, true);
-			}
-			return (object) [
-				'success' => true,
-				'status'  => 200,
-				'social_profiles' => $social_profiles,
-			];
+		foreach ( Configuration_workout_helper::$person_social_profiles as $field_name ) {
+			$social_profiles[ $field_name ] = \get_user_meta( $person_id, $field_name, true );
 		}
-
 		return (object) [
-			'success' => false,
-			'status'  => 500,
-			'error'    => 'The current user has not the permission to edit the selected user',
+			'success'         => true,
+			'status'          => 200,
+			'social_profiles' => $social_profiles,
 		];
 	}
 

--- a/src/actions/configuration/configuration-workout-action.php
+++ b/src/actions/configuration/configuration-workout-action.php
@@ -34,24 +34,6 @@ class Configuration_Workout_Action {
 	];
 
 	/**
-	 * The fields for the person social profiles payload.
-	 */
-	// To be removed
-	const PERSON_SOCIAL_PROFILES_FIELDS = [
-		'facebook',
-		'twitter',
-		'instagram',
-		'linkedin',
-		'myspace',
-		'pinterest',
-		'soundcloud',
-		'tumblr',
-		'twitter',
-		'youtube',
-		'wikipedia',
-	];
-
-	/**
 	 * The Options_Helper instance.
 	 *
 	 * @var Options_Helper
@@ -162,10 +144,10 @@ class Configuration_Workout_Action {
 	 */
 	public function set_person_social_profiles( $params ) {
 		$failures = [];
-        // Validation to be added
+		// Validation to be added.
 		foreach ( Configuration_workout_helper::$person_social_profiles as $field_name ) {
 			if ( isset( $params[ $field_name ] ) ) {
-				\update_user_meta( $params['person_id'], $field_name, $params[ $field_name ] );
+				\update_user_meta( $params['user_id'], $field_name, $params[ $field_name ] );
 			}
 		}
 
@@ -186,14 +168,14 @@ class Configuration_Workout_Action {
 	/**
 	 * Gets the values for the social profiles.
 	 *
-	 * @param int $person_id the person id.
+	 * @param int $user_id the person id.
 	 *
 	 * @return object The response object.
 	 */
-	public function get_person_social_profiles( $person_id ) {
+	public function get_person_social_profiles( $user_id ) {
 		$social_profiles = [];
 		foreach ( Configuration_workout_helper::$person_social_profiles as $field_name ) {
-			$social_profiles[ $field_name ] = \get_user_meta( $person_id, $field_name, true );
+			$social_profiles[ $field_name ] = \get_user_meta( $user_id, $field_name, true );
 		}
 		return (object) [
 			'success'         => true,
@@ -227,6 +209,27 @@ class Configuration_Workout_Action {
 			'success' => false,
 			'status'  => 500,
 			'error'   => 'Could not save the option in the database',
+		];
+	}
+
+	/**
+	 * Checks if the current user has the capability a specific user.
+	 *
+	 * @param int $user_id The id of the user to be edited.
+	 *
+	 * @return object The response object.
+	 */
+	public function check_capability( $user_id ) {
+		if ( \current_user_can( 'edit_user', $user_id ) ) {
+			return (object) [
+				'success' => true,
+				'status'  => 200,
+			];
+		}
+
+		return (object) [
+			'success' => false,
+			'status'  => 403,
 		];
 	}
 }

--- a/src/integrations/admin/configuration-workout-helper.php
+++ b/src/integrations/admin/configuration-workout-helper.php
@@ -1,0 +1,6 @@
+<?php
+namespace Yoast\WP\SEO\Integrations\Admin;
+
+class Configuration_workout_helper {
+    public static $person_social_profiles = [ "facebook", "instagram", "linkedin", "myspace", "pinterest", "soundcloud", "tumblr", "twitter", "youtube", "wikipedia" ];
+}

--- a/src/integrations/admin/configuration-workout-integration.php
+++ b/src/integrations/admin/configuration-workout-integration.php
@@ -11,6 +11,7 @@ use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Product_Helper;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
 use Yoast\WP\SEO\Routes\Indexing_Route;
+use Yoast\WP\SEO\Integrations\Admin\Configuration_workout_helper;
 
 /**
  * ConfigurationWorkoutsIntegration class
@@ -124,6 +125,7 @@ class Configuration_Workout_Integration implements Integration_Interface {
 		$this->admin_asset_manager->localize_script( 'indexation', 'yoastIndexingData', $data );
 
 		$social_profiles = $this->get_social_profiles();
+		$person_social_profiles = $this->get_person_social_profiles();
 
 		// This filter is documented in admin/views/tabs/metas/paper-content/general/knowledge-graph.php.
 		$knowledge_graph_message = \apply_filters( 'wpseo_knowledge_graph_setting_msg', '' );
@@ -150,6 +152,7 @@ class Configuration_Workout_Integration implements Integration_Interface {
 					"companyLogo": "%s",
 					"companyLogoId": %d,
 					"personId": %d,
+					"canEditUser": %d,
 					"personName": "%s",
 					"personLogo": "%s",
 					"personLogoId": %d,
@@ -158,6 +161,18 @@ class Configuration_Workout_Integration implements Integration_Interface {
 						"facebookUrl": "%s",
 						"twitterUsername": "%s",
 						"otherSocialUrls": %s,
+					},
+					"personSocialProfiles" : {
+						"facebook" : "%s",
+						"instagram" : "%s",
+						"linkedin" : "%s",
+						"myspace" : "%s",
+						"pinterest" : "%s",
+						"soundcloud" : "%s",
+						"tumblr" : "%s",
+						"twitter" : "%s",
+						"youtube" : "%s",
+						"wikipedia" : "%s",
 					},
 					"tracking": %d,
 					"companyOrPersonOptions": %s,
@@ -175,6 +190,7 @@ class Configuration_Workout_Integration implements Integration_Interface {
 				$this->get_company_logo(),
 				$this->get_company_logo_id(),
 				$this->get_person_id(),
+				$this->get_can_edit_user(),
 				$this->get_person_name(),
 				$this->get_person_logo(),
 				$this->get_person_logo_id(),
@@ -182,6 +198,16 @@ class Configuration_Workout_Integration implements Integration_Interface {
 				$social_profiles['facebook_url'],
 				$social_profiles['twitter_username'],
 				WPSEO_Utils::format_json_encode( $social_profiles['other_social_urls'] ),
+				$person_social_profiles['facebook'],
+				$person_social_profiles['instagram'],
+				$person_social_profiles['linkedin'],
+				$person_social_profiles['myspace'],
+				$person_social_profiles['pinterest'],
+				$person_social_profiles['soundcloud'],
+				$person_social_profiles['tumblr'],
+				$person_social_profiles['twitter'],
+				$person_social_profiles['youtube'],
+				$person_social_profiles['wikipedia'],
 				$this->has_tracking_enabled(),
 				WPSEO_Utils::format_json_encode( $options ),
 				$this->should_force_company(),
@@ -266,6 +292,15 @@ class Configuration_Workout_Integration implements Integration_Interface {
 	}
 
 	/**
+	 * Gets Wether or not current user can edit the selected person.
+	 *
+	 * @return bool Wether or not current user can edit the selected person.
+	 */
+	private function get_can_edit_user() {
+		return \current_user_can( 'edit_user', $this->get_person_id() );
+	}
+
+	/**
 	 * Gets the person id from the option in the database.
 	 *
 	 * @return int|null The person id, null if empty.
@@ -316,6 +351,26 @@ class Configuration_Workout_Integration implements Integration_Interface {
 			'twitter_username'  => $this->options_helper->get( 'twitter_site', '' ),
 			'other_social_urls' => $this->options_helper->get( 'other_social_urls', [] ),
 		];
+	}
+
+	/**
+	 * Gets the person social profiles stored in the database.
+	 *
+	 * @return string[] The social profiles.
+	 */
+	private function get_person_social_profiles() {
+		$person_social_profiles= \array_combine( 
+			Configuration_workout_helper::$person_social_profiles, 
+			\array_fill(0, sizeof(Configuration_workout_helper::$person_social_profiles), "")
+		);
+
+		if ($this->is_company_or_person() === "person") {
+			foreach (Configuration_workout_helper::$person_social_profiles as $field_name) {
+				$person_social_profiles[$field_name] = \get_user_meta($this->get_person_id(), $field_name, true);
+			}
+		}
+
+		return $person_social_profiles;
 	}
 
 	/**

--- a/src/integrations/admin/configuration-workout-integration.php
+++ b/src/integrations/admin/configuration-workout-integration.php
@@ -124,7 +124,7 @@ class Configuration_Workout_Integration implements Integration_Interface {
 
 		$this->admin_asset_manager->localize_script( 'indexation', 'yoastIndexingData', $data );
 
-		$social_profiles = $this->get_social_profiles();
+		$social_profiles        = $this->get_social_profiles();
 		$person_social_profiles = $this->get_person_social_profiles();
 
 		// This filter is documented in admin/views/tabs/metas/paper-content/general/knowledge-graph.php.
@@ -292,7 +292,7 @@ class Configuration_Workout_Integration implements Integration_Interface {
 	}
 
 	/**
-	 * Gets Wether or not current user can edit the selected person.
+	 * Gets wether or not current user can edit the selected person.
 	 *
 	 * @return bool Wether or not current user can edit the selected person.
 	 */
@@ -359,14 +359,14 @@ class Configuration_Workout_Integration implements Integration_Interface {
 	 * @return string[] The social profiles.
 	 */
 	private function get_person_social_profiles() {
-		$person_social_profiles= \array_combine( 
-			Configuration_workout_helper::$person_social_profiles, 
-			\array_fill(0, sizeof(Configuration_workout_helper::$person_social_profiles), "")
+		$person_social_profiles = \array_combine(
+			Configuration_workout_helper::$person_social_profiles,
+			\array_fill( 0, count( Configuration_workout_helper::$person_social_profiles ), '' )
 		);
 
-		if ($this->is_company_or_person() === "person") {
-			foreach (Configuration_workout_helper::$person_social_profiles as $field_name) {
-				$person_social_profiles[$field_name] = \get_user_meta($this->get_person_id(), $field_name, true);
+		if ( $this->is_company_or_person() === 'person' ) {
+			foreach ( Configuration_workout_helper::$person_social_profiles as $field_name ) {
+				$person_social_profiles[ $field_name ] = \get_user_meta( $this->get_person_id(), $field_name, true );
 			}
 		}
 

--- a/src/routes/configuration-workout-route.php
+++ b/src/routes/configuration-workout-route.php
@@ -30,6 +30,13 @@ class Configuration_Workout_Route implements Route_Interface {
 	const SOCIAL_PROFILES_ROUTE = '/social_profiles';
 
 	/**
+	 * Represents a person's social profiles route.
+	 *
+	 * @var string
+	 */
+	const PERSON_SOCIAL_PROFILES_ROUTE = '/person_social_profiles';
+
+	/**
 	 * Represents a route to enable/disable tracking.
 	 *
 	 * @var string
@@ -117,6 +124,60 @@ class Configuration_Workout_Route implements Route_Interface {
 		];
 
 		\register_rest_route( Main::API_V1_NAMESPACE, Workouts_Route::WORKOUTS_ROUTE . self::SOCIAL_PROFILES_ROUTE, $social_profiles_route );
+		$person_social_profiles_route = [
+			[
+				'methods'             => 'GET',
+				'callback'            => [ $this, 'get_person_social_profiles' ],
+				'permission_callback' => [ $this, 'can_manage_options' ],
+				'args'                => [
+					'person_id' => [
+						'required' => true,
+					],
+				],
+			],
+			[
+				'methods'             => 'POST',
+				'callback'            => [ $this, 'set_person_social_profiles' ],
+				'permission_callback' => [ $this, 'can_manage_options' ],
+				'args'                => [
+					'person_id' => [
+						'type'     => 'string',
+					],
+					'facebook' => [
+						'type'     => 'string',
+					],
+					'instagram' => [
+						'type'     => 'string',
+					],
+					'linkedin' => [
+						'type'     => 'string',
+					],
+					'myspace' => [
+						'type'     => 'string',
+					],
+					'pinterest' => [
+						'type'     => 'string',
+					],
+					'soundcloud' => [
+						'type'     => 'string',
+					],
+					'tumblr' => [
+						'type'     => 'string',
+					],
+					'twitter' => [
+						'type'     => 'string',
+					],
+					'youtube' => [
+						'type'     => 'string',
+					],
+					'wikipedia' => [
+						'type'     => 'string',
+					],
+				],
+			],
+		];
+
+		\register_rest_route( Main::API_V1_NAMESPACE, Workouts_Route::WORKOUTS_ROUTE . self::PERSON_SOCIAL_PROFILES_ROUTE, $person_social_profiles_route );
 
 		$enable_tracking_route = [
 			'methods'             => 'POST',
@@ -159,6 +220,36 @@ class Configuration_Workout_Route implements Route_Interface {
 		$data = $this
 			->configuration_workout_action
 			->set_social_profiles( $request->get_json_params() );
+
+		return new WP_REST_Response( $data, $data->status );
+	}
+
+	/**
+	 * Gets a person's social profiles values.
+	 *
+	 * @param WP_REST_Request $request The request.
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function get_person_social_profiles( WP_REST_Request $request ) {
+		$data = $this
+			->configuration_workout_action
+			->get_person_social_profiles( $request->get_param('person_id') );
+
+		return new WP_REST_Response( $data, $data->status );
+	}
+
+	/**
+	 * Sets a person's social profiles values.
+	 *
+	 * @param WP_REST_Request $request The request.
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function set_person_social_profiles( WP_REST_Request $request ) {
+		$data = $this
+			->configuration_workout_action
+			->set_person_social_profiles( $request->get_json_params() );
 
 		return new WP_REST_Response( $data, $data->status );
 	}

--- a/src/routes/configuration-workout-route.php
+++ b/src/routes/configuration-workout-route.php
@@ -7,7 +7,7 @@ use WP_REST_Response;
 use Yoast\WP\SEO\Actions\Configuration\Configuration_Workout_Action;
 use Yoast\WP\SEO\Conditionals\No_Conditionals;
 use Yoast\WP\SEO\Main;
-
+use Yoast\WP\SEO\Integrations\Admin\Configuration_workout_helper;
 /**
  * Configuration_Workout_Route class.
  */
@@ -128,7 +128,7 @@ class Configuration_Workout_Route implements Route_Interface {
 			[
 				'methods'             => 'GET',
 				'callback'            => [ $this, 'get_person_social_profiles' ],
-				'permission_callback' => [ $this, 'can_manage_options' ],
+				'permission_callback' => [ $this, 'can_edit_user' ],
 				'args'                => [
 					'person_id' => [
 						'required' => true,
@@ -138,10 +138,10 @@ class Configuration_Workout_Route implements Route_Interface {
 			[
 				'methods'             => 'POST',
 				'callback'            => [ $this, 'set_person_social_profiles' ],
-				'permission_callback' => [ $this, 'can_manage_options' ],
+				'permission_callback' => [ $this, 'can_edit_user' ],
 				'args'                => [
 					'person_id' => [
-						'type'     => 'string',
+						'type'     => 'integer',
 					],
 					'facebook' => [
 						'type'     => 'string',
@@ -234,7 +234,7 @@ class Configuration_Workout_Route implements Route_Interface {
 	public function get_person_social_profiles( WP_REST_Request $request ) {
 		$data = $this
 			->configuration_workout_action
-			->get_person_social_profiles( $request->get_param('person_id') );
+			->get_person_social_profiles( $request->get_param( 'person_id' ) );
 
 		return new WP_REST_Response( $data, $data->status );
 	}
@@ -276,5 +276,16 @@ class Configuration_Workout_Route implements Route_Interface {
 	 */
 	public function can_manage_options() {
 		return \current_user_can( 'wpseo_manage_options' );
+	}
+
+	/**
+	 * Checks if the current user has the capability to edit a specific user.
+	 *
+	 * @param int $user_id The id of the user to be modified.
+	 *
+	 * @return bool
+	 */
+	public function can_edit_user( $user_id ) {
+		return \current_user_can( 'edit_user', $user_id );
 	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Tailwindification of the first time configuration

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Add Tailwindified Social Profiles step to the first time configuration

## Relevant technical choices:

* To cover as many cases as possible,  the server-side check wether the current user can edit the selected user's profile is carried out by passing the `edit_user` meta capability to wp `current_user_can` statement.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install and activate the [User Switching](https://wordpress.org/plugins/user-switching/) plugin
* Change the role of one of the users to `SEO Manager`: by doing so, the user will still be able to access the first time configuration but will not have the capabilities to edit another user's profile information
* Login as admin and navigate to the first-time configuration Site representation step
* Choose `person` from the first dropdown and leave `admin` as the name 
* Click `Save and continue` to proceed to the next step  
* Verify the text fields are enabled and you can type into them
* Click `Save and continue` and refresh the page
* Click `Go back to` go back to the Social profiles step and verify the information you have entered have been kept
* Navigate to the site's users list and switch to the user you have checked as SEO Manager (hover on the user's name and click `switch to`
* Navigate to the first-time configuration Social Profiles step and verify there's a blue alert stating: 
  _You're not allowed to edit the social profiles of the user admin. Please ask this user or an admin to do this._
* Try to edit a text field and verify it is disabled
* Click `Go back` to go back to the Site representation step and verify the blue alert states the following:
 _You have selected the user admin as the person this site represents. This user profile information will now be used in search results. You're not allowed to update this user profile, so please ask this user or an admin to make sure the information is correct._
* Change the user name from the second dropdown menu to the user you have switched to and verify the blue alert box message changes to: 
_You have selected the user `selected_user_name` as the person this site represents. This user profile information will now be used in search results. Update this profile to make sure the information is correct_
* Verify the link works as intended
* Click `Save and continue` to advance to the Social profiles step
* Verify you can edit the text boxes and there's no alert displayed

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes [DUPP-329](https://yoast.atlassian.net/browse/DUPP-329)
