### PR TITLE
Remove the unnecessary fallback value for tag replace var

### DIFF
--- a/packages/js/src/classic-editor/replacement-variables/configurations.js
+++ b/packages/js/src/classic-editor/replacement-variables/configurations.js
@@ -99,12 +99,8 @@ export const tag = {
 	name: "tag",
 	getLabel: () => __( "Tag", "wordpress-seo" ),
 	getReplacement: () => {
-		// On page load, the tags are not available in the store and in that case we get them from the window.
 		const tagsFromStore = select( SEO_STORE_NAME ).selectTerms( "tags" );
-
-		return tagsFromStore.length > 0
-			? tagsFromStore.map( term => term ).join( ", " )
-			: get( window, "wpseoScriptData.analysis.plugins.replaceVars.replace_vars.tag" );
+		return tagsFromStore.map( term => term ).join( ", " );
 	},
 };
 

--- a/packages/js/tests/classic-editor/replacement-variables/configurations.test.js
+++ b/packages/js/tests/classic-editor/replacement-variables/configurations.test.js
@@ -98,7 +98,6 @@ self.wpseoScriptData = {
 		plugins: {
 			replaceVars: {
 				replace_vars: {
-					tag: "cats",
 					custom_taxonomies: {
 						actors: {
 							description: "",
@@ -127,8 +126,7 @@ describe( "a test for getting the replacement of the tag variable in classic edi
 		expect( tag.getReplacement() ).toEqual( "tortie cat, tortoiseshell cat" );
 	} );
 
-	it( "should return the replacement for tag variable when the store returns an empty array of tag(s): " +
-		"it should return the tags from wpseoScriptData", () => {
+	it( "should return an empty string as the replacement for tag variable when the store returns an empty array of tag(s)", () => {
 		selectTerms = jest.fn().mockReturnValue( [] );
 		jest.spyOn( data, "select" ).mockImplementation( () => {
 			return {
@@ -136,7 +134,7 @@ describe( "a test for getting the replacement of the tag variable in classic edi
 			};
 		} );
 
-		expect( tag.getReplacement() ).toEqual( "cats" );
+		expect( tag.getReplacement() ).toEqual( "" );
 	} );
 } );
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* When all tags are removed from a post, they are still shown in the snippet editor preview. This was caused by the fact that the tag replacement variable is retrieved from `wpseoScriptData` object when the tags value in `@yoast/seo` store is empty. 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Removes unnecessary fallback value for the tag replacement variable.

## Relevant technical choices:

* It turns out that assigning a fallback value for when the data for tags in `@yoast/seo` is empty is unnecessary. The store already reflect the correct situation of when the tags are assigned or removed in the post.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install and activate Classic editor
* Create a post and save it

**Test with tags created from inside the Post**
* Add `%tag%` variable in the SEO title field and in the meta description field
* Create a tag in the `Tags` field
<img width="282" alt="Screenshot 2022-02-22 at 09 15 09" src="https://user-images.githubusercontent.com/48715883/155090460-e46fa7d0-8af6-48c6-850d-c0f6e89a0e07.png">

* Confirm that the tag you just added is previewed in Google preview both in the SEO title and in Meta description
* Create multiple tags separated by comma in the `Tags` field
* Confirm that the tags you just added are also previewed in Google preview both in the SEO title and in Meta description
* Remove one or two tags from the tags list
* Confirm that the removed tags are no longer previewed in Google preview both in the SEO title and in Meta description
* Save your changes and confirm that the selected tags are still previewed in Google preview
* Remove all the tags from the tags list
* Confirm that no tag is previewed inside the snippet editor
* Save your changes and confirm that there is still no tag previewed inside the snippet editor


**Regression test with tags that were already created from `Choose from the most used tags`**
* In a post, choose a tag from `Choose from the most used tags`
<img width="282" alt="Screenshot 2022-02-22 at 09 15 09" src="https://user-images.githubusercontent.com/48715883/155091426-0ac280ce-0d8d-43d4-b59b-acff1866f5c1.png">

* Confirm that the tag you just added is also previewed in Google preview


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* None

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes https://yoast.atlassian.net/browse/LINGO-1372
