### PR TITLE
Make sure that the global shortlinker is not overwritten if it has already been defined.

### DIFF
--- a/packages/yoastseo/src/helpers/shortlinker/singleton.js
+++ b/packages/yoastseo/src/helpers/shortlinker/singleton.js
@@ -17,7 +17,7 @@ if ( typeof window === "undefined" ) {
 }
 
 globalScope.yoast = globalScope.yoast || {};
-globalScope.yoast.shortlinker = null;
+globalScope.yoast.shortlinker = globalScope.yoast.shortlinker || null;
 
 /**
  * Retrieves the Shortlinker instance.


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* When using WooCommerce SEO we load in the `packages/yoastseo/src/helpers/shortlinker/singleton.js` file twice, once in WordPress SEO and once in WooCommerce SEO. This currently resets the globally defined shortlinker to `null` on the second file load. This PR prevents this reset when the global shortlinker is already defined.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [wpseo-woocommerce] Fixes a bug where no telemetry parameters were added to the links in the SEO and Readability analysis results on product pages. 

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Within WooCommerce SEO, go to `trunk` and require this branch of WordPress SEO using Composer: 
     ```
     composer require --dev yoast/wordpress-seo dev-LINGO-1076-the-short-links-in-all-assessments-in-woo-omit-tracking-parameters@dev
     ```
* Build WooCommerce SEO as you normally would.
* In the WordPress admin, install and activate Yoast SEO, WooCommerce and WooCommerce SEO.
* Create a product in WooCommerce.
* Check the links in the SEO and Readability analyses, they should have telemetry parameters. For example like this:
  ```
  https://yoa.st/33i?php_version=7.4&platform=wordpress&platform_version=5.9.2&software=free&software_version=18.5-RC4&days_active=31-90&user_language=en_US
  ```
* Without this change, these parameters would be missing:
  ```
  https://yoa.st/33i
  ```  

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Install the latest RC version of WooCommerce SEO.
* In the WordPress admin, install and activate Yoast SEO, WooCommerce and WooCommerce SEO.
* Create a product in WooCommerce.
* Check the links in the SEO and the Readability analyses, they should have telemetry parameters. For example like this:
  ```
  https://yoa.st/33i?php_version=7.4&platform=wordpress&platform_version=5.9.2&software=free&software_version=18.5-RC4&days_active=31-90&user_language=en_US
  ```
* Without this change, these parameters would be missing:
  ```
  https://yoa.st/33i
  ```

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes #
