### PR TITLE
Dupp 326 correct version in upgrade routine

### DIFF
--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -78,7 +78,7 @@ class WPSEO_Upgrade {
 			'17.9-RC0'   => 'upgrade_179',
 			'18.3-RC3'   => 'upgrade_183',
 			'18.6-RC0'   => 'upgrade_186',
-			'18.3-ftc'   => 'upgrade_first_time_configuration',
+			'18.8-RC0'   => 'upgrade_first_time_configuration',
 		];
 
 		array_walk( $routines, [ $this, 'run_upgrade_routine' ], $version );

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -78,7 +78,7 @@ class WPSEO_Upgrade {
 			'17.9-RC0'   => 'upgrade_179',
 			'18.3-RC3'   => 'upgrade_183',
 			'18.6-RC0'   => 'upgrade_186',
-			'18.8-RC0'   => 'upgrade_first_time_configuration',
+			'18.8-RC0'   => 'upgrade_188',
 		];
 
 		array_walk( $routines, [ $this, 'run_upgrade_routine' ], $version );
@@ -873,11 +873,18 @@ class WPSEO_Upgrade {
 	}
 
 	/**
-	 * Performs the upgrade routine for the first time configuration.
-	 *
-	 * @TODO Set the right version number when the feature branch is merged.
+	 * Performs the 18.6 upgrade routine.
 	 */
-	private function upgrade_first_time_configuration() {
+	private function upgrade_186() {
+		if ( is_multisite() ) {
+			WPSEO_Options::set( 'allow_wincher_integration_active', false );
+		}
+	}
+
+	/**
+	 * Performs the 18.8 upgrade routine.
+	 */
+	private function upgrade_188() {
 		$other   = [];
 		$other[] = WPSEO_Options::get( 'instagram_url' );
 		$other[] = WPSEO_Options::get( 'linkedin_url' );
@@ -887,15 +894,6 @@ class WPSEO_Upgrade {
 		$other[] = WPSEO_Options::get( 'wikipedia_url' );
 
 		WPSEO_Options::set( 'other_social_urls', array_values( array_unique( array_filter( $other ) ) ) );
-	}
-
-	/**
-	 * Performs the 18.6 upgrade routine.
-	 */
-	private function upgrade_186() {
-		if ( is_multisite() ) {
-			WPSEO_Options::set( 'allow_wincher_integration_active', false );
-		}
 	}
 
 	/**

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -886,7 +886,7 @@ class WPSEO_Upgrade {
 		$other[] = WPSEO_Options::get( 'youtube_url' );
 		$other[] = WPSEO_Options::get( 'wikipedia_url' );
 
-		WPSEO_Options::set( 'other_social_urls', array_unique( array_filter( $other ) ) );
+		WPSEO_Options::set( 'other_social_urls', array_values( array_unique( array_filter( $other ) ) ) );
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Performs the upgrade routine on 18.8 to transfer the Social URLs in the format that the new First Time Configuration expects

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* With trunk (or the 18.7 version if you're in QA), set up Organization and go to SEO->Social
* Add a couple of URLs there.
* Checkout this branch (or install the 18.8 RC if you're in QA)
* Via the Test Helper, perform the 18.8. upgrade by going to Tools->Yoast test, set as DB version for Yoast SEO, a version lower than what the current RC/PR is on. So, if we're on 18.7, set 18.6 there.
* Go to SEO->General->First-Time configuration
* Confirm that the URLs you added while on trunk (or the 18.7 version if you're in QA) have been transferred and are shown properly in the Social Profiles step 



### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes #
