### PR TITLE
Change order of integration tests to check

### DIFF
--- a/tests/integration/sitemaps/test-class-wpseo-author-sitemap-provider.php
+++ b/tests/integration/sitemaps/test-class-wpseo-author-sitemap-provider.php
@@ -127,32 +127,6 @@ class WPSEO_Author_Sitemap_Provider_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	 * Makes sure the filtered out entries do not cause a sitemap index link to return a 404.
-	 *
-	 * @covers WPSEO_Post_Type_Sitemap_Provider::get_index_links
-	 */
-	public function test_get_index_links_empty_sitemap() {
-		// Doesn't remove authors with no posts.
-		WPSEO_Options::set( 'noindex-author-noposts-wpseo', false );
-
-		// Makes sure the author archives are enabled.
-		WPSEO_Options::set( 'disable-author', false );
-
-		// Fetches the global sitemap.
-		set_query_var( 'sitemap', 'author' );
-
-		// Sets the page to the second one, which should not contain an entry, and should not exist.
-		set_query_var( 'sitemap_n', '2' );
-
-		// Loads the sitemap.
-		$sitemaps = new WPSEO_Sitemaps_Double();
-		$sitemaps->redirect( $GLOBALS['wp_the_query'] );
-
-		// Expects an empty page (404) to be returned.
-		$this->expectOutputString( '' );
-	}
-
-	/**
 	 * Makes sure there is no sitemap when the author archives have been disabled.
 	 *
 	 * @covers WPSEO_Author_Sitemap_Provider::get_index_links
@@ -176,6 +150,32 @@ class WPSEO_Author_Sitemap_Provider_Test extends WPSEO_UnitTestCase {
 
 		// Cleanup.
 		WPSEO_Options::set( 'disable-author', false );
+	}
+
+	/**
+	 * Makes sure the filtered out entries do not cause a sitemap index link to return a 404.
+	 *
+	 * @covers WPSEO_Post_Type_Sitemap_Provider::get_index_links
+	 */
+	public function test_get_index_links_empty_sitemap() {
+		// Doesn't remove authors with no posts.
+		WPSEO_Options::set( 'noindex-author-noposts-wpseo', false );
+
+		// Makes sure the author archives are enabled.
+		WPSEO_Options::set( 'disable-author', false );
+
+		// Fetches the global sitemap.
+		set_query_var( 'sitemap', 'author' );
+
+		// Sets the page to the second one, which should not contain an entry, and should not exist.
+		set_query_var( 'sitemap_n', '2' );
+
+		// Loads the sitemap.
+		$sitemaps = new WPSEO_Sitemaps_Double();
+		$sitemaps->redirect( $GLOBALS['wp_the_query'] );
+
+		// Expects an empty page (404) to be returned.
+		$this->expectOutputString( '' );
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

*

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

*


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes #
