### PR TITLE
Fixing site URL instead of WordPress URL within ‘Check links to this URL’ option of Yoast admin bar menu.

### DIFF
--- a/inc/class-wpseo-admin-bar-menu.php
+++ b/inc/class-wpseo-admin-bar-menu.php
@@ -309,7 +309,7 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 			[
 				'id'     => 'wpseo-inlinks',
 				'title'  => __( 'Check links to this URL', 'wordpress-seo' ),
-				'href'   => 'https://search.google.com/search-console/links/drilldown?resource_id=' . urlencode( get_option( 'siteurl' ) ) . '&type=EXTERNAL&target=' . $encoded_url . '&domain=',
+				'href'   => 'https://search.google.com/search-console/links/drilldown?resource_id=' . urlencode( get_option( 'home' ) ) . '&type=EXTERNAL&target=' . $encoded_url . '&domain=',
 			],
 			[
 				'id'     => 'wpseo-kwdensity',


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

‘Check links to this URL’ option on admin bar menu should take current home URL ’home’ instead of the WordPress installation directory URL ‘siteurl’. In subdirectory WP setup, it is taking to unreachable Google Search Console page. This pull request will fix this case by passing the Site Address (URL) instead of WordPress Address (URL). 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the "Check links to this URL" option on admin bar menu would lead to an error page on setups with home URL different from the site URL. Props to @suascat.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:


* Login to your WP setup which should be either subdirectory or subdomain install. Assuming the **WordPress Address (URL)** setting is `http://example.com/wp` while **Home URL** is `http://example.com`
* Ideally you should have registered the website on Google Search Console: if you can't (e.g. it's a local test site) please keep in mind that you would use the **home URL** to identify the site.
* Open any page or post on the front end. 
* From the admin bar within the Yoast menu, click ‘Check links to this URL’ menu. It should take you to your Google Search Console respective page.
  * if the site is not registered in Google Search Console, check the target URL of the link and see it has the **home URL** as `resource_id`: e.g. `https://search.google.com/search-console/links/drilldown?resource_id=http%3A%2F%2Fexample.com&type=EXTERNAL&target=http%3A%2F%2Fexample.com%2F&domain=` instead of  `https://search.google.com/search-console/links/drilldown?resource_id=http%3A%2F%2Fexample.com%2Fwp&type=EXTERNAL&target=http%3A%2F%2Fexample.com%2F&domain=`
(`resource_id=http%3A%2F%2Fexample.com` vs `resource_id=http%3A%2F%2Fexample.com%2Fwp`)



### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:


## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes [DUPP-532]


[DUPP-532]: https://yoast.atlassian.net/browse/DUPP-532?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ