### PR TITLE
Dupp 416 ftc there are no placeholders for social profile fields and other social profiles

### DIFF
--- a/packages/js/src/first-time-configuration/tailwind-components/helpers/index.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/helpers/index.js
@@ -1,16 +1,18 @@
+import { __ } from "@wordpress/i18n";
+
 import classNames from "classnames";
 
 export const socialMedia = [
-	{ name: "Facebook", placeholder: "E.g. https://www.facebook.com/yoast" },
-	{ name: "Instagram", placeholder: "E.g. https://www.instagram.com/yoast" },
-	{ name: "LinkedIn", placeholder: "E.g. https://www.linkedin.com/yoast" },
-	{ name: "MySpace", placeholder: "E.g. https://www.myspace.com/yoast" },
-	{ name: "Pinterest", placeholder: "E.g. https://www.pinterest.com/yoast" },
-	{ name: "SoundCloud", placeholder: "E.g. https://www.soundcloud.com/yoast" },
-	{ name: "Tumblr", placeholder: "E.g. https://www.tumblr.com/yoast" },
-	{ name: "Twitter", placeholder: "E.g. https://www.twitter.com/yoast" },
-	{ name: "YouTube", placeholder: "E.g. https://www.youtube.com/yoast" },
-	{ name: "Wikipedia", placeholder: "E.g. https://www.wikipedia.com/yoast" },
+	{ name: "Facebook", placeholder: __( "E.g. https://www.facebook.com/yoast", "wordpress-seo" ) },
+	{ name: "Instagram", placeholder: __( "E.g. https://www.instagram.com/yoast", "wordpress-seo" ) },
+	{ name: "LinkedIn", placeholder: __( "E.g. https://www.linkedin.com/yoast", "wordpress-seo" ) },
+	{ name: "MySpace", placeholder: __( "E.g. https://www.myspace.com/yoast", "wordpress-seo" ) },
+	{ name: "Pinterest", placeholder: __( "E.g. https://www.pinterest.com/yoast", "wordpress-seo" ) },
+	{ name: "SoundCloud", placeholder: __( "E.g. https://www.soundcloud.com/yoast", "wordpress-seo" ) },
+	{ name: "Tumblr", placeholder: __( "E.g. https://www.tumblr.com/yoast", "wordpress-seo" ) },
+	{ name: "Twitter", placeholder: __( "E.g. https://www.twitter.com/yoast", "wordpress-seo" ) },
+	{ name: "YouTube", placeholder: __( "E.g. https://www.youtube.com/yoast", "wordpress-seo" ) },
+	{ name: "Wikipedia", placeholder: __( "E.g. https://www.wikipedia.com/yoast", "wordpress-seo" ) },
 ];
 
 /**

--- a/packages/js/src/first-time-configuration/tailwind-components/helpers/index.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/helpers/index.js
@@ -1,5 +1,18 @@
 import classNames from "classnames";
 
+export const socialMedia = [
+	{ name: "Facebook", placeholder: "E.g. https://www.facebook.com/yoast" },
+	{ name: "Instagram", placeholder: "E.g. https://www.instagram.com/yoast" },
+	{ name: "LinkedIn", placeholder: "E.g. https://www.linkedin.com/yoast" },
+	{ name: "MySpace", placeholder: "E.g. https://www.myspace.com/yoast" },
+	{ name: "Pinterest", placeholder: "E.g. https://www.pinterest.com/yoast" },
+	{ name: "SoundCloud", placeholder: "E.g. https://www.soundcloud.com/yoast" },
+	{ name: "Tumblr", placeholder: "E.g. https://www.tumblr.com/yoast" },
+	{ name: "Twitter", placeholder: "E.g. https://www.twitter.com/yoast" },
+	{ name: "YouTube", placeholder: "E.g. https://www.youtube.com/yoast" },
+	{ name: "Wikipedia", placeholder: "E.g. https://www.wikipedia.com/yoast" },
+];
+
 /**
  * Creates the error ID for the error component.
  *

--- a/packages/js/src/first-time-configuration/tailwind-components/steps/social-profiles/social-field-array.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/steps/social-profiles/social-field-array.js
@@ -36,6 +36,7 @@ const SocialFieldArray = ( { items, onAddProfile, onRemoveProfile, onChangeProfi
 							socialMedium="other"
 							index={ index }
 							onChange={ onChangeProfile }
+							placeholder={ "E.g. https://social-platform.com/yoast" }
 							feedback={ {
 								type: "error",
 								isVisible: errorFields.includes( "other_social_urls-" + index ),

--- a/packages/js/src/first-time-configuration/tailwind-components/steps/social-profiles/social-field-array.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/steps/social-profiles/social-field-array.js
@@ -36,7 +36,7 @@ const SocialFieldArray = ( { items, onAddProfile, onRemoveProfile, onChangeProfi
 							socialMedium="other"
 							index={ index }
 							onChange={ onChangeProfile }
-							placeholder={ "E.g. https://social-platform.com/yoast" }
+							placeholder={ __( "E.g. https://social-platform.com/yoast", "wordpress-seo" ) }
 							feedback={ {
 								type: "error",
 								isVisible: errorFields.includes( "other_social_urls-" + index ),

--- a/packages/js/src/first-time-configuration/tailwind-components/steps/social-profiles/social-input-person-section.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/steps/social-profiles/social-input-person-section.js
@@ -5,6 +5,7 @@ import PropTypes from "prop-types";
 
 import { Alert } from "@yoast/components";
 import { addLinkToString } from "../../../../helpers/stringHelpers.js";
+import { socialMedia } from "../../helpers";
 import SocialInput from "./social-input";
 
 /* eslint-disable max-len */
@@ -21,8 +22,6 @@ import SocialInput from "./social-input";
  * @returns {WPElement} The SocialInputPersonSection component.
  */
 function SocialInputPersonSection( { socialProfiles, errorFields, dispatch, canEditUser, personId } ) {
-	const socialMedia = [ "Facebook", "Instagram", "LinkedIn", "MySpace", "Pinterest", "SoundCloud", "Tumblr", "Twitter", "YouTube", "Wikipedia" ];
-
 	const onChangeHandler = useCallback(
 		( newValue, socialMedium ) => {
 			dispatch( { type: "CHANGE_PERSON_SOCIAL_PROFILE", payload: { socialMedium, value: newValue } } );
@@ -133,18 +132,19 @@ function SocialInputPersonSection( { socialProfiles, errorFields, dispatch, canE
 							<SocialInput
 								key={ index }
 								className="yst-mt-4"
-								label={ social }
-								id={ social.toLowerCase() }
-								value={ socialProfiles[ social.toLowerCase() ] }
-								socialMedium={ social.toLowerCase() }
+								label={ social.name }
+								id={ social.name.toLowerCase() }
+								value={ socialProfiles[ social.name.toLowerCase() ] }
+								socialMedium={ social.name.toLowerCase() }
 								onChange={ onChangeHandler }
 								isDisabled={ ! canEditUser }
+								placeholder={ social.placeholder }
 								feedback={ {
-									message: [ social === "Twitter"
+									message: [ social.name === "Twitter"
 										? __( "Could not save this value. Please check the URL or username.", "wordpress-seo" )
 										: __( "Could not save this value. Please check the URL.", "wordpress-seo" ),
 									],
-									isVisible: errorFields.includes( social.toLowerCase() ),
+									isVisible: errorFields.includes( social.name.toLowerCase() ),
 									type: "error",
 								} }
 							/>

--- a/packages/js/src/first-time-configuration/tailwind-components/steps/social-profiles/social-input-section.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/steps/social-profiles/social-input-section.js
@@ -52,6 +52,7 @@ export default function SocialInputSection( { socialProfiles, errorFields, dispa
 				value={ socialProfiles.facebookUrl }
 				socialMedium="facebookUrl"
 				onChange={ onChangeHandler }
+				placeholder={ "E.g. https://www.facebook.com/yoast" }
 				feedback={ {
 					message: [ __( "Could not save this value. Please check the URL.", "wordpress-seo" ) ],
 					isVisible: errorFields.includes( "facebook_site" ),
@@ -65,6 +66,7 @@ export default function SocialInputSection( { socialProfiles, errorFields, dispa
 				value={ socialProfiles.twitterUsername }
 				socialMedium="twitterUsername"
 				onChange={ onChangeHandler }
+				placeholder={ "E.g. https://www.twitter.com/yoast" }
 				feedback={ {
 					message: [ __( "Could not save this value. Please check the URL or username.", "wordpress-seo" ) ],
 					isVisible: errorFields.includes( "twitter_site" ),

--- a/packages/js/src/first-time-configuration/tailwind-components/steps/social-profiles/social-input-section.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/steps/social-profiles/social-input-section.js
@@ -52,7 +52,7 @@ export default function SocialInputSection( { socialProfiles, errorFields, dispa
 				value={ socialProfiles.facebookUrl }
 				socialMedium="facebookUrl"
 				onChange={ onChangeHandler }
-				placeholder={ __( "E.g. https://www.facebook.com/yoast", "wordpress_seo" ) }
+				placeholder={ __( "E.g. https://www.facebook.com/yoast", "wordpress-seo" ) }
 				feedback={ {
 					message: [ __( "Could not save this value. Please check the URL.", "wordpress-seo" ) ],
 					isVisible: errorFields.includes( "facebook_site" ),
@@ -66,7 +66,7 @@ export default function SocialInputSection( { socialProfiles, errorFields, dispa
 				value={ socialProfiles.twitterUsername }
 				socialMedium="twitterUsername"
 				onChange={ onChangeHandler }
-				placeholder={ __( "E.g. https://www.twitter.com/yoast", "wordpress_seo" ) }
+				placeholder={ __( "E.g. https://www.twitter.com/yoast", "wordpress-seo" ) }
 				feedback={ {
 					message: [ __( "Could not save this value. Please check the URL or username.", "wordpress-seo" ) ],
 					isVisible: errorFields.includes( "twitter_site" ),

--- a/packages/js/src/first-time-configuration/tailwind-components/steps/social-profiles/social-input-section.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/steps/social-profiles/social-input-section.js
@@ -52,7 +52,7 @@ export default function SocialInputSection( { socialProfiles, errorFields, dispa
 				value={ socialProfiles.facebookUrl }
 				socialMedium="facebookUrl"
 				onChange={ onChangeHandler }
-				placeholder={ "E.g. https://www.facebook.com/yoast" }
+				placeholder={ __( "E.g. https://www.facebook.com/yoast", "wordpress_seo" ) }
 				feedback={ {
 					message: [ __( "Could not save this value. Please check the URL.", "wordpress-seo" ) ],
 					isVisible: errorFields.includes( "facebook_site" ),
@@ -66,7 +66,7 @@ export default function SocialInputSection( { socialProfiles, errorFields, dispa
 				value={ socialProfiles.twitterUsername }
 				socialMedium="twitterUsername"
 				onChange={ onChangeHandler }
-				placeholder={ "E.g. https://www.twitter.com/yoast" }
+				placeholder={ __( "E.g. https://www.twitter.com/yoast", "wordpress_seo" ) }
 				feedback={ {
 					message: [ __( "Could not save this value. Please check the URL or username.", "wordpress-seo" ) ],
 					isVisible: errorFields.includes( "twitter_site" ),


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* After QA preliminary testing, a series of enhancements and bug fixes are being made to the first time configuration before shipping it


## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds placeholders to social URLs input fields

## Relevant technical choices:

* N/A

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Navigate to the first time configuration and reach the `Personal Preferences` step
* Select your site to represent a person, then click `Save and continue`
* Verify that each input field has a placeholder accordingly to the social medium it represents
* * Navigate back to the `Personal Preferences` step
* Select your site to represent an organization, then click `Save and continue`
* Verify that both the Facebook and Twitter input fields have a placeholder accordingly to the social medium they represent
* Add some other input field by clicking on `Add another URL`
* Verify that in each of the added input fields there's a placeholder, and it is as follows: `E.g. https://social-platform.com/yoast`

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes [DUPP-416](https://yoast.atlassian.net/browse/DUPP-416)
