### PR TITLE
Adds extra sanitization in the Social Profiles endpoint

### DIFF
--- a/src/integrations/admin/social-profiles-helper.php
+++ b/src/integrations/admin/social-profiles-helper.php
@@ -111,6 +111,7 @@ class Social_Profiles_Helper {
 
 		// All social profiles look good, now let's try to save them.
 		foreach ( $this->person_social_profile_fields as $field_name => $validation_method ) {
+			$social_profiles[ $field_name ] = $this->sanitize_social_field( $social_profiles[ $field_name ] );
 			\update_user_meta( $person_id, $field_name, $social_profiles[ $field_name ] );
 		}
 
@@ -133,6 +134,7 @@ class Social_Profiles_Helper {
 				$failures[] = $field_name;
 				continue;
 			}
+			$social_profiles[ $field_name ] = $this->sanitize_social_field( $social_profiles[ $field_name ] );
 
 			$value_to_validate = $social_profiles[ $field_name ];
 			$failures          = \array_merge( $failures, \call_user_func( [ $this, $validation_method ], $value_to_validate, $field_name ) );
@@ -179,6 +181,25 @@ class Social_Profiles_Helper {
 		}
 
 		return [];
+	}
+
+	/**
+	 * Returns a sanitized social field.
+	 *
+	 * @param string|array $social_field The social field to sanitize.
+	 *
+	 * @return string|array The sanitized social field.
+	 */
+	protected function sanitize_social_field( $social_field ) {
+		if ( \is_array( $social_field ) ) {
+			foreach ( $social_field as $key => $value ) {
+				$social_field[ $key ] = \sanitize_text_field( $value );
+			}
+
+			return $social_field;
+		}
+
+		return \sanitize_text_field( $social_field );
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds extra sanitization in the Social Profiles endpoint

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Go to the FTC
* Select Person 
* Add `https://dfd.dsf</script><script>alert(document.domain)</script><script>` in one of the Social Profiles there and Save
* Refresh the page and go to the Social Profiles step again, to check what has been saved in the db.
With this PR/RC:
* The malicious part of the url has been stripped and only `https://dfd.dsf` has been left there.
With the previous RC:
* The malicious part would not have been stripped and `https://dfd.dsf</script><script>alert(document.domain)</script><script>` would have been inserted in the db

We also improved the UX for when saving malicious urls in Organizations. To test that:

* Go to the FTC
* Select Organization
* Add `https://dfd.dsf</script><script>alert(document.domain)</script><script>` in the FB or in the Other Social URLs fields and Save
With this PR/RC:
* You won't get any `Could not save this value. Please check the URL` messages. 
* Refresh the page and go to the Social Profiles step again, to check what has been saved in the db.
* The malicious part of the url has been stripped and only `https://dfd.dsf` has been left there.
With the previous RC:
* You would have gotten a `Could not save this value. Please check the URL` message, but if you refreshed the page, you would see that the values would have been saved, so that's a UX mismatch


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Social Profiles for both person and organization

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes #
