### PR TITLE
Create JSON decode/encode + sanitize text field validator

### DIFF
--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -705,38 +705,6 @@ class WPSEO_Utils {
 	}
 
 	/**
-	 * Determine if Yoast SEO is in development mode?
-	 *
-	 * Inspired by JetPack (https://github.com/Automattic/jetpack/blob/master/class.jetpack.php#L1383-L1406).
-	 *
-	 * @since 3.0.0
-	 *
-	 * @return bool
-	 */
-	public static function is_development_mode() {
-		$development_mode = false;
-
-		if ( defined( 'YOAST_ENVIRONMENT' ) && YOAST_ENVIRONMENT === 'development' ) {
-			$development_mode = true;
-		}
-		elseif ( defined( 'WPSEO_DEBUG' ) ) {
-			$development_mode = WPSEO_DEBUG;
-		}
-		elseif ( site_url() && strpos( site_url(), '.' ) === false ) {
-			$development_mode = true;
-		}
-
-		/**
-		 * Filter the Yoast SEO development mode.
-		 *
-		 * @since 3.0
-		 *
-		 * @param bool $development_mode Is Yoast SEOs development mode active.
-		 */
-		return apply_filters( 'yoast_seo_development_mode', $development_mode );
-	}
-
-	/**
 	 * Retrieve home URL with proper trailing slash.
 	 *
 	 * @since 3.3.0
@@ -947,21 +915,7 @@ class WPSEO_Utils {
 	 * @return false|string The prepared JSON string.
 	 */
 	public static function format_json_encode( $data ) {
-		$flags = ( JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
-
-		if ( self::is_development_mode() ) {
-			$flags = ( $flags | JSON_PRETTY_PRINT );
-
-			/**
-			 * Filter the Yoast SEO development mode.
-			 *
-			 * @api array $data Allows filtering of the JSON data for debug purposes.
-			 */
-			$data = apply_filters( 'wpseo_debug_json_data', $data );
-		}
-
-		// phpcs:ignore Yoast.Yoast.AlternativeFunctions.json_encode_wp_json_encodeWithAdditionalParams -- This is the definition of format_json_encode.
-		return wp_json_encode( $data, $flags );
+		return YoastSEO()->helpers->json->format_encode( $data );
 	}
 
 	/**
@@ -1416,5 +1370,20 @@ SVG;
 		}
 
 		return is_super_admin();
+	}
+
+	/**
+	 * Determine if Yoast SEO is in development mode?
+	 *
+	 * Inspired by JetPack (https://github.com/Automattic/jetpack/blob/master/class.jetpack.php#L1383-L1406).
+	 *
+	 * @since 3.0.0
+	 *
+	 * @return bool
+	 */
+	public static function is_development_mode() {
+		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'YoastSEO()->helpers->environment->is_yoast_seo_in_development_mode' );
+
+		return YoastSEO()->helpers->environment->is_yoast_seo_in_development_mode();
 	}
 }

--- a/lib/abstract-main.php
+++ b/lib/abstract-main.php
@@ -104,17 +104,17 @@ abstract class Abstract_Main {
 	abstract protected function get_surfaces();
 
 	/**
-	 * Returns whether or not we're in an environment for Yoast development.
+	 * Returns whether we're in an environment for Yoast development.
 	 *
-	 * @return bool Whether or not to load in development mode.
+	 * @return bool Whether to load in development mode.
 	 */
 	protected function is_development() {
-		try {
-			return \WPSEO_Utils::is_development_mode();
+		if ( \defined( 'YOAST_ENVIRONMENT' ) && \YOAST_ENVIRONMENT === 'development' ) {
+			return true;
 		}
-		catch ( \Exception $exception ) {
-			// E.g. when WordPress and/or WordPress SEO are not loaded.
-			return \defined( 'YOAST_ENVIRONMENT' ) && \YOAST_ENVIRONMENT === 'development';
+		elseif ( \defined( 'WPSEO_DEBUG' ) ) {
+			return \WPSEO_DEBUG;
 		}
+		return false;
 	}
 }

--- a/src/builders/indexable-social-image-trait.php
+++ b/src/builders/indexable-social-image-trait.php
@@ -2,8 +2,8 @@
 
 namespace Yoast\WP\SEO\Builders;
 
-use WPSEO_Utils;
 use Yoast\WP\SEO\Helpers\Image_Helper;
+use Yoast\WP\SEO\Helpers\Json_Helper;
 use Yoast\WP\SEO\Helpers\Open_Graph\Image_Helper as Open_Graph_Image_Helper;
 use Yoast\WP\SEO\Helpers\Twitter\Image_Helper as Twitter_Image_Helper;
 use Yoast\WP\SEO\Models\Indexable;
@@ -39,6 +39,13 @@ trait Indexable_Social_Image_Trait {
 	protected $twitter_image;
 
 	/**
+	 * Holds the JSON helper instance.
+	 *
+	 * @var Json_Helper
+	 */
+	protected $json_helper;
+
+	/**
 	 * Sets the helpers for the trait.
 	 *
 	 * @required
@@ -46,15 +53,18 @@ trait Indexable_Social_Image_Trait {
 	 * @param Image_Helper            $image            The image helper.
 	 * @param Open_Graph_Image_Helper $open_graph_image The Open Graph image helper.
 	 * @param Twitter_Image_Helper    $twitter_image    The Twitter image helper.
+	 * @param Json_Helper             $json_helper      The JSON helper.
 	 */
 	public function set_social_image_helpers(
 		Image_Helper $image,
 		Open_Graph_Image_Helper $open_graph_image,
-		Twitter_Image_Helper $twitter_image
+		Twitter_Image_Helper $twitter_image,
+		Json_Helper $json_helper
 	) {
 		$this->image            = $image;
 		$this->open_graph_image = $open_graph_image;
 		$this->twitter_image    = $twitter_image;
+		$this->json_helper      = $json_helper;
 	}
 
 	/**
@@ -106,7 +116,7 @@ trait Indexable_Social_Image_Trait {
 
 		if ( ! empty( $image ) ) {
 			$indexable->open_graph_image      = $image['url'];
-			$indexable->open_graph_image_meta = WPSEO_Utils::format_json_encode( $image );
+			$indexable->open_graph_image_meta = $this->json_helper->format_encode( $image );
 		}
 	}
 

--- a/src/conditionals/development-conditional.php
+++ b/src/conditionals/development-conditional.php
@@ -2,7 +2,7 @@
 
 namespace Yoast\WP\SEO\Conditionals;
 
-use WPSEO_Utils;
+use Yoast\WP\SEO\Helpers\Environment_Helper;
 
 /**
  * Conditional that is only met when in development mode.
@@ -10,11 +10,27 @@ use WPSEO_Utils;
 class Development_Conditional implements Conditional {
 
 	/**
+	 * Holds the environment helper instance.
+	 *
+	 * @var Environment_Helper
+	 */
+	protected $environment_helper;
+
+	/**
+	 * Constructs the development conditional instance.
+	 *
+	 * @param Environment_Helper $environment_helper The environment helper.
+	 */
+	public function __construct( Environment_Helper $environment_helper ) {
+		$this->environment_helper = $environment_helper;
+	}
+
+	/**
 	 * Returns whether or not this conditional is met.
 	 *
 	 * @return bool Whether or not the conditional is met.
 	 */
 	public function is_met() {
-		return WPSEO_Utils::is_development_mode();
+		return $this->environment_helper->is_yoast_seo_in_development_mode();
 	}
 }

--- a/src/exceptions/validation/invalid-json-exception.php
+++ b/src/exceptions/validation/invalid-json-exception.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Yoast\WP\SEO\Exceptions\Validation;
+
+/**
+ * Invalid JSON validation exception class.
+ */
+class Invalid_Json_Exception extends Abstract_Validation_Exception {
+
+	/**
+	 * Constructs an invalid JSON validation exception instance.
+	 */
+	public function __construct() {
+		parent::__construct( \esc_html__( 'Invalid JSON.', 'wordpress-seo' ) );
+	}
+}

--- a/src/exceptions/validation/not-in-array-exception.php
+++ b/src/exceptions/validation/not-in-array-exception.php
@@ -2,8 +2,6 @@
 
 namespace Yoast\WP\SEO\Exceptions\Validation;
 
-use WPSEO_Utils;
-
 /**
  * Not in array validation exception class.
  *
@@ -21,7 +19,7 @@ class Not_In_Array_Exception extends Abstract_Validation_Exception {
 			\sprintf(
 			/* translators: %s expands to a list of values that are allowed. */
 				\esc_html__( 'Please change the value to be one of: %s.', 'wordpress-seo' ),
-				'<strong>' . \esc_html( WPSEO_Utils::format_json_encode( $allow ) ) . '</strong>'
+				'<strong>' . \esc_html( \YoastSEO()->helpers->json->format_encode( $allow ) ) . '</strong>'
 			)
 		);
 	}

--- a/src/helpers/environment-helper.php
+++ b/src/helpers/environment-helper.php
@@ -24,4 +24,32 @@ class Environment_Helper {
 	public function get_wp_environment() {
 		return \wp_get_environment_type();
 	}
+
+	/**
+	 * Determines if Yoast SEO is in development mode.
+	 *
+	 * Inspired by JetPack (https://github.com/Automattic/jetpack/blob/master/class.jetpack.php#L1383-L1406).
+	 *
+	 * @return bool Whether Yoast SEO is in development mode.
+	 */
+	public function is_yoast_seo_in_development_mode() {
+		$development_mode = false;
+
+		if ( \defined( 'YOAST_ENVIRONMENT' ) && \YOAST_ENVIRONMENT === 'development' ) {
+			$development_mode = true;
+		}
+		elseif ( \defined( 'WPSEO_DEBUG' ) ) {
+			$development_mode = \WPSEO_DEBUG;
+		}
+		elseif ( \site_url() && \strpos( \site_url(), '.' ) === false ) {
+			$development_mode = true;
+		}
+
+		/**
+		 * Filter: 'yoast_seo_development_mode' - Allows changing the Yoast SEO development mode.
+		 *
+		 * @param bool $development_mode Whether Yoast SEOs development mode is active.
+		 */
+		return \apply_filters( 'yoast_seo_development_mode', $development_mode );
+	}
 }

--- a/src/helpers/json-helper.php
+++ b/src/helpers/json-helper.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Yoast\WP\SEO\Helpers;
+
+/**
+ * A helper object for JSON operations.
+ */
+class Json_Helper {
+
+	/**
+	 * Holds the environment helper instance.
+	 *
+	 * @var Environment_Helper
+	 */
+	protected $environment_helper;
+
+	/**
+	 * Constructs a JSON helper instance.
+	 *
+	 * @param Environment_Helper $environment_helper The environment helper.
+	 */
+	public function __construct( Environment_Helper $environment_helper ) {
+		$this->environment_helper = $environment_helper;
+	}
+
+	/**
+	 * Prepares data for outputting as JSON.
+	 *
+	 * @param array $data The data to format.
+	 *
+	 * @return false|string The prepared JSON string.
+	 */
+	public function format_encode( $data ) {
+		$flags = ( JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
+
+		if ( $this->environment_helper->is_yoast_seo_in_development_mode() ) {
+			$flags |= JSON_PRETTY_PRINT;
+
+			/**
+			 * Allows filtering of the JSON data for debug purposes.
+			 *
+			 * @api array $data Allows filtering of the JSON data for debug purposes.
+			 */
+			$data = \apply_filters( 'wpseo_debug_json_data', $data );
+		}
+
+		// phpcs:ignore Yoast.Yoast.AlternativeFunctions.json_encode_wp_json_encodeWithAdditionalParams -- This is the definition of format_json_encode.
+		return \wp_json_encode( $data, $flags );
+	}
+}

--- a/src/integrations/admin/configuration-workout-integration.php
+++ b/src/integrations/admin/configuration-workout-integration.php
@@ -5,8 +5,8 @@ namespace Yoast\WP\SEO\Integrations\Admin;
 use WPSEO_Addon_Manager;
 use WPSEO_Admin_Asset_Manager;
 use WPSEO_Shortlinker;
-use WPSEO_Utils;
 use Yoast\WP\SEO\Conditionals\Admin_Conditional;
+use Yoast\WP\SEO\Helpers\Json_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Product_Helper;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
@@ -53,6 +53,13 @@ class Configuration_Workout_Integration implements Integration_Interface {
 	private $product_helper;
 
 	/**
+	 * The json helper.
+	 *
+	 * @var Json_Helper
+	 */
+	private $json_helper;
+
+	/**
 	 * {@inheritDoc}
 	 */
 	public static function get_conditionals() {
@@ -67,19 +74,22 @@ class Configuration_Workout_Integration implements Integration_Interface {
 	 * @param WPSEO_Shortlinker         $shortlinker         The shortlinker.
 	 * @param Options_Helper            $options_helper      The options helper.
 	 * @param Product_Helper            $product_helper      The product helper.
+	 * @param Json_Helper               $json_helper         The JSON helper.
 	 */
 	public function __construct(
 		WPSEO_Admin_Asset_Manager $admin_asset_manager,
 		WPSEO_Addon_Manager $addon_manager,
 		WPSEO_Shortlinker $shortlinker,
 		Options_Helper $options_helper,
-		Product_Helper $product_helper
+		Product_Helper $product_helper,
+		Json_Helper $json_helper
 	) {
 		$this->admin_asset_manager = $admin_asset_manager;
 		$this->addon_manager       = $addon_manager;
 		$this->shortlinker         = $shortlinker;
 		$this->options_helper      = $options_helper;
 		$this->product_helper      = $product_helper;
+		$this->json_helper         = $json_helper;
 	}
 
 	/**
@@ -192,7 +202,7 @@ class Configuration_Workout_Integration implements Integration_Interface {
 				$social_profiles['youtube_url'],
 				$social_profiles['wikipedia_url'],
 				$this->has_tracking_enabled(),
-				WPSEO_Utils::format_json_encode( $options ),
+				$this->json_helper->format_encode( $options ),
 				$this->should_force_company(),
 				$knowledge_graph_message,
 				$this->shortlinker->build_shortlink( 'https://yoa.st/config-workout-guide' ),

--- a/src/presenters/schema-presenter.php
+++ b/src/presenters/schema-presenter.php
@@ -2,8 +2,6 @@
 
 namespace Yoast\WP\SEO\Presenters;
 
-use WPSEO_Utils;
-
 /**
  * Presenter class for the schema object.
  */
@@ -43,8 +41,9 @@ class Schema_Presenter extends Abstract_Indexable_Presenter {
 
 		$schema = $this->get();
 		if ( \is_array( $schema ) ) {
-			$output = WPSEO_Utils::format_json_encode( $schema );
+			$output = \YoastSEO()->helpers->json->format_encode( $schema );
 			$output = \str_replace( "\n", \PHP_EOL . "\t", $output );
+
 			return '<script type="application/ld+json" class="yoast-schema-graph">' . $output . '</script>';
 		}
 

--- a/src/schema-templates/recipe.block.php
+++ b/src/schema-templates/recipe.block.php
@@ -31,10 +31,10 @@ $yoast_seo_recommended_blocks = [
 	[ 'name' => 'yoast/recipe-description' ],
 ];
 
-// phpcs:disable WordPress.Security.EscapeOutput -- Reason: WPSEO_Utils::format_json_encode is safe.
+// phpcs:disable WordPress.Security.EscapeOutput -- Reason: YoastSEO()->helpers->json->format_encode is safe.
 ?>
 {{block name="yoast/recipe" title="<?php echo esc_attr( $yoast_seo_block_title ); ?>" category="yoast-structured-data-blocks" keywords=[ "SEO", "Schema"] description="<?php esc_attr_e( 'Create a Recipe in an SEO-friendly way. You can only use one Recipe block per post.', 'wordpress-seo' ); ?>" supports={"multiple": false} }}
 {{sidebar-input name="yield" output=false type="number" label="<?php esc_attr_e( 'Serves #', 'wordpress-seo' ); ?>" }}
 <div class={{class-name}}>
-	{{inner-blocks template=<?php echo WPSEO_Utils::format_json_encode( $yoast_seo_block_template ); ?> required-blocks=<?php echo WPSEO_Utils::format_json_encode( $yoast_seo_required_blocks ); ?> recommended-blocks=<?php echo WPSEO_Utils::format_json_encode( $yoast_seo_recommended_blocks ); ?> appender="button" appenderLabel="<?php esc_attr_e( 'Add a block to your recipe...', 'wordpress-seo' ); ?>" }}
+	{{inner-blocks template=<?php echo YoastSEO()->helpers->json->format_encode( $yoast_seo_block_template ); ?> required-blocks=<?php echo YoastSEO()->helpers->json->format_encode( $yoast_seo_required_blocks ); ?> recommended-blocks=<?php echo YoastSEO()->helpers->json->format_encode( $yoast_seo_recommended_blocks ); ?> appender="button" appenderLabel="<?php esc_attr_e( 'Add a block to your recipe...', 'wordpress-seo' ); ?>" }}
 </div>

--- a/src/services/health-check/ryte-runner.php
+++ b/src/services/health-check/ryte-runner.php
@@ -3,7 +3,7 @@
 namespace Yoast\WP\SEO\Services\Health_Check;
 
 use WPSEO_Ryte_Option;
-use WPSEO_Utils;
+use Yoast\WP\SEO\Helpers\Environment_Helper;
 use Yoast\WP\SEO\Integrations\Admin\Ryte_Integration;
 
 /**
@@ -40,24 +40,26 @@ class Ryte_Runner implements Runner_Interface {
 	private $ryte_option;
 
 	/**
-	 * The WPSEO_Utils class used to determine whether the site is in development mode.
+	 * The environment helper class used to determine whether the site is in development mode.
 	 *
-	 * @var WPSEO_Utils
+	 * @var Environment_Helper
 	 */
-	private $utils;
+	private $environment_helper;
 
 	/**
 	 * Constructor.
 	 *
-	 * @param Ryte_Integration $ryte The Ryte_Integration object that the health check uses to check indexability.
-	 * @param WPSEO_Utils      $utils The WPSEO_Utils object used to determine whether the site is in development mode.
+	 * @param Ryte_Integration   $ryte               The Ryte_Integration object that the health check uses to check
+	 *                                               indexability.
+	 * @param Environment_Helper $environment_helper The Environment_Helper used to determine whether Yoast SEO is in
+	 *                                               development mode.
 	 */
 	public function __construct(
 		Ryte_Integration $ryte,
-		WPSEO_Utils $utils
+		Environment_Helper $environment_helper
 	) {
 		$this->ryte               = $ryte;
-		$this->utils              = $utils;
+		$this->environment_helper = $environment_helper;
 		$this->got_valid_response = false;
 		$this->ryte_option        = $ryte->get_option();
 	}
@@ -93,6 +95,7 @@ class Ryte_Runner implements Runner_Interface {
 		if ( is_array( $response ) && isset( $response['is_error'] ) ) {
 			$this->got_valid_response = false;
 			$this->response_error     = $response;
+
 			return;
 		}
 
@@ -118,7 +121,7 @@ class Ryte_Runner implements Runner_Interface {
 			return false;
 		}
 
-		if ( wp_debug_mode() || $this->utils->is_development_mode() ) {
+		if ( wp_debug_mode() || $this->environment_helper->is_yoast_seo_in_development_mode() ) {
 			return false;
 		}
 
@@ -156,7 +159,8 @@ class Ryte_Runner implements Runner_Interface {
 	/**
 	 * Checks if the site's indexability is unknown.
 	 *
-	 * @return bool Returns true if the site indexability is unknown even though getting a response from Ryte was successful.
+	 * @return bool Returns true if the site indexability is unknown even though getting a response from Ryte was
+	 *              successful.
 	 */
 	public function has_unknown_indexability() {
 		if ( ! $this->could_fetch() ) {

--- a/src/validators/json-text-fields-validator.php
+++ b/src/validators/json-text-fields-validator.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Yoast\WP\SEO\Validators;
+
+use Yoast\WP\SEO\Exceptions\Validation\Invalid_Json_Exception;
+use Yoast\WP\SEO\Exceptions\Validation\Invalid_Type_Exception;
+use Yoast\WP\SEO\Helpers\Json_Helper;
+
+/**
+ * The JSON text fields validator class.
+ *
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded -- Validator is not part of the name.
+ */
+class Json_Text_Fields_Validator extends String_Validator {
+
+	/**
+	 * Holds the regex validator instance.
+	 *
+	 * @var Text_Field_Validator
+	 */
+	protected $text_field_validator;
+
+	/**
+	 * Holds the array validator instance.
+	 *
+	 * @var Array_Validator
+	 */
+	protected $array_validator;
+
+	/**
+	 * Holds the JSON helper instance.
+	 *
+	 * @var Json_Helper
+	 */
+	protected $json_helper;
+
+	/**
+	 * Constructs a JSON text fields validator instance.
+	 *
+	 * @param Text_Field_Validator $text_field_validator The regex validator.
+	 * @param Array_Validator      $array_validator      The array validator.
+	 * @param Json_Helper          $json_helper          The JSON helper.
+	 */
+	public function __construct( Text_Field_Validator $text_field_validator, Array_Validator $array_validator, Json_Helper $json_helper ) {
+		$this->text_field_validator = $text_field_validator;
+		$this->array_validator      = $array_validator;
+		$this->json_helper          = $json_helper;
+	}
+
+	// phpcs:disable Squiz.Commenting.FunctionCommentThrowTag.WrongNumber -- Reason: The string, array and text field validates can throw too.
+
+	/**
+	 * Validates if a value is stringified JSON and the values as text fields.
+	 *
+	 * @param mixed      $value    The value to validate.
+	 * @param array|null $settings Optional settings.
+	 *
+	 * @throws Invalid_Type_Exception When the type of the value is not a string or the type of the decoded string is
+	 *                                not an array.
+	 * @throws Invalid_Json_Exception When an error occurred during decoding or encoding of JSON.
+	 *
+	 * @return string A valid stringified JSON containing text fields.
+	 */
+	public function validate( $value, array $settings = null ) {
+		$string = parent::validate( $value, $settings );
+
+		$decoded = \json_decode( $string, true );
+		if ( \json_last_error() !== \JSON_ERROR_NONE ) {
+			throw new Invalid_Json_Exception();
+		}
+
+		$array = $this->array_validator->validate( $decoded );
+
+		$sanitized = [];
+		foreach ( $array as $key => $value ) {
+			$sanitized[ $this->text_field_validator->validate( $key ) ] = $this->text_field_validator->validate( $value );
+		}
+
+		$json = $this->json_helper->format_encode( $sanitized );
+		if ( ! $json ) {
+			throw new Invalid_Json_Exception();
+		}
+
+		return $json;
+	}
+
+	// phpcs:enable Squiz.Commenting.FunctionCommentThrowTag.WrongNumber
+}

--- a/src/validators/json-text-fields-validator.php
+++ b/src/validators/json-text-fields-validator.php
@@ -100,7 +100,7 @@ class Json_Text_Fields_Validator extends String_Validator {
 	 * Checks if a key is allowed.
 	 *
 	 * The settings can have an allow-list. If that exists, the key should be present there to be allowed. Otherwise,
-	 * the key is allowed.
+	 * the key is disallowed.
 	 *
 	 * @param mixed      $key      The key to check.
 	 * @param array|null $settings Optional settings.

--- a/src/validators/json-text-fields-validator.php
+++ b/src/validators/json-text-fields-validator.php
@@ -14,6 +14,13 @@ use Yoast\WP\SEO\Helpers\Json_Helper;
 class Json_Text_Fields_Validator extends String_Validator {
 
 	/**
+	 * The setting' allow-list key.
+	 *
+	 * @var string
+	 */
+	const ALLOW_KEY = 'allow';
+
+	/**
 	 * Holds the regex validator instance.
 	 *
 	 * @var Text_Field_Validator
@@ -73,7 +80,10 @@ class Json_Text_Fields_Validator extends String_Validator {
 
 		$sanitized = [];
 		foreach ( $array as $key => $value ) {
-			$sanitized[ $this->text_field_validator->validate( $key ) ] = $this->text_field_validator->validate( $value );
+			$sanitized_key = $this->text_field_validator->validate( $key );
+			if ( $this->is_key_allowed( $sanitized_key, $settings ) ) {
+				$sanitized[ $sanitized_key ] = $this->text_field_validator->validate( $value );
+			}
 		}
 
 		$json = $this->json_helper->format_encode( $sanitized );
@@ -85,4 +95,23 @@ class Json_Text_Fields_Validator extends String_Validator {
 	}
 
 	// phpcs:enable Squiz.Commenting.FunctionCommentThrowTag.WrongNumber
+
+	/**
+	 * Checks if a key is allowed.
+	 *
+	 * The settings can have an allow-list. If that exists, the key should be present there to be allowed. Otherwise,
+	 * the key is allowed.
+	 *
+	 * @param mixed      $key      The key to check.
+	 * @param array|null $settings Optional settings.
+	 *
+	 * @return bool Whether the key is allowed.
+	 */
+	protected function is_key_allowed( $key, $settings ) {
+		if ( $settings !== null && \array_key_exists( self::ALLOW_KEY, $settings ) ) {
+			return \in_array( $key, $settings[ self::ALLOW_KEY ], true );
+		}
+
+		return true;
+	}
 }

--- a/tests/unit/config/wincher-client-test.php
+++ b/tests/unit/config/wincher-client-test.php
@@ -7,6 +7,7 @@ use Mockery\LegacyMockInterface;
 use Mockery\MockInterface;
 use Yoast\WP\SEO\Config\Wincher_Client;
 use Yoast\WP\SEO\Config\Wincher_PKCE_Provider;
+use Yoast\WP\SEO\Helpers\Json_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 use Yoast\WP\SEO\Wrappers\WP_Remote_Handler;
@@ -21,11 +22,18 @@ use Yoast\WP\SEO\Wrappers\WP_Remote_Handler;
 class Wincher_Client_Test extends TestCase {
 
 	/**
-	 * The optins helper.
+	 * Holds the options helper instance.
 	 *
 	 * @var LegacyMockInterface|MockInterface|Options_Helper
 	 */
 	protected $options_helper;
+
+	/**
+	 * Holds the JSON helper instance.
+	 *
+	 * @var LegacyMockInterface|MockInterface|Json_Helper
+	 */
+	protected $json_helper;
 
 	/**
 	 * The test instance.
@@ -48,6 +56,7 @@ class Wincher_Client_Test extends TestCase {
 		parent::set_up();
 
 		$this->options_helper = Mockery::mock( Options_Helper::class );
+		$this->json_helper    = Mockery::mock( Json_Helper::class );
 	}
 
 	/**
@@ -73,6 +82,7 @@ class Wincher_Client_Test extends TestCase {
 			Wincher_Client::class,
 			[
 				$this->options_helper,
+				$this->json_helper,
 				Mockery::mock( WP_Remote_Handler::class ),
 			]
 		)->makePartial();
@@ -85,6 +95,11 @@ class Wincher_Client_Test extends TestCase {
 		$this->assertInstanceOf(
 			Options_Helper::class,
 			$this->getPropertyValue( $instance, 'options_helper' )
+		);
+
+		$this->assertInstanceOf(
+			Json_Helper::class,
+			$this->getPropertyValue( $instance, 'json_helper' )
 		);
 	}
 }

--- a/tests/unit/generators/open-graph-image-generator-test.php
+++ b/tests/unit/generators/open-graph-image-generator-test.php
@@ -5,7 +5,6 @@ namespace Yoast\WP\SEO\Tests\Unit\Generators;
 use Brain\Monkey;
 use Error;
 use Mockery;
-use WPSEO_Utils;
 use Yoast\WP\SEO\Generators\Open_Graph_Image_Generator;
 use Yoast\WP\SEO\Helpers\Image_Helper;
 use Yoast\WP\SEO\Helpers\Open_Graph\Image_Helper as Open_Graph_Image_Helper;
@@ -125,7 +124,8 @@ class Open_Graph_Image_Generator_Test extends TestCase {
 	}
 
 	/**
-	 * Tests the open_graph_image_id set for an indexable where the `wpseo_add_opengraph_images_filter` filter throws an error.
+	 * Tests the open_graph_image_id set for an indexable where the `wpseo_add_opengraph_images_filter` filter throws
+	 * an error.
 	 *
 	 * @covers ::generate
 	 * @covers ::add_from_indexable
@@ -148,7 +148,8 @@ class Open_Graph_Image_Generator_Test extends TestCase {
 	}
 
 	/**
-	 * Tests the open_graph_image_id set for an indexable where the `wpseo_add_opengraph_additional_images` filter throws an error.
+	 * Tests the open_graph_image_id set for an indexable where the `wpseo_add_opengraph_additional_images` filter
+	 * throws an error.
 	 *
 	 * @covers ::generate
 	 * @covers ::add_from_indexable
@@ -218,13 +219,11 @@ class Open_Graph_Image_Generator_Test extends TestCase {
 	 */
 	public function test_generate_with_image_url_from_indexable_with_open_graph_image_meta() {
 		$this->indexable->open_graph_image      = 'image.jpg';
-		$this->indexable->open_graph_image_meta = WPSEO_Utils::format_json_encode(
-			[
-				'height' => 1024,
-				'width'  => 2048,
-				'url'    => 'image.jpg',
-			]
-		);
+		$this->indexable->open_graph_image_meta = [
+			'height' => 1024,
+			'width'  => 2048,
+			'url'    => 'image.jpg',
+		];
 
 		$this->instance->expects( 'add_from_templates' )->andReturnNull();
 		$this->instance->expects( 'add_from_default' )->andReturnNull();

--- a/tests/unit/inc/addon-manager-test.php
+++ b/tests/unit/inc/addon-manager-test.php
@@ -5,7 +5,6 @@ namespace Yoast\WP\SEO\Tests\Unit\Inc;
 use Brain\Monkey;
 use Mockery;
 use stdClass;
-use WPSEO_Utils;
 use Yoast\WP\SEO\Helpers\Product_Helper;
 use Yoast\WP\SEO\Tests\Unit\Doubles\Inc\Addon_Manager_Double;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
@@ -503,7 +502,10 @@ class Addon_Manager_Test extends TestCase {
 			$product_helper_mock = Mockery::mock( Product_Helper::class );
 			$product_helper_mock->shouldReceive( 'is_premium' )->atMost()->times( 2 )->andReturn( false );
 			$helpers_mock = (object) [ 'product' => $product_helper_mock ];
-			Monkey\Functions\expect( 'YoastSEO' )->atMost()->times( 2 )->andReturn( (object) [ 'helpers' => $helpers_mock ] );
+			Monkey\Functions\expect( 'YoastSEO' )
+				->atMost()
+				->times( 2 )
+				->andReturn( (object) [ 'helpers' => $helpers_mock ] );
 		}
 
 		Monkey\Functions\expect( 'get_plugin_updates' )
@@ -896,37 +898,32 @@ class Addon_Manager_Test extends TestCase {
 	 * @return stdClass Subscriptions.
 	 */
 	protected function get_subscriptions() {
-		return \json_decode(
-			WPSEO_Utils::format_json_encode(
-				[
-					'wp-seo-premium.php' => [
-						'expiry_date' => $this->get_future_date(),
-						'product'     => [
-							'version'      => '10.0',
-							'name'         => 'Extension',
-							'slug'         => 'yoast-seo-wordpress-premium',
-							'last_updated' => 'yesterday',
-							'store_url'    => 'https://example.org/store',
-							'download'     => 'https://example.org/extension.zip',
-							'changelog'    => 'changelog',
-						],
-					],
-					'wpseo-news.php'     => [
-						'expiry_date' => $this->get_past_date(),
-						'product'     => [
-							'version'      => '10.0',
-							'name'         => 'Extension',
-							'slug'         => 'yoast-seo-news',
-							'last_updated' => 'yesterday',
-							'store_url'    => 'https://example.org/store',
-							'download'     => 'https://example.org/extension.zip',
-							'changelog'    => 'changelog',
-						],
-					],
-				]
-			),
-			false
-		);
+		return (object) [
+			'wp-seo-premium.php' => (object) [
+				'expiry_date' => $this->get_future_date(),
+				'product'     => (object) [
+					'version'      => '10.0',
+					'name'         => 'Extension',
+					'slug'         => 'yoast-seo-wordpress-premium',
+					'last_updated' => 'yesterday',
+					'store_url'    => 'https://example.org/store',
+					'download'     => 'https://example.org/extension.zip',
+					'changelog'    => 'changelog',
+				],
+			],
+			'wpseo-news.php'     => (object) [
+				'expiry_date' => $this->get_past_date(),
+				'product'     => (object) [
+					'version'      => '10.0',
+					'name'         => 'Extension',
+					'slug'         => 'yoast-seo-news',
+					'last_updated' => 'yesterday',
+					'store_url'    => 'https://example.org/store',
+					'download'     => 'https://example.org/extension.zip',
+					'changelog'    => 'changelog',
+				],
+			],
+		];
 	}
 
 	/**

--- a/tests/unit/services/health-check/ryte-runner-test.php
+++ b/tests/unit/services/health-check/ryte-runner-test.php
@@ -2,14 +2,14 @@
 
 namespace Yoast\WP\SEO\Tests\Unit\Services\Health_Check;
 
+use Brain\Monkey;
 use Mockery;
 use WPSEO_Ryte_Option;
-use WPSEO_Utils;
+use Yoast\WP\SEO\Helpers\Environment_Helper;
 use Yoast\WP\SEO\Integrations\Admin\Ryte_Integration;
 use Yoast\WP\SEO\Services\Health_Check\Ryte_Option_Factory;
 use Yoast\WP\SEO\Services\Health_Check\Ryte_Runner;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
-use Brain\Monkey;
 
 /**
  * Ryte_Runner
@@ -40,11 +40,11 @@ class Ryte_Runner_Test extends TestCase {
 	private $ryte_option_mock;
 
 	/**
-	 * A mock for WPSEO_Utils.
+	 * A mock for Environment_Helper.
 	 *
-	 * @var WPSEO_Utils
+	 * @var Environment_Helper|Mockery\Mock
 	 */
-	private $utils_mock;
+	private $environment_helper;
 
 	/**
 	 * Set up the test fixtures.
@@ -52,13 +52,13 @@ class Ryte_Runner_Test extends TestCase {
 	protected function set_up() {
 		parent::set_up();
 
-		$this->utils_mock       = Mockery::mock( WPSEO_Utils::class );
-		$this->ryte_mock        = Mockery::mock( Ryte_Integration::class );
-		$this->ryte_option_mock = Mockery::mock( WPSEO_Ryte_Option::class );
+		$this->environment_helper = Mockery::mock( Environment_Helper::class );
+		$this->ryte_mock          = Mockery::mock( Ryte_Integration::class );
+		$this->ryte_option_mock   = Mockery::mock( WPSEO_Ryte_Option::class );
 
 		$this->ryte_mock->shouldReceive( 'get_option' )->andReturn( $this->ryte_option_mock );
 
-		$this->instance = new Ryte_Runner( $this->ryte_mock, $this->utils_mock );
+		$this->instance = new Ryte_Runner( $this->ryte_mock, $this->environment_helper );
 	}
 
 	/**
@@ -90,8 +90,8 @@ class Ryte_Runner_Test extends TestCase {
 		Monkey\Functions\expect( 'wp_get_environment_type' )
 			->andReturn( 'production' );
 		Monkey\Functions\expect( 'wp_debug_mode' );
-		$this->utils_mock
-			->shouldReceive( 'is_development_mode' )
+		$this->environment_helper
+			->shouldReceive( 'is_yoast_seo_in_development_mode' )
 			->andReturn( true );
 
 		$this->instance->run();
@@ -111,8 +111,8 @@ class Ryte_Runner_Test extends TestCase {
 		Monkey\Functions\expect( 'wp_get_environment_type' )
 			->andReturn( 'production' );
 		Monkey\Functions\expect( 'wp_debug_mode' );
-		$this->utils_mock
-			->shouldReceive( 'is_development_mode' )
+		$this->environment_helper
+			->shouldReceive( 'is_yoast_seo_in_development_mode' )
 			->andReturn( false );
 		Monkey\Functions\expect( 'get_option' )
 			->with( 'blog_public' )
@@ -135,8 +135,8 @@ class Ryte_Runner_Test extends TestCase {
 		Monkey\Functions\expect( 'wp_get_environment_type' )
 			->andReturn( 'production' );
 		Monkey\Functions\expect( 'wp_debug_mode' );
-		$this->utils_mock
-			->shouldReceive( 'is_development_mode' )
+		$this->environment_helper
+			->shouldReceive( 'is_yoast_seo_in_development_mode' )
 			->andReturn( false );
 		Monkey\Functions\expect( 'get_option' )
 			->with( 'blog_public' )
@@ -201,7 +201,8 @@ class Ryte_Runner_Test extends TestCase {
 	}
 
 	/**
-	 * Checks if the health check has the right state when it wasn't able to fetch the indexability status from Ryte due to an error response.
+	 * Checks if the health check has the right state when it wasn't able to fetch the indexability status from Ryte
+	 * due to an error response.
 	 *
 	 * @return void
 	 * @covers ::__construct
@@ -389,8 +390,8 @@ class Ryte_Runner_Test extends TestCase {
 		Monkey\Functions\expect( 'wp_get_environment_type' )
 			->andReturn( 'production' );
 		Monkey\Functions\expect( 'wp_debug_mode' );
-		$this->utils_mock
-			->shouldReceive( 'is_development_mode' )
+		$this->environment_helper
+			->shouldReceive( 'is_yoast_seo_in_development_mode' )
 			->andReturn( false );
 		Monkey\Functions\expect( 'get_option' )
 			->with( 'blog_public' )

--- a/tests/unit/validators/in-array-validator-test.php
+++ b/tests/unit/validators/in-array-validator-test.php
@@ -2,8 +2,11 @@
 
 namespace Yoast\WP\SEO\Tests\Unit\Validators;
 
+use Brain\Monkey;
+use Mockery;
 use Yoast\WP\SEO\Exceptions\Validation\Missing_Settings_Key_Exception;
 use Yoast\WP\SEO\Exceptions\Validation\Not_In_Array_Exception;
+use Yoast\WP\SEO\Helpers\Json_Helper;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 use Yoast\WP\SEO\Validators\In_Array_Validator;
 
@@ -51,6 +54,7 @@ class In_Array_Validator_Test extends TestCase {
 	 */
 	public function test_validate( $value, $settings, $expected, $exception = '' ) {
 		if ( $exception !== '' ) {
+			$this->mock_json_helper( ( $exception === Not_In_Array_Exception::class ) ? 1 : 0 );
 			$this->expectException( $exception );
 			$this->instance->validate( $value, $settings );
 
@@ -97,13 +101,13 @@ class In_Array_Validator_Test extends TestCase {
 				'exception' => Not_In_Array_Exception::class,
 			],
 
-			'not_allowed'          => [
+			'not_allowed' => [
 				'value'     => 'something',
 				'settings'  => [ 'allow' => [ 'summary', 'summary_large_image' ] ],
 				'expected'  => false,
 				'exception' => Not_In_Array_Exception::class,
 			],
-			'missing_settings'     => [
+			'missing_settings' => [
 				'value'     => 'something',
 				'settings'  => null,
 				'expected'  => false,
@@ -116,5 +120,31 @@ class In_Array_Validator_Test extends TestCase {
 				'exception' => Missing_Settings_Key_Exception::class,
 			],
 		];
+	}
+
+	/**
+	 * Mocks the JSON helper via the YoastSEO API.
+	 *
+	 * @param int $times The amount of times the call is expected.
+	 *
+	 * @return void
+	 */
+	protected function mock_json_helper( $times ) {
+		$json_helper = Mockery::mock( Json_Helper::class );
+
+		$json_helper->expects( 'format_encode' )->times( $times )->andReturnUsing(
+			static function ( $value ) {
+				// phpcs:ignore Yoast.Yoast.AlternativeFunctions.json_encode_json_encodeWithAdditionalParams -- Test code, mocking WP.
+				return \json_encode( $value, ( JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) );
+			}
+		);
+
+		Monkey\Functions\expect( 'YoastSEO' )->times( $times )->andReturn(
+			(object) [
+				'helpers' => (object) [
+					'json' => $json_helper,
+				],
+			]
+		);
 	}
 }

--- a/tests/unit/validators/json-text-fields-validator-test.php
+++ b/tests/unit/validators/json-text-fields-validator-test.php
@@ -1,0 +1,156 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Validators;
+
+use Mockery;
+use Yoast\WP\SEO\Exceptions\Validation\Invalid_Json_Exception;
+use Yoast\WP\SEO\Exceptions\Validation\Invalid_Type_Exception;
+use Yoast\WP\SEO\Helpers\Json_Helper;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+use Yoast\WP\SEO\Validators\Array_Validator;
+use Yoast\WP\SEO\Validators\Json_Text_Fields_Validator;
+use Yoast\WP\SEO\Validators\Text_Field_Validator;
+
+/**
+ * Tests the Json_Text_Fields_Validator class.
+ *
+ * @group options
+ * @group validators
+ * @group test
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Validators\Json_Text_Fields_Validator
+ *
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded -- Validator & Test should not count.
+ */
+class Json_Text_Fields_Validator_Test extends TestCase {
+
+	/**
+	 * Holds the instance to test.
+	 *
+	 * @var Json_Text_Fields_Validator
+	 */
+	protected $instance;
+
+	/**
+	 * Holds the text field validator mock.
+	 *
+	 * @var Text_Field_Validator|Mockery\Mock
+	 */
+	protected $text_field_validator;
+
+	/**
+	 * Holds the array validator mock.
+	 *
+	 * @var Array_Validator|Mockery\Mock
+	 */
+	protected $array_validator;
+
+	/**
+	 * Holds the JSON helper mock.
+	 *
+	 * @var Json_Helper|Mockery\Mock
+	 */
+	protected $json_helper;
+
+	/**
+	 * Sets up the test fixtures.
+	 */
+	protected function set_up() {
+		parent::set_up();
+		$this->stubTranslationFunctions();
+
+		$this->text_field_validator = Mockery::mock( Text_Field_Validator::class );
+		$this->array_validator      = Mockery::mock( Array_Validator::class );
+		$this->json_helper          = Mockery::mock( Json_Helper::class );
+
+		$this->instance = new Json_Text_Fields_Validator( $this->text_field_validator, $this->array_validator, $this->json_helper );
+	}
+
+	/**
+	 * Tests if the needed attributes are set correctly.
+	 *
+	 * @covers ::__construct
+	 */
+	public function test_construct() {
+		$this->assertInstanceOf( Json_Text_Fields_Validator::class, $this->instance );
+		$this->assertInstanceOf(
+			Text_Field_Validator::class,
+			$this->getPropertyValue( $this->instance, 'text_field_validator' )
+		);
+		$this->assertInstanceOf(
+			Array_Validator::class,
+			$this->getPropertyValue( $this->instance, 'array_validator' )
+		);
+		$this->assertInstanceOf(
+			Json_Helper::class,
+			$this->getPropertyValue( $this->instance, 'json_helper' )
+		);
+	}
+
+	/**
+	 * Tests validation, happy path.
+	 *
+	 * @covers ::validate
+	 */
+	public function test_validate() {
+		$json  = '{ "foo": "bar", "baz": "qux" }';
+		$array = \json_decode( $json, true );
+
+		$this->array_validator->expects( 'validate' )->with( $array )->andReturn( $array );
+
+		// Create an expectation for each key and value in the JSON.
+		foreach ( [ 'foo', 'bar', 'baz', 'qux' ] as $entry ) {
+			$this->text_field_validator->expects( 'validate' )->with( $entry )->andReturnArg( 0 );
+		}
+
+		$this->json_helper->expects( 'format_encode' )->with( $array )->andReturn( $json );
+
+		$this->assertEquals( $json, $this->instance->validate( $json ) );
+	}
+
+	/**
+	 * Tests validation fails when the input is not a string.
+	 *
+	 * @covers ::validate
+	 */
+	public function test_validate_non_string_input() {
+		$this->expectException( Invalid_Type_Exception::class );
+		$this->expectExceptionMessageMatches( '/string/' );
+
+		$this->instance->validate( 123 );
+	}
+
+	/**
+	 * Tests validation fails when JSON decode errored.
+	 *
+	 * @covers ::validate
+	 */
+	public function test_validate_json_decode_error() {
+		$this->expectException( Invalid_Json_Exception::class );
+
+		$this->instance->validate( 'foo' );
+	}
+
+	/**
+	 * Tests validation fails when JSON encode errored.
+	 *
+	 * @covers ::validate
+	 */
+	public function test_validate_json_encode_error() {
+		$json  = '{ "foo": "bar" }';
+		$array = \json_decode( $json, true );
+
+		$this->array_validator->expects( 'validate' )->with( $array )->andReturn( $array );
+
+		// Create an expectation for each key and value in the JSON.
+		foreach ( [ 'foo', 'bar' ] as $entry ) {
+			$this->text_field_validator->expects( 'validate' )->with( $entry )->andReturnArg( 0 );
+		}
+
+		$this->json_helper->expects( 'format_encode' )->with( $array )->andReturn( false );
+
+		$this->expectException( Invalid_Json_Exception::class );
+
+		$this->instance->validate( $json );
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Prepare a validator to use for the `wpseo_focuskeywords` and `wpseo_keywordsynonyms` options. Note no already implemented option is using this right now, so only preparation.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds the `Json_Text_Fields_Validator` class.

## Relevant technical choices:

* [Move format_json_encode to new JSON helper](https://github.com/Yoast/wordpress-seo/commit/4f5b6d80d6a1f217a842f558576b20160854f766) 
  * Used `WPSEO_Utils::is_development_mode`. So also moving that to the environment helper in this commit.
  * Deprecated the old `is_development_mode` because that was not used that much.
  * All code in `src` (where possible) should now use the helper, mostly via DI.
  * Note: the Abstract_Main used the `is_development_mode` too, but can not use the helper via dependency injection. Reverting to a hybrid approach there after asking why it was changed (answer: not sure, possibly nicer to DRY)
  * Note: the Schema_Presenter can not use DI due to presenters being excluded in `config/dependency-injection/services.php`, hence the usage of `YoastSEO`
* Leaving the PHP lint warning `Yoast.NamingConventions.ValidHookName.WrongPrefix` in the environment helper about the moved filter `yoast_seo_development_mode` instead of either ignoring or deprecating it. The moving is already beyond the scope, but I went on anyway. Deprecating it will have more consequences, I'd rather avoid that right now. Ignoring it will make the fact blind, I think we should rename it in the future?

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Tests should make sense and cover the code
* You can play around with requesting validations, using this code: 
```php
function _test_validate( $value, $settings = null ) {
	/** @var \Yoast\WP\SEO\Validators\Json_Text_Fields_Validator $validator */
	$validator = YoastSEO()->classes->get( \Yoast\WP\SEO\Validators\Json_Text_Fields_Validator::class );
	echo 'Value: ';
	var_dump( $value );
	echo '<br>Result: ';
	try {
		var_dump( $validator->validate( $value, $settings ) );
	} catch ( \Yoast\WP\SEO\Exceptions\Validation\Abstract_Validation_Exception $exception ) {
		echo $exception->getMessage();
	}
	echo '<br>';
}

_test_validate( "foo" );
_test_validate( '{ "<b>html is stripped</b>": "<strong>html is stripped</strong>" }' );
_test_validate( '{ "foo": "bar", "baz": "qux" }' );
_test_validate( '{ "foo": "bar", "baz": "qux" }', [ 'allow' => [ 'foo' ] ] );
```
* Note the validator has settings, which can contain an allow-list. Which should be an array of strings. If provided, any keys not in the allow-list will be ignored in the output.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Part of bigger feature, please test the whole feature when done.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes https://yoast.atlassian.net/browse/P1-1206
