### PR TITLE
Remove deprecated properties and attributes

### DIFF
--- a/inc/sitemaps/class-sitemap-image-parser.php
+++ b/inc/sitemaps/class-sitemap-image-parser.php
@@ -84,9 +84,7 @@ class WPSEO_Sitemap_Image_Parser {
 		if ( $thumbnail_id ) {
 
 			$src      = $this->get_absolute_url( $this->image_url( $thumbnail_id ) );
-			$alt      = WPSEO_Image_Utils::get_alt_tag( $thumbnail_id );
-			$title    = get_post_field( 'post_title', $thumbnail_id );
-			$images[] = $this->get_image_item( $post, $src, $title, $alt );
+			$images[] = $this->get_image_item( $post, $src );
 		}
 
 		/**
@@ -100,23 +98,17 @@ class WPSEO_Sitemap_Image_Parser {
 		$unfiltered_images = $this->parse_html_images( $content );
 
 		foreach ( $unfiltered_images as $image ) {
-			$images[] = $this->get_image_item( $post, $image['src'], $image['title'], $image['alt'] );
+			$images[] = $this->get_image_item( $post, $image['src'] );
 		}
 
 		foreach ( $this->parse_galleries( $content, $post->ID ) as $attachment ) {
-
-			$src = $this->get_absolute_url( $this->image_url( $attachment->ID ) );
-			$alt = WPSEO_Image_Utils::get_alt_tag( $attachment->ID );
-
-			$images[] = $this->get_image_item( $post, $src, $attachment->post_title, $alt );
+			$src      = $this->get_absolute_url( $this->image_url( $attachment->ID ) );
+			$images[] = $this->get_image_item( $post, $src );
 		}
 
 		if ( $post->post_type === 'attachment' && wp_attachment_is_image( $post ) ) {
-
-			$src = $this->get_absolute_url( $this->image_url( $post->ID ) );
-			$alt = WPSEO_Image_Utils::get_alt_tag( $post->ID );
-
-			$images[] = $this->get_image_item( $post, $src, $post->post_title, $alt );
+			$src      = $this->get_absolute_url( $this->image_url( $post->ID ) );
+			$images[] = $this->get_image_item( $post, $src );
 		}
 
 		foreach ( $images as $key => $image ) {
@@ -152,8 +144,6 @@ class WPSEO_Sitemap_Image_Parser {
 
 			$images[] = [
 				'src'   => $this->get_absolute_url( $this->image_url( $attachment->ID ) ),
-				'title' => $attachment->post_title,
-				'alt'   => WPSEO_Image_Utils::get_alt_tag( $attachment->ID ),
 			];
 		}
 
@@ -220,8 +210,6 @@ class WPSEO_Sitemap_Image_Parser {
 
 			$images[] = [
 				'src'   => $src,
-				'title' => $img->getAttribute( 'title' ),
-				'alt'   => $img->getAttribute( 'alt' ),
 			];
 		}
 
@@ -298,12 +286,10 @@ class WPSEO_Sitemap_Image_Parser {
 	 *
 	 * @param WP_Post $post  Post object for the context.
 	 * @param string  $src   Image URL.
-	 * @param string  $title Optional image title.
-	 * @param string  $alt   Optional image alt text.
 	 *
 	 * @return array
 	 */
-	protected function get_image_item( $post, $src, $title = '', $alt = '' ) {
+	protected function get_image_item( $post, $src ) {
 
 		$image = [];
 
@@ -315,14 +301,6 @@ class WPSEO_Sitemap_Image_Parser {
 		 */
 		$image['src'] = apply_filters( 'wpseo_xml_sitemap_img_src', $src, $post );
 
-		if ( ! empty( $title ) ) {
-			$image['title'] = $title;
-		}
-
-		if ( ! empty( $alt ) ) {
-			$image['alt'] = $alt;
-		}
-
 		/**
 		 * Filter image data to be included in XML sitemap for the post.
 		 *
@@ -330,8 +308,6 @@ class WPSEO_Sitemap_Image_Parser {
 		 *     Array of image data.
 		 *
 		 *     @type string  $src   Image URL.
-		 *     @type string  $title Image title attribute (optional).
-		 *     @type string  $alt   Image alt attribute (optional).
 		 * }
 		 *
 		 * @param object $post  Post object.

--- a/inc/sitemaps/class-sitemap-image-parser.php
+++ b/inc/sitemaps/class-sitemap-image-parser.php
@@ -178,7 +178,11 @@ class WPSEO_Sitemap_Image_Parser {
 		// Clear the errors, so they don't get kept in memory.
 		libxml_clear_errors();
 
-		/** @var DOMElement $img */
+		/**
+		 * Image attribute.
+		 *
+		 * @var DOMElement $img
+		 */
 		foreach ( $post_dom->getElementsByTagName( 'img' ) as $img ) {
 
 			$src = $img->getAttribute( 'src' );

--- a/inc/sitemaps/class-sitemaps-renderer.php
+++ b/inc/sitemaps/class-sitemaps-renderer.php
@@ -230,31 +230,6 @@ class WPSEO_Sitemaps_Renderer {
 
 			$output .= "\t\t<image:image>\n";
 			$output .= "\t\t\t<image:loc>" . $this->encode_and_escape( $img['src'] ) . "</image:loc>\n";
-
-			if ( ! empty( $img['title'] ) ) {
-
-				$title = $img['title'];
-
-				if ( $this->needs_conversion ) {
-					$title = mb_convert_encoding( $title, $this->output_charset, $this->charset );
-				}
-
-				$title   = _wp_specialchars( html_entity_decode( $title, ENT_QUOTES, $this->output_charset ) );
-				$output .= "\t\t\t<image:title><![CDATA[{$title}]]></image:title>\n";
-			}
-
-			if ( ! empty( $img['alt'] ) ) {
-
-				$alt = $img['alt'];
-
-				if ( $this->needs_conversion ) {
-					$alt = mb_convert_encoding( $alt, $this->output_charset, $this->charset );
-				}
-
-				$alt     = _wp_specialchars( html_entity_decode( $alt, ENT_QUOTES, $this->output_charset ) );
-				$output .= "\t\t\t<image:caption><![CDATA[{$alt}]]></image:caption>\n";
-			}
-
 			$output .= "\t\t</image:image>\n";
 		}
 		unset( $img, $title, $alt );

--- a/tests/integration/sitemaps/test-class-wpseo-sitemap-image-parser.php
+++ b/tests/integration/sitemaps/test-class-wpseo-sitemap-image-parser.php
@@ -35,8 +35,8 @@ class WPSEO_Sitemap_Image_Parser_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_get_images() {
 
-		$content_src   = 'http://example.org/content-image.jpg';
-		$post_id       = $this->factory->post->create(
+		$content_src = 'http://example.org/content-image.jpg';
+		$post_id     = $this->factory->post->create(
 			[ 'post_content' => "<img src='{$content_src}' alt='jibberish' />" ]
 		);
 

--- a/tests/integration/sitemaps/test-class-wpseo-sitemap-image-parser.php
+++ b/tests/integration/sitemaps/test-class-wpseo-sitemap-image-parser.php
@@ -36,18 +36,14 @@ class WPSEO_Sitemap_Image_Parser_Test extends WPSEO_UnitTestCase {
 	public function test_get_images() {
 
 		$content_src   = 'http://example.org/content-image.jpg';
-		$content_title = 'Content image title.';
-		$content_alt   = 'Content image alt.';
 		$post_id       = $this->factory->post->create(
-			[ 'post_content' => "<img src='{$content_src}' title='{$content_title}' alt='{$content_alt}' />" ]
+			[ 'post_content' => "<img src='{$content_src}' alt='jibberish' />" ]
 		);
 
 		$images = self::$class_instance->get_images( get_post( $post_id ) );
 		$this->assertNotEmpty( $images[0] );
 		$content_image = $images[0];
 		$this->assertEquals( $content_src, $content_image['src'] );
-		$this->assertEquals( $content_title, $content_image['title'] );
-		$this->assertEquals( $content_alt, $content_image['alt'] );
 	}
 
 	/**

--- a/tests/integration/sitemaps/test-class-wpseo-sitemaps-renderer.php
+++ b/tests/integration/sitemaps/test-class-wpseo-sitemaps-renderer.php
@@ -61,8 +61,6 @@ class WPSEO_Sitemaps_Renderer_Test extends WPSEO_UnitTestCase {
 		$image_a = 'http://example.com/image.jpg';
 		$image_b = 'example.com/my category/my=page*without"enco@ding/';
 		$image_c = '//example.com/my category?s=keyword&p=2';
-		$title   = 'Image title.';
-		$alt     = 'Image alt.';
 		$links   = [
 			[
 				'loc'    => $loc,
@@ -72,18 +70,12 @@ class WPSEO_Sitemaps_Renderer_Test extends WPSEO_UnitTestCase {
 				'images' => [
 					[
 						'src'   => $image_a,
-						'title' => $title . 'A',
-						'alt'   => $alt . 'A',
 					],
 					[
 						'src'   => $image_b,
-						'title' => $title . 'B',
-						'alt'   => $alt . 'B',
 					],
 					[
 						'src'   => $image_c,
-						'title' => $title . 'C',
-						'alt'   => $alt . 'C',
 					],
 				],
 			],
@@ -98,8 +90,6 @@ class WPSEO_Sitemaps_Renderer_Test extends WPSEO_UnitTestCase {
 		$this->assertStringContainsString( "<image:loc>{$image_a}</image:loc>", $index );
 		$this->assertStringContainsString( "<image:loc>{$expected_b}</image:loc>", $index );
 		$this->assertStringContainsString( "<image:loc>{$expected_c}</image:loc>", $index );
-		$this->assertStringContainsString( "<image:title><![CDATA[{$title}A]]></image:title>", $index );
-		$this->assertStringContainsString( "<image:caption><![CDATA[{$alt}C]]></image:caption>", $index );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Remove XML sitemap image properties `title` and `caption` as Google has deprecated them.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Create a post with a thumbnail image, an image gallery, and a single image in the post content. Make sure all have an alt text and/or a title.
* Open the xml sitemap source (cmd+option+U in chrome) and find your post.
* See that `<image:title>` and `<image:caption>` no longer appear in XML sitemaps.
![Pasted_Image_02_05_2022__10_25](https://user-images.githubusercontent.com/5352634/166206016-6a684622-8ef6-4a9e-8a5b-69855731a1d9.png)
* Install WooCommerce SEO 14.7 or trunk
* Create a product with a product image gallery with images with an alt text and title.
* Open the products sitemaps and see that the product images.
* See that the `<image:title>` and `<image:caption>` no longer appear in XML sitemaps for all products, including the new product.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact
- This mostly impacts sitemaps generated by Yoast SEO free with images.
- It also impacts images added by WooCommerce SEO: it should no longer show title and caption for those images.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes IM-1825
