### PR TITLE
PHP >= 8 Avoid array key warnings in meta-surface and add test

### DIFF
--- a/src/surfaces/meta-surface.php
+++ b/src/surfaces/meta-surface.php
@@ -310,6 +310,13 @@ class Meta_Surface {
 	public function for_url( $url ) {
 		$url_parts  = \wp_parse_url( $url );
 		$site_parts = \wp_parse_url( \site_url() );
+
+		if ( ( ! is_array( $url_parts ) || ! is_array( $site_parts ) )
+			|| ! isset( $url_parts['host'], $site_parts['host'], $site_parts['scheme'], $url_parts['path'] )
+		) {
+			return false;
+		}
+
 		if ( $url_parts['host'] !== $site_parts['host'] ) {
 			return false;
 		}

--- a/src/surfaces/meta-surface.php
+++ b/src/surfaces/meta-surface.php
@@ -311,7 +311,7 @@ class Meta_Surface {
 		$url_parts  = \wp_parse_url( $url );
 		$site_parts = \wp_parse_url( \site_url() );
 
-		if ( ( ! is_array( $url_parts ) || ! is_array( $site_parts ) )
+		if ( ( ! \is_array( $url_parts ) || ! \is_array( $site_parts ) )
 			|| ! isset( $url_parts['host'], $url_parts['path'], $site_parts['host'], $site_parts['scheme'] )
 		) {
 			return false;

--- a/src/surfaces/meta-surface.php
+++ b/src/surfaces/meta-surface.php
@@ -312,7 +312,7 @@ class Meta_Surface {
 		$site_parts = \wp_parse_url( \site_url() );
 
 		if ( ( ! is_array( $url_parts ) || ! is_array( $site_parts ) )
-			|| ! isset( $url_parts['host'], $site_parts['host'], $site_parts['scheme'], $url_parts['path'] )
+			|| ! isset( $url_parts['host'], $url_parts['path'], $site_parts['host'], $site_parts['scheme'] )
 		) {
 			return false;
 		}

--- a/tests/unit/surfaces/meta-surface-test.php
+++ b/tests/unit/surfaces/meta-surface-test.php
@@ -551,12 +551,12 @@ class Meta_Surface_Test extends TestCase {
 	}
 
 	/**
-	 * Tests the url function.
+	 * Tests the for_url function with malformed and invalid URL values.
 	 *
 	 * @covers ::for_url
 	 * @dataProvider data_for_url_with_unexpected_value
 	 *
-	 * @param string $url The URL.
+	 * @param string $url The malformed/invalud URL.
 	 */
 	public function test_for_url_with_unexpected_value( $url ) {
 
@@ -572,9 +572,9 @@ class Meta_Surface_Test extends TestCase {
 	}
 
 	/**
-	 * Data provider.
+	 * Data provider for the test_for_url_with_unexpected_value test.
 	 *
-	 * @return array
+	 * @return array The test parameters.
 	 */
 	public function data_for_url_with_unexpected_value() {
 		return [

--- a/tests/unit/surfaces/meta-surface-test.php
+++ b/tests/unit/surfaces/meta-surface-test.php
@@ -549,4 +549,37 @@ class Meta_Surface_Test extends TestCase {
 			'Error_Page'         => [ 'system-page', '404', 1, 'Error_Page' ],
 		];
 	}
+
+	/**
+	 * Tests the url function.
+	 *
+	 * @covers ::for_url
+	 * @dataProvider data_for_url_with_unexpected_value
+	 *
+	 * @param string $url The URL.
+	 */
+	public function test_for_url_with_unexpected_value( $url ) {
+
+		Monkey\Functions\stubs(
+			[
+				'wp_parse_url' => static function( $url ) {
+					return \parse_url( $url );
+				},
+			]
+		);
+
+		$this->assertFalse( $this->instance->for_url( $url ) );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_for_url_with_unexpected_value() {
+		return [
+			'malformed_url' => [ 'http:///example.com' ],
+			'invalid_url'   => [ '' ],
+		];
+	}
 }

--- a/tests/unit/surfaces/meta-surface-test.php
+++ b/tests/unit/surfaces/meta-surface-test.php
@@ -556,7 +556,7 @@ class Meta_Surface_Test extends TestCase {
 	 * @covers ::for_url
 	 * @dataProvider data_for_url_with_unexpected_value
 	 *
-	 * @param string $url The malformed/invalud URL.
+	 * @param string $url The malformed/invalid URL.
 	 */
 	public function test_for_url_with_unexpected_value( $url ) {
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Workshop PHP 8.1 compatibility 2022-02-24
* Written together with @jrfnl 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Avoids array key warnings in empty array and non-array returns from wp_parse_url.

## Relevant technical choices:

* Technically this is not the issue with null return values being passed on (since here wp_parse_url will only ever return an array or "false", however, I think the mixed return type of wp_parse_url warrants some defensive coding.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Tests should run.
* I couldn't find an implementation for this for_url function, I guess because it is split up with call_user_func. It is potentially used in the indexables get_head function, so that should still work as expected.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.


