### PR TITLE
Add component, styling, and rudimentary state

### DIFF
--- a/admin/class-config.php
+++ b/admin/class-config.php
@@ -66,6 +66,7 @@ class WPSEO_Admin_Pages {
 
 		if ( $page === 'wpseo_social' || $page === 'wpseo_licenses' ) {
 			$this->asset_manager->enqueue_style( 'monorepo' );
+			$this->asset_manager->enqueue_style( 'tailwind' );
 		}
 	}
 

--- a/admin/class-config.php
+++ b/admin/class-config.php
@@ -131,7 +131,13 @@ class WPSEO_Admin_Pages {
 		}
 
 		if ( $page === 'wpseo_social' ) {
-			$script_data['social'] = true;
+			$script_data['social'] = [
+				'facebook_url'      => WPSEO_Options::get( 'facebook_site', '' ),
+				'twitter_username'  => WPSEO_Options::get( 'twitter_site', '' ),
+				'other_social_urls' => WPSEO_Options::get( 'other_social_urls', [] ),
+				'company_or_person' => WPSEO_Options::get( 'company_or_person', '' ),
+			];
+			$script_data['search_appearance_link'] = admin_url( 'admin.php?page=wpseo_titles' );
 		}
 
 		$this->asset_manager->localize_script( 'settings', 'wpseoScriptData', $script_data );

--- a/admin/class-config.php
+++ b/admin/class-config.php
@@ -131,12 +131,23 @@ class WPSEO_Admin_Pages {
 		}
 
 		if ( $page === 'wpseo_social' ) {
+			$user_id = WPSEO_Options::get( 'company_or_person_user_id', '' );
+			$user = \get_userdata( $user_id );
+
+			$user_name = '';
+			if ( $user instanceof \WP_User ) {
+				$user_name = $user->get( 'display_name' );
+			}
+
 			$script_data['social'] = [
 				'facebook_url'      => WPSEO_Options::get( 'facebook_site', '' ),
 				'twitter_username'  => WPSEO_Options::get( 'twitter_site', '' ),
 				'other_social_urls' => WPSEO_Options::get( 'other_social_urls', [] ),
 				'company_or_person' => WPSEO_Options::get( 'company_or_person', '' ),
+				'user_id'           => $user_id,
+				'user_name'         => $user_name
 			];
+
 			$script_data['search_appearance_link'] = admin_url( 'admin.php?page=wpseo_titles' );
 		}
 

--- a/admin/views/tabs/social/accounts.php
+++ b/admin/views/tabs/social/accounts.php
@@ -21,33 +21,7 @@ $social_profiles_help = new WPSEO_Admin_Help_Panel(
 	'has-wrapper'
 );
 
-$company_or_person = WPSEO_Options::get( 'company_or_person', '' );
+echo '<div id="yoast-social-profiles"></div>';
 
-if ( $company_or_person === 'person' ) {
-	echo '<div class="paper tab-block">';
-	echo '<h2>' . esc_html__( 'Personal social profiles', 'wordpress-seo' ) . '</h2>';
-	echo '<p>';
-	$user_id = WPSEO_Options::get( 'company_or_person_user_id', '' );
-	$person  = get_userdata( $user_id );
-	printf(
-		/* translators: 1: link to edit user page. */
-		esc_html__( 'Your website is currently configured to represent a person. If you want to edit the social accounts for your site, please go to the user profile of the selected person: %1$s.', 'wordpress-seo' ),
-		'<a href="' . esc_url( admin_url( 'user-edit.php?user_id=' . $user_id ) ) . '">' . esc_html( $person->display_name ) . '</a>'
-	);
-	echo '</p>';
-	echo '<p>';
-	printf(
-		/* translators: 1: link tag to the relevant WPSEO admin page; 2: link close tag. */
-		esc_html__( 'If you want your site to represent an Organization, please select \'Organization\' in the \'Knowledge Graph & Schema.org\' section of the %1$sSearch Appearance%2$s settings.', 'wordpress-seo' ),
-		'<a href="' . esc_url( admin_url( 'admin.php?page=wpseo_titles' ) ) . '">',
-		'</a>'
-	);
-	echo '</p></div>';
-}
-
-if ( $company_or_person === 'company' ) {
-	// phpcs:ignore WordPress.Security.EscapeOutput -- string is properly escaped.
-	echo '<div id="yoast-social-profiles"></div>';
-}
 
 do_action( 'wpseo_admin_other_section' );

--- a/admin/views/tabs/social/accounts.php
+++ b/admin/views/tabs/social/accounts.php
@@ -47,23 +47,6 @@ if ( $company_or_person === 'person' ) {
 
 if ( $company_or_person === 'company' ) {
 	// phpcs:ignore WordPress.Security.EscapeOutput -- string is properly escaped.
-	echo '<h2>' . esc_html__( 'Organization\'s social profiles', 'wordpress-seo' ) . '</h2>';
-	echo '<p>';
-	printf(
-		/* translators: 1: link tag to the first time configuration; 2: link close tag. */
-		esc_html__( 'Your website is currently configured to represent an Organization. If you want to edit the social accounts for your site, please go to the %1$sfirst-time configuration%2$s and navigate to the \'Social profiles\' step.', 'wordpress-seo' ),
-		'<a href="' . esc_url( admin_url( 'admin.php?page=wpseo_dashboard#top#first-time-configuration' ) ) . '">',
-		'</a>'
-	);
-	echo '</p>';
-	echo '<p>';
-	printf(
-		/* translators: 1: link tag to the relevant WPSEO admin page; 2: link close tag. */
-		esc_html__( 'If you want your site to represent a Person, please select \'Person\' in the \'Knowledge Graph & Schema.org\' section of the %1$sSearch Appearance%2$s settings.', 'wordpress-seo' ),
-		'<a href="' . esc_url( admin_url( 'admin.php?page=wpseo_titles' ) ) . '">',
-		'</a>'
-	);
-	echo '</p>';
 	echo '<div id="yoast-social-profiles"></div>';
 }
 

--- a/admin/views/tabs/social/accounts.php
+++ b/admin/views/tabs/social/accounts.php
@@ -64,6 +64,7 @@ if ( $company_or_person === 'company' ) {
 		'</a>'
 	);
 	echo '</p>';
+	echo '<div id="yoast-social-profiles"></div>';
 }
 
 do_action( 'wpseo_admin_other_section' );

--- a/css/src/tailwind.css
+++ b/css/src/tailwind.css
@@ -429,7 +429,7 @@
 		
 		/* Override aggressive WordPress inputs styling */
 		.yst-input {
-			@apply yst-py-2 yst-px-3 yst-border yst-bg-white yst-rounded-md yst-shadow-sm yst-text-sm yst-placeholder-gray-500 !important;
+			@apply yst-py-2 yst-px-3 yst-border yst-bg-white yst-rounded-md yst-shadow-sm yst-text-sm yst-placeholder-gray-400 !important;
 		}
 	
 		.yst-card {
@@ -478,7 +478,7 @@
 		}
 		
 		.yst-radio__label {
-			@apply yst-ml-3 yst-font-medium !important;
+			@apply yst-ml-3 yst-font-medium yst-text-gray-700 !important;
 		}
 		
 		.yst-radio-group__label {

--- a/packages/js/src/first-time-configuration/first-time-configuration-steps.js
+++ b/packages/js/src/first-time-configuration/first-time-configuration-steps.js
@@ -595,7 +595,7 @@ export default function FirstTimeConfigurationSteps() {
 	}, [ beforeUnloadEventHandler ] );
 
 	return (
-		<div id="yoast-configuration" className="yst-card">
+		<div id="yoast-configuration" className="yst-card yst-text-gray-500">
 			<h2 id="yoast-configuration-title" className="yst-text-lg yst-text-primary-500 yst-font-medium">{ __( "Tell us about your site, so we can get your site ranked!", "wordpress-seo" ) }</h2>
 			<p className="yst-py-2">
 				{

--- a/packages/js/src/first-time-configuration/first-time-configuration-steps.js
+++ b/packages/js/src/first-time-configuration/first-time-configuration-steps.js
@@ -563,7 +563,7 @@ export default function FirstTimeConfigurationSteps() {
 		 * @returns {void}
 		 */
 		function preventEnterSubmit( event ) {
-			if ( event.key === "Enter" && event.target.tagName === "INPUT" ) {
+			if ( event.key === "Enter" && document.querySelector( ".nav-tab.nav-tab-active" ).id === "first-time-configuration-tab" && event.target.tagName === "INPUT" ) {
 				event.preventDefault();
 			}
 		}

--- a/packages/js/src/first-time-configuration/first-time-configuration-steps.js
+++ b/packages/js/src/first-time-configuration/first-time-configuration-steps.js
@@ -304,7 +304,7 @@ function calculateInitialState( windowObject, isStepFinished ) {
 
 	if ( shouldForceCompany ) {
 		companyOrPerson = "company";
-	} else if ( companyOrPerson === "company" && ( ! companyName && ! companyLogo ) && ! isStepFinished( 2 ) ) {
+	} else if ( companyOrPerson === "company" && ( ! companyName && ! companyLogo ) && ! isStepFinished( STEPS.siteRepresentation ) ) {
 		// Set the stage for an empty step 2 in case the customer does seem to have consciously finished step 2 without setting data.
 		companyOrPerson = "emptyChoice";
 	}

--- a/packages/js/src/first-time-configuration/tailwind-components/base/combo-box.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/base/combo-box.js
@@ -93,7 +93,7 @@ export default function YoastComboBox( { value, label, onChange, onQueryChange, 
 							as="div"
 						>
 							<Combobox.Input
-								className="yst-w-full yst-text-gray-700 yst-rounded-md yst-border-0 yst-outline-none yst-bg-white yst-py-2 yst-pl-0 yst-pr-10 yst-shadow-sm sm:yst-text-sm"
+								className="yst-w-full yst-text-gray-700 yst-rounded-md yst-border-0 yst-outline-none yst-bg-white yst-py-2 yst-pl-0 yst-pr-10 yst-shadow-none sm:yst-text-sm"
 								onChange={ handleInputChange }
 								displayValue={ getDisplayValue }
 								placeholder={ placeholder }

--- a/packages/js/src/first-time-configuration/tailwind-components/base/image-select.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/base/image-select.js
@@ -59,7 +59,7 @@ export default function ImageSelect( {
 
 	return (
 		<div className={ classNames( "yst-max-w-sm", className ) } { ...getErrorAriaProps( id, error ) }>
-			<label htmlFor={ id } className="yst-block yst-mb-2 yst-font-medium">{ label }</label>
+			<label htmlFor={ id } className="yst-block yst-mb-2 yst-font-medium yst-text-gray-700">{ label }</label>
 			<button
 				id={ id }
 				className={ imageClassName }

--- a/packages/js/src/first-time-configuration/tailwind-components/base/single-select.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/base/single-select.js
@@ -1,6 +1,6 @@
 import { Listbox, Transition } from "@headlessui/react";
 import { CheckIcon, ExclamationCircleIcon, SelectorIcon } from "@heroicons/react/solid";
-import { Fragment, useMemo, useState } from "@wordpress/element";
+import { Fragment, useMemo } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
 import classNames from "classnames";
 import { PropTypes } from "prop-types";
@@ -20,16 +20,10 @@ import MultiLineText from "./multi-line-text";
  * @returns {WPElement} The Select element.
  */
 export default function Select( { id, value, choices, label, onChange, error, disabled } ) {
-	const [ valueSelected, setValueSelected ] = useState( false );
-
 	// Find label to display for value of selected choice.
 	const valueLabel = useMemo( () => {
 		const selectedChoice = choices.find( ( choice ) => value === choice.value );
-		if ( ! selectedChoice ) {
-			return  __( "Select an option", "wordpress-seo" );
-		}
-		setValueSelected( true );
-		return selectedChoice.label;
+		return selectedChoice ? selectedChoice.label : __( "Select an option", "wordpress-seo" );
 	}, [ choices, value ] );
 
 	return (
@@ -44,10 +38,9 @@ export default function Select( { id, value, choices, label, onChange, error, di
 									"yst-relative yst-h-[45px] yst-w-full yst-leading-6 yst-py-2 yst-pl-3 yst-pr-10 yst-text-left yst-bg-white yst-border yst-border-gray-300 yst-rounded-md yst-shadow-sm yst-cursor-default focus:yst-outline-none focus:yst-ring-1 focus:yst-ring-primary-500 focus:yst-border-primary-500 sm:yst-text-sm",
 									{
 										"yst-border-red-300": error.isVisible,
-										"yst-text-gray-400": ! valueSelected,
-										"yst-text-gray-700": valueSelected,
 										"yst-opacity-50": disabled,
-									}
+									},
+									value === "emptyChoice" ? "yst-text-gray-400" : "yst-text-gray-700"
 								) }
 								{ ...getErrorAriaProps( id, error ) }
 							>

--- a/packages/js/src/first-time-configuration/tailwind-components/base/single-select.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/base/single-select.js
@@ -1,6 +1,6 @@
 import { Listbox, Transition } from "@headlessui/react";
 import { CheckIcon, ExclamationCircleIcon, SelectorIcon } from "@heroicons/react/solid";
-import { Fragment, useMemo } from "@wordpress/element";
+import { Fragment, useMemo, useState } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
 import classNames from "classnames";
 import { PropTypes } from "prop-types";
@@ -20,10 +20,16 @@ import MultiLineText from "./multi-line-text";
  * @returns {WPElement} The Select element.
  */
 export default function Select( { id, value, choices, label, onChange, error, disabled } ) {
+	const [ valueSelected, setValueSelected ] = useState( false );
+
 	// Find label to display for value of selected choice.
 	const valueLabel = useMemo( () => {
 		const selectedChoice = choices.find( ( choice ) => value === choice.value );
-		return selectedChoice ? selectedChoice.label : __( "Select an option", "wordpress-seo" );
+		if ( ! selectedChoice ) {
+			return  __( "Select an option", "wordpress-seo" );
+		}
+		setValueSelected( true );
+		return selectedChoice.label;
 	}, [ choices, value ] );
 
 	return (
@@ -35,9 +41,13 @@ export default function Select( { id, value, choices, label, onChange, error, di
 						<div className="yst-relative">
 							<Listbox.Button
 								className={ classNames(
-									"yst-relative yst-h-[45px] yst-w-full yst-leading-6 yst-py-2 yst-pl-3 yst-pr-10 yst-text-left yst-text-gray-700 yst-bg-white yst-border yst-rounded-md yst-shadow-sm yst-cursor-default focus:yst-outline-none focus:yst-ring-1 focus:yst-ring-primary-500 focus:yst-border-primary-500 sm:yst-text-sm",
-									error.isVisible ? "yst-border-red-300" : "yst-border-gray-300",
-									disabled ? "yst-opacity-50" : "yst-opacity-100"
+									"yst-relative yst-h-[45px] yst-w-full yst-leading-6 yst-py-2 yst-pl-3 yst-pr-10 yst-text-left yst-bg-white yst-border yst-border-gray-300 yst-rounded-md yst-shadow-sm yst-cursor-default focus:yst-outline-none focus:yst-ring-1 focus:yst-ring-primary-500 focus:yst-border-primary-500 sm:yst-text-sm",
+									{
+										"yst-border-red-300": error.isVisible,
+										"yst-text-gray-400": ! valueSelected,
+										"yst-text-gray-700": valueSelected,
+										"yst-opacity-50": disabled,
+									}
 								) }
 								{ ...getErrorAriaProps( id, error ) }
 							>

--- a/packages/js/src/first-time-configuration/tailwind-components/base/text-input.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/base/text-input.js
@@ -61,7 +61,7 @@ export default function TextInput( { className, id, label, description, value, o
 
 	return (
 		<div className={ className }>
-			{ label && <label className="yst-block yst-mb-2 yst-font-medium" htmlFor={ id }>
+			{ label && <label className="yst-block yst-mb-2 yst-font-medium yst-text-gray-700" htmlFor={ id }>
 				{ label }
 			</label> }
 			<div className="yst-relative">

--- a/packages/js/src/first-time-configuration/tailwind-components/step-header.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/step-header.js
@@ -19,7 +19,7 @@ function getNameClassNames( isFinished, isActiveStep, isLastStep ) {
 	if ( isActiveStep && ! isLastStep ) {
 		return "yst-text-primary-500";
 	}
-	return isFinished ? "" : "yst-text-gray-500";
+	return isFinished ? "yst-text-gray-900" : "yst-text-gray-500";
 }
 
 /* eslint-disable complexity */

--- a/packages/js/src/first-time-configuration/tailwind-components/steps/social-profiles/social-input-section.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/steps/social-profiles/social-input-section.js
@@ -79,10 +79,9 @@ export function SocialInputSection(	{
 	onAddProfileHandler,
 	onRemoveProfileHandler,
 	errorFields,
-	className,
 } ) {
 	return (
-		<div id="social-input-section" className={ className }>
+		<div id="social-input-section">
 			<SocialInput
 				className="yst-mt-4"
 				label={ __( "Facebook", "wordpress-seo" ) }
@@ -130,9 +129,4 @@ SocialInputSection.propTypes = {
 	onAddProfileHandler: PropTypes.func.isRequired,
 	onRemoveProfileHandler: PropTypes.func.isRequired,
 	errorFields: PropTypes.array.isRequired,
-	className: PropTypes.string,
-};
-
-SocialInputSection.defaultProps = {
-	className: "",
 };

--- a/packages/js/src/first-time-configuration/tailwind-components/steps/social-profiles/social-input-section.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/steps/social-profiles/social-input-section.js
@@ -14,9 +14,9 @@ import SocialInput from "./social-input";
  * @param {array}    props.errorFields    The array containing the names of the fields with an invalid value.
  * @param {function} props.dispatch       A dispatch function to communicate with the Stepper store.
  *
- * @returns {WPElement} The SocialInputSection.
+ * @returns {WPElement} The SocialInputSectionContainer.
  */
-export default function SocialInputSection( { socialProfiles, errorFields, dispatch } ) {
+export default function SocialInputSectionContainer( { socialProfiles, errorFields, dispatch } ) {
 	const onChangeHandler = useCallback(
 		( newValue, socialMedium ) => {
 			dispatch( { type: "CHANGE_SOCIAL_PROFILE", payload: { socialMedium, value: newValue } } );
@@ -44,7 +44,45 @@ export default function SocialInputSection( { socialProfiles, errorFields, dispa
 	);
 
 	return (
-		<div id="social-input-section" className="yoast-social-profiles-input-fields">
+		<SocialInputSection
+			socialProfiles={ socialProfiles }
+			onChangeHandler={ onChangeHandler }
+			onChangeOthersHandler={ onChangeOthersHandler }
+			onAddProfileHandler={ onAddProfileHandler }
+			onRemoveProfileHandler={ onRemoveProfileHandler }
+			errorFields={ errorFields }
+		/>
+	);
+}
+/* eslint-enable complexity */
+
+SocialInputSectionContainer.propTypes = {
+	socialProfiles: PropTypes.object.isRequired,
+	dispatch: PropTypes.func.isRequired,
+	errorFields: PropTypes.array,
+};
+
+SocialInputSectionContainer.defaultProps = {
+	errorFields: [],
+};
+
+/**
+ * The social input section.
+ *
+ * @param {Object} props The props.
+ * @returns {WPElement} The Social Input Section.
+ */
+export function SocialInputSection(	{
+	socialProfiles,
+	onChangeHandler,
+	onChangeOthersHandler,
+	onAddProfileHandler,
+	onRemoveProfileHandler,
+	errorFields,
+	className,
+} ) {
+	return (
+		<div id="social-input-section" className={ className }>
 			<SocialInput
 				className="yst-mt-4"
 				label={ __( "Facebook", "wordpress-seo" ) }
@@ -73,7 +111,6 @@ export default function SocialInputSection( { socialProfiles, errorFields, dispa
 					type: "error",
 				} }
 			/>
-
 			<SocialFieldArray
 				items={ socialProfiles.otherSocialUrls }
 				onAddProfile={ onAddProfileHandler }
@@ -85,14 +122,17 @@ export default function SocialInputSection( { socialProfiles, errorFields, dispa
 		</div>
 	);
 }
-/* eslint-enable complexity */
 
 SocialInputSection.propTypes = {
 	socialProfiles: PropTypes.object.isRequired,
-	dispatch: PropTypes.func.isRequired,
-	errorFields: PropTypes.array,
+	onChangeHandler: PropTypes.func.isRequired,
+	onChangeOthersHandler: PropTypes.func.isRequired,
+	onAddProfileHandler: PropTypes.func.isRequired,
+	onRemoveProfileHandler: PropTypes.func.isRequired,
+	errorFields: PropTypes.array.isRequired,
+	className: PropTypes.string,
 };
 
 SocialInputSection.defaultProps = {
-	errorFields: [],
+	className: "",
 };

--- a/packages/js/src/initializers/social-settings.js
+++ b/packages/js/src/initializers/social-settings.js
@@ -1,8 +1,10 @@
 import apiFetch from "@wordpress/api-fetch";
 import { render, Fragment, useState, useCallback, useEffect } from "@wordpress/element";
+import { CheckIcon } from "@heroicons/react/solid";
 import ImageSelectPortal from "../components/portals/ImageSelectPortal";
 import Portal from "../components/portals/Portal";
-import { __ } from "@wordpress/i18n";
+import { __, sprintf } from "@wordpress/i18n";
+import { addLinkToString } from "../helpers/stringHelpers.js";
 import { SocialInputSection } from "../first-time-configuration/tailwind-components/steps/social-profiles/social-input-section";
 
 /**
@@ -37,9 +39,9 @@ async function updateSocialProfiles( facebookUrl, twitterUsername, otherSocialUr
  * @returns {WPElement} The SocialProfilesWrapper
  */
 function SocialProfilesWrapper() {
-	const [ facebookValue, setFacebookValue ] = useState( "" );
-	const [ twitterValue, setTwitterValue ] = useState( "" );
-	const [ otherSocialUrls, setOtherSocialUrls ] = useState( [] );
+	const [ facebookValue, setFacebookValue ] = useState( window.wpseoScriptData.social.facebook_url );
+	const [ twitterValue, setTwitterValue ] = useState( window.wpseoScriptData.social.twitter_username );
+	const [ otherSocialUrls, setOtherSocialUrls ] = useState( window.wpseoScriptData.social.other_social_urls );
 	const [ errorFields, setErrorFields ] = useState( [] );
 	const [ isSaved, setIsSaved ] = useState( false );
 
@@ -97,8 +99,10 @@ function SocialProfilesWrapper() {
 	}, [ setOtherSocialUrls ] );
 	return (
 		<div
-			className="yst-root yst-bg-white yst-rounded-lg yst-p-6 yst-shadow-md yst-max-w-2xl yoast-social-profiles-input-fields"
+			className="yst-root yst-bg-white yst-rounded-lg yst-p-6 yst-shadow-md yst-max-w-2xl yst-mt-6"
 		>
+			<h2 className="yst-text-lg yst-text-primary-500 yst-font-medium">{ __( "Organization's social profiles", "wordpress-seo" ) }</h2>
+			<p className="yst-my-2 yst-text-gray-500">{ __( "Tell us if you have any other profiles on the web that belong to your organization. You can also add profiles from platforms like Instagram, YouTube, LinkedIn, Pinterest or Wikipedia.", "wordpress-seo" ) }</p>
 			<SocialInputSection
 				socialProfiles={ {
 					facebookUrl: facebookValue,
@@ -120,10 +124,22 @@ function SocialProfilesWrapper() {
 					onClick={ onSaveHandler }
 				>{ __( "Save changes", "wordpress-seo" ) }</button>
 				{ isSaved && <span className="yst-inline-flex yst-items-center yst-text-lime-600 yst-relative yst-ml-6 yst-text-sm">
-					<span className="yst-bg-[image:var(--yoast-svg-icon-check)] yst-w-[18px] yst-h-[13px] yst-bg-contain yst-bg-no-repeat" />
+					<CheckIcon className={ "yst-w-5 yst-h-5 yst-text-lime-600 yst-mr-1" } aria-hidden="true" />
 					{ __( "Saved!", "wordpress-seo" ) }
 				</span> }
 			</div>
+			<p className="yst-mt-8 yst-text-gray-500">{
+				addLinkToString(
+					sprintf(
+						/* translators: 1: link tag to the relevant WPSEO admin page; 2: link close tag. */
+						__( "Your website is currently configured to represent an Organization. If you want your site to represent a Person, please select 'Person' in the 'Knowledge Graph & Schema.org' section of the %1$sSearch Appearance%2$s settings.", "wordpress-seo" ),
+						"<a>",
+						"</a>"
+					),
+					window.wpseoScriptData.search_appearance_link,
+					"yoast-search-appearance-link"
+				)
+			}</p>
 		</div>
 	);
 }

--- a/packages/js/src/initializers/social-settings.js
+++ b/packages/js/src/initializers/social-settings.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import apiFetch from "@wordpress/api-fetch";
 import { render, Fragment, useState, useCallback, useEffect } from "@wordpress/element";
 import { CheckIcon } from "@heroicons/react/solid";
@@ -32,6 +33,32 @@ async function updateSocialProfiles( facebookUrl, twitterUsername, otherSocialUr
 	} );
 	return await response.json;
 }
+
+/**
+ * Because this component is rendered inside a form, we have to pass the data via inputs.
+ * We chose to copy the data into hidden fields, to avoid having to wire a "name" prop through all TextInput components.
+ *
+ * @param {Object} props The props.
+ *
+ * @returns {WPElement} A social hidden fields section.
+ */
+function SocialHiddenFields( { facebookValue, twitterValue, otherSocialUrls } ) {
+	return (
+		<Fragment>
+			<input type="hidden" name="wpseo_social[facebook_site]" value={ facebookValue } />
+			<input type="hidden" name="wpseo_social[twitter_site]" value={ twitterValue } />
+			{
+				otherSocialUrls.map( ( otherUrl, index ) => <input key={ `other-social-url-${ index }` } type="hidden" name="wpseo_social[other_social_urls][]" value={ otherUrl } /> )
+			}
+		</Fragment>
+	);
+}
+
+SocialHiddenFields.propTypes = {
+	facebookValue: PropTypes.string.isRequired,
+	twitterValue: PropTypes.string.isRequired,
+	otherSocialUrls: PropTypes.array.isRequired,
+};
 
 /**
  * Wraps the SocialInputSection to provide some state.
@@ -120,45 +147,83 @@ function SocialProfilesWrapper() {
 		<div
 			className="yst-root yst-bg-white yst-rounded-lg yst-p-6 yst-shadow-md yst-max-w-2xl yst-mt-6"
 		>
-			<h2 className="yst-text-lg yst-text-primary-500 yst-font-medium">{ __( "Organization's social profiles", "wordpress-seo" ) }</h2>
-			<p className="yst-my-2 yst-text-gray-500">{ __( "Tell us if you have any other profiles on the web that belong to your organization. You can also add profiles from platforms like Instagram, YouTube, LinkedIn, Pinterest or Wikipedia.", "wordpress-seo" ) }</p>
-			<SocialInputSection
-				socialProfiles={ {
-					facebookUrl: facebookValue,
-					twitterUsername: twitterValue,
-					otherSocialUrls: otherSocialUrls,
-				} }
-				onChangeHandler={ onChangeHandler }
-				onRemoveProfileHandler={ onRemoveProfileHandler }
-				onChangeOthersHandler={ onChangeOthersHandler }
-				onAddProfileHandler={ onAddProfileHandler }
-				errorFields={ errorFields }
+			{ window.wpseoScriptData.social.company_or_person === "person" &&
+				<Fragment>
+					<h2 className="yst-text-lg yst-text-primary-500 yst-font-medium">{ __( "Personal social profiles", "wordpress-seo" ) }</h2>
+					<p className="yst-mt-4 yst-text-gray-500">{
+						/* translators: 1: a link to the user edit page, containing the name of the user selected as the person this site represents */
+						addLinkToString(
+							sprintf(
+								__( "Your website is currently configured to represent a Person. If you want to edit the social accounts for your site, please go to the user profile of the selected person%1$s.", "wordpress-seo" ),
+								window.wpseoScriptData.social.user_id ? `: <a>${ window.wpseoScriptData.social.user_name }</a>` : ""
+							),
+							window.wpseoScriptData.userEditUrl.replace( "{user_id}", window.wpseoScriptData.social.user_id ),
+							"yoast-person-edit-link"
+						)
+					}</p>
+					<p className="yst-mt-4 yst-text-gray-500">{
+						addLinkToString(
+							sprintf(
+								/* translators: 1: link tag to the relevant WPSEO admin page; 2: link close tag. */
+								__( "If you want your site to represent an Organization, please select 'Organization' in the 'Knowledge Graph & Schema.org' section of the %1$sSearch Appearance%2$s settings.", "wordpress-seo" ),
+								"<a>",
+								"</a>"
+							),
+							window.wpseoScriptData.search_appearance_link,
+							"yoast-search-appearance-link"
+						)
+					}</p>
+				</Fragment>
+			}
+			{
+				window.wpseoScriptData.social.company_or_person === "company" &&
+				<Fragment>
+					<h2 className="yst-text-lg yst-text-primary-500 yst-font-medium">{ __( "Organization's social profiles", "wordpress-seo" ) }</h2>
+					<p className="yst-my-2 yst-text-gray-500">{ __( "Tell us if you have any other profiles on the web that belong to your organization. You can also add profiles from platforms like Instagram, YouTube, LinkedIn, Pinterest or Wikipedia.", "wordpress-seo" ) }</p>
+					<SocialInputSection
+						socialProfiles={ {
+							facebookUrl: facebookValue,
+							twitterUsername: twitterValue,
+							otherSocialUrls: otherSocialUrls,
+						} }
+						onChangeHandler={ onChangeHandler }
+						onRemoveProfileHandler={ onRemoveProfileHandler }
+						onChangeOthersHandler={ onChangeOthersHandler }
+						onAddProfileHandler={ onAddProfileHandler }
+						errorFields={ errorFields }
+					/>
+					<div
+						className="yst-flex yst-items-center yst-pt-8"
+					>
+						<button
+							className="yst-button yst-button--primary"
+							type="button"
+							onClick={ onSaveHandler }
+						>{ __( "Save changes", "wordpress-seo" ) }</button>
+						{ isSaved && <span className="yst-inline-flex yst-items-center yst-text-lime-600 yst-relative yst-ml-6 yst-text-sm">
+							<CheckIcon className={ "yst-w-5 yst-h-5 yst-text-lime-600 yst-mr-1" } aria-hidden="true" />
+							{ __( "Saved!", "wordpress-seo" ) }
+						</span> }
+					</div>
+					<p className="yst-mt-8 yst-text-gray-500">{
+						addLinkToString(
+							sprintf(
+								/* translators: 1: link tag to the relevant WPSEO admin page; 2: link close tag. */
+								__( "Your website is currently configured to represent an Organization. If you want your site to represent a Person, please select 'Person' in the 'Knowledge Graph & Schema.org' section of the %1$sSearch Appearance%2$s settings.", "wordpress-seo" ),
+								"<a>",
+								"</a>"
+							),
+							window.wpseoScriptData.search_appearance_link,
+							"yoast-search-appearance-link"
+						)
+					}</p>
+				</Fragment>
+			}
+			<SocialHiddenFields
+				facebookValue={ facebookValue }
+				twitterValue={ twitterValue }
+				otherSocialUrls={ otherSocialUrls }
 			/>
-			<div
-				className="yst-flex yst-items-center yst-pt-8"
-			>
-				<button
-					className="yst-button yst-button--primary"
-					type="button"
-					onClick={ onSaveHandler }
-				>{ __( "Save changes", "wordpress-seo" ) }</button>
-				{ isSaved && <span className="yst-inline-flex yst-items-center yst-text-lime-600 yst-relative yst-ml-6 yst-text-sm">
-					<CheckIcon className={ "yst-w-5 yst-h-5 yst-text-lime-600 yst-mr-1" } aria-hidden="true" />
-					{ __( "Saved!", "wordpress-seo" ) }
-				</span> }
-			</div>
-			<p className="yst-mt-8 yst-text-gray-500">{
-				addLinkToString(
-					sprintf(
-						/* translators: 1: link tag to the relevant WPSEO admin page; 2: link close tag. */
-						__( "Your website is currently configured to represent an Organization. If you want your site to represent a Person, please select 'Person' in the 'Knowledge Graph & Schema.org' section of the %1$sSearch Appearance%2$s settings.", "wordpress-seo" ),
-						"<a>",
-						"</a>"
-					),
-					window.wpseoScriptData.search_appearance_link,
-					"yoast-search-appearance-link"
-				)
-			}</p>
 		</div>
 	);
 }

--- a/packages/js/src/initializers/social-settings.js
+++ b/packages/js/src/initializers/social-settings.js
@@ -1,8 +1,35 @@
-import { render, Fragment, useState, useCallback } from "@wordpress/element";
+import apiFetch from "@wordpress/api-fetch";
+import { render, Fragment, useState, useCallback, useEffect } from "@wordpress/element";
 import ImageSelectPortal from "../components/portals/ImageSelectPortal";
 import Portal from "../components/portals/Portal";
 import { __ } from "@wordpress/i18n";
 import { SocialInputSection } from "../first-time-configuration/tailwind-components/steps/social-profiles/social-input-section";
+
+/**
+ * Updates the social profiles in the database.
+ *
+ * @param {String} facebookUrl     The facebook url to save.
+ * @param {String} twitterUsername The twitter username/url to save.
+ * @param {Array}  otherSocialUrls The other urls array to save.
+ *
+ * @returns {Promise|bool} A promise, or false if the call fails.
+ */
+async function updateSocialProfiles( facebookUrl, twitterUsername, otherSocialUrls ) {
+	const socialProfiles = {
+		/* eslint-disable camelcase */
+		facebook_site: facebookUrl,
+		twitter_site: twitterUsername,
+		other_social_urls: otherSocialUrls,
+		/* eslint-enable camelcase */
+	};
+
+	const response = await apiFetch( {
+		path: "yoast/v1/configuration/social_profiles",
+		method: "POST",
+		data: socialProfiles,
+	} );
+	return await response.json;
+}
 
 /**
  * Wraps the SocialInputSection to provide some state.
@@ -14,6 +41,31 @@ function SocialProfilesWrapper() {
 	const [ twitterValue, setTwitterValue ] = useState( "" );
 	const [ otherSocialUrls, setOtherSocialUrls ] = useState( [] );
 	const [ errorFields, setErrorFields ] = useState( [] );
+
+	// Clear errorFields when values are edited.
+	useEffect( () => {
+		setErrorFields( [] );
+	}, [ facebookValue, twitterValue, otherSocialUrls ] );
+
+	const onSaveHandler = useCallback( () => {
+		updateSocialProfiles( facebookValue, twitterValue, otherSocialUrls )
+			.then( ( response ) => {
+				if ( response.success === false ) {
+					setErrorFields( response.failures );
+					return Promise.reject( "There were errors saving social profiles" );
+				}
+				return response;
+			} )
+			.then( () => { setErrorFields( [] ) } )
+			.catch(
+				( e ) => {
+					if ( e.failures ) {
+						setErrorFields( e.failures );
+					}
+					return false;
+				}
+			)
+	}, [ updateSocialProfiles, setErrorFields, facebookValue, twitterValue, otherSocialUrls ] );
 
 	const onChangeHandler = useCallback( ( value, socialMedium ) => {
 		if ( socialMedium === "facebookUrl" ) {
@@ -57,6 +109,7 @@ function SocialProfilesWrapper() {
 			<button
 				className="yst-button yst-button--primary yst-mt-8"
 				type="button"
+				onClick={ onSaveHandler }
 			>{ __( "Save changes", "wordpress-seo" ) }</button>
 		</div>
 	);

--- a/packages/js/src/initializers/social-settings.js
+++ b/packages/js/src/initializers/social-settings.js
@@ -151,7 +151,7 @@ function SocialProfilesWrapper() {
 				<Fragment>
 					<h2 className="yst-text-lg yst-text-primary-500 yst-font-medium">{ __( "Personal social profiles", "wordpress-seo" ) }</h2>
 					<p className="yst-mt-4 yst-text-gray-500">{
-						/* translators: 1: a link to the user edit page, containing the name of the user selected as the person this site represents */
+						/* translators: 1: a colon (:) followed by a link to the user edit page, containing the name of the user selected as the person this site represents */
 						addLinkToString(
 							sprintf(
 								__( "Your website is currently configured to represent a Person. If you want to edit the social accounts for your site, please go to the user profile of the selected person%1$s.", "wordpress-seo" ),

--- a/packages/js/src/initializers/social-settings.js
+++ b/packages/js/src/initializers/social-settings.js
@@ -51,6 +51,25 @@ function SocialProfilesWrapper() {
 		setIsSaved( false );
 	}, [ facebookValue, twitterValue, otherSocialUrls ] );
 
+	/* eslint-disable max-len */
+	useEffect( () => {
+		/**
+		 * Prevents the submission of the form upon pressing enter.
+		 *
+		 * @param {KeyboardEvent} event The keydown event this function is listening to.
+		 *
+		 * @returns {void}
+		 */
+		function preventEnterSubmit( event ) {
+			if ( event.key === "Enter" && document.querySelector( ".nav-tab.nav-tab-active" ).id === "accounts-tab" && event.target.tagName === "INPUT" ) {
+				event.preventDefault();
+			}
+		}
+
+		addEventListener( "keydown", preventEnterSubmit );
+		return () => removeEventListener( "keydown", preventEnterSubmit );
+	}, [] );
+
 	const onSaveHandler = useCallback( () => {
 		updateSocialProfiles( facebookValue, twitterValue, otherSocialUrls )
 			.then( ( response ) => {

--- a/packages/js/src/initializers/social-settings.js
+++ b/packages/js/src/initializers/social-settings.js
@@ -41,10 +41,12 @@ function SocialProfilesWrapper() {
 	const [ twitterValue, setTwitterValue ] = useState( "" );
 	const [ otherSocialUrls, setOtherSocialUrls ] = useState( [] );
 	const [ errorFields, setErrorFields ] = useState( [] );
+	const [ isSaved, setIsSaved ] = useState( false );
 
-	// Clear errorFields when values are edited.
+	// Clear errorFields and isSaved when values are edited.
 	useEffect( () => {
 		setErrorFields( [] );
+		setIsSaved( false );
 	}, [ facebookValue, twitterValue, otherSocialUrls ] );
 
 	const onSaveHandler = useCallback( () => {
@@ -56,7 +58,10 @@ function SocialProfilesWrapper() {
 				}
 				return response;
 			} )
-			.then( () => { setErrorFields( [] ) } )
+			.then( () => {
+				setErrorFields( [] );
+				setIsSaved( true );
+			} )
 			.catch(
 				( e ) => {
 					if ( e.failures ) {
@@ -64,8 +69,8 @@ function SocialProfilesWrapper() {
 					}
 					return false;
 				}
-			)
-	}, [ updateSocialProfiles, setErrorFields, facebookValue, twitterValue, otherSocialUrls ] );
+			);
+	}, [ updateSocialProfiles, setErrorFields, setIsSaved, facebookValue, twitterValue, otherSocialUrls ] );
 
 	const onChangeHandler = useCallback( ( value, socialMedium ) => {
 		if ( socialMedium === "facebookUrl" ) {
@@ -106,11 +111,19 @@ function SocialProfilesWrapper() {
 				onAddProfileHandler={ onAddProfileHandler }
 				errorFields={ errorFields }
 			/>
-			<button
-				className="yst-button yst-button--primary yst-mt-8"
-				type="button"
-				onClick={ onSaveHandler }
-			>{ __( "Save changes", "wordpress-seo" ) }</button>
+			<div
+				className="yst-flex yst-items-center yst-pt-8"
+			>
+				<button
+					className="yst-button yst-button--primary"
+					type="button"
+					onClick={ onSaveHandler }
+				>{ __( "Save changes", "wordpress-seo" ) }</button>
+				{ isSaved && <span className="yst-inline-flex yst-items-center yst-text-lime-600 yst-relative yst-ml-6 yst-text-sm">
+					<span className="yst-bg-[image:var(--yoast-svg-icon-check)] yst-w-[18px] yst-h-[13px] yst-bg-contain yst-bg-no-repeat" />
+					{ __( "Saved!", "wordpress-seo" ) }
+				</span> }
+			</div>
 		</div>
 	);
 }

--- a/packages/js/src/initializers/social-settings.js
+++ b/packages/js/src/initializers/social-settings.js
@@ -39,19 +39,26 @@ function SocialProfilesWrapper() {
 		setOtherSocialUrls( prevState => [ ...prevState, "" ] );
 	}, [ setOtherSocialUrls ] );
 	return (
-		<SocialInputSection
+		<div
 			className="yst-root yst-bg-white yst-rounded-lg yst-p-6 yst-shadow-md yst-max-w-2xl yoast-social-profiles-input-fields"
-			socialProfiles={ {
-				facebookUrl: facebookValue,
-				twitterUsername: twitterValue,
-				otherSocialUrls: otherSocialUrls,
-			} }
-			onChangeHandler={ onChangeHandler }
-			onRemoveProfileHandler={ onRemoveProfileHandler }
-			onChangeOthersHandler={ onChangeOthersHandler }
-			onAddProfileHandler={ onAddProfileHandler }
-			errorFields={ errorFields }
-		/>
+		>
+			<SocialInputSection
+				socialProfiles={ {
+					facebookUrl: facebookValue,
+					twitterUsername: twitterValue,
+					otherSocialUrls: otherSocialUrls,
+				} }
+				onChangeHandler={ onChangeHandler }
+				onRemoveProfileHandler={ onRemoveProfileHandler }
+				onChangeOthersHandler={ onChangeOthersHandler }
+				onAddProfileHandler={ onAddProfileHandler }
+				errorFields={ errorFields }
+			/>
+			<button
+				className="yst-button yst-button--primary yst-mt-8"
+				type="button"
+			>{ __( "Save changes", "wordpress-seo" ) }</button>
+		</div>
 	);
 }
 

--- a/packages/js/src/initializers/social-settings.js
+++ b/packages/js/src/initializers/social-settings.js
@@ -1,6 +1,59 @@
-import { render, Fragment } from "@wordpress/element";
+import { render, Fragment, useState, useCallback } from "@wordpress/element";
 import ImageSelectPortal from "../components/portals/ImageSelectPortal";
+import Portal from "../components/portals/Portal";
 import { __ } from "@wordpress/i18n";
+import { SocialInputSection } from "../first-time-configuration/tailwind-components/steps/social-profiles/social-input-section";
+
+/**
+ * Wraps the SocialInputSection to provide some state.
+ *
+ * @returns {WPElement} The SocialProfilesWrapper
+ */
+function SocialProfilesWrapper() {
+	const [ facebookValue, setFacebookValue ] = useState( "" );
+	const [ twitterValue, setTwitterValue ] = useState( "" );
+	const [ otherSocialUrls, setOtherSocialUrls ] = useState( [] );
+	const [ errorFields, setErrorFields ] = useState( [] );
+
+	const onChangeHandler = useCallback( ( value, socialMedium ) => {
+		if ( socialMedium === "facebookUrl" ) {
+			setFacebookValue( value );
+		} else if ( socialMedium === "twitterUsername" ) {
+			setTwitterValue( value );
+		}
+	}, [ setFacebookValue, setTwitterValue ] );
+
+	const onChangeOthersHandler = useCallback( ( value, index ) => {
+		setOtherSocialUrls( prevState => {
+			const nextState = [ ...prevState ];
+			nextState[ index ] = value;
+			return nextState;
+		} );
+	}, [ setOtherSocialUrls ] );
+
+	const onRemoveProfileHandler = useCallback( ( index ) => {
+		setOtherSocialUrls( prevState => prevState.filter( ( _, prevStateIndex ) => prevStateIndex !== index ) );
+	}, [ setOtherSocialUrls ] );
+
+	const onAddProfileHandler = useCallback( () => {
+		setOtherSocialUrls( prevState => [ ...prevState, "" ] );
+	}, [ setOtherSocialUrls ] );
+	return (
+		<SocialInputSection
+			className="yst-root yst-bg-white yst-rounded-lg yst-p-6 yst-shadow-md yst-max-w-2xl yoast-social-profiles-input-fields"
+			socialProfiles={ {
+				facebookUrl: facebookValue,
+				twitterUsername: twitterValue,
+				otherSocialUrls: otherSocialUrls,
+			} }
+			onChangeHandler={ onChangeHandler }
+			onRemoveProfileHandler={ onRemoveProfileHandler }
+			onChangeOthersHandler={ onChangeOthersHandler }
+			onAddProfileHandler={ onAddProfileHandler }
+			errorFields={ errorFields }
+		/>
+	);
+}
 
 /**
  * @summary Initializes the search appearance settings script.
@@ -23,6 +76,11 @@ export default function initSocialSettings() {
 				removeImageButtonId="yoast-og-default-image-remove-button"
 				hasImageValidation={ true }
 			/>
+			<Portal
+				target="yoast-social-profiles"
+			>
+				<SocialProfilesWrapper />
+			</Portal>
 		</Fragment>,
 		element
 	);


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Updates the look of the Accounts tab in the Social menu.

## Relevant technical choices:

* Also fixes various (unreleased) bugs and debts:
	* Submitting with Enter in the _other_ tabs of "general" and "social" is available again.
	* Submitting e.g. the Pinterest field would delete the facebook_site, twitter_username and other_social_urls values. ⚠️ this could have been a serious bug, but we caught it on time.
	*	* Submitting e.g. the Pinterest field when person was selected would still delete the facebook_site, twitter_username and other_social_urls values for organization. ⚠️ this could have been a serious bug, but we caught it on time.
	* Text and placeholder color now conforms with the design everywhere.
	* If you set Site representation to person, but dont select a user, the text on `trunk` would be something like "edit the selected user: ." which is a bug. That no longer occurs.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

Sorry in advance for the long instructions.
* With the test helper, reset options
* Go to Social > Accounts
* Observe the brand spanking new look.
* Give it a good UX pass.
* Enter some values. Also some other urls. Feel free to add some empty fields.
* Press save. (Verify that pressing enter does not submit the page).
* Reload, values should still be there (without empty "other" inputs).
* Go to pinterest tab. Click in the input, and press enter. Form should submit.
* Reload and go to accounts tab, values should still be correct.
* Go to the First Time Configuration.
* Step through till you reach the social profiles (keep organization selected).
* Values should be as you entered. (this does not work if you had the FTC open in an other tab without reloading. No other option for now I'm afraid).
* Now set person in stead of organization. Don't select a user.
* Go to Social > Accounts. Observe that the text is correct and that you like the new design. Specifically it should not read: "edit the selected user: ." with an empty place.
* Follow the search appearance link and select a user. Save.
* Go to Social > Accounts (or reload that if you were still there). Observe that the text has changed to include the person's name, with a link to their profile.
* Verify that submitting the form by pressing enter in the Pinterest input does not delete the Organization social inputs (by going to search appearance, switching to Organization, saving, going to Social > Accounts / reloading. ).



### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes DUPP-457
