### PR TITLE
Dupp 366 update create routes

### DIFF
--- a/inc/options/class-wpseo-option-wpseo.php
+++ b/inc/options/class-wpseo-option-wpseo.php
@@ -81,7 +81,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 		'algolia_integration_active'               => false,
 		'import_cursors'                           => [],
 		'workouts_data'                            => [ 'configuration' => [ 'finishedSteps' => [] ] ],
-		'configuration'                 => [ 'finishedSteps' => [] ],
+		'configuration'                            => [ 'finishedSteps' => [] ],
 		'dismiss_configuration_workout_notice'     => false,
 		'importing_completed'                      => [],
 		'wincher_integration_active'               => true,

--- a/inc/options/class-wpseo-option-wpseo.php
+++ b/inc/options/class-wpseo-option-wpseo.php
@@ -81,6 +81,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 		'algolia_integration_active'               => false,
 		'import_cursors'                           => [],
 		'workouts_data'                            => [ 'configuration' => [ 'finishedSteps' => [] ] ],
+		'configuration'                 => [ 'finishedSteps' => [] ],
 		'dismiss_configuration_workout_notice'     => false,
 		'importing_completed'                      => [],
 		'wincher_integration_active'               => true,
@@ -350,6 +351,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 				case 'zapier_subscription':
 				case 'wincher_tokens':
 				case 'workouts_data':
+				case 'configuration':
 					$clean[ $key ] = $old[ $key ];
 
 					if ( isset( $dirty[ $key ] ) ) {

--- a/src/actions/configuration/first-time-configuration-action.php
+++ b/src/actions/configuration/first-time-configuration-action.php
@@ -1,0 +1,300 @@
+<?php
+
+namespace Yoast\WP\SEO\Actions\Configuration;
+
+use Yoast\WP\SEO\Helpers\Options_Helper;
+use Yoast\WP\SEO\Integrations\Admin\Social_Profiles_Helper;
+
+/**
+ * Class First_Time_Configuration_Action.
+ */
+// phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded -- First time configuration simply has a lot of words.
+class First_Time_Configuration_Action {
+
+	/**
+	 * The fields for the site representation payload.
+	 */
+	const SITE_REPRESENTATION_FIELDS = [
+		'company_or_person',
+		'company_name',
+		'company_logo',
+		'company_logo_id',
+		'person_logo',
+		'person_logo_id',
+		'company_or_person_user_id',
+		'description',
+	];
+
+	/**
+	 * The fields for the social profiles payload.
+	 */
+	const SOCIAL_PROFILES_FIELDS = [
+		'facebook_site',
+		'twitter_site',
+		'other_social_urls',
+	];
+
+	/**
+	 * The Options_Helper instance.
+	 *
+	 * @var Options_Helper
+	 */
+	protected $options_helper;
+
+	/**
+	 * The Social_Profiles_Helper instance.
+	 *
+	 * @var Social_Profiles_Helper
+	 */
+	protected $social_profiles_helper;
+
+	/**
+	 * First_Time_Configuration_Action constructor.
+	 *
+	 * @param Options_Helper         $options_helper         The WPSEO options helper.
+	 * @param Social_Profiles_Helper $social_profiles_helper The social profiles helper.
+	 */
+	public function __construct( Options_Helper $options_helper, Social_Profiles_Helper $social_profiles_helper ) {
+		$this->options_helper         = $options_helper;
+		$this->social_profiles_helper = $social_profiles_helper;
+	}
+
+	/**
+	 * Stores the values for the site representation.
+	 *
+	 * @param array $params The values to store.
+	 *
+	 * @return object The response object.
+	 */
+	public function set_site_representation( $params ) {
+		$failures = [];
+
+		foreach ( self::SITE_REPRESENTATION_FIELDS as $field_name ) {
+			if ( isset( $params[ $field_name ] ) ) {
+				if ( $field_name === 'description' && \current_user_can( 'manage_options' ) ) {
+					$result = \update_option( 'blogdescription', $params['description'] );
+					if ( ! $result && $params['description'] === \get_option( 'blogdescription' ) ) {
+						$result = true;
+					}
+				}
+				else {
+					$result = $this->options_helper->set( $field_name, $params[ $field_name ] );
+				}
+				if ( ! $result ) {
+					$failures[] = $field_name;
+				}
+			}
+		}
+
+		if ( \count( $failures ) === 0 ) {
+			return (object) [
+				'success' => true,
+				'status'  => 200,
+			];
+		}
+		return (object) [
+			'success'  => false,
+			'status'   => 500,
+			'error'    => 'Could not save some options in the database',
+			'failures' => $failures,
+		];
+	}
+
+	/**
+	 * Stores the values for the social profiles.
+	 *
+	 * @param array $params The values to store.
+	 *
+	 * @return object The response object.
+	 */
+	public function set_social_profiles( $params ) {
+		$failures = [];
+
+		foreach ( self::SOCIAL_PROFILES_FIELDS as $field_name ) {
+			if ( isset( $params[ $field_name ] ) ) {
+				$result = $this->options_helper->set( $field_name, $params[ $field_name ] );
+				if ( ! $result ) {
+					/**
+					 * The value for Twitter might have been sanitised from URL to username.
+					 * If so, $result will be false. We should check if the option value is part of the received value.
+					 */
+					if ( $field_name === 'twitter_site' ) {
+						$current_option = $this->options_helper->get( $field_name );
+						if ( ! \strpos( $params[ $field_name ], 'twitter.com/' . $current_option ) ) {
+							$failures[] = $field_name;
+						}
+					}
+					else {
+						$failures[] = $field_name;
+					}
+				}
+			}
+		}
+
+		if ( \count( $failures ) === 0 ) {
+			return (object) [
+				'success' => true,
+				'status'  => 200,
+			];
+		}
+		return (object) [
+			'success'  => false,
+			'status'   => 500,
+			'error'    => 'Could not save some options in the database',
+			'failures' => $failures,
+		];
+	}
+
+	/**
+	 * Stores the values for the social profiles.
+	 *
+	 * @param array $params The values to store.
+	 *
+	 * @return object The response object.
+	 */
+	public function set_person_social_profiles( $params ) {
+		$social_profiles = \array_filter(
+			$params,
+			function ( $key ) {
+				return $key !== 'user_id';
+			},
+			ARRAY_FILTER_USE_KEY
+		);
+
+		$failures = $this->social_profiles_helper->set_person_social_profiles( $params['user_id'], $social_profiles );
+
+		if ( \count( $failures ) === 0 ) {
+			return (object) [
+				'success' => true,
+				'status'  => 200,
+			];
+		}
+		return (object) [
+			'success'  => false,
+			'status'   => 500,
+			'error'    => 'Could not save some options in the database',
+			'failures' => $failures,
+		];
+	}
+
+	/**
+	 * Gets the values for the social profiles.
+	 *
+	 * @param int $user_id the person id.
+	 *
+	 * @return object The response object.
+	 */
+	public function get_person_social_profiles( $user_id ) {
+
+		return (object) [
+			'success'         => true,
+			'status'          => 200,
+			'social_profiles' => $this->social_profiles_helper->get_person_social_profiles( $user_id ),
+		];
+	}
+
+	/**
+	 * Stores the values to enable/disable tracking.
+	 *
+	 * @param array $params The values to store.
+	 *
+	 * @return object The response object.
+	 */
+	public function set_enable_tracking( $params ) {
+		$success      = true;
+		$option_value = $this->options_helper->get( 'tracking' );
+
+		if ( $option_value !== $params['tracking'] ) {
+			$success = $this->options_helper->set( 'tracking', $params['tracking'] );
+		}
+
+		if ( $success ) {
+			return (object) [
+				'success' => true,
+				'status'  => 200,
+			];
+		}
+		return (object) [
+			'success' => false,
+			'status'  => 500,
+			'error'   => 'Could not save the option in the database',
+		];
+	}
+
+	/**
+	 * Checks if the current user has the capability a specific user.
+	 *
+	 * @param int $user_id The id of the user to be edited.
+	 *
+	 * @return object The response object.
+	 */
+	public function check_capability( $user_id ) {
+		if ( $this->social_profiles_helper->can_edit_profile( $user_id ) ) {
+			return (object) [
+				'success' => true,
+				'status'  => 200,
+			];
+		}
+
+		return (object) [
+			'success' => false,
+			'status'  => 403,
+		];
+	}
+
+	/**
+	 * Stores the first time configuration state.
+	 *
+	 * @param array $params The values to store.
+	 *
+	 * @return object The response object.
+	 */
+	public function save_configuration_state( $params ) {
+		$configuration_data                      = [];
+		$configuration_data['finishedSteps']     = $params['finishedSteps'];
+		$configuration_data['indexablesBySteps'] = $params['indexablesBySteps'];
+		$configuration_data['priority']          = $params['priority'];
+
+		$success = $this->options_helper->set( 'configuration', $configuration_data );
+
+		if ( \count( $configuration_data['finishedSteps'] ) === 5 ) {
+			$this->options_helper->set( 'first_time_install', false );
+		}
+
+		if ( $success ) {
+			return (object) [
+				'success' => true,
+				'status'  => 200,
+			];
+		}
+
+		return (object) [
+			'success' => false,
+			'status'  => 500,
+			'error'   => 'Could not save the option in the database',
+		];
+	}
+
+	/**
+	 * Gets the first time configuration state.
+	 *
+	 * @return object The response object.
+	 */
+	public function get_configuration_state() {
+		$configuration_option = $this->options_helper->get( 'configuration' );
+
+		if ( ! is_null( $configuration_option ) ) {
+			return (object) [
+				'success' => true,
+				'status'  => 200,
+				'data'    => $configuration_option,
+			];
+		}
+
+		return (object) [
+			'success' => false,
+			'status'  => 500,
+			'error'   => 'Could not get data from the database',
+		];
+	}
+}

--- a/src/actions/configuration/first-time-configuration-action.php
+++ b/src/actions/configuration/first-time-configuration-action.php
@@ -5,10 +5,10 @@ namespace Yoast\WP\SEO\Actions\Configuration;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Integrations\Admin\Social_Profiles_Helper;
 
+// phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded -- First time configuration simply has a lot of words.
 /**
  * Class First_Time_Configuration_Action.
  */
-// phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded -- First time configuration simply has a lot of words.
 class First_Time_Configuration_Action {
 
 	/**

--- a/src/routes/first-time-configuration-route.php
+++ b/src/routes/first-time-configuration-route.php
@@ -365,7 +365,8 @@ class First_Time_Configuration_Route implements Route_Interface {
 	 * @return bool
 	 */
 	public function can_edit_user( WP_REST_Request $request ) {
-		return $this->first_time_configuration_action->check_capability( $request->get_param( 'user_id' ) );
+		$response = $this->first_time_configuration_action->check_capability( $request->get_param( 'user_id' ) );
+		return $response->success;
 	}
 
 	/**

--- a/src/routes/first-time-configuration-route.php
+++ b/src/routes/first-time-configuration-route.php
@@ -1,0 +1,406 @@
+<?php
+
+namespace Yoast\WP\SEO\Routes;
+
+use WP_REST_Request;
+use WP_REST_Response;
+use Yoast\WP\SEO\Actions\Configuration\First_Time_Configuration_Action;
+use Yoast\WP\SEO\Conditionals\No_Conditionals;
+use Yoast\WP\SEO\Main;
+/**
+ * First_Time_Configuration_Route class.
+ */
+// phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded -- First time configuration simply has a lot of words.
+class First_Time_Configuration_Route implements Route_Interface {
+
+	use No_Conditionals;
+
+	/**
+	 * Represents the first time configuration route.
+	 *
+	 * @var string
+	 */
+	const CONFIGURATION_ROUTE = '/configuration';
+
+	/**
+	 * Represents a site representation route.
+	 *
+	 * @var string
+	 */
+	const SITE_REPRESENTATION_ROUTE = '/site_representation';
+
+	/**
+	 * Represents a social profiles route.
+	 *
+	 * @var string
+	 */
+	const SOCIAL_PROFILES_ROUTE = '/social_profiles';
+
+	/**
+	 * Represents a person's social profiles route.
+	 *
+	 * @var string
+	 */
+	const PERSON_SOCIAL_PROFILES_ROUTE = '/person_social_profiles';
+
+	/**
+	 * Represents a route to enable/disable tracking.
+	 *
+	 * @var string
+	 */
+	const ENABLE_TRACKING_ROUTE = '/enable_tracking';
+
+	/**
+	 * Represents a route to check if current user has the correct capabilities to edit another user's profile.
+	 *
+	 * @var string
+	 */
+	const CHECK_CAPABILITY_ROUTE = '/check_capability';
+
+	/**
+	 * Represents a route to save the first time configuration state.
+	 *
+	 * @var string
+	 */
+	const SAVE_CONFIGURATION_STATE_ROUTE = '/save_configuration_state';
+
+	/**
+	 * Represents a route to save the first time configuration state.
+	 *
+	 * @var string
+	 */
+	const GET_CONFIGURATION_STATE_ROUTE = '/get_configuration_state';
+
+	/**
+	 *  The first tinme configuration action.
+	 *
+	 * @var First_Time_Configuration_Action
+	 */
+	private $first_time_configuration_action;
+
+	/**
+	 * First_Time_Configuration_Route constructor.
+	 *
+	 * @param First_Time_Configuration_Action $first_time_configuration_action; The configuration workout action.
+	 */
+	public function __construct(
+		First_Time_Configuration_Action $first_time_configuration_action
+	) {
+		$this->first_time_configuration_action = $first_time_configuration_action;
+	}
+
+	/**
+	 * Registers routes with WordPress.
+	 *
+	 * @return void
+	 */
+	public function register_routes() {
+		$site_representation_route = [
+			'methods'             => 'POST',
+			'callback'            => [ $this, 'set_site_representation' ],
+			'permission_callback' => [ $this, 'can_manage_options' ],
+			'args'                => [
+				'company_or_person' => [
+					'type'     => 'string',
+					'enum'     => [
+						'company',
+						'person',
+					],
+					'required' => true,
+				],
+				'company_name' => [
+					'type'     => 'string',
+				],
+				'company_logo' => [
+					'type'     => 'string',
+				],
+				'company_logo_id' => [
+					'type'     => 'integer',
+				],
+				'person_logo' => [
+					'type'     => 'string',
+				],
+				'person_logo_id' => [
+					'type'     => 'integer',
+				],
+				'company_or_person_user_id' => [
+					'type'     => 'integer',
+				],
+				'description' => [
+					'type'     => 'string',
+				],
+			],
+		];
+		\register_rest_route( Main::API_V1_NAMESPACE, self::CONFIGURATION_ROUTE . self::SITE_REPRESENTATION_ROUTE, $site_representation_route );
+
+		$social_profiles_route = [
+			'methods'             => 'POST',
+			'callback'            => [ $this, 'set_social_profiles' ],
+			'permission_callback' => [ $this, 'can_manage_options' ],
+			'args'                => [
+				'facebook_site' => [
+					'type'     => 'string',
+				],
+				'twitter_site' => [
+					'type'     => 'string',
+				],
+				'other_social_urls' => [
+					'type'     => 'array',
+				],
+			],
+		];
+		\register_rest_route( Main::API_V1_NAMESPACE, self::CONFIGURATION_ROUTE . self::SOCIAL_PROFILES_ROUTE, $social_profiles_route );
+
+		$person_social_profiles_route = [
+			[
+				'methods'             => 'GET',
+				'callback'            => [ $this, 'get_person_social_profiles' ],
+				'permission_callback' => [ $this, 'can_manage_options' ],
+				'args'                => [
+					'user_id' => [
+						'required' => true,
+					],
+				],
+			],
+			[
+				'methods'             => 'POST',
+				'callback'            => [ $this, 'set_person_social_profiles' ],
+				'permission_callback' => [ $this, 'can_edit_user' ],
+				'args'                => [
+					'user_id' => [
+						'type'     => 'integer',
+					],
+					'facebook' => [
+						'type'     => 'string',
+					],
+					'instagram' => [
+						'type'     => 'string',
+					],
+					'linkedin' => [
+						'type'     => 'string',
+					],
+					'myspace' => [
+						'type'     => 'string',
+					],
+					'pinterest' => [
+						'type'     => 'string',
+					],
+					'soundcloud' => [
+						'type'     => 'string',
+					],
+					'tumblr' => [
+						'type'     => 'string',
+					],
+					'twitter' => [
+						'type'     => 'string',
+					],
+					'youtube' => [
+						'type'     => 'string',
+					],
+					'wikipedia' => [
+						'type'     => 'string',
+					],
+				],
+			],
+		];
+		\register_rest_route( Main::API_V1_NAMESPACE, self::CONFIGURATION_ROUTE . self::PERSON_SOCIAL_PROFILES_ROUTE, $person_social_profiles_route );
+
+		$check_capability_route = [
+			'methods'             => 'GET',
+			'callback'            => [ $this, 'check_capability' ],
+			'args'                => [
+				'user_id' => [
+					'required' => true,
+				],
+			],
+		];
+		\register_rest_route( Main::API_V1_NAMESPACE, self::CONFIGURATION_ROUTE . self::CHECK_CAPABILITY_ROUTE, $check_capability_route );
+
+		$enable_tracking_route = [
+			'methods'             => 'POST',
+			'callback'            => [ $this, 'set_enable_tracking' ],
+			'args'                => [
+				'tracking' => [
+					'type'     => 'boolean',
+					'required' => true,
+				],
+			],
+		];
+		\register_rest_route( Main::API_V1_NAMESPACE, self::CONFIGURATION_ROUTE . self::ENABLE_TRACKING_ROUTE, $enable_tracking_route );
+
+		$save_configuration_state_route = [
+			'methods'             => 'POST',
+			'callback'            => [ $this, 'save_configuration_state' ],
+			'permission_callback' => [ $this, 'can_edit_other_posts' ],
+			'args'                => [
+				'finishedSteps' => [
+					'type'     => 'array',
+					'required' => true,
+				],
+				'IndexablesBySteps' => [
+					'type'     => 'array',
+				],
+				'priority' => [
+					'type'     => 'integer',
+					'required' => true,
+				],
+			],
+		];
+		\register_rest_route( Main::API_V1_NAMESPACE, self::CONFIGURATION_ROUTE . self::SAVE_CONFIGURATION_STATE_ROUTE, $save_configuration_state_route );
+
+		$get_configuration_state_route = [
+			[
+				'methods'             => 'GET',
+				'callback'            => [ $this, 'get_configuration_state' ],
+			],
+		];
+		\register_rest_route( Main::API_V1_NAMESPACE, self::CONFIGURATION_ROUTE . self::GET_CONFIGURATION_STATE_ROUTE, $get_configuration_state_route );
+	}
+
+	/**
+	 * Sets the site representation values.
+	 *
+	 * @param WP_REST_Request $request The request.
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function set_site_representation( WP_REST_Request $request ) {
+		$data = $this
+			->first_time_configuration_action
+			->set_site_representation( $request->get_json_params() );
+
+		return new WP_REST_Response( $data, $data->status );
+	}
+
+	/**
+	 * Sets the social profiles values.
+	 *
+	 * @param WP_REST_Request $request The request.
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function set_social_profiles( WP_REST_Request $request ) {
+		$data = $this
+			->first_time_configuration_action
+			->set_social_profiles( $request->get_json_params() );
+
+		return new WP_REST_Response( $data, $data->status );
+	}
+
+	/**
+	 * Gets a person's social profiles values.
+	 *
+	 * @param WP_REST_Request $request The request.
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function get_person_social_profiles( WP_REST_Request $request ) {
+		$data = $this
+			->first_time_configuration_action
+			->get_person_social_profiles( $request->get_param( 'user_id' ) );
+
+		return new WP_REST_Response( $data, $data->status );
+	}
+
+	/**
+	 * Sets a person's social profiles values.
+	 *
+	 * @param WP_REST_Request $request The request.
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function set_person_social_profiles( WP_REST_Request $request ) {
+		$data = $this
+			->first_time_configuration_action
+			->set_person_social_profiles( $request->get_json_params() );
+
+		return new WP_REST_Response( $data, $data->status );
+	}
+
+	/**
+	 * Checks if the current user has the correct capability to edit a specific user.
+	 *
+	 * @param WP_REST_Request $request The request.
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function check_capability( WP_REST_Request $request ) {
+		$data = $this
+			->first_time_configuration_action
+			->check_capability( $request->get_param( 'user_id' ) );
+
+		return new WP_REST_Response( $data );
+	}
+
+	/**
+	 * Enables or disables tracking.
+	 *
+	 * @param WP_REST_Request $request The request.
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function set_enable_tracking( WP_REST_Request $request ) {
+		$data = $this
+			->first_time_configuration_action
+			->set_enable_tracking( $request->get_json_params() );
+
+		return new WP_REST_Response( $data, $data->status );
+	}
+
+	/**
+	 * Checks if the current user has the right capability.
+	 *
+	 * @return bool
+	 */
+	public function can_manage_options() {
+		return \current_user_can( 'wpseo_manage_options' );
+	}
+
+	/**
+	 * Checks if the current user has the capability to edit a specific user.
+	 *
+	 * @param WP_REST_Request $request The request.
+	 *
+	 * @return bool
+	 */
+	public function can_edit_user( WP_REST_Request $request ) {
+		return $this->first_time_configuration_action->check_capability( $request->get_param( 'user_id' ) );
+	}
+
+	/**
+	 * Checks if the current user has the capability to edit posts of other users.
+	 *
+	 * @return bool
+	 */
+	public function can_edit_other_posts() {
+		return \current_user_can( 'edit_others_posts' );
+	}
+
+	/**
+	 * Saves the first time configuration state.
+	 *
+	 * @param WP_REST_Request $request The request.
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function save_configuration_state( WP_REST_Request $request ) {
+		$data = $this
+			->first_time_configuration_action
+			->save_configuration_state( $request->get_json_params() );
+
+		return new WP_REST_Response( $data, $data->status );
+	}
+
+	/**
+	 * Returns the first time configuration state.
+	 *
+	 * @return WP_REST_Response the configuration of the workouts.
+	 */
+	public function get_configuration_state() {
+		$data = $this
+			->first_time_configuration_action
+			->get_configuration_state();
+
+		return new WP_REST_Response( $data, $data->status );
+	}
+}

--- a/src/routes/first-time-configuration-route.php
+++ b/src/routes/first-time-configuration-route.php
@@ -7,10 +7,11 @@ use WP_REST_Response;
 use Yoast\WP\SEO\Actions\Configuration\First_Time_Configuration_Action;
 use Yoast\WP\SEO\Conditionals\No_Conditionals;
 use Yoast\WP\SEO\Main;
+
+// phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded -- First time configuration simply has a lot of words.
 /**
  * First_Time_Configuration_Route class.
  */
-// phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded -- First time configuration simply has a lot of words.
 class First_Time_Configuration_Route implements Route_Interface {
 
 	use No_Conditionals;
@@ -81,7 +82,7 @@ class First_Time_Configuration_Route implements Route_Interface {
 	/**
 	 * First_Time_Configuration_Route constructor.
 	 *
-	 * @param First_Time_Configuration_Action $first_time_configuration_action; The configuration workout action.
+	 * @param First_Time_Configuration_Action $first_time_configuration_action The configuration workout action.
 	 */
 	public function __construct(
 		First_Time_Configuration_Action $first_time_configuration_action

--- a/tests/unit/actions/configuration/first-time-configuration-action-test.php
+++ b/tests/unit/actions/configuration/first-time-configuration-action-test.php
@@ -1,0 +1,649 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Actions\Configuration;
+
+use Brain\Monkey;
+use Mockery;
+use Yoast\WP\SEO\Actions\Configuration\First_Time_Configuration_Action;
+use Yoast\WP\SEO\Helpers\Options_Helper;
+use Yoast\WP\SEO\Integrations\Admin\Social_profiles_Helper;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+// phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded -- First time configuration simply has a lot of words.
+/**
+ * Class First_Time_Configuration_Action_Test
+ *
+ * @group actions
+ * @group configuration
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Actions\Configuration\First_Time_Configuration_Action
+ */
+class First_Time_Configuration_Action_Test extends TestCase {
+
+	/**
+	 * The class instance.
+	 *
+	 * @var First_Time_Configuration_Action
+	 */
+	protected $instance;
+
+	/**
+	 * The options helper.
+	 *
+	 * @var Mockery\MockInterface|Options_Helper
+	 */
+	protected $options_helper;
+
+	/**
+	 * The social profiles helper.
+	 *
+	 * @var Mockery\MockInterface|Social_profiles_Helper
+	 */
+	protected $social_profiles_helper;
+
+	/**
+	 * Set up the test fixtures.
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->options_helper         = Mockery::mock( Options_Helper::class );
+		$this->social_profiles_helper = Mockery::mock( Social_profiles_Helper::class );
+
+		$this->instance = new First_Time_Configuration_Action( $this->options_helper, $this->social_profiles_helper );
+	}
+
+	/**
+	 * Tests if the needed attributes are set correctly.
+	 *
+	 * @covers ::__construct
+	 */
+	public function test_constructor() {
+		$this->assertInstanceOf(
+			Options_Helper::class,
+			$this->getPropertyValue( $this->instance, 'options_helper' )
+		);
+		$this->assertInstanceOf(
+			Social_profiles_Helper::class,
+			$this->getPropertyValue( $this->instance, 'social_profiles_helper' )
+		);
+	}
+
+	/**
+	 * Tests setting the site representation options in the database.
+	 *
+	 * @covers ::set_site_representation
+	 *
+	 * @dataProvider site_representation_provider
+	 *
+	 * @param array  $params                The parameters.
+	 * @param int    $times                 The number of times the Options_Helper::set is expected to be called.
+	 * @param bool[] $yoast_options_results The array of expected results.
+	 * @param bool   $wp_option_result      The result of the update_option call.
+	 * @param object $expected              The expected result object.
+	 */
+	public function test_set_site_representation( $params, $times, $yoast_options_results, $wp_option_result, $expected ) {
+		$this->options_helper
+			->expects( 'set' )
+			->times( $times )
+			->andReturn( ...$yoast_options_results );
+
+		Monkey\Functions\expect( 'current_user_can' )
+			->with( 'manage_options' )
+			->andReturnTrue();
+
+		Monkey\Functions\expect( 'update_option' )
+			->with( 'blogdescription' )
+			->andReturn( $wp_option_result );
+
+		$this->assertEquals(
+			$expected,
+			$this->instance->set_site_representation( $params )
+		);
+	}
+
+	/**
+	 * Dataprovider for test_set_site_representation function.
+	 *
+	 * @return array Data for test_set_site_representation function.
+	 */
+	public function site_representation_provider() {
+		$success_company = [
+			'params'                => [
+				'company_or_person' => 'company',
+				'company_name'      => 'Acme Inc.',
+				'company_logo'      => 'https://acme.com/someimage.jpg',
+				'company_logo_id'   => 123,
+				'description'       => 'A nice tagline',
+			],
+			'times'                 => 4,
+			'yoast_options_results' => [ true, true, true, true ],
+			'wp_option_result'      => true,
+			'expected'              => (object) [
+				'success' => true,
+				'status'  => 200,
+			],
+		];
+
+		$success_person = [
+			'params'                => [
+				'company_or_person'         => 'person',
+				'person_logo'               => 'https://acme.com/someimage.jpg',
+				'person_logo_id'            => 123,
+				'company_or_person_user_id' => 321,
+				'description'               => 'A nice tagline',
+			],
+			'times'                 => 4,
+			'yoast_options_results' => [ true, true, true, true ],
+			'wp_option_result'      => true,
+			'expected'              => (object) [
+				'success' => true,
+				'status'  => 200,
+			],
+		];
+
+		$success_person_failure_tagline = [
+			'params'                => [
+				'company_or_person'         => 'person',
+				'person_logo'               => 'https://acme.com/someimage.jpg',
+				'person_logo_id'            => 123,
+				'company_or_person_user_id' => 321,
+				'description'               => 'A tagline that will fail for some reason',
+			],
+			'times'                 => 4,
+			'yoast_options_results' => [ true, true, true, true ],
+			'wp_option_result'      => false,
+			'expected'              => (object) [
+				'success'  => false,
+				'status'   => 500,
+				'error'    => 'Could not save some options in the database',
+				'failures' => [ 'description' ],
+			],
+		];
+
+		$some_failures_company = [
+			'params'                => [
+				'company_or_person' => 'company',
+				'company_name'      => 'Acme Inc.',
+				'company_logo'      => 'https://acme.com/someimage.jpg',
+				'company_logo_id'   => 123,
+				'description'       => 'A nice tagline',
+			],
+			'times'                 => 4,
+			'yoast_options_results' => [ true, false, false, true ],
+			'wp_option_result'      => true,
+			'expected'              => (object) [
+				'success'  => false,
+				'status'   => 500,
+				'error'    => 'Could not save some options in the database',
+				'failures' => [ 'company_name', 'company_logo' ],
+			],
+		];
+
+		return [
+			'Successful call with company params'    => $success_company,
+			'Successful call with person params'     => $success_person,
+			'Person params with failing description' => $success_person_failure_tagline,
+			'Company params with some failures'      => $some_failures_company,
+		];
+	}
+
+	/**
+	 * Tests setting the social profiles options in the database.
+	 *
+	 * @covers ::set_social_profiles
+	 *
+	 * @dataProvider social_profiles_provider
+	 *
+	 * @param array  $params                The parameters.
+	 * @param int    $times                 The number of times the Options_Helper::set is expected to be called.
+	 * @param bool[] $yoast_options_results The array of expected results.
+	 * @param object $expected              The expected result object.
+	 */
+	public function test_set_social_profiles( $params, $times, $yoast_options_results, $expected ) {
+		$this->options_helper
+			->expects( 'set' )
+			->times( $times )
+			->andReturn( ...$yoast_options_results );
+
+		$this->assertEquals(
+			$expected,
+			$this->instance->set_social_profiles( $params )
+		);
+	}
+
+	/**
+	 * Dataprovider for test_set_social_profiles function.
+	 *
+	 * @return array Data for test_set_social_profiles function.
+	 */
+	public function social_profiles_provider() {
+		$success_all = [
+			'params'                => [
+				'facebook_site'     => 'https://facebook.com/somepage',
+				'twitter_site'      => 'somenick',
+				'other_social_urls' => [
+					'https://instagram.com/somepage',
+					'https://linked.in/somepage',
+					'https://myspace.com/somepage',
+					'https://pinterest.com/somepage',
+					'https://youtube.com/somepage',
+					'https://en.wikipedia.org/somepage',
+				],
+			],
+			'times'                 => 3,
+			'yoast_options_results' => [ true ],
+			'expected'              => (object) [
+				'success' => true,
+				'status'  => 200,
+			],
+		];
+
+		$success_some = [
+			'params'                => [
+				'facebook_site' => 'https://facebook.com/somepage',
+				'twitter_site'  => 'somenick',
+			],
+			'times'                 => 2,
+			'yoast_options_results' => [ true ],
+			'expected'              => (object) [
+				'success' => true,
+				'status'  => 200,
+			],
+		];
+
+		$some_failures = [
+			'params'                => [
+				'facebook_site'     => 'https://facebook.com/somepage',
+				'twitter_site'      => 'somenick',
+				'other_social_urls' => 'https://instagram.com/somepage',
+			],
+			'times'                 => 3,
+			'yoast_options_results' => [ true, true, false ],
+			'expected'              => (object) [
+				'success'  => false,
+				'status'   => 500,
+				'error'    => 'Could not save some options in the database',
+				'failures' => [ 'other_social_urls' ],
+			],
+		];
+
+		return [
+			'Successful call with all params'  => $success_all,
+			'Successful call with some params' => $success_some,
+			'Some failures'                    => $some_failures,
+		];
+	}
+
+	/**
+	 * Tests setting the social profiles options in the database when Twitter value is a URL.
+	 *
+	 * @covers ::set_social_profiles
+	 */
+	public function test_set_social_profiles_twitter_url() {
+		$params = [
+			'facebook_site'     => 'https://facebook.com/somepage',
+			'twitter_site'      => 'https://twitter.com/somenick',
+			'other_social_urls' => 'https://instagram.com/somepage',
+		];
+
+		$yoast_options_results = [ true, false, false ];
+
+		$this->options_helper
+			->expects( 'set' )
+			->times( 3 )
+			->andReturn( ...$yoast_options_results );
+
+		$this->options_helper
+			->expects( 'get' )
+			->with( 'twitter_site' )
+			->andReturn( 'somenick' );
+
+		$this->assertEquals(
+			(object) [
+				'success'  => false,
+				'status'   => 500,
+				'error'    => 'Could not save some options in the database',
+				'failures' => [ 'other_social_urls' ],
+			],
+			$this->instance->set_social_profiles( $params )
+		);
+	}
+
+	/**
+	 * Tests setting the social profiles options in the database when Twitter value is a URL and saving fails.
+	 *
+	 * @covers ::set_social_profiles
+	 */
+	public function test_set_social_profiles_twitter_url_failure() {
+		$params = [
+			'facebook_site'     => 'https://facebook.com/somepage',
+			'twitter_site'      => 'https://twitter.com/somenick',
+			'other_social_urls' => 'https://instagram.com/somepage',
+		];
+
+		$yoast_options_results = [ true, false, false ];
+
+		$this->options_helper
+			->expects( 'set' )
+			->times( 3 )
+			->andReturn( ...$yoast_options_results );
+
+		$this->options_helper
+			->expects( 'get' )
+			->with( 'twitter_site' )
+			->andReturn( 'someothernick' );
+
+		$this->assertEquals(
+			(object) [
+				'success'  => false,
+				'status'   => 500,
+				'error'    => 'Could not save some options in the database',
+				'failures' => [ 'twitter_site', 'other_social_urls' ],
+			],
+			$this->instance->set_social_profiles( $params )
+		);
+	}
+
+	/**
+	 * Tests setting the 'enable tracking' options in the database.
+	 *
+	 * @covers ::set_enable_tracking
+	 *
+	 * @dataProvider enable_tracking_provider
+	 *
+	 * @param array  $params        The parameters.
+	 * @param bool   $old_value     The existing value for the option.
+	 * @param int    $times         The number of times the Options_Helper::set is expected to be called.
+	 * @param bool   $option_result The success state of the option setting operation.
+	 * @param object $expected      The expected result object.
+	 */
+	public function test_set_enable_tracking( $params, $old_value, $times, $option_result, $expected ) {
+		$this->options_helper
+			->expects( 'get' )
+			->andReturn( $old_value );
+
+		$this->options_helper
+			->expects( 'set' )
+			->times( $times )
+			->andReturn( $option_result );
+
+		$this->assertEquals(
+			$expected,
+			$this->instance->set_enable_tracking( $params )
+		);
+	}
+
+	/**
+	 * Dataprovider for test_set_enable_tracking function.
+	 *
+	 * @return array Data for test_set_enable_tracking function.
+	 */
+	public function enable_tracking_provider() {
+		$false_to_true = [
+			'params'                => [
+				'tracking' => true,
+			],
+			'old_value'             => false,
+			'times'                 => 1,
+			'option_result'         => true,
+			'expected'              => (object) [
+				'success' => true,
+				'status'  => 200,
+			],
+		];
+
+		$true_to_false = [
+			'params'                => [
+				'tracking' => true,
+			],
+			'old_value'             => false,
+			'times'                 => 1,
+			'option_result'         => true,
+			'expected'              => (object) [
+				'success' => true,
+				'status'  => 200,
+			],
+		];
+
+		$false_on_false = [
+			'params'                => [
+				'tracking' => false,
+			],
+			'old_value'             => false,
+			'times'                 => 0,
+			'option_result'         => true,
+			'expected'              => (object) [
+				'success' => true,
+				'status'  => 200,
+			],
+		];
+
+		$true_on_true = [
+			'params'                => [
+				'tracking' => true,
+			],
+			'old_value'             => true,
+			'times'                 => 0,
+			'option_result'         => true,
+			'expected'              => (object) [
+				'success' => true,
+				'status'  => 200,
+			],
+		];
+
+		$failure = [
+			'params'                => [
+				'tracking' => true,
+			],
+			'old_value'             => false,
+			'times'                 => 1,
+			'option_result'         => false,
+			'expected'              => (object) [
+				'success' => false,
+				'status'  => 500,
+				'error'   => 'Could not save the option in the database',
+			],
+		];
+
+		return [
+			'False to true'  => $false_to_true,
+			'True to false'  => $true_to_false,
+			'False on false' => $false_on_false,
+			'True on true'   => $true_on_true,
+			'Failure'        => $failure,
+		];
+	}
+
+	/**
+	 * Tests the check_capability method.
+	 *
+	 * @param int    $user_id the id of the user.
+	 * @param bool   $can_edit      The result of the current_user_can call.
+	 * @param object $expected              The expected result object.
+	 *
+	 * @covers ::check_capability
+	 *
+	 * @dataProvider check_capability_provider
+	 */
+	public function test_check_capability( $user_id, $can_edit, $expected ) {
+		$this->social_profiles_helper
+			->expects( 'can_edit_profile' )
+			->with( $user_id )
+			->andReturn( $can_edit );
+
+		$this->assertEquals(
+			$expected,
+			$this->instance->check_capability( $user_id )
+		);
+	}
+
+	/**
+	 * Dataprovider for test_check_capability function.
+	 *
+	 * @return array Data for test_check_capability function.
+	 */
+	public function check_capability_provider() {
+		$success = [
+			'user_id'  => 123,
+			'can_edit' => true,
+			'expected' => (object) [
+				'success' => true,
+				'status'  => 200,
+			],
+		];
+
+		$failed = [
+			'user_id'  => 123,
+			'can_edit' => false,
+			'expected' => (object) [
+				'success' => false,
+				'status'  => 403,
+			],
+		];
+
+		return [
+			'Capabilites are right'  => $success,
+			'Capabilities are wrong' => $failed,
+		];
+	}
+
+	/**
+	 * Tests saving the configuration state in the database.
+	 *
+	 * @covers ::save_configuration_state
+	 *
+	 * @dataProvider configuration_provider
+	 *
+	 * @param array  $params                The parameters.
+	 * @param int    $times                 The number of times the Options_Helper::set is expected to be called.
+	 * @param bool[] $yoast_options_results The array of expected results.
+	 * @param object $expected              The expected result object.
+	 */
+	public function test_save_configuration_state( $params, $times, $yoast_options_results, $expected ) {
+		$this->options_helper
+			->expects( 'set' )
+			->times( $times )
+			->andReturn( ...$yoast_options_results );
+
+		Monkey\Functions\expect( 'current_user_can' )
+			->with( 'edit_others_posts' )
+			->andReturnTrue();
+
+		$this->assertEquals(
+			$expected,
+			$this->instance->save_configuration_state( $params )
+		);
+	}
+
+	/**
+	 * Dataprovider for save_configuration_state function.
+	 *
+	 * @return array Data for save_configuration_state function.
+	 */
+	public function configuration_provider() {
+		$success_save = [
+			'params'                => [
+				'finishedSteps'     => [],
+				'indexablesBySteps' => [],
+				'priority'          => 10,
+			],
+			'times'                 => 1,
+			'yoast_options_results' => [ true ],
+			'expected'              => (object) [
+				'success' => true,
+				'status'  => 200,
+			],
+		];
+
+		$failed_save = [
+			'params'                => [
+				'finishedSteps'     => [],
+				'indexablesBySteps' => [],
+				'priority'          => 10,
+			],
+			'times'                 => 1,
+			'yoast_options_results' => [ false ],
+			'expected'              => (object) [
+				'success' => false,
+				'status'  => 500,
+				'error'   => 'Could not save the option in the database',
+			],
+		];
+
+		$finish_configuration = [
+			'params'                => [
+				'finishedSteps'     => [ 'step1', 'step2', 'step3', 'step4', 'step5' ],
+				'indexablesBySteps' => [],
+				'priority'          => 10,
+			],
+			'times'                 => 2,
+			'yoast_options_results' => [ true ],
+			'expected'              => (object) [
+				'success' => true,
+				'status'  => 200,
+			],
+		];
+
+		return [
+			'Successful saved configuration state' => $success_save,
+			'Failed saved configuration state'     => $failed_save,
+			'Checked finished configuration'       => $finish_configuration,
+		];
+	}
+
+	/**
+	 * Tests saving the configuration state in the database.
+	 *
+	 * @covers ::get_configuration_state
+	 */
+	public function test_get_configuration_state() {
+
+		$expected_options_helper_return = [
+			'finishedSteps'     => [ 'step1', 'step2' ],
+			'indexablesBySteps' => [],
+			'priority'          => 10,
+		];
+
+		$this->options_helper
+			->expects( 'get' )
+			->with( 'configuration' )
+			->once()
+			->andReturn( $expected_options_helper_return );
+
+		$this->assertEquals(
+			(object) [
+				'success' => true,
+				'status'  => 200,
+				'data'    => [
+					'finishedSteps'     => [ 'step1', 'step2' ],
+					'indexablesBySteps' => [],
+					'priority'          => 10,
+				],
+			],
+			$this->instance->get_configuration_state()
+		);
+	}
+
+	/**
+	 * Tests failure path for saving the configuration state in the database.
+	 *
+	 * @covers ::get_configuration_state
+	 */
+	public function test_get_configuration_state_failure() {
+		$this->options_helper
+			->expects( 'get' )
+			->with( 'configuration' )
+			->once()
+			->andReturn( null );
+
+		$this->assertEquals(
+			(object) [
+				'success' => false,
+				'status'  => 500,
+				'error'   => 'Could not get data from the database',
+			],
+			$this->instance->get_configuration_state()
+		);
+	}
+}

--- a/tests/unit/actions/configuration/first-time-configuration-action-test.php
+++ b/tests/unit/actions/configuration/first-time-configuration-action-test.php
@@ -458,9 +458,9 @@ class First_Time_Configuration_Action_Test extends TestCase {
 	/**
 	 * Tests the check_capability method.
 	 *
-	 * @param int    $user_id the id of the user.
-	 * @param bool   $can_edit      The result of the current_user_can call.
-	 * @param object $expected              The expected result object.
+	 * @param int    $user_id  The id of the user.
+	 * @param bool   $can_edit The result of the current_user_can call.
+	 * @param object $expected The expected result object.
 	 *
 	 * @covers ::check_capability
 	 *

--- a/tests/unit/routes/first-time-configuration-route-test.php
+++ b/tests/unit/routes/first-time-configuration-route-test.php
@@ -270,6 +270,8 @@ class First_Time_Configuration_Route_Test extends TestCase {
 	/**
 	 * Tests the can_edit_user method.
 	 *
+	 * @param bool   $can_edit The result of the check_capability call.
+	 * @param object $expected The expected result object.
 	 * @covers ::can_edit_user
 	 *
 	 * @dataProvider can_edit_user_provider

--- a/tests/unit/routes/first-time-configuration-route-test.php
+++ b/tests/unit/routes/first-time-configuration-route-test.php
@@ -1,0 +1,336 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Routes;
+
+use Brain\Monkey;
+use Mockery;
+use Yoast\WP\SEO\Actions\Configuration\First_Time_Configuration_Action;
+use Yoast\WP\SEO\Routes\First_Time_Configuration_Route;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+// phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded -- First time configuration simply has a lot of words.
+/**
+ * Class First_Time_Configuration_Route_Test.
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Routes\First_Time_Configuration_Route
+ *
+ * @group routes
+ * @group workout
+ */
+class First_Time_Configuration_Route_Test extends TestCase {
+
+	/**
+	 * Represents the action.
+	 *
+	 * @var Mockery\MockInterface|First_Time_Configuration_Action
+	 */
+	protected $first_time_configuration_action;
+
+	/**
+	 * Represents the instance to test.
+	 *
+	 * @var First_Time_Configuration_Route
+	 */
+	protected $instance;
+
+	/**
+	 * Set up the test fixtures.
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->first_time_configuration_action = Mockery::mock( First_Time_Configuration_Action::class );
+		$this->instance                        = new First_Time_Configuration_Route( $this->first_time_configuration_action );
+	}
+
+	/**
+	 * Tests if the needed attributes are set correctly.
+	 *
+	 * @covers ::__construct
+	 */
+	public function test_construct() {
+		$this->assertInstanceOf(
+			First_Time_Configuration_Action::class,
+			$this->getPropertyValue( $this->instance, 'first_time_configuration_action' )
+		);
+	}
+
+	/**
+	 * Tests the registration of the routes.
+	 *
+	 * @covers ::register_routes
+	 */
+	public function test_register_routes() {
+		Monkey\Functions\expect( 'register_rest_route' )
+			->with(
+				'yoast/v1',
+				'/configuration/site_representation',
+				[
+					'methods'             => 'POST',
+					'callback'            => [ $this->instance, 'set_site_representation' ],
+					'permission_callback' => [ $this->instance, 'can_manage_options' ],
+					'args'                => [
+						'company_or_person' => [
+							'type'     => 'string',
+							'enum'     => [
+								'company',
+								'person',
+							],
+							'required' => true,
+						],
+						'company_name' => [
+							'type'     => 'string',
+						],
+						'company_logo' => [
+							'type'     => 'string',
+						],
+						'company_logo_id' => [
+							'type'     => 'integer',
+						],
+						'person_logo' => [
+							'type'     => 'string',
+						],
+						'person_logo_id' => [
+							'type'     => 'integer',
+						],
+						'company_or_person_user_id' => [
+							'type'     => 'integer',
+						],
+						'description' => [
+							'type'     => 'string',
+						],
+					],
+				]
+			);
+
+		Monkey\Functions\expect( 'register_rest_route' )
+			->with(
+				'yoast/v1',
+				'/configuration/social_profiles',
+				[
+					'methods'             => 'POST',
+					'callback'            => [ $this->instance, 'set_social_profiles' ],
+					'permission_callback' => [ $this->instance, 'can_manage_options' ],
+					'args'                => [
+						'facebook_site' => [
+							'type'     => 'string',
+						],
+						'twitter_site' => [
+							'type'     => 'string',
+						],
+						'other_social_urls' => [
+							'type'     => 'array',
+						],
+					],
+				]
+			);
+
+			Monkey\Functions\expect( 'register_rest_route' )
+				->with(
+					'yoast/v1',
+					'/configuration/person_social_profiles',
+					[
+						[
+							'methods'             => 'GET',
+							'callback'            => [ $this->instance, 'get_person_social_profiles' ],
+							'permission_callback' => [ $this->instance, 'can_manage_options' ],
+							'args'                => [
+								'user_id' => [
+									'required' => true,
+								],
+							],
+						],
+						[
+							'methods'             => 'POST',
+							'callback'            => [ $this->instance, 'set_person_social_profiles' ],
+							'permission_callback' => [ $this->instance, 'can_edit_user' ],
+							'args'                => [
+								'user_id' => [
+									'type'     => 'integer',
+								],
+								'facebook' => [
+									'type'     => 'string',
+								],
+								'instagram' => [
+									'type'     => 'string',
+								],
+								'linkedin' => [
+									'type'     => 'string',
+								],
+								'myspace' => [
+									'type'     => 'string',
+								],
+								'pinterest' => [
+									'type'     => 'string',
+								],
+								'soundcloud' => [
+									'type'     => 'string',
+								],
+								'tumblr' => [
+									'type'     => 'string',
+								],
+								'twitter' => [
+									'type'     => 'string',
+								],
+								'youtube' => [
+									'type'     => 'string',
+								],
+								'wikipedia' => [
+									'type'     => 'string',
+								],
+							],
+						],
+					]
+				);
+
+			Monkey\Functions\expect( 'register_rest_route' )
+				->with(
+					'yoast/v1',
+					'/configuration/check_capability',
+					[
+						'methods'             => 'GET',
+						'callback'            => [ $this->instance, 'check_capability' ],
+						'args'                => [
+							'user_id' => [
+								'required' => true,
+							],
+						],
+					]
+				);
+
+			Monkey\Functions\expect( 'register_rest_route' )
+				->with(
+					'yoast/v1',
+					'/configuration/enable_tracking',
+					[
+						'methods'             => 'POST',
+						'callback'            => [ $this->instance, 'set_enable_tracking' ],
+						'args'                => [
+							'tracking' => [
+								'type'     => 'boolean',
+								'required' => true,
+							],
+						],
+					]
+				);
+
+			Monkey\Functions\expect( 'register_rest_route' )
+				->with(
+					'yoast/v1',
+					'/configuration/save_configuration_state',
+					[
+						'methods'             => 'POST',
+						'callback'            => [ $this->instance, 'save_configuration_state' ],
+						'permission_callback' => [ $this->instance, 'can_edit_other_posts' ],
+						'args'                => [
+							'finishedSteps' => [
+								'type'     => 'array',
+								'required' => true,
+							],
+							'IndexablesBySteps' => [
+								'type'     => 'array',
+							],
+							'priority' => [
+								'type'     => 'integer',
+								'required' => true,
+							],
+						],
+					]
+				);
+
+			Monkey\Functions\expect( 'register_rest_route' )
+				->with(
+					'yoast/v1',
+					'/configuration/get_configuration_state',
+					[
+						[
+							'methods'             => 'GET',
+							'callback'            => [ $this->instance, 'get_configuration_state' ],
+						],
+					]
+				);
+
+		$this->instance->register_routes();
+	}
+
+	/**
+	 * Tests the can_manage_options method.
+	 *
+	 * @covers ::can_manage_options
+	 */
+	public function test_can_manage_options() {
+		Monkey\Functions\expect( 'current_user_can' )
+			->with( 'wpseo_manage_options' )
+			->andReturn( true, false );
+
+		$this->assertTrue( $this->instance->can_manage_options() );
+		$this->assertFalse( $this->instance->can_manage_options() );
+	}
+
+	/**
+	 * Tests the can_edit_user method.
+	 *
+	 * @covers ::can_edit_user
+	 *
+	 * @dataProvider can_edit_user_provider
+	 */
+	public function test_can_edit_user( $can_edit, $expected ) {
+		$request = Mockery::mock( 'WP_Rest_Request' );
+		$request
+			->shouldReceive( 'get_param' )
+			->with( 'user_id' )
+			->andReturn( 123 );
+
+		$this->first_time_configuration_action
+			->expects( 'check_capability' )
+			->with( $request->get_param( 'user_id' ) )
+			->andReturn( $can_edit );
+
+			$this->assertEquals(
+				$expected,
+				$this->instance->can_edit_user( $request )
+			);
+	}
+
+	/**
+	 * Dataprovider for can_edit_user function.
+	 *
+	 * @return array Data for can_edit_user function.
+	 */
+	public function can_edit_user_provider() {
+		$success = [
+			'can_edit' => (object) [
+				'success' => true,
+				'status'  => 200,
+			],
+			'expected' => true,
+		];
+
+		$failed = [
+			'can_edit' => (object) [
+				'success' => false,
+				'status'  => 403,
+			],
+			'expected' => false,
+		];
+
+		return [
+			'User can edit other users'    => $success,
+			'User cannot edit other users' => $failed,
+		];
+	}
+
+	/**
+	 * Tests the can_edit_other_posts method.
+	 *
+	 * @covers ::can_edit_other_posts
+	 */
+	public function test_can_edit_other_posts() {
+		Monkey\Functions\expect( 'current_user_can' )
+			->with( 'edit_others_posts' )
+			->andReturn( true, false );
+
+		$this->assertTrue( $this->instance->can_edit_other_posts() );
+		$this->assertFalse( $this->instance->can_edit_other_posts() );
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->
* The first time configuration stepper needs to be moved outside the workouts tab, so routes need to be updated

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Updates routes for the first time configuration and adds actions to save/retrieve configuration state

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install (if you don't have it installed already) and activate [JSON API Auth](https://wordpress.org/plugins/json-api-auth/) plugin
* Send a REST request as follows: 
`http://basic.wordpress.test/wp-json/yoast/v1/configuration/save_configuration_state`
With JSON body:
```
{
	"finishedSteps": ["step1", "step2"],
	"indexablesBySteps": [],
	"priority": 10
}
```
* Verify the response body is as follows:
```
{
    "success": true,
    "status": 200
}
```
* In the database, check `first_time_install` key in `wpseo` option and verify it is set to `1`
* Send a REST request as follows:
`http://basic.wordpress.test/wp-json/yoast/v1/configuration/get_configuration_state`
with an empty body
*Verify the response body is as follows:
```
{
    "success": true,
    "status": 200,
    "data": {
        "finishedSteps": [
            "step1",
            "step2"
        ],
        "indexablesBySteps": [],
        "priority": 10
    }
}
```
* Send a REST request as follows: 
`http://basic.wordpress.test/wp-json/yoast/v1/configuration/save_configuration_state`
With JSON body:
```
{
	"finishedSteps": ["step1", "step2", "step3", "step4". "step5"],
	"indexablesBySteps": [],
	"priority": 10
}
```
* In the database, check `first_time_install` key in `wpseo` option and verify it is now set to `0`

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [X] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes [DUPP-366](https://yoast.atlassian.net/browse/DUPP-366)
