### PR TITLE
Revert "Issues with new Image schema, when post has no featured image but has a resized image in its content"

### DIFF
--- a/src/context/meta-tags-context.php
+++ b/src/context/meta-tags-context.php
@@ -50,7 +50,6 @@ use Yoast\WP\SEO\Repositories\Indexable_Repository;
  * @property bool         $has_image
  * @property int          $main_image_id
  * @property string       $main_image_url
- * @property string       $primary_image_id
  */
 class Meta_Tags_Context extends Abstract_Presentation {
 
@@ -559,19 +558,6 @@ class Meta_Tags_Context extends Abstract_Presentation {
 		}
 
 		return $url;
-	}
-
-	/**
-	 * Retrieves the ID of the primary image of the page.
-	 *
-	 * @return string|null The primary image ID.
-	 */
-	public function generate_primary_image_id() {
-		if ( $this->main_image_url !== null ) {
-			return $this->canonical . Schema_IDs::PRIMARY_IMAGE_HASH . md5( $this->main_image_url );
-		}
-
-		return null;
 	}
 
 	/**

--- a/src/generators/schema/article.php
+++ b/src/generators/schema/article.php
@@ -151,11 +151,13 @@ class Article extends Abstract_Schema_Piece {
 	 * @return array The Article data.
 	 */
 	private function add_image( $data ) {
-		if ( $this->context->main_image_url !== null && $this->context->primary_image_id !== null ) {
+		if ( $this->context->main_image_url !== null ) {
+			$url = $this->context->main_image_url;
+
 			$data['image']        = [
-				'@id' => $this->context->primary_image_id,
+				'@id' => $this->context->canonical . Schema_IDs::PRIMARY_IMAGE_HASH . md5( $url ),
 			];
-			$data['thumbnailUrl'] = $this->context->main_image_url;
+			$data['thumbnailUrl'] = $url;
 		}
 
 		return $data;

--- a/src/generators/schema/main-image.php
+++ b/src/generators/schema/main-image.php
@@ -31,37 +31,33 @@ class Main_Image extends Abstract_Schema_Piece {
 
 		// The Open Graph image.
 		if ( isset( $this->context->indexable->open_graph_image_id ) && $this->context->indexable->open_graph_image_source === 'set-by-user' ) {
-			$generated_schema                = $this->helpers->schema->image->generate_from_attachment_id( $image_id, $this->context->indexable->open_graph_image_id );
-			$this->context->main_image_url   = $generated_schema['url'];
-			$this->context->main_image_id    = $this->context->indexable->open_graph_image_id;
-			$this->context->primary_image_id = $generated_schema['@id'];
+			$generated_schema              = $this->helpers->schema->image->generate_from_attachment_id( $image_id, $this->context->indexable->open_graph_image_id );
+			$this->context->main_image_url = $generated_schema['url'];
+			$this->context->main_image_id  = $this->context->indexable->open_graph_image_id;
 
 			return $generated_schema;
 		}
 
 		// The Twitter image.
 		if ( isset( $this->context->indexable->twitter_image_id ) && $this->context->indexable->twitter_image_source === 'set-by-user' ) {
-			$generated_schema                = $this->helpers->schema->image->generate_from_attachment_id( $image_id, $this->context->indexable->twitter_image_id );
-			$this->context->main_image_url   = $generated_schema['url'];
-			$this->context->main_image_id    = $this->context->indexable->twitter_image_id;
-			$this->context->primary_image_id = $generated_schema['@id'];
+			$generated_schema              = $this->helpers->schema->image->generate_from_attachment_id( $image_id, $this->context->indexable->twitter_image_id );
+			$this->context->main_image_url = $generated_schema['url'];
+			$this->context->main_image_id  = $this->context->indexable->twitter_image_id;
 
 			return $generated_schema;
 		}
 
 		// The featured image.
 		if ( $this->context->main_image_id ) {
-			$generated_schema                = $this->helpers->schema->image->generate_from_attachment_id( $image_id, $this->context->main_image_id );
-			$this->context->main_image_url   = $generated_schema['url'];
-			$this->context->primary_image_id = $generated_schema['@id'];
+			$generated_schema              = $this->helpers->schema->image->generate_from_attachment_id( $image_id, $this->context->main_image_id );
+			$this->context->main_image_url = $generated_schema['url'];
 
 			return $generated_schema;
 		}
 
 		// The first image in the content.
 		if ( $this->context->main_image_url ) {
-			$generated_schema                = $this->helpers->schema->image->generate_from_url( $image_id, $this->context->main_image_url );
-			$this->context->primary_image_id = $generated_schema['@id'];
+			$generated_schema = $this->helpers->schema->image->generate_from_url( $image_id, $this->context->main_image_url );
 
 			return $generated_schema;
 		}

--- a/src/generators/schema/webpage.php
+++ b/src/generators/schema/webpage.php
@@ -98,8 +98,8 @@ class WebPage extends Abstract_Schema_Piece {
 	 * @param array $data WebPage schema data.
 	 */
 	public function add_image( &$data ) {
-		if ( $this->context->primary_image_id !== null ) {
-			$data['primaryImageOfPage'] = [ '@id' => $this->context->primary_image_id ];
+		if ( $this->context->main_image_url !== null ) {
+			$data['primaryImageOfPage'] = [ '@id' => $this->context->canonical . Schema_IDs::PRIMARY_IMAGE_HASH . md5( $this->context->main_image_url ) ];
 		}
 	}
 

--- a/tests/unit/generators/schema-generator-test.php
+++ b/tests/unit/generators/schema-generator-test.php
@@ -301,7 +301,7 @@ class Schema_Generator_Test extends TestCase {
 			'post_date_gmt'     => 'date',
 			'post_modified_gmt' => 'date',
 		];
-		$this->context->primary_image_id           = null;
+		$this->context->has_image                  = false;
 
 		Monkey\Functions\expect( 'post_password_required' )
 			->once()
@@ -484,7 +484,7 @@ class Schema_Generator_Test extends TestCase {
 			'post_date_gmt'     => 'date',
 			'post_modified_gmt' => 'date',
 		];
-		$this->context->primary_image_id           = null;
+		$this->context->has_image                  = false;
 
 		Monkey\Functions\expect( 'post_password_required' )
 			->once()
@@ -543,7 +543,7 @@ class Schema_Generator_Test extends TestCase {
 			'post_date_gmt'     => 'date',
 			'post_modified_gmt' => 'date',
 		];
-		$this->context->primary_image_id           = null;
+		$this->context->has_image                  = false;
 
 		Monkey\Functions\expect( 'post_password_required' )
 			->once()
@@ -637,7 +637,7 @@ class Schema_Generator_Test extends TestCase {
 			'post_date_gmt'     => 'date',
 			'post_modified_gmt' => 'date',
 		];
-		$this->context->primary_image_id           = null;
+		$this->context->has_image                  = false;
 
 		Monkey\Functions\expect( 'post_password_required' )
 			->once()
@@ -726,7 +726,7 @@ class Schema_Generator_Test extends TestCase {
 			'post_date_gmt'     => 'date',
 			'post_modified_gmt' => 'date',
 		];
-		$this->context->primary_image_id           = null;
+		$this->context->has_image                  = false;
 
 		Monkey\Functions\expect( 'post_password_required' )
 			->once()

--- a/tests/unit/generators/schema/article-test.php
+++ b/tests/unit/generators/schema/article-test.php
@@ -111,7 +111,6 @@ class Article_Test extends TestCase {
 		$this->context_mock->schema_article_type     = 'Article';
 		$this->context_mock->has_image               = true;
 		$this->context_mock->main_image_url          = 'https://www.example.com/image.jpg';
-		$this->context_mock->primary_image_id        = 'https://permalink#primaryimage/' . md5( 'https://www.example.com/image.jpg' );
 		$this->context_mock->canonical               = 'https://permalink';
 		$this->context_mock->post->post_content      = 'This is test content.';
 		$this->context_mock->post->post_title        = 'Test title';

--- a/tests/unit/generators/schema/webpage-test.php
+++ b/tests/unit/generators/schema/webpage-test.php
@@ -105,7 +105,6 @@ class WebPage_Test extends TestCase {
 		$this->meta_tags_context->description      = '';
 		$this->meta_tags_context->site_url         = 'https://example.com/';
 		$this->meta_tags_context->main_image_url   = null;
-		$this->meta_tags_context->primary_image_id = null;
 		$this->meta_tags_context->post             = (object) [
 			'post_date_gmt'     => '2345-12-12 12:12:12',
 			'post_modified_gmt' => '2345-12-12 23:23:23',
@@ -194,8 +193,7 @@ class WebPage_Test extends TestCase {
 	 * @param string $message        The message to show in case a test fails.
 	 */
 	public function test_generate_with_provider( $values_to_test, $expected, $message ) {
-		$this->meta_tags_context->main_image_url   = $values_to_test['main_image_url'];
-		$this->meta_tags_context->primary_image_id = $values_to_test['primary_image_id'];
+		$this->meta_tags_context->main_image_url = $values_to_test['main_image_url'];
 
 		$this->id->primary_image_hash = '#primaryimage';
 		$this->id->breadcrumb_hash    = '#breadcrumb';
@@ -558,7 +556,6 @@ class WebPage_Test extends TestCase {
 			[
 				'values_to_test' => [
 					'main_image_url'           => null,
-					'primary_image_id'         => null,
 				],
 				'expected'       => [
 					'@type'           => [ 'WebPage' ],
@@ -584,7 +581,6 @@ class WebPage_Test extends TestCase {
 			[
 				'values_to_test' => [
 					'main_image_url'           => 'https://example.com/main_image',
-					'primary_image_id'         => 'https://example.com/the-post/#primaryimage/' . md5( 'https://example.com/main_image' ),
 				],
 				'expected'       => [
 					'@type'              => [ 'WebPage' ],
@@ -611,7 +607,6 @@ class WebPage_Test extends TestCase {
 			[
 				'values_to_test' => [
 					'main_image_url'           => null,
-					'primary_image_id'         => null,
 				],
 				'expected'       => [
 					'@type'           => [ 'WebPage' ],


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Reverts https://github.com/Yoast/wordpress-seo/pull/18286

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Reverts the no-feature-image-in-post bug fix for https://github.com/Yoast/wordpress-seo/pull/18286

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* N/A
* We will perform Acceptance Test when the last revert of the CoAuthor Plus integration is to be merged

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* 

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes #
