### PR TITLE
Dupp 403 if local seo then organization selected

### DIFF
--- a/packages/js/src/workouts/components/ConfigurationWorkout.js
+++ b/packages/js/src/workouts/components/ConfigurationWorkout.js
@@ -319,7 +319,10 @@ const FinishStep = () => <Fragment>
  */
 function calculateInitialState( windowObject, isStepFinished ) {
 	// Overrule default state to empty and add empty choice.
-	let { companyOrPerson, companyName,	companyLogo, companyOrPersonOptions } = windowObject; // eslint-disable-line prefer-const
+	let { companyOrPerson, companyName,	companyLogo, companyOrPersonOptions, shouldForceCompany } = windowObject; // eslint-disable-line prefer-const
+	if ( shouldForceCompany ) {
+		companyOrPerson = "company";
+	} else
 	if ( companyOrPerson === "company" && ( ! companyName && ! companyLogo ) && ! isStepFinished( "configuration", STEPS.configuration.siteRepresentation ) ) {
 		companyOrPerson = "emptyChoice";
 	}

--- a/packages/js/src/workouts/tailwind-components/base/single-select.js
+++ b/packages/js/src/workouts/tailwind-components/base/single-select.js
@@ -19,7 +19,7 @@ import MultiLineText from "./multi-line-text";
  *
  * @returns {WPElement} The Select element.
  */
-export default function Select( { id, value, choices, label, onChange, error } ) {
+export default function Select( { id, value, choices, label, onChange, error, disabled } ) {
 	// Find label to display for value of selected choice.
 	const valueLabel = useMemo( () => {
 		const selectedChoice = choices.find( ( choice ) => value === choice.value );
@@ -27,7 +27,7 @@ export default function Select( { id, value, choices, label, onChange, error } )
 	}, [ choices, value ] );
 
 	return (
-		<Listbox value={ value } onChange={ onChange }>
+		<Listbox value={ value } onChange={ onChange } disabled={ disabled }>
 			{ ( { open } ) => (
 				<>
 					{ label && <Listbox.Label className="yst-block yst-max-w-sm yst-mb-1 yst-text-sm yst-font-medium yst-text-gray-700">{ label }</Listbox.Label> }
@@ -36,7 +36,8 @@ export default function Select( { id, value, choices, label, onChange, error } )
 							<Listbox.Button
 								className={ classNames(
 									"yst-relative yst-h-[45px] yst-w-full yst-leading-6 yst-py-2 yst-pl-3 yst-pr-10 yst-text-left yst-text-gray-700 yst-bg-white yst-border yst-rounded-md yst-shadow-sm yst-cursor-default focus:yst-outline-none focus:yst-ring-1 focus:yst-ring-primary-500 focus:yst-border-primary-500 sm:yst-text-sm",
-									error.isVisible ? "yst-border-red-300" : "yst-border-gray-300"
+									error.isVisible ? "yst-border-red-300" : "yst-border-gray-300",
+									disabled ? "yst-opacity-50" : "yst-opacity-100"
 								) }
 								{ ...getErrorAriaProps( id, error ) }
 							>
@@ -118,6 +119,7 @@ Select.propTypes = {
 		message: PropTypes.string,
 		isVisible: PropTypes.bool,
 	} ),
+	disabled: PropTypes.bool,
 };
 
 Select.defaultProps = {
@@ -125,4 +127,5 @@ Select.defaultProps = {
 		message: "",
 		isVisible: false,
 	},
+	disabled: false,
 };

--- a/packages/js/src/workouts/tailwind-components/steps/site-representation/site-representation-step.js
+++ b/packages/js/src/workouts/tailwind-components/steps/site-representation/site-representation-step.js
@@ -29,7 +29,7 @@ export default function SiteRepresentationStep( { onOrganizationOrPersonChange, 
 	} );
 
 	return <Fragment>
-		{  window.wpseoWorkoutsData.configuration.knowledgeGraphMessage &&  <Alert type="warning">
+		{  window.wpseoWorkoutsData.configuration.knowledgeGraphMessage &&  <Alert type="info">
 			{  window.wpseoWorkoutsData.configuration.knowledgeGraphMessage }
 		</Alert> }
 		<p className="yst-text-sm yst-whitespace-pre-line yst-mb-6">
@@ -58,6 +58,7 @@ export default function SiteRepresentationStep( { onOrganizationOrPersonChange, 
 			value={ state.shouldForceCompany ? "company" : state.companyOrPerson }
 			onChange={ onOrganizationOrPersonChange }
 			choices={ state.companyOrPersonOptions }
+			disabled={ state.shouldForceCompany }
 		/>
 		<ReactAnimateHeight
 			height={ [ "company", "person" ].includes( state.companyOrPerson ) ? "auto" : 0 }

--- a/packages/js/src/workouts/tailwind-components/steps/site-representation/site-representation-step.js
+++ b/packages/js/src/workouts/tailwind-components/steps/site-representation/site-representation-step.js
@@ -58,7 +58,7 @@ export default function SiteRepresentationStep( { onOrganizationOrPersonChange, 
 			value={ state.shouldForceCompany ? "company" : state.companyOrPerson }
 			onChange={ onOrganizationOrPersonChange }
 			choices={ state.companyOrPersonOptions }
-			disabled={ state.shouldForceCompany }
+			disabled={ !! state.shouldForceCompany }
 		/>
 		<ReactAnimateHeight
 			height={ [ "company", "person" ].includes( state.companyOrPerson ) ? "auto" : 0 }

--- a/packages/js/src/workouts/tailwind-components/steps/site-representation/site-representation-step.js
+++ b/packages/js/src/workouts/tailwind-components/steps/site-representation/site-representation-step.js
@@ -7,7 +7,6 @@ import classNames from "classnames";
 import { addLinkToString } from "../../../../helpers/stringHelpers.js";
 import Alert, { FadeInAlert } from "../../base/alert";
 import SingleSelect from "../../base/single-select";
-import TextInput from "../../base/text-input";
 import { OrganizationSection } from "./organization-section";
 import { PersonSection } from "./person-section";
 
@@ -50,26 +49,16 @@ export default function SiteRepresentationStep( { onOrganizationOrPersonChange, 
 				)
 			}
 		</p>
-		{
-			window.wpseoWorkoutsData.configuration.shouldForceCompany === 0 && <SingleSelect
-				id="organization-person-select"
-				htmlFor="organization-person-select"
-				name="organization"
-				label={ __( "Does your site represent an Organization or Person?", "wordpress-seo" ) }
-				value={ state.companyOrPerson }
-				onChange={ onOrganizationOrPersonChange }
-				choices={ state.companyOrPersonOptions }
-			/>
-		}
-		{
-			window.wpseoWorkoutsData.configuration.shouldForceCompany === 1 && <TextInput
-				id="organization-forced-readonly-text"
-				name="organization"
-				label={ __( "Does your site represent an Organization or Person?", "wordpress-seo" ) }
-				value={ state.companyOrPersonLabel }
-				readOnly={ true }
-			/>
-		}
+
+		<SingleSelect
+			id="organization-person-select"
+			htmlFor="organization-person-select"
+			name="organization"
+			label={ __( "Does your site represent an Organization or Person?", "wordpress-seo" ) }
+			value={ state.shouldForceCompany ? "company" : state.companyOrPerson }
+			onChange={ onOrganizationOrPersonChange }
+			choices={ state.companyOrPersonOptions }
+		/>
 		<ReactAnimateHeight
 			height={ [ "company", "person" ].includes( state.companyOrPerson ) ? "auto" : 0 }
 			duration={ 400 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* When Local SEO is activated, we want to force-select `Organization` as entity the site represents

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Forces `Organization` in the Social Representation step of the first time configuration when Local SEO is activated

## Relevant technical choices:

* N/A

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install and activate WPSEO Local
* Go to the first time configuration and navigate to the `Site representation` step
* Verify that:
  * An alert is shown as follows:

   <img width="790" alt="Screenshot 2022-04-20 at 16 28 53" src="https://user-images.githubusercontent.com/68744851/164253970-f370e78e-24b1-410b-8c83-a53a6da95f79.png">

    *  The select below `Does your site represent an Organization or Person?` is greyed-out and disabled
    * The pre-selected value in the select is `organization`
    * `Organization name` and `Organization logo` are editable

* Deactivate WPSEO Local
* Go to the first time configuration and navigate to the `Site representation` step
* Verify that:
  * The select below `Does your site represent an Organization or Person?` is now active
  * You can select between `person` and `organization`

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes [DUPP-403](https://yoast.atlassian.net/browse/DUPP-403)
