### PR TITLE
Change RichText to use onFocus instead of unstableOnFocus

### DIFF
--- a/packages/js/src/structured-data-blocks/faq/components/Question.js
+++ b/packages/js/src/structured-data-blocks/faq/components/Question.js
@@ -343,7 +343,7 @@ export default class Question extends Component {
 					value={ question }
 					onChange={ this.onChangeQuestion }
 					isSelected={ isSelected && subElement === "question" }
-					unstableOnFocus={ this.onFocusQuestion }
+					onFocus={ this.onFocusQuestion }
 					placeholder={ __( "Enter a question", "wordpress-seo" ) }
 					formattingControls={ [ "italic", "strikethrough", "link" ] }
 				/>
@@ -354,7 +354,7 @@ export default class Question extends Component {
 					value={ answer }
 					onChange={ this.onChangeAnswer }
 					isSelected={ isSelected && subElement === "answer" }
-					unstableOnFocus={ this.onFocusAnswer }
+					onFocus={ this.onFocusAnswer }
 					placeholder={ __( "Enter the answer to the question", "wordpress-seo" ) }
 				/>
 				{ isSelected &&

--- a/packages/js/src/structured-data-blocks/how-to/components/HowTo.js
+++ b/packages/js/src/structured-data-blocks/how-to/components/HowTo.js
@@ -735,7 +735,7 @@ export default class HowTo extends Component {
 					className="schema-how-to-description"
 					value={ attributes.description }
 					isSelected={ this.state.focus === "description" }
-					unstableOnFocus={ this.focusDescription }
+					onFocus={ this.focusDescription }
 					onChange={ this.onChangeDescription }
 					placeholder={ __( "Enter a description", "wordpress-seo" ) }
 				/>

--- a/packages/js/src/structured-data-blocks/how-to/components/HowToStep.js
+++ b/packages/js/src/structured-data-blocks/how-to/components/HowToStep.js
@@ -333,7 +333,7 @@ export default class HowToStep extends Component {
 					onChange={ this.onChangeTitle }
 					isSelected={ isSelected && subElement === "name" }
 					placeholder={ __( "Enter a step title", "wordpress-seo" ) }
-					unstableOnFocus={ this.onFocusTitle }
+					onFocus={ this.onFocusTitle }
 					formattingControls={ [ "italic", "strikethrough", "link" ] }
 				/>
 				<RichTextWithAppendedSpace
@@ -344,7 +344,7 @@ export default class HowToStep extends Component {
 					onChange={ this.onChangeText }
 					isSelected={ isSelected && subElement === "text" }
 					placeholder={ __( "Enter a step description", "wordpress-seo" ) }
-					unstableOnFocus={ this.onFocusText }
+					onFocus={ this.onFocusText }
 				/>
 				{ isSelected &&
 					<div className="schema-how-to-step-controls-container">


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where our How To and FAQ blocks would not handle focus correctly when using WordPress 6.0.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Set up a clean environment with WP 6.0 Beta version (Default editor)
* To change to WP 6.0, change the update channel to Bleeding edge / Nightlies (under Tools -> Beta testing) and update WP
* Install and activate the code of this PR
* Create a new post
* Add How-To or FAQ block
* At How-To block add a description
* By mouse-click try to navigate to Enter a step title or Enter a step description (see issue)

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes https://yoast.atlassian.net/browse/P1-1354
