### PR TITLE
Add the taxonomy name to term crumb.

### DIFF
--- a/src/generators/breadcrumbs-generator.php
+++ b/src/generators/breadcrumbs-generator.php
@@ -232,6 +232,7 @@ class Breadcrumbs_Generator implements Generator_Interface {
 	 */
 	private function get_term_crumb( $crumb, $ancestor ) {
 		$crumb['term_id'] = $ancestor->object_id;
+    	$crumb['taxonomy'] = $ancestor->object_sub_type;
 
 		return $crumb;
 	}

--- a/src/generators/breadcrumbs-generator.php
+++ b/src/generators/breadcrumbs-generator.php
@@ -232,7 +232,7 @@ class Breadcrumbs_Generator implements Generator_Interface {
 	 */
 	private function get_term_crumb( $crumb, $ancestor ) {
 		$crumb['term_id']  = $ancestor->object_id;
-    	$crumb['taxonomy'] = $ancestor->object_sub_type;
+		$crumb['taxonomy'] = $ancestor->object_sub_type;
 
 		return $crumb;
 	}

--- a/src/generators/breadcrumbs-generator.php
+++ b/src/generators/breadcrumbs-generator.php
@@ -231,7 +231,7 @@ class Breadcrumbs_Generator implements Generator_Interface {
 	 * @return array The crumb.
 	 */
 	private function get_term_crumb( $crumb, $ancestor ) {
-		$crumb['term_id'] = $ancestor->object_id;
+		$crumb['term_id']  = $ancestor->object_id;
     	$crumb['taxonomy'] = $ancestor->object_sub_type;
 
 		return $crumb;


### PR DESCRIPTION
Improves the possibility to filter the term crumbs in a breadcrumb with "wpseo_breadcrumb_links".

## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* I want to be able to get the proper taxonomy from my term, while filtering the term crumbs. This is not possible without the actual taxonomy value. For example to get taxonomy data with: https://developer.wordpress.org/reference/functions/get_term_by/

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds taxonomy information to crumbs of type "term" to be able to filter them better with `wpseo_breadcrumb_links`. Props to @svenvonarx.

## Relevant technical choices:

* Extends the crumb array with one entry called taxonomy. There should be no negative consequences by that.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Nothing to test really. Other then checking the values, since its not used by core. More for expanding via filters.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* [ ] QA should use the same steps as above.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [x] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes #
