### PR TITLE
Refactor labels be strings

### DIFF
--- a/packages/ui-library/package.json
+++ b/packages/ui-library/package.json
@@ -58,7 +58,9 @@
     "@heroicons/react": "^1.0.5",
     "classnames": "^2.3.1",
     "lodash": "^4.17.21",
-    "prop-types": "^15.8.1"
+    "prop-types": "^15.8.1",
+    "react": "^16.14.0",
+    "react-dom": "^16.14.0"
   },
   "peerDependencies": {
     "@wordpress/element": "^4.1.1"

--- a/packages/ui-library/package.json
+++ b/packages/ui-library/package.json
@@ -51,6 +51,8 @@
     "jest": "^27.5.1",
     "postcss": "^8.4.5",
     "puppeteer": "^13.4.0",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2",
     "tailwindcss": "^3.0.23"
   },
   "dependencies": {

--- a/packages/ui-library/package.json
+++ b/packages/ui-library/package.json
@@ -51,8 +51,6 @@
     "jest": "^27.5.1",
     "postcss": "^8.4.5",
     "puppeteer": "^13.4.0",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2",
     "tailwindcss": "^3.0.23"
   },
   "dependencies": {

--- a/packages/ui-library/src/components/checkbox-group/index.js
+++ b/packages/ui-library/src/components/checkbox-group/index.js
@@ -10,7 +10,7 @@ import Label from "../../elements/label";
  * @param {string} id Identifier.
  * @param {string} name Name.
  * @param {string[]} values Values.
- * @param {JSX.node} label Label.
+ * @param {string} label Label.
  * @param {{ value: string, label: string }[]} options Options to choose from.
  * @param {Function} onChange Change handler.
  * @param {string} [className] CSS class.
@@ -36,7 +36,7 @@ const CheckboxGroup = ( {
 
 	return (
 		<fieldset className={ classNames( "yst-checkbox-group", className ) }>
-			{ label && <Label as="legend" className="yst-checkbox-group__label">{ label }</Label> }
+			<Label as="legend" className="yst-checkbox-group__label" label={ label } />
 			{ children && <div className="yst-checkbox-group__description">{ children }</div> }
 			<div className="yst-checkbox-group__options">
 				{ options.map( ( option, index ) => {
@@ -62,7 +62,7 @@ CheckboxGroup.propTypes = {
 	id: PropTypes.string.isRequired,
 	name: PropTypes.string.isRequired,
 	values: PropTypes.arrayOf( PropTypes.string ),
-	label: PropTypes.node.isRequired,
+	label: PropTypes.string.isRequired,
 	options: PropTypes.arrayOf( PropTypes.shape( {
 		value: PropTypes.string.isRequired,
 		label: PropTypes.string.isRequired,

--- a/packages/ui-library/src/components/checkbox-group/stories.js
+++ b/packages/ui-library/src/components/checkbox-group/stories.js
@@ -7,7 +7,6 @@ export default {
 	component: CheckboxGroup,
 	argTypes: {
 		children: { control: "text" },
-		label: { control: "text" },
 	},
 	parameters: {
 		docs: {

--- a/packages/ui-library/src/components/radio-group/index.js
+++ b/packages/ui-library/src/components/radio-group/index.js
@@ -1,10 +1,10 @@
 /* eslint-disable no-undefined */
+import { useCallback } from "@wordpress/element";
 import classNames from "classnames";
 import PropTypes from "prop-types";
-import { useCallback } from "@wordpress/element";
+import Label from "../../elements/label";
 
 import Radio from "../../elements/radio";
-import Label from "../../elements/label";
 
 const classNameMap = {
 	variant: {
@@ -18,7 +18,7 @@ const classNameMap = {
  * @param {string} id Identifier.
  * @param {string} name Name.
  * @param {string} value Value.
- * @param {JSX.node} [label] Label.
+ * @param {string} [label] Label.
  * @param {{ value: string, label: string, srLabel: string }[]} options Options to choose from.
  * @param {Function} onChange Change handler.
  * @param {string} [variant] Variant.
@@ -47,7 +47,7 @@ const RadioGroup = ( {
 				className,
 			) }
 		>
-			{ label && <Label as="legend" className="yst-radio-group__label">{ label }</Label> }
+			{ label && <Label as="legend" className="yst-radio-group__label" label={ label } /> }
 			{ children && <div className="yst-radio-group__description">{ children }</div> }
 			<div className="yst-radio-group__options">
 				{ options.map( ( option, index ) => {
@@ -75,7 +75,7 @@ RadioGroup.propTypes = {
 	id: PropTypes.string.isRequired,
 	name: PropTypes.string.isRequired,
 	value: PropTypes.string.isRequired,
-	label: PropTypes.node.isRequired,
+	label: PropTypes.string.isRequired,
 	options: PropTypes.arrayOf( PropTypes.shape( {
 		value: PropTypes.string.isRequired,
 		label: PropTypes.string.isRequired,

--- a/packages/ui-library/src/components/radio-group/stories.js
+++ b/packages/ui-library/src/components/radio-group/stories.js
@@ -8,7 +8,6 @@ export default {
 	component: RadioGroup,
 	argTypes: {
 		children: { control: "text" },
-		label: { control: "text" },
 	},
 	parameters: {
 		docs: {

--- a/packages/ui-library/src/components/select-field/index.js
+++ b/packages/ui-library/src/components/select-field/index.js
@@ -11,8 +11,8 @@ import { useDescribedBy } from "../../hooks";
  * @param {{ value, label }[]} options Options to choose from.
  * @param {Function} onChange Change callback.
  * @param {JSX.Element} error Error node.
- * @param {string} [className] CSS class.
- * @param {JSX.node} [label] Optional label.
+ * @param {string} [className] Optional CSS class.
+ * @param {string} label Label.
  * @param {JSX.node} [children] Optional description.
  * @param {Object} [props] Any extra props.
  * @returns {JSX.Element} SelectField component.
@@ -32,7 +32,7 @@ const SelectField = ( {
 
 	return (
 		<div className={ classNames( "yst-select-field", className ) }>
-			{ label && <Label className="yst-select-field__label">{ label }</Label> }
+			<Label className="yst-select-field__label" label={ label } />
 			<Select
 				id={ id }
 				value={ value }
@@ -54,7 +54,7 @@ SelectField.propTypes = {
 	id: PropTypes.string.isRequired,
 	name: PropTypes.string.isRequired,
 	value: PropTypes.string,
-	label: PropTypes.node.isRequired,
+	label: PropTypes.string.isRequired,
 	options: PropTypes.arrayOf( PropTypes.shape( {
 		value: PropTypes.string.isRequired,
 		label: PropTypes.string.isRequired,

--- a/packages/ui-library/src/components/select-field/stories.js
+++ b/packages/ui-library/src/components/select-field/stories.js
@@ -6,7 +6,6 @@ export default {
 	component: SelectField,
 	argTypes: {
 		children: { control: "text" },
-		label: { control: "text" },
 		error: { control: "text" },
 	},
 	parameters: {

--- a/packages/ui-library/src/components/text-field/index.js
+++ b/packages/ui-library/src/components/text-field/index.js
@@ -8,7 +8,7 @@ import { useDescribedBy, useSvgAria } from "../../hooks";
 /**
  * @param {string} id The ID of the input.
  * @param {function} onChange The input change handler.
- * @param {JSX.node} [label] A label.
+ * @param {string} label The label.
  * @param {string} [className] The HTML class.
  * @param {JSX.node} [description] A description.
  * @param {JSX.node} [error] An error "message".
@@ -29,7 +29,7 @@ const TextField = ( {
 
 	return (
 		<div className={ classNames( "yst-text-field", className ) }>
-			{ label && <Label className="yst-text-field__label" htmlFor={ id }>{ label }</Label> }
+			<Label className="yst-text-field__label" htmlFor={ id } label={ label } />
 			<div className="yst-relative">
 				<TextInput
 					id={ id }
@@ -54,7 +54,7 @@ const TextField = ( {
 TextField.propTypes = {
 	id: PropTypes.string.isRequired,
 	onChange: PropTypes.func.isRequired,
-	label: PropTypes.node.isRequired,
+	label: PropTypes.string.isRequired,
 	className: PropTypes.string,
 	description: PropTypes.node,
 	error: PropTypes.node,

--- a/packages/ui-library/src/components/text-field/stories.js
+++ b/packages/ui-library/src/components/text-field/stories.js
@@ -6,7 +6,6 @@ export default {
 	title: "2. Components/Text Field",
 	component: InputField,
 	argTypes: {
-		label: { control: "text" },
 		description: { control: "text" },
 		error: { control: "text" },
 	},

--- a/packages/ui-library/src/components/textarea-field/index.js
+++ b/packages/ui-library/src/components/textarea-field/index.js
@@ -8,7 +8,7 @@ import { useDescribedBy, useSvgAria } from "../../hooks";
 /**
  * @param {string} id The ID of the input.
  * @param {function} onChange The input change handler.
- * @param {JSX.node} [label] A label.
+ * @param {string} label The label.
  * @param {string} [className] The HTML class.
  * @param {JSX.node} [description] A description.
  * @param {JSX.node} [error] An error "message".
@@ -28,7 +28,7 @@ const TextareaField = ( {
 
 	return (
 		<div className={ classNames( "yst-textarea-field", className ) }>
-			{ label && <Label className="yst-textarea-field__label" htmlFor={ id }>{ label }</Label> }
+			<Label className="yst-textarea-field__label" htmlFor={ id } label={ label } />
 			<div className="yst-relative">
 				<Textarea
 					id={ id }
@@ -51,7 +51,7 @@ const TextareaField = ( {
 
 TextareaField.propTypes = {
 	id: PropTypes.string.isRequired,
-	label: PropTypes.node.isRequired,
+	label: PropTypes.string.isRequired,
 	className: PropTypes.string,
 	description: PropTypes.node,
 	error: PropTypes.node,

--- a/packages/ui-library/src/components/textarea-field/stories.js
+++ b/packages/ui-library/src/components/textarea-field/stories.js
@@ -4,7 +4,6 @@ export default {
 	title: "2. Components/Textarea Field",
 	component: TextareaField,
 	argTypes: {
-		label: { control: "text" },
 		description: { control: "text" },
 		error: { control: "text" },
 	},

--- a/packages/ui-library/src/components/toggle-field/index.js
+++ b/packages/ui-library/src/components/toggle-field/index.js
@@ -6,7 +6,7 @@ import Toggle from "../../elements/toggle";
 
 /**
  * @param {JSX.node} children Children are rendered below the checkbox group.
- * @param {JSX.node} label Label.
+ * @param {string} label The Label.
  * @param {boolean} [checked] Default state.
  * @param {Function} onChange Change callback.
  * @param {{ value, label }[]} options Options to choose from.
@@ -24,7 +24,7 @@ const ToggleField = ( {
 	<Switch.Group as="div" className={ classNames( "yst-toggle-field", className ) }>
 		{ ( label || children ) && (
 			<div className="yst-toggle-field__text">
-				{ label && <Label as={ Switch.Label } className="yst-toggle-field__label">{ label }</Label> }
+				<Label as={ Switch.Label } className="yst-toggle-field__label" label={ label } />
 				{ children && <Switch.Description className="yst-toggle-field__description">{ children }</Switch.Description> }
 			</div>
 		) }
@@ -38,7 +38,7 @@ const ToggleField = ( {
 
 ToggleField.propTypes = {
 	children: PropTypes.node,
-	label: PropTypes.node.isRequired,
+	label: PropTypes.string.isRequired,
 	checked: PropTypes.bool.isRequired,
 	onChange: PropTypes.func.isRequired,
 	className: PropTypes.string,

--- a/packages/ui-library/src/components/toggle-field/stories.js
+++ b/packages/ui-library/src/components/toggle-field/stories.js
@@ -8,7 +8,6 @@ export default {
 	component: ToggleField,
 	argTypes: {
 		children: { control: "text" },
-		label: { control: "text" },
 	},
 	parameters: {
 		docs: {
@@ -48,7 +47,7 @@ export const Checked = ( args ) => (
 	<ToggleField
 		name="name-2"
 		checked={ true }
-		label="Toggle field with a label"
+		label="Checked toggle field"
 		onChange={ noop }
 	/>
 );

--- a/packages/ui-library/src/elements/checkbox/index.js
+++ b/packages/ui-library/src/elements/checkbox/index.js
@@ -8,7 +8,7 @@ import Label from "../label";
  * @param {string} id Identifier.
  * @param {string} name Name.
  * @param {string} value Value.
- * @param {JSX.node} label Label.
+ * @param {string} label Label.
  * @param {string} [className] CSS class.
  * @returns {JSX.Element} Checkbox component.
  */
@@ -34,7 +34,7 @@ const Checkbox = ( {
 			className="yst-checkbox__input"
 			{ ...props }
 		/>
-		{ label && <Label htmlFor={ id } className="yst-checkbox__label">{ label }</Label> }
+		<Label htmlFor={ id } className="yst-checkbox__label" label={ label } />
 	</div>
 );
 
@@ -42,7 +42,7 @@ Checkbox.propTypes = {
 	id: PropTypes.string.isRequired,
 	name: PropTypes.string.isRequired,
 	value: PropTypes.string.isRequired,
-	label: PropTypes.node.isRequired,
+	label: PropTypes.string.isRequired,
 	className: PropTypes.string,
 };
 

--- a/packages/ui-library/src/elements/checkbox/stories.js
+++ b/packages/ui-library/src/elements/checkbox/stories.js
@@ -3,9 +3,7 @@ import Checkbox from ".";
 export default {
 	title: "1. Elements/Checkbox",
 	component: Checkbox,
-	argTypes: {
-		label: { control: "text" },
-	},
+	argTypes: {},
 	parameters: {
 		docs: {
 			description: {

--- a/packages/ui-library/src/elements/label/index.js
+++ b/packages/ui-library/src/elements/label/index.js
@@ -2,27 +2,27 @@ import classNames from "classnames";
 import PropTypes from "prop-types";
 
 /**
- * @param {JSX.node} children Content of the Label.
+ * @param {string} label Content of the Label. Note that this is a string ONLY for a11y reasons.
  * @param {string|function} [as="label"] Base component.
  * @param {string} [className] CSS class.
  * @returns {JSX.Element} Label component.
  */
 const Label = ( {
-	children,
 	as: Component,
 	className,
+	label,
 	...props
 } ) => (
 	<Component
 		className={ classNames( "yst-label", className ) }
 		{ ...props }
 	>
-		{ children }
+		{ label }
 	</Component>
 );
 
 Label.propTypes = {
-	children: PropTypes.node.isRequired,
+	label: PropTypes.string.isRequired,
 	as: PropTypes.elementType,
 	className: PropTypes.string,
 };

--- a/packages/ui-library/src/elements/label/stories.js
+++ b/packages/ui-library/src/elements/label/stories.js
@@ -4,7 +4,6 @@ export default {
 	title: "1. Elements/Label",
 	component: Label,
 	argTypes: {
-		children: { control: "text" },
 		as: { options: [ "label", "span", "div" ] },
 	},
 	parameters: {
@@ -16,12 +15,12 @@ export default {
 	},
 };
 
-export const Factory = ( { children, ...args } ) => (
-	<Label { ...args }>{ children }</Label>
+export const Factory = ( { ...args } ) => (
+	<Label { ...args } />
 );
 Factory.parameters = {
 	controls: { disable: false },
 };
 Factory.args = {
-	children: "Label Factory",
+	label: "Label Factory",
 };

--- a/packages/ui-library/src/elements/radio/index.js
+++ b/packages/ui-library/src/elements/radio/index.js
@@ -15,8 +15,8 @@ const classNameMap = {
  * @param {string} id Identifier.
  * @param {string} name Name.
  * @param {string} value Value.
- * @param {JSX.string} label Label.
- * @param {JSX.string} srLabel Screen reader label.
+ * @param {string} label Label.
+ * @param {string} srLabel Screen reader label.
  * @param {string} [variant] Variant.
  * @param {string} [className] CSS class.
  * @returns {JSX.Element} Radio component.
@@ -51,10 +51,10 @@ const Radio = ( {
 					aria-label={ srLabel }
 					{ ...props }
 				/>
-				<label htmlFor={ id } className="yst-radio__label">
-					{ label }
+				<span className="yst-radio__label_check_container">
+					<Label htmlFor={ id } className="yst-radio__label" label={ label } />
 					<CheckCircleIcon className="yst-radio__check" { ...svgAriaProps } />
-				</label>
+				</span>
 			</div>
 		);
 	}
@@ -74,7 +74,7 @@ const Radio = ( {
 				className="yst-radio__input"
 				{ ...props }
 			/>
-			{ label && <Label htmlFor={ id } className="yst-radio__label">{ label }</Label> }
+			<Label htmlFor={ id } className="yst-radio__label" label={ label } />
 		</div>
 	);
 };

--- a/packages/ui-library/src/elements/radio/index.js
+++ b/packages/ui-library/src/elements/radio/index.js
@@ -51,7 +51,7 @@ const Radio = ( {
 					aria-label={ srLabel }
 					{ ...props }
 				/>
-				<span className="yst-radio__label_check_container">
+				<span className="yst-radio__content">
 					<Label htmlFor={ id } className="yst-radio__label" label={ label } />
 					<CheckCircleIcon className="yst-radio__check" { ...svgAriaProps } />
 				</span>

--- a/packages/ui-library/src/elements/radio/stories.js
+++ b/packages/ui-library/src/elements/radio/stories.js
@@ -3,9 +3,7 @@ import Radio from ".";
 export default {
 	title: "1. Elements/Radio",
 	component: Radio,
-	argTypes: {
-		label: { control: "text" },
-	},
+	argTypes: {},
 	parameters: {
 		docs: {
 			description: {

--- a/packages/ui-library/src/elements/radio/style.css
+++ b/packages/ui-library/src/elements/radio/style.css
@@ -12,7 +12,7 @@
 		.yst-radio__input {
 			@apply yst-sr-only;
 
-			&:checked + .yst-radio__label_check_container {
+			&:checked + .yst-radio__content {
 				.yst-radio__label {
 					@apply yst-border-transparent yst-ring-2 yst-ring-primary-500;
 				}
@@ -23,7 +23,7 @@
 			}
 		}
 
-		.yst-radio__label_check_container {
+		.yst-radio__content {
 			@apply yst-relative;
 		}
 

--- a/packages/ui-library/src/elements/radio/style.css
+++ b/packages/ui-library/src/elements/radio/style.css
@@ -1,75 +1,76 @@
 @layer components {
-    .yst-radio {
-        @apply
-            yst-flex
-            yst-items-center;
-    }
+	.yst-radio {
+		@apply yst-flex yst-items-center;
+	}
 
-    /* Variants */
-    .yst-radio--inline-block {
-        @apply yst-inline-flex;
+	/* Variants */
+	.yst-radio--inline-block {
+		@apply yst-inline-flex;
 
-        /* Elements of the inline-block variant */
-        .yst-radio__input {
-            @apply yst-sr-only;
+		/* Elements of the inline-block variant */
 
-            &:checked + .yst-radio__label {
-                @apply
-                    yst-border-transparent
-                    yst-ring-2
-                    yst-ring-primary-500;
-    
-                .yst-radio__check {
-                    @apply yst-visible;
-                }
-            }
-        }
+		.yst-radio__input {
+			@apply yst-sr-only;
 
-        .yst-radio__label {
-            @apply
-                yst-relative
-                yst-flex
-                yst-h-14
-                yst-w-14
-                yst-ml-0
-                yst-justify-center
-                yst-items-center
-                yst-text-base
-                yst-bg-white
-                yst-border
-                yst-rounded-lg
-                yst-shadow-sm
-                yst-cursor-pointer
-                yst-border-gray-300
+			&:checked + .yst-radio__label_check_container {
+				.yst-radio__label {
+					@apply yst-border-transparent yst-ring-2 yst-ring-primary-500;
+				}
 
-                hover:yst-border-gray-400
-                focus:yst-outline-none;
-        }
+				.yst-radio__check {
+					@apply yst-visible;
+				}
+			}
+		}
 
-        .yst-radio__check {
-            @apply
-                yst-invisible
-                yst-absolute
-                yst-top-0.5
-                yst-right-0.5
-                yst-h-5
-                yst-w-5
-                yst-text-primary-600;
-        }
-    }
+		.yst-radio__label_check_container {
+			@apply yst-relative;
+		}
 
-    /* State */
-    .yst-radio__input {
-        @apply
-            yst-h-4
-            yst-w-4
-            yst-text-primary-500
-            yst-border-gray-300
+		.yst-radio__label {
+			@apply
+			yst-flex
+			yst-h-14
+			yst-w-14
+			yst-ml-0
+			yst-justify-center
+			yst-items-center
+			yst-text-base
+			yst-bg-white
+			yst-border
+			yst-rounded-lg
+			yst-shadow-sm
+			yst-cursor-pointer
+			yst-border-gray-300
 
-            focus:yst-ring-primary-500;
-    }
+			hover:yst-border-gray-400
+			focus:yst-outline-none;
+		}
 
-    .yst-radio__label {
-        @apply yst-ml-3;
-    }
+		.yst-radio__check {
+			@apply
+			yst-invisible
+			yst-absolute
+			yst-top-0.5
+			yst-right-0.5
+			yst-h-5
+			yst-w-5
+			yst-text-primary-600;
+		}
+	}
+
+	/* State */
+	.yst-radio__input {
+		@apply
+		yst-h-4
+		yst-w-4
+		yst-text-primary-500
+		yst-border-gray-300
+
+		focus:yst-ring-primary-500;
+	}
+
+	.yst-radio__label {
+		@apply yst-ml-3;
+	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -24076,7 +24076,7 @@ react-dock@^0.3.0:
     lodash.debounce "^4.0.8"
     prop-types "^15.7.2"
 
-"react-dom@^0.14.3 || ^15.1.0 || ^16.0.0", react-dom@^16.13.1, react-dom@^16.9.0:
+"react-dom@^0.14.3 || ^15.1.0 || ^16.0.0", react-dom@^16.13.1, react-dom@^16.14.0, react-dom@^16.9.0:
   version "16.14.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.14.0.tgz#7ad838ec29a777fb3c75c3a190f661cf92ab8b89"
   integrity sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==
@@ -24482,7 +24482,7 @@ react-with-styles@^3.2.0:
     prop-types "^15.6.2"
     react-with-direction "^1.3.0"
 
-"react@0.14.8 || ^15.5.0 || ^16.0.0", "react@^0.14.3 || ^15.1.0 || ^16.0.0", react@^16.13.1, react@^16.9.0:
+"react@0.14.8 || ^15.5.0 || ^16.0.0", "react@^0.14.3 || ^15.1.0 || ^16.0.0", react@^16.13.1, react@^16.14.0, react@^16.9.0:
   version "16.14.0"
   resolved "https://registry.yarnpkg.com/react/-/react-16.14.0.tgz#94d776ddd0aaa37da3eda8fc5b6b18a4c9a3114d"
   integrity sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* For a11y, the labels should _only_ contain text.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [@yoast/ui-library] Refactors Label to be a string, instead of a node, for a11y.

## Relevant technical choices:

* Any extra elements within a label should be moved outside the label for a11y
* To enforce this this commit changes the types to string and makes it a prop (instead of children in the label itself). I think this reduces the risk of people adding more than a string in their labels, which would then result in React warnings.
* The Radio element' check has moved outside of the label now

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Start the storybook: `cd package/ui-library && yarn storybook`
* Verify the stories look correct still. Specifically the elements: label, checkbox and radio. And the components: checkbox group, radio group, select field, text field, textarea field and toggle field.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Assuming this is published by now you can check on https://ui-library.yoast.com/ instead of building
* Verify the stories look correct still. Specifically the elements: label, checkbox and radio. And the components: checkbox group, radio group, select field, text field, textarea field and toggle field.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes https://yoast.atlassian.net/browse/P1-1289
