### PR TITLE
LINGO-1362 add a twitter editor container to the seo-integration package

### DIFF
--- a/packages/seo-integration/src/index.js
+++ b/packages/seo-integration/src/index.js
@@ -33,6 +33,7 @@ export { SEO_STORE_NAME, FOCUS_KEYPHRASE_ID, useAnalyze, MARKER_STATUS } from "@
 export { ReadabilityResultsContainer, SeoResultsContainer } from "./analysis-results/containers";
 export { default as GooglePreviewContainer } from "./google-preview/containers/google-preview-container";
 export { default as FacebookContainer } from "./social/containers/facebook-container";
+export { default as TwitterContainer } from "./social/containers/twitter-container";
 export * as replacementVariableConfigurations from "./replacement-variables/configurations";
 export { useSeoContext } from "./seo-context";
 

--- a/packages/seo-integration/src/social/containers/twitter-container.js
+++ b/packages/seo-integration/src/social/containers/twitter-container.js
@@ -1,0 +1,49 @@
+import { useDispatch, useSelect } from "@wordpress/data";
+import { SEO_STORE_NAME } from "@yoast/seo-store";
+import { PropTypes } from "prop-types";
+import { useReplacementVariables } from "../../hooks/useReplacementVariables";
+
+/**
+ * Handles known data for a Twitter editor component.
+ *
+ * @param {JSX.Element} as A Twitter editor component.
+ * @param {Object} restProps Props to pass to the Twitter editor component, that are unhandled by this container.
+ *
+ * @returns {JSX.Element} A wrapped Twitter editor component.
+ */
+const TwitterEditorContainer = ( { as: Component, ...restProps } ) => {
+	const imageIsLarge = useSelect( select => select( "yoast-seo/editor" ).getTwitterImageType() ) !== "summary";
+	const title = useSelect( select => select( SEO_STORE_NAME ).selectTwitterTitle() );
+	const description = useSelect( select => select( SEO_STORE_NAME ).selectTwitterDescription() );
+	const imageData = useSelect( select => select( SEO_STORE_NAME ).selectTwitterImage() );
+	const imageUrl = imageData.url;
+	const imageAlt = imageData.alt;
+	const { updateTwitterTitle, updateTwitterDescription } = useDispatch( SEO_STORE_NAME );
+	const titleInputPlaceholder = "";
+	const descriptionInputPlaceholder = "";
+	const socialMediumName = "Twitter";
+
+	const { replacementVariables, recommendedReplacementVariables } = useReplacementVariables();
+
+	return <Component
+		title={ title }
+		description={ description }
+		imageUrl={ imageUrl }
+		alt={ imageAlt }
+		isLarge={ imageIsLarge }
+		onTitleChange={ updateTwitterTitle }
+		onDescriptionChange={ updateTwitterDescription }
+		replacementVariables={ replacementVariables }
+		recommendedReplacementVariables={ recommendedReplacementVariables }
+		titleInputPlaceholder={ titleInputPlaceholder }
+		descriptionInputPlaceholder={ descriptionInputPlaceholder }
+		socialMediumName={ socialMediumName }
+		{ ...restProps }
+	/>;
+};
+
+TwitterEditorContainer.propTypes = {
+	as: PropTypes.elementType.isRequired,
+};
+
+export default TwitterEditorContainer;

--- a/packages/seo-integration/src/social/containers/twitter-container.js
+++ b/packages/seo-integration/src/social/containers/twitter-container.js
@@ -6,8 +6,8 @@ import { useReplacementVariables } from "../../hooks/useReplacementVariables";
 /**
  * Handles known data for a Twitter editor component.
  *
- * @param {JSX.Element} as A Twitter editor component.
- * @param {Object} restProps Props to pass to the Twitter editor component, that are unhandled by this container.
+ * @param {JSX.Element} as          A Twitter editor component.
+ * @param {Object}      restProps   Props to pass to the Twitter editor component, that are unhandled by this container.
  *
  * @returns {JSX.Element} A wrapped Twitter editor component.
  */

--- a/packages/seo-integration/tests/social/containers/facebook-container.test.js
+++ b/packages/seo-integration/tests/social/containers/facebook-container.test.js
@@ -1,15 +1,13 @@
 import { shallow } from "enzyme";
-
-import { useReplacementVariables } from "../../../src/hooks/useReplacementVariables";
 import { useSelect, useDispatch } from "@wordpress/data";
 
+import { useReplacementVariables } from "../../../src/hooks/useReplacementVariables";
 import Container from "../../../src/social/containers/facebook-container";
 
 jest.mock( "@wordpress/data" );
 jest.mock( "../../../src/hooks/useReplacementVariables" );
 
 const Wrapper = jest.fn();
-
 
 describe( "The FacebookContainer components", () => {
 	it( "creates a new Facebook editor container", () => {

--- a/packages/seo-integration/tests/social/containers/twitter-container.test.js
+++ b/packages/seo-integration/tests/social/containers/twitter-container.test.js
@@ -1,0 +1,69 @@
+import { shallow } from "enzyme";
+
+import { useReplacementVariables } from "../../../src/hooks/useReplacementVariables";
+import { useSelect, useDispatch } from "@wordpress/data";
+
+import Container from "../../../src/social/containers/twitter-container";
+
+jest.mock( "@wordpress/data" );
+jest.mock( "../../../src/hooks/useReplacementVariables" );
+
+const Wrapper = jest.fn();
+
+
+describe( "a test for TwitterEditorContainer component", () => {
+	it( "creates a new Twitter editor container", () => {
+		const select = jest.fn();
+		useSelect.mockImplementation( func => func( select ) );
+
+		select.mockReturnValue( {
+			selectTwitterTitle: jest.fn( () => "Successful cat meow-nager" ),
+			selectTwitterDescription: jest.fn( () => "A collection of stories of successful cat meow-nagers in meow-naging their human: less work more treats." ),
+			selectTwitterImage: jest.fn( () => (
+				{
+					url: "https://example.com/assets/images/cat.jpeg",
+					alt: "A cat wearing a robe",
+				}
+			) ),
+			getTwitterImageType: jest.fn( () => "summary" ),
+		} );
+
+		const updateTwitterTitle = jest.fn();
+		const updateTwitterDescription = jest.fn();
+
+		useDispatch.mockReturnValue( {
+			updateTwitterTitle: updateTwitterTitle,
+			updateTwitterDescription: updateTwitterDescription,
+		} );
+
+		const replacementVariables = jest.fn();
+		const recommendedReplacementVariables = jest.fn();
+
+		useReplacementVariables.mockReturnValue( {
+			replacementVariables,
+			recommendedReplacementVariables,
+		} );
+
+		const TwitterContainer = shallow( <Container as={ Wrapper } extraProp={ 10 } /> );
+
+		// Name, title and description.
+		expect( TwitterContainer.props().socialMediumName ).toEqual( "Twitter" );
+		expect( TwitterContainer.props().title ).toEqual( "Successful cat meow-nager" );
+		expect( TwitterContainer.props().description ).toEqual( "A collection of stories of successful cat meow-nagers in meow-naging their human: less work more treats." );
+		// Image.
+		expect( TwitterContainer.props().imageUrl ).toEqual( "https://example.com/assets/images/cat.jpeg" );
+		expect( TwitterContainer.props().alt ).toEqual( "A cat wearing a robe" );
+		expect( TwitterContainer.props().isLarge ).toEqual( false );
+		// Update actions.
+		expect( TwitterContainer.props().onTitleChange ).toEqual( updateTwitterTitle );
+		expect( TwitterContainer.props().onDescriptionChange ).toEqual( updateTwitterDescription );
+		// Replacement variables.
+		expect( TwitterContainer.props().replacementVariables ).toEqual( replacementVariables );
+		expect( TwitterContainer.props().recommendedReplacementVariables ).toEqual( recommendedReplacementVariables );
+		// Placeholders.
+		expect( TwitterContainer.props().titleInputPlaceholder ).toBe( "" );
+		expect( TwitterContainer.props().descriptionInputPlaceholder ).toBe( "" );
+		// Extra props.
+		expect( TwitterContainer.props().extraProp ).toBe( 10 );
+	} );
+} );

--- a/packages/seo-integration/tests/social/containers/twitter-container.test.js
+++ b/packages/seo-integration/tests/social/containers/twitter-container.test.js
@@ -1,6 +1,7 @@
 import { shallow } from "enzyme";
-import { useReplacementVariables } from "../../../src/hooks/useReplacementVariables";
 import { useSelect, useDispatch } from "@wordpress/data";
+
+import { useReplacementVariables } from "../../../src/hooks/useReplacementVariables";
 import Container from "../../../src/social/containers/twitter-container";
 
 jest.mock( "@wordpress/data" );
@@ -29,8 +30,8 @@ describe( "a test for TwitterEditorContainer component", () => {
 		const updateTwitterDescription = jest.fn();
 
 		useDispatch.mockReturnValue( {
-			updateTwitterTitle: updateTwitterTitle,
-			updateTwitterDescription: updateTwitterDescription,
+			updateTwitterTitle,
+			updateTwitterDescription,
 		} );
 
 		const replacementVariables = jest.fn();

--- a/packages/seo-integration/tests/social/containers/twitter-container.test.js
+++ b/packages/seo-integration/tests/social/containers/twitter-container.test.js
@@ -1,15 +1,12 @@
 import { shallow } from "enzyme";
-
 import { useReplacementVariables } from "../../../src/hooks/useReplacementVariables";
 import { useSelect, useDispatch } from "@wordpress/data";
-
 import Container from "../../../src/social/containers/twitter-container";
 
 jest.mock( "@wordpress/data" );
 jest.mock( "../../../src/hooks/useReplacementVariables" );
 
 const Wrapper = jest.fn();
-
 
 describe( "a test for TwitterEditorContainer component", () => {
 	it( "creates a new Twitter editor container", () => {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* This PR provides a Container for the Twitter editor. It will be used in a later PR to connect the Twitter data (title, image, description) from the agnostic analysis SEO store, to the Twitter editor form in the metabox.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [seo-integration] Adds Twitter editor container.

## Relevant technical choices:

* None

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

**Note**: This container is not used yet in the code, so it cannot yet be acceptance tested. It will be tested in the PR that implements [LINGO-1389](https://yoast.atlassian.net/browse/LINGO-1389), since that combines this code and other code into a feature that can be tested.

What you can do:

* Check that the unit tests pass.
* Check that the unit tests cover 100% of the lines of the newly added TwitterEditorContainer.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

**Note**: This container is not used yet in the code, so it cannot yet be acceptance tested. It will be tested in the PR that implements [LINGO-1389](https://yoast.atlassian.net/browse/LINGO-1389), since that combines this code and other code into a feature that can be tested.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* NA

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes https://yoast.atlassian.net/browse/LINGO-1362
