### PR TITLE
Rename MyYoast_API_Request_Factory to MyYoast_Api_Request_Factory

### DIFF
--- a/src/services/health-check/curl-runner.php
+++ b/src/services/health-check/curl-runner.php
@@ -58,7 +58,7 @@ class Curl_Runner implements Runner_Interface {
 	/**
 	 * Factory for the MyYoast API request object that the health check uses to check if cURL works correctly.
 	 *
-	 * @var MyYoast_API_Request_Factory
+	 * @var MyYoast_Api_Request_Factory
 	 */
 	private $my_yoast_api_request_factory;
 

--- a/src/services/health-check/myyoast-api-request-factory.php
+++ b/src/services/health-check/myyoast-api-request-factory.php
@@ -8,7 +8,7 @@ use WPSEO_MyYoast_Api_Request;
 /**
  * Creates WPSEO_MyYoast_Api_Request objects.
  */
-class MyYoast_API_Request_Factory {
+class MyYoast_Api_Request_Factory {
 
 	/**
 	 * Creates a new WPSEO_MyYoast_API_Request.

--- a/tests/unit/services/health-check/curl-runner-test.php
+++ b/tests/unit/services/health-check/curl-runner-test.php
@@ -7,7 +7,7 @@ use Mockery;
 use WPSEO_Addon_Manager;
 use WPSEO_MyYoast_Api_Request;
 use Yoast\WP\SEO\Helpers\Curl_Helper;
-use Yoast\WP\SEO\Services\Health_Check\MyYoast_API_Request_Factory;
+use Yoast\WP\SEO\Services\Health_Check\MyYoast_Api_Request_Factory;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 use Yoast\WP\SEO\Services\Health_Check\Curl_Runner;
 
@@ -49,7 +49,7 @@ class Curl_Runner_Test extends TestCase {
 	/**
 	 * A mocked MyYoast API request factory that returns a mocked MyYoast API request.
 	 *
-	 * @var MyYoast_API_Request_Factory
+	 * @var MyYoast_Api_Request_Factory
 	 */
 	private $my_yoast_api_request_factory_mock;
 
@@ -62,7 +62,7 @@ class Curl_Runner_Test extends TestCase {
 		$this->my_yoast_api_mock                 = Mockery::mock( WPSEO_MyYoast_Api_Request::class );
 		$this->addon_manager_mock                = Mockery::mock( WPSEO_Addon_Manager::class );
 		$this->curl_helper_mock                  = Mockery::mock( Curl_Helper::class );
-		$this->my_yoast_api_request_factory_mock = Mockery::mock( MyYoast_API_Request_Factory::class );
+		$this->my_yoast_api_request_factory_mock = Mockery::mock( MyYoast_Api_Request_Factory::class );
 
 		// Incorrectly detects direct calls to cURL.
 		// phpcs:ignore WordPress.WP.AlternativeFunctions -- Reason: Incorrectly detects direct calls to cURL.

--- a/tests/unit/services/health-check/myyoast-api-request-factory-test.php
+++ b/tests/unit/services/health-check/myyoast-api-request-factory-test.php
@@ -3,22 +3,22 @@
 namespace Yoast\WP\SEO\Tests\Unit\Services\Health_Check;
 
 use WPSEO_MyYoast_Api_Request;
-use Yoast\WP\SEO\Services\Health_Check\MyYoast_API_Request_Factory;
+use Yoast\WP\SEO\Services\Health_Check\MyYoast_Api_Request_Factory;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
-// phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
-
 /**
- * MyYoast_API_Request_Factory
+ * MyYoast_Api_Request_Factory_Test
  *
- * @coversDefaultClass Yoast\WP\SEO\Services\Health_Check\MyYoast_API_Request_Factory
+ * @coversDefaultClass \Yoast\WP\SEO\Services\Health_Check\MyYoast_Api_Request_Factory
+ *
+ * phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
-class MyYoast_API_Request_Factory_Test extends TestCase {
+class MyYoast_Api_Request_Factory_Test extends TestCase {
 
 	/**
-	 * The MyYoast_API_Request_Factory instance to be tested.
+	 * The MyYoast_Api_Request_Factory instance to be tested.
 	 *
-	 * @var MyYoast_API_Request_Factory
+	 * @var MyYoast_Api_Request_Factory
 	 */
 	private $instance;
 
@@ -29,7 +29,7 @@ class MyYoast_API_Request_Factory_Test extends TestCase {
 	 */
 	protected function set_up() {
 		parent::set_up();
-		$this->instance = new MyYoast_API_Request_Factory();
+		$this->instance = new MyYoast_Api_Request_Factory();
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* This prevents a deprecation warning of Symfony that mentions case sensitive services coming up.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased deprecation warning trigger by renaming `MyYoast_API_Request_Factory` to `MyYoast_Api_Request_Factory` (as well as the test), notice the capitalization of `API`.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Have a development build of this PR (or `release/18.5` branch after merge)
* Ensure you have Query Monitor active
* Go to the plugins page
* Deactivate Yoast SEO
* Activate Yoast SEO
* Notice the following PHP Error in Query Monitor is no longer present:
```
Service identifiers will be made case sensitive in Symfony 4.0. Using "Yoast\WP\SEO\Services\Health_Check\MyYoast_Api_Request_Factory" instead of "Yoast\WP\SEO\Services\Health_Check\MyYoast_API_Request_Factory" is deprecated since Symfony 3.3.
```

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Not sure if you have access to a dev build. If you can, follow the steps, otherwise ignore? 😇 

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes https://yoast.atlassian.net/browse/P1-1333
