### PR TITLE
LINGO-1430 Google preview snippet should open by default

### DIFF
--- a/packages/js/src/classic-editor/components/google-preview.js
+++ b/packages/js/src/classic-editor/components/google-preview.js
@@ -25,7 +25,8 @@ const GooglePreview = () => {
 	return (
 		<MetaboxCollapsible
 			id={ "yoast-snippet-editor-metabox" }
-			title={ __( "Google preview", "wordpress-seo" ) } initialIsOpen={ true }
+			title={ __( "Google preview", "wordpress-seo" ) }
+			initialIsOpen={ true }
 		>
 			<GooglePreviewContainer
 				as={ SnippetEditor }
@@ -33,6 +34,8 @@ const GooglePreview = () => {
 				faviconSrc={ siteIconUrl }
 				mobileImageSrc={ featuredImageUrl }
 				isTaxonomy={ analysisType === "term" }
+				showCloseButton={ false }
+				hasPaperStyle={ false }
 			/>
 		</MetaboxCollapsible>
 	);


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The Google preview snippet was not opened by default in the agnostic analysis feature branch, while it is opened automatically on `trunk`. This issue was found when running the automated tests.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Opens the Google preview snippet by default.

## Relevant technical choices:

* None

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Activate the Classic Editor plug-in.
* Create a new post.
* Confirm that the Google preview snippet is open by default (there is no "Edit snippet" button as shown in the first screenshot of [LINGO-1430](https://yoast.atlassian.net/browse/LINGO-1430), but there is rather an editing pane as shown in the second screenshot)
* Repeat above two steps for a page and a category.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The Google preview snippet.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes https://yoast.atlassian.net/browse/LINGO-1430
