### PR TITLE
P1-1359 fix faq and how to block controls

### DIFF
--- a/packages/js/src/structured-data-blocks/faq/components/Question.js
+++ b/packages/js/src/structured-data-blocks/faq/components/Question.js
@@ -342,7 +342,6 @@ export default class Question extends Component {
 					key={ id + "-question" }
 					value={ question }
 					onChange={ this.onChangeQuestion }
-					isSelected={ isSelected && subElement === "question" }
 					unstableOnFocus={ this.onFocusQuestion }
 					placeholder={ __( "Enter a question", "wordpress-seo" ) }
 					formattingControls={ [ "italic", "strikethrough", "link" ] }
@@ -353,7 +352,6 @@ export default class Question extends Component {
 					key={ id + "-answer" }
 					value={ answer }
 					onChange={ this.onChangeAnswer }
-					isSelected={ isSelected && subElement === "answer" }
 					unstableOnFocus={ this.onFocusAnswer }
 					placeholder={ __( "Enter the answer to the question", "wordpress-seo" ) }
 				/>

--- a/packages/js/src/structured-data-blocks/faq/components/Question.js
+++ b/packages/js/src/structured-data-blocks/faq/components/Question.js
@@ -343,7 +343,7 @@ export default class Question extends Component {
 					value={ question }
 					onChange={ this.onChangeQuestion }
 					isSelected={ isSelected && subElement === "question" }
-					onFocus={ this.onFocusQuestion }
+					unstableOnFocus={ this.onFocusQuestion }
 					placeholder={ __( "Enter a question", "wordpress-seo" ) }
 					formattingControls={ [ "italic", "strikethrough", "link" ] }
 				/>
@@ -354,7 +354,7 @@ export default class Question extends Component {
 					value={ answer }
 					onChange={ this.onChangeAnswer }
 					isSelected={ isSelected && subElement === "answer" }
-					onFocus={ this.onFocusAnswer }
+					unstableOnFocus={ this.onFocusAnswer }
 					placeholder={ __( "Enter the answer to the question", "wordpress-seo" ) }
 				/>
 				{ isSelected &&

--- a/packages/js/src/structured-data-blocks/how-to/components/HowTo.js
+++ b/packages/js/src/structured-data-blocks/how-to/components/HowTo.js
@@ -734,7 +734,6 @@ export default class HowTo extends Component {
 					tagName="p"
 					className="schema-how-to-description"
 					value={ attributes.description }
-					isSelected={ this.state.focus === "description" }
 					unstableOnFocus={ this.focusDescription }
 					onChange={ this.onChangeDescription }
 					placeholder={ __( "Enter a description", "wordpress-seo" ) }

--- a/packages/js/src/structured-data-blocks/how-to/components/HowTo.js
+++ b/packages/js/src/structured-data-blocks/how-to/components/HowTo.js
@@ -735,7 +735,7 @@ export default class HowTo extends Component {
 					className="schema-how-to-description"
 					value={ attributes.description }
 					isSelected={ this.state.focus === "description" }
-					onFocus={ this.focusDescription }
+					unstableOnFocus={ this.focusDescription }
 					onChange={ this.onChangeDescription }
 					placeholder={ __( "Enter a description", "wordpress-seo" ) }
 				/>

--- a/packages/js/src/structured-data-blocks/how-to/components/HowToStep.js
+++ b/packages/js/src/structured-data-blocks/how-to/components/HowToStep.js
@@ -331,7 +331,6 @@ export default class HowToStep extends Component {
 					key={ `${ id }-name` }
 					value={ name }
 					onChange={ this.onChangeTitle }
-					isSelected={ isSelected && subElement === "name" }
 					placeholder={ __( "Enter a step title", "wordpress-seo" ) }
 					unstableOnFocus={ this.onFocusTitle }
 					formattingControls={ [ "italic", "strikethrough", "link" ] }
@@ -342,7 +341,6 @@ export default class HowToStep extends Component {
 					key={ `${ id }-text` }
 					value={ text }
 					onChange={ this.onChangeText }
-					isSelected={ isSelected && subElement === "text" }
 					placeholder={ __( "Enter a step description", "wordpress-seo" ) }
 					unstableOnFocus={ this.onFocusText }
 				/>

--- a/packages/js/src/structured-data-blocks/how-to/components/HowToStep.js
+++ b/packages/js/src/structured-data-blocks/how-to/components/HowToStep.js
@@ -333,7 +333,7 @@ export default class HowToStep extends Component {
 					onChange={ this.onChangeTitle }
 					isSelected={ isSelected && subElement === "name" }
 					placeholder={ __( "Enter a step title", "wordpress-seo" ) }
-					onFocus={ this.onFocusTitle }
+					unstableOnFocus={ this.onFocusTitle }
 					formattingControls={ [ "italic", "strikethrough", "link" ] }
 				/>
 				<RichTextWithAppendedSpace
@@ -344,7 +344,7 @@ export default class HowToStep extends Component {
 					onChange={ this.onChangeText }
 					isSelected={ isSelected && subElement === "text" }
 					placeholder={ __( "Enter a step description", "wordpress-seo" ) }
-					onFocus={ this.onFocusText }
+					unstableOnFocus={ this.onFocusText }
 				/>
 				{ isSelected &&
 					<div className="schema-how-to-step-controls-container">


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Fix https://github.com/Yoast/wordpress-seo/pull/18386

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where the controls of the How-To and FAQ blocks were not showing.

## Relevant technical choices:

* Gutenberg forces a focus event when a RichText is unfocused. By removing the `isSelected` this no longer happens. Most likely this is due to our focus state being out of sync with those events.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Set up a clean environment with WP 6.0 Beta version (Default editor)
* To change to WP 6.0, change the update channel to Bleeding edge / Nightlies (under Tools -> Beta testing) and update WP
* Install and activate the code of this PR
* Create a new post
* Add How-To block and add a description
* By mouse-click try to navigate to Enter a step title or Enter a step description (see issue)
* Verify the controls are visible for the step that has focus: <img width="253" alt="image" src="https://user-images.githubusercontent.com/35524806/166663384-c70c992f-4b77-4c10-97ca-2491831d5e6b.png">
* Verify the text controls are visible for the text that has focus:  <img width="325" alt="image" src="https://user-images.githubusercontent.com/35524806/166663469-3fcd493b-d4ce-4b2e-8118-431ccdf4d1f3.png">
* Verify the controls work too 😉 
* Do the same for the FAQ block

#### Safety checks for full site editing
* Go to Appearance -> Editor
* Add How-To or FAQ block in the footer and add a description
* Verify it works, even though the styling is certainly wrong.
* Switch theme to 2021
* Go to Appearance -> Widgets
* Repeat the test steps (though no footer)

#### Safety check for current WP version
* Switch to WP 5.9.x
* Verify the blocks also work.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Verify that when using a post with a How-To and FAQ block already saved in Yoast SEO 18.7 works in this version without any problems.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes https://yoast.atlassian.net/browse/P1-1359
