### PR TITLE
Add feature flag for the CoAuthors Plus integration.

### DIFF
--- a/src/conditionals/third-party/coauthors-plus-flag-conditional.php
+++ b/src/conditionals/third-party/coauthors-plus-flag-conditional.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Yoast\WP\SEO\Conditionals\Third_Party;
+
+use Yoast\WP\SEO\Conditionals\Feature_Flag_Conditional;
+
+/**
+ * Feature flag conditional for the CoAuthors Plus integration.
+ */
+class CoAuthors_Plus_Flag_Conditional extends Feature_Flag_Conditional {
+
+	/**
+	 * Returns the name of the CoAuthors Plus integration feature flag.
+	 *
+	 * @return string The name of the feature flag.
+	 */
+	protected function get_feature_flag() {
+		return 'COAUTHORS_PLUS';
+	}
+}

--- a/src/integrations/third-party/coauthors-plus.php
+++ b/src/integrations/third-party/coauthors-plus.php
@@ -4,7 +4,9 @@ namespace Yoast\WP\SEO\Integrations\Third_Party;
 
 use Yoast\WP\SEO\Config\Schema_Types;
 use Yoast\WP\SEO\Conditionals\Third_Party\CoAuthors_Plus_Activated_Conditional;
+use Yoast\WP\SEO\Conditionals\Third_Party\CoAuthors_Plus_Flag_Conditional;
 use Yoast\WP\SEO\Context\Meta_Tags_Context;
+use Yoast\WP\SEO\Generators\Schema\Abstract_Schema_Piece;
 use Yoast\WP\SEO\Generators\Schema\Third_Party\CoAuthor;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
 use Yoast\WP\SEO\Surfaces\Helpers_Surface;
@@ -37,7 +39,10 @@ class CoAuthors_Plus implements Integration_Interface {
 	 * @return array
 	 */
 	public static function get_conditionals() {
-		return [ CoAuthors_Plus_Activated_Conditional::class ];
+		return [
+			CoAuthors_Plus_Activated_Conditional::class,
+			CoAuthors_Plus_Flag_Conditional::class,
+		];
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to put the CoAuthors Plus integration behind a feature flag.

**NOTE: when and if this is merged, please update #18331 to make it non-user-facing. **

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds a feature flag for the CoAuthors Plus integration.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### with the feature flag ON
* add `define( 'YOAST_SEO_COAUTHORS_PLUS', true );` to your `wp-config.php`
* enable the CoAuthors Plus plugin
* repeat all the tests from https://github.com/Yoast/wordpress-seo/pull/18331, nothing should behave differently

#### with the feature flag ON
* remove `define( 'YOAST_SEO_COAUTHORS_PLUS', true );` to your `wp-config.php`
* enable the CoAuthors Plus plugin
* repeat tests from https://github.com/Yoast/wordpress-seo/pull/18331:
   * Test 2 and 4 should still be valid
   * In Tests 1 and 3 you should always see only one author for the article pointing to the right Person (the main author) and no piece for the secondary authors.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [x] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes [DUPP-448]


[DUPP-448]: https://yoast.atlassian.net/browse/DUPP-448?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ