### PR TITLE
title should change color as slide opens

### DIFF
--- a/packages/js/src/workouts/tailwind-components/StepHeader.js
+++ b/packages/js/src/workouts/tailwind-components/StepHeader.js
@@ -1,5 +1,6 @@
 import { StepCircle } from "./StepCircle";
 import PropTypes from "prop-types";
+import { useEffect, useState } from "@wordpress/element";
 import { stepperTimings } from "../stepper-helper";
 import { useStepperContext } from "./Stepper";
 
@@ -40,7 +41,18 @@ export default function StepHeader( { name, description, isFinished, children } 
 	const { stepIndex, activeStepIndex, lastStepIndex } = useStepperContext();
 	const isActiveStep = activeStepIndex === stepIndex;
 	const isLastStep = lastStepIndex === stepIndex;
-	const nameClassNames = getNameClassnames( isFinished, isActiveStep, isLastStep );
+	const [ nameClassNames, setNameClassNames ] = useState( getNameClassnames( isFinished, isActiveStep, isLastStep ) );
+
+	/**
+	 * Delay calculating new styles for the name classnames if a step changes to isActiveStep === true.
+	 */
+	useEffect( () => {
+		if ( isActiveStep ) {
+			setTimeout( () => setNameClassNames( getNameClassnames( isFinished, isActiveStep, isLastStep ) ), stepperTimings.delayBeforeOpening );
+		} else {
+			setNameClassNames( getNameClassnames( isFinished, isActiveStep, isLastStep ) );
+		}
+	}, [ isActiveStep, isFinished, isLastStep ] );
 
 	return <div className="yst-relative yst-flex yst-items-center yst-group" aria-current={ isActiveStep ? "step" : null }>
 		<span className="yst-flex yst-items-center" aria-hidden={ isActiveStep ? "true" : null }>
@@ -52,7 +64,7 @@ export default function StepHeader( { name, description, isFinished, children } 
 		</span>
 		{ /* Name and description. */ }
 		<span className="yst-ml-4 yst-min-w-0 yst-flex yst-flex-col">
-			<span className={ "yst-text-xs yst-font-[650] yst-tracking-wide yst-uppercase " + nameClassNames }>
+			<span className={ `yst-transition-colors yst-duration-500 yst-text-xs yst-font-[650] yst-tracking-wide yst-uppercase ${ nameClassNames }` }>
 				{ name }
 			</span>
 			{ description && <span className="yst-text-sm yst-text-gray-500">{ description }</span> }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Color should change as step slides open

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Step title now changes to purple as the step slides open.

## Relevant technical choices:

* Used `settimeout` because adding `yst-delay-....` in some cases but not others does not work. That is, if the step is active there should be no delay on the `yst-transition-colors` transition (as it always go to inactive), whereas if it's inactive there should be a delay (as it can only go to active). However, at the moment of switching, the className is already removed. So it only works via JS.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Open and close slides. A step title should only turn purple as it slides open.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes DUPP-261
