### PR TITLE
Let empty Other Social URLs pass validation and dont save them

### DIFF
--- a/src/helpers/options-helper.php
+++ b/src/helpers/options-helper.php
@@ -125,7 +125,7 @@ class Options_Helper {
 	 * @return string|false The validated URL or false if the URL is not valid.
 	 */
 	public function validate_social_url( $url ) {
-		return WPSEO_Option_Social::get_instance()->validate_social_url( $url );
+		return empty( $url ) || WPSEO_Option_Social::get_instance()->validate_social_url( $url );
 	}
 
 	/**

--- a/src/helpers/options-helper.php
+++ b/src/helpers/options-helper.php
@@ -125,7 +125,7 @@ class Options_Helper {
 	 * @return string|false The validated URL or false if the URL is not valid.
 	 */
 	public function validate_social_url( $url ) {
-		return empty( $url ) || WPSEO_Option_Social::get_instance()->validate_social_url( $url );
+		return $url === '' || WPSEO_Option_Social::get_instance()->validate_social_url( $url );
 	}
 
 	/**

--- a/src/integrations/admin/social-profiles-helper.php
+++ b/src/integrations/admin/social-profiles-helper.php
@@ -150,12 +150,14 @@ class Social_Profiles_Helper {
 
 			// Remove empty strings in Other Social URLs.
 			if ( $field_name === 'other_social_urls' ) {
-				$social_profiles[ $field_name ] = \array_filter(
+				$other_social_urls = \array_filter(
 					$social_profiles[ $field_name ],
 					static function( $other_social_url ) {
 						return $other_social_url !== '';
 					}
 				);
+
+				$social_profiles[ $field_name ] = \array_values( $other_social_urls );
 			}
 
 			$result = $this->options_helper->set( $field_name, $social_profiles[ $field_name ] );

--- a/src/integrations/admin/social-profiles-helper.php
+++ b/src/integrations/admin/social-profiles-helper.php
@@ -148,6 +148,16 @@ class Social_Profiles_Helper {
 				continue;
 			}
 
+			// Remove empty strings in Other Social URLs.
+			if ( $field_name === 'other_social_urls' ) {
+				$social_profiles[ $field_name ] = \array_filter(
+					$social_profiles[ $field_name ],
+					static function( $other_social_url ) {
+						return $other_social_url !== '';
+					}
+				);
+			}
+
 			$result = $this->options_helper->set( $field_name, $social_profiles[ $field_name ] );
 			if ( ! $result ) {
 				/**
@@ -193,7 +203,7 @@ class Social_Profiles_Helper {
 	 * @return array An array with the setting that the non-valid url is about to update.
 	 */
 	protected function get_non_valid_url( $url, $url_setting ) {
-		if ( empty( $url ) || $this->options_helper->validate_social_url( $url ) ) {
+		if ( $this->options_helper->validate_social_url( $url ) ) {
 			return [];
 		}
 

--- a/src/integrations/admin/social-profiles-helper.php
+++ b/src/integrations/admin/social-profiles-helper.php
@@ -144,10 +144,6 @@ class Social_Profiles_Helper {
 
 		// All social profiles look good, now let's try to save them.
 		foreach ( \array_keys( $this->organization_social_profile_fields ) as $field_name ) {
-			if ( empty( $social_profiles[ $field_name ] ) ) {
-				continue;
-			}
-
 			// Remove empty strings in Other Social URLs.
 			if ( $field_name === 'other_social_urls' ) {
 				$other_social_urls = \array_filter(

--- a/tests/unit/integrations/admin/social-profiles-helper-test.php
+++ b/tests/unit/integrations/admin/social-profiles-helper-test.php
@@ -226,6 +226,15 @@ class Social_Profiles_Helper_Test extends TestCase {
 			->andReturn( ...$validate_twitter_id_results );
 
 		foreach ( $fields as $field ) {
+			if ( $field === 'other_social_urls' ) {
+				$social_profiles[ $field ] = \array_filter(
+					$social_profiles[ $field ],
+					static function( $other_social_url ) {
+						return $other_social_url !== '';
+					}
+				);
+			}
+
 			$this->options_helper
 				->expects( 'set' )
 				->with( $field, $social_profiles[ $field ] )
@@ -253,6 +262,7 @@ class Social_Profiles_Helper_Test extends TestCase {
 				'twitter_site'           => 'https://twitter.com/janedoe',
 				'other_social_urls'      => [
 					'https://youtube.com/janedoe',
+					'',
 				],
 			],
 			'validate_social_url_results' => [ true ],


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to allow the user to save an empty string in some of the Other Social URLs and when that happens we delete those entries/fields in the back-end.
* We also want to allow users to delete their previously saved Facebook and Twitter values, as we didn't before

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Allow the user to save an empty string in some of the Other Social URLs
* Fix an unreleased bug, where deleting a previously saved Facebook or Twitter value would not be saved in the db.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

For the `Allow the user to save an empty string in some of the Other Social URLs`  part:
* Set Organization and move to the SOCIAL PROFILES step
* Add a couple of `Other social profile` fields
* If even one of them fields is not a valid url, the `Could not save this value. Please check the URL` message should appear under it and no field is saved.
* If any of those fields is an empty fields, the the `Could not save this value. Please check the URL` message should NOT appear under it. If there were no other errors in other fields, then that empty field is not saved in the db. To check that, refresh the page and check the saved fields.
* Try with some combinations of empty/valid/not-valid fields for the `Other social profile` fields and refresh the page to verify that the db is of the expected state

For the `Fix an unreleased bug, where deleting a previously saved Facebook or Twitter value would not be saved in the db`  part:
* Set Organization and move to the SOCIAL PROFILES step
* Add a url in the Facebook (or Twitter) field and click Save and continue
* Refresh the page and go again to the SOCIAL PROFILES step
* Try and delete the Facebook field
* Refresh the page and go again to the SOCIAL PROFILES step
* Verify that the Facebook field is indeed empty

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes #
