### PR TITLE
Run upgrade routine to transfer progress of the configuration workout

### DIFF
--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -78,7 +78,7 @@ class WPSEO_Upgrade {
 			'17.9-RC0'   => 'upgrade_179',
 			'18.3-RC3'   => 'upgrade_183',
 			'18.6-RC0'   => 'upgrade_186',
-			'18.8-RC0'   => 'upgrade_188',
+			'18.9-RC0'   => 'upgrade_189',
 		];
 
 		array_walk( $routines, [ $this, 'run_upgrade_routine' ], $version );
@@ -882,9 +882,10 @@ class WPSEO_Upgrade {
 	}
 
 	/**
-	 * Performs the 18.8 upgrade routine.
+	 * Performs the 18.9 upgrade routine.
 	 */
-	private function upgrade_188() {
+	private function upgrade_189() {
+		// Transfer the Social URLs.
 		$other   = [];
 		$other[] = WPSEO_Options::get( 'instagram_url' );
 		$other[] = WPSEO_Options::get( 'linkedin_url' );
@@ -894,6 +895,20 @@ class WPSEO_Upgrade {
 		$other[] = WPSEO_Options::get( 'wikipedia_url' );
 
 		WPSEO_Options::set( 'other_social_urls', array_values( array_unique( array_filter( $other ) ) ) );
+
+		// Transfer the progress of the old Configuration Workout.
+		$workout_data      = WPSEO_Options::get( 'workouts_data' );
+		$old_conf_progress = isset( $workout_data['configuration']['finishedSteps'] ) ? $workout_data['configuration']['finishedSteps'] : [];
+
+		if ( in_array( 'optimizeSeoData', $old_conf_progress, true ) && in_array( 'siteRepresentation', $old_conf_progress, true ) ) {
+			// If completed ‘SEO optimization’ and ‘Site representation’ step, we assume the workout was completed.
+			$configuration_finished_steps = [
+				'siteRepresentation',
+				'socialProfiles',
+				'personalPreferences',
+			];
+			WPSEO_Options::set( 'configuration_finished_steps', $configuration_finished_steps );
+		}
 	}
 
 	/**

--- a/src/actions/configuration/first-time-configuration-action.php
+++ b/src/actions/configuration/first-time-configuration-action.php
@@ -244,7 +244,7 @@ class First_Time_Configuration_Action {
 		}
 
 		// If all the five steps of the configuration have been completed, set first_time_install option to false.
-		if ( \count( $params['finishedSteps'] ) === 5 ) {
+		if ( \count( $params['finishedSteps'] ) === 3 ) {
 			$this->options_helper->set( 'first_time_install', false );
 		}
 

--- a/tests/unit/actions/configuration/first-time-configuration-action-test.php
+++ b/tests/unit/actions/configuration/first-time-configuration-action-test.php
@@ -494,7 +494,7 @@ class First_Time_Configuration_Action_Test extends TestCase {
 
 		$finish_configuration = [
 			'params'                => [
-				'finishedSteps'     => [ 'step1', 'step2', 'step3', 'step4', 'step5' ],
+				'finishedSteps'     => [ 'step1', 'step2', 'step3' ],
 			],
 			'times'                 => 2,
 			'yoast_options_results' => [ true ],


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to show the FTC as completed if the user had completed the 2 first steps of the Configuration Workout (SEO optimization and Site Representation)

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Transfers progress from the old configuration workout upon upgrading to the new plugin version

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Checkout master (or use the 18.8 version if on RC)
* Complete the first 2 steps of the Configuration Workout
* Checkout this PR (or install the current RC)
* [Run the upgrade routine by going into the Test Helper and putting 18.8 in the DB version and hitting Save] _(note by @enricobattocchi: I don't think it's needed, the upgrade routine should already run by itself)_
* Go to the dashboard and confirm that you don't get the FTC notice
* Go to the FTC and confirm that it shows as completed

Notes
* We will show as completed only if both SEO optimization and Site Representation steps were completed in the workout (completed as in, the Continue button was pressed)
* If either one of those steps was not completed, the FTC will be shown as not completed.

We also fix the `first_time_install` entry when we complete the FTC. To test that:
* Reset options
* Deactivate and reactivate the plugin
* Go to the FTC.
* Before completing it, confirm in the db that the `first_time_install` setting in the `wpseo` option is `true`.
* Complete the FTC
* Confirm in the db that the `first_time_install` setting in the `wpseo` option is now `false`.



### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes #
