### PR TITLE
DUPP-455 Hide FTC notice when configuration is finished

### DIFF
--- a/src/integrations/admin/first-time-configuration-notice-integration.php
+++ b/src/integrations/admin/first-time-configuration-notice-integration.php
@@ -70,7 +70,7 @@ class First_Time_Configuration_Notice_Integration implements Integration_Interfa
 	}
 
 	/**
-	 * Dismisses the First-time configuration workout notice.
+	 * Dismisses the First-time configuration notice.
 	 *
 	 * @return bool
 	 */
@@ -88,7 +88,7 @@ class First_Time_Configuration_Notice_Integration implements Integration_Interfa
 			return false;
 		}
 
-		if ( ! $this->user_can_do_configuration_workout() ) {
+		if ( ! $this->user_can_do_first_time_configuration() ) {
 			return false;
 		}
 
@@ -96,7 +96,7 @@ class First_Time_Configuration_Notice_Integration implements Integration_Interfa
 			return false;
 		}
 
-		if ( $this->is_configuration_workout_finished() ) {
+		if ( $this->is_first_time_configuration_finished() ) {
 			return false;
 		}
 
@@ -122,7 +122,7 @@ class First_Time_Configuration_Notice_Integration implements Integration_Interfa
 		$notice = new Notice_Presenter(
 			\__( 'First-time SEO configuration', 'wordpress-seo' ),
 			\sprintf(
-			/* translators: 1: Link start tag to the configuration workout, 2: Yoast SEO, 3: Link closing tag. */
+			/* translators: 1: Link start tag to the first-time configuration, 2: Yoast SEO, 3: Link closing tag. */
 				\__( 'Get started quickly with the %1$s%2$s First-time configuration%3$s and configure Yoast SEO with the optimal SEO settings for your site!', 'wordpress-seo' ),
 				'<a href="' . \esc_url( \self_admin_url( 'admin.php?page=wpseo_dashboard#top#first-time-configuration' ) ) . '">',
 				'Yoast SEO',
@@ -158,11 +158,11 @@ class First_Time_Configuration_Notice_Integration implements Integration_Interfa
 	}
 
 	/**
-	 * Whether the user can do the configuration workout.
+	 * Whether the user can do the first-time configuration.
 	 *
-	 * @return bool Whether the current user can do the configuration workout.
+	 * @return bool Whether the current user can do the first-time configuration.
 	 */
-	private function user_can_do_configuration_workout() {
+	private function user_can_do_first_time_configuration() {
 		return \current_user_can( 'wpseo_manage_options' );
 	}
 
@@ -197,14 +197,14 @@ class First_Time_Configuration_Notice_Integration implements Integration_Interfa
 	}
 
 	/**
-	 * Whether all steps of the configuration workout have been finished.
+	 * Whether all steps of the first-time configuration have been finished.
 	 *
-	 * @return bool Whether the configuration workout has been finished.
+	 * @return bool Whether the first-time configuration has been finished.
 	 */
-	private function is_configuration_workout_finished() {
-		$workouts_option = $this->options_helper->get( 'workouts_data', [] );
+	private function is_first_time_configuration_finished() {
+		$configuration_finished_steps = $this->options_helper->get( 'configuration_finished_steps', [] );
 
-		return \count( $workouts_option['configuration']['finishedSteps'] ) === 5;
+		return \count( $configuration_finished_steps ) === 3;
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to fix the first time conf. notice so it disappears when the FTC is completed.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where the notice would be displayed again after the first-time configuration was finished.

## Relevant technical choices:

* If you complete the FTC and move to another tab in the same page the notice will appear again. We will address this in another issue since it has a lower priority.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Setup
* make sure you can see the notice: start in a clean env, or reset the options/the first time conf. with the Test Helper
* as an admin or SEO Manager you should be able to see the notice.

#### Check against regressions for users who can't perform the FTC
* make a user SEO Editor
* use the User Switching plugin to switch to that user
* check that you cannot see the notice anywhere
* switch back to the initial user

#### Check the solution
* perform the FTC to the end
* reload the SEO > General page or navigate to the Dashboard or another SEO page
* check that you cannot see the FTC notice anymore


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes [DUPP-455]
