### PR TITLE
Set term keyphrase to its title if no keyphrase is set

### DIFF
--- a/packages/js/src/classic-editor/initial-state.js
+++ b/packages/js/src/classic-editor/initial-state.js
@@ -76,7 +76,7 @@ export const getInitialTermState = () => ( {
 		keyphrases: {
 			[ FOCUS_KEYPHRASE_ID ]: {
 				id: FOCUS_KEYPHRASE_ID,
-				keyphrase: dom.getTermFocusKeyphrase(),
+				keyphrase: dom.getTermFocusKeyphrase() || dom.getTermName(),
 			},
 		},
 	},

--- a/packages/js/tests/classic-editor/initial-state.test.js
+++ b/packages/js/tests/classic-editor/initial-state.test.js
@@ -20,7 +20,7 @@ jest.mock( "../../src/classic-editor/helpers/dom", () => ( {
 	getTermMetaDescription: jest.fn( () => "An example of a description for a cat." ),
 	getTermSlug: jest.fn( () => "www.sweetcat.com/categories/cat" ),
 	getTermIsCornerstone: jest.fn( () => false ),
-	getTermFocusKeyphrase: jest.fn( () => "cat" ),
+	getTermFocusKeyphrase: jest.fn( () => "panda" ),
 	getPostCategories: jest.fn( () => [
 		{
 			id: "1",
@@ -98,6 +98,7 @@ describe( "a test for getting the initial state of a post or a term", () => {
 		expect( actual.form.seo.description ).toEqual( "An example of a description for a cat." );
 		expect( actual.form.seo.slug ).toEqual( "www.sweetcat.com/categories/cat" );
 		expect( actual.form.seo.isCornerstone ).toEqual( false );
-		expect( actual.form.keyphrases ).toEqual( { focus: { id: "focus", keyphrase: "cat" } } );
+		expect( actual.form.keyphrases ).toEqual( { focus: { id: "focus", keyphrase: "panda" } } );
 	} );
 } );
+


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* On trunk, the term keyphrase is automatically set to the term title before another keyphrase is set.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Sets the term keyphrase to the term title if no other keyphrase has been set.

## Relevant technical choices:

* The fallback value was not included in the test in in `initial-state-test.js` because the test mocks what `getTermFocusKeyphrase` returns 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Make sure you have the Classic Editor enabled
* Create a new tag
* Open the editor to edit the tag
* Confirm that the focus keyphrase is set to the name of the tag
* Set another keyphrase, save and exit the editor
* Open the tag again and confirm that the keyphrase is set to the one that you had entered
* Repeat the same steps for a category and a custom taxonomy
* Repeat the same steps (for a term, category, and custom taxonomy) with Classic Editor disabled


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes https://yoast.atlassian.net/browse/LINGO-1440
