### PR TITLE
Removes Wincher output from unit test summary

### DIFF
--- a/src/integrations/third-party/wincher.php
+++ b/src/integrations/third-party/wincher.php
@@ -93,10 +93,7 @@ class Wincher implements Integration_Interface {
 	public function after_integration_toggle( $integration ) {
 		if ( $integration->setting === 'wincher_integration_active' ) {
 
-			// Check if 'WPSEO_PATH' is defined else the relevant unittest will require the file.
-			if ( defined( 'WPSEO_PATH' ) ) {
-				require \WPSEO_PATH . 'admin/views/tabs/metas/paper-content/integrations/wincher.php';
-			}
+			require \WPSEO_PATH . 'admin/views/tabs/metas/paper-content/integrations/wincher.php';
 
 			if ( \is_multisite() ) {
 				$this->get_disabled_note();

--- a/tests/unit/integrations/third-party/wincher-test.php
+++ b/tests/unit/integrations/third-party/wincher-test.php
@@ -139,6 +139,8 @@ class Wincher_Test extends TestCase {
 
 		$this->instance->expects( 'get_disabled_note' )->never();
 
+		$this->expectOutputContains( 'hidden_wincher_website_id' );
+
 		$this->instance->after_integration_toggle( $wincher_integration_toggle );
 	}
 
@@ -154,6 +156,8 @@ class Wincher_Test extends TestCase {
 		];
 
 		Monkey\Functions\stubs( [ 'is_multisite' => true ] );
+
+		$this->expectOutputContains( 'hidden_wincher_website_id' );
 
 		$this->instance->expects( 'get_disabled_note' )->once();
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* This PR removes the Wincher output from the unit test summary.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Removes unwanted output from the test summary.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Run `composer test -- --filter Wincher_Test`
* Verify no unwanted output is visible in the test summary

Before:
<img width="867" alt="image" src="https://user-images.githubusercontent.com/20287474/162390781-c5032ce2-8c3f-42f4-9108-b65e57b28c74.png">

After:
<img width="687" alt="image" src="https://user-images.githubusercontent.com/20287474/162390907-cf64d76d-c3d6-4709-8f2c-7a7127850c36.png">


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes #
