### PR TITLE
Dupp 486 ux fixes to ftc

### DIFF
--- a/css/src/tailwind.css
+++ b/css/src/tailwind.css
@@ -390,21 +390,7 @@
 		/* Custom button classes because we're not using a Button component. This will ensure all buttons being exactly the same. */
 		.yst-button {
 			@apply
-				yst-inline-flex
-				yst-justify-center
-				yst-py-2 yst-px-3
-				yst-border
-				yst-shadow-sm
-				yst-rounded-md
-				yst-text-sm
-				yst-font-medium
-				yst-leading-4
-				yst-no-underline
-	
-				focus:yst-outline-none
-				focus:yst-ring-2
-				focus:yst-ring-offset-2
-				focus:yst-ring-primary-500;
+				yst-inline-flex yst-justify-center yst-py-2 yst-px-3 yst-border yst-shadow-sm yst-rounded-md yst-text-sm yst-font-medium yst-leading-4 yst-no-underline focus:yst-outline-none focus:yst-ring-2 focus:yst-ring-offset-2 focus:yst-ring-primary-500;
 		}
 		
 		.yst-button--primary {
@@ -427,6 +413,11 @@
 			@apply yst-text-[12px] yst-px-2.5 yst-py-1.5;
 		}
 		
+		.yst-button--disabled {
+			@apply
+				yst-opacity-50 yst-cursor-not-allowed yst-pointer-events-none focus:yst-ring-0;
+		}
+
 		/* Override aggressive WordPress inputs styling */
 		.yst-input {
 			@apply yst-py-2 yst-px-3 yst-border yst-bg-white yst-rounded-md yst-shadow-sm yst-text-sm yst-placeholder-gray-400 !important;

--- a/packages/js/src/first-time-configuration/tailwind-components/steps/indexation/indexation.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/steps/indexation/indexation.js
@@ -313,7 +313,7 @@ export class Indexation extends Component {
 			<p>
 				<button
 					type="button"
-					className="yst-button yst-button--secondary"
+					className="yst-button yst-button--secondary yst-button--disabled"
 					disabled={ true }
 				>
 					{ __( "Start SEO data optimization", "wordpress-seo" ) }

--- a/packages/js/src/first-time-configuration/tailwind-components/steps/indexation/indexation.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/steps/indexation/indexation.js
@@ -267,7 +267,7 @@ export class Indexation extends Component {
 	 */
 	renderFirstIndexationNotice() {
 		return (
-			<Alert type={ "info" } className="yst-mb-6">
+			<Alert type={ "info" } className="yst-mt-6">
 				{ __( "This feature includes and replaces the Text Link Counter and Internal Linking Analysis", "wordpress-seo" ) }
 			</Alert>
 		);
@@ -319,7 +319,7 @@ export class Indexation extends Component {
 					{ __( "Start SEO data optimization", "wordpress-seo" ) }
 				</button>
 			</p>
-			<Alert type={ "info" }>
+			<Alert type={ "info" } className="yst-mt-6">
 				{ __( "SEO data optimization is disabled for non-production environments.", "wordpress-seo" ) }
 			</Alert>
 		</Fragment>;
@@ -403,12 +403,12 @@ export class Indexation extends Component {
 				>
 					{ this.renderProgressBar() }
 					{ this.isState( STATE.ERRORED ) && this.renderErrorAlert() }
-					{ this.isState( STATE.IDLE ) && this.state.firstTime && this.renderFirstIndexationNotice() }
 					{ this.isState( STATE.IN_PROGRESS )
 						? this.renderStopButton()
 						: this.renderStartButton()
 					}
 					{ this.renderCaption() }
+					{ this.isState( STATE.IDLE ) && this.state.firstTime && this.renderFirstIndexationNotice() }
 				</Transition>
 			</div>
 		);

--- a/packages/js/src/first-time-configuration/tailwind-components/steps/personal-preferences/personal-preferences-step.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/steps/personal-preferences/personal-preferences-step.js
@@ -25,7 +25,7 @@ export default function PersonalPreferencesStep( { state, setTracking } ) {
 				sprintf( __( "%s usage tracking", "wordpress-seo" ), "Yoast SEO" )
 			}
 		</h4>
-		<p className="yst-text-normal yst-mt-2 yst-mb-4">{ __( "Can we collect anonymous information about your website and how you use it?", "wordpress-seo" ) }</p>
+		<p className="yst-text-normal yst-mt-2 yst-mb-4">{ __( "We need your help to improve Yoast SEO. Can we collect anonymous information about your website and how you use it?", "wordpress-seo" ) }</p>
 		{ <RadioGroup
 			id="yoast-configuration-tracking-radio-button"
 			name="yoast-configuration-tracking"

--- a/packages/js/src/first-time-configuration/tailwind-components/steps/social-profiles/social-field-array.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/steps/social-profiles/social-field-array.js
@@ -81,7 +81,7 @@ SocialFieldArray.propTypes = {
 
 SocialFieldArray.defaultProps = {
 	errorFields: [],
-	addButtonChildren: __( "Add another URL", "wordpress-seo" ),
+	addButtonChildren: __( "Add another profile", "wordpress-seo" ),
 };
 
 export default SocialFieldArray;

--- a/packages/js/src/initializers/social-settings.js
+++ b/packages/js/src/initializers/social-settings.js
@@ -149,7 +149,7 @@ function SocialProfilesWrapper() {
 		>
 			{ window.wpseoScriptData.social.company_or_person === "person" &&
 				<Fragment>
-					<h2 className="yst-text-lg yst-text-primary-500 yst-font-medium">{ __( "Personal social profiles", "wordpress-seo" ) }</h2>
+					<h2 className="yst-text-lg yst-text-gray-900 yst-font-medium">{ __( "Personal social profiles", "wordpress-seo" ) }</h2>
 					<p className="yst-mt-4 yst-text-gray-500">{
 						/* translators: 1: a colon (:) followed by a link to the user edit page, containing the name of the user selected as the person this site represents */
 						addLinkToString(
@@ -178,7 +178,7 @@ function SocialProfilesWrapper() {
 			{
 				window.wpseoScriptData.social.company_or_person === "company" &&
 				<Fragment>
-					<h2 className="yst-text-lg yst-text-primary-500 yst-font-medium">{ __( "Organization's social profiles", "wordpress-seo" ) }</h2>
+					<h2 className="yst-text-lg yst-text-gray-900 yst-font-medium">{ __( "Organization's social profiles", "wordpress-seo" ) }</h2>
 					<p className="yst-my-2 yst-text-gray-500">{ __( "Tell us if you have any other profiles on the web that belong to your organization. You can also add profiles from platforms like Instagram, YouTube, LinkedIn, Pinterest or Wikipedia.", "wordpress-seo" ) }</p>
 					<SocialInputSection
 						socialProfiles={ {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Some minor UX changes were needed, we bundled them in this PR



## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Performs minor UX enhancements to the unreleased First time configuration

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Confirm that:
    * Heading is now dark gray in Accounts tab (for Person and Organization)
    ![Screenshot 2022-05-09 at 11 41 29](https://user-images.githubusercontent.com/69148430/167388938-85b669f8-56ac-41ab-979f-b381d8795926.png)

    * Button label becomes “Add another profile” in Accounts tab and FTC
    * “This feature includes and replaces the Text Link Counter and Internal Linking Analysis” Alert moved to bottom of step
    ![Screenshot 2022-05-09 at 11 49 36](https://user-images.githubusercontent.com/69148430/167389099-f5533df6-2b1e-4d90-a80c-3c2754aa827b.png)
    * Non-production environment Alert gets a top margin (this one is visible in Local by Flywheel, not in Rancher afaik - or you can add `define('WP_ENVIRONMENT_TYPE', 'development');` in the wp-config.php file of your setup and re-start it)
    * If the the non-production environment Alert is shown, the Indexation button should be disabled (greyed out and not clickable)
    ![Screenshot 2022-05-09 at 16 48 30](https://user-images.githubusercontent.com/69148430/167436130-5ab3ca86-5555-48c1-8982-881d4a68b947.png)
    * In the Personal preferences tab a line of text is added that explains why we want to track people: "We need your help to improve Yoast SEO."
    ![Screenshot 2022-05-09 at 16 51 30](https://user-images.githubusercontent.com/69148430/167436686-b862d2f7-6dc3-4362-863f-d09035bbaa4a.png)



### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.

Fixes DUPP-486 and DUPP-476
