### PR TITLE
Add the URL hash to the primary image ID in the schema piece for a single event

### DIFF
--- a/src/generators/schema/third-party/events-calendar-schema.php
+++ b/src/generators/schema/third-party/events-calendar-schema.php
@@ -142,17 +142,19 @@ class Events_Calendar_Schema extends Abstract_Schema_Piece {
 
 			// Transform the post_thumbnail from the url to the @id of #primaryimage.
 			if ( \has_post_thumbnail( $post_id ) ) {
+				$image_id     = \get_post_thumbnail_id( $post_id );
+				$schema_id    = $permalink . Schema_IDs::PRIMARY_IMAGE_HASH;
+				$schema_piece = $this->helpers->schema->image->generate_from_attachment_id( $schema_id, $image_id );
+
 				if ( \is_singular( 'tribe_events' ) ) {
 					// On a single view we can assume that Yoast SEO already printed the
 					// image schema for the post thumbnail.
 					$d->image = (object) [
-						'@id' => $permalink . '#primaryimage',
+						'@id' => $schema_piece['@id'],
 					];
 				}
 				else {
-					$image_id  = \get_post_thumbnail_id( $post_id );
-					$schema_id = $permalink . '#primaryimage';
-					$d->image  = $this->helpers->schema->image->generate_from_attachment_id( $schema_id, $image_id );
+					$d->image = $schema_piece;
 				}
 			}
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want the Schema piece for a single Event (with Events Calendar) to reference the already existing `ImageObject` for the featured image.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where the Schema piece for a single Event when using The Events Calendar would not reference the ImageObject for featured image in the correct way.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install and activate The Events Calendar
* create an event and set a featured image for it
* inspect the Schema:
  * without this patch, the `Event` piece would have a `image` property with `@id` set to e.g. `http://basic.wordpress.test/event/altro-evento/#primaryimage`, without any hash
  * with this patch, the `Event` piece would have a `image` property with `@id` correctly set to the id of the `ImageObject` for the featured image, already referenced by the `WebPage` piece
  
* also check for regression for a month:
  * add some other events in the same month as the first one and add featured images to them
  * visit the calendar for a month (eg. http://basic.wordpress.test/events/month/)
  * inspect the schema and check that every `Event` piece has the `image` property set to a full `ImageObject` piece (i.e. not referencing an external one) where the `@id` is correct.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes #
