### PR TITLE
Fix Paginated URL if there are query params

### DIFF
--- a/src/helpers/pagination-helper.php
+++ b/src/helpers/pagination-helper.php
@@ -64,16 +64,33 @@ class Pagination_Helper {
 	 *
 	 * @return string The paginated URL.
 	 */
-	public function get_paginated_url( $url, $page, $add_pagination_base = true, $pagination_query_name = 'page' ) {
-		$wp_rewrite = $this->wp_rewrite_wrapper->get();
+	 public function get_paginated_url( $url, $page, $add_pagination_base = true, $pagination_query_name = 'page' ) {
+		$wp_rewrite     = $this->wp_rewrite_wrapper->get();
+		$url_parts      = parse_url( $url );
+		$has_url_params = array_key_exists( 'query', $url_parts );
 
 		if ( $wp_rewrite->using_permalinks() ) {
-			$url = \trailingslashit( $url );
+
+			if ( $has_url_params ) {
+				parse_str( $url_parts['query'], $query_parts );
+
+				$url_without_query_param =& $url;
+
+				$url_without_query_param = \trailingslashit( remove_query_arg( array_keys( $query_parts ), $url ) );
+			}
+
 			if ( $add_pagination_base ) {
 				$url .= \trailingslashit( $wp_rewrite->pagination_base );
 			}
 
-			return \user_trailingslashit( $url . $page );
+			if ( $has_url_params ) {
+				$url = \user_trailingslashit( $url . $page );
+
+				return add_query_arg( $query_parts, $url );
+			} else {
+				return \user_trailingslashit( $url . $page );
+			}
+
 		}
 
 		return \add_query_arg( $pagination_query_name, $page, \user_trailingslashit( $url ) );


### PR DESCRIPTION
## Context
<!--
Fix the pagination url to show the query params at the end and not in the middle.
-->

* Fix the pagination url to show the query params at the end and not in the middle.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixed paginated canonical URL when we are having query params in the url.


## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

1. Set up WooCommerce
2. Install Yoast SEO
3. Create 3 products and translate
4. Go to Appearance > Customize > WooCommerce > Product catalog > Set "Products per row:2" and "Rows per page:1"
5. Add this snippet in `functions.php` of the current theme
```php
add_filter( 'page_link', function( $url ) {
    return add_query_arg( 'foo', 'bar', $url );
} );
```
6. Check page source and  the canonical entry
7. The canonical link should shows something like this `/page/page/2/?foo=bar`

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* The test steps for the acceptance can be the same as test instructions 


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* 

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes https://github.com/Yoast/wordpress-seo/issues/18275

