### PR TITLE
Remove unnecessary language specific tests

### DIFF
--- a/packages/yoastseo/spec/languageProcessing/researches/altTagCountSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/altTagCountSpec.js
@@ -284,7 +284,7 @@ describe( "Counts images in a text", function() {
 	} );
 } );
 
-describe( "test for alt tag attributes in Japanese", () => {
+/*describe( "test for alt tag attributes in Japanese", () => {
 	it( "returns result when no morphology data is supplied", () => {
 		const paper = new Paper( "<img src=\"http://basic.wordpress.test/wp-content/uploads/2021/10/images.jpeg\" alt=\"会えるトイレ\"> " +
 			"<img src=\"http://basic.wordpress.test/wp-content/uploads/2021/10/images.jpeg\" alt=\"我が家はみんな元気じゃないです\">",
@@ -297,4 +297,4 @@ describe( "test for alt tag attributes in Japanese", () => {
 		expect( stringToCheck.withAltKeyword ).toBe( 1 );
 		expect( stringToCheck.withAltNonKeyword ).toBe( 1 );
 	} );
-} );
+} );*/

--- a/packages/yoastseo/spec/languageProcessing/researches/altTagCountSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/altTagCountSpec.js
@@ -1,4 +1,4 @@
-/* eslint-disable capitalized-comments */
+/* eslint-disable capitalized-comments, spaced-comment */
 import Researcher from "../../../src/languageProcessing/languages/en/Researcher";
 import getMorphologyData from "../../specHelpers/getMorphologyData";
 import altTagCountFunction from "../../../src/languageProcessing/researches/altTagCount";

--- a/packages/yoastseo/spec/languageProcessing/researches/altTagCountSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/altTagCountSpec.js
@@ -1,3 +1,4 @@
+/* eslint-disable capitalized-comments */
 import Researcher from "../../../src/languageProcessing/languages/en/Researcher";
 import getMorphologyData from "../../specHelpers/getMorphologyData";
 import altTagCountFunction from "../../../src/languageProcessing/researches/altTagCount";

--- a/packages/yoastseo/spec/languageProcessing/researches/altTagCountSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/altTagCountSpec.js
@@ -1,5 +1,4 @@
 import Researcher from "../../../src/languageProcessing/languages/en/Researcher";
-import JapaneseResearcher from "../../../src/languageProcessing/languages/ja/Researcher";
 import getMorphologyData from "../../specHelpers/getMorphologyData";
 import altTagCountFunction from "../../../src/languageProcessing/researches/altTagCount";
 import Paper from "../../../src/values/Paper";

--- a/packages/yoastseo/spec/languageProcessing/researches/countSentencesFromTextSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/countSentencesFromTextSpec.js
@@ -1,6 +1,5 @@
 import getSentences from "../../../src/languageProcessing/researches/countSentencesFromText.js";
 import Paper from "../../../src/values/Paper";
-import JapaneseResearcher from "../../../src/languageProcessing/languages/ja/Researcher";
 import EnglishResearcher from "../../../src/languageProcessing/languages/en/Researcher";
 
 describe( "counts words in sentences from text", function() {

--- a/packages/yoastseo/spec/languageProcessing/researches/countSentencesFromTextSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/countSentencesFromTextSpec.js
@@ -1,3 +1,4 @@
+/* eslint-disable capitalized-comments */
 import getSentences from "../../../src/languageProcessing/researches/countSentencesFromText.js";
 import Paper from "../../../src/values/Paper";
 import EnglishResearcher from "../../../src/languageProcessing/languages/en/Researcher";

--- a/packages/yoastseo/spec/languageProcessing/researches/countSentencesFromTextSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/countSentencesFromTextSpec.js
@@ -33,7 +33,7 @@ describe( "counts words in sentences from text", function() {
 		expect( getSentences( paper, new EnglishResearcher() )[ 0 ].sentenceLength ).toBe( 4 );
 		expect( getSentences( paper, new EnglishResearcher() )[ 1 ].sentenceLength ).toBe( 2 );
 	} );
-	it( "returns sentences with question mark in Japanese", function() {
+	/*it( "returns sentences with question mark in Japanese", function() {
 		paper = new Paper( "雨が降っている。 いつ終わるの？ さようなら" );
 		expect( getSentences( paper, new JapaneseResearcher() )[ 0 ].sentenceLength ).toBe( 8 );
 		expect( getSentences( paper, new JapaneseResearcher() )[ 1 ].sentenceLength ).toBe( 7 );
@@ -59,5 +59,5 @@ describe( "counts words in sentences from text", function() {
 		paper = new Paper( "いつ終わるの <img src='http://domain.com/image.jpg' alt='自分を大事にして下さい' />. 春がやってきます。" );
 		expect( getSentences( paper, new JapaneseResearcher() )[ 0 ].sentenceLength ).toBe( 7 );
 		expect( getSentences( paper, new JapaneseResearcher() )[ 1 ].sentenceLength ).toBe( 9 );
-	} );
+	} );*/
 } );

--- a/packages/yoastseo/spec/languageProcessing/researches/countSentencesFromTextSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/countSentencesFromTextSpec.js
@@ -1,4 +1,4 @@
-/* eslint-disable capitalized-comments */
+/* eslint-disable capitalized-comments, spaced-comment */
 import getSentences from "../../../src/languageProcessing/researches/countSentencesFromText.js";
 import Paper from "../../../src/values/Paper";
 import EnglishResearcher from "../../../src/languageProcessing/languages/en/Researcher";

--- a/packages/yoastseo/spec/languageProcessing/researches/findKeywordInFirstParagraphSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/findKeywordInFirstParagraphSpec.js
@@ -184,7 +184,7 @@ describe( "checks for the content words from a synonym phrase in the first parag
 	} );
 } );
 
-const keyphraseFR = "se promener dans la nature avantages";
+/*const keyphraseFR = "se promener dans la nature avantages";
 const sentenceWithAllKeywordsFR = "J'aime a me promener dans la nature pour toutes les avantages pour mon corps et mon cerveau! ";
 const sentenceWithSomeKeywordsFR = "J'aime a me promener dans la nature. ";
 const sentenceWithTheOtherKeywordsFR = "Il'y a pleusieurs d'avantages pour mon corps et mon cerveau! ";
@@ -249,9 +249,9 @@ describe( "checks for the content words from the keyphrase in the first paragrap
 			keyphraseOrSynonym: "",
 		} );
 	} );
-} );
+} );*/
 
-describe( "checks for the content words from a synonym phrase in the first paragraph (French - no morphology)", function() {
+/*describe( "checks for the content words from a synonym phrase in the first paragraph (French - no morphology)", function() {
 	it( "returns whether all keywords were matched in one sentence", function() {
 		const paper = new Paper(
 			paragraphWithSentenceMatchFR, {
@@ -308,7 +308,7 @@ describe( "checks for the content words from a synonym phrase in the first parag
 			keyphraseOrSynonym: "",
 		} );
 	} );
-} );
+} );*/
 
 describe( "tests for edge cases", function() {
 	it( "returns not found if no keyphrase or synonyms were specified", function() {
@@ -563,7 +563,7 @@ describe( "tests for edge cases", function() {
 		} );
 	} );
 
-	it( "returns correct result for Turkish with dotted I", function() {
+	/*it( "returns correct result for Turkish with dotted I", function() {
 		const paper = new Paper(
 			"<p>Bu yıldız, Vikipedi'deki seçkin içeriği sembolize eder İstanbul.</p>", {
 				keyword: "İstanbul",
@@ -591,9 +591,9 @@ describe( "tests for edge cases", function() {
 			foundInParagraph: true,
 			keyphraseOrSynonym: "keyphrase",
 		} );
-	} );
+	} );*/
 
-	it( "returns correct result for German", function() {
+	/*it( "returns correct result for German", function() {
 		const paper = new Paper(
 			"<p>äbc und Äbc</p>", {
 				keyword: "äbc",
@@ -607,7 +607,7 @@ describe( "tests for edge cases", function() {
 			foundInParagraph: true,
 			keyphraseOrSynonym: "keyphrase",
 		} );
-	} );
+	} );*/
 
 	it( "returns correct result if the text contains image tag", function() {
 		const paper = new Paper(
@@ -627,7 +627,7 @@ describe( "tests for edge cases", function() {
 	} );
 } );
 
-const keyphraseJA = "自然の中を歩く";
+/*const keyphraseJA = "自然の中を歩く";
 const sentenceWithAllKeywordsJA = "人によって心地よく感じるポイントは異なりますが、自然の中で本来あるべき場所に、明るく爽やかな森の中を歩く時間は、それだけで心と体を癒してくれるものです。";
 const sentenceWithSomeKeywordsJA = "自然とは、人為によってではなく、おのずから存在しているもの。";
 const sentenceWithTheOtherKeywordsJA = "歩くさわやかな森の中で時間が速くなります。";
@@ -638,13 +638,13 @@ const paragraphWithParagraphMatchJA = "<p>" + sentenceWithSomeKeywordsJA + sente
 	sentenceWithSomeKeywordsJA + sentenceWithoutKeywordsJA + "/<p>";
 const paragraphWithoutMatchJA = "<p>" + sentenceWithoutKeywordsJA + sentenceWithoutKeywordsJA + sentenceWithoutKeywordsJA + "/<p>";
 
-/**
+/!**
  * Mocks Japanese Researcher.
  * @param {Array} keyphraseForms        The morphological forms of the kyphrase to be added to the researcher.
  * @param {Array} synonymsForms         The morphological forms of the synonyms to be added to the researcher.
  * @param {function} helper1    A helper needed for the assesment.
  * @returns {Researcher} The mock researcher with added morphological forms and custom helper.
- */
+ *!/
 const buildJapaneseMockResearcher = function( keyphraseForms, synonymsForms, helper1 ) {
 	return factory.buildMockResearcher( {
 		morphology: {
@@ -704,9 +704,9 @@ describe( "checks for the content words from the keyphrase in the first paragrap
 			keyphraseOrSynonym: "",
 		} );
 	} );
-} );
+} );*/
 
-describe( "checks for the content words from the keyphrase in the first paragraph (Japanese)", function() {
+/*describe( "checks for the content words from the keyphrase in the first paragraph (Japanese)", function() {
 	it( "returns whether all keywords were matched in one sentence", function() {
 		const paper = new Paper(
 			paragraphWithSentenceMatchJA, {
@@ -766,9 +766,9 @@ describe( "checks for the content words from the keyphrase in the first paragrap
 			keyphraseOrSynonym: "",
 		} );
 	} );
-} );
+} );*/
 
-describe( "checks for the content words from a synonym phrase in the first paragraph (Japanese)", function() {
+/*describe( "checks for the content words from a synonym phrase in the first paragraph (Japanese)", function() {
 	it( "returns whether all keywords were matched in one sentence", function() {
 		const paper = new Paper(
 			paragraphWithSentenceMatchJA, {
@@ -829,7 +829,7 @@ describe( "checks for the content words from a synonym phrase in the first parag
 			keyphraseOrSynonym: "",
 		} );
 	} );
-} );
+} );*/
 
 describe( "a test for the keyphrase in first paragraph research when the exact match is requested", function() {
 	it( "returns a bad result when the first paragraph doesn't contain the exact match of the keyphrase", function() {
@@ -871,7 +871,7 @@ describe( "a test for the keyphrase in first paragraph research when the exact m
 		} );
 	} );
 
-	it( "returns a bad result when the first paragraph doesn't contain the exact match of the keyphrase in Japanese", function() {
+	/*it( "returns a bad result when the first paragraph doesn't contain the exact match of the keyphrase in Japanese", function() {
 		const paper = new Paper( "小さくて可愛い花の刺繍に関する一般一般の記事です。私は美しい猫を飼っています。", { keyword: "『小さい花の刺繍』",
 			synonyms: "野生のハーブの刺繡",
 		} );
@@ -909,5 +909,5 @@ describe( "a test for the keyphrase in first paragraph research when the exact m
 			foundInParagraph: true,
 			keyphraseOrSynonym: "synonym",
 		} );
-	} );
+	} );*/
 } );

--- a/packages/yoastseo/spec/languageProcessing/researches/findKeywordInFirstParagraphSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/findKeywordInFirstParagraphSpec.js
@@ -1,3 +1,4 @@
+/* eslint-disable capitalized-comments */
 import EnglishResearcher from "../../../src/languageProcessing/languages/en/Researcher";
 import getMorphologyData from "../../specHelpers/getMorphologyData";
 import firstParagraph from "../../../src/languageProcessing/researches/findKeywordInFirstParagraph.js";

--- a/packages/yoastseo/spec/languageProcessing/researches/findKeywordInFirstParagraphSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/findKeywordInFirstParagraphSpec.js
@@ -1,4 +1,4 @@
-/* eslint-disable capitalized-comments */
+/* eslint-disable capitalized-comments, spaced-comment */
 import EnglishResearcher from "../../../src/languageProcessing/languages/en/Researcher";
 import getMorphologyData from "../../specHelpers/getMorphologyData";
 import firstParagraph from "../../../src/languageProcessing/researches/findKeywordInFirstParagraph.js";

--- a/packages/yoastseo/spec/languageProcessing/researches/findKeywordInFirstParagraphSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/findKeywordInFirstParagraphSpec.js
@@ -1,20 +1,9 @@
-import { primeLanguageSpecificData } from "../../../src/languageProcessing/helpers/morphology/buildTopicStems";
 import EnglishResearcher from "../../../src/languageProcessing/languages/en/Researcher";
-import GermanResearcher from "../../../src/languageProcessing/languages/de/Researcher";
-import FrenchResearcher from "../../../src/languageProcessing/languages/fr/Researcher";
-import TurkishResearcher from "../../../src/languageProcessing/languages/tr/Researcher";
-import JapaneseResearcher from "../../../src/languageProcessing/languages/ja/Researcher";
-import factory from "../../../../yoastseo/spec/specHelpers/factory";
-import matchWordsHelper from "../../../src/languageProcessing/languages/ja/helpers/matchTextWithWord";
-
 import getMorphologyData from "../../specHelpers/getMorphologyData";
 import firstParagraph from "../../../src/languageProcessing/researches/findKeywordInFirstParagraph.js";
 import Paper from "../../../src/values/Paper.js";
 
 const morphologyData = getMorphologyData( "en" );
-const morphologyDataDe = getMorphologyData( "de" ).de;
-const morphologyDataFR = getMorphologyData( "fr" ).fr;
-const morphologyDataJA = getMorphologyData( "ja" );
 
 const keyphraseEN = "walking in nature benefits";
 const sentenceWithAllKeywordsEN = "I like to take walks in the nature, because my body and brain benefit from it! ";

--- a/packages/yoastseo/spec/languageProcessing/researches/findTransitionWordsSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/findTransitionWordsSpec.js
@@ -1,21 +1,7 @@
 import transitionWordsResearch from "../../../src/languageProcessing/researches/findTransitionWords.js";
 import Paper from "../../../src/values/Paper.js";
 import EnglishResearcher from "../../../src/languageProcessing/languages/en/Researcher";
-import GermanResearcher from "../../../src/languageProcessing/languages/de/Researcher";
 import FrenchResearcher from "../../../src/languageProcessing/languages/fr/Researcher";
-import SpanishResearcher from "../../../src/languageProcessing/languages/es/Researcher";
-import IndonesianResearcher from "../../../src/languageProcessing/languages/id/Researcher";
-import ItalianResearcher from "../../../src/languageProcessing/languages/it/Researcher";
-import CatalanResearcher from "../../../src/languageProcessing/languages/ca/Researcher";
-import ArabicResearcher from "../../../src/languageProcessing/languages/ar/Researcher";
-import RussianResearcher from "../../../src/languageProcessing/languages/ru/Researcher";
-import SwedishResearcher from "../../../src/languageProcessing/languages/sv/Researcher";
-import PortugueseResearcher from "../../../src/languageProcessing/languages/pt/Researcher";
-import DutchResearcher from "../../../src/languageProcessing/languages/nl/Researcher";
-import PolishResearcher from "../../../src/languageProcessing/languages/pl/Researcher";
-import HungarianResearcher from "../../../src/languageProcessing/languages/hu/Researcher";
-import HebrewResearcher from "../../../src/languageProcessing/languages/he/Researcher";
-import TurkishResearcher from "../../../src/languageProcessing/languages/tr/Researcher";
 import JapaneseResearcher from "../../../src/languageProcessing/languages/ja/Researcher";
 
 // eslint-disable-next-line max-statements
@@ -158,7 +144,7 @@ describe( "a test for finding transition words from a string", function() {
 		expect( result.transitionWordSentences ).toBe( 0 );
 	} );
 
-	it( "returns 1 when a transition word is found in a sentence (German)", function() {
+	/*it( "returns 1 when a transition word is found in a sentence (German)", function() {
 		// Transition word: zuerst.
 		mockPaper = new Paper( "Zuerst werde ich versuchen zu verstehen, warum er so denkt.", { locale: "de_DE" } );
 		result = transitionWordsResearch( mockPaper, new GermanResearcher( mockPaper ) );
@@ -189,8 +175,8 @@ describe( "a test for finding transition words from a string", function() {
 		expect( result.totalSentences ).toBe( 1 );
 		expect( result.transitionWordSentences ).toBe( 0 );
 	} );
-
-	it( "returns 1 when a transition word is found in a sentence (French)", function() {
+*/
+/*	it( "returns 1 when a transition word is found in a sentence (French)", function() {
 		// Transition word: deuxièmement.
 		mockPaper = new Paper( "Deuxièmement, il convient de reconnaître la complexité des tâches à entreprendre.", { locale: "fr_FR" } );
 		result = transitionWordsResearch( mockPaper, new FrenchResearcher( mockPaper ) );
@@ -204,7 +190,7 @@ describe( "a test for finding transition words from a string", function() {
 		result = transitionWordsResearch( mockPaper, new FrenchResearcher( mockPaper ) );
 		expect( result.totalSentences ).toBe( 1 );
 		expect( result.transitionWordSentences ).toBe( 1 );
-	} );
+	} );*/
 
 	it( "returns 1 when a transition word with an apostrophe is found in a sentence (French)", function() {
 		// Transition word: quoi qu’il en soit.
@@ -214,7 +200,7 @@ describe( "a test for finding transition words from a string", function() {
 		expect( result.transitionWordSentences ).toBe( 1 );
 	} );
 
-	it( "returns 0 when no transition words are present in a sentence (French)", function() {
+	/*it( "returns 0 when no transition words are present in a sentence (French)", function() {
 		mockPaper = new Paper( "Une, deux, trois.", { locale: "fr_FR" } );
 		result = transitionWordsResearch( mockPaper, new FrenchResearcher( mockPaper ) );
 		expect( result.totalSentences ).toBe( 1 );
@@ -352,8 +338,8 @@ describe( "a test for finding transition words from a string", function() {
 		expect( result.totalSentences ).toBe( 1 );
 		expect( result.transitionWordSentences ).toBe( 1 );
 	} );
-
-	it( "returns 1 when a transition word with a punt volat (·) is found in a sentence (Catalan)", function() {
+*/
+	/*it( "returns 1 when a transition word with a punt volat (·) is found in a sentence (Catalan)", function() {
 		// Transition word: per il·lustrar.
 		mockPaper = new Paper( "Roma proposa un concurs de curtmetratges per il·lustrar com ha de ser la ciutat ideal", { locale: "ca_ES" } );
 		result = transitionWordsResearch( mockPaper, new CatalanResearcher( mockPaper ) );
@@ -441,8 +427,8 @@ describe( "a test for finding transition words from a string", function() {
 		result = transitionWordsResearch( mockPaper, new HungarianResearcher( mockPaper ) );
 		expect( result.totalSentences ).toBe( 1 );
 		expect( result.transitionWordSentences ).toBe( 1 );
-	} );
-	it( "returns 1 when a three-part transition word is found in a sentence (Hungarian)", function() {
+	} );*/
+	/*it( "returns 1 when a three-part transition word is found in a sentence (Hungarian)", function() {
 		// Transition word: nemcsak, hanem, is
 		mockPaper = new Paper( "Nemcsak a csokoládét szeretem, hanem a süteményt is.", { locale: "hu_HU" } );
 		result = transitionWordsResearch( mockPaper, new HungarianResearcher( mockPaper ) );
@@ -570,8 +556,9 @@ describe( "a test for finding transition words from a string", function() {
 		expect( result.totalSentences ).toBe( 1 );
 		expect( result.transitionWordSentences ).toBe( 1 );
 	} );
-
-	it( "returns 1 when a (multiple) transition word is found in a sentence (Japanese)", function() {
+*/
+	it( "returns 1 when a (multiple) transition word is found in a language that uses a custom" +
+		" match transition word helper (Japanese)", function() {
 		// Transition word: ゆえに (tokenized: [ "ゆえ", "に" ])
 		mockPaper = new Paper( "我思う、ゆえに我あり。", { locale: "ja" } );
 		result = transitionWordsResearch( mockPaper, new JapaneseResearcher( mockPaper ) );
@@ -579,7 +566,8 @@ describe( "a test for finding transition words from a string", function() {
 		expect( result.transitionWordSentences ).toBe( 1 );
 	} );
 
-	it( "returns 0 when no transition words are present in a sentence (Japanese)", function() {
+	it( "returns 0 when no transition words are present in a sentence for a language that uses a" +
+		" custom match transition word helper (Japanese)", function() {
 		mockPaper = new Paper( "この例文は、書き方のサンプルなので必要に応じて内容を追加削除をしてからお使いください。", { locale: "ja" } );
 		result = transitionWordsResearch( mockPaper, new JapaneseResearcher( mockPaper ) );
 		expect( result.totalSentences ).toBe( 1 );

--- a/packages/yoastseo/spec/languageProcessing/researches/findTransitionWordsSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/findTransitionWordsSpec.js
@@ -1,4 +1,4 @@
-/* eslint-disable capitalized-comments */
+/* eslint-disable capitalized-comments, spaced-comment */
 import transitionWordsResearch from "../../../src/languageProcessing/researches/findTransitionWords.js";
 import Paper from "../../../src/values/Paper.js";
 import EnglishResearcher from "../../../src/languageProcessing/languages/en/Researcher";
@@ -177,7 +177,7 @@ describe( "a test for finding transition words from a string", function() {
 		expect( result.transitionWordSentences ).toBe( 0 );
 	} );
 */
-/*	it( "returns 1 when a transition word is found in a sentence (French)", function() {
+	/*	it( "returns 1 when a transition word is found in a sentence (French)", function() {
 		// Transition word: deuxièmement.
 		mockPaper = new Paper( "Deuxièmement, il convient de reconnaître la complexité des tâches à entreprendre.", { locale: "fr_FR" } );
 		result = transitionWordsResearch( mockPaper, new FrenchResearcher( mockPaper ) );

--- a/packages/yoastseo/spec/languageProcessing/researches/findTransitionWordsSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/findTransitionWordsSpec.js
@@ -1,3 +1,4 @@
+/* eslint-disable capitalized-comments */
 import transitionWordsResearch from "../../../src/languageProcessing/researches/findTransitionWords.js";
 import Paper from "../../../src/values/Paper.js";
 import EnglishResearcher from "../../../src/languageProcessing/languages/en/Researcher";

--- a/packages/yoastseo/spec/languageProcessing/researches/functionWordsInKeyphraseSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/functionWordsInKeyphraseSpec.js
@@ -1,4 +1,4 @@
-/* eslint-disable capitalized-comments */
+/* eslint-disable capitalized-comments, spaced-comment */
 import functionWordsInKeyphrase from "../../../src/languageProcessing/researches/functionWordsInKeyphrase.js";
 import EnglishResearcher from "../../../src/languageProcessing/languages/en/Researcher";
 import DefaultResearcher from "../../../src/languageProcessing/languages/_default/Researcher";

--- a/packages/yoastseo/spec/languageProcessing/researches/functionWordsInKeyphraseSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/functionWordsInKeyphraseSpec.js
@@ -1,29 +1,22 @@
 import functionWordsInKeyphrase from "../../../src/languageProcessing/researches/functionWordsInKeyphrase.js";
 import EnglishResearcher from "../../../src/languageProcessing/languages/en/Researcher";
-import DutchResearcher from "../../../src/languageProcessing/languages/nl/Researcher";
-import FrenchResearcher from "../../../src/languageProcessing/languages/fr/Researcher";
 import DefaultResearcher from "../../../src/languageProcessing/languages/_default/Researcher";
 import JapaneseResearcher from "../../../src/languageProcessing/languages/ja/Researcher";
 
 import Paper from "../../../src/values/Paper.js";
 
 describe( "Test for checking if the keyphrase contains function words only", function() {
-	it( "returns true if the keyphrase contains one function word only", function() {
-		const mockPaper = new Paper( "", { keyword: "a", locale: "en_EN" } );
-		expect( functionWordsInKeyphrase( mockPaper, new EnglishResearcher( mockPaper ) ) ).toBe( true );
-	} );
-
-	it( "returns true if the keyphrase contains function words only", function() {
+	/*it( "returns true if the keyphrase contains function words only", function() {
 		const mockPaper = new Paper( "", { keyword: "un deux", locale: "fr_FR" } );
 		expect( functionWordsInKeyphrase( mockPaper, new FrenchResearcher( mockPaper ) ) ).toBe( true );
-	} );
+	} );*/
 
-	it( "returns true if the keyphrase contains function words only (empty locale)", function() {
+	it( "returns true if the keyphrase contains function words only", function() {
 		const mockPaper = new Paper( "", { keyword: "something was there" } );
 		expect( functionWordsInKeyphrase( mockPaper, new EnglishResearcher( mockPaper ) ) ).toBe( true );
 	} );
 
-	it( "returns false for unknown locale", function() {
+	it( "returns false when the default researcher is used", function() {
 		const mockPaper = new Paper( "", { keyword: "something", locale: "xx_XX" } );
 		expect( functionWordsInKeyphrase( mockPaper, new DefaultResearcher( mockPaper ) ) ).toBe( false );
 	} );
@@ -38,28 +31,15 @@ describe( "Test for checking if the keyphrase contains function words only", fun
 		expect( functionWordsInKeyphrase( mockPaper, new EnglishResearcher( mockPaper ) ) ).toBe( false );
 	} );
 
-	it( "returns false if there are content words in the keyphrase", function() {
-		const mockPaper = new Paper( "", { keyword: "something was there and it was pretty", locale: "en_EN" } );
-		expect( functionWordsInKeyphrase( mockPaper, new EnglishResearcher( mockPaper )  ) ).toBe( false );
-	} );
-
-	it( "returns false if there are content words in the keyphrase", function() {
+	/*it( "returns false if there are content words in the keyphrase", function() {
 		const mockPaper = new Paper( "", { keyword: "daar zat iets en het was mooi", locale: "nl_NL" } );
 		expect( functionWordsInKeyphrase( mockPaper, new DutchResearcher( mockPaper ) ) ).toBe( false );
-	} );
-
-	it( "returns false if there are content words in the keyphrase", function() {
-		const mockPaper = new Paper( "", { keyword: "Keyphrase keyphrase keyphrase" } );
-		expect( functionWordsInKeyphrase( mockPaper, new EnglishResearcher( mockPaper ) ) ).toBe( false );
-	} );
+	} );*/
 } );
 
-describe( "Test for checking if the keyphrase contains only Japanese function words", () => {
-	it( "returns false if the keyphrase is embedded in Japanese quotes", () => {
+describe( "Test for checking if the keyphrase contains only function words for a language that uses a custom getWords helper (Japanese)", () => {
+	/*it( "returns false if the keyphrase is embedded in Japanese quotes", () => {
 		let mockPaper = new Paper( "私の猫は愛らしいです。", { keyword: "「私の猫」", locale: "ja" } );
-		expect( functionWordsInKeyphrase( mockPaper, new JapaneseResearcher( mockPaper ) ) ).toBe( false );
-
-		mockPaper = new Paper( "私の猫は愛らしいです。", { keyword: "『私の猫』", locale: "ja" } );
 		expect( functionWordsInKeyphrase( mockPaper, new JapaneseResearcher( mockPaper ) ) ).toBe( false );
 
 		// All the keyphrase words are function words, but it is embedded in quotes.
@@ -70,7 +50,7 @@ describe( "Test for checking if the keyphrase contains only Japanese function wo
 	it( "returns false if the Japanese keyphrase is embedded in normal quotes", () => {
 		const mockPaper = new Paper( "私の猫は愛らしいです。", { keyword: "\"私の猫\"", locale: "ja" } );
 		expect( functionWordsInKeyphrase( mockPaper, new JapaneseResearcher( mockPaper ) ) ).toBe( false );
-	} );
+	} );*/
 
 	it( "returns false if not all the words in the keyphrase are function words", () => {
 		const mockPaper = new Paper( "私の猫は愛らしいです。", { keyword: "私の猫", locale: "ja" } );
@@ -82,8 +62,8 @@ describe( "Test for checking if the keyphrase contains only Japanese function wo
 		expect( functionWordsInKeyphrase( mockPaper, new JapaneseResearcher( mockPaper ) ) ).toBe( true );
 	} );
 
-	it( "returns true if all the words in the keyphrase are function words (separated by spaces)", () => {
+	/*it( "returns true if all the words in the keyphrase are function words (separated by spaces)", () => {
 		const mockPaper = new Paper( "私の猫は愛らしいです。", { keyword: "かしら かい を ばっかり", locale: "ja" } );
 		expect( functionWordsInKeyphrase( mockPaper, new JapaneseResearcher( mockPaper ) ) ).toBe( true );
-	} );
+	} );*/
 } );

--- a/packages/yoastseo/spec/languageProcessing/researches/functionWordsInKeyphraseSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/functionWordsInKeyphraseSpec.js
@@ -1,3 +1,4 @@
+/* eslint-disable capitalized-comments */
 import functionWordsInKeyphrase from "../../../src/languageProcessing/researches/functionWordsInKeyphrase.js";
 import EnglishResearcher from "../../../src/languageProcessing/languages/en/Researcher";
 import DefaultResearcher from "../../../src/languageProcessing/languages/_default/Researcher";

--- a/packages/yoastseo/spec/languageProcessing/researches/getFleschReadingScoreSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/getFleschReadingScoreSpec.js
@@ -1,3 +1,4 @@
+/* eslint-disable capitalized-comments */
 import fleschFunction from "../../../src/languageProcessing/researches/getFleschReadingScore";
 import Paper from "../../../src/values/Paper.js";
 import EnglishResearcher from "../../../src/languageProcessing/languages/en/Researcher";

--- a/packages/yoastseo/spec/languageProcessing/researches/getFleschReadingScoreSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/getFleschReadingScoreSpec.js
@@ -1,27 +1,20 @@
 import fleschFunction from "../../../src/languageProcessing/researches/getFleschReadingScore";
 import Paper from "../../../src/values/Paper.js";
 import EnglishResearcher from "../../../src/languageProcessing/languages/en/Researcher";
-import DutchResearcher from "../../../src/languageProcessing/languages/nl/Researcher";
-import GermanResearcher from "../../../src/languageProcessing/languages/de/Researcher";
-import ItalianResearcher from "../../../src/languageProcessing/languages/it/Researcher";
-import PortugueseResearcher from "../../../src/languageProcessing/languages/pt/Researcher";
-import FrenchResearcher from "../../../src/languageProcessing/languages/fr/Researcher";
-import RussianResearcher from "../../../src/languageProcessing/languages/ru/Researcher";
-import SpanishResearcher from "../../../src/languageProcessing/languages/es/Researcher";
 
 describe( "a test to calculate the fleschReading score", function() {
 	it( "returns a score", function() {
 		let mockPaper = new Paper( "A piece of text to calculate scores." );
-		const mockResearch = new EnglishResearcher( mockPaper );
-		expect( fleschFunction( mockPaper, mockResearch ) ).toBe( 91 );
+		const researcher = new EnglishResearcher( mockPaper );
+		expect( fleschFunction( mockPaper, researcher ) ).toBe( 91 );
 
 		mockPaper = new Paper( "One question we get quite often in our website reviews is whether we can help people recover " +
 			"from the drop they noticed in their rankings or traffic. A lot of the times, this is a legitimate drop " +
 			"and people were actually in a bit of trouble" );
-		expect( fleschFunction( mockPaper, mockResearch ) ).toBe( 63.9 );
+		expect( fleschFunction( mockPaper, researcher ) ).toBe( 63.9 );
 
 		mockPaper = new Paper( "" );
-		expect( fleschFunction( mockPaper, mockResearch ) ).toBe( 0 );
+		expect( fleschFunction( mockPaper, researcher ) ).toBe( 0 );
 	} );
 } );
 describe( "A test to check the filter of digits", function() {
@@ -33,6 +26,7 @@ describe( "A test to check the filter of digits", function() {
 	} );
 } );
 
+/*
 describe( "A test that uses the Dutch Flesch Reading", function() {
 	it( "returns a score", function() {
 		const mockPaper = new Paper( "Een kort stukje tekst in het Nederlands om te testen.", { locale: "nl_NL" } );
@@ -103,6 +97,7 @@ describe( "A test that uses the Portuguese Flesch Reading", function() {
 		expect( fleschFunction( mockPaper, new PortugueseResearcher( mockPaper ) ) ).toBe( 77.9 );
 	} );
 } );
+*/
 
 describe( "A test that returns 0 after sentence formatting", function() {
 	it( "returns a score of 0", function() {

--- a/packages/yoastseo/spec/languageProcessing/researches/getKeywordDensitySpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/getKeywordDensitySpec.js
@@ -73,13 +73,13 @@ describe( "test for counting the keyword density in a text in a language that we
 	} );
 } );
 
-describe( "test for counting the keyword density in a text in Japanese", function() {
-	it( "returns keyword density when the keyword is not found in the sentence", function() {
+describe( "test for counting the keyword density in a text in a language that uses a custom getWords helper (Japanese)", function() {
+	/*it( "returns keyword density when the keyword is not found in the sentence", function() {
 		const mockPaper = new Paper( "小さくて可愛い花の刺繍に関する一般一般の記事です。", { keyword: "猫" } );
 		const mockResearcher = new JapaneseResearcher( mockPaper );
 		mockResearcher.addResearchData( "morphology", morphologyDataJA );
 		expect( getKeywordDensity( mockPaper, mockResearcher ) ).toBe( 0 );
-	} );
+	} );*/
 
 	it( "returns the keyword density when the keyword is found once", function() {
 		const mockPaper = new Paper( "私の猫はかわいいです。", { keyword: "猫" } );
@@ -96,7 +96,7 @@ describe( "test for counting the keyword density in a text in Japanese", functio
 		expect( getKeywordDensity( mockPaper, mockResearcher ) ).toBe( 6.666666666666667 );
 	} );
 
-	it( "returns the keyword density when the morphologyData is not available to detect inflected forms", function() {
+	/*it( "returns the keyword density when the morphologyData is not available to detect inflected forms", function() {
 		// 小さく is the inflected form of 小さい.
 		const mockPaper = new Paper( "小さくて可愛い花の刺繍に関する一般一般の記事です。", { keyword: "小さい花の刺繍" } );
 		const mockResearcher = new JapaneseResearcher( mockPaper );
@@ -122,7 +122,7 @@ describe( "test for counting the keyword density in a text in Japanese", functio
 		const mockResearcher = new JapaneseResearcher( mockPaper );
 		mockResearcher.addResearchData( "morphology", morphologyDataJA );
 		expect( getKeywordDensity( mockPaper, mockResearcher ) ).toBe( 0 );
-	} );
+	} );*/
 } );
 
 

--- a/packages/yoastseo/spec/languageProcessing/researches/getKeywordDensitySpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/getKeywordDensitySpec.js
@@ -1,3 +1,4 @@
+/* eslint-disable capitalized-comments */
 import getKeywordDensity from "../../../src/languageProcessing/researches/getKeywordDensity.js";
 import Paper from "../../../src/values/Paper.js";
 import EnglishResearcher from "../../../src/languageProcessing/languages/en/Researcher";

--- a/packages/yoastseo/spec/languageProcessing/researches/getKeywordDensitySpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/getKeywordDensitySpec.js
@@ -1,4 +1,4 @@
-/* eslint-disable capitalized-comments */
+/* eslint-disable capitalized-comments, spaced-comment */
 import getKeywordDensity from "../../../src/languageProcessing/researches/getKeywordDensity.js";
 import Paper from "../../../src/values/Paper.js";
 import EnglishResearcher from "../../../src/languageProcessing/languages/en/Researcher";

--- a/packages/yoastseo/spec/languageProcessing/researches/getSentenceBeginningsSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/getSentenceBeginningsSpec.js
@@ -1,4 +1,4 @@
-/* eslint-disable capitalized-comments */
+/* eslint-disable capitalized-comments, spaced-comment */
 import getSentenceBeginnings from "../../../src/languageProcessing/researches/getSentenceBeginnings";
 
 import Paper from "../../../src/values/Paper.js";
@@ -458,7 +458,7 @@ describe( "gets the sentence beginnings and the count of consecutive duplicates.
 		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 3 );
 	} );*/
 
-/*	it( "returns an object with sentence beginnings and counts for three sentences in Arabic all starting " +
+	/*	it( "returns an object with sentence beginnings and counts for three sentences in Arabic all starting " +
 		"with one of the exception words.", function() {
 		mockPaper = new Paper( "هؤلاء الأولاد غائبون. هؤلاء الأولاد هم طلاب. هؤلاء الأولاد في المنزل.", { locale: "ar_AR" } );
 		researcher = new ArabicResearcher( mockPaper );

--- a/packages/yoastseo/spec/languageProcessing/researches/getSentenceBeginningsSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/getSentenceBeginningsSpec.js
@@ -3,26 +3,17 @@ import getSentenceBeginnings from "../../../src/languageProcessing/researches/ge
 import Paper from "../../../src/values/Paper.js";
 import EnglishResearcher from "../../../src/languageProcessing/languages/en/Researcher";
 import FrenchResearcher from "../../../src/languageProcessing/languages/fr/Researcher";
-import GermanResearcher from "../../../src/languageProcessing/languages/de/Researcher";
 import SpanishResearcher from "../../../src/languageProcessing/languages/es/Researcher";
-import ItalianResearcher from "../../../src/languageProcessing/languages/it/Researcher";
-import PortugueseResearcher from "../../../src/languageProcessing/languages/pt/Researcher";
-import PolishResearcher from "../../../src/languageProcessing/languages/pl/Researcher";
-import IndonesianResearcher from "../../../src/languageProcessing/languages/id/Researcher";
-import SwedishResearcher from "../../../src/languageProcessing/languages/sv/Researcher";
-import DutchResearcher from "../../../src/languageProcessing/languages/nl/Researcher";
-import RussianResearcher from "../../../src/languageProcessing/languages/ru/Researcher";
-import ArabicResearcher from "../../../src/languageProcessing/languages/ar/Researcher";
 import GreekResearcher from "../../../src/languageProcessing/languages/el/Researcher";
 import JapaneseResearcher from "../../../src/languageProcessing/languages/ja/Researcher";
 
 // eslint-disable-next-line max-statements
 describe( "gets the sentence beginnings and the count of consecutive duplicates.", function() {
-	let mockPaper = new Paper( "How are you? Bye!", { locale: "en_US" } );
+	let mockPaper = new Paper( "How are you? Bye!" );
 	let researcher = new EnglishResearcher( mockPaper );
 
-	it( "returns an object with sentence beginnings and counts for two sentences in English starting w" +
-		"ith different words.", function() {
+	it( "returns an object with sentence beginnings and counts for two sentences in English starting " +
+		"with different words.", function() {
 		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "how" );
 		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 1 );
 		expect( getSentenceBeginnings( mockPaper, researcher )[ 1 ].word ).toBe( "bye" );
@@ -30,7 +21,7 @@ describe( "gets the sentence beginnings and the count of consecutive duplicates.
 	} );
 
 	it( "returns an object with sentence beginnings and counts for two sentences in English starting with the same word.", function() {
-		mockPaper = new Paper( "Hey, hey! Hey.", { locale: "en_US" } );
+		mockPaper = new Paper( "Hey, hey! Hey." );
 		researcher = new EnglishResearcher( mockPaper );
 		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "hey" );
 		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 2 );
@@ -39,7 +30,7 @@ describe( "gets the sentence beginnings and the count of consecutive duplicates.
 	it( "returns an object with sentence beginnings and counts for four sentences in English, " +
 		"the first two starting with the same word. The fourth is starting with the same word as the first two. " +
 		"The count for this word should be reset.", function() {
-		mockPaper = new Paper( "Hey, hey! Hey. Bye. Hey.", { locale: "en_US" } );
+		mockPaper = new Paper( "Hey, hey! Hey. Bye. Hey." );
 		researcher = new EnglishResearcher( mockPaper );
 		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 2 );
 		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "hey" );
@@ -51,7 +42,7 @@ describe( "gets the sentence beginnings and the count of consecutive duplicates.
 
 	it( "returns an object with sentence beginnings and counts for three sentences in English all starting " +
 		"with one of the exception words.", function() {
-		mockPaper = new Paper( "The boy, hey! The boy. The boy.", { locale: "en_US" } );
+		mockPaper = new Paper( "The boy, hey! The boy. The boy." );
 		researcher = new EnglishResearcher( mockPaper );
 		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "the boy" );
 		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 3 );
@@ -60,51 +51,20 @@ describe( "gets the sentence beginnings and the count of consecutive duplicates.
 	it( "returns an object with sentence beginnings and counts for three sentences in English all starting " +
 		"with one of the exception words. The second word of all sentences is also in the list " +
 		"of exception words, which should not matter.", function() {
-		mockPaper = new Paper( "One, two, three. One, two, three. One, two, three.", { locale: "en_US" } );
+		mockPaper = new Paper( "One, two, three. One, two, three. One, two, three." );
 		researcher = new EnglishResearcher( mockPaper );
 		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "one two" );
 		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 3 );
 	} );
 
-	it( "returns an object with sentence beginnings and counts based on the default (English) when no locale is included.", function() {
-		mockPaper = new Paper( "The boy, hey! The boy. The boy." );
-		researcher = new EnglishResearcher( mockPaper );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "the boy" );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 3 );
-	} );
-
-	it( "returns only an exclusion word, if that is the only word in a sentences (English)", function() {
+	it( "returns only an exclusion word, if that is the only word in a sentence (English)", function() {
 		mockPaper = new Paper( "A" );
 		researcher = new EnglishResearcher( mockPaper );
 		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "a" );
 		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 1 );
 	} );
 
-	it( "returns an object with sentence beginnings and counts for two sentences in French starting with different words.", function() {
-		mockPaper = new Paper( "Sur le pont d'Avignon. Liberté, égalité, fraternité. ", { locale: "fr_FR" } );
-		researcher = new FrenchResearcher( mockPaper );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "sur" );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 1 );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 1 ].word ).toBe( "liberté" );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 1 ].count ).toBe( 1 );
-	} );
-
-	it( "returns an object with sentence beginnings and counts for two sentences in French starting with the same word.", function() {
-		mockPaper = new Paper( "Bonjour, tout le monde! Bonjour.", { locale: "fr_FR" } );
-		researcher = new FrenchResearcher( mockPaper );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "bonjour" );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 2 );
-	} );
-
-	it( "returns an object with sentence beginnings and counts for three sentences in French all starting " +
-		"with one of the exception words.", function() {
-		mockPaper = new Paper( "La vache qui rit. La vache qui pleure. La vache qui vole.", { locale: "fr_FR" } );
-		researcher = new FrenchResearcher( mockPaper );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "la vache" );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 3 );
-	} );
-
-	it( "returns an object with sentence beginnings and counts for sentences in French that start with a character with a diacritic.", function() {
+	it( "returns an object with sentence beginnings and counts for sentences that start with a character with a diacritic.", function() {
 		mockPaper = new Paper( "À Paris, certaines prisons sont restées célèbres. À Paris, certaines prisons " +
 		"sont restées célèbres. À Paris, certaines prisons sont restées célèbres.", { locale: "fr_FR" } );
 		researcher = new FrenchResearcher( mockPaper );
@@ -112,283 +72,10 @@ describe( "gets the sentence beginnings and the count of consecutive duplicates.
 		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 3 );
 	} );
 
-	it( "returns an object with sentence beginnings and counts for two sentences in German starting with different words.", function() {
-		mockPaper = new Paper( "Ich bin wie du. Auf wiedersehen. ", { locale: "de_DE" } );
-		researcher = new GermanResearcher( mockPaper );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "ich" );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 1 );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 1 ].word ).toBe( "auf" );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 1 ].count ).toBe( 1 );
-	} );
-
-	it( "returns an object with sentence beginnings and counts for two sentences in German starting with the same word.", function() {
-		mockPaper = new Paper( "Hallo, hallo! Hallo.", { locale: "de_DE" } );
-		researcher = new GermanResearcher( mockPaper );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "hallo" );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 2 );
-	} );
-
-	it( "returns an object with sentence beginnings and counts for three sentences in German all starting " +
-		"with one of the exception words.", function() {
-		mockPaper = new Paper( "Eine kleine Nachtmusik. Eine kleine Geige. Eine kleine Wolke.", { locale: "de_DE" } );
-		researcher = new GermanResearcher( mockPaper );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "eine kleine" );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 3 );
-	} );
-
-	it( "returns an object with sentence beginnings and counts for sentences in German that start with a character with a diacritic.", function() {
-		mockPaper = new Paper( "Österreich ist ein schönes Land. Österreich ist ein schönes Land. Österreich " +
-				"ist ein schönes Land.", { locale: "de_DE" } );
-		researcher = new GermanResearcher( mockPaper );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "österreich" );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 3 );
-	} );
-
-	it( "returns an object with sentence beginnings and counts for two sentences in Spanish starting with different words.", function() {
-		mockPaper = new Paper( "Vamos a la playa. Muy buenos. ", { locale: "es_ES" } );
-		researcher = new SpanishResearcher( mockPaper );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "vamos" );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 1 );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 1 ].word ).toBe( "muy" );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 1 ].count ).toBe( 1 );
-	} );
-
-	it( "returns an object with sentence beginnings and counts for two sentences in Spanish starting with the same word.", function() {
-		mockPaper = new Paper( "Que si, Que no. Que nunca te decides.", { locale: "es_ES" } );
-		researcher = new SpanishResearcher( mockPaper );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "que" );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 2 );
-	} );
-
-	it( "returns an object with sentence beginnings and counts for three sentences in Spanish all starting " +
-		"with one of the exception words.", function() {
-		mockPaper = new Paper( "Aquellas pequeñas cosas. Aquellas pequeñas decisiones. Aquellas pequeñas ideas.", { locale: "es_ES" } );
-		researcher = new SpanishResearcher( mockPaper );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "aquellas pequeñas" );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 3 );
-	} );
-
-	it( "returns an object with sentence beginnings and counts for sentences in Spanish that start with a character with a diacritic.", function() {
-		mockPaper = new Paper( "África es un gran continente. África es un gran continente. África es un gran continente.", { locale: "es_ES" } );
-		researcher = new SpanishResearcher( mockPaper );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "áfrica" );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 3 );
-	} );
-
-	it( "returns an object with sentence beginnings and counts for two sentences in Portuguese starting with different words.", function() {
-		mockPaper = new Paper( "Quem sou? Para onde vou?", { locale: "pt_PT" } );
-		researcher = new PortugueseResearcher( mockPaper );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "quem" );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 1 );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 1 ].word ).toBe( "para" );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 1 ].count ).toBe( 1 );
-	} );
-
-	it( "returns an object with sentence beginnings and counts for two sentences in Portuguese starting with the same word.", function() {
-		mockPaper = new Paper( "Dora pensa sobre o quanto ela ama sua floresta. Dora ama explorar a floresta, saltando de ramo para ramo " +
-			"entre as árvores altas.", { locale: "pt_PT" } );
-		researcher = new PortugueseResearcher( mockPaper );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "dora" );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 2 );
-	} );
-
-	it( "returns an object with sentence beginnings and counts for three sentences in Portuguese all starting " +
-		"with one of the exception words.", function() {
-		mockPaper = new Paper( "O mês estava frio. O mês foi difícil. O final disso os fez felizes.", { locale: "pt_PT" } );
-		researcher = new PortugueseResearcher( mockPaper );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "o mês" );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 2 );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 1 ].word ).toBe( "o final" );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 1 ].count ).toBe( 1 );
-	} );
-
-	it( "returns an object with sentence beginnings and counts for sentences in Portuguese that start " +
-		"with a character with a diacritic.", function() {
-		mockPaper = new Paper( "Não viajo faz muito tempo. Não vi montanhas em anos. Não vi o mar desde que eu era pequeno.", { locale: "es_ES" } );
-		researcher = new PortugueseResearcher( mockPaper );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "não" );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 3 );
-	} );
-
-	it( "returns an object with sentence beginnings and counts for two sentences in Dutch starting with different words.", function() {
-		mockPaper = new Paper( "Hallo wereld. Hoe gaat het? ", { locale: "nl_NL" } );
-		researcher = new DutchResearcher( mockPaper );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "hallo" );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 1 );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 1 ].word ).toBe( "hoe" );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 1 ].count ).toBe( 1 );
-	} );
-
-	it( "returns an object with sentence beginnings and counts for two sentences in Dutch starting with the same word.", function() {
-		mockPaper = new Paper( "Hallo wereld. Hallo mensheid.", { locale: "nl_NL" } );
-		researcher = new DutchResearcher( mockPaper );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "hallo" );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 2 );
-	} );
-
-	it( "returns an object with sentence beginnings and counts for three sentences in Dutch all starting " +
-		"with one of the exception words.", function() {
-		mockPaper = new Paper( "Het is een nacht die je normaal alleen in films ziet. Het is een nacht die wordt bezongen in het mooiste lied. " +
-			"Het is een nacht waarvan ik dacht dat ik 'm nooit beleven zou", { locale: "nl_NL" } );
-		researcher = new DutchResearcher( mockPaper );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "het is" );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 3 );
-	} );
-
-	it( "returns an object with sentence beginnings and counts for two sentences in Italian starting with different words.", function() {
-		mockPaper = new Paper( "Volare, oh oh. Cantare, oh oh oh oh.", { locale: "it_IT" } );
-		researcher = new ItalianResearcher( mockPaper );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "volare" );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 1 );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 1 ].word ).toBe( "cantare" );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 1 ].count ).toBe( 1 );
-	} );
-
-	it( "returns an object with sentence beginnings and counts for two sentences in Italian starting with " +
-		"the same word.", function() {
-		mockPaper = new Paper( "E che dici di stare lassù. E volavo, volavo felice più in alto del sole ed ancora più su.", { locale: "it_IT" } );
-		researcher = new ItalianResearcher( mockPaper );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "e" );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 2 );
-	} );
-
-	it( "returns an object with sentence beginnings and counts for three sentences in Italian all starting " +
-		"with one of the exception words.", function() {
-		mockPaper = new Paper( "Una musica dolce. Una musica brutal. Una musica de cine.", { locale: "it_IT" } );
-		researcher = new ItalianResearcher( mockPaper );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "una musica" );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 3 );
-	} );
-
-	it( "returns an object with sentence beginnings and counts for two sentences in Italian that start " +
-		"with a character with a diacritic.", function() {
-		mockPaper = new Paper( "È freddo. È freddo.", { locale: "it_IT" } );
-		researcher = new ItalianResearcher( mockPaper );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "è" );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 2 );
-	} );
-
-	it( "returns an object with sentence beginnings and counts for two sentences in Russian starting with the same word.", function() {
-		mockPaper = new Paper( "Здравствуй, мир! Здравствуй, человек!", { locale: "ru_RU" } );
-		researcher = new RussianResearcher( mockPaper );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "здравствуй" );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 2 );
-	} );
-
-	it( "returns an object with sentence beginnings and counts for three sentences in Russian all starting " +
-		"with one of the exception words.", function() {
-		mockPaper = new Paper( "Этот человек ее унизил. Этот человек ее уничтожил. Этот человек стал ее проклятием.",
-			{ locale: "ru_RU" } );
-		researcher = new RussianResearcher( mockPaper );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "этот человек" );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 3 );
-	} );
-
-	it( "returns an object with sentence beginnings and counts for two sentences in Russian starting with different words.", function() {
-		mockPaper = new Paper( "Плюсы и минусы. Где в итоге лучше и почему?", { locale: "ru_RU" } );
-		researcher = new RussianResearcher( mockPaper );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "плюсы" );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 1 );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 1 ].word ).toBe( "где" );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 1 ].count ).toBe( 1 );
-	} );
-
-	it( "returns an object with sentence beginnings and counts for two sentences in Polish starting with different words.", function() {
-		mockPaper = new Paper( "Najpierw zjem jabłko. Potem zjem gruszkę. ", { locale: "pl_PL" } );
-		researcher = new PolishResearcher( mockPaper );
-
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "najpierw" );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 1 );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 1 ].word ).toBe( "potem" );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 1 ].count ).toBe( 1 );
-	} );
-
-	it( "returns an object with sentence beginnings and counts for two sentences in Polish starting with the same word.", function() {
-		mockPaper = new Paper( "Zawsze cię widzę. Zawsze cię słyszę.", { locale: "pl_PL" } );
-		researcher = new PolishResearcher( mockPaper );
-
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "zawsze" );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 2 );
-	} );
-
-	it( "returns an object with sentence beginnings and counts for three sentences in Polish all starting " +
-		"with one of the exception words.", function() {
-		mockPaper = new Paper( "To dziecko jest ładne. To dziecko jest brzydkie. To dziecko jest małe.", { locale: "pl_PL" } );
-		researcher = new PolishResearcher( mockPaper );
-
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "to dziecko" );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 3 );
-	} );
-
-	it( "returns an object with sentence beginnings and counts for three sentences in Polish that start " +
-		"with a character with a diacritic.", function() {
-		mockPaper = new Paper( "Żona mojego brata jest miła. Żona mojej siostry jest piękna. Żona moja jest najlepsza.", { locale: "pl_PL" } );
-		researcher = new PolishResearcher( mockPaper );
-
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "żona" );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 3 );
-	} );
-
-	it( "returns an object with sentence beginnings and counts for two sentences in Swedish starting with different words.", function() {
-		mockPaper = new Paper( "Är du osäker, testa en kort fristående kurs hellre än ett program. Passar ämnet dig kan du hoppa " +
-			"på ett program och tillgodoräkna dig kursen.", { locale: "sv_SE" } );
-		researcher = new SwedishResearcher( mockPaper );
-
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "är" );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 1 );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 1 ].word ).toBe( "passar" );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 1 ].count ).toBe( 1 );
-	} );
-
-	it( "returns an object with sentence beginnings and counts for two sentences in Swedish starting with the same word.", function() {
-		mockPaper = new Paper( "Du är lång. Du är kort.", { locale: "sv_SE" } );
-		researcher = new SwedishResearcher( mockPaper );
-
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "du" );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 2 );
-	} );
-
-	it( "returns an object with sentence beginnings and counts for three sentences in Swedish all starting " +
-		"with one of the exception words.", function() {
-		mockPaper = new Paper( "Detta barn är litet. Detta barn är stort. Detta barn är lyckligt.", { locale: "sv_SE" } );
-		researcher = new SwedishResearcher( mockPaper );
-
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "detta barn" );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 3 );
-	} );
-
-	it( "returns an object with sentence beginnings and counts for two sentences in Indonesian starting with different words.", function() {
-		mockPaper = new Paper( "Halo dunia!. Apa kabarmu? ", { locale: "id_ID" } );
-		researcher = new IndonesianResearcher( mockPaper );
-
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "halo" );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 1 );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 1 ].word ).toBe( "apa" );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 1 ].count ).toBe( 1 );
-	} );
-
-	it( "returns an object with sentence beginnings and counts for two sentences in Indonesian starting with the same word.", function() {
-		mockPaper = new Paper( "Bukunya murah. Bukunya mahal.", { locale: "id_ID" } );
-		researcher = new IndonesianResearcher( mockPaper );
-
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "bukunya" );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 2 );
-	} );
-
-	it( "returns an object with sentence beginnings and counts for three sentences in Indonesian all starting " +
-		"with one of the exception words.", function() {
-		mockPaper = new Paper( "Seorang pemimpin seharusnya bijaksana. Seorang pemimpin seharusnya memberi contoh yang baik. " +
-			"Seorang pemimpin seharusnya memikirkan rakyatnya", { locale: "id_ID" } );
-		researcher = new IndonesianResearcher( mockPaper );
-
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "seorang pemimpin" );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 3 );
-	} );
-
 	it( "returns an object with English sentence beginnings in lists", function() {
 		mockPaper = new Paper( "<ul><li>item 1</li><li>item 2</li><li>item 3</li><li>item 4</li></ul>" );
 		researcher = new EnglishResearcher( mockPaper );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "item", { locale: "en_US" } );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "item" );
 		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 4 );
 	} );
 
@@ -404,7 +91,7 @@ describe( "gets the sentence beginnings and the count of consecutive duplicates.
 		mockPaper = new Paper( "<p>Sentence 1. Sentence 2.</p><p>Sentence 3.</p>" );
 		researcher = new EnglishResearcher( mockPaper );
 
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "sentence", { locale: "en_US" } );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "sentence" );
 		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 3 );
 	} );
 
@@ -412,7 +99,7 @@ describe( "gets the sentence beginnings and the count of consecutive duplicates.
 		mockPaper = new Paper( "Sentence 1. SENTENCE 2. Sentence 3." );
 		researcher = new EnglishResearcher( mockPaper );
 
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "sentence", { locale: "en_US" } );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "sentence" );
 		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 3 );
 	} );
 
@@ -453,18 +140,18 @@ describe( "gets the sentence beginnings and the count of consecutive duplicates.
 			{ word: "test", count: 3, sentences: [ "Test one.", "Test two.", "Test three." ] } );
 	} );
 
-	it( "returns an object with three Spanish sentences starting with the same word when those words are " +
+	it( "returns an object with three sentences starting with the same word when those words are " +
 		"preceded by different special characters in each sentence.", function() {
 		mockPaper = new Paper( "¡Hola! ¡Hola? (¡Hola!)" );
 		researcher = new SpanishResearcher( mockPaper );
 
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "hola", { locale: "es_ES" } );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "hola" );
 		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 3 );
 	} );
 
-	it( "returns an object with sentence beginnings and counts for two sentences in English, " +
+	it( "returns an object with sentence beginnings and counts for two sentences " +
 		"when the sentences start with the same special character, but with different words.", function() {
-		mockPaper = new Paper( "(First sentence). (Second sentence).", { locale: "en_US" } );
+		mockPaper = new Paper( "(First sentence). (Second sentence)." );
 		researcher = new EnglishResearcher( mockPaper );
 
 		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "first" );
@@ -473,46 +160,8 @@ describe( "gets the sentence beginnings and the count of consecutive duplicates.
 		expect( getSentenceBeginnings( mockPaper, researcher )[ 1 ].count ).toBe( 1 );
 	} );
 
-	it( "returns an object with sentence beginnings and counts for three sentences in Arabic all starting " +
-		"with one of the exception words.", function() {
-		mockPaper = new Paper( "هؤلاء الأولاد غائبون. هؤلاء الأولاد هم طلاب. هؤلاء الأولاد في المنزل.", { locale: "ar_AR" } );
-		researcher = new ArabicResearcher( mockPaper );
-
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "هؤلاء الأولاد" );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 3 );
-	} );
-
-	it( "returns an object with sentence beginnings and counts for two sentences in Arabic starting with different words.", function() {
-		mockPaper = new Paper( "العشاء جاهز. ارجو أن تنضم الينا.", { locale: "ar_AR" } );
-		researcher = new ArabicResearcher( mockPaper );
-
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 1 );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 1 ].word ).toBe( "ارجو" );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 1 ].count ).toBe( 1 );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "العشاء" );
-	} );
-
-	it( "returns an object with sentence beginnings and counts for two sentences in Arabic starting with the same word.", function() {
-		mockPaper = new Paper( "مرحبا بالزائرين. مرحبا بالعالم.", { locale: "ar_AR" } );
-		researcher = new ArabicResearcher( mockPaper );
-
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "مرحبا" );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 2 );
-	} );
-} );
-
-describe( "gets the sentence beginnings data for Greek", () => {
-	let mockPaper;
-	let researcher;
-	it( "returns an object with sentence beginnings and counts for three sentences all starting with the same words", () => {
-		mockPaper = new Paper( "Οι γάτες είναι χαριτωμένες. Οι γάτες είναι γλυκές. Οι γάτες είναι αξιολάτρευτες.", { locale: "el" } );
-		researcher = new GreekResearcher( mockPaper );
-
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "οι" );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 3 );
-	} );
 	it( "returns an object with sentence beginnings and counts for three sentences all starting with the same words" +
-		" that are listed in first word exception list", () => {
+		" that are listed in first word exception list for a language that also has a list of second word exceptions", () => {
 		mockPaper = new Paper( " Ένα από τα πιο σημαντικά προβλήματα στην εποχή μας είναι η υπερθέρμανση του πλανήτη." +
 			" Ένα πρωινό, όπως πήγαινα στην δουλειά, βλέπω ένα μικρό γατάκι κάτω από ένα αυτοκίνητο." +
 			" Ένα παιδί έχει ανάγκη την οικογένεια του.", { locale: "el" } );
@@ -522,6 +171,7 @@ describe( "gets the sentence beginnings data for Greek", () => {
 		expect( getSentenceBeginnings( mockPaper, researcher )[ 1 ].word ).toBe( "ένα πρωινό" );
 		expect( getSentenceBeginnings( mockPaper, researcher )[ 2 ].word ).toBe( "ένα παιδί" );
 	} );
+
 	it( "returns an object with sentence beginnings and counts for three sentences all starting with the same words" +
 		" that are listed in first word exception list and followed by a word that is also in second word exception list", () => {
 		mockPaper = new Paper( "Αυτός ο μπαμπάς είναι φοβερός. Αυτός ο παππούς είναι καλός. Αυτός ο άνδρας είναι όμορφος.", { locale: "el" } );
@@ -531,35 +181,9 @@ describe( "gets the sentence beginnings data for Greek", () => {
 		expect( getSentenceBeginnings( mockPaper, researcher )[ 1 ].word ).toBe( "αυτός ο παππούς" );
 		expect( getSentenceBeginnings( mockPaper, researcher )[ 2 ].word ).toBe( "αυτός ο άνδρας" );
 	} );
-} );
 
-describe( "tests the sentence beginnings data for Japanese", () => {
-	let mockPaper;
-	let researcher;
-	it( "returns an object with sentence beginnings and counts for two sentences in Japanese starting with different words.", function() {
-		// https://tatoeba.org/en/sentences/show/425148
-		// https://tatoeba.org/en/sentences/show/9431906
-		mockPaper = new Paper( "私たちはよくチェスをします。チェスは難しい。", { locale: "ja_JP" } );
-		researcher = new JapaneseResearcher( mockPaper );
-
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "私" );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 1 );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 1 ].word ).toBe( "チェス" );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 1 ].count ).toBe( 1 );
-	} );
-
-	it( "returns an object with sentence beginnings and counts for two sentences in Japanese starting with the same word.", function() {
-		// https://tatoeba.org/en/sentences/show/810883
-		// https://tatoeba.org/en/sentences/show/2337881
-		mockPaper = new Paper( "寿司が好きです。寿司はおいしいです。", { locale: "ja_JP" } );
-		researcher = new JapaneseResearcher( mockPaper );
-
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "寿司" );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 2 );
-	} );
-
-	it( "returns an object with sentence beginnings and counts for four sentences in Japanese all starting " +
-		"with one of the exception words.", function() {
+	it( "returns an object with sentence beginnings and counts for four sentences in a language with a custom" +
+		"getWords helper (Japanese) all starting with one of the exception words.", function() {
 		// https://tatoeba.org/en/sentences/show/441382
 		// https://tatoeba.org/en/sentences/show/982233
 		// https://tatoeba.org/en/sentences/show/5289451
@@ -575,3 +199,4 @@ describe( "tests the sentence beginnings data for Japanese", () => {
 		expect( getSentenceBeginnings( mockPaper, researcher )[ 2 ].count ).toBe( 1 );
 	} );
 } );
+

--- a/packages/yoastseo/spec/languageProcessing/researches/getSentenceBeginningsSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/getSentenceBeginningsSpec.js
@@ -142,7 +142,7 @@ describe( "gets the sentence beginnings and the count of consecutive duplicates.
 
 	it( "returns an object with three sentences starting with the same word when those words are " +
 		"preceded by different special characters in each sentence.", function() {
-		mockPaper = new Paper( "¡Hola! ¡Hola? (¡Hola!)" );
+		mockPaper = new Paper( "¡Hola! ¿Hola? (¡Hola!)" );
 		researcher = new SpanishResearcher( mockPaper );
 
 		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "hola" );
@@ -159,6 +159,338 @@ describe( "gets the sentence beginnings and the count of consecutive duplicates.
 		expect( getSentenceBeginnings( mockPaper, researcher )[ 1 ].word ).toBe( "second" );
 		expect( getSentenceBeginnings( mockPaper, researcher )[ 1 ].count ).toBe( 1 );
 	} );
+
+	/*it( "returns an object with sentence beginnings and counts for two sentences in German starting with different words.", function() {
+		mockPaper = new Paper( "Ich bin wie du. Auf wiedersehen. ", { locale: "de_DE" } );
+		researcher = new GermanResearcher( mockPaper );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "ich" );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 1 );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 1 ].word ).toBe( "auf" );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 1 ].count ).toBe( 1 );
+	} );
+
+	it( "returns an object with sentence beginnings and counts for two sentences in German starting with the same word.", function() {
+		mockPaper = new Paper( "Hallo, hallo! Hallo.", { locale: "de_DE" } );
+		researcher = new GermanResearcher( mockPaper );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "hallo" );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 2 );
+	} );
+
+	it( "returns an object with sentence beginnings and counts for three sentences in German all starting " +
+		"with one of the exception words.", function() {
+		mockPaper = new Paper( "Eine kleine Nachtmusik. Eine kleine Geige. Eine kleine Wolke.", { locale: "de_DE" } );
+		researcher = new GermanResearcher( mockPaper );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "eine kleine" );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 3 );
+	} );
+
+	it( "returns an object with sentence beginnings and counts for sentences in German that start with a character with a diacritic.", function() {
+		mockPaper = new Paper( "Österreich ist ein schönes Land. Österreich ist ein schönes Land. Österreich " +
+			"ist ein schönes Land.", { locale: "de_DE" } );
+		researcher = new GermanResearcher( mockPaper );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "österreich" );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 3 );
+	} );
+
+	it( "returns an object with sentence beginnings and counts for two sentences in Spanish starting with different words.", function() {
+		mockPaper = new Paper( "Vamos a la playa. Muy buenos. ", { locale: "es_ES" } );
+		researcher = new SpanishResearcher( mockPaper );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "vamos" );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 1 );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 1 ].word ).toBe( "muy" );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 1 ].count ).toBe( 1 );
+	} );
+
+	it( "returns an object with sentence beginnings and counts for two sentences in Spanish starting with the same word.", function() {
+		mockPaper = new Paper( "Que si, Que no. Que nunca te decides.", { locale: "es_ES" } );
+		researcher = new SpanishResearcher( mockPaper );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "que" );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 2 );
+	} );
+
+	it( "returns an object with sentence beginnings and counts for three sentences in Spanish all starting " +
+		"with one of the exception words.", function() {
+		mockPaper = new Paper( "Aquellas pequeñas cosas. Aquellas pequeñas decisiones. Aquellas pequeñas ideas.", { locale: "es_ES" } );
+		researcher = new SpanishResearcher( mockPaper );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "aquellas pequeñas" );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 3 );
+	} );
+
+	it( "returns an object with sentence beginnings and counts for sentences in Spanish that start with a character with a diacritic.", function() {
+		mockPaper = new Paper( "África es un gran continente. África es un gran continente. África es un gran continente.", { locale: "es_ES" } );
+		researcher = new SpanishResearcher( mockPaper );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "áfrica" );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 3 );
+	} );
+
+	it( "returns an object with sentence beginnings and counts for two sentences in Portuguese starting with different words.", function() {
+		mockPaper = new Paper( "Quem sou? Para onde vou?", { locale: "pt_PT" } );
+		researcher = new PortugueseResearcher( mockPaper );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "quem" );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 1 );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 1 ].word ).toBe( "para" );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 1 ].count ).toBe( 1 );
+	} );
+
+	it( "returns an object with sentence beginnings and counts for two sentences in Portuguese starting with the same word.", function() {
+		mockPaper = new Paper( "Dora pensa sobre o quanto ela ama sua floresta. Dora ama explorar a floresta, saltando de ramo para ramo " +
+			"entre as árvores altas.", { locale: "pt_PT" } );
+		researcher = new PortugueseResearcher( mockPaper );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "dora" );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 2 );
+	} );
+
+	it( "returns an object with sentence beginnings and counts for three sentences in Portuguese all starting " +
+		"with one of the exception words.", function() {
+		mockPaper = new Paper( "O mês estava frio. O mês foi difícil. O final disso os fez felizes.", { locale: "pt_PT" } );
+		researcher = new PortugueseResearcher( mockPaper );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "o mês" );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 2 );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 1 ].word ).toBe( "o final" );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 1 ].count ).toBe( 1 );
+	} );
+
+	it( "returns an object with sentence beginnings and counts for sentences in Portuguese that start " +
+		"with a character with a diacritic.", function() {
+		mockPaper = new Paper( "Não viajo faz muito tempo. Não vi montanhas em anos. Não vi o mar desde que eu era pequeno.", { locale: "es_ES" } );
+		researcher = new PortugueseResearcher( mockPaper );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "não" );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 3 );
+	} );
+
+	it( "returns an object with sentence beginnings and counts for two sentences in Dutch starting with different words.", function() {
+		mockPaper = new Paper( "Hallo wereld. Hoe gaat het? ", { locale: "nl_NL" } );
+		researcher = new DutchResearcher( mockPaper );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "hallo" );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 1 );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 1 ].word ).toBe( "hoe" );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 1 ].count ).toBe( 1 );
+	} );
+
+	it( "returns an object with sentence beginnings and counts for two sentences in Dutch starting with the same word.", function() {
+		mockPaper = new Paper( "Hallo wereld. Hallo mensheid.", { locale: "nl_NL" } );
+		researcher = new DutchResearcher( mockPaper );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "hallo" );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 2 );
+	} );
+
+	it( "returns an object with sentence beginnings and counts for three sentences in Dutch all starting " +
+		"with one of the exception words.", function() {
+		mockPaper = new Paper( "Het is een nacht die je normaal alleen in films ziet. Het is een nacht die wordt bezongen in het mooiste lied. " +
+			"Het is een nacht waarvan ik dacht dat ik 'm nooit beleven zou", { locale: "nl_NL" } );
+		researcher = new DutchResearcher( mockPaper );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "het is" );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 3 );
+	} );
+
+	it( "returns an object with sentence beginnings and counts for two sentences in Italian starting with different words.", function() {
+		mockPaper = new Paper( "Volare, oh oh. Cantare, oh oh oh oh.", { locale: "it_IT" } );
+		researcher = new ItalianResearcher( mockPaper );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "volare" );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 1 );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 1 ].word ).toBe( "cantare" );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 1 ].count ).toBe( 1 );
+	} );
+
+	it( "returns an object with sentence beginnings and counts for two sentences in Italian starting with " +
+		"the same word.", function() {
+		mockPaper = new Paper( "E che dici di stare lassù. E volavo, volavo felice più in alto del sole ed ancora più su.", { locale: "it_IT" } );
+		researcher = new ItalianResearcher( mockPaper );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "e" );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 2 );
+	} );
+
+	it( "returns an object with sentence beginnings and counts for three sentences in Italian all starting " +
+		"with one of the exception words.", function() {
+		mockPaper = new Paper( "Una musica dolce. Una musica brutal. Una musica de cine.", { locale: "it_IT" } );
+		researcher = new ItalianResearcher( mockPaper );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "una musica" );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 3 );
+	} );
+
+	it( "returns an object with sentence beginnings and counts for two sentences in Italian that start " +
+		"with a character with a diacritic.", function() {
+		mockPaper = new Paper( "È freddo. È freddo.", { locale: "it_IT" } );
+		researcher = new ItalianResearcher( mockPaper );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "è" );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 2 );
+	} );
+
+	it( "returns an object with sentence beginnings and counts for two sentences in Russian starting with the same word.", function() {
+		mockPaper = new Paper( "Здравствуй, мир! Здравствуй, человек!", { locale: "ru_RU" } );
+		researcher = new RussianResearcher( mockPaper );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "здравствуй" );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 2 );
+	} );
+
+	it( "returns an object with sentence beginnings and counts for three sentences in Russian all starting " +
+		"with one of the exception words.", function() {
+		mockPaper = new Paper( "Этот человек ее унизил. Этот человек ее уничтожил. Этот человек стал ее проклятием.",
+			{ locale: "ru_RU" } );
+		researcher = new RussianResearcher( mockPaper );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "этот человек" );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 3 );
+	} );
+
+	it( "returns an object with sentence beginnings and counts for two sentences in Russian starting with different words.", function() {
+		mockPaper = new Paper( "Плюсы и минусы. Где в итоге лучше и почему?", { locale: "ru_RU" } );
+		researcher = new RussianResearcher( mockPaper );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "плюсы" );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 1 );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 1 ].word ).toBe( "где" );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 1 ].count ).toBe( 1 );
+	} );
+
+	it( "returns an object with sentence beginnings and counts for two sentences in Polish starting with different words.", function() {
+		mockPaper = new Paper( "Najpierw zjem jabłko. Potem zjem gruszkę. ", { locale: "pl_PL" } );
+		researcher = new PolishResearcher( mockPaper );
+
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "najpierw" );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 1 );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 1 ].word ).toBe( "potem" );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 1 ].count ).toBe( 1 );
+	} );
+
+	it( "returns an object with sentence beginnings and counts for two sentences in Polish starting with the same word.", function() {
+		mockPaper = new Paper( "Zawsze cię widzę. Zawsze cię słyszę.", { locale: "pl_PL" } );
+		researcher = new PolishResearcher( mockPaper );
+
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "zawsze" );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 2 );
+	} );
+
+	it( "returns an object with sentence beginnings and counts for three sentences in Polish all starting " +
+		"with one of the exception words.", function() {
+		mockPaper = new Paper( "To dziecko jest ładne. To dziecko jest brzydkie. To dziecko jest małe.", { locale: "pl_PL" } );
+		researcher = new PolishResearcher( mockPaper );
+
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "to dziecko" );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 3 );
+	} );
+
+	it( "returns an object with sentence beginnings and counts for three sentences in Polish that start " +
+		"with a character with a diacritic.", function() {
+		mockPaper = new Paper( "Żona mojego brata jest miła. Żona mojej siostry jest piękna. Żona moja jest najlepsza.", { locale: "pl_PL" } );
+		researcher = new PolishResearcher( mockPaper );
+
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "żona" );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 3 );
+	} );
+
+	it( "returns an object with sentence beginnings and counts for two sentences in Swedish starting with different words.", function() {
+		mockPaper = new Paper( "Är du osäker, testa en kort fristående kurs hellre än ett program. Passar ämnet dig kan du hoppa " +
+			"på ett program och tillgodoräkna dig kursen.", { locale: "sv_SE" } );
+		researcher = new SwedishResearcher( mockPaper );
+
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "är" );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 1 );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 1 ].word ).toBe( "passar" );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 1 ].count ).toBe( 1 );
+	} );
+
+	it( "returns an object with sentence beginnings and counts for two sentences in Swedish starting with the same word.", function() {
+		mockPaper = new Paper( "Du är lång. Du är kort.", { locale: "sv_SE" } );
+		researcher = new SwedishResearcher( mockPaper );
+
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "du" );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 2 );
+	} );
+
+	it( "returns an object with sentence beginnings and counts for three sentences in Swedish all starting " +
+		"with one of the exception words.", function() {
+		mockPaper = new Paper( "Detta barn är litet. Detta barn är stort. Detta barn är lyckligt.", { locale: "sv_SE" } );
+		researcher = new SwedishResearcher( mockPaper );
+
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "detta barn" );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 3 );
+	} );
+
+	it( "returns an object with sentence beginnings and counts for two sentences in Indonesian starting with different words.", function() {
+		mockPaper = new Paper( "Halo dunia!. Apa kabarmu? ", { locale: "id_ID" } );
+		researcher = new IndonesianResearcher( mockPaper );
+
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "halo" );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 1 );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 1 ].word ).toBe( "apa" );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 1 ].count ).toBe( 1 );
+	} );
+
+	it( "returns an object with sentence beginnings and counts for two sentences in Indonesian starting with the same word.", function() {
+		mockPaper = new Paper( "Bukunya murah. Bukunya mahal.", { locale: "id_ID" } );
+		researcher = new IndonesianResearcher( mockPaper );
+
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "bukunya" );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 2 );
+	} );
+
+	it( "returns an object with sentence beginnings and counts for three sentences in Indonesian all starting " +
+		"with one of the exception words.", function() {
+		mockPaper = new Paper( "Seorang pemimpin seharusnya bijaksana. Seorang pemimpin seharusnya memberi contoh yang baik. " +
+			"Seorang pemimpin seharusnya memikirkan rakyatnya", { locale: "id_ID" } );
+		researcher = new IndonesianResearcher( mockPaper );
+
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "seorang pemimpin" );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 3 );
+	} );
+
+	it( "returns an object with sentence beginnings and counts for two sentences in French starting with different words.", function() {
+		mockPaper = new Paper( "Sur le pont d'Avignon. Liberté, égalité, fraternité. ", { locale: "fr_FR" } );
+		researcher = new FrenchResearcher( mockPaper );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "sur" );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 1 );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 1 ].word ).toBe( "liberté" );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 1 ].count ).toBe( 1 );
+	} );
+
+	it( "returns an object with sentence beginnings and counts for two sentences in French starting with the same word.", function() {
+		mockPaper = new Paper( "Bonjour, tout le monde! Bonjour.", { locale: "fr_FR" } );
+		researcher = new FrenchResearcher( mockPaper );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "bonjour" );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 2 );
+	} );
+
+	it( "returns an object with sentence beginnings and counts for three sentences in French all starting " +
+		"with one of the exception words.", function() {
+		mockPaper = new Paper( "La vache qui rit. La vache qui pleure. La vache qui vole.", { locale: "fr_FR" } );
+		researcher = new FrenchResearcher( mockPaper );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "la vache" );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 3 );
+	} );*/
+
+/*	it( "returns an object with sentence beginnings and counts for three sentences in Arabic all starting " +
+		"with one of the exception words.", function() {
+		mockPaper = new Paper( "هؤلاء الأولاد غائبون. هؤلاء الأولاد هم طلاب. هؤلاء الأولاد في المنزل.", { locale: "ar_AR" } );
+		researcher = new ArabicResearcher( mockPaper );
+
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "هؤلاء الأولاد" );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 3 );
+	} );
+
+	it( "returns an object with sentence beginnings and counts for two sentences in Arabic starting with different words.", function() {
+		mockPaper = new Paper( "العشاء جاهز. ارجو أن تنضم الينا.", { locale: "ar_AR" } );
+		researcher = new ArabicResearcher( mockPaper );
+
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 1 );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 1 ].word ).toBe( "ارجو" );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 1 ].count ).toBe( 1 );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "العشاء" );
+	} );
+
+	it( "returns an object with sentence beginnings and counts for two sentences in Arabic starting with the same word.", function() {
+		mockPaper = new Paper( "مرحبا بالزائرين. مرحبا بالعالم.", { locale: "ar_AR" } );
+		researcher = new ArabicResearcher( mockPaper );
+
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "مرحبا" );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 2 );
+	} );*/
+
+	/*it( "returns an object with sentence beginnings and counts for three sentences all starting with the same words", () => {
+		mockPaper = new Paper( "Οι γάτες είναι χαριτωμένες. Οι γάτες είναι γλυκές. Οι γάτες είναι αξιολάτρευτες.", { locale: "el" } );
+		researcher = new GreekResearcher( mockPaper );
+
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "οι" );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 3 );
+	} );*/
 
 	it( "returns an object with sentence beginnings and counts for three sentences all starting with the same words" +
 		" that are listed in first word exception list for a language that also has a list of second word exceptions", () => {
@@ -181,6 +513,28 @@ describe( "gets the sentence beginnings and the count of consecutive duplicates.
 		expect( getSentenceBeginnings( mockPaper, researcher )[ 1 ].word ).toBe( "αυτός ο παππούς" );
 		expect( getSentenceBeginnings( mockPaper, researcher )[ 2 ].word ).toBe( "αυτός ο άνδρας" );
 	} );
+
+	/*it( "returns an object with sentence beginnings and counts for two sentences in Japanese starting with different words.", function() {
+		// https://tatoeba.org/en/sentences/show/425148
+		// https://tatoeba.org/en/sentences/show/9431906
+		mockPaper = new Paper( "私たちはよくチェスをします。チェスは難しい。", { locale: "ja_JP" } );
+		researcher = new JapaneseResearcher( mockPaper );
+
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "私" );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 1 );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 1 ].word ).toBe( "チェス" );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 1 ].count ).toBe( 1 );
+	} );
+
+	it( "returns an object with sentence beginnings and counts for two sentences in Japanese starting with the same word.", function() {
+		// https://tatoeba.org/en/sentences/show/810883
+		// https://tatoeba.org/en/sentences/show/2337881
+		mockPaper = new Paper( "寿司が好きです。寿司はおいしいです。", { locale: "ja_JP" } );
+		researcher = new JapaneseResearcher( mockPaper );
+
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "寿司" );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 2 );
+	} );*/
 
 	it( "returns an object with sentence beginnings and counts for four sentences in a language with a custom" +
 		"getWords helper (Japanese) all starting with one of the exception words.", function() {

--- a/packages/yoastseo/spec/languageProcessing/researches/getSentenceBeginningsSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/getSentenceBeginningsSpec.js
@@ -1,3 +1,4 @@
+/* eslint-disable capitalized-comments */
 import getSentenceBeginnings from "../../../src/languageProcessing/researches/getSentenceBeginnings";
 
 import Paper from "../../../src/values/Paper.js";

--- a/packages/yoastseo/spec/languageProcessing/researches/getWordFormsSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/getWordFormsSpec.js
@@ -37,7 +37,7 @@ describe( "A test for getting word forms from the text, based on the stems of a 
 		);
 	} );
 
-	it( "returns forms found in the text for multiple keyphrases and synonyms with multiple words;" +
+/*	it( "returns forms found in the text for multiple keyphrases and synonyms with multiple words;" +
 		"German stemmer", () => {
 		const text = "Eine Orange und eine Heidelbeere. Die Apfelsinen sind sauer. Die Blaubeeren sind süß.";
 		const attributes = {
@@ -64,7 +64,7 @@ describe( "A test for getting word forms from the text, based on the stems of a 
 				],
 			}
 		);
-	} );
+	} );*/
 
 	it( "returns empty structure if no keyword or synonyms are supplied", () => {
 		const attributes = {
@@ -314,6 +314,7 @@ describe( "A test for getting word forms from the text, based on the stems of a 
 	} );
 } );
 
+/*
 describe( "A test for creating basic morphology forms in supported languages", () => {
 	it( "returns all possible prefixed forms for Hebrew keyphrases", () => {
 		const attributes = {
@@ -366,7 +367,9 @@ describe( "A test for creating basic morphology forms in supported languages", (
 		);
 	} );
 } );
+*/
 
+/*
 describe( "A test for creating basic morphology forms in supported languages", () => {
 	it( "returns all possible prefixed forms for Arabic keyphrases", () => {
 		const attributes = {
@@ -466,6 +469,8 @@ describe( "A test for creating basic morphology forms in supported languages", (
 		);
 	} );
 } );
+*/
+/*
 
 describe( "A test for creating basic morphology forms in supported languages", () => {
 	it( "returns all possible prefixed forms for Farsi keyphrases", () => {
@@ -519,3 +524,4 @@ describe( "A test for creating basic morphology forms in supported languages", (
 		);
 	} );
 } );
+*/

--- a/packages/yoastseo/spec/languageProcessing/researches/getWordFormsSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/getWordFormsSpec.js
@@ -1,17 +1,12 @@
 import EnglishResearcher from "../../../src/languageProcessing/languages/en/Researcher";
-import GermanResearcher from "../../../src/languageProcessing/languages/de/Researcher";
 import ItalianResearcher from "../../../src/languageProcessing/languages/it/Researcher";
-import HebrewResearcher from "../../../src/languageProcessing/languages/he/Researcher";
-import ArabicResearcher from "../../../src/languageProcessing/languages/ar/Researcher";
 import SwedishResearcher from "../../../src/languageProcessing/languages/sv/Researcher";
-import FarsiResearcher from "../../../src/languageProcessing/languages/fa/Researcher";
 import DefaultResearcher from "../../../src/languageProcessing/languages/_default/Researcher";
 import getWordForms from "../../../src/languageProcessing/researches/getWordForms";
 import { primeLanguageSpecificData } from "../../../src/languageProcessing/helpers/morphology/buildTopicStems";
 import Paper from "../../../src/values/Paper";
 import getMorphologyData from "../../specHelpers/getMorphologyData";
 const morphologyDataEN = getMorphologyData( "en" );
-const morphologyDataDE = getMorphologyData( "de" );
 
 const testText = "I walked my dog. The cat walks along. The canine and the feline were walking.";
 

--- a/packages/yoastseo/spec/languageProcessing/researches/getWordFormsSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/getWordFormsSpec.js
@@ -1,3 +1,4 @@
+/* eslint-disable capitalized-comments */
 import EnglishResearcher from "../../../src/languageProcessing/languages/en/Researcher";
 import ItalianResearcher from "../../../src/languageProcessing/languages/it/Researcher";
 import SwedishResearcher from "../../../src/languageProcessing/languages/sv/Researcher";

--- a/packages/yoastseo/spec/languageProcessing/researches/getWordFormsSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/getWordFormsSpec.js
@@ -1,4 +1,4 @@
-/* eslint-disable capitalized-comments */
+/* eslint-disable capitalized-comments, spaced-comment */
 import EnglishResearcher from "../../../src/languageProcessing/languages/en/Researcher";
 import ItalianResearcher from "../../../src/languageProcessing/languages/it/Researcher";
 import SwedishResearcher from "../../../src/languageProcessing/languages/sv/Researcher";
@@ -33,7 +33,7 @@ describe( "A test for getting word forms from the text, based on the stems of a 
 		);
 	} );
 
-/*	it( "returns forms found in the text for multiple keyphrases and synonyms with multiple words;" +
+	/*	it( "returns forms found in the text for multiple keyphrases and synonyms with multiple words;" +
 		"German stemmer", () => {
 		const text = "Eine Orange und eine Heidelbeere. Die Apfelsinen sind sauer. Die Blaubeeren sind süß.";
 		const attributes = {

--- a/packages/yoastseo/spec/languageProcessing/researches/keyphraseDistributionSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/keyphraseDistributionSpec.js
@@ -126,9 +126,8 @@ const sentencesIT = [
 ];
 
 
-// Removing the italian tests also makes topicShortIT and topicLingIT redundant
 
-/*const topicShortIT = [
+const topicShortIT = [
 	[ "parola" ],
 	[ "chiave" ],
 ];
@@ -138,7 +137,7 @@ const topicLongIT = [
 	[ "chiave" ],
 	[ "straordinaria" ],
 	[ "qualcosa" ],
-];*/
+];
 
 
 describe( "Test for computing the sentence score", function() {
@@ -150,15 +149,14 @@ describe( "Test for computing the sentence score", function() {
 		expect( computeScoresPerSentenceLongTopic( topicLong, sentences, "en_EN" ) ).toEqual( [ 3, 9, 9, 9, 3, 3, 3, 3 ]  );
 	} );
 
-/*	it( "for a short topic for a language that doesn't support morphology", function() {
+	it( "for a short topic for a language that doesn't support morphology", function() {
 		expect( computeScoresPerSentenceShortTopic( topicShortIT, sentencesIT, "it_IT" ) ).toEqual( [ 3, 3, 9, 3, 3, 3, 3, 3 ] );
 	} );
 
 	it( "for a long topic for a language that doesn't support morphology", function() {
 		expect( computeScoresPerSentenceLongTopic( topicLongIT, sentencesIT, "it_IT" ) ).toEqual( [ 3, 9, 9, 9, 3, 3, 3, 3 ] );
-	} );*/
+	} );
 } );
-
 
 describe( "Test for the research", function() {
 	it( "returns a score over all sentences and all topic forms; returns markers for sentences that contain the topic", function() {
@@ -260,7 +258,9 @@ describe( "Test for the research", function() {
 		} );
 	} );
 
-	it( "returns a score (for a language without morphology support) over all sentences and all topic forms; returns markers for " +
+	//It’s the same as the English one above it, excepts the locale is Italian. But still the English morphology data is added.
+
+	/*it( "returns a score (for a language without morphology support) over all sentences and all topic forms; returns markers for " +
 		"sentences that contain the topic", function() {
 		const paper = new Paper(
 			sentencesIT.join( " " ),
@@ -307,6 +307,8 @@ describe( "Test for the research", function() {
 			],
 		} );
 	} );
+*/
+	// I figured that the following italian tests are not language specific as they are an example of languages in general that have no morphology support.
 
 	it( "returns the same score when function words are added (for a language without morphological support, but with function words, " +
 		"e.g. Italian in Free)", function() {
@@ -354,7 +356,6 @@ describe( "Test for the research", function() {
 			],
 		} );
 	} );
-
 	it( "when the topic words don't contain function words and the function words for this locale are not available, " +
 		"returns the same score", function() {
 		const paper = new Paper(
@@ -740,6 +741,8 @@ describe( "Test for the research", function() {
 		} );
 	} );
 } );
+
+//Did not remove Japanese tests below as they test the function with different helpers as well as japaneseTopicLength
 
 const japaneseSentences = "私はペットとして2匹の猫を飼っています。" +
 	"どちらもとても可愛くて甘い猫で、猫の餌を食べるのが大好きです。" +

--- a/packages/yoastseo/spec/languageProcessing/researches/keyphraseDistributionSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/keyphraseDistributionSpec.js
@@ -1,4 +1,4 @@
-/* eslint-disable capitalized-comments */
+/* eslint-disable capitalized-comments, spaced-comment */
 import { primeLanguageSpecificData } from "../../../src/languageProcessing/helpers/morphology/buildTopicStems";
 import {
 	computeScoresPerSentenceShortTopic,
@@ -125,8 +125,6 @@ const sentencesIT = [
 	"Ancora niente!",
 	"Una parola e ancora un'altra e poi un'altra ancora, che schifo!",
 ];
-
-
 
 const topicShortIT = [
 	[ "parola" ],

--- a/packages/yoastseo/spec/languageProcessing/researches/keyphraseDistributionSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/keyphraseDistributionSpec.js
@@ -125,7 +125,10 @@ const sentencesIT = [
 	"Una parola e ancora un'altra e poi un'altra ancora, che schifo!",
 ];
 
-const topicShortIT = [
+
+// Removing the italian tests also makes topicShortIT and topicLingIT redundant
+
+/*const topicShortIT = [
 	[ "parola" ],
 	[ "chiave" ],
 ];
@@ -135,7 +138,7 @@ const topicLongIT = [
 	[ "chiave" ],
 	[ "straordinaria" ],
 	[ "qualcosa" ],
-];
+];*/
 
 
 describe( "Test for computing the sentence score", function() {
@@ -147,13 +150,13 @@ describe( "Test for computing the sentence score", function() {
 		expect( computeScoresPerSentenceLongTopic( topicLong, sentences, "en_EN" ) ).toEqual( [ 3, 9, 9, 9, 3, 3, 3, 3 ]  );
 	} );
 
-	it( "for a short topic for a language that doesn't support morphology", function() {
+/*	it( "for a short topic for a language that doesn't support morphology", function() {
 		expect( computeScoresPerSentenceShortTopic( topicShortIT, sentencesIT, "it_IT" ) ).toEqual( [ 3, 3, 9, 3, 3, 3, 3, 3 ] );
 	} );
 
 	it( "for a long topic for a language that doesn't support morphology", function() {
 		expect( computeScoresPerSentenceLongTopic( topicLongIT, sentencesIT, "it_IT" ) ).toEqual( [ 3, 9, 9, 9, 3, 3, 3, 3 ] );
-	} );
+	} );*/
 } );
 
 

--- a/packages/yoastseo/spec/languageProcessing/researches/keyphraseDistributionSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/keyphraseDistributionSpec.js
@@ -1,3 +1,4 @@
+/* eslint-disable capitalized-comments */
 import { primeLanguageSpecificData } from "../../../src/languageProcessing/helpers/morphology/buildTopicStems";
 import {
 	computeScoresPerSentenceShortTopic,

--- a/packages/yoastseo/spec/languageProcessing/researches/keyphraseLengthSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/keyphraseLengthSpec.js
@@ -1,5 +1,4 @@
 import EnglishResearcher from "../../../src/languageProcessing/languages/en/Researcher";
-import FrenchResearcher from "../../../src/languageProcessing/languages/fr/Researcher";
 import getMorphologyData from "../../specHelpers/getMorphologyData";
 import keyphraseLength from "../../../src/languageProcessing/researches/keyphraseLength.js";
 import Paper from "../../../src/values/Paper.js";

--- a/packages/yoastseo/spec/languageProcessing/researches/keyphraseLengthSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/keyphraseLengthSpec.js
@@ -31,7 +31,7 @@ describe( "the keyphrase length research", function() {
 } );
 
 /*
-describe( "the keyphrase length research", function() {
+Describe( "the keyphrase length research", function() {
 	it( "should count the words in the input and filters function words", function() {
 		const paper = new Paper( "", { keyword: "mot mot le mot", locale: "fr_FR" } );
 		const researcher = new FrenchResearcher( paper );

--- a/packages/yoastseo/spec/languageProcessing/researches/keyphraseLengthSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/keyphraseLengthSpec.js
@@ -30,6 +30,7 @@ describe( "the keyphrase length research", function() {
 	} );
 } );
 
+/*
 describe( "the keyphrase length research", function() {
 	it( "should count the words in the input and filters function words", function() {
 		const paper = new Paper( "", { keyword: "mot mot le mot", locale: "fr_FR" } );
@@ -40,6 +41,7 @@ describe( "the keyphrase length research", function() {
 		expect( result.keyphraseLength ).toBe( 3 );
 	} );
 } );
+*/
 
 describe( "the keyphrase length research for empty keyword", function() {
 	it( "should count the words in the input", function() {

--- a/packages/yoastseo/spec/languageProcessing/researches/keywordCountInUrlSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/keywordCountInUrlSpec.js
@@ -1,3 +1,4 @@
+/* eslint-disable capitalized-comments */
 import { keywordCountInSlug as slugKeyword, keywordCountInUrl as urlKeyword } from "../../../src/languageProcessing/researches/keywordCountInUrl.js";
 import Paper from "../../../src/values/Paper.js";
 import EnglishResearcher from "../../../src/languageProcessing/languages/en/Researcher";

--- a/packages/yoastseo/spec/languageProcessing/researches/keywordCountInUrlSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/keywordCountInUrlSpec.js
@@ -107,34 +107,21 @@ describe( "test to check slug for keyword", function() {
 		expect( slugKeyword( paper, researcher ) ).toEqual( { keyphraseLength: 1, percentWordMatches: 100 } );
 	} );
 
-	it( "returns matches with special diacritics rules for German", function() {
-		const paper = new Paper( "", { slug: "natuerlich", keyword: "natürlich", locale: "de_DE" } );
-		const researcher = new GermanResearcher( paper );
-		researcher.addResearchData( "morphology", morphologyDataDe );
-		expect( slugKeyword( paper, researcher ) ).toEqual( { keyphraseLength: 1, percentWordMatches: 100 } );
-	} );
+	// it( "returns matches with special diacritics rules for German", function() {
+	// 	const paper = new Paper( "", { slug: "natuerlich", keyword: "natürlich", locale: "de_DE" } );
+	// 	const researcher = new GermanResearcher( paper );
+	// 	researcher.addResearchData( "morphology", morphologyDataDe );
+	// 	expect( slugKeyword( paper, researcher ) ).toEqual( { keyphraseLength: 1, percentWordMatches: 100 } );
+	// } );
+	//
+	// it( "returns matches with diacritics differences for German", function() {
+	// 	const paper = new Paper( "", { slug: "naturlich", keyword: "natürlich", locale: "de_DE" } );
+	// 	const researcher = new GermanResearcher( paper );
+	// 	researcher.addResearchData( "morphology", morphologyDataDe );
+	// 	expect( slugKeyword( paper, researcher ) ).toEqual( { keyphraseLength: 1, percentWordMatches: 0 } );
+	// } );
 
-	it( "returns matches with diacritics differences for German", function() {
-		const paper = new Paper( "", { slug: "naturlich", keyword: "natürlich", locale: "de_DE" } );
-		const researcher = new GermanResearcher( paper );
-		researcher.addResearchData( "morphology", morphologyDataDe );
-		expect( slugKeyword( paper, researcher ) ).toEqual( { keyphraseLength: 1, percentWordMatches: 0 } );
-	} );
-
-	it( "returns matches with diacritics differences for Swedish", function() {
-		const paper = new Paper( "", { slug: "bla-bla-oeverlaatelsebesiktning", keyword: "överlåtelsebesiktning", locale: "sv_SE" } );
-		const researcher = new EnglishResearcher( paper );
-		researcher.addResearchData( "morphology", morphologyData );
-		expect( slugKeyword( paper, researcher ) ).toEqual( { keyphraseLength: 1, percentWordMatches: 100 } );
-	} );
-
-	it( "returns matches with diacritics differences for Swedish", function() {
-		const paper = new Paper( "", { slug: "bla-bla-overlatelsebesiktning", keyword: "överlåtelsebesiktning", locale: "sv_SE" } );
-		const researcher = new EnglishResearcher( paper );
-		researcher.addResearchData( "morphology", morphologyData );
-		expect( slugKeyword( paper, researcher ) ).toEqual( { keyphraseLength: 1, percentWordMatches: 100 } );
-	} );
-
+	// git a
 	it( "does not break for English if no morphology is supplied", function() {
 		const paper = new Paper( "", { slug: "a-a-a-keyphrase-a-a-a", keyword: "keyphrase", locale: "en_EN" } );
 		const researcher = new EnglishResearcher( paper );

--- a/packages/yoastseo/spec/languageProcessing/researches/keywordCountInUrlSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/keywordCountInUrlSpec.js
@@ -121,7 +121,7 @@ describe( "test to check slug for keyword", function() {
 	// 	expect( slugKeyword( paper, researcher ) ).toEqual( { keyphraseLength: 1, percentWordMatches: 0 } );
 	// } );
 
-	// git a
+	//
 	it( "does not break for English if no morphology is supplied", function() {
 		const paper = new Paper( "", { slug: "a-a-a-keyphrase-a-a-a", keyword: "keyphrase", locale: "en_EN" } );
 		const researcher = new EnglishResearcher( paper );

--- a/packages/yoastseo/spec/languageProcessing/researches/keywordCountInUrlSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/keywordCountInUrlSpec.js
@@ -1,12 +1,10 @@
 import { keywordCountInSlug as slugKeyword, keywordCountInUrl as urlKeyword } from "../../../src/languageProcessing/researches/keywordCountInUrl.js";
 import Paper from "../../../src/values/Paper.js";
 import EnglishResearcher from "../../../src/languageProcessing/languages/en/Researcher";
-import GermanResearcher from "../../../src/languageProcessing/languages/de/Researcher";
 import getMorphologyData from "../../specHelpers/getMorphologyData";
 
 
 const morphologyData = getMorphologyData( "en" );
-const morphologyDataDe = getMorphologyData( "de" );
 
 describe( "test to check slug for keyword", function() {
 	it( "returns simple matches", function() {

--- a/packages/yoastseo/spec/languageProcessing/researches/keywordCountSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/keywordCountSpec.js
@@ -201,6 +201,8 @@ const buildJapaneseMockResearcher = function( keyphraseForms, helper1, helper2 )
 	} );
 };
 
+
+// Decided not to remove test below as it tests the added logic of the Japanese helpers.
 describe( "Test for counting the keyword in a text for Japanese", () => {
 	it( "counts/marks a string of text with a keyword in it.", function() {
 		const mockPaper = new Paper( "私の猫はかわいいです。", { locale: "ja", keyphrase: "猫" } );

--- a/packages/yoastseo/spec/languageProcessing/researches/matchKeywordInSubheadingsSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/matchKeywordInSubheadingsSpec.js
@@ -67,6 +67,7 @@ const buildJapaneseMockResearcher = function( keyphraseForms, synonymsForms, mat
 		matchWordCustomHelper: matchWords,
 	} );
 };
+/*
 
 describe( "Matching keyphrase in subheadings with custom helper to match word in text", () => {
 	// The Japanese researcher has a custom helper to match word in text.
@@ -166,3 +167,4 @@ describe( "Matching keyphrase in subheadings with custom helper to match word in
 		expect( result.percentReflectingTopic ).toBe( 0 );
 	} );
 } );
+*/

--- a/packages/yoastseo/spec/languageProcessing/researches/matchKeywordInSubheadingsSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/matchKeywordInSubheadingsSpec.js
@@ -1,3 +1,4 @@
+/* eslint-disable capitalized-comments */
 import matchKeywordInSubheadings from "../../../src/languageProcessing/researches/matchKeywordInSubheadings";
 import Paper from "../../../src/values/Paper";
 import Researcher from "../../../src/languageProcessing/languages/en/Researcher";

--- a/packages/yoastseo/spec/languageProcessing/researches/matchKeywordInSubheadingsSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/matchKeywordInSubheadingsSpec.js
@@ -2,9 +2,6 @@ import matchKeywordInSubheadings from "../../../src/languageProcessing/researche
 import Paper from "../../../src/values/Paper";
 import Researcher from "../../../src/languageProcessing/languages/en/Researcher";
 import DefaultResearcher from "../../../src/languageProcessing/languages/_default/Researcher";
-import factory from "../../specHelpers/factory";
-import japaneseFunctionWords from "../../../src/languageProcessing/languages/ja/config/functionWords";
-import matchWordsHelper from "../../../src/languageProcessing/languages/ja/helpers/matchTextWithWord";
 
 describe( "Matching keyphrase in subheadings", () => {
 	it( "matches only h2 and h3 subheadings", () => {
@@ -50,7 +47,6 @@ describe( "Matching keyphrase in subheadings", () => {
  * @param {function} matchWords         A helper needed for the assesment.
  * @param {Object} functionWordsConfig  Function words config needed for the assesment.
  * @returns {Researcher} The mock researcher with added morphological forms and custom helper.
- */
 const buildJapaneseMockResearcher = function( keyphraseForms, synonymsForms, matchWords, functionWordsConfig ) {
 	return factory.buildMockResearcher( {
 		morphology: {
@@ -66,7 +62,7 @@ const buildJapaneseMockResearcher = function( keyphraseForms, synonymsForms, mat
 	{
 		matchWordCustomHelper: matchWords,
 	} );
-};
+};*/
 /*
 
 describe( "Matching keyphrase in subheadings with custom helper to match word in text", () => {

--- a/packages/yoastseo/spec/languageProcessing/researches/metaDescriptionKeywordSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/metaDescriptionKeywordSpec.js
@@ -1,3 +1,4 @@
+/* eslint-disable capitalized-comments */
 import metaDescriptionKeyword from "../../../src/languageProcessing/researches/metaDescriptionKeyword.js";
 import Paper from "../../../src/values/Paper.js";
 import Researcher from "../../../src/languageProcessing/languages/en/Researcher";

--- a/packages/yoastseo/spec/languageProcessing/researches/metaDescriptionKeywordSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/metaDescriptionKeywordSpec.js
@@ -1,4 +1,4 @@
-/* eslint-disable capitalized-comments */
+/* eslint-disable capitalized-comments, spaced-comment */
 import metaDescriptionKeyword from "../../../src/languageProcessing/researches/metaDescriptionKeyword.js";
 import Paper from "../../../src/values/Paper.js";
 import Researcher from "../../../src/languageProcessing/languages/en/Researcher";
@@ -134,8 +134,6 @@ describe( "the metadescription keyword match research", function() {
 		expect( result ).toEqual( 1 );
 	} );
 } );
-
-
 
 /*
 

--- a/packages/yoastseo/spec/languageProcessing/researches/metaDescriptionKeywordSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/metaDescriptionKeywordSpec.js
@@ -1,13 +1,9 @@
 import metaDescriptionKeyword from "../../../src/languageProcessing/researches/metaDescriptionKeyword.js";
 import Paper from "../../../src/values/Paper.js";
 import Researcher from "../../../src/languageProcessing/languages/en/Researcher";
-import JapaneseResearcher from "../../../src/languageProcessing/languages/ja/Researcher";
-import TurkishResearcher from "../../../src/languageProcessing/languages/tr/Researcher";
 import getMorphologyData from "../../specHelpers/getMorphologyData";
 
 const morphologyData = getMorphologyData( "en" );
-const morphologyDataJA = getMorphologyData( "ja" );
-const morphologyDataTR = getMorphologyData( "tr" );
 
 describe( "the metadescription keyword match research", function() {
 	it( "returns the number ( 1 ) of keywords found", function() {

--- a/packages/yoastseo/spec/languageProcessing/researches/metaDescriptionKeywordSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/metaDescriptionKeywordSpec.js
@@ -138,6 +138,10 @@ describe( "the metadescription keyword match research", function() {
 	} );
 } );
 
+
+
+/*
+
 describe( "the meta description keyphrase match research for keyphrases that contain apostrophe", () => {
 	it( "returns 1 for Turkish when the keyphrase has an apostrophe and starts with an uppercase letter and a match " +
 		"with a different form is found in the meta description", function() {
@@ -176,6 +180,13 @@ describe( "the meta description keyphrase match research for keyphrases that con
 		expect( result ).toEqual( 1 );
 	} );
 } );
+*/
+
+
+// ============
+
+
+/*
 
 describe( "the meta description keyword match research for languages that have custom helper to match words", function() {
 	// Japanese has a custom helper to match words.
@@ -337,4 +348,5 @@ describe( "the meta description keyword match research for languages that have c
 		} );
 	} );
 } );
+*/
 

--- a/packages/yoastseo/spec/languageProcessing/researches/metaDescriptionLengthSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/metaDescriptionLengthSpec.js
@@ -20,6 +20,7 @@ describe( "the meta description length research", function() {
 		expect( result ).toBe( 0 );
 	} );
 } );
+/*
 
 describe( "the meta description length research for Japanese", function() {
 	it( "returns the length of the description when the date is empty", function() {
@@ -34,3 +35,4 @@ describe( "the meta description length research for Japanese", function() {
 		expect( result ).toBe( 36 );
 	} );
 } );
+*/

--- a/packages/yoastseo/spec/languageProcessing/researches/metaDescriptionLengthSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/metaDescriptionLengthSpec.js
@@ -1,3 +1,4 @@
+/* eslint-disable capitalized-comments */
 import metaDescriptionLength from "../../../src/languageProcessing/researches/metaDescriptionLength.js";
 import Paper from "../../../src/values/Paper.js";
 

--- a/packages/yoastseo/spec/languageProcessing/researches/readingTimeSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/readingTimeSpec.js
@@ -135,6 +135,7 @@ describe( "Calculates the reading time for the paper (rounded up to the next hig
 	} );
 } );
 
+
 describe( "Calculates the reading time for the paper (rounded up to the next highest full minute), using characters per minute formula", function() {
 	it( "calculates the reading time for a Japanese paper with a short text", function() {
 		const mockPaper = new Paper( "これは短いテキストです。", { locale: "ja" } );
@@ -242,3 +243,4 @@ describe( "Calculates the reading time for the paper (rounded up to the next hig
 		expect( readingTime( mockPaper, researcher ) ).toEqual( 3 );
 	} );
 } );
+

--- a/packages/yoastseo/spec/scoring/assessments/readability/SentenceBeginningsAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/readability/SentenceBeginningsAssessmentSpec.js
@@ -1,17 +1,5 @@
 import DefaultResearcher from "../../../../src/languageProcessing/languages/_default/Researcher";
-import FrenchResearcher from "../../../../src/languageProcessing/languages/fr/Researcher";
-import GermanResearcher from "../../../../src/languageProcessing/languages/de/Researcher";
-import SpanishResearcher from "../../../../src/languageProcessing/languages/es/Researcher";
 import ItalianResearcher from "../../../../src/languageProcessing/languages/it/Researcher";
-import EnglishResearcher from "../../../../src/languageProcessing/languages/en/Researcher";
-import DutchResearcher from "../../../../src/languageProcessing/languages/nl/Researcher";
-import PolishResearcher from "../../../../src/languageProcessing/languages/pl/Researcher";
-import SwedishResearcher from "../../../../src/languageProcessing/languages/sv/Researcher";
-import IndonesianResearcher from "../../../../src/languageProcessing/languages/id/Researcher";
-import RussianResearcher from "../../../../src/languageProcessing/languages/ru/Researcher";
-import HungarianResearcher from "../../../../src/languageProcessing/languages/hu/Researcher";
-import TurkishResearcher from "../../../../src/languageProcessing/languages/tr/Researcher";
-
 import SentenceBeginningsAssessment from "../../../../src/scoring/assessments/readability/SentenceBeginningsAssessment.js";
 import Paper from "../../../../src/values/Paper.js";
 import Factory from "../../../specHelpers/factory.js";
@@ -20,7 +8,7 @@ import Mark from "../../../../src/values/Mark.js";
 let paper = new Paper();
 // eslint-disable-next-line max-statements
 describe( "An assessment for scoring repeated sentence beginnings.", function() {
-	it( "scores one instance with 4 consecutive English sentences starting with the same word.", function() {
+	it( "scores one instance with 4 consecutive sentences starting with the same word.", function() {
 		const assessment = new SentenceBeginningsAssessment().getResult( paper, Factory.buildMockResearcher( [ { word: "hey", count: 2 },
 			{ word: "cup", count: 2 },
 			{ word: "laptop", count: 1 },
@@ -31,7 +19,7 @@ describe( "An assessment for scoring repeated sentence beginnings.", function() 
 			" <a href='https://yoa.st/35g' target='_blank'>Try to mix things up</a>!" );
 	} );
 
-	it( "scores two instance with too many consecutive English sentences starting with the same word, 5 being the lowest count.", function() {
+	it( "scores two instance with too many consecutive sentences starting with the same word, 5 being the lowest count.", function() {
 		const assessment = new SentenceBeginningsAssessment().getResult( paper, Factory.buildMockResearcher( [ { word: "hey", count: 2 },
 			{ word: "banana", count: 6 }, { word: "pencil", count: 1 },
 			{ word: "bottle", count: 5 } ] ) );
@@ -41,7 +29,7 @@ describe( "An assessment for scoring repeated sentence beginnings.", function() 
 			"target='_blank'>Try to mix things up</a>!" );
 	} );
 
-	it( "scores zero instance with too many consecutive English sentences starting with the same word.", function() {
+	it( "scores zero instance with too many consecutive sentences starting with the same word.", function() {
 		const assessment = new SentenceBeginningsAssessment().getResult( paper, Factory.buildMockResearcher( [ { word: "hey", count: 1 },
 			{ word: "telephone", count: 2 }, { word: "towel", count: 2 },
 			{ word: "couch", count: 1 } ] ) );
@@ -50,260 +38,19 @@ describe( "An assessment for scoring repeated sentence beginnings.", function() 
 			"There is enough variety in your sentences. That's great!" );
 	} );
 
-	it( "scores one instance with 4 consecutive German sentences starting with the same word.", function() {
-		const assessment = new SentenceBeginningsAssessment().getResult( paper, Factory.buildMockResearcher( [ { word: "hallo", count: 2 },
-			{ word: "Stuhl", count: 2 }, { word: "Banane", count: 1 },
-			{ word: "Tafel", count: 4 } ] ) );
-		expect( assessment.getScore() ).toBe( 3 );
-		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: T" +
-			"he text contains 4 consecutive sentences starting with the same word." +
-			" <a href='https://yoa.st/35g' target='_blank'>Try to mix things up</a>!" );
-	} );
-
-	it( "scores two instance with too many consecutive German sentences starting with the same word, 5 being the lowest count.", function() {
-		const assessment = new SentenceBeginningsAssessment().getResult( paper, Factory.buildMockResearcher( [ { word: "hallo", count: 2 },
-			{ word: "Banane", count: 6 }, { word: "Blatt", count: 1 },
-			{ word: "Schloss", count: 5 } ] ) );
-		expect( assessment.getScore() ).toBe( 3 );
-		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: " +
-			"The text contains 2 instances where 5 or more consecutive sentences start with the same word. <a href='https://yoa.st/35g' " +
-			"target='_blank'>Try to mix things up</a>!" );
-	} );
-
-	it( "scores zero instance with too many consecutive German sentences starting with the same word.", function() {
-		const assessment = new SentenceBeginningsAssessment().getResult( paper, Factory.buildMockResearcher( [ { word: "hallo", count: 1 },
-			{ word: "Telefon", count: 2 }, { word: "Hund", count: 2 },
-			{ word: "Haus", count: 1 } ] ) );
-		expect( assessment.getScore() ).toBe( 9 );
-		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: " +
-			"There is enough variety in your sentences. That's great!" );
-	} );
-
-	it( "scores one instance with 4 consecutive Indonesian sentences starting with the same word.", function() {
-		const assessment = new SentenceBeginningsAssessment().getResult( paper, Factory.buildMockResearcher( [ { word: "halo", count: 2 },
-			{ word: "cangkir", count: 2 }, { word: "pisang", count: 1 },
-			{ word: "meja", count: 4 } ] ) );
-		expect( assessment.getScore() ).toBe( 3 );
-		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: " +
-			"The text contains 4 consecutive sentences starting with the same word." +
-			" <a href='https://yoa.st/35g' target='_blank'>Try to mix things up</a>!" );
-	} );
-
-	it( "scores two instance with too many consecutive Indonesian sentences starting with the same word, 5 being the lowest count.", function() {
-		const assessment = new SentenceBeginningsAssessment().getResult( paper, Factory.buildMockResearcher( [ { word: "halo", count: 2 },
-			{ word: "cangkir", count: 6 }, { word: "pisang", count: 1 },
-			{ word: "botol", count: 5 } ] ) );
-		expect( assessment.getScore() ).toBe( 3 );
-		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: " +
-			"The text contains 2 instances where 5 or more consecutive sentences start with the same word. <a href='https://yoa.st/35g' " +
-			"target='_blank'>Try to mix things up</a>!" );
-	} );
-
-	it( "scores zero instance with too many consecutive Indonesian sentences starting with the same word.", function() {
-		const assessment = new SentenceBeginningsAssessment().getResult( paper, Factory.buildMockResearcher( [ { word: "halo", count: 1 },
-			{ word: "pensil", count: 2 }, { word: "kopi", count: 2 },
-			{ word: "sofa", count: 1 } ] ) );
-		expect( assessment.getScore() ).toBe( 9 );
-		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: " +
-			"There is enough variety in your sentences. That's great!" );
-	} );
-
-	it( "scores one instance with 4 consecutive Hungarian sentences starting with the same word.", function() {
-		const assessment = new SentenceBeginningsAssessment().getResult( paper, Factory.buildMockResearcher( [ { word: "hé", count: 2 },
-			{ word: "csésze", count: 2 }, { word: "laptop", count: 1 },
-			{ word: "asztal", count: 4 } ] ) );
-		expect( assessment.getScore() ).toBe( 3 );
-		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: " +
-			"The text contains 4 consecutive sentences starting with the same word." +
-			" <a href='https://yoa.st/35g' target='_blank'>Try to mix things up</a>!" );
-	} );
-
-	it( "scores two instance with too many consecutive Hungarian sentences starting with the same word, 5 being the lowest count.", function() {
-		const assessment = new SentenceBeginningsAssessment().getResult( paper, Factory.buildMockResearcher( [ { word: "hé", count: 2 },
-			{ word: "banán", count: 6 }, { word: "ceruza", count: 1 },
-			{ word: "üveg", count: 5 } ] ) );
-		expect( assessment.getScore() ).toBe( 3 );
-		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: " +
-			"The text contains 2 instances where 5 or more consecutive sentences start with the same word. <a href='https://yoa.st/35g' " +
-			"target='_blank'>Try to mix things up</a>!" );
-	} );
-
-	it( "scores zero instance with too many consecutive Hungarian sentences starting with the same word.", function() {
-		const assessment = new SentenceBeginningsAssessment().getResult( paper, Factory.buildMockResearcher( [ { word: "helló", count: 1 },
-			{ word: "ceruza", count: 2 }, { word: "kávé", count: 2 },
-			{ word: "kanapé", count: 1 } ] ) );
-		expect( assessment.getScore() ).toBe( 9 );
-		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: " +
-			"There is enough variety in your sentences. That's great!" );
-	} );
-
-	it( "scores one instance with 4 consecutive Turkish sentences starting with the same word.", function() {
-		const assessment = new SentenceBeginningsAssessment().getResult( paper, Factory.buildMockResearcher( [ { word: "merhaba", count: 2 },
-			{ word: "bilgisayar", count: 2 }, { word: "köpek", count: 1 },
-			{ word: "kedi", count: 4 } ] ) );
-		expect( assessment.getScore() ).toBe( 3 );
-		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: " +
-			"The text contains 4 consecutive sentences starting with the same word." +
-			" <a href='https://yoa.st/35g' target='_blank'>Try to mix things up</a>!" );
-	} );
-
-	it( "scores two instance with too many consecutive Turkish sentences starting with the same word, 5 being the lowest count.", function() {
-		const assessment = new SentenceBeginningsAssessment().getResult( paper, Factory.buildMockResearcher( [ { word: "hayvan", count: 2 },
-			{ word: "muz", count: 6 }, { word: "makyaj", count: 1 },
-			{ word: "çay", count: 5 } ] ) );
-		expect( assessment.getScore() ).toBe( 3 );
-		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: " +
-			"The text contains 2 instances where 5 or more consecutive sentences start with the same word. <a href='https://yoa.st/35g' " +
-			"target='_blank'>Try to mix things up</a>!" );
-	} );
-
-	it( "scores zero instance with too many consecutive Turkish sentences starting with the same word.", function() {
-		const assessment = new SentenceBeginningsAssessment().getResult( paper, Factory.buildMockResearcher( [ { word: "hoşgeldiniz", count: 1 },
-			{ word: "ayakkabı", count: 2 }, { word: "kayıt", count: 2 },
-			{ word: "ceket", count: 1 } ] ) );
-		expect( assessment.getScore() ).toBe( 9 );
-		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: " +
-			"There is enough variety in your sentences. That's great!" );
-	} );
-
-	it( "is not applicable for a paper without text.", function() {
-		const assessment = new SentenceBeginningsAssessment().isApplicable( new Paper( "" ), new EnglishResearcher( new Paper( "" ) ) );
-		expect( assessment ).toBe( false );
-	} );
-
-	it( "is not applicable for a German paper without text.", function() {
-		paper = new Paper( "", { locale: "de_DE" } );
-		const assessment = new SentenceBeginningsAssessment().isApplicable( paper, new GermanResearcher( paper ) );
-		expect( assessment ).toBe( false );
-	} );
-
-	it( "is applicable for a German paper with text.", function() {
-		paper = new Paper( "hallo", { locale: "de_DE" } );
-		const assessment = new SentenceBeginningsAssessment().isApplicable( paper, new GermanResearcher( paper ) );
-		expect( assessment ).toBe( true );
-	} );
-
-	it( "is not applicable for a French paper without text.", function() {
-		paper = new Paper( "", { locale: "fr_FR" } );
-		const assessment = new SentenceBeginningsAssessment().isApplicable( paper, new FrenchResearcher( paper )  );
-		expect( assessment ).toBe( false );
-	} );
-
-	it( "is applicable for a French paper with text.", function() {
-		paper = new Paper( "bonjour", { locale: "fr_FR" } );
-		const assessment = new SentenceBeginningsAssessment().isApplicable( paper, new FrenchResearcher( paper ) );
-		expect( assessment ).toBe( true );
-	} );
-
-	it( "is not applicable for a Spanish paper without text.", function() {
-		paper = new Paper( "", { locale: "es_ES" } );
-		const assessment = new SentenceBeginningsAssessment().isApplicable( paper, new SpanishResearcher( paper ) );
-		expect( assessment ).toBe( false );
-	} );
-
-	it( "is applicable for a Spanish paper with text.", function() {
-		paper = new Paper( "hola", { locale: "es_ES" } );
-		const assessment = new SentenceBeginningsAssessment().isApplicable( paper, new SpanishResearcher( paper ) );
-		expect( assessment ).toBe( true );
-	} );
-
-	it( "is not applicable for a Dutch paper without text.", function() {
-		paper =  new Paper( "", { locale: "nl_NL" } );
-		const assessment = new SentenceBeginningsAssessment().isApplicable( paper, new DutchResearcher( paper ) );
-		expect( assessment ).toBe( false );
-	} );
-
-	it( "is applicable for a Dutch paper with text.", function() {
-		paper = new Paper( "hallo", { locale: "nl_NL" } );
-		const assessment = new SentenceBeginningsAssessment().isApplicable( paper, new DutchResearcher( paper ) );
-		expect( assessment ).toBe( true );
-	} );
-
-	it( "is not applicable for an Italian paper without text.", function() {
+	it( "is not applicable for a paper without text and a researcher that has the getSentenceBeginnings research.", function() {
 		paper = new Paper( "", { locale: "it_IT" } );
 		const assessment = new SentenceBeginningsAssessment().isApplicable( paper, new ItalianResearcher( paper ) );
 		expect( assessment ).toBe( false );
 	} );
 
-	it( "is applicable for an Italian paper with text.", function() {
+	it( "is applicable for an paper with text and a researcher that has the getSentenceBeginnings research.", function() {
 		paper = new Paper( "ciao", { locale: "it_IT" } );
 		const assessment = new SentenceBeginningsAssessment().isApplicable( paper, new ItalianResearcher( paper ) );
 		expect( assessment ).toBe( true );
 	} );
 
-	it( "is not applicable for a Russian paper without text.", function() {
-		paper = new Paper( "", { locale: "ru_RU" } );
-		const assessment = new SentenceBeginningsAssessment().isApplicable( paper, new RussianResearcher( paper ) );
-		expect( assessment ).toBe( false );
-	} );
-
-	it( "is applicable for a Russian paper with text.", function() {
-		paper = new Paper( "почему", { locale: "ru_RU" } );
-		const assessment = new SentenceBeginningsAssessment().isApplicable( paper, new RussianResearcher( paper ) );
-		expect( assessment ).toBe( true );
-	} );
-
-	it( "is not applicable for a Polish paper without text.", function() {
-		paper = new Paper( "", { locale: "pl_PL" } );
-		const assessment = new SentenceBeginningsAssessment().isApplicable( paper, new PolishResearcher( paper ) );
-		expect( assessment ).toBe( false );
-	} );
-
-	it( "is applicable for a Polish paper with text.", function() {
-		paper = new Paper( "cześć", { locale: "pl_PL" } );
-		const assessment = new SentenceBeginningsAssessment().isApplicable( paper, new PolishResearcher( paper ) );
-		expect( assessment ).toBe( true );
-	} );
-
-	it( "is not applicable for a Swedish paper without text.", function() {
-		paper = new Paper( "", { locale: "sv_SE" } );
-		const assessment = new SentenceBeginningsAssessment().isApplicable( paper, new SwedishResearcher( paper ) );
-		expect( assessment ).toBe( false );
-	} );
-
-	it( "is applicable for a Swedish paper with text.", function() {
-		paper = new Paper( "hej", { locale: "sv_SE" } );
-		const assessment = new SentenceBeginningsAssessment().isApplicable( paper, new SwedishResearcher( paper ) );
-		expect( assessment ).toBe( true );
-	} );
-
-	it( "is not applicable for an Indonesian paper without text.", function() {
-		paper = new Paper( "", { locale: "id_ID" } );
-		const assessment = new SentenceBeginningsAssessment().isApplicable( paper, new IndonesianResearcher( paper ) );
-		expect( assessment ).toBe( false );
-	} );
-
-	it( "is applicable for an Indonesian paper with text.", function() {
-		paper = new Paper( "hai", { locale: "id_ID" } );
-		const assessment = new SentenceBeginningsAssessment().isApplicable( paper, new IndonesianResearcher( paper ) );
-		expect( assessment ).toBe( true );
-	} );
-
-	it( "is not applicable for a Hungarian paper without text.", function() {
-		paper = new Paper( "", { locale: "hu_HU" } );
-		const assessment = new SentenceBeginningsAssessment().isApplicable( paper, new HungarianResearcher( paper ) );
-		expect( assessment ).toBe( false );
-	} );
-
-	it( "is applicable for a Hungarian paper with text.", function() {
-		paper = new Paper( "magyar", { locale: "hu_HU" } );
-		const assessment = new SentenceBeginningsAssessment().isApplicable( paper, new HungarianResearcher( paper ) );
-		expect( assessment ).toBe( true );
-	} );
-
-	it( "is not applicable for a Turkish paper without text.", function() {
-		paper = new Paper( "", { locale: "tr_TR" } );
-		const assessment = new SentenceBeginningsAssessment().isApplicable( paper, new TurkishResearcher( paper ) );
-		expect( assessment ).toBe( false );
-	} );
-
-	it( "is applicable for a Turkish paper with text.", function() {
-		paper = new Paper( "türk", { locale: "tr_TR" } );
-		const assessment = new SentenceBeginningsAssessment().isApplicable( paper, new TurkishResearcher( paper ) );
-		expect( assessment ).toBe( true );
-	} );
-
-	it( "is not applicable for a paper with text and a locale without sentence beginning support.", function() {
+	it( "is not applicable for a paper with text and a researcher without sentence beginning support.", function() {
 		paper = new Paper( "hello", { locale: "jv_ID" } );
 		const assessment = new SentenceBeginningsAssessment().isApplicable( paper, new DefaultResearcher( paper ) );
 		expect( assessment ).toBe( false );

--- a/packages/yoastseo/spec/scoring/assessments/readability/SentenceLengthInTextAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/readability/SentenceLengthInTextAssessmentSpec.js
@@ -1,4 +1,4 @@
-/* eslint-disable capitalized-comments */
+/* eslint-disable capitalized-comments, spaced-comment */
 import SentenceLengthInTextAssessment from "../../../../src/scoring/assessments/readability/SentenceLengthInTextAssessment";
 
 import Paper from "../../../../src/values/Paper.js";
@@ -355,8 +355,8 @@ describe( "A test for getting the right scoring config", function() {
 	} );
 } );
 
-describe( "An assessment for sentence length for cornerstone content", function() {/*
-	it( "returns the score for 100% short sentences in a language with custom scoring config for cornerstone", function() {
+describe( "An assessment for sentence length for cornerstone content", function() {
+	/* it( "returns the score for 100% short sentences in a language with custom scoring config for cornerstone", function() {
 		const mockPaper = new Paper( shortSentenceDefault );
 		const assessment = new SentenceLengthInTextAssessment( {
 			slightlyTooMany: 20,

--- a/packages/yoastseo/spec/scoring/assessments/readability/SentenceLengthInTextAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/readability/SentenceLengthInTextAssessmentSpec.js
@@ -11,18 +11,13 @@ import PolishResearcher from "../../../../src/languageProcessing/languages/pl/Re
 import RussianResearcher from "../../../../src/languageProcessing/languages/ru/Researcher";
 import ItalianResearcher from "../../../../src/languageProcessing/languages/it/Researcher";
 import TurkishResearcher from "../../../../src/languageProcessing/languages/tr/Researcher";
-import JapaneseResearcher from "../../../../src/languageProcessing/languages/ja/Researcher";
 
 const shortSentenceDefault = "Word ".repeat( 18 ) + "word. ";
 const longSentenceDefault = "Word ".repeat( 20 ) + "word. ";
 const shortSentence15WordsLimit = "Word ".repeat( 13 ) + "word. ";
 const longSentence15WordsLimit = "Word ".repeat( 15 ) + "word. ";
-const shortSentence25WordsLimit = "Word ".repeat( 23 ) + "word. ";
-const longSentence25WordsLimit = "Word ".repeat( 25 ) + "word. ";
 
-import hebrewConfig from "../../../../src/languageProcessing/languages/he/config/sentenceLength";
 import japaneseConfig from "../../../../src/languageProcessing/languages/ja/config/sentenceLength";
-import turkishConfig from "../../../../src/languageProcessing/languages/tr/config/sentenceLength";
 
 // eslint-disable-next-line max-statements
 describe( "An assessment for sentence length", function() {
@@ -82,7 +77,7 @@ describe( "An assessment for sentence length", function() {
 		expect( assessment.hasMarks() ).toBe( true );
 	} );
 
-	it( "returns the score for 100% long sentences in a language with the sentence length limit of 15 words", function() {
+	it( "returns the score for 100% long sentences in a language that overrides the default recommended length config", function() {
 		const mockPaper = new Paper( longSentence15WordsLimit );
 		const assessment = new SentenceLengthInTextAssessment().getResult( mockPaper, new RussianResearcher( mockPaper ) );
 
@@ -100,7 +95,7 @@ describe( "An assessment for sentence length", function() {
 		] );
 	} );
 
-	it( "returns the score for 100% long sentences in a language with the sentence length limit of 25 words", function() {
+	/*it( "returns the score for 100% long sentences in a language with the sentence length limit of 25 words", function() {
 		const mockPaper = new Paper( longSentence25WordsLimit );
 		const assessment = new SentenceLengthInTextAssessment().getResult( mockPaper, new ItalianResearcher( mockPaper ) );
 
@@ -128,9 +123,9 @@ describe( "An assessment for sentence length", function() {
 		expect( assessment.getScore() ).toEqual( 9 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34v' target='_blank'>Sentence length</a>: Great!" );
 		expect( assessment.hasMarks() ).toBe( false );
-	} );
+	} );*/
 
-	it( "returns the score for 100% short sentences in a language with the maximum allowed percentage of long sentences of 15%", function() {
+	/*it( "returns the score for 100% short sentences in a language that overrides the default with the maximum allowed percentage of long sentences of 15%", function() {
 		const mockPaper = new Paper( shortSentenceDefault );
 		const assessment = new SentenceLengthInTextAssessment().getResult( mockPaper, new PolishResearcher( mockPaper ) );
 
@@ -172,9 +167,10 @@ describe( "An assessment for sentence length", function() {
 			"25% of the sentences contain more than 20 words, which is more than the recommended maximum of 15%." +
 			" <a href='https://yoa.st/34w' target='_blank'>Try to shorten the sentences</a>." );
 		expect( assessment.hasMarks() ).toBe( true );
-	} );
+	} );*/
 
-	it( "returns the score for 20% long sentences in a language with the maximum allowed percentage of long sentences of 15%", function() {
+	it( "returns the score for 20% long sentences in a language that overrides the default config" +
+		" for maximum allowed percentage of long sentences", function() {
 		const mockPaper = new Paper( longSentenceDefault.repeat( 4 ) + shortSentenceDefault.repeat( 16 ) );
 		const assessment = new SentenceLengthInTextAssessment().getResult( mockPaper, new PolishResearcher( mockPaper ) );
 
@@ -186,8 +182,8 @@ describe( "An assessment for sentence length", function() {
 		expect( assessment.hasMarks() ).toBe( true );
 	} );
 
-	it( "returns the score for 25% long sentences in a language with a sentence length limit of 15 " +
-		"and the maximum allowed percentage of long sentences of 20%", function() {
+	it( "returns the score for 25% long sentences in a language that overrides the default config for both recommended " +
+		"maximum sentence length, and the maximum allowed percentage of long sentences", function() {
 		const mockPaper = new Paper( longSentence15WordsLimit + shortSentence15WordsLimit.repeat( 3 ) );
 		const assessment = new SentenceLengthInTextAssessment().getResult( mockPaper, new TurkishResearcher( mockPaper ) );
 
@@ -199,19 +195,7 @@ describe( "An assessment for sentence length", function() {
 		expect( assessment.hasMarks() ).toBe( true );
 	} );
 
-	it( "Replaces 'words' with 'characters' in the feedbacks string for Japanese", function() {
-		const mockPaper = new Paper( "は は は は は は は は は は は は は は は は は は は は は は は は は." );
-		const assessment = new SentenceLengthInTextAssessment().getResult( mockPaper, new JapaneseResearcher( mockPaper ) );
-
-		expect( assessment.hasScore() ).toBe( true );
-		expect( assessment.getScore() ).toEqual( 3 );
-		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34v' target='_blank'>Sentence length</a>: " +
-			"100% of the sentences contain more than 40 characters, which is more than the recommended maximum of 25%." +
-			" <a href='https://yoa.st/34w' target='_blank'>Try to shorten the sentences</a>." );
-		expect( assessment.hasMarks() ).toBe( true );
-	} );
-
-	it( "returns the score for 25% long sentences in Hebrew", function() {
+	/*it( "returns the score for 25% long sentences in Hebrew", function() {
 		const mockPaper = new Paper( "text", { locale: "he_IL" } );
 		const assessment = new SentenceLengthInTextAssessment().getResult( mockPaper, Factory.buildMockResearcher( [
 			{ sentence: "", sentenceLength: 16 },
@@ -236,9 +220,9 @@ describe( "An assessment for sentence length", function() {
 		expect( assessment.getScore() ).toEqual( 9 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34v' target='_blank'>Sentence length</a>: Great!" );
 		expect( assessment.hasMarks() ).toBe( false );
-	} );
+	} );*/
 
-	it( "returns the score for 100% short sentences in Turkish", function() {
+	/*it( "returns the score for 100% short sentences in Turkish", function() {
 		const mockPaper = new Paper();
 		const assessment = new SentenceLengthInTextAssessment().getResult( mockPaper, Factory.buildMockResearcher( [
 			{ sentence: "", sentenceLength: 14 },
@@ -248,9 +232,9 @@ describe( "An assessment for sentence length", function() {
 		expect( assessment.getScore() ).toEqual( 9 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34v' target='_blank'>Sentence length</a>: Great!" );
 		expect( assessment.hasMarks() ).toBe( false );
-	} );
+	} );*/
 
-	it( "returns the score for 100% long sentences in Japanese", function() {
+	it( "returns the score for 100% long sentences in a language that should count sentence length in characters (Japanese)", function() {
 		const mockPaper = new Paper( "" );
 		const assessment = new SentenceLengthInTextAssessment().getResult( mockPaper, Factory.buildMockResearcher( [
 			{ sentence: "", sentenceLength: 41 },
@@ -264,7 +248,7 @@ describe( "An assessment for sentence length", function() {
 		expect( assessment.hasMarks() ).toBe( true );
 	} );
 
-	it( "returns the score for 100% short sentences in Japanese", function() {
+	/*it( "returns the score for 100% short sentences in Japanese", function() {
 		const mockPaper = new Paper( "" );
 		const assessment = new SentenceLengthInTextAssessment().getResult( mockPaper, Factory.buildMockResearcher( [
 			{ sentence: "", sentenceLength: 39 },
@@ -289,7 +273,7 @@ describe( "An assessment for sentence length", function() {
 		expect( assessment.getScore() ).toEqual( 9 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34v' target='_blank'>Sentence length</a>: Great!" );
 		expect( assessment.hasMarks() ).toBe( true );
-	} );
+	} );*/
 
 	it( "is not applicable for empty papers", function() {
 		const mockPaper = new Paper();
@@ -370,7 +354,7 @@ describe( "A test for getting the right scoring config", function() {
 	} );
 } );
 
-describe( "An assessment for sentence length for cornerstone content", function() {
+describe( "An assessment for sentence length for cornerstone content", function() {/*
 	it( "returns the score for 100% short sentences in a language with custom scoring config for cornerstone", function() {
 		const mockPaper = new Paper( shortSentenceDefault );
 		const assessment = new SentenceLengthInTextAssessment( {
@@ -397,9 +381,9 @@ describe( "An assessment for sentence length for cornerstone content", function(
 			" contain more than 20 words, which is more than the recommended maximum of 15%. <a href='https://yoa.st/34w' target='_blank'>Try to" +
 			" shorten the sentences</a>." );
 		expect( assessment.hasMarks() ).toBe( true );
-	} );
+	} );*/
 
-	it( "returns the score for 25% long sentences in Polish using the cornerstone configuration", function() {
+	it( "returns the score for 25% long sentences in a language that overrides the default cornerstone configuration", function() {
 		const mockPaper = new Paper( longSentenceDefault + shortSentenceDefault.repeat( 3 ) );
 		const assessment = new SentenceLengthInTextAssessment( {
 			slightlyTooMany: 20,
@@ -414,7 +398,7 @@ describe( "An assessment for sentence length for cornerstone content", function(
 		expect( assessment.hasMarks() ).toBe( true );
 	} );
 
-	it( "returns the score for 20% long sentences in Polish using the cornerstone configuration", function() {
+	/*it( "returns the score for 20% long sentences in Polish using the cornerstone configuration", function() {
 		const mockPaper = new Paper( longSentenceDefault.repeat( 4 ) + shortSentenceDefault.repeat( 16 ) );
 		const assessment = new SentenceLengthInTextAssessment( {
 			slightlyTooMany: 20,
@@ -427,7 +411,7 @@ describe( "An assessment for sentence length for cornerstone content", function(
 			"20% of the sentences contain more than 20 words, which is more than the recommended maximum of 15%." +
 			" <a href='https://yoa.st/34w' target='_blank'>Try to shorten the sentences</a>." );
 		expect( assessment.hasMarks() ).toBe( true );
-	} );
+	} );*/
 
 	it( "returns the score for 25% long sentences using the default cornerstone configuration", function() {
 		const mockPaper = new Paper( longSentenceDefault + shortSentenceDefault.repeat( 3 ) );

--- a/packages/yoastseo/spec/scoring/assessments/readability/SentenceLengthInTextAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/readability/SentenceLengthInTextAssessmentSpec.js
@@ -1,3 +1,4 @@
+/* eslint-disable capitalized-comments */
 import SentenceLengthInTextAssessment from "../../../../src/scoring/assessments/readability/SentenceLengthInTextAssessment";
 
 import Paper from "../../../../src/values/Paper.js";

--- a/packages/yoastseo/spec/scoring/assessments/readability/SubheadingDistributionTooLongAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/readability/SubheadingDistributionTooLongAssessmentSpec.js
@@ -148,8 +148,10 @@ describe( "An assessment for scoring too long text fragments without a subheadin
 	} );
 } );
 
+
+// Only keep last two tests to test the this.getLanguageSpecificConfig( researcher ) logic in isApplicable method.
 describe( "An assessment for scoring too long text fragments without a subheading in Japanese.", function() {
-	it( "Scores a short text in Japanese (<600 characters), which does not have subheadings.", function() {
+/*	it( "Scores a short text in Japanese (<600 characters), which does not have subheadings.", function() {
 		const paper = new Paper( shortTextJapanese );
 		const japaneseResearcher = new JapaneseResearcher( paper );
 		const subheadingDistributionTooLongJA = new SubheadingDistributionTooLong();
@@ -245,7 +247,7 @@ describe( "An assessment for scoring too long text fragments without a subheadin
 		expect( results.getText( paper, japaneseResearcher ) ).toBe( "<a href='https://yoa.st/34x' target='_blank'>" +
 			"Subheading distribution</a>: 2 sections of your text are longer than 600 characters and are not separated " +
 			"by any subheadings. <a href='https://yoa.st/34y' target='_blank'>Add subheadings to improve readability</a>." );
-	} );
+	} );*/
 
 	it( "Returns false when the assessment shouldn't appear in short text analysis and the text contains less " +
 		"than 600 characters in Japanese", function() {
@@ -325,8 +327,8 @@ describe( "Language-specific configuration for specific types of content is used
 			expect( assessment._config.slightlyTooMany ).toEqual( japaneseConfig.cornerstoneParameters.slightlyTooMany );
 			expect( assessment._config.farTooMany ).toEqual( japaneseConfig.cornerstoneParameters.farTooMany );
 		} );
-
-		it( "should score short cornerstone content in Japanese (<500 characters), " +
+//Only need one test for japanese to test getLanguageSpecificConfig. The other tests are redundant.
+/*		it( "should score short cornerstone content in Japanese (<500 characters), " +
 		"which does not have subheadings, as OK.", function() {
 			const paper = new Paper( shortCornerstoneTextJapanese );
 			const assessment = assessor.getAssessment( "subheadingsTooLong" );
@@ -345,7 +347,7 @@ describe( "Language-specific configuration for specific types of content is used
 			expect( results.getText() ).toBe( "<a href='https://yoa.st/34x' target='_blank'>Subheading distribution</a>: " +
 			"You are not using any subheadings, although your text is rather long. " +
 			"<a href='https://yoa.st/34y' target='_blank'>Try and add some subheadings</a>." );
-		} );
+		} );*/
 	} );
 } );
 
@@ -361,8 +363,8 @@ describe( "A test for scoring too long text fragments without a subheading for l
 			"1 section of your text is longer than 600 characters and is not separated by any subheadings." +
 			" <a href='https://yoa.st/34y' target='_blank'>Add subheadings to improve readability</a>." );
 	} );
-
-	it( "Scores a text where multiple sections are slightly too long.", function() {
+	// you need 1 test to test the getLanguageSpecificConfig in the get result method. The rest of the tests is redundant.
+	/*it( "Scores a text where multiple sections are slightly too long.", function() {
 		const paper = new Paper( shortTextJapanese + subheading + longTextJapanese + subheading + longTextJapanese );
 		const assessment = subheadingDistributionTooLong.getResult( paper, new JapaneseResearcher( paper ) );
 
@@ -390,7 +392,7 @@ describe( "A test for scoring too long text fragments without a subheading for l
 		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/34x' target='_blank'>Subheading distribution</a>: " +
 			"2 sections of your text are longer than 600 characters and are not separated by any subheadings." +
 			" <a href='https://yoa.st/34y' target='_blank'>Add subheadings to improve readability</a>." );
-	} );
+	} );*/
 } );
 
 describe.skip( "A test for marking too long text segments not separated by a subheading", function() {

--- a/packages/yoastseo/spec/scoring/assessments/readability/SubheadingDistributionTooLongAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/readability/SubheadingDistributionTooLongAssessmentSpec.js
@@ -17,7 +17,7 @@ const longText = "a ".repeat( 330 );
 const veryLongText = "a ".repeat( 360 );
 const shortTextJapanese = "熱".repeat( 599 );
 const longTextJapanese = "熱".repeat( 601 );
-const veryLongTextJapanese = "熱".repeat( 701 );
+// const veryLongTextJapanese = "熱".repeat( 701 );  // Variable is used in language specific test (and thus removed)
 const subheading = "<h2> some subheading </h2>";
 
 describe( "An assessment for scoring too long text fragments without a subheading.", function() {
@@ -152,103 +152,103 @@ describe( "An assessment for scoring too long text fragments without a subheadin
 
 // Only keep last two tests to test the this.getLanguageSpecificConfig( researcher ) logic in isApplicable method.
 describe( "An assessment for scoring too long text fragments without a subheading in Japanese.", function() {
-/*	it( "Scores a short text in Japanese (<600 characters), which does not have subheadings.", function() {
-		const paper = new Paper( shortTextJapanese );
-		const japaneseResearcher = new JapaneseResearcher( paper );
-		const subheadingDistributionTooLongJA = new SubheadingDistributionTooLong();
-		const results = subheadingDistributionTooLongJA.getResult( paper, japaneseResearcher );
-		expect( results.getScore() ).toBe( 9 );
-		expect( results.getText() ).toBe( "<a href='https://yoa.st/34x' target='_blank'>Subheading distribution</a>: " +
-			"You are not using any subheadings, but your text is short enough and probably doesn't need them." );
-	} );
-
-	it( "Scores a short text in Japanese (<600 characters), which has subheadings.", function() {
-		const paper = new Paper( "定冠詞 " + subheading + shortTextJapanese );
-		const japaneseResearcher = new JapaneseResearcher( paper );
-		const subheadingDistributionTooLongJA = new SubheadingDistributionTooLong();
-		const results = subheadingDistributionTooLongJA.getResult( paper, japaneseResearcher );
-		expect( results.getScore() ).toBe( 9 );
-		expect( results.getText() ).toBe( "<a href='https://yoa.st/34x' target='_blank'>Subheading distribution</a>: Great job!" );
-	} );
-
-	it( "Scores a long text in Japanese (>600 characters), which does not have subheadings.", function() {
-		const paper = new Paper( longTextJapanese );
-		const japaneseResearcher = new JapaneseResearcher( paper );
-		const subheadingDistributionTooLongJA = new SubheadingDistributionTooLong();
-		const results = subheadingDistributionTooLongJA.getResult( paper, japaneseResearcher );
-		expect( results.getScore() ).toBe( 2 );
-		expect( results.getText() ).toBe( "<a href='https://yoa.st/34x' target='_blank'>Subheading distribution</a>: " +
-			"You are not using any subheadings, although your text is rather long. <a href='https://yoa.st/34y' target='_blank'>" +
-			"Try and add some subheadings</a>." );
-	} );
-
-	it( "Scores a long text in Japanese (>600 characters), which has subheadings and all sections of the text are <600 characters.", function() {
-		const paper = new Paper( shortTextJapanese + subheading + shortTextJapanese );
-		const japaneseResearcher = new JapaneseResearcher( paper );
-		const subheadingDistributionTooLongJA = new SubheadingDistributionTooLong();
-		const results = subheadingDistributionTooLongJA.getResult( paper, japaneseResearcher );
-		expect( results.getScore() ).toBe( 9 );
-		expect( results.getText() ).toBe( "<a href='https://yoa.st/34x' target='_blank'>Subheading distribution</a>: Great job!" );
-	} );
-
-	it( "Scores a long text in Japanese (>600 characters), which has subheadings and all sections of the " +
-		"text are <600 characters, except for one, which is between 650 and 700 characters long.", function() {
-		const paper = new Paper( shortTextJapanese + subheading + longTextJapanese + subheading + shortTextJapanese );
-		const japaneseResearcher = new JapaneseResearcher( paper );
-		const subheadingDistributionTooLongJA = new SubheadingDistributionTooLong();
-		const results = subheadingDistributionTooLongJA.getResult( paper, japaneseResearcher );
-		expect( results.getScore() ).toBe( 6 );
-		expect( results.getText() ).toBe( "<a href='https://yoa.st/34x' target='_blank'>Subheading distribution</a>: " +
-			"1 section of your text is longer than 600 characters and is not separated by any subheadings." +
-			" <a href='https://yoa.st/34y' target='_blank'>Add subheadings to improve readability</a>." );
-	} );
-	it( "Scores a long text in Japanese (>600 characters), which has subheadings and all sections of the " +
-		"text are <600 characters, except for two, which are between 650 and 700 characters long.", function() {
-		const paper = new Paper( shortTextJapanese + subheading + longTextJapanese + subheading + longTextJapanese );
-		const japaneseResearcher = new JapaneseResearcher( paper );
-		const subheadingDistributionTooLongJA = new SubheadingDistributionTooLong();
-		const results = subheadingDistributionTooLongJA.getResult( paper, japaneseResearcher );
-		expect( results.getScore() ).toBe( 6 );
-		expect( results.getText() ).toBe( "<a href='https://yoa.st/34x' target='_blank'>Subheading distribution</a>: " +
-			"2 sections of your text are longer than 600 characters and are not separated by any subheadings." +
-			" <a href='https://yoa.st/34y' target='_blank'>Add subheadings to improve readability</a>." );
-	} );
-
-	it( "Scores a long text in Japanese (>600 characters), which has subheadings and some sections of the" +
-		" text are above 700 characters long.", function() {
-		const paper = new Paper( shortTextJapanese + subheading + veryLongTextJapanese + subheading + veryLongTextJapanese );
-		const japaneseResearcher = new JapaneseResearcher( paper );
-		const subheadingDistributionTooLongJA = new SubheadingDistributionTooLong();
-		const results = subheadingDistributionTooLongJA.getResult( paper, japaneseResearcher );
-		expect( results.getScore() ).toBe( 3 );
-		expect( results.getText() ).toBe( "<a href='https://yoa.st/34x' target='_blank'>Subheading distribution</a>: " +
-			"2 sections of your text are longer than 600 characters and are not separated by any subheadings." +
-			" <a href='https://yoa.st/34y' target='_blank'>Add subheadings to improve readability</a>." );
-	} );
-
-	it( "Scores a long text in Japanese (>600 characters), which has subheadings and all sections of the " +
-		"text are <600 characters, except for one, which is above 700 characters long.", function() {
-		const paper = new Paper( shortTextJapanese + subheading + veryLongTextJapanese + subheading + shortTextJapanese );
-		const japaneseResearcher = new JapaneseResearcher( paper );
-		const subheadingDistributionTooLongJA = new SubheadingDistributionTooLong();
-		const results = subheadingDistributionTooLongJA.getResult( paper, japaneseResearcher );
-		expect( results.getScore() ).toBe( 3 );
-		expect( results.getText() ).toBe( "<a href='https://yoa.st/34x' target='_blank'>Subheading distribution</a>: " +
-			"1 section of your text is longer than 600 characters and is not separated by any subheadings." +
-			" <a href='https://yoa.st/34y' target='_blank'>Add subheadings to improve readability</a>." );
-	} );
-
-	it( "Scores a long text (>600 characters), which has subheadings and some sections of the text are " +
-		"above 700 characters long.", function() {
-		const paper = new Paper( shortTextJapanese + subheading + veryLongTextJapanese + subheading + veryLongTextJapanese );
-		const japaneseResearcher = new JapaneseResearcher( paper );
-		const subheadingDistributionTooLongJA = new SubheadingDistributionTooLong();
-		const results = subheadingDistributionTooLongJA.getResult( paper, japaneseResearcher );
-		expect( results.getScore( paper, japaneseResearcher ) ).toBe( 3 );
-		expect( results.getText( paper, japaneseResearcher ) ).toBe( "<a href='https://yoa.st/34x' target='_blank'>" +
-			"Subheading distribution</a>: 2 sections of your text are longer than 600 characters and are not separated " +
-			"by any subheadings. <a href='https://yoa.st/34y' target='_blank'>Add subheadings to improve readability</a>." );
-	} );*/
+	// it( "Scores a short text in Japanese (<600 characters), which does not have subheadings.", function() {
+	// 	const paper = new Paper( shortTextJapanese );
+	// 	const japaneseResearcher = new JapaneseResearcher( paper );
+	// 	const subheadingDistributionTooLongJA = new SubheadingDistributionTooLong();
+	// 	const results = subheadingDistributionTooLongJA.getResult( paper, japaneseResearcher );
+	// 	expect( results.getScore() ).toBe( 9 );
+	// 	expect( results.getText() ).toBe( "<a href='https://yoa.st/34x' target='_blank'>Subheading distribution</a>: " +
+	// 		"You are not using any subheadings, but your text is short enough and probably doesn't need them." );
+	// } );
+	//
+	// it( "Scores a short text in Japanese (<600 characters), which has subheadings.", function() {
+	// 	const paper = new Paper( "定冠詞 " + subheading + shortTextJapanese );
+	// 	const japaneseResearcher = new JapaneseResearcher( paper );
+	// 	const subheadingDistributionTooLongJA = new SubheadingDistributionTooLong();
+	// 	const results = subheadingDistributionTooLongJA.getResult( paper, japaneseResearcher );
+	// 	expect( results.getScore() ).toBe( 9 );
+	// 	expect( results.getText() ).toBe( "<a href='https://yoa.st/34x' target='_blank'>Subheading distribution</a>: Great job!" );
+	// } );
+	//
+	// it( "Scores a long text in Japanese (>600 characters), which does not have subheadings.", function() {
+	// 	const paper = new Paper( longTextJapanese );
+	// 	const japaneseResearcher = new JapaneseResearcher( paper );
+	// 	const subheadingDistributionTooLongJA = new SubheadingDistributionTooLong();
+	// 	const results = subheadingDistributionTooLongJA.getResult( paper, japaneseResearcher );
+	// 	expect( results.getScore() ).toBe( 2 );
+	// 	expect( results.getText() ).toBe( "<a href='https://yoa.st/34x' target='_blank'>Subheading distribution</a>: " +
+	// 		"You are not using any subheadings, although your text is rather long. <a href='https://yoa.st/34y' target='_blank'>" +
+	// 		"Try and add some subheadings</a>." );
+	// } );
+	//
+	// it( "Scores a long text in Japanese (>600 characters), which has subheadings and all sections of the text are <600 characters.", function() {
+	// 	const paper = new Paper( shortTextJapanese + subheading + shortTextJapanese );
+	// 	const japaneseResearcher = new JapaneseResearcher( paper );
+	// 	const subheadingDistributionTooLongJA = new SubheadingDistributionTooLong();
+	// 	const results = subheadingDistributionTooLongJA.getResult( paper, japaneseResearcher );
+	// 	expect( results.getScore() ).toBe( 9 );
+	// 	expect( results.getText() ).toBe( "<a href='https://yoa.st/34x' target='_blank'>Subheading distribution</a>: Great job!" );
+	// } );
+	//
+	// it( "Scores a long text in Japanese (>600 characters), which has subheadings and all sections of the " +
+	// 	"text are <600 characters, except for one, which is between 650 and 700 characters long.", function() {
+	// 	const paper = new Paper( shortTextJapanese + subheading + longTextJapanese + subheading + shortTextJapanese );
+	// 	const japaneseResearcher = new JapaneseResearcher( paper );
+	// 	const subheadingDistributionTooLongJA = new SubheadingDistributionTooLong();
+	// 	const results = subheadingDistributionTooLongJA.getResult( paper, japaneseResearcher );
+	// 	expect( results.getScore() ).toBe( 6 );
+	// 	expect( results.getText() ).toBe( "<a href='https://yoa.st/34x' target='_blank'>Subheading distribution</a>: " +
+	// 		"1 section of your text is longer than 600 characters and is not separated by any subheadings." +
+	// 		" <a href='https://yoa.st/34y' target='_blank'>Add subheadings to improve readability</a>." );
+	// } );
+	// it( "Scores a long text in Japanese (>600 characters), which has subheadings and all sections of the " +
+	// 	"text are <600 characters, except for two, which are between 650 and 700 characters long.", function() {
+	// 	const paper = new Paper( shortTextJapanese + subheading + longTextJapanese + subheading + longTextJapanese );
+	// 	const japaneseResearcher = new JapaneseResearcher( paper );
+	// 	const subheadingDistributionTooLongJA = new SubheadingDistributionTooLong();
+	// 	const results = subheadingDistributionTooLongJA.getResult( paper, japaneseResearcher );
+	// 	expect( results.getScore() ).toBe( 6 );
+	// 	expect( results.getText() ).toBe( "<a href='https://yoa.st/34x' target='_blank'>Subheading distribution</a>: " +
+	// 		"2 sections of your text are longer than 600 characters and are not separated by any subheadings." +
+	// 		" <a href='https://yoa.st/34y' target='_blank'>Add subheadings to improve readability</a>." );
+	// } );
+	//
+	// it( "Scores a long text in Japanese (>600 characters), which has subheadings and some sections of the" +
+	// 	" text are above 700 characters long.", function() {
+	// 	const paper = new Paper( shortTextJapanese + subheading + veryLongTextJapanese + subheading + veryLongTextJapanese );
+	// 	const japaneseResearcher = new JapaneseResearcher( paper );
+	// 	const subheadingDistributionTooLongJA = new SubheadingDistributionTooLong();
+	// 	const results = subheadingDistributionTooLongJA.getResult( paper, japaneseResearcher );
+	// 	expect( results.getScore() ).toBe( 3 );
+	// 	expect( results.getText() ).toBe( "<a href='https://yoa.st/34x' target='_blank'>Subheading distribution</a>: " +
+	// 		"2 sections of your text are longer than 600 characters and are not separated by any subheadings." +
+	// 		" <a href='https://yoa.st/34y' target='_blank'>Add subheadings to improve readability</a>." );
+	// } );
+	//
+	// it( "Scores a long text in Japanese (>600 characters), which has subheadings and all sections of the " +
+	// 	"text are <600 characters, except for one, which is above 700 characters long.", function() {
+	// 	const paper = new Paper( shortTextJapanese + subheading + veryLongTextJapanese + subheading + shortTextJapanese );
+	// 	const japaneseResearcher = new JapaneseResearcher( paper );
+	// 	const subheadingDistributionTooLongJA = new SubheadingDistributionTooLong();
+	// 	const results = subheadingDistributionTooLongJA.getResult( paper, japaneseResearcher );
+	// 	expect( results.getScore() ).toBe( 3 );
+	// 	expect( results.getText() ).toBe( "<a href='https://yoa.st/34x' target='_blank'>Subheading distribution</a>: " +
+	// 		"1 section of your text is longer than 600 characters and is not separated by any subheadings." +
+	// 		" <a href='https://yoa.st/34y' target='_blank'>Add subheadings to improve readability</a>." );
+	// } );
+	//
+	// it( "Scores a long text (>600 characters), which has subheadings and some sections of the text are " +
+	// 	"above 700 characters long.", function() {
+	// 	const paper = new Paper( shortTextJapanese + subheading + veryLongTextJapanese + subheading + veryLongTextJapanese );
+	// 	const japaneseResearcher = new JapaneseResearcher( paper );
+	// 	const subheadingDistributionTooLongJA = new SubheadingDistributionTooLong();
+	// 	const results = subheadingDistributionTooLongJA.getResult( paper, japaneseResearcher );
+	// 	expect( results.getScore( paper, japaneseResearcher ) ).toBe( 3 );
+	// 	expect( results.getText( paper, japaneseResearcher ) ).toBe( "<a href='https://yoa.st/34x' target='_blank'>" +
+	// 		"Subheading distribution</a>: 2 sections of your text are longer than 600 characters and are not separated " +
+	// 		"by any subheadings. <a href='https://yoa.st/34y' target='_blank'>Add subheadings to improve readability</a>." );
+	// } );
 
 	it( "Returns false when the assessment shouldn't appear in short text analysis and the text contains less " +
 		"than 600 characters in Japanese", function() {
@@ -272,8 +272,8 @@ describe( "Language-specific configuration for specific types of content is used
 	const shortCornerstoneText = "a ".repeat( 225 );
 	const longCornerstoneText = "a ".repeat( 275 );
 	const japaneseResearcher = new JapaneseResearcher( mockPaper );
-	const shortCornerstoneTextJapanese = "熱".repeat( 450 );
-	const longCornerstoneTextJapanese = "熱".repeat( 550 );
+	// const shortCornerstoneTextJapanese = "熱".repeat( 450 );  // Variable is used in language specific test (and thus removed)
+	// const longCornerstoneTextJapanese = "熱".repeat( 550 );   // Variable is used in language specific test (and thus removed)
 
 	it( "should use a language-specific default configuration", function() {
 		const assessment = new SubheadingDistributionTooLong();
@@ -328,27 +328,27 @@ describe( "Language-specific configuration for specific types of content is used
 			expect( assessment._config.slightlyTooMany ).toEqual( japaneseConfig.cornerstoneParameters.slightlyTooMany );
 			expect( assessment._config.farTooMany ).toEqual( japaneseConfig.cornerstoneParameters.farTooMany );
 		} );
-//Only need one test for japanese to test getLanguageSpecificConfig. The other tests are redundant.
-/*		it( "should score short cornerstone content in Japanese (<500 characters), " +
-		"which does not have subheadings, as OK.", function() {
-			const paper = new Paper( shortCornerstoneTextJapanese );
-			const assessment = assessor.getAssessment( "subheadingsTooLong" );
-			const results = assessment.getResult( paper, japaneseResearcher );
-			expect( results.getScore() ).toBe( 9 );
-			expect( results.getText() ).toBe( "<a href='https://yoa.st/34x' target='_blank'>Subheading distribution</a>: " +
-			"You are not using any subheadings, but your text is short enough and probably doesn't need them." );
-		} );
-
-		it( "should score slightly too long cornerstone content in Japanese (>500, <600 characters), " +
-		"which does not have subheadings, as bad.", function() {
-			const paper = new Paper( longCornerstoneTextJapanese );
-			const assessment = assessor.getAssessment( "subheadingsTooLong" );
-			const results = assessment.getResult( paper, japaneseResearcher );
-			expect( results.getScore() ).toBe( 2 );
-			expect( results.getText() ).toBe( "<a href='https://yoa.st/34x' target='_blank'>Subheading distribution</a>: " +
-			"You are not using any subheadings, although your text is rather long. " +
-			"<a href='https://yoa.st/34y' target='_blank'>Try and add some subheadings</a>." );
-		} );*/
+		//Only need one test for japanese to test getLanguageSpecificConfig. The other tests are redundant.
+		// it( "should score short cornerstone content in Japanese (<500 characters), " +
+		// "which does not have subheadings, as OK.", function() {
+		// 	const paper = new Paper( shortCornerstoneTextJapanese );
+		// 	const assessment = assessor.getAssessment( "subheadingsTooLong" );
+		// 	const results = assessment.getResult( paper, japaneseResearcher );
+		// 	expect( results.getScore() ).toBe( 9 );
+		// 	expect( results.getText() ).toBe( "<a href='https://yoa.st/34x' target='_blank'>Subheading distribution</a>: " +
+		// 	"You are not using any subheadings, but your text is short enough and probably doesn't need them." );
+		// } );
+		//
+		// it( "should score slightly too long cornerstone content in Japanese (>500, <600 characters), " +
+		// "which does not have subheadings, as bad.", function() {
+		// 	const paper = new Paper( longCornerstoneTextJapanese );
+		// 	const assessment = assessor.getAssessment( "subheadingsTooLong" );
+		// 	const results = assessment.getResult( paper, japaneseResearcher );
+		// 	expect( results.getScore() ).toBe( 2 );
+		// 	expect( results.getText() ).toBe( "<a href='https://yoa.st/34x' target='_blank'>Subheading distribution</a>: " +
+		// 	"You are not using any subheadings, although your text is rather long. " +
+		// 	"<a href='https://yoa.st/34y' target='_blank'>Try and add some subheadings</a>." );
+		// } );
 	} );
 } );
 

--- a/packages/yoastseo/spec/scoring/assessments/readability/SubheadingDistributionTooLongAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/readability/SubheadingDistributionTooLongAssessmentSpec.js
@@ -1,3 +1,4 @@
+/* eslint-disable capitalized-comments, spaced-comment */
 import SubheadingDistributionTooLong from "../../../../src/scoring/assessments/readability/SubheadingDistributionTooLongAssessment.js";
 import Paper from "../../../../src/values/Paper.js";
 import Factory from "../../../specHelpers/factory.js";

--- a/packages/yoastseo/spec/scoring/assessments/readability/fleschReadingEaseAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/readability/fleschReadingEaseAssessmentSpec.js
@@ -87,7 +87,7 @@ describe( "An assessment for the Flesch reading ease test", function() {
 			" which is considered very easy to read. Good job!" );
 	} );
 
-	it( "returns a 'very easy' score and the associated feedback text for a paper using the Russian config when the score is 100.", function() {
+	/*it( "returns a 'very easy' score and the associated feedback text for a paper using the Russian config when the score is 100.", function() {
 		const paper = new Paper( "This is a very interesting paper" );
 		const result = fleschReadingAssessment.getResult( paper, factory.buildMockResearcher( 100, false, false, russianConfig ) );
 
@@ -124,10 +124,9 @@ describe( "An assessment for the Flesch reading ease test", function() {
 		expect( result.getScore() ).toBe( 9 );
 		expect( result.getText() ).toBe( "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 72.9 in the test," +
 			" which is considered easy to read. Good job!" );
-	} );
+	} );*/
 
-	it( "returns a 'fairly easy' score and the associated feedback text for a paper using the Russian config when the score is" +
-		" between 60 and 70.", function() {
+	it( "returns the correct score and feedback for a language that overrides the default config (Russian)", function() {
 		const paper = new Paper( "This is a very interesting paper" );
 		const result = fleschReadingAssessment.getResult( paper, factory.buildMockResearcher( 66.6, false, false, russianConfig ) );
 
@@ -136,7 +135,7 @@ describe( "An assessment for the Flesch reading ease test", function() {
 			" which is considered fairly easy to read. Good job!" );
 	} );
 
-	it( "returns an 'okay' score and the associated feedback text for a paper using the Russian config when the score is" +
+	/*it( "returns an 'okay' score and the associated feedback text for a paper using the Russian config when the score is" +
 		" between 50 and 60.", function() {
 		const paper = new Paper( "This is a very interesting paper" );
 		const result = fleschReadingAssessment.getResult( paper, factory.buildMockResearcher( 55.5, false, false, russianConfig ) );
@@ -178,7 +177,7 @@ describe( "An assessment for the Flesch reading ease test", function() {
 			" test, which is considered very difficult to read. <a href='https://yoa.st/34s' target='_blank'>Try to make shorter sentences, using " +
 			"less difficult words to improve readability</a>." );
 	} );
-
+*/
 	it( "returns a feedback text containing '100' for a paper with a Flesch score above 100.", function() {
 		const paper = new Paper( "This is a very interesting paper" );
 		const result = fleschReadingAssessment.getResult( paper, factory.buildMockResearcher( 103.0, false, false, russianConfig ) );

--- a/packages/yoastseo/spec/scoring/assessments/readability/fleschReadingEaseAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/readability/fleschReadingEaseAssessmentSpec.js
@@ -1,3 +1,4 @@
+/* eslint-disable capitalized-comments */
 import EnglishResearcher from "../../../../src/languageProcessing/languages/en/Researcher";
 import DefaultResearcher from "../../../../src/languageProcessing/languages/_default/Researcher";
 import fleschReadingAssessment from "../../../../src/scoring/assessments/readability/fleschReadingEaseAssessment.js";

--- a/packages/yoastseo/spec/scoring/assessments/readability/fleschReadingEaseAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/readability/fleschReadingEaseAssessmentSpec.js
@@ -1,4 +1,4 @@
-/* eslint-disable capitalized-comments */
+/* eslint-disable capitalized-comments, spaced-comment */
 import EnglishResearcher from "../../../../src/languageProcessing/languages/en/Researcher";
 import DefaultResearcher from "../../../../src/languageProcessing/languages/_default/Researcher";
 import fleschReadingAssessment from "../../../../src/scoring/assessments/readability/fleschReadingEaseAssessment.js";

--- a/packages/yoastseo/spec/scoring/assessments/seo/IntroductionKeywordAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/IntroductionKeywordAssessmentSpec.js
@@ -1,4 +1,4 @@
-/* eslint-disable capitalized-comments */
+/* eslint-disable capitalized-comments, spaced-comment */
 import EnglishResearcher from "../../../../src/languageProcessing/languages/en/Researcher";
 import IntroductionKeywordAssessment from "../../../../src/scoring/assessments/seo/IntroductionKeywordAssessment";
 import Paper from "../../../../src/values/Paper";

--- a/packages/yoastseo/spec/scoring/assessments/seo/IntroductionKeywordAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/IntroductionKeywordAssessmentSpec.js
@@ -1,12 +1,10 @@
 import EnglishResearcher from "../../../../src/languageProcessing/languages/en/Researcher";
-import JapaneseResearcher from "../../../../src/languageProcessing/languages/ja/Researcher";
 import IntroductionKeywordAssessment from "../../../../src/scoring/assessments/seo/IntroductionKeywordAssessment";
 import Paper from "../../../../src/values/Paper";
 import Factory from "../../../specHelpers/factory";
 import getMorphologyData from "../../../specHelpers/getMorphologyData";
 
 const morphologyData = getMorphologyData( "en" );
-const morphologyDataJA = getMorphologyData( "ja" );
 
 describe( "An assessment for finding the keyword in the first paragraph", function() {
 	it( "returns keyphrase words found in one sentence of the first paragraph", function() {

--- a/packages/yoastseo/spec/scoring/assessments/seo/IntroductionKeywordAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/IntroductionKeywordAssessmentSpec.js
@@ -141,7 +141,7 @@ describe( "a test for the keyphrase in first paragraph assessment when the exact
 		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/33e' target='_blank'>Keyphrase in introduction</a>: Well done!" );
 	} );
 
-	it( "returns a bad result when the first paragraph doesn't contain the exact match of the keyphrase in Japanese", function() {
+	/*it( "returns a bad result when the first paragraph doesn't contain the exact match of the keyphrase in Japanese", function() {
 		const mockPaper = new Paper( "小さくて可愛い花の刺繍に関する一般一般の記事です。私は美しい猫を飼っています。",
 			{
 				keyword: "『小さい花の刺繍』",
@@ -194,5 +194,5 @@ describe( "a test for the keyphrase in first paragraph assessment when the exact
 
 		expect( assessment.getScore() ).toBe( 9 );
 		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/33e' target='_blank'>Keyphrase in introduction</a>: Well done!" );
-	} );
+	} );*/
 } );

--- a/packages/yoastseo/spec/scoring/assessments/seo/IntroductionKeywordAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/IntroductionKeywordAssessmentSpec.js
@@ -1,3 +1,4 @@
+/* eslint-disable capitalized-comments */
 import EnglishResearcher from "../../../../src/languageProcessing/languages/en/Researcher";
 import IntroductionKeywordAssessment from "../../../../src/scoring/assessments/seo/IntroductionKeywordAssessment";
 import Paper from "../../../../src/values/Paper";

--- a/packages/yoastseo/spec/scoring/assessments/seo/KeyphraseInImageTextAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/KeyphraseInImageTextAssessmentSpec.js
@@ -286,30 +286,32 @@ describe( "An image count assessment", function() {
 			"<a href='https://yoa.st/4f6' target='_blank'>Add your keyphrase or synonyms to the alt tags of relevant images</a>!" );
 	} );
 
-	it( "assesses a single image with alt-tag containing a non-exact match of the keyphrase when the keyphrase is enclosed in double quotes in Japanese", function() {
-		const mockPaper = new Paper( "These are just five words <img src='image.jpg' alt='小さくて可愛い花の刺繍に関する一般一般の記事です' />", {
-			keyword: "『小さい花の刺繍』",
-		} );
+	// Japanese testers test no additional logic.
 
-		const result = keyphraseInImagesAssessment.getResult( mockPaper, new JapaneseResearcher( mockPaper ) );
+	// it( "assesses a single image with alt-tag containing a non-exact match of the keyphrase when the keyphrase is enclosed in double quotes in Japanese", function() {
+	// 	const mockPaper = new Paper( "These are just five words <img src='image.jpg' alt='小さくて可愛い花の刺繍に関する一般一般の記事です' />", {
+	// 		keyword: "『小さい花の刺繍』",
+	// 	} );
+	//
+	// 	const result = keyphraseInImagesAssessment.getResult( mockPaper, new JapaneseResearcher( mockPaper ) );
+	//
+	// 	expect( result.getScore() ).toEqual( 6 );
+	// 	expect( result.getText() ).toEqual( "<a href='https://yoa.st/4f7' target='_blank'>Image Keyphrase</a>:" +
+	// 		" Images on this page do not have alt attributes with at least half of the words from your keyphrase." +
+	// 		" <a href='https://yoa.st/4f6' target='_blank'>Fix that</a>!"  );
+	// } );
 
-		expect( result.getScore() ).toEqual( 6 );
-		expect( result.getText() ).toEqual( "<a href='https://yoa.st/4f7' target='_blank'>Image Keyphrase</a>:" +
-			" Images on this page do not have alt attributes with at least half of the words from your keyphrase." +
-			" <a href='https://yoa.st/4f6' target='_blank'>Fix that</a>!"  );
-	} );
-
-	it( "assesses a single image with alt-tag containing an exact match of the keyphrase when the keyphrase is enclosed in double quotes in Japanese", function() {
-		const mockPaper = new Paper( "These are just five words <img src='image.jpg' alt='小さい花の刺繍' />", {
-			keyword: "『小さい花の刺繍』",
-		} );
-
-		const result = keyphraseInImagesAssessment.getResult( mockPaper, new JapaneseResearcher( mockPaper ) );
-
-		expect( result.getScore() ).toEqual( 9 );
-		expect( result.getText() ).toEqual( "<a href='https://yoa.st/4f7' target='_blank'>Image Keyphrase</a>: " +
-			"Good job!" );
-	} );
+	// it( "assesses a single image with alt-tag containing an exact match of the keyphrase when the keyphrase is enclosed in double quotes in Japanese", function() {
+	// 	const mockPaper = new Paper( "These are just five words <img src='image.jpg' alt='小さい花の刺繍' />", {
+	// 		keyword: "『小さい花の刺繍』",
+	// 	} );
+	//
+	// 	const result = keyphraseInImagesAssessment.getResult( mockPaper, new JapaneseResearcher( mockPaper ) );
+	//
+	// 	expect( result.getScore() ).toEqual( 9 );
+	// 	expect( result.getText() ).toEqual( "<a href='https://yoa.st/4f7' target='_blank'>Image Keyphrase</a>: " +
+	// 		"Good job!" );
+	// } );
 } );
 
 describe( "tests for the assessment applicability.", function() {

--- a/packages/yoastseo/spec/scoring/assessments/seo/KeyphraseInImageTextAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/KeyphraseInImageTextAssessmentSpec.js
@@ -1,3 +1,4 @@
+/* eslint-disable capitalized-comments, spaced-comment */
 import KeyphraseInImagesAssessment from "../../../../src/scoring/assessments/seo/KeyphraseInImageTextAssessment";
 import Paper from "../../../../src/values/Paper.js";
 import Factory from "../../../specHelpers/factory.js";

--- a/packages/yoastseo/spec/scoring/assessments/seo/KeyphraseInImageTextAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/KeyphraseInImageTextAssessmentSpec.js
@@ -2,7 +2,7 @@
 import KeyphraseInImagesAssessment from "../../../../src/scoring/assessments/seo/KeyphraseInImageTextAssessment";
 import Paper from "../../../../src/values/Paper.js";
 import Factory from "../../../specHelpers/factory.js";
-import JapaneseResearcher from "../../../../src/languageProcessing/languages/ja/Researcher";
+// import JapaneseResearcher from "../../../../src/languageProcessing/languages/ja/Researcher";   // Variable is used in language specific test (and thus removed)
 
 const keyphraseInImagesAssessment = new KeyphraseInImagesAssessment();
 

--- a/packages/yoastseo/spec/scoring/assessments/seo/KeyphraseLengthAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/KeyphraseLengthAssessmentSpec.js
@@ -1,3 +1,4 @@
+/* eslint-disable capitalized-comments, spaced-comment */
 import { merge } from "lodash-es";
 
 import KeyphraseLengthAssessment from "../../../../src/scoring/assessments/seo/KeyphraseLengthAssessment";

--- a/packages/yoastseo/spec/scoring/assessments/seo/KeyphraseLengthAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/KeyphraseLengthAssessmentSpec.js
@@ -242,6 +242,7 @@ describe( "the keyphrase length assessment for regular posts and pages", functio
 	} );
 } );
 
+//Japanese tests do test character specific logic. So not removed.
 describe( "the keyphrase length assessment for Japanese", function() {
 	it( "should clear the memoized data", function() {
 		primeLanguageSpecificData.cache.clear();

--- a/packages/yoastseo/spec/scoring/assessments/seo/KeywordDensityAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/KeywordDensityAssessmentSpec.js
@@ -10,14 +10,14 @@ import getMorphologyData from "../../../specHelpers/getMorphologyData";
 
 const morphologyData = getMorphologyData( "en" );
 const morphologyDataDe = getMorphologyData( "de" );
-const morphologyDataJA = getMorphologyData( "ja" );
+// const morphologyDataJA = getMorphologyData( "ja" ); // Variable is used in language specific test (and thus removed)
 const nonkeyword = "nonkeyword, ";
 const keyword = "keyword, ";
 const shortTextJapanese = "熱".repeat( 199 );
 const longTextJapanese = "熱".repeat( 200 );
-const japaneseSentence = "私の猫はかわいいです。小さくて可愛い花の刺繍に関する一般一般の記事です。".repeat( 20 );
-const japaneseSentenceWithKeyphrase = "一日一冊の面白い本を買って読んでるのはできるかどうかやってみます。";
-const japaneseSentenceWithKeyphraseExactMatch = "一日一冊の本を読むのはできるかどうかやってみます。";
+// const japaneseSentence = "私の猫はかわいいです。小さくて可愛い花の刺繍に関する一般一般の記事です。".repeat( 20 );   // Variable is used in language specific test (and thus removed)
+// const japaneseSentenceWithKeyphrase = "一日一冊の面白い本を買って読んでるのはできるかどうかやってみます。";   // Variable is used in language specific test (and thus removed)
+// const japaneseSentenceWithKeyphraseExactMatch = "一日一冊の本を読むのはできるかどうかやってみます。";   // Variable is used in language specific test (and thus removed)
 
 describe( "Tests for the keywordDensity assessment for languages without morphology", function() {
 	it( "runs the keywordDensity on the paper without keyword in the text", function() {

--- a/packages/yoastseo/spec/scoring/assessments/seo/KeywordDensityAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/KeywordDensityAssessmentSpec.js
@@ -1,3 +1,4 @@
+/* eslint-disable capitalized-comments, spaced-comment */
 import KeywordDensityAssessment from "../../../../src/scoring/assessments/seo/KeywordDensityAssessment";
 import EnglishResearcher from "../../../../src/languageProcessing/languages/en/Researcher";
 import GermanResearcher from "../../../../src/languageProcessing/languages/de/Researcher";
@@ -206,193 +207,194 @@ describe( "A test for marking the keyword", function() {
 				original: "This is the release of YoastSEO 9.3." } ) ];
 		expect( keywordDensityAssessment.getMarks() ).toEqual( expected );
 	} );
-	it( "returns markers for a Japanese keyphrase enclosed in double quotes", function() {
-		const paper = new Paper( japaneseSentenceWithKeyphraseExactMatch.repeat( 3 ), {
-			keyword: "『一冊の本を読む』",
-			locale: "ja",
-		} );
-		const researcher = new JapaneseResearcher( paper );
-		const assessment = new KeywordDensityAssessment();
-		researcher.addResearchData( "morphology", morphologyDataJA );
 
-		const result = assessment.getResult( paper, researcher );
-		const marks = [
-			new Mark( {
-				marked: "一日<yoastmark class='yoast-text-mark'>一冊の本を読む</yoastmark>のはできるかどうかやってみます。",
-				original: "一日一冊の本を読むのはできるかどうかやってみます。",
-			} ),
-			new Mark( {
-				marked: "一日<yoastmark class='yoast-text-mark'>一冊の本を読む</yoastmark>のはできるかどうかやってみます。",
-				original: "一日一冊の本を読むのはできるかどうかやってみます。",
-			} ),
-			new Mark( {
-				marked: "一日<yoastmark class='yoast-text-mark'>一冊の本を読む</yoastmark>のはできるかどうかやってみます。",
-				original: "一日一冊の本を読むのはできるかどうかやってみます。",
-			} ),
-		];
-
-		expect( result.getScore() ).toBe( -50 );
-		expect( result.getText() ).toBe( "<a href='https://yoa.st/33v' target='_blank'>Keyphrase density</a>: " +
-			"The focus keyphrase was found 3 times." +
-			" That's way more than the recommended maximum of 2 times for a text of this length. <a href='https://yoa.st/33w' target='_blank'>Don't" +
-			" overoptimize</a>!" );
-		expect( assessment.getMarks() ).toEqual( marks );
-	} );
+	// it( "returns markers for a Japanese keyphrase enclosed in double quotes", function() {
+	// 	const paper = new Paper( japaneseSentenceWithKeyphraseExactMatch.repeat( 3 ), {
+	// 		keyword: "『一冊の本を読む』",
+	// 		locale: "ja",
+	// 	} );
+	// 	const researcher = new JapaneseResearcher( paper );
+	// 	const assessment = new KeywordDensityAssessment();
+	// 	researcher.addResearchData( "morphology", morphologyDataJA );
+	//
+	// 	const result = assessment.getResult( paper, researcher );
+	// 	const marks = [
+	// 		new Mark( {
+	// 			marked: "一日<yoastmark class='yoast-text-mark'>一冊の本を読む</yoastmark>のはできるかどうかやってみます。",
+	// 			original: "一日一冊の本を読むのはできるかどうかやってみます。",
+	// 		} ),
+	// 		new Mark( {
+	// 			marked: "一日<yoastmark class='yoast-text-mark'>一冊の本を読む</yoastmark>のはできるかどうかやってみます。",
+	// 			original: "一日一冊の本を読むのはできるかどうかやってみます。",
+	// 		} ),
+	// 		new Mark( {
+	// 			marked: "一日<yoastmark class='yoast-text-mark'>一冊の本を読む</yoastmark>のはできるかどうかやってみます。",
+	// 			original: "一日一冊の本を読むのはできるかどうかやってみます。",
+	// 		} ),
+	// 	];
+	//
+	// 	expect( result.getScore() ).toBe( -50 );
+	// 	expect( result.getText() ).toBe( "<a href='https://yoa.st/33v' target='_blank'>Keyphrase density</a>: " +
+	// 		"The focus keyphrase was found 3 times." +
+	// 		" That's way more than the recommended maximum of 2 times for a text of this length. <a href='https://yoa.st/33w' target='_blank'>Don't" +
+	// 		" overoptimize</a>!" );
+	// 	expect( assessment.getMarks() ).toEqual( marks );
+	// } );
 } );
-
-describe( "A test for keyword density in Japanese", function() {
-	it( "shouldn't return NaN/infinity times of keyphrase occurrence when the keyphrase contains only function words " +
-		"and there is no match in the text", function() {
-		const paper = new Paper( japaneseSentence + japaneseSentenceWithKeyphrase.repeat( 32 ), {
-			keyword: "ばっかり",
-			locale: "ja",
-		} );
-		const researcher = new JapaneseResearcher( paper );
-		researcher.addResearchData( "morphology", morphologyDataJA );
-		const result = new KeywordDensityAssessment().getResult( paper, researcher );
-		expect( result.getScore() ).toBe( 4 );
-		expect( result.getText() ).toBe( "<a href='https://yoa.st/33v' target='_blank'>Keyphrase density</a>: " +
-			"The focus keyphrase was found 0 times. That's less than the recommended minimum of 6 times for a text of this length. " +
-			"<a href='https://yoa.st/33w' target='_blank'>Focus on your keyphrase</a>!" );
-	} );
-
-	it( "shouldn't return NaN/infinity times of synonym occurrence when the synonym contains only function words " +
-		"and there is no match in the text", function() {
-		const paper = new Paper( japaneseSentence + japaneseSentenceWithKeyphrase.repeat( 32 ), {
-			keyword: "",
-			synonyms: "ばっかり",
-			locale: "ja",
-		} );
-		const researcher = new JapaneseResearcher( paper );
-		researcher.addResearchData( "morphology", morphologyDataJA );
-		const result = new KeywordDensityAssessment().getResult( paper, researcher );
-		expect( result.getScore() ).toBe( 4 );
-		expect( result.getText() ).toBe( "<a href='https://yoa.st/33v' target='_blank'>Keyphrase density</a>: " +
-			"The focus keyphrase was found 0 times. That's less than the recommended minimum of 6 times for a text of this length. " +
-			"<a href='https://yoa.st/33w' target='_blank'>Focus on your keyphrase</a>!" );
-	} );
-
-	it( "shouldn't return NaN/infinity times of keyphrase occurrence when the keyphrase contains spaces " +
-		"and there is no match in the text", function() {
-		const paper = new Paper( japaneseSentence + japaneseSentenceWithKeyphrase.repeat( 32 ), {
-			keyword: "かしら かい を ばっかり",
-			locale: "ja",
-		} );
-		const researcher = new JapaneseResearcher( paper );
-		researcher.addResearchData( "morphology", morphologyDataJA );
-		const result = new KeywordDensityAssessment().getResult( paper, researcher );
-		expect( result.getScore() ).toBe( 4 );
-		expect( result.getText() ).toBe( "<a href='https://yoa.st/33v' target='_blank'>Keyphrase density</a>: " +
-			"The focus keyphrase was found 0 times. That's less than the recommended minimum of 6 times for a text of this length. " +
-			"<a href='https://yoa.st/33w' target='_blank'>Focus on your keyphrase</a>!" );
-	} );
-
-	it( "gives a very BAD result when keyword density is above 4% when the text contains way too many instances" +
-		" of the keyphrase forms", function() {
-		const paper = new Paper( japaneseSentence + japaneseSentenceWithKeyphrase.repeat( 32 ), {
-			keyword: "一冊の本を読む",
-			locale: "ja",
-		} );
-		const researcher = new JapaneseResearcher( paper );
-		researcher.addResearchData( "morphology", morphologyDataJA );
-		const result = new KeywordDensityAssessment().getResult( paper, researcher );
-		expect( result.getScore() ).toBe( -50 );
-		expect( result.getText() ).toBe( "<a href='https://yoa.st/33v' target='_blank'>Keyphrase density</a>: " +
-			"The focus keyphrase was found 32 times. That's way more than the recommended maximum of 23 times for a text of " +
-			"this length. <a href='https://yoa.st/33w' target='_blank'>Don't overoptimize</a>!" );
-	} );
-
-	it( "gives a BAD result when keyword density is between 3% and 4% when the text contains too many instances" +
-		" of the keyphrase forms", function() {
-		const paper = new Paper( japaneseSentence + japaneseSentenceWithKeyphrase.repeat( 16 ), {
-			keyword: "一冊の本を読む",
-			locale: "ja",
-		} );
-		const researcher = new JapaneseResearcher( paper );
-		researcher.addResearchData( "morphology", morphologyDataJA );
-		const result = new KeywordDensityAssessment().getResult( paper, researcher );
-		expect( result.getScore() ).toBe( -10 );
-		expect( result.getText() ).toBe( "<a href='https://yoa.st/33v' target='_blank'>Keyphrase density</a>:" +
-			" The focus keyphrase was found 16 times. That's more than the recommended maximum of 15 times for a text of this length." +
-			" <a href='https://yoa.st/33w' target='_blank'>Don't overoptimize</a>!" );
-	} );
-
-	it( "gives a BAD result when keyword density is 0", function() {
-		const paper = new Paper( japaneseSentence, { keyword: "一冊の本を読む", locale: "ja" } );
-		const researcher = new JapaneseResearcher( paper );
-		researcher.addResearchData( "morphology", morphologyDataJA );
-		const result = new KeywordDensityAssessment().getResult( paper, researcher );
-		expect( result.getScore() ).toBe( 4 );
-		expect( result.getText() ).toBe( "<a href='https://yoa.st/33v' target='_blank'>Keyphrase density</a>: " +
-			"The focus keyphrase was found 0 times. That's less than the recommended minimum of 2 times for a text of this length." +
-			" <a href='https://yoa.st/33w' target='_blank'>Focus on your keyphrase</a>!" );
-	} );
-
-	it( "gives a BAD result when keyword density is between 0 and 0.5%", function() {
-		const paper = new Paper( japaneseSentence + japaneseSentenceWithKeyphrase.repeat( 1 ), {
-			keyword: "一冊の本を読む",
-			locale: "ja",
-		} );
-		const researcher = new JapaneseResearcher( paper );
-		researcher.addResearchData( "morphology", morphologyDataJA );
-		const result = new KeywordDensityAssessment().getResult( paper, researcher );
-		expect( result.getScore() ).toBe( 4 );
-		expect( result.getText() ).toBe( "<a href='https://yoa.st/33v' target='_blank'>Keyphrase density</a>:" +
-			" The focus keyphrase was found 1 time. That's less than the recommended minimum of 2 times for a text of this length." +
-			" <a href='https://yoa.st/33w' target='_blank'>Focus on your keyphrase</a>!" );
-	} );
-
-	it( "gives a GOOD result when keyword density is between 0.5% and 3.5% when the text contains keyphrase forms", function() {
-		const paper = new Paper( japaneseSentence + japaneseSentenceWithKeyphrase.repeat( 8 ), {
-			keyword: "一冊の本を読む",
-			locale: "ja",
-		} );
-		const researcher = new JapaneseResearcher( paper );
-		researcher.addResearchData( "morphology", morphologyDataJA );
-		const result = new KeywordDensityAssessment().getResult( paper, researcher );
-		expect( result.getScore() ).toBe( 9 );
-		expect( result.getText() ).toBe( "<a href='https://yoa.st/33v' target='_blank'>Keyphrase density</a>: " +
-			"The focus keyphrase was found 8 times. This is great!" );
-	} );
-
-	it( "gives a GOOD result when keyword density is between 0.5% and 3%, when the exact match of the keyphrase is in the text", function() {
-		const paper = new Paper( japaneseSentence + japaneseSentenceWithKeyphraseExactMatch.repeat( 8 ), {
-			keyword: "一冊の本を読む",
-			locale: "ja",
-		} );
-		const researcher = new JapaneseResearcher( paper );
-		researcher.addResearchData( "morphology", morphologyDataJA );
-		const result = new KeywordDensityAssessment().getResult( paper, researcher );
-		expect( result.getScore() ).toBe( 9 );
-		expect( result.getText() ).toBe( "<a href='https://yoa.st/33v' target='_blank'>Keyphrase density</a>: " +
-			"The focus keyphrase was found 8 times. This is great!" );
-	} );
-
-	it( "should still gives a GOOD result when keyword density is between 0.5% and 3%, when the exact match of the keyphrase is in the text " +
-		"and the keyphrase is enclosed in double quotes", function() {
-		const paper = new Paper( japaneseSentence + japaneseSentenceWithKeyphraseExactMatch.repeat( 8 ), {
-			keyword: "「一冊の本を読む」",
-			locale: "ja",
-		} );
-		const researcher = new JapaneseResearcher( paper );
-		researcher.addResearchData( "morphology", morphologyDataJA );
-		const result = new KeywordDensityAssessment().getResult( paper, researcher );
-		expect( result.getScore() ).toBe( 9 );
-		expect( result.getText() ).toBe( "<a href='https://yoa.st/33v' target='_blank'>Keyphrase density</a>: " +
-			"The focus keyphrase was found 8 times. This is great!" );
-	} );
-
-	it( "gives a BAD result when keyword density is between 0.5% and 3.5%, if morphology is added, but there is no morphology data", function() {
-		const paper = new Paper( japaneseSentence + japaneseSentenceWithKeyphrase.repeat( 8 ), {
-			keyword: "一冊の本を読む",
-			locale: "ja",
-		} );
-		const researcher = new JapaneseResearcher( paper );
-		const result = new KeywordDensityAssessment().getResult( paper, researcher );
-		expect( result.getScore() ).toBe( 4 );
-		expect( result.getText() ).toBe( "<a href='https://yoa.st/33v' target='_blank'>Keyphrase density</a>: " +
-			"The focus keyphrase was found 0 times. That's less than the recommended minimum of 2 times for a text of this length." +
-			" <a href='https://yoa.st/33w' target='_blank'>Focus on your keyphrase</a>!" );
-	} );
-} );
-
+//
+// describe( "A test for keyword density in Japanese", function() {
+// 	it( "shouldn't return NaN/infinity times of keyphrase occurrence when the keyphrase contains only function words " +
+// 		"and there is no match in the text", function() {
+// 		const paper = new Paper( japaneseSentence + japaneseSentenceWithKeyphrase.repeat( 32 ), {
+// 			keyword: "ばっかり",
+// 			locale: "ja",
+// 		} );
+// 		const researcher = new JapaneseResearcher( paper );
+// 		researcher.addResearchData( "morphology", morphologyDataJA );
+// 		const result = new KeywordDensityAssessment().getResult( paper, researcher );
+// 		expect( result.getScore() ).toBe( 4 );
+// 		expect( result.getText() ).toBe( "<a href='https://yoa.st/33v' target='_blank'>Keyphrase density</a>: " +
+// 			"The focus keyphrase was found 0 times. That's less than the recommended minimum of 6 times for a text of this length. " +
+// 			"<a href='https://yoa.st/33w' target='_blank'>Focus on your keyphrase</a>!" );
+// 	} );
+//
+// 	it( "shouldn't return NaN/infinity times of synonym occurrence when the synonym contains only function words " +
+// 		"and there is no match in the text", function() {
+// 		const paper = new Paper( japaneseSentence + japaneseSentenceWithKeyphrase.repeat( 32 ), {
+// 			keyword: "",
+// 			synonyms: "ばっかり",
+// 			locale: "ja",
+// 		} );
+// 		const researcher = new JapaneseResearcher( paper );
+// 		researcher.addResearchData( "morphology", morphologyDataJA );
+// 		const result = new KeywordDensityAssessment().getResult( paper, researcher );
+// 		expect( result.getScore() ).toBe( 4 );
+// 		expect( result.getText() ).toBe( "<a href='https://yoa.st/33v' target='_blank'>Keyphrase density</a>: " +
+// 			"The focus keyphrase was found 0 times. That's less than the recommended minimum of 6 times for a text of this length. " +
+// 			"<a href='https://yoa.st/33w' target='_blank'>Focus on your keyphrase</a>!" );
+// 	} );
+//
+// 	it( "shouldn't return NaN/infinity times of keyphrase occurrence when the keyphrase contains spaces " +
+// 		"and there is no match in the text", function() {
+// 		const paper = new Paper( japaneseSentence + japaneseSentenceWithKeyphrase.repeat( 32 ), {
+// 			keyword: "かしら かい を ばっかり",
+// 			locale: "ja",
+// 		} );
+// 		const researcher = new JapaneseResearcher( paper );
+// 		researcher.addResearchData( "morphology", morphologyDataJA );
+// 		const result = new KeywordDensityAssessment().getResult( paper, researcher );
+// 		expect( result.getScore() ).toBe( 4 );
+// 		expect( result.getText() ).toBe( "<a href='https://yoa.st/33v' target='_blank'>Keyphrase density</a>: " +
+// 			"The focus keyphrase was found 0 times. That's less than the recommended minimum of 6 times for a text of this length. " +
+// 			"<a href='https://yoa.st/33w' target='_blank'>Focus on your keyphrase</a>!" );
+// 	} );
+//
+// 	it( "gives a very BAD result when keyword density is above 4% when the text contains way too many instances" +
+// 		" of the keyphrase forms", function() {
+// 		const paper = new Paper( japaneseSentence + japaneseSentenceWithKeyphrase.repeat( 32 ), {
+// 			keyword: "一冊の本を読む",
+// 			locale: "ja",
+// 		} );
+// 		const researcher = new JapaneseResearcher( paper );
+// 		researcher.addResearchData( "morphology", morphologyDataJA );
+// 		const result = new KeywordDensityAssessment().getResult( paper, researcher );
+// 		expect( result.getScore() ).toBe( -50 );
+// 		expect( result.getText() ).toBe( "<a href='https://yoa.st/33v' target='_blank'>Keyphrase density</a>: " +
+// 			"The focus keyphrase was found 32 times. That's way more than the recommended maximum of 23 times for a text of " +
+// 			"this length. <a href='https://yoa.st/33w' target='_blank'>Don't overoptimize</a>!" );
+// 	} );
+//
+// 	it( "gives a BAD result when keyword density is between 3% and 4% when the text contains too many instances" +
+// 		" of the keyphrase forms", function() {
+// 		const paper = new Paper( japaneseSentence + japaneseSentenceWithKeyphrase.repeat( 16 ), {
+// 			keyword: "一冊の本を読む",
+// 			locale: "ja",
+// 		} );
+// 		const researcher = new JapaneseResearcher( paper );
+// 		researcher.addResearchData( "morphology", morphologyDataJA );
+// 		const result = new KeywordDensityAssessment().getResult( paper, researcher );
+// 		expect( result.getScore() ).toBe( -10 );
+// 		expect( result.getText() ).toBe( "<a href='https://yoa.st/33v' target='_blank'>Keyphrase density</a>:" +
+// 			" The focus keyphrase was found 16 times. That's more than the recommended maximum of 15 times for a text of this length." +
+// 			" <a href='https://yoa.st/33w' target='_blank'>Don't overoptimize</a>!" );
+// 	} );
+//
+// 	it( "gives a BAD result when keyword density is 0", function() {
+// 		const paper = new Paper( japaneseSentence, { keyword: "一冊の本を読む", locale: "ja" } );
+// 		const researcher = new JapaneseResearcher( paper );
+// 		researcher.addResearchData( "morphology", morphologyDataJA );
+// 		const result = new KeywordDensityAssessment().getResult( paper, researcher );
+// 		expect( result.getScore() ).toBe( 4 );
+// 		expect( result.getText() ).toBe( "<a href='https://yoa.st/33v' target='_blank'>Keyphrase density</a>: " +
+// 			"The focus keyphrase was found 0 times. That's less than the recommended minimum of 2 times for a text of this length." +
+// 			" <a href='https://yoa.st/33w' target='_blank'>Focus on your keyphrase</a>!" );
+// 	} );
+//
+// 	it( "gives a BAD result when keyword density is between 0 and 0.5%", function() {
+// 		const paper = new Paper( japaneseSentence + japaneseSentenceWithKeyphrase.repeat( 1 ), {
+// 			keyword: "一冊の本を読む",
+// 			locale: "ja",
+// 		} );
+// 		const researcher = new JapaneseResearcher( paper );
+// 		researcher.addResearchData( "morphology", morphologyDataJA );
+// 		const result = new KeywordDensityAssessment().getResult( paper, researcher );
+// 		expect( result.getScore() ).toBe( 4 );
+// 		expect( result.getText() ).toBe( "<a href='https://yoa.st/33v' target='_blank'>Keyphrase density</a>:" +
+// 			" The focus keyphrase was found 1 time. That's less than the recommended minimum of 2 times for a text of this length." +
+// 			" <a href='https://yoa.st/33w' target='_blank'>Focus on your keyphrase</a>!" );
+// 	} );
+//
+// 	it( "gives a GOOD result when keyword density is between 0.5% and 3.5% when the text contains keyphrase forms", function() {
+// 		const paper = new Paper( japaneseSentence + japaneseSentenceWithKeyphrase.repeat( 8 ), {
+// 			keyword: "一冊の本を読む",
+// 			locale: "ja",
+// 		} );
+// 		const researcher = new JapaneseResearcher( paper );
+// 		researcher.addResearchData( "morphology", morphologyDataJA );
+// 		const result = new KeywordDensityAssessment().getResult( paper, researcher );
+// 		expect( result.getScore() ).toBe( 9 );
+// 		expect( result.getText() ).toBe( "<a href='https://yoa.st/33v' target='_blank'>Keyphrase density</a>: " +
+// 			"The focus keyphrase was found 8 times. This is great!" );
+// 	} );
+//
+// 	it( "gives a GOOD result when keyword density is between 0.5% and 3%, when the exact match of the keyphrase is in the text", function() {
+// 		const paper = new Paper( japaneseSentence + japaneseSentenceWithKeyphraseExactMatch.repeat( 8 ), {
+// 			keyword: "一冊の本を読む",
+// 			locale: "ja",
+// 		} );
+// 		const researcher = new JapaneseResearcher( paper );
+// 		researcher.addResearchData( "morphology", morphologyDataJA );
+// 		const result = new KeywordDensityAssessment().getResult( paper, researcher );
+// 		expect( result.getScore() ).toBe( 9 );
+// 		expect( result.getText() ).toBe( "<a href='https://yoa.st/33v' target='_blank'>Keyphrase density</a>: " +
+// 			"The focus keyphrase was found 8 times. This is great!" );
+// 	} );
+//
+// 	it( "should still gives a GOOD result when keyword density is between 0.5% and 3%, when the exact match of the keyphrase is in the text " +
+// 		"and the keyphrase is enclosed in double quotes", function() {
+// 		const paper = new Paper( japaneseSentence + japaneseSentenceWithKeyphraseExactMatch.repeat( 8 ), {
+// 			keyword: "「一冊の本を読む」",
+// 			locale: "ja",
+// 		} );
+// 		const researcher = new JapaneseResearcher( paper );
+// 		researcher.addResearchData( "morphology", morphologyDataJA );
+// 		const result = new KeywordDensityAssessment().getResult( paper, researcher );
+// 		expect( result.getScore() ).toBe( 9 );
+// 		expect( result.getText() ).toBe( "<a href='https://yoa.st/33v' target='_blank'>Keyphrase density</a>: " +
+// 			"The focus keyphrase was found 8 times. This is great!" );
+// 	} );
+//
+// 	it( "gives a BAD result when keyword density is between 0.5% and 3.5%, if morphology is added, but there is no morphology data", function() {
+// 		const paper = new Paper( japaneseSentence + japaneseSentenceWithKeyphrase.repeat( 8 ), {
+// 			keyword: "一冊の本を読む",
+// 			locale: "ja",
+// 		} );
+// 		const researcher = new JapaneseResearcher( paper );
+// 		const result = new KeywordDensityAssessment().getResult( paper, researcher );
+// 		expect( result.getScore() ).toBe( 4 );
+// 		expect( result.getText() ).toBe( "<a href='https://yoa.st/33v' target='_blank'>Keyphrase density</a>: " +
+// 			"The focus keyphrase was found 0 times. That's less than the recommended minimum of 2 times for a text of this length." +
+// 			" <a href='https://yoa.st/33w' target='_blank'>Focus on your keyphrase</a>!" );
+// 	} );
+// } );
+//

--- a/packages/yoastseo/spec/scoring/assessments/seo/MetaDescriptionKeywordAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/MetaDescriptionKeywordAssessmentSpec.js
@@ -1,4 +1,4 @@
-/* eslint-disable capitalized-comments */
+/* eslint-disable capitalized-comments, spaced-comment */
 import MetaDescriptionKeywordAssessment from "../../../../src/scoring/assessments/seo/MetaDescriptionKeywordAssessment";
 import Paper from "../../../../src/values/Paper";
 import Factory from "../../../specHelpers/factory";

--- a/packages/yoastseo/spec/scoring/assessments/seo/MetaDescriptionKeywordAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/MetaDescriptionKeywordAssessmentSpec.js
@@ -1,3 +1,4 @@
+/* eslint-disable capitalized-comments */
 import MetaDescriptionKeywordAssessment from "../../../../src/scoring/assessments/seo/MetaDescriptionKeywordAssessment";
 import Paper from "../../../../src/values/Paper";
 import Factory from "../../../specHelpers/factory";

--- a/packages/yoastseo/spec/scoring/assessments/seo/MetaDescriptionKeywordAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/MetaDescriptionKeywordAssessmentSpec.js
@@ -2,7 +2,6 @@ import MetaDescriptionKeywordAssessment from "../../../../src/scoring/assessment
 import Paper from "../../../../src/values/Paper";
 import Factory from "../../../specHelpers/factory";
 import EnglishResearcher from "../../../../src/languageProcessing/languages/en/Researcher";
-import JapaneseResearcher from "../../../../src/languageProcessing/languages/ja/Researcher";
 import getMorphologyData from "../../../specHelpers/getMorphologyData";
 
 const mockResearcherNoMatches = Factory.buildMockResearcher( 0 );
@@ -11,7 +10,6 @@ const mockResearcherTwoMatches = Factory.buildMockResearcher( 2 );
 const mockResearcherThreeMatches = Factory.buildMockResearcher( 3 );
 
 const morphologyData = getMorphologyData( "en" );
-const morphologyDataJA = getMorphologyData( "ja" );
 
 describe( "a test for the meta description keyword assessment", function() {
 	it( "returns a bad result when the meta description doesn't contain the keyword", function() {
@@ -121,7 +119,7 @@ describe( "a test for the meta description keyword assessment when the exact mat
 	} );
 
 
-	it( "returns a bad result when the meta description doesn't contain the exact match of the keyphrase in Japanese", function() {
+	/*it( "returns a bad result when the meta description doesn't contain the exact match of the keyphrase in Japanese", function() {
 		const mockPaper = new Paper( "", { keyword: "『小さい花の刺繍』",
 			synonyms: "野生のハーブの刺繡",
 			description: "小さくて可愛い花の刺繍に関する一般一般の記事です。私は美しい猫を飼っています。" }  );
@@ -170,5 +168,5 @@ describe( "a test for the meta description keyword assessment when the exact mat
 		expect( assessment.getScore() ).toBe( 9 );
 		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/33k' target='_blank'>Keyphrase in meta " +
 			"description</a>: Keyphrase or synonym appear in the meta description. Well done!" );
-	} );
+	} );*/
 } );

--- a/packages/yoastseo/spec/scoring/assessments/seo/SubHeadingsKeywordAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/SubHeadingsKeywordAssessmentSpec.js
@@ -1,3 +1,4 @@
+/* eslint-disable capitalized-comments */
 import SubheadingsKeywordAssessment from "../../../../src/scoring/assessments/seo/SubHeadingsKeywordAssessment";
 import Paper from "../../../../src/values/Paper";
 import Factory from "../../../specHelpers/factory";

--- a/packages/yoastseo/spec/scoring/assessments/seo/SubHeadingsKeywordAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/SubHeadingsKeywordAssessmentSpec.js
@@ -1,4 +1,4 @@
-/* eslint-disable capitalized-comments */
+/* eslint-disable capitalized-comments, spaced-comment */
 import SubheadingsKeywordAssessment from "../../../../src/scoring/assessments/seo/SubHeadingsKeywordAssessment";
 import Paper from "../../../../src/values/Paper";
 import Factory from "../../../specHelpers/factory";
@@ -95,7 +95,7 @@ describe( "An assessment for matching keywords in subheadings", () => {
 		);
 	} );
 
-/*	it( "returns a bad score and appropriate feedback when the subheading contains a non-exact match of a Japanese keyphrase when the keyphrase" +
+	/*	it( "returns a bad score and appropriate feedback when the subheading contains a non-exact match of a Japanese keyphrase when the keyphrase" +
 		" is in double quotes.", function() {
 		const mockPaper = new Paper( "<h2>小さくて可愛い花の刺繍に関する一般一般の記事です</h2>私は美しい猫を飼っています。野生のハーブの刺繡。", { keyword: "『小さい花の刺繍』" } );
 		const result = matchKeywordAssessment.getResult( mockPaper, new JapaneseResearcher( mockPaper ) );

--- a/packages/yoastseo/spec/scoring/assessments/seo/SubHeadingsKeywordAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/SubHeadingsKeywordAssessmentSpec.js
@@ -1,7 +1,6 @@
 import SubheadingsKeywordAssessment from "../../../../src/scoring/assessments/seo/SubHeadingsKeywordAssessment";
 import Paper from "../../../../src/values/Paper";
 import Factory from "../../../specHelpers/factory";
-import JapaneseResearcher from "../../../../src/languageProcessing/languages/ja/Researcher";
 
 const matchKeywordAssessment = new SubheadingsKeywordAssessment();
 

--- a/packages/yoastseo/spec/scoring/assessments/seo/SubHeadingsKeywordAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/SubHeadingsKeywordAssessmentSpec.js
@@ -95,7 +95,7 @@ describe( "An assessment for matching keywords in subheadings", () => {
 		);
 	} );
 
-	it( "returns a bad score and appropriate feedback when the subheading contains a non-exact match of a Japanese keyphrase when the keyphrase" +
+/*	it( "returns a bad score and appropriate feedback when the subheading contains a non-exact match of a Japanese keyphrase when the keyphrase" +
 		" is in double quotes.", function() {
 		const mockPaper = new Paper( "<h2>小さくて可愛い花の刺繍に関する一般一般の記事です</h2>私は美しい猫を飼っています。野生のハーブの刺繡。", { keyword: "『小さい花の刺繍』" } );
 		const result = matchKeywordAssessment.getResult( mockPaper, new JapaneseResearcher( mockPaper ) );
@@ -116,7 +116,7 @@ describe( "An assessment for matching keywords in subheadings", () => {
 		expect( result.getText() ).toEqual(
 			"<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: Your H2 or H3 subheading reflects the topic of your copy. Good job!"
 		);
-	} );
+	} );*/
 
 	it( "checks isApplicable for a paper without text", function() {
 		const paper = new Paper( "", { keyword: "some keyword" } );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We have a lot of language-specific unit tests for researches and assessments that are not necessary for unit-testing purposes. In this PR, we remove the tests that are deemed unnecessary. Additionally, there are tests that are unnecessary but nice to have, for the general purpose of having good test coverage for many languages. We want to move those tests to separate language-specific files. This will be done in a separate PR, but in this PR we mark those tests by commenting them out.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [yoastseo] Removes unnecessary language-specific tests for assessments and researchers, and comments out unnecessary-but-nice-to-have language-specific tests (they will be moved to separate files in a separate PR).

## Relevant technical choices:

*  Guidelines that were used in deciding whether a test should be kept, removed, or moved:
     * if there is language/researcher-specific logic inside the file, we keep the language-specific tests that cover it (e.g. when a custom helper is used for Japanese)
     * if there is no language-specific logic for the research/assessment, we comment out the tests (and in a separate PR, we'll move them to new files)
     * if there are multiple tests that have the same purpose (e.g., testing whether a research/assessment works for texts containing diacritics), we remove the duplicates
     
There may also be some exceptions to these rules, or cases that don't firmly fall into any of the three categories.

* ESLint errors for uncapitalized comments and no space at the beginning of the comment have been disabled in the files where we commented out tests. They will be enabled again in the following PR.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Make sure that the tests pass with 100% coverage for the files that were changed (note: `keyphraseDistributionSpec` and `keyphraseLengthAssessmentSpec` already had under 100% coverage, an issue has been created to fix it)


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* no need for QA testing as the changes don't affect the plugin

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes https://yoast.atlassian.net/browse/LINGO-1384
