### PR TITLE
Dupp 413 fix rewrite_rules performance problem

### DIFF
--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -448,7 +448,7 @@ class WPSEO_Utils {
 	 * @since 1.8.0
 	 */
 	public static function clear_rewrites() {
-		update_option( 'rewrite_rules', '');
+		update_option( 'rewrite_rules', '' );
 	}
 
 	/**

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -448,7 +448,7 @@ class WPSEO_Utils {
 	 * @since 1.8.0
 	 */
 	public static function clear_rewrites() {
-		delete_option( 'rewrite_rules' );
+		update_option( 'rewrite_rules', '');
 	}
 
 	/**

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -205,7 +205,7 @@ function _wpseo_activate() {
 	WPSEO_Options::ensure_options_exist();
 
 	if ( is_multisite() && ms_is_switched() ) {
-		update_option( 'rewrite_rules', '');
+		update_option( 'rewrite_rules', '' );
 	}
 	else {
 		if ( WPSEO_Options::get( 'stripcategorybase' ) === true ) {
@@ -252,7 +252,7 @@ function _wpseo_deactivate() {
 	require_once WPSEO_PATH . 'inc/wpseo-functions.php';
 
 	if ( is_multisite() && ms_is_switched() ) {
-		update_option( 'rewrite_rules', '');
+		update_option( 'rewrite_rules', '' );
 	}
 	else {
 		add_action( 'shutdown', 'flush_rewrite_rules' );

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -205,7 +205,7 @@ function _wpseo_activate() {
 	WPSEO_Options::ensure_options_exist();
 
 	if ( is_multisite() && ms_is_switched() ) {
-		delete_option( 'rewrite_rules' );
+		update_option( 'rewrite_rules', '');
 	}
 	else {
 		if ( WPSEO_Options::get( 'stripcategorybase' ) === true ) {
@@ -252,7 +252,7 @@ function _wpseo_deactivate() {
 	require_once WPSEO_PATH . 'inc/wpseo-functions.php';
 
 	if ( is_multisite() && ms_is_switched() ) {
-		delete_option( 'rewrite_rules' );
+		update_option( 'rewrite_rules', '');
 	}
 	else {
 		add_action( 'shutdown', 'flush_rewrite_rules' );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Automattic is experiencing  timeout issues related to how we empty the `rewrite_rules` option, which causes a race condition when using persistence object caching

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug that would lead to race conditions when using persistent object caching.

## Relevant technical choices:

* Instead of deleting the `rewrite_rules` option and then recreate and fill it, we use `update_option` and pass an empty string as value. 
*  There are 3 scenarios where `rewrite_rules` option is being emptied:
    1. In a multisite wp installation, when network-activating wpseo
    2. In a multisite wp installation, when network-deactivating wpseo
    3. Every time an option is being updated

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:
_Scenario 1_
* Start with a fresh wp multisite installation
* Without applying this patch:
  * From the upper admin bar, Visit `My Sites` -> `Network Admin `-> `Dashboard`
  * Go to `Plugins` and (network) activate wpseo
  * Visit the homepage of your sites (this makes `rewrite_rules` to be filled)
  * From the database, copy the value of `rewrite_rules` and past it in one of the two sides [here](https://text-compare.com/) (or in any other tool which lets you compare texts)
* Now apply the patch and perform the same steps as above (network-activate wpseo, visit the home page and copy the value of `rewrite_rules`)
* Past the text into the other side of the text comparison tool and verify the two texts are the same

_Scenario 2_
* Now (network-)deactivate wpseo
* Visit the homepage of your sites (this makes `rewrite_rules` to be filled)
* From the database, copy the value of `rewrite_rules` and past it in one of the two sides [here](https://text-compare.com/) (or in any other tool which lets you compare texts)
* Revert this patch
* (network-)activate and deactivate wpseo
* Copy the value of `rewrite_rules` from the database
* Past the text into the other side of the text comparison tool and verify the two texts are the same

_Scenario 3_
* Go to one of your site's Dashboard
* Visit `SEO` -> `Search Appearance`
* In Knowledge Graph & Schema.org section, edit `Organization name` and save the changes
* From the database, copy the value of `rewrite_rules` and past it in one of the two sides [here](https://text-compare.com/) (or in any other tool which lets you compare texts)
* Re-apply this patch
* Edit again the `Organization name` and save the changes
* Copy the value of `rewrite_rules` from the database
* Past the text into the other side of the text comparison tool and verify the two texts are the same

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:
1.
Go to Settings->Permalinks
Change settings for permalinks and make sure that permalinks work
2.
Go to SEO-> Search Apperance-> Taxonomies
Check that 'Remove the categories prefix?' functionality works

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes [#6229 ](https://github.com/Yoast/wordpress-seo/issues/6229)
