### PR TITLE
Id of the google preview should be yoast google preview description metabox

### DIFF
--- a/packages/js/src/classic-editor/components/google-preview.js
+++ b/packages/js/src/classic-editor/components/google-preview.js
@@ -36,6 +36,7 @@ const GooglePreview = () => {
 				isTaxonomy={ analysisType === "term" }
 				showCloseButton={ false }
 				hasPaperStyle={ false }
+				idSuffix={ "metabox" }
 			/>
 		</MetaboxCollapsible>
 	);

--- a/packages/js/tests/classic-editor/components/google-preview.test.js
+++ b/packages/js/tests/classic-editor/components/google-preview.test.js
@@ -1,0 +1,26 @@
+import { shallow } from "enzyme";
+import { useSelect } from "@wordpress/data";
+
+import GooglePreview from "../../../src/classic-editor/components/google-preview";
+import { GooglePreviewContainer } from "@yoast/seo-integration";
+
+jest.mock( "@wordpress/data" );
+
+describe( "The GooglePreview component", () => {
+	it( "renders with the correct id suffix", () => {
+		const select = jest.fn();
+		select.mockReturnValue( {
+			getShoppingData: jest.fn(),
+			getSiteIconUrlFromSettings: jest.fn(),
+			selectAnalysisType: jest.fn(),
+			selectFeaturedImage: jest.fn( () => ( {
+				url: "https://example.org/images/image.jpeg",
+			} ) ),
+			selectContent: jest.fn(),
+		} );
+
+		useSelect.mockImplementation( func => func( select ) );
+		const renderedComponent = shallow( <GooglePreview /> );
+		expect( renderedComponent.find( GooglePreviewContainer ).props().idSuffix ).toEqual( "metabox" );
+	} );
+} );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds the `"metabox"` suffix to the IDs of the Google Preview elements for the classic editor agnostic analysis integration.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Create a new post or open an existing one in the classic editor.
* In the classic editor, open the page source.
   * E.g. open the developer tools.
* The source code should contain an HTML-element with an id of `"yoast-google-preview-description-metabox".

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* 

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes #
