### PR TITLE
Keep PHP and JavaScript data aligned as much as possible

### DIFF
--- a/packages/js/src/first-time-configuration/first-time-configuration-steps.js
+++ b/packages/js/src/first-time-configuration/first-time-configuration-steps.js
@@ -478,6 +478,13 @@ export default function FirstTimeConfigurationSteps() {
 	 */
 	function updateOnFinishPersonalPreferences() {
 		return updateTracking( state )
+			.then( () => {
+				if ( isTrackingOptionSelected ) {
+					document.getElementById( "tracking-on" ).checked = true;
+				} else {
+					document.getElementById( "tracking-off" ).checked = true;
+				}
+			} )
 			.then( () => setStepIsSaved( 4 ) )
 			.then( () => finishSteps( STEPS.personalPreferences ) )
 			.then( () => {

--- a/packages/js/src/first-time-configuration/first-time-configuration-steps.js
+++ b/packages/js/src/first-time-configuration/first-time-configuration-steps.js
@@ -548,6 +548,15 @@ export default function FirstTimeConfigurationSteps() {
 		}
 	}, [ isStepperFinished ] );
 
+	useEffect( () => {
+		if ( isStep2Finished ) {
+			const configurationNotice = document.getElementById( "yoast-first-time-configuration-notice" );
+			if ( configurationNotice ) {
+				document.getElementById( "yoast-first-time-configuration-notice" ).remove();
+			}
+		}
+	}, [ isStep2Finished ] );
+
 	/* In order to refresh data in the php form, once the stepper is done, we need to reload upon haschanges triggered by the tabswitching */
 	const isStepperFinishedAtBeginning = useRef( isStep2Finished && isStep3Finished && isStep4Finished );
 	useEffect( () => {

--- a/packages/js/src/first-time-configuration/first-time-configuration-steps.js
+++ b/packages/js/src/first-time-configuration/first-time-configuration-steps.js
@@ -1,6 +1,6 @@
 /* global wpseoFirstTimeConfigurationData */
 import apiFetch from "@wordpress/api-fetch";
-import { useCallback, useReducer, useState, useEffect } from "@wordpress/element";
+import { useCallback, useReducer, useState, useEffect, useRef } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
 import { cloneDeep, uniq } from "lodash";
 
@@ -547,6 +547,24 @@ export default function FirstTimeConfigurationSteps() {
 			setStepperFinishedOnce( true );
 		}
 	}, [ isStepperFinished ] );
+
+	/* In order to refresh data in the php form, once the stepper is done, we need to reload upon haschanges triggered by the tabswitching */
+	const isStepperFinishedAtBeginning = useRef( isStep2Finished && isStep3Finished && isStep4Finished );
+	useEffect( () => {
+		/**
+		 * Reloads the window.
+		 *
+		 * @returns {void}
+		 */
+		const reloadFunction = () => {
+			window.location.reload( true );
+		};
+
+		if ( isStepperFinished && ! isStepperFinishedAtBeginning.current ) {
+			window.addEventListener( "hashchange", reloadFunction );
+		}
+		return () => window.removeEventListener( "hashchange", reloadFunction );
+	}, [ isStepperFinished, isStepperFinishedAtBeginning ] );
 
 	// If stepperFinishedOnce changes or isStepBeingEdited changes, evaluate edit button state.
 	useEffect( () => {

--- a/packages/js/src/first-time-configuration/first-time-configuration-steps.js
+++ b/packages/js/src/first-time-configuration/first-time-configuration-steps.js
@@ -555,15 +555,6 @@ export default function FirstTimeConfigurationSteps() {
 		}
 	}, [ isStepperFinished ] );
 
-	useEffect( () => {
-		if ( isStep2Finished ) {
-			const configurationNotice = document.getElementById( "yoast-first-time-configuration-notice" );
-			if ( configurationNotice ) {
-				document.getElementById( "yoast-first-time-configuration-notice" ).remove();
-			}
-		}
-	}, [ isStep2Finished ] );
-
 	/* In order to refresh data in the php form, once the stepper is done, we need to reload upon haschanges triggered by the tabswitching */
 	const isStepperFinishedAtBeginning = useRef( isStep2Finished && isStep3Finished && isStep4Finished );
 	useEffect( () => {

--- a/packages/js/src/initializers/admin.js
+++ b/packages/js/src/initializers/admin.js
@@ -139,37 +139,11 @@ export default function initAdmin( jQuery ) {
 	}
 
 	/**
-	 * When the hash changes, get the base url from the action and then add the current hash
-	 */
-	jQuery( window ).on( "hashchange", wpseoSetTabHash );
-
-	/**
-	 * Adds select2 for selected fields.
-	 *
-	 * @returns {void}
-	 */
-	function initSelect2() {
-		var select2Width = "400px";
-
-		// Select2 for Twitter card meta data in Settings
-		jQuery( "#twitter_card_type" ).select2( {
-			width: select2Width,
-			language: wpseoScriptData.userLanguageCode,
-		} );
-
-		// Select2 for taxonomy breadcrumbs in Advanced
-		jQuery( "#breadcrumbs select" ).select2( {
-			width: select2Width,
-			language: wpseoScriptData.userLanguageCode,
-		} );
-	}
-
-	/**
 	 * Set the initial active tab in the settings pages.
 	 *
 	 * @returns {void}
 	 */
-	function setInitialActiveTab() {
+	 function setInitialActiveTab() {
 		var activeTabId = window.location.hash.replace( "#top#", "" );
 		/* In some cases, the second # gets replace by %23, which makes the tab
 		 * switching not work unless we do this. */
@@ -192,6 +166,35 @@ export default function initAdmin( jQuery ) {
 
 		jQuery( "#" + activeTabId ).addClass( "active" );
 		jQuery( "#" + activeTabId + "-tab" ).addClass( "nav-tab-active" ).trigger( "click" );
+	}
+
+	/**
+	 * When the hash changes, get the base url from the action and then add the current hash
+	 */
+	jQuery( window ).on( "hashchange", function() {
+		setInitialActiveTab();
+		wpseoSetTabHash();
+	 } );
+
+	/**
+	 * Adds select2 for selected fields.
+	 *
+	 * @returns {void}
+	 */
+	function initSelect2() {
+		var select2Width = "400px";
+
+		// Select2 for Twitter card meta data in Settings
+		jQuery( "#twitter_card_type" ).select2( {
+			width: select2Width,
+			language: wpseoScriptData.userLanguageCode,
+		} );
+
+		// Select2 for taxonomy breadcrumbs in Advanced
+		jQuery( "#breadcrumbs select" ).select2( {
+			width: select2Width,
+			language: wpseoScriptData.userLanguageCode,
+		} );
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We use javascript to dynamically change values, but the PHP values in other tabs did not get refreshed. This is hard to do without a reload, but we can at least change the enable tracking and remove the notice. Also, we still reload when swapping tabs after the stepper is finished.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where the First-time Configuration notification would still be shown after finished the configuration.
* Fixes an unreleased bug where the Usage tracking radio button on the features tab would not be updated after editing  the tracking in the First-time configuration.
* Fixes a bug where pressing back and forward in the browser after switching tabs on the General page would not change tabs.

## Relevant technical choices:

* These changes are suboptimal, however in light of the impending settings-ui redesign an overhaul of the way tabs and data management work on this page was out of scope.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Start with a fresh install (or use the test helper to reset options, and deactivate and reactivate Yoast SEO).
* Go to General
* Notice the notice
* Go on to the Personal Preferences step in the FTC.
* Change the tracking setting and press save. This should also finish the FTC.
* Go to the feature tab or any other tab in the General section. This should trigger a reload after switching tabs.
* Data should now be as expected (Usage tracking is like you set, and notice is gone).
* On the feature tab, notice the setting of Usage tracking.
* Go to the Personal Preferences step by pressing edit in the FTC.
* Change the setting and save.
* Go to the features tab. There should be no reload, but the setting should reflect your changes anyways.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes DUPP-472
