### PR TITLE
P1-1207 support taxonomy metadata

### DIFF
--- a/src/exceptions/option/delete-failed-exception.php
+++ b/src/exceptions/option/delete-failed-exception.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Yoast\WP\SEO\Exceptions\Option;
+
+/**
+ * Delete failed exception class.
+ */
+class Delete_Failed_Exception extends Abstract_Option_Exception {
+
+	/**
+	 * Creates exception for an option.
+	 *
+	 * @param string $option_name The option name that failed to delete.
+	 *
+	 * @return static Instance of the exception.
+	 */
+	public static function for_option( $option_name ) {
+		return new static(
+			\sprintf(
+			/* translators: %1$s expands to the option name (database row) that failed to delete. */
+				\__( 'Failed to delete the option (%1$s).', 'wordpress-seo' ),
+				$option_name
+			)
+		);
+	}
+}

--- a/src/exceptions/option/method-unimplemented-exception.php
+++ b/src/exceptions/option/method-unimplemented-exception.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Yoast\WP\SEO\Exceptions\Option;
+
+/**
+ * Unimplemented method exception class.
+ */
+class Method_Unimplemented_Exception extends Abstract_Option_Exception {
+
+	/**
+	 * Creates exception for a method that is not implemented in a class.
+	 *
+	 * @param string $method     The method that does not exist.
+	 * @param string $class_name The class name.
+	 *
+	 * @return static Instance of the exception.
+	 */
+	public static function for_method( $method, $class_name ) {
+		return new static(
+			\sprintf(
+			/* translators: %1$s expands to the method name. %2$s expands to the class name. */
+				\__( 'Method %1$s() is not implemented in class %2$s', 'wordpress-seo' ),
+				$method,
+				$class_name
+			)
+		);
+	}
+}

--- a/src/exceptions/option/save-failed-exception.php
+++ b/src/exceptions/option/save-failed-exception.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Yoast\WP\SEO\Exceptions\Option;
+
+/**
+ * Save failed exception class.
+ */
+class Save_Failed_Exception extends Abstract_Option_Exception {
+
+	/**
+	 * Creates exception for an option.
+	 *
+	 * @param string $option_name The option name that failed to save.
+	 *
+	 * @return static Instance of the exception.
+	 */
+	public static function for_option( $option_name ) {
+		return new static(
+			\sprintf(
+			/* translators: %1$s expands to the option name (database row) that failed to save. */
+				\__( 'Failed to save the option (%1$s).', 'wordpress-seo' ),
+				$option_name
+			)
+		);
+	}
+}

--- a/src/exceptions/option/term-not-found-exception.php
+++ b/src/exceptions/option/term-not-found-exception.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Yoast\WP\SEO\Exceptions\Option;
+
+/**
+ * Term not found exception class.
+ *
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded -- Exception should not count.
+ */
+class Term_Not_Found_Exception extends Abstract_Option_Exception {
+
+	/**
+	 * Creates exception for a term that was not found.
+	 *
+	 * @param mixed  $term     The term name, (int) term id or (object) term.
+	 * @param string $taxonomy The taxonomy.
+	 *
+	 * @return static Instance of the exception.
+	 */
+	public static function for_term( $term, $taxonomy ) {
+		$term_name = $term;
+		if ( \is_object( $term ) ) {
+			$term_name = isset( $term->name ) ? $term->name : \__( 'object', 'wordpress-seo' );
+		}
+
+		return new static(
+			\sprintf(
+			/* translators: %1$s expands to the term ID, slug or name. %2$s expands to the taxonomy name. */
+				\__( 'Term (%1$s) for taxonomy (%2$s) was not found.', 'wordpress-seo' ),
+				$term_name,
+				$taxonomy
+			)
+		);
+	}
+}

--- a/src/exceptions/option/unknown-exception.php
+++ b/src/exceptions/option/unknown-exception.php
@@ -8,12 +8,14 @@ namespace Yoast\WP\SEO\Exceptions\Option;
 class Unknown_Exception extends Abstract_Option_Exception {
 
 	/**
-	 * Constructs an unknown option exception instance.
+	 * Creates exception for an option.
 	 *
 	 * @param string $name The option name.
+	 *
+	 * @return static Instance of the exception.
 	 */
-	public function __construct( $name ) {
-		parent::__construct(
+	public static function for_option( $name ) {
+		return new static(
 			\sprintf(
 			/* translators: %s expands to the name of the option. */
 				\esc_html__( 'Option "%s" does not exist.', 'wordpress-seo' ),

--- a/src/helpers/options-helper.php
+++ b/src/helpers/options-helper.php
@@ -3,6 +3,7 @@
 namespace Yoast\WP\SEO\Helpers;
 
 use WPSEO_Option_Titles;
+use Yoast\WP\SEO\Exceptions\Option\Save_Failed_Exception;
 use Yoast\WP\SEO\Exceptions\Option\Unknown_Exception;
 use Yoast\WP\SEO\Exceptions\Validation\Abstract_Validation_Exception;
 use Yoast\WP\SEO\Services\Options\Site_Options_Service;
@@ -64,6 +65,7 @@ class Options_Helper {
 			return true;
 		} catch ( Unknown_Exception $exception ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- Deliberately left empty.
 		} catch ( Abstract_Validation_Exception $exception ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- Deliberately left empty.
+		} catch ( Save_Failed_Exception $exception ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- Deliberately left empty.
 		}
 
 		return false;

--- a/src/services/options/abstract-options-service.php
+++ b/src/services/options/abstract-options-service.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\WP\SEO\Services\Options;
 
+use Yoast\WP\SEO\Exceptions\Option\Delete_Failed_Exception;
 use Yoast\WP\SEO\Exceptions\Option\Save_Failed_Exception;
 use Yoast\WP\SEO\Exceptions\Option\Unknown_Exception;
 use Yoast\WP\SEO\Helpers\Post_Type_Helper;
@@ -194,14 +195,14 @@ abstract class Abstract_Options_Service {
 	/**
 	 * Saves the options with their default values.
 	 *
+	 * @throws Delete_Failed_Exception When the deletion failed.
 	 * @throws Save_Failed_Exception When the save failed.
 	 *
 	 * @return void
 	 */
 	public function reset_options() {
-		if ( $this->get_values() !== $this->get_defaults() ) {
-			$this->update_options( $this->get_defaults() );
-		}
+		$this->delete_options();
+		$this->update_options( $this->get_defaults() );
 	}
 
 	/**
@@ -337,7 +338,7 @@ abstract class Abstract_Options_Service {
 	}
 
 	/**
-	 * Updates options.
+	 * Updates the options.
 	 *
 	 * @param array $values The option values.
 	 *
@@ -348,6 +349,19 @@ abstract class Abstract_Options_Service {
 	protected function update_options( $values ) {
 		if ( ! \update_option( $this->option_name, $values ) ) {
 			throw Save_Failed_Exception::for_option( $this->option_name );
+		}
+	}
+
+	/**
+	 * Deletes the options.
+	 *
+	 * @throws Delete_Failed_Exception When the deletion failed.
+	 *
+	 * @return void
+	 */
+	protected function delete_options() {
+		if ( ! \delete_option( $this->option_name ) ) {
+			throw Delete_Failed_Exception::for_option( $this->option_name );
 		}
 	}
 

--- a/src/services/options/abstract-options-service.php
+++ b/src/services/options/abstract-options-service.php
@@ -109,7 +109,7 @@ abstract class Abstract_Options_Service {
 			return $this->get_values()[ $key ];
 		}
 
-		throw new Unknown_Exception( $key );
+		throw Unknown_Exception::for_option( $key );
 	}
 
 	/*
@@ -133,7 +133,7 @@ abstract class Abstract_Options_Service {
 	 */
 	public function __set( $key, $value ) {
 		if ( ! \array_key_exists( $key, $this->get_configurations() ) ) {
-			throw new Unknown_Exception( $key );
+			throw Unknown_Exception::for_option( $key );
 		}
 
 		// Presuming the default is safe.
@@ -231,7 +231,7 @@ abstract class Abstract_Options_Service {
 	 */
 	public function get_default( $key ) {
 		if ( ! \array_key_exists( $key, $this->get_defaults() ) ) {
-			throw new Unknown_Exception( $key );
+			throw Unknown_Exception::for_option( $key );
 		}
 
 		return $this->get_defaults()[ $key ];

--- a/src/services/options/site-options-service.php
+++ b/src/services/options/site-options-service.php
@@ -27,66 +27,66 @@ class Site_Options_Service extends Abstract_Options_Service {
 	 */
 	protected $configurations = [
 		// Social.
-		'facebook_site'                                       => [
+		'facebook_site'                               => [
 			'default' => '',
 			'types'   => [ 'empty_string', 'url' ],
 		],
-		'instagram_url'                                       => [
+		'instagram_url'                               => [
 			'default' => '',
 			'types'   => [ 'empty_string', 'url' ],
 		],
-		'linkedin_url'                                        => [
+		'linkedin_url'                                => [
 			'default' => '',
 			'types'   => [ 'empty_string', 'url' ],
 		],
-		'myspace_url'                                         => [
+		'myspace_url'                                 => [
 			'default' => '',
 			'types'   => [ 'empty_string', 'url' ],
 		],
-		'og_default_image'                                    => [
+		'og_default_image'                            => [
 			'default' => '',
 			'types'   => [ 'empty_string', 'url' ],
 		],
-		'og_default_image_id'                                 => [
+		'og_default_image_id'                         => [
 			'default' => '',
 			'types'   => [ 'empty_string', 'integer' ],
 		],
-		'og_frontpage_desc'                                   => [
+		'og_frontpage_desc'                           => [
 			'default' => '',
 			'types'   => [ 'text_field' ],
 		],
-		'og_frontpage_image'                                  => [
+		'og_frontpage_image'                          => [
 			'default' => '',
 			'types'   => [ 'empty_string', 'url' ],
 		],
-		'og_frontpage_image_id'                               => [
+		'og_frontpage_image_id'                       => [
 			'default' => '',
 			'types'   => [ 'empty_string', 'integer' ],
 		],
-		'og_frontpage_title'                                  => [
+		'og_frontpage_title'                          => [
 			'default' => '',
 			'types'   => [ 'text_field' ],
 		],
-		'opengraph'                                           => [
+		'opengraph'                                   => [
 			'default' => true,
 			'types'   => [ 'boolean' ],
 		],
-		'pinterest_url'                                       => [
+		'pinterest_url'                               => [
 			'default' => '',
 			'types'   => [ 'empty_string', 'url' ],
 		],
-		'pinterestverify'                                     => [
+		'pinterestverify'                             => [
 			'default' => '',
 			'types'   => [
 				'empty_string',
 				'verification' => [ 'pattern' => '`^[A-Fa-f0-9_-]+$`' ],
 			],
 		],
-		'twitter'                                             => [
+		'twitter'                                     => [
 			'default' => true,
 			'types'   => [ 'boolean' ],
 		],
-		'twitter_card_type'                                   => [
+		'twitter_card_type'                           => [
 			'default' => 'summary_large_image',
 			'types'   => [
 				'in_array' => [
@@ -97,166 +97,88 @@ class Site_Options_Service extends Abstract_Options_Service {
 				],
 			],
 		],
-		'twitter_site'                                        => [
+		'twitter_site'                                => [
 			'default' => '',
 			'types'   => [
 				'empty_string',
 				'twitter_username',
 			],
 		],
-		'wikipedia_url'                                       => [
+		'wikipedia_url'                               => [
 			'default' => '',
 			'types'   => [ 'empty_string', 'url' ],
 		],
-		'youtube_url'                                         => [
+		'youtube_url'                                 => [
 			'default' => '',
 			'types'   => [ 'empty_string', 'url' ],
-		],
-
-		// Taxonomy meta.
-		'wpseo_bctitle-<TaxonomyName>-<TermId>'               => [
-			'default' => '',
-			'types'   => [ 'text_field' ],
-		],
-		'wpseo_canonical-<TaxonomyName>-<TermId>'             => [
-			'default' => '',
-			'types'   => [ 'empty_string', 'url' ],
-		],
-		'wpseo_content_score-<TaxonomyName>-<TermId>'         => [
-			'default' => '',
-			'types'   => [ 'text_field' ],
-		],
-		'wpseo_desc-<TaxonomyName>-<TermId>'                  => [
-			'default' => '',
-			'types'   => [ 'text_field' ],
-		],
-		'wpseo_focuskeywords-<TaxonomyName>-<TermId>'         => [
-			'default' => '',
-			'types'   => [ 'string' ],
-		],
-		'wpseo_focuskw-<TaxonomyName>-<TermId>'               => [
-			'default' => '',
-			'types'   => [ 'text_field' ],
-		],
-		'wpseo_is_cornerstone-<TaxonomyName>-<TermId>'        => [
-			'default' => '',
-			'types'   => [ 'string' ],
-		],
-		'wpseo_keywordsynonyms-<TaxonomyName>-<TermId>'       => [
-			'default' => '',
-			'types'   => [ 'string' ],
-		],
-		'wpseo_linkdex-<TaxonomyName>-<TermId>'               => [
-			'default' => '',
-			'types'   => [ 'text_field' ],
-		],
-		'wpseo_noindex-<TaxonomyName>-<TermId>'               => [
-			'default' => '',
-			'types'   => [ 'string' ],
-		],
-		'wpseo_opengraph-description-<TaxonomyName>-<TermId>' => [
-			'default' => '',
-			'types'   => [ 'text_field' ],
-		],
-		'wpseo_opengraph-image-<TaxonomyName>-<TermId>'       => [
-			'default' => '',
-			'types'   => [ 'text_field' ],
-		],
-		'wpseo_opengraph-image-id-<TaxonomyName>-<TermId>'    => [
-			'default' => '',
-			'types'   => [ 'text_field' ],
-		],
-		'wpseo_opengraph-title-<TaxonomyName>-<TermId>'       => [
-			'default' => '',
-			'types'   => [ 'text_field' ],
-		],
-		'wpseo_title-<TaxonomyName>-<TermId>'                 => [
-			'default' => '',
-			'types'   => [ 'text_field' ],
-		],
-		'wpseo_twitter-description-<TaxonomyName>-<TermId>'   => [
-			'default' => '',
-			'types'   => [ 'text_field' ],
-		],
-		'wpseo_twitter-image-<TaxonomyName>-<TermId>'         => [
-			'default' => '',
-			'types'   => [ 'text_field' ],
-		],
-		'wpseo_twitter-image-id-<TaxonomyName>-<TermId>'      => [
-			'default' => '',
-			'types'   => [ 'text_field' ],
-		],
-		'wpseo_twitter-title-<TaxonomyName>-<TermId>'         => [
-			'default' => '',
-			'types'   => [ 'text_field' ],
 		],
 
 		// Titles.
-		'activation_redirect_timestamp_free'                  => [
+		'activation_redirect_timestamp_free'          => [
 			'default' => 0,
 			'types'   => [ 'integer' ],
 		],
-		'alternate_website_name'                              => [
+		'alternate_website_name'                      => [
 			'default' => '',
 			'types'   => [ 'text_field' ],
 		],
-		'bctitle-ptarchive-<PostTypeName>'                    => [
+		'bctitle-ptarchive-<PostTypeName>'            => [
 			'default' => '',
 			'types'   => [ 'text_field' ],
 		],
-		'breadcrumbs-404crumb'                                => [
+		'breadcrumbs-404crumb'                        => [
 			'default' => 'Error 404: Page not found',
 			'types'   => [ 'empty_string', 'wp_kses_post' ],
 		],
-		'breadcrumbs-archiveprefix'                           => [
+		'breadcrumbs-archiveprefix'                   => [
 			'default' => 'Archives for',
 			'types'   => [ 'empty_string', 'wp_kses_post' ],
 		],
-		'breadcrumbs-boldlast'                                => [
+		'breadcrumbs-boldlast'                        => [
 			'default' => false,
 			'types'   => [ 'boolean' ],
 		],
-		'breadcrumbs-display-blog-page'                       => [
+		'breadcrumbs-display-blog-page'               => [
 			'default' => true,
 			'types'   => [ 'boolean' ],
 		],
-		'breadcrumbs-enable'                                  => [
+		'breadcrumbs-enable'                          => [
 			'default' => true,
 			'types'   => [ 'boolean' ],
 		],
-		'breadcrumbs-home'                                    => [
+		'breadcrumbs-home'                            => [
 			'default' => 'Home',
 			'types'   => [ 'empty_string', 'wp_kses_post' ],
 		],
-		'breadcrumbs-prefix'                                  => [
+		'breadcrumbs-prefix'                          => [
 			'default' => '',
 			'types'   => [ 'empty_string', 'wp_kses_post' ],
 		],
-		'breadcrumbs-searchprefix'                            => [
+		'breadcrumbs-searchprefix'                    => [
 			'default' => 'You searched for',
 			'types'   => [ 'empty_string', 'wp_kses_post' ],
 		],
-		'breadcrumbs-sep'                                     => [
+		'breadcrumbs-sep'                             => [
 			'default' => '&raquo;',
 			'types'   => [ 'empty_string', 'wp_kses_post' ],
 		],
-		'company_logo'                                        => [
+		'company_logo'                                => [
 			'default' => '',
 			'types'   => [ 'empty_string', 'url' ],
 		],
-		'company_logo_id'                                     => [
+		'company_logo_id'                             => [
 			'default' => 0,
 			'types'   => [ 'integer' ],
 		],
-		'company_logo_meta'                                   => [
+		'company_logo_meta'                           => [
 			'default' => false,
 			'types'   => [ 'string' ],
 		],
-		'company_name'                                        => [
+		'company_name'                                => [
 			'default' => '',
 			'types'   => [ 'text_field' ],
 		],
-		'company_or_person'                                   => [
+		'company_or_person'                           => [
 			'default' => 'company',
 			'types'   => [
 				'in_array' => [
@@ -267,7 +189,7 @@ class Site_Options_Service extends Abstract_Options_Service {
 				],
 			],
 		],
-		'company_or_person_user_id'                           => [
+		'company_or_person_user_id'                   => [
 			'default' => false,
 			'types'   => [
 				'empty_string',
@@ -275,116 +197,116 @@ class Site_Options_Service extends Abstract_Options_Service {
 				'integer',
 			],
 		],
-		'disable-attachment'                                  => [
+		'disable-attachment'                          => [
 			'default' => true,
 			'types'   => [ 'boolean' ],
 		],
-		'disable-author'                                      => [
+		'disable-author'                              => [
 			'default' => false,
 			'types'   => [ 'boolean' ],
 		],
-		'disable-date'                                        => [
+		'disable-date'                                => [
 			'default' => false,
 			'types'   => [ 'boolean' ],
 		],
-		'disable-post_format'                                 => [
+		'disable-post_format'                         => [
 			'default' => false,
 			'types'   => [ 'boolean' ],
 		],
-		'display-metabox-pt-<PostTypeName>'                   => [
+		'display-metabox-pt-<PostTypeName>'           => [
 			'default' => false, // True for public post types.
 			'types'   => [ 'boolean' ],
 		],
-		'display-metabox-tax-<TaxonomyName>'                  => [
+		'display-metabox-tax-<TaxonomyName>'          => [
 			'default' => false, // True for public taxonomies.
 			'types'   => [ 'boolean' ],
 		],
-		'forcerewritetitle'                                   => [
+		'forcerewritetitle'                           => [
 			'default'    => false,
 			'types'      => [ 'boolean' ],
 			'ms_exclude' => true,
 		],
-		'metadesc-<PostTypeName>'                             => [
+		'metadesc-<PostTypeName>'                     => [
 			'default' => '',
 			'types'   => [ 'text_field' ],
 		],
-		'metadesc-archive-wpseo'                              => [
+		'metadesc-archive-wpseo'                      => [
 			'default' => '',
 			'types'   => [ 'text_field' ],
 		],
-		'metadesc-author-wpseo'                               => [
+		'metadesc-author-wpseo'                       => [
 			'default' => '',
 			'types'   => [ 'text_field' ],
 		],
-		'metadesc-home-wpseo'                                 => [
+		'metadesc-home-wpseo'                         => [
 			'default' => '',
 			'types'   => [ 'text_field' ],
 		],
-		'metadesc-ptarchive-<PostTypeName>'                   => [
+		'metadesc-ptarchive-<PostTypeName>'           => [
 			'default' => '',
 			'types'   => [ 'text_field' ],
 		],
-		'metadesc-tax-<TaxonomyName>'                         => [
+		'metadesc-tax-<TaxonomyName>'                 => [
 			'default' => '',
 			'types'   => [ 'text_field' ],
 		],
-		'noindex-<PostTypeName>'                              => [
+		'noindex-<PostTypeName>'                      => [
 			'default' => false,
 			'types'   => [ 'boolean' ],
 		],
-		'noindex-archive-wpseo'                               => [
+		'noindex-archive-wpseo'                       => [
 			'default' => true,
 			'types'   => [ 'boolean' ],
 		],
-		'noindex-author-noposts-wpseo'                        => [
+		'noindex-author-noposts-wpseo'                => [
 			'default' => true,
 			'types'   => [ 'boolean' ],
 		],
-		'noindex-author-wpseo'                                => [
+		'noindex-author-wpseo'                        => [
 			'default' => false,
 			'types'   => [ 'boolean' ],
 		],
-		'noindex-ptarchive-<PostTypeName>'                    => [
+		'noindex-ptarchive-<PostTypeName>'            => [
 			'default' => false,
 			'types'   => [ 'boolean' ],
 		],
-		'noindex-tax-<TaxonomyName>'                          => [
+		'noindex-tax-<TaxonomyName>'                  => [
 			'default' => false, // Except when the taxonomy name === 'post_format'.
 			'types'   => [ 'boolean' ],
 		],
-		'open_graph_frontpage_desc'                           => [
+		'open_graph_frontpage_desc'                   => [
 			'default' => '',
 			'types'   => [ 'text_field' ],
 		],
-		'open_graph_frontpage_image'                          => [
+		'open_graph_frontpage_image'                  => [
 			'default' => '',
 			'types'   => [ 'empty_string', 'url' ],
 		],
-		'open_graph_frontpage_image_id'                       => [
+		'open_graph_frontpage_image_id'               => [
 			'default' => 0,
 			'types'   => [ 'integer' ],
 		],
-		'open_graph_frontpage_title'                          => [
+		'open_graph_frontpage_title'                  => [
 			'default' => '%%sitename%%',
 			'types'   => [ 'text_field' ],
 		],
-		'person_logo'                                         => [
+		'person_logo'                                 => [
 			'default' => '',
 			'types'   => [ 'empty_string', 'url' ],
 		],
-		'person_logo_id'                                      => [
+		'person_logo_id'                              => [
 			'default' => 0,
 			'types'   => [ 'integer' ],
 		],
-		'person_logo_meta'                                    => [
+		'person_logo_meta'                            => [
 			'default' => false,
 			'types'   => [ 'string' ],
 		],
-		'person_name'                                         => [
+		'person_name'                                 => [
 			'default' => '',
 			'types'   => [ 'text_field' ],
 		],
-		'post_types_<PostTypeName>_maintax'                   => [
+		'post_types_<PostTypeName>_maintax'           => [
 			'default' => '',
 			'types'   => [
 				'in_array_provider' => [
@@ -396,15 +318,15 @@ class Site_Options_Service extends Abstract_Options_Service {
 				'is_equal',
 			],
 		],
-		'rssafter'                                            => [
+		'rssafter'                                    => [
 			'default' => 'The post %%POSTLINK%% appeared first on %%BLOGLINK%%.',
 			'types'   => [ 'empty_string', 'wp_kses_post' ],
 		],
-		'rssbefore'                                           => [
+		'rssbefore'                                   => [
 			'default' => '',
 			'types'   => [ 'empty_string', 'wp_kses_post' ],
 		],
-		'schema-article-type-<PostTypeName>'                  => [
+		'schema-article-type-<PostTypeName>'          => [
 			'default' => 'None',
 			'types'   => [
 				'in_array_provider' => [
@@ -415,7 +337,7 @@ class Site_Options_Service extends Abstract_Options_Service {
 				],
 			],
 		],
-		'schema-page-type-<PostTypeName>'                     => [
+		'schema-page-type-<PostTypeName>'             => [
 			'default' => 'WebPage',
 			'types'   => [
 				'in_array_key' => [
@@ -423,7 +345,7 @@ class Site_Options_Service extends Abstract_Options_Service {
 				],
 			],
 		],
-		'separator'                                           => [
+		'separator'                                   => [
 			'default' => 'sc-dash',
 			'types'   => [
 				'in_array_provider' => [
@@ -434,144 +356,144 @@ class Site_Options_Service extends Abstract_Options_Service {
 				],
 			],
 		],
-		'social-description-<PostTypeName>'                   => [
+		'social-description-<PostTypeName>'           => [
 			'default' => '',
 			'types'   => [ 'text_field' ],
 		],
-		'social-description-archive-wpseo'                    => [
+		'social-description-archive-wpseo'            => [
 			'default' => '',
 			'types'   => [ 'text_field' ],
 		],
-		'social-description-author-wpseo'                     => [
+		'social-description-author-wpseo'             => [
 			'default' => '',
 			'types'   => [ 'text_field' ],
 		],
-		'social-description-ptarchive-<PostTypeName>'         => [
+		'social-description-ptarchive-<PostTypeName>' => [
 			'default' => '',
 			'types'   => [ 'text_field' ],
 		],
-		'social-description-tax-<TaxonomyName>'               => [
+		'social-description-tax-<TaxonomyName>'       => [
 			'default' => '',
 			'types'   => [ 'text_field' ],
 		],
-		'social-image-id-<PostTypeName>'                      => [
+		'social-image-id-<PostTypeName>'              => [
 			'default' => '',
 			'types'   => [ 'integer' ],
 		],
-		'social-image-id-archive-wpseo'                       => [
+		'social-image-id-archive-wpseo'               => [
 			'default' => 0,
 			'types'   => [ 'integer' ],
 		],
-		'social-image-id-author-wpseo'                        => [
+		'social-image-id-author-wpseo'                => [
 			'default' => 0,
 			'types'   => [ 'integer' ],
 		],
-		'social-image-id-ptarchive-<PostTypeName>'            => [
+		'social-image-id-ptarchive-<PostTypeName>'    => [
 			'default' => '',
 			'types'   => [ 'integer' ],
 		],
-		'social-image-id-tax-{TaxonomyName}'                  => [
+		'social-image-id-tax-{TaxonomyName}'          => [
 			'default' => '',
 			'types'   => [ 'integer' ],
 		],
-		'social-image-url-<PostTypeName>'                     => [
+		'social-image-url-<PostTypeName>'             => [
 			'default' => '',
 			'types'   => [ 'empty_string', 'url' ],
 		],
-		'social-image-url-archive-wpseo'                      => [
+		'social-image-url-archive-wpseo'              => [
 			'default' => '',
 			'types'   => [ 'empty_string', 'url' ],
 		],
-		'social-image-url-author-wpseo'                       => [
+		'social-image-url-author-wpseo'               => [
 			'default' => '',
 			'types'   => [ 'empty_string', 'url' ],
 		],
-		'social-image-url-ptarchive-<PostTypeName>'           => [
+		'social-image-url-ptarchive-<PostTypeName>'   => [
 			'default' => '',
 			'types'   => [ 'empty_string', 'url' ],
 		],
-		'social-image-url-tax-{TaxonomyName}'                 => [
+		'social-image-url-tax-{TaxonomyName}'         => [
 			'default' => '',
 			'types'   => [ 'empty_string', 'url' ],
 		],
-		'social-title-<PostTypeName>'                         => [
+		'social-title-<PostTypeName>'                 => [
 			'default' => '%%title%%',
 			'types'   => [ 'text_field' ],
 		],
-		'social-title-archive-wpseo'                          => [
+		'social-title-archive-wpseo'                  => [
 			'default' => '%%date%%',
 			'types'   => [ 'text_field' ],
 		],
-		'social-title-author-wpseo'                           => [
+		'social-title-author-wpseo'                   => [
 			'default' => '%%name%%',
 			'types'   => [ 'text_field' ],
 		],
-		'social-title-ptarchive-<PostTypeName>'               => [
+		'social-title-ptarchive-<PostTypeName>'       => [
 			'default' => '%%pt_plural%% Archive', // Needs translation.
 			'types'   => [ 'text_field' ],
 		],
-		'social-title-tax-<TaxonomyName>'                     => [
+		'social-title-tax-<TaxonomyName>'             => [
 			'default' => '%%term_title%% Archives', // Needs translation.
 			'types'   => [ 'text_field' ],
 		],
-		'stripcategorybase'                                   => [
+		'stripcategorybase'                           => [
 			'default' => false,
 			'types'   => [ 'boolean' ],
 		],
-		'taxonomy-<TaxonomyName>-ptparent'                    => [
+		'taxonomy-<TaxonomyName>-ptparent'            => [
 			'default' => '',
 			'types'   => [ 'string' ],
 		],
-		'title-<PostTypeName>'                                => [
+		'title-<PostTypeName>'                        => [
 			'default' => '%%title%% %%page%% %%sep%% %%sitename%%',
 			'types'   => [ 'text_field' ],
 		],
-		'title-404-wpseo'                                     => [
+		'title-404-wpseo'                             => [
 			'default' => 'Page not found %%sep%% %%sitename%%', // Needs translation.
 			'types'   => [ 'text_field' ],
 		],
-		'title-archive-wpseo'                                 => [
+		'title-archive-wpseo'                         => [
 			'default' => '%%date%% %%page%% %%sep%% %%sitename%%',
 			'types'   => [ 'text_field' ],
 		],
-		'title-author-wpseo'                                  => [
+		'title-author-wpseo'                          => [
 			'default' => '%%name%%, Author at %%sitename%% %%page%% ', // Needs translation.
 			'types'   => [ 'text_field' ],
 		],
-		'title-home-wpseo'                                    => [
+		'title-home-wpseo'                            => [
 			'default' => '%%sitename%% %%page%% %%sep%% %%sitedesc%%',
 			'types'   => [ 'text_field' ],
 		],
-		'title-ptarchive-<PostTypeName>'                      => [
+		'title-ptarchive-<PostTypeName>'              => [
 			'default' => '%%pt_plural%% Archive %%page%% %%sep%% %%sitename%%', // Needs translation.
 			'types'   => [ 'text_field' ],
 		],
-		'title-search-wpseo'                                  => [
+		'title-search-wpseo'                          => [
 			'default' => 'You searched for %%searchphrase%% %%page%% %%sep%% %%sitename%%', // Needs translation.
 			'types'   => [ 'text_field' ],
 		],
-		'title-tax-<TaxonomyName>'                            => [
+		'title-tax-<TaxonomyName>'                    => [
 			'default' => '%%term_title%% Archives %%page%% %%sep%% %%sitename%%',
 			'types'   => [ 'text_field' ],
 		],
-		'website_name'                                        => [
+		'website_name'                                => [
 			'default' => '',
 			'types'   => [ 'text_field' ],
 		],
 
 		// WPSEO.
-		'algolia_integration_active'                          => [
+		'algolia_integration_active'                  => [
 			'default' => false,
 			'types'   => [ 'boolean' ],
 		],
-		'baiduverify'                                         => [
+		'baiduverify'                                 => [
 			'default' => '',
 			'types'   => [
 				'empty_string',
 				'verification' => [ 'pattern' => '`^[A-Za-z0-9_-]+$`' ],
 			],
 		],
-		'category_base_url'                                   => [
+		'category_base_url'                           => [
 			'default' => '',
 			'types'   => [
 				'empty_string',
@@ -580,69 +502,69 @@ class Site_Options_Service extends Abstract_Options_Service {
 				],
 			],
 		],
-		'content_analysis_active'                             => [
+		'content_analysis_active'                     => [
 			'default'   => true,
 			'types'     => [ 'boolean' ],
 			'ms_verify' => true,
 		],
-		'custom_taxonomy_slugs'                               => [
+		'custom_taxonomy_slugs'                       => [
 			'default' => [],
 			'types'   => [ 'string' ],
 		],
-		'disableadvanced_meta'                                => [
+		'disableadvanced_meta'                        => [
 			'default'   => true,
 			'types'     => [ 'boolean' ],
 			'ms_verify' => true,
 		],
-		'dismiss_configuration_workout_notice'                => [
+		'dismiss_configuration_workout_notice'        => [
 			'default' => false,
 			'types'   => [ 'boolean' ],
 		],
-		'dynamic_permalinks'                                  => [
+		'dynamic_permalinks'                          => [
 			'default' => false,
 			'types'   => [ 'boolean' ],
 		],
-		'enable_admin_bar_menu'                               => [
+		'enable_admin_bar_menu'                       => [
 			'default'   => true,
 			'types'     => [ 'boolean' ],
 			'ms_verify' => true,
 		],
-		'enable_cornerstone_content'                          => [
+		'enable_cornerstone_content'                  => [
 			'default'   => true,
 			'types'     => [ 'boolean' ],
 			'ms_verify' => true,
 		],
-		'enable_enhanced_slack_sharing'                       => [
+		'enable_enhanced_slack_sharing'               => [
 			'default'   => true,
 			'types'     => [ 'boolean' ],
 			'ms_verify' => true,
 		],
-		'enable_headless_rest_endpoints'                      => [
+		'enable_headless_rest_endpoints'              => [
 			'default'   => true,
 			'types'     => [ 'boolean' ],
 			'ms_verify' => true,
 		],
-		'enable_link_suggestions'                             => [
+		'enable_link_suggestions'                     => [
 			'default'   => true,
 			'types'     => [ 'boolean' ],
 			'ms_verify' => true,
 		],
-		'enable_metabox_insights'                             => [
+		'enable_metabox_insights'                     => [
 			'default'   => true,
 			'types'     => [ 'boolean' ],
 			'ms_verify' => true,
 		],
-		'enable_text_link_counter'                            => [
+		'enable_text_link_counter'                    => [
 			'default'   => true,
 			'types'     => [ 'boolean' ],
 			'ms_verify' => true,
 		],
-		'enable_xml_sitemap'                                  => [
+		'enable_xml_sitemap'                          => [
 			'default'   => true,
 			'types'     => [ 'boolean' ],
 			'ms_verify' => true,
 		],
-		'environment_type'                                    => [
+		'environment_type'                            => [
 			'default' => '',
 			'types'   => [
 				'empty_string',
@@ -651,22 +573,22 @@ class Site_Options_Service extends Abstract_Options_Service {
 				],
 			],
 		],
-		'first_activated_on'                                  => [
+		'first_activated_on'                          => [
 			'default' => false,
 			'types'   => [ 'integer' ],
 		],
-		'first_time_install'                                  => [
+		'first_time_install'                          => [
 			'default' => false,
 			'types'   => [ 'boolean' ],
 		],
-		'googleverify'                                        => [
+		'googleverify'                                => [
 			'default' => '',
 			'types'   => [
 				'empty_string',
 				'verification' => [ 'pattern' => '`^[A-Za-z0-9_-]+$`' ],
 			],
 		],
-		'has_multiple_authors'                                => [
+		'has_multiple_authors'                        => [
 			'default' => '',
 			'types'   => [
 				'empty_string',
@@ -675,60 +597,60 @@ class Site_Options_Service extends Abstract_Options_Service {
 				],
 			],
 		],
-		'home_url'                                            => [
+		'home_url'                                    => [
 			'default' => '',
 			'types'   => [ 'string' ],
 		],
-		'ignore_search_engines_discouraged_notice'            => [
+		'ignore_search_engines_discouraged_notice'    => [
 			'default'    => false,
 			'types'      => [ 'boolean' ],
 			'ms_exclude' => true,
 		],
-		'import_cursors'                                      => [
+		'import_cursors'                              => [
 			'default' => [],
 			'types'   => [ 'string' ],
 		],
-		'importing_completed'                                 => [
+		'importing_completed'                         => [
 			'default' => [],
 			'types'   => [ 'string' ],
 		],
-		'indexables_indexing_completed'                       => [
+		'indexables_indexing_completed'               => [
 			'default' => false,
 			'types'   => [ 'boolean' ],
 		],
-		'indexing_first_time'                                 => [
+		'indexing_first_time'                         => [
 			'default' => true,
 			'types'   => [ 'boolean' ],
 		],
-		'indexing_reason'                                     => [
+		'indexing_reason'                             => [
 			'default' => '',
 			'types'   => [ 'text_field' ],
 		],
-		'indexing_started'                                    => [
+		'indexing_started'                            => [
 			'default' => null,
 			'types'   => [ 'integer' ],
 		],
-		'keyword_analysis_active'                             => [
+		'keyword_analysis_active'                     => [
 			'default'   => true,
 			'types'     => [ 'boolean' ],
 			'ms_verify' => true,
 		],
-		'license_server_version'                              => [
+		'license_server_version'                      => [
 			'default' => false,
 			'types'   => [ 'string' ],
 		],
-		'ms_defaults_set'                                     => [
+		'ms_defaults_set'                             => [
 			'default' => false,
 			'types'   => [ 'boolean' ],
 		],
-		'msverify'                                            => [
+		'msverify'                                    => [
 			'default' => '',
 			'types'   => [
 				'empty_string',
 				'verification' => [ 'pattern' => '`^[A-Fa-f0-9_-]+$`' ],
 			],
 		],
-		'myyoast-oauth'                                       => [
+		'myyoast-oauth'                               => [
 			'default' => [
 				'config'        => [
 					'clientId' => null,
@@ -738,7 +660,7 @@ class Site_Options_Service extends Abstract_Options_Service {
 			],
 			'types'   => [ 'string' ],
 		],
-		'permalink_structure'                                 => [
+		'permalink_structure'                         => [
 			'default' => '',
 			'types'   => [
 				'empty_string',
@@ -747,37 +669,37 @@ class Site_Options_Service extends Abstract_Options_Service {
 				],
 			],
 		],
-		'previous_version'                                    => [
+		'previous_version'                            => [
 			'default' => '',
 			'types'   => [ 'string' ],
 		],
-		'ryte_indexability'                                   => [
+		'ryte_indexability'                           => [
 			'default'   => true,
 			'types'     => [ 'boolean' ],
 			'ms_verify' => true,
 		],
-		'semrush_country_code'                                => [
+		'semrush_country_code'                        => [
 			'default' => 'us',
 			'types'   => [ 'string' ],
 		],
-		'semrush_integration_active'                          => [
+		'semrush_integration_active'                  => [
 			'default'   => true,
 			'types'     => [ 'boolean' ],
 			'ms_verify' => true,
 		],
-		'semrush_tokens'                                      => [
+		'semrush_tokens'                              => [
 			'default' => [],
 			'types'   => [ 'string' ],
 		],
-		'should_redirect_after_install_free'                  => [
+		'should_redirect_after_install_free'          => [
 			'default' => false,
 			'types'   => [ 'boolean' ],
 		],
-		'show_onboarding_notice'                              => [
+		'show_onboarding_notice'                      => [
 			'default' => false,
 			'types'   => [ 'boolean' ],
 		],
-		'site_type'                                           => [
+		'site_type'                                   => [
 			'default' => '',
 			'types'   => [
 				'empty_string',
@@ -793,7 +715,7 @@ class Site_Options_Service extends Abstract_Options_Service {
 				],
 			],
 		],
-		'tag_base_url'                                        => [
+		'tag_base_url'                                => [
 			'default' => '',
 			'types'   => [
 				'empty_string',
@@ -802,53 +724,53 @@ class Site_Options_Service extends Abstract_Options_Service {
 				],
 			],
 		],
-		'tracking'                                            => [
+		'tracking'                                    => [
 			'default'   => false,
 			'types'     => [ 'boolean' ],
 			'ms_verify' => true,
 		],
-		'version'                                             => [
+		'version'                                     => [
 			'default' => '',
 			'types'   => [ 'is_equal' => [ 'equals' => WPSEO_VERSION ] ],
 		],
-		'wincher_automatically_add_keyphrases'                => [
+		'wincher_automatically_add_keyphrases'        => [
 			'default' => false,
 			'types'   => [ 'boolean' ],
 		],
-		'wincher_integration_active'                          => [
+		'wincher_integration_active'                  => [
 			'default'   => true,
 			'types'     => [ 'boolean' ],
 			'ms_verify' => true,
 		],
-		'wincher_tokens'                                      => [
+		'wincher_tokens'                              => [
 			'default' => [],
 			'types'   => [ 'string' ],
 		],
-		'wincher_website_id'                                  => [
+		'wincher_website_id'                          => [
 			'default' => '',
 			'types'   => [ 'string' ],
 		],
-		'workouts_data'                                       => [
+		'workouts_data'                               => [
 			'default' => [ 'configuration' => [ 'finishedSteps' => [] ] ],
 			'types'   => [ 'string' ],
 		],
-		'yandexverify'                                        => [
+		'yandexverify'                                => [
 			'default' => '',
 			'types'   => [
 				'empty_string',
 				'verification' => [ 'pattern' => '`^[A-Fa-f0-9_-]+$`' ],
 			],
 		],
-		'zapier_api_key'                                      => [
+		'zapier_api_key'                              => [
 			'default' => '',
 			'types'   => [ 'string' ],
 		],
-		'zapier_integration_active'                           => [
+		'zapier_integration_active'                   => [
 			'default'   => false,
 			'types'     => [ 'boolean' ],
 			'ms_verify' => true,
 		],
-		'zapier_subscription'                                 => [
+		'zapier_subscription'                         => [
 			'default' => [],
 			'types'   => [ 'string' ],
 		],

--- a/src/services/options/taxonomy-metadata-service.php
+++ b/src/services/options/taxonomy-metadata-service.php
@@ -158,7 +158,7 @@ class Taxonomy_Metadata_Service extends Abstract_Options_Service {
 
 		$prefixed_key = $this->get_prefixed_key( $key );
 		if ( ! \array_key_exists( $prefixed_key, $values ) ) {
-			throw new Unknown_Exception( $prefixed_key );
+			throw Unknown_Exception::for_option( $prefixed_key );
 		}
 
 		return $values[ $prefixed_key ];
@@ -187,7 +187,7 @@ class Taxonomy_Metadata_Service extends Abstract_Options_Service {
 
 		$prefixed_key = $this->get_prefixed_key( $key );
 		if ( ! \array_key_exists( $prefixed_key, $this->get_configurations() ) ) {
-			throw new Unknown_Exception( $prefixed_key );
+			throw Unknown_Exception::for_option( $prefixed_key );
 		}
 
 		// Presuming the default is safe.

--- a/src/services/options/taxonomy-metadata-service.php
+++ b/src/services/options/taxonomy-metadata-service.php
@@ -229,9 +229,10 @@ class Taxonomy_Metadata_Service extends Abstract_Options_Service {
 		// Loop over the defaults. Resulting in unknown values being ignored.
 		$new_term_values = $this->get_defaults();
 		foreach ( $new_term_values as $key => $default_value ) {
-			if ( \array_key_exists( $key, $values ) ) {
+			$prefixed_key = $this->get_prefixed_key( $key );
+			if ( \array_key_exists( $prefixed_key, $values ) ) {
 				// Validate, this can throw a Validation_Exception.
-				$new_term_values[ $key ] = $this->validation_helper->validate_as( $values[ $key ], $this->get_configurations()[ $key ]['types'] );
+				$new_term_values[ $prefixed_key ] = $this->validation_helper->validate_as( $values[ $prefixed_key ], $this->get_configurations()[ $prefixed_key ]['types'] );
 			}
 		}
 
@@ -271,12 +272,16 @@ class Taxonomy_Metadata_Service extends Abstract_Options_Service {
 	}
 
 	/**
-	 * Saves the options with their default values.
+	 * Deletes the options.
+	 *
+	 * As this services lazy saves, no data is saved in the reset.
+	 *
+	 * @throws \Yoast\WP\SEO\Exceptions\Option\Delete_Failed_Exception When the deletion failed.
 	 *
 	 * @return void
 	 */
 	public function reset_options() {
-		\update_option( $this->option_name, [] );
+		$this->delete_options();
 	}
 
 	/**
@@ -357,6 +362,8 @@ class Taxonomy_Metadata_Service extends Abstract_Options_Service {
 	 * @param mixed  $value The option value.
 	 *
 	 * @throws Method_Unimplemented_Exception Always, use set_term_option instead.
+	 *
+	 * @codeCoverageIgnore Not testable, because it is never called.
 	 *
 	 * @return void
 	 */

--- a/src/services/options/taxonomy-metadata-service.php
+++ b/src/services/options/taxonomy-metadata-service.php
@@ -2,8 +2,18 @@
 
 namespace Yoast\WP\SEO\Services\Options;
 
+use Yoast\WP\SEO\Exceptions\Option\Method_Unimplemented_Exception;
+use Yoast\WP\SEO\Exceptions\Option\Save_Failed_Exception;
+use Yoast\WP\SEO\Exceptions\Option\Term_Not_Found_Exception;
+use Yoast\WP\SEO\Exceptions\Option\Unknown_Exception;
+
 /**
  * The taxonomy metadata service class.
+ *
+ * BE AWARE!
+ * This service is different from the other options services!
+ * The option values are the term metadata. They are scoped within taxonomy (slug) and term (ID).
+ * To make that happen the get/set require the term and taxonomy as input. Which is why the interface is different.
  */
 class Taxonomy_Metadata_Service extends Abstract_Options_Service {
 
@@ -97,4 +107,323 @@ class Taxonomy_Metadata_Service extends Abstract_Options_Service {
 			'types'   => [ 'text_field' ],
 		],
 	];
+
+	/**
+	 * Magic getter to get the option value.
+	 *
+	 * @param string $key The option key.
+	 *
+	 * @throws Method_Unimplemented_Exception Always, use get instead.
+	 *
+	 * @return mixed The option value.
+	 */
+	public function __get( $key ) {
+		throw Method_Unimplemented_Exception::for_method( __METHOD__, __CLASS__ );
+	}
+
+	/**
+	 * Magic setter to set the option value.
+	 *
+	 * @param string $key   The option key.
+	 * @param mixed  $value The option value.
+	 *
+	 * @throws Method_Unimplemented_Exception Always, use set instead.
+	 */
+	public function __set( $key, $value ) {
+		throw Method_Unimplemented_Exception::for_method( __METHOD__, __CLASS__ );
+	}
+
+	/**
+	 * Retrieves the option/metadata value for a term.
+	 *
+	 * @param mixed       $term     The term name, (int) term id or (object) term.
+	 * @param string      $taxonomy The taxonomy the term belongs to.
+	 * @param string|null $key      Optional. Meta value to get (with or without prefix).
+	 *
+	 * @throws Term_Not_Found_Exception When the term is not found.
+	 * @throws Unknown_Exception When the option does not exist.
+	 *
+	 * @return mixed The term metadata values or value if a key was provided.
+	 */
+	public function get( $term, $taxonomy, $key = null ) {
+		$term_id = $this->get_term_id( $term, $taxonomy );
+		if ( $term_id === null ) {
+			throw Term_Not_Found_Exception::for_term( $term, $taxonomy );
+		}
+
+		$values = $this->get_term_values( $term_id, $taxonomy );
+		if ( $key === null ) {
+			return $values;
+		}
+
+		$prefixed_key = $this->get_prefixed_key( $key );
+		if ( ! \array_key_exists( $prefixed_key, $values ) ) {
+			throw new Unknown_Exception( $prefixed_key );
+		}
+
+		return $values[ $prefixed_key ];
+	}
+
+	// phpcs:disable Squiz.Commenting.FunctionCommentThrowTag.WrongNumber -- PHPCS doesn't take into account exceptions thrown in called methods.
+
+	/**
+	 * Sets the option/metadata value for a term.
+	 *
+	 * @param mixed  $term     The term name, (int) term id or (object) term.
+	 * @param string $taxonomy The taxonomy the term belongs to.
+	 * @param string $key      The option key.
+	 * @param mixed  $value    The option value.
+	 *
+	 * @throws Term_Not_Found_Exception When the term is not found.
+	 * @throws Unknown_Exception When the option does not exist.
+	 * @throws \Yoast\WP\SEO\Exceptions\Validation\Abstract_Validation_Exception When the value is invalid.
+	 * @throws Save_Failed_Exception When the save failed.
+	 */
+	public function set( $term, $taxonomy, $key, $value ) {
+		$term_id = $this->get_term_id( $term, $taxonomy );
+		if ( $term_id === null ) {
+			throw Term_Not_Found_Exception::for_term( $term, $taxonomy );
+		}
+
+		$prefixed_key = $this->get_prefixed_key( $key );
+		if ( ! \array_key_exists( $prefixed_key, $this->get_configurations() ) ) {
+			throw new Unknown_Exception( $prefixed_key );
+		}
+
+		// Presuming the default is safe.
+		if ( $value === $this->get_configurations()[ $prefixed_key ]['default'] ) {
+			$this->set_term_option( $term_id, $taxonomy, $prefixed_key, $value );
+
+			return;
+		}
+		// Only save when changed.
+		if ( isset( $this->get_values()[ $taxonomy ][ $term_id ][ $prefixed_key ] ) && $value === $this->get_values()[ $taxonomy ][ $term_id ][ $prefixed_key ] ) {
+			return;
+		}
+
+		// Validate, this can throw a Validation_Exception.
+		$value = $this->validation_helper->validate_as( $value, $this->get_configurations()[ $prefixed_key ]['types'] );
+
+		$this->set_term_option( $term_id, $taxonomy, $prefixed_key, $value );
+	}
+
+	/**
+	 * Sets all option/metadata values for a term.
+	 *
+	 * @param mixed  $term     The term name, (int) term id or (object) term.
+	 * @param string $taxonomy The taxonomy the term belongs to.
+	 * @param array  $values   The option values to set.
+	 *
+	 * @throws Term_Not_Found_Exception When the term is not found.
+	 * @throws \Yoast\WP\SEO\Exceptions\Validation\Abstract_Validation_Exception When a value is invalid.
+	 * @throws Save_Failed_Exception When the save failed.
+	 *
+	 * @return void
+	 */
+	public function set_options( $term, $taxonomy, $values ) {
+		$term_id = $this->get_term_id( $term, $taxonomy );
+		if ( $term_id === null ) {
+			throw Term_Not_Found_Exception::for_term( $term, $taxonomy );
+		}
+
+		// Loop over the defaults. Resulting in unknown values being ignored.
+		$new_term_values = $this->get_defaults();
+		foreach ( $new_term_values as $key => $default_value ) {
+			if ( \array_key_exists( $key, $values ) ) {
+				// Validate, this can throw a Validation_Exception.
+				$new_term_values[ $key ] = $this->validation_helper->validate_as( $values[ $key ], $this->get_configurations()[ $key ]['types'] );
+			}
+		}
+
+		$new_values = $this->get_values();
+		if ( ! isset( $new_values[ $taxonomy ] ) ) {
+			$new_values[ $taxonomy ] = [];
+		}
+		$new_values[ $taxonomy ][ $term_id ] = $new_term_values;
+
+		/*
+		 * Only update when changed.
+		 * This might seem strange, but WP returns false if we try to save the same values.
+		 * Which we can not differ from an actual database error.
+		 */
+		if ( $new_values === $this->get_values() ) {
+			return;
+		}
+
+		// Update the cache.
+		$this->cached_values = $new_values;
+
+		// Save to the database.
+		$this->update_options( $this->cached_values );
+	}
+
+	// phpcs:enable Squiz.Commenting.FunctionCommentThrowTag.WrongNumber
+
+	/**
+	 * Retrieves the options.
+	 *
+	 * @param string[] $keys Optionally request only these options.
+	 *
+	 * @return array The options.
+	 */
+	public function get_options( array $keys = [] ) {
+		return $this->get_values();
+	}
+
+	/**
+	 * Saves the options with their default values.
+	 *
+	 * @return void
+	 */
+	public function reset_options() {
+		\update_option( $this->option_name, [] );
+	}
+
+	/**
+	 * Retrieves the default option value.
+	 *
+	 * @param string $key The option key.
+	 *
+	 * @throws Method_Unimplemented_Exception Always.
+	 *
+	 * @return mixed The default value.
+	 */
+	public function get_default( $key ) {
+		throw Method_Unimplemented_Exception::for_method( __METHOD__, __CLASS__ );
+	}
+
+	/**
+	 * Retrieves the term option/metadata values.
+	 *
+	 * @param int    $term_id  The term ID.
+	 * @param string $taxonomy The taxonomy.
+	 *
+	 * @return array The defaults for the term.
+	 */
+	protected function get_term_values( $term_id, $taxonomy ) {
+		$values = $this->get_values();
+
+		if ( isset( $values[ $taxonomy ][ $term_id ] ) ) {
+			return \array_merge( $this->get_defaults(), $values[ $taxonomy ][ $term_id ] );
+		}
+
+		return $this->get_defaults();
+	}
+
+	/**
+	 * Retrieves the term ID.
+	 *
+	 * @param mixed  $term     The term name, (int) term id or (object) term.
+	 * @param string $taxonomy The taxonomy the term belongs to.
+	 *
+	 * @return int|null The term ID or null.
+	 */
+	protected function get_term_id( $term, $taxonomy ) {
+		if ( \is_int( $term ) ) {
+			$term = \get_term_by( 'id', $term, $taxonomy );
+		}
+		elseif ( \is_string( $term ) ) {
+			$term = \get_term_by( 'slug', $term, $taxonomy );
+		}
+
+		if ( \is_object( $term ) && isset( $term->term_id ) ) {
+			return $term->term_id;
+		}
+
+		return null;
+	}
+
+	/**
+	 * Retrieves the (cached) values.
+	 *
+	 * @return array The values.
+	 */
+	protected function get_values() {
+		if ( $this->cached_values === null ) {
+			$this->cached_values = \get_option( $this->option_name );
+			// Database row does not exist. We need an array.
+			if ( ! $this->cached_values ) {
+				$this->cached_values = [];
+			}
+		}
+
+		return $this->cached_values;
+	}
+
+	/**
+	 * Updates an option.
+	 *
+	 * @param string $key   The option key.
+	 * @param mixed  $value The option value.
+	 *
+	 * @throws Method_Unimplemented_Exception Always, use set_term_option instead.
+	 *
+	 * @return void
+	 */
+	protected function update_option( $key, $value ) {
+		throw Method_Unimplemented_Exception::for_method( __METHOD__, __CLASS__ );
+	}
+
+	/**
+	 * Sets a term option/metadata value.
+	 *
+	 * @param int    $term_id  The term ID.
+	 * @param string $taxonomy The taxonomy.
+	 * @param string $key      The option key.
+	 * @param mixed  $value    The value to set.
+	 *
+	 * @throws Save_Failed_Exception When the save failed.
+	 *
+	 * @return void
+	 */
+	protected function set_term_option( $term_id, $taxonomy, $key, $value ) {
+		// Ensure the cache is filled.
+		if ( $this->cached_values === null ) {
+			$this->get_values();
+		}
+
+		// Only save when changed.
+		if ( isset( $this->cached_values[ $taxonomy ][ $term_id ][ $key ] ) && $value === $this->cached_values[ $taxonomy ][ $term_id ][ $key ] ) {
+			return;
+		}
+
+		// Update the cache.
+		if ( ! isset( $this->cached_values[ $taxonomy ] ) ) {
+			$this->cached_values[ $taxonomy ]             = [];
+			$this->cached_values[ $taxonomy ][ $term_id ] = $this->get_defaults();
+		}
+		elseif ( ! isset( $this->cached_values[ $taxonomy ][ $term_id ] ) ) {
+			$this->cached_values[ $taxonomy ][ $term_id ] = $this->get_defaults();
+		}
+		$this->cached_values[ $taxonomy ][ $term_id ][ $key ] = $value;
+
+		// Save to the database.
+		$this->update_options( $this->cached_values );
+	}
+
+	/**
+	 * Expands the post types & taxonomies "wildcards" in the configurations.
+	 *
+	 * @param array $configurations The configurations to expand.
+	 *
+	 * @return array The expanded configurations.
+	 */
+	protected function expand_configurations( array $configurations ) {
+		return $configurations;
+	}
+
+	/**
+	 * Ensures the key is prefixed with `wpseo_`.
+	 *
+	 * @param string $key The key.
+	 *
+	 * @return string The prefixed key.
+	 */
+	protected function get_prefixed_key( $key ) {
+		if ( \substr( \strtolower( $key ), 0, 6 ) !== 'wpseo_' ) {
+			return "wpseo_$key";
+		}
+
+		return $key;
+	}
 }

--- a/src/services/options/taxonomy-metadata-service.php
+++ b/src/services/options/taxonomy-metadata-service.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Yoast\WP\SEO\Services\Options;
+
+/**
+ * The taxonomy metadata service class.
+ */
+class Taxonomy_Metadata_Service extends Abstract_Options_Service {
+
+	/**
+	 * Holds the WordPress options' option name.
+	 *
+	 * @var string
+	 */
+	public $option_name = 'wpseo_taxonomy_metadata';
+
+	/**
+	 * The option configurations.
+	 *
+	 * @var array
+	 */
+	protected $configurations = [
+		'wpseo_bctitle'               => [
+			'default' => '',
+			'types'   => [ 'text_field' ],
+		],
+		'wpseo_canonical'             => [
+			'default' => '',
+			'types'   => [ 'empty_string', 'url' ],
+		],
+		'wpseo_content_score'         => [
+			'default' => '',
+			'types'   => [ 'text_field' ],
+		],
+		'wpseo_desc'                  => [
+			'default' => '',
+			'types'   => [ 'text_field' ],
+		],
+		'wpseo_focuskeywords'         => [
+			'default' => '',
+			'types'   => [ 'string' ],
+		],
+		'wpseo_focuskw'               => [
+			'default' => '',
+			'types'   => [ 'text_field' ],
+		],
+		'wpseo_is_cornerstone'        => [
+			'default' => '',
+			'types'   => [ 'string' ],
+		],
+		'wpseo_keywordsynonyms'       => [
+			'default' => '',
+			'types'   => [ 'string' ],
+		],
+		'wpseo_linkdex'               => [
+			'default' => '',
+			'types'   => [ 'text_field' ],
+		],
+		'wpseo_noindex'               => [
+			'default' => '',
+			'types'   => [ 'string' ],
+		],
+		'wpseo_opengraph-description' => [
+			'default' => '',
+			'types'   => [ 'text_field' ],
+		],
+		'wpseo_opengraph-image'       => [
+			'default' => '',
+			'types'   => [ 'text_field' ],
+		],
+		'wpseo_opengraph-image-id'    => [
+			'default' => '',
+			'types'   => [ 'text_field' ],
+		],
+		'wpseo_opengraph-title'       => [
+			'default' => '',
+			'types'   => [ 'text_field' ],
+		],
+		'wpseo_title'                 => [
+			'default' => '',
+			'types'   => [ 'text_field' ],
+		],
+		'wpseo_twitter-description'   => [
+			'default' => '',
+			'types'   => [ 'text_field' ],
+		],
+		'wpseo_twitter-image'         => [
+			'default' => '',
+			'types'   => [ 'text_field' ],
+		],
+		'wpseo_twitter-image-id'      => [
+			'default' => '',
+			'types'   => [ 'text_field' ],
+		],
+		'wpseo_twitter-title'         => [
+			'default' => '',
+			'types'   => [ 'text_field' ],
+		],
+	];
+}

--- a/tests/unit/actions/importing/aioseo-cleanup-action-test.php
+++ b/tests/unit/actions/importing/aioseo-cleanup-action-test.php
@@ -121,7 +121,6 @@ class Aioseo_Cleanup_Action_Test extends TestCase {
 	 * @covers ::cleanup_postmeta_query
 	 * @covers ::truncate_query
 	 * @covers ::get_postmeta_table
-	 * @covers ::get_aioseo_table
 	 *
 	 * @param array     $completed_option   The persistent completed option.
 	 * @param int       $query_times        The times we're gonna run the cleanup queries.

--- a/tests/unit/exceptions/importing/aioseo-validation-exception-test.php
+++ b/tests/unit/exceptions/importing/aioseo-validation-exception-test.php
@@ -10,7 +10,7 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  *
  * @group exceptions
  *
- * @coversDefaultClass \Yoast\WP\SEO\Exceptions\Indexable\Aioseo_Validation_Exception
+ * @coversDefaultClass \Yoast\WP\SEO\Exceptions\Importing\Aioseo_Validation_Exception
  */
 class Aioseo_Validation_Exception_Test extends TestCase {
 

--- a/tests/unit/services/options/site-options-service-test.php
+++ b/tests/unit/services/options/site-options-service-test.php
@@ -187,6 +187,7 @@ class Site_Options_Service_Test extends TestCase {
 		$this->taxonomy_helper->expects( 'get_public_taxonomies' )->andReturn( [] );
 
 		$this->expectException( Unknown_Exception::class );
+		$this->expectExceptionMessage( Unknown_Exception::for_option( 'bar' )->getMessage() );
 
 		$this->instance->bar;
 	}
@@ -322,6 +323,7 @@ class Site_Options_Service_Test extends TestCase {
 		$this->taxonomy_helper->expects( 'get_public_taxonomies' )->andReturn( [] );
 
 		$this->expectException( Unknown_Exception::class );
+		$this->expectExceptionMessage( Unknown_Exception::for_option( 'foo' )->getMessage() );
 
 		Monkey\Functions\expect( 'update_option' )->never();
 
@@ -524,6 +526,7 @@ class Site_Options_Service_Test extends TestCase {
 		$this->taxonomy_helper->expects( 'get_public_taxonomies' )->andReturn( [] );
 
 		$this->expectException( Unknown_Exception::class );
+		$this->expectExceptionMessage( Unknown_Exception::for_option( 'unknown' )->getMessage() );
 
 		$this->instance->get_default( 'unknown' );
 	}

--- a/tests/unit/services/options/taxonomy-metadata-service-test.php
+++ b/tests/unit/services/options/taxonomy-metadata-service-test.php
@@ -1,0 +1,568 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Services\Options;
+
+use Brain\Monkey;
+use Mockery;
+use Yoast\WP\SEO\Exceptions\Option\Method_Unimplemented_Exception;
+use Yoast\WP\SEO\Exceptions\Option\Term_Not_Found_Exception;
+use Yoast\WP\SEO\Exceptions\Option\Unknown_Exception;
+use Yoast\WP\SEO\Helpers\Post_Type_Helper;
+use Yoast\WP\SEO\Helpers\Taxonomy_Helper;
+use Yoast\WP\SEO\Helpers\Validation_Helper;
+use Yoast\WP\SEO\Services\Options\Taxonomy_Metadata_Service;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Tests the Taxonomy_Metadata_Service class.
+ *
+ * @group options
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Services\Options\Taxonomy_Metadata_Service
+ */
+class Taxonomy_Metadata_Service_Test extends TestCase {
+
+	/**
+	 * Holds the instance to test.
+	 *
+	 * @var Taxonomy_Metadata_Service|Mockery\Mock
+	 */
+	protected $instance;
+
+	/**
+	 * Holds the validation helper instance.
+	 *
+	 * @var Validation_Helper|Mockery\Mock
+	 */
+	protected $validation_helper;
+
+	/**
+	 * Holds the post type helper instance.
+	 *
+	 * @var Post_Type_Helper|Mockery\Mock
+	 */
+	protected $post_type_helper;
+
+	/**
+	 * Holds the taxonomy helper instance.
+	 *
+	 * @var Taxonomy_Helper|Mockery\Mock
+	 */
+	protected $taxonomy_helper;
+
+	/**
+	 * Sets up the test fixtures.
+	 */
+	protected function set_up() {
+		$this->stubEscapeFunctions();
+		$this->stubTranslationFunctions();
+
+		$this->validation_helper = Mockery::mock( Validation_Helper::class );
+		$this->post_type_helper  = Mockery::mock( Post_Type_Helper::class );
+		$this->taxonomy_helper   = Mockery::mock( Taxonomy_Helper::class );
+
+		$this->instance = new Taxonomy_Metadata_Service( $this->validation_helper, $this->post_type_helper, $this->taxonomy_helper );
+	}
+
+	/**
+	 * Tests the attributes after constructing.
+	 *
+	 * @covers ::__construct
+	 */
+	public function test_constructor() {
+		$this->assertInstanceOf( Taxonomy_Metadata_Service::class, $this->instance );
+		$this->assertEquals(
+			'wpseo_taxonomy_metadata',
+			$this->getPropertyValue( $this->instance, 'option_name' )
+		);
+		$this->assertNotEmpty(
+			$this->getPropertyValue( $this->instance, 'configurations' )
+		);
+		$this->assertInstanceOf(
+			Validation_Helper::class,
+			$this->getPropertyValue( $this->instance, 'validation_helper' )
+		);
+		$this->assertInstanceOf(
+			Post_Type_Helper::class,
+			$this->getPropertyValue( $this->instance, 'post_type_helper' )
+		);
+		$this->assertInstanceOf(
+			Taxonomy_Helper::class,
+			$this->getPropertyValue( $this->instance, 'taxonomy_helper' )
+		);
+	}
+
+	/**
+	 * Tests that the magic get throws an exception.
+	 *
+	 * @covers ::__get
+	 */
+	public function test_magic_getter() {
+		$this->expectException( Method_Unimplemented_Exception::class );
+
+		$this->instance->foo;
+	}
+
+	/**
+	 * Tests that the magic set throws an exception.
+	 *
+	 * @covers ::__set
+	 */
+	public function test_magic_setter() {
+		$this->expectException( Method_Unimplemented_Exception::class );
+
+		$this->instance->foo = 'bar';
+	}
+
+	/**
+	 * Tests getting the option/metadata values for a term.
+	 *
+	 * @covers ::get
+	 * @covers ::get_term_id
+	 * @covers ::get_term_values
+	 * @covers ::get_values
+	 * @covers ::get_defaults
+	 * @covers ::get_configurations
+	 * @covers ::expand_configurations
+	 */
+	public function test_get_all() {
+		Monkey\Functions\expect( 'get_term_by' )
+			->with( 'id', 1, 'category' )
+			->once()
+			->andReturn( (object) [ 'term_id' => 1 ] );
+
+		Monkey\Functions\expect( 'get_option' )
+			->with( 'wpseo_taxonomy_metadata' )
+			->once()
+			->andReturn( [] );
+
+		Monkey\Functions\expect( 'apply_filters' )
+			->once()
+			->with( 'wpseo_additional_option_configurations', [] )
+			->andReturn( [] );
+
+		$this->assertArrayHasKey( 'wpseo_title', $this->instance->get( 1, 'category' ) );
+	}
+
+	/**
+	 * Tests getting an option/metadata value for a term.
+	 *
+	 * @covers ::get
+	 * @covers ::get_term_id
+	 * @covers ::get_term_values
+	 * @covers ::get_defaults
+	 * @covers ::get_configurations
+	 * @covers ::expand_configurations
+	 * @covers ::get_prefixed_key
+	 */
+	public function test_get() {
+		Monkey\Functions\expect( 'get_term_by' )
+			->with( 'slug', 'slug', 'category' )
+			->once()
+			->andReturn( (object) [ 'term_id' => 1 ] );
+
+		Monkey\Functions\expect( 'get_option' )
+			->with( 'wpseo_taxonomy_metadata' )
+			->once()
+			->andReturn( [ 'category' => [ 1 => [ 'wpseo_foo' => 'bar' ] ] ] );
+
+		Monkey\Functions\expect( 'apply_filters' )
+			->once()
+			->with( 'wpseo_additional_option_configurations', [] )
+			->andReturn( [] );
+
+		$this->assertEquals( 'bar', $this->instance->get( 'slug', 'category', 'foo' ) );
+	}
+
+	/**
+	 * Tests getting an option/metadata value for a term, with an already prefixed key.
+	 *
+	 * @covers ::get
+	 * @covers ::get_prefixed_key
+	 */
+	public function test_get_prefixed_key() {
+		Monkey\Functions\expect( 'get_term_by' )
+			->with( 'slug', 'slug', 'category' )
+			->once()
+			->andReturn( (object) [ 'term_id' => 1 ] );
+
+		Monkey\Functions\expect( 'get_option' )
+			->with( 'wpseo_taxonomy_metadata' )
+			->once()
+			->andReturn( [ 'category' => [ 1 => [ 'wpseo_foo' => 'bar' ] ] ] );
+
+		Monkey\Functions\expect( 'apply_filters' )
+			->once()
+			->with( 'wpseo_additional_option_configurations', [] )
+			->andReturn( [] );
+
+		$this->assertEquals( 'bar', $this->instance->get( 'slug', 'category', 'wpseo_foo' ) );
+	}
+
+	/**
+	 * Tests getting an option/metadata value for an unknown term.
+	 *
+	 * @covers ::get
+	 * @covers ::get_term_id
+	 */
+	public function test_get_unknown_term() {
+		Monkey\Functions\expect( 'get_term_by' )
+			->with( 'id', 1, 'category' )
+			->once()
+			->andReturn( false );
+
+		$this->expectException( Term_Not_Found_Exception::class );
+		$this->expectExceptionMessage( Term_Not_Found_Exception::for_term( 1, 'category' )->getMessage() );
+
+		$this->instance->get( 1, 'category' );
+	}
+
+	/**
+	 * Tests getting an unknown option/metadata value for a term.
+	 *
+	 * @covers ::get
+	 * @covers ::get_term_id
+	 * @covers ::get_term_values
+	 * @covers ::get_defaults
+	 * @covers ::get_configurations
+	 * @covers ::expand_configurations
+	 * @covers ::get_prefixed_key
+	 */
+	public function test_get_unknown_key() {
+		Monkey\Functions\expect( 'get_term_by' )
+			->with( 'slug', 'slug', 'category' )
+			->once()
+			->andReturn( (object) [ 'term_id' => 1 ] );
+
+		Monkey\Functions\expect( 'get_option' )
+			->with( 'wpseo_taxonomy_metadata' )
+			->once()
+			->andReturn( [] );
+
+		Monkey\Functions\expect( 'apply_filters' )
+			->once()
+			->with( 'wpseo_additional_option_configurations', [] )
+			->andReturn( [] );
+
+		$this->expectException( Unknown_Exception::class );
+		$this->expectExceptionMessage( Unknown_Exception::for_option( 'wpseo_foo' )->getMessage() );
+
+		$this->instance->get( 'slug', 'category', 'foo' );
+	}
+
+	/**
+	 * Tests setting an option/metadata value for a term.
+	 *
+	 * @covers ::set
+	 * @covers ::set_term_option
+	 */
+	public function test_set() {
+		Monkey\Functions\expect( 'get_term_by' )
+			->with( 'id', 1, 'category' )
+			->once()
+			->andReturn( (object) [ 'term_id' => 1 ] );
+
+		Monkey\Functions\expect( 'apply_filters' )
+			->once()
+			->with( 'wpseo_additional_option_configurations', [] )
+			->andReturn( [] );
+
+		Monkey\Functions\expect( 'get_option' )
+			->with( 'wpseo_taxonomy_metadata' )
+			->once()
+			->andReturn( [] );
+
+		$this->validation_helper->expects( 'validate_as' )
+			->with( 'foo', [ 'text_field' ] )
+			->once()
+			->andReturn( 'foo' );
+
+		Monkey\Functions\expect( 'update_option' )->once()->andReturn( true );
+
+		$this->instance->set( 1, 'category', 'wpseo_title', 'foo' );
+	}
+
+	/**
+	 * Tests setting an option/metadata value for a term. Path in set_term_option where the category is already present.
+	 *
+	 * @covers ::set
+	 * @covers ::set_term_option
+	 */
+	public function test_set_taxonomy_already_present() {
+		Monkey\Functions\expect( 'get_term_by' )
+			->with( 'id', 1, 'category' )
+			->once()
+			->andReturn( (object) [ 'term_id' => 1 ] );
+
+		Monkey\Functions\expect( 'apply_filters' )
+			->once()
+			->with( 'wpseo_additional_option_configurations', [] )
+			->andReturn( [] );
+
+		Monkey\Functions\expect( 'get_option' )
+			->with( 'wpseo_taxonomy_metadata' )
+			->once()
+			->andReturn( [ 'category' => [] ] );
+
+		$this->validation_helper->expects( 'validate_as' )
+			->with( 'foo', [ 'text_field' ] )
+			->once()
+			->andReturn( 'foo' );
+
+		Monkey\Functions\expect( 'update_option' )->once()->andReturn( true );
+
+		$this->instance->set( 1, 'category', 'wpseo_title', 'foo' );
+	}
+
+	/**
+	 * Tests setting an option/metadata value for a term, same value after validation.
+	 *
+	 * @covers ::set
+	 * @covers ::set_term_option
+	 */
+	public function test_set_same_value_after_validation() {
+		Monkey\Functions\expect( 'get_term_by' )
+			->with( 'id', 1, 'category' )
+			->once()
+			->andReturn( (object) [ 'term_id' => 1 ] );
+
+		Monkey\Functions\expect( 'apply_filters' )
+			->once()
+			->with( 'wpseo_additional_option_configurations', [] )
+			->andReturn( [] );
+
+		Monkey\Functions\expect( 'get_option' )
+			->with( 'wpseo_taxonomy_metadata' )
+			->once()
+			->andReturn( [ 'category' => [ 1 => [ 'wpseo_title' => 'foo' ] ] ] );
+
+		$this->validation_helper->expects( 'validate_as' )
+			->with( 'foo_', [ 'text_field' ] )
+			->once()
+			->andReturn( 'foo' );
+
+		Monkey\Functions\expect( 'update_option' )->never();
+
+		$this->instance->set( 1, 'category', 'wpseo_title', 'foo_' );
+	}
+
+	/**
+	 * Tests setting an option/metadata value for a term, same value.
+	 *
+	 * @covers ::set
+	 * @covers ::set_term_option
+	 */
+	public function test_set_same_value() {
+		Monkey\Functions\expect( 'get_term_by' )
+			->with( 'id', 1, 'category' )
+			->once()
+			->andReturn( (object) [ 'term_id' => 1 ] );
+
+		Monkey\Functions\expect( 'apply_filters' )
+			->once()
+			->with( 'wpseo_additional_option_configurations', [] )
+			->andReturn( [] );
+
+		Monkey\Functions\expect( 'get_option' )
+			->with( 'wpseo_taxonomy_metadata' )
+			->once()
+			->andReturn( [ 'category' => [ 1 => [ 'wpseo_title' => 'foo' ] ] ] );
+
+		Monkey\Functions\expect( 'update_option' )->never();
+
+		$this->instance->set( 1, 'category', 'wpseo_title', 'foo' );
+	}
+
+	/**
+	 * Tests setting an option/metadata value for a term, same value as configuration default.
+	 *
+	 * @covers ::set
+	 * @covers ::set_term_option
+	 */
+	public function test_set_same_value_as_configuration_default() {
+		Monkey\Functions\expect( 'get_term_by' )
+			->with( 'id', 1, 'category' )
+			->once()
+			->andReturn( (object) [ 'term_id' => 1 ] );
+
+		Monkey\Functions\expect( 'apply_filters' )
+			->once()
+			->with( 'wpseo_additional_option_configurations', [] )
+			->andReturn( [] );
+
+		Monkey\Functions\expect( 'get_option' )
+			->with( 'wpseo_taxonomy_metadata' )
+			->once()
+			->andReturn( [] );
+
+		Monkey\Functions\expect( 'update_option' )->once()->andReturn( true );
+
+		$this->instance->set( 1, 'category', 'wpseo_title', '' );
+	}
+
+	/**
+	 * Tests setting an unknown option/metadata value for a term.
+	 *
+	 * @covers ::set
+	 */
+	public function test_set_unknown_key() {
+		Monkey\Functions\expect( 'get_term_by' )
+			->with( 'id', 1, 'category' )
+			->once()
+			->andReturn( (object) [ 'term_id' => 1 ] );
+
+		Monkey\Functions\expect( 'apply_filters' )
+			->once()
+			->with( 'wpseo_additional_option_configurations', [] )
+			->andReturn( [] );
+
+		$this->expectException( Unknown_Exception::class );
+		$this->expectExceptionMessage( Unknown_Exception::for_option( 'wpseo_foo' )->getMessage() );
+
+		$this->instance->set( 1, 'category', 'foo', 'bar' );
+	}
+
+	/**
+	 * Tests setting an option/metadata value for an unknown term.
+	 *
+	 * @covers ::set
+	 */
+	public function test_set_unknown_term() {
+		Monkey\Functions\expect( 'get_term_by' )
+			->with( 'id', 1, 'category' )
+			->once()
+			->andReturn( false );
+
+		$this->expectException( Term_Not_Found_Exception::class );
+		$this->expectExceptionMessage( Term_Not_Found_Exception::for_term( 1, 'category' )->getMessage() );
+
+		$this->instance->set( 1, 'category', 'foo', 'bar' );
+	}
+
+	/**
+	 * Tests setting all option/metadata values for a term.
+	 *
+	 * @covers ::set_options
+	 */
+	public function test_set_options() {
+		Monkey\Functions\expect( 'get_term_by' )
+			->with( 'id', 1, 'category' )
+			->once()
+			->andReturn( (object) [ 'term_id' => 1 ] );
+
+		Monkey\Functions\expect( 'apply_filters' )
+			->once()
+			->with( 'wpseo_additional_option_configurations', [] )
+			->andReturn( [] );
+
+		Monkey\Functions\expect( 'get_option' )
+			->with( 'wpseo_taxonomy_metadata' )
+			->once()
+			->andReturn( [] );
+
+		foreach ( [ 'foo', 'bar' ] as $value ) {
+			$this->validation_helper->expects( 'validate_as' )
+				->with( $value, [ 'text_field' ] )
+				->once()
+				->andReturn( $value );
+		}
+
+		Monkey\Functions\expect( 'update_option' )->once()->andReturn( true );
+
+		$this->instance->set_options( 1, 'category', [ 'wpseo_title' => 'foo', 'wpseo_desc' => 'bar' ] );
+	}
+
+	/**
+	 * Tests setting the same option/metadata values for a term.
+	 *
+	 * @covers ::set_options
+	 */
+	public function test_set_options_same_values() {
+		Monkey\Functions\expect( 'get_term_by' )
+			->with( 'id', 1, 'category' )
+			->once()
+			->andReturn( (object) [ 'term_id' => 1 ] );
+
+		Monkey\Functions\expect( 'apply_filters' )
+			->once()
+			->with( 'wpseo_additional_option_configurations', [] )
+			->andReturn( [] );
+
+		// We need the defaults to try to set them again.
+		$values = $this->instance->get_defaults();
+
+		Monkey\Functions\expect( 'get_option' )
+			->with( 'wpseo_taxonomy_metadata' )
+			->once()
+			->andReturn( [ 'category' => [ 1 => $values ] ] );
+
+		$this->validation_helper->expects( 'validate_as' )
+			->withAnyArgs()
+			->times( \count( $values ) )
+			->andReturnArg( 0 );
+
+
+		Monkey\Functions\expect( 'update_option' )->never();
+
+		$this->instance->set_options( 1, 'category', $values );
+	}
+
+	/**
+	 * Tests setting the option/metadata values for an unknown term.
+	 *
+	 * @covers ::set_options
+	 */
+	public function test_set_options_unknown_term() {
+		Monkey\Functions\expect( 'get_term_by' )
+			->with( 'id', 1, 'category' )
+			->once()
+			->andReturn( false );
+
+		$this->expectException( Term_Not_Found_Exception::class );
+		$this->expectExceptionMessage( Term_Not_Found_Exception::for_term( 1, 'category' )->getMessage() );
+
+		$this->instance->set_options( 1, 'category', [] );
+	}
+
+	/**
+	 * Tests getting the option/metadata values for a term.
+	 *
+	 * @covers ::get_options
+	 * @covers ::get_values
+	 */
+	public function test_get_options() {
+		$values = [ 'category' => [ 1 => [ 'wpseo_title' => 'foo' ] ] ];
+
+		Monkey\Functions\expect( 'get_option' )
+			->with( 'wpseo_taxonomy_metadata' )
+			->once()
+			->andReturn( $values );
+
+		$this->assertSame( $values, $this->instance->get_options() );
+	}
+
+	/**
+	 * Tests that reset options deletes the options.
+	 *
+	 * @covers ::reset_options
+	 */
+	public function test_reset_options() {
+		Monkey\Functions\expect( 'delete_option' )
+			->with( 'wpseo_taxonomy_metadata' )
+			->once()
+			->andReturn( true );
+
+		$this->instance->reset_options();
+	}
+
+	/**
+	 * Tests that getting the default throws an exception.
+	 *
+	 * @covers ::get_default
+	 */
+	public function test_get_default() {
+		$this->expectException( Method_Unimplemented_Exception::class );
+
+		$this->instance->get_default( 'wpseo_title' );
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Support taxonomy metadata.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds Taxonomy_Metadata_Service, which replaces the WPSEO_Taxonomy_Meta options class.

## Relevant technical choices:

* Have a separate service for the taxonomy metadata. This one won't be going through the options helper because the interface requires the term and taxonomy to be passed too. And the old one was called directly already anyway, so no loss there.
* Only changed the functions in the old class that are used in our plugins:
  * get_term_meta -> get
  * set_values -> set_options
  * set_value -> set
  * inside get_keyword_usage: get_tax_meta -> get_options
* I did not deprecate the other methods of the WPSEO_Taxonomy_Meta class. Should I? 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Some notes
* Both the old class and the new service should do the same thing, as the old calls the new.
* However, the service can throw exceptions, whereas the old options class will (should) not.
* Please change the ID and taxonomy to something that exists in your environment, or not if you want to test that!
* The `key` is automagically prefixed with `wpseo_` if that is missing.
* I put the code in my tiny test plugin, but in theory you could put it anywhere. Though load order is a thing.

#### Setup
Due to the defaults not being set for "enriched" options the SEO metabox is disabled for taxonomies on the feature branch.
You can fix this by either changing the `display-metabox-tax-<TaxonomyName>` default to true in the Site_Options_Service and then removing the `wpseo_options` column (don't forget to undo the code once you are done testing). Or editing the `wpseo_options` in your database to have those `display-metabox-tax-<TaxonomyName>` set to `true` for each taxonomy you want to use/test.

#### Test `get`
```php
// Retrieve the options for a single term.
function _test_get( $term, $taxonomy, $key = null ) {
	/** @var \Yoast\WP\SEO\Services\Options\Taxonomy_Metadata_Service $service */
	$service = \YoastSEO()->classes->get( \Yoast\WP\SEO\Services\Options\Taxonomy_Metadata_Service::class );
	echo '<br>Old: ';
	var_dump( WPSEO_Taxonomy_Meta::get_term_meta( $term, $taxonomy, $key ) );
	echo '<br>New: ';
	try {
		var_dump( $service->get( $term, $taxonomy, $key ) );
	} catch ( Abstract_Option_Exception $exception ) {
		echo $exception->getMessage();
	}
	echo '<br>';
}
// Gets all options for a term.
_test_get( 12, 'post_tag' );
// Gets a single option for a term.
_test_get( 12, 'post_tag', 'wpseo_title' );
```
* If you change the above to something that does not exist, the first old class should return `false`, and the service will error.

#### Test `set`
```php
// Set an option for a single term:
function _test_set( $term, $taxonomy, $key, $value ) {
	/** @var \Yoast\WP\SEO\Services\Options\Taxonomy_Metadata_Service $service */
	$service = \YoastSEO()->classes->get( \Yoast\WP\SEO\Services\Options\Taxonomy_Metadata_Service::class );
	try {
		$service->set( $term, $taxonomy, $key, $value );
		var_dump( $service->get( $term, $taxonomy, $key ) );
	} catch ( Abstract_Option_Exception $exception ) {
		echo $exception->getMessage();
	}
	echo '<br>';
}
_test_set( 12, 'post_tag', 'wpseo_focuskw', 'FOCUS!' );
```
* You could try the old interface: `WPSEO_Taxonomy_Meta::set_value( $term, $taxonomy, $key, $value );`

#### Test `set_options`
```php
// Set all the options for a single term:
function _test_set_options( $term, $taxonomy, $values ) {
	/** @var \Yoast\WP\SEO\Services\Options\Taxonomy_Metadata_Service $service */
	$service = \YoastSEO()->classes->get( \Yoast\WP\SEO\Services\Options\Taxonomy_Metadata_Service::class );
	try {
		$service->set_options( $term, $taxonomy, $values );
		var_dump( $service->get( $term, $taxonomy ) );
	} catch ( Abstract_Option_Exception $exception ) {
		echo $exception->getMessage();
	}
	echo '<br>';
}
// Change only a few while getting the rest is convenient for testing?
$term     = 12;
$taxonomy = 'post_tag';
/** @var \Yoast\WP\SEO\Services\Options\Taxonomy_Metadata_Service $service */
$service                  = \YoastSEO()->classes->get( \Yoast\WP\SEO\Services\Options\Taxonomy_Metadata_Service::class );
$options                  = $service->get( $term, $taxonomy );
$options['wpseo_focuskw'] = 'changing this';
$options['wpseo_title']   = 'TITLE';
$options['wpseo_desc']    = 'DESCRIPTION';
_test_set_options( $term, $taxonomy, $options );
```
* You could try the old interface: `WPSEO_Taxonomy_Meta::set_values( $term, $taxonomy, $values )`

#### Test the old interface' `get_keyword_usage`
This should still function as before.
Note: while testing it I noticed that before this feature branch, this function does not handle `get_option` returning `false`. Which can happen if you call it too early. To prevent this you can wrap it in a `init` action, this is not needed on this branch. But that is why it is in this test, so you can test it in another version still.
* Have at least 2 terms with the same keyphrase.
* Fill in the id/slug and taxonomy of one of those terms in the code below, as well as the keyphrase you used.
* Run the following code, it should output an array with the keyphrase that contains an array with all the IDs of the terms with the same keyphrase.
```php
// Retrieve the keyphrase usage:
add_action( 'init', static function() {
	var_dump( WPSEO_Taxonomy_Meta::get_keyword_usage( 'keyphrase', 8, 'category' ) );
} );
```

#### Test the metabox on a term edit page
* Edit a term (for which you have the SEO settings enabled)
* Edit something in the metabox, e.g. the SEO title?
* Save the term
* Verify the change persisted:
  * the value should again be in the input (the "auto" refresh after save)
  * the value is therefor in the `wpseo_taxonomy_metadata` row in your database
  * the value is visible when you go to the frontend of the term (for things like SEO title & description)

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Part of bigger feature, please test the whole feature when done.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Addons (Premium, Video and Local)! But because I searched which methods they use, they should all work still. Except the ones that use the WP database `*_option` functions directly... that is [another issue](https://yoast.atlassian.net/browse/P1-1341).

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes https://yoast.atlassian.net/browse/P1-1207
