### PR TITLE
Dupp 465 modify modal pop up behaviour related to general panel tabs switching

### DIFF
--- a/packages/js/src/first-time-configuration/first-time-configuration-steps.js
+++ b/packages/js/src/first-time-configuration/first-time-configuration-steps.js
@@ -586,7 +586,7 @@ export default function FirstTimeConfigurationSteps() {
 		} else {
 			window.isStepBeingEdited = false;
 		}
-	}, [ state.editedSteps, indexingState ] );
+	}, [ state.editedSteps, indexingState, activeStepIndex ] );
 
 	/**
 	 * Handles the "before page unloads" event.

--- a/packages/js/src/first-time-configuration/first-time-configuration-steps.js
+++ b/packages/js/src/first-time-configuration/first-time-configuration-steps.js
@@ -587,9 +587,16 @@ export default function FirstTimeConfigurationSteps() {
 	 * @returns {void}
 	 */
 	const beforeUnloadEventHandler = useCallback( ( event ) => {
-		if ( state.editedSteps.includes( activeStepIndex + 1 ) || indexingState === "in_progress"  ) {
-			event.preventDefault();
-			event.returnValue = "";
+		/* Show the pop-up modal if the user wants to leave the first time configuration if:
+		 - the current step is being edited but not saved, or
+		 - the indexation process is still in progress
+		 */
+		if ( state.editedSteps.includes( activeStepIndex + 1 ) || indexingState === "in_progress" ) {
+			// Show the pup-up modal only if the user is in the first time configuration tab
+			if ( location.href.indexOf( "page=wpseo_dashboard#top#first-time-configuration" ) !== -1 ) {
+				event.preventDefault();
+				event.returnValue = "";
+			}
 		}
 	}, [ state.editedSteps, indexingState ] );
 

--- a/packages/js/src/first-time-configuration/first-time-configuration-steps.js
+++ b/packages/js/src/first-time-configuration/first-time-configuration-steps.js
@@ -607,7 +607,7 @@ export default function FirstTimeConfigurationSteps() {
 				event.returnValue = "";
 			}
 		}
-	}, [ state.editedSteps, indexingState ] );
+	}, [ state.editedSteps, indexingState, activeStepIndex ] );
 
 	useEffect( () => {
 		window.addEventListener( "beforeunload", beforeUnloadEventHandler );

--- a/packages/js/src/first-time-configuration/first-time-configuration-steps.js
+++ b/packages/js/src/first-time-configuration/first-time-configuration-steps.js
@@ -579,6 +579,15 @@ export default function FirstTimeConfigurationSteps() {
 		return () => removeEventListener( "keydown", preventEnterSubmit );
 	}, [] );
 
+	// Used by admin.js to decide wether to show the confirmation dialog when user switches tabs in General.
+	useEffect( () => {
+		if ( state.editedSteps.includes( activeStepIndex + 1 ) || indexingState === "in_progress" ) {
+			window.isStepBeingEdited = true;
+		} else {
+			window.isStepBeingEdited = false;
+		}
+	}, [ state.editedSteps, indexingState ] );
+
 	/**
 	 * Handles the "before page unloads" event.
 	 *

--- a/packages/js/src/first-time-configuration/first-time-configuration-steps.js
+++ b/packages/js/src/first-time-configuration/first-time-configuration-steps.js
@@ -282,6 +282,13 @@ async function updateTracking( state ) {
 	return await response.json;
 }
 
+/**
+ * Saves the first time configuration finished steps in the database.
+ *
+ * @param {Array} finishedSteps Array of finished steps.
+ *
+ * @returns {Promise|bool} A promise, or false if the call fails.
+ */
 async function saveFinishedSteps( finishedSteps ) {
 	const response = await apiFetch( {
 		path: "yoast/v1/configuration/save_configuration_state",

--- a/packages/js/src/initializers/admin.js
+++ b/packages/js/src/initializers/admin.js
@@ -311,7 +311,7 @@ export default function initAdmin( jQuery ) {
 	 */
 	function canShowConfirmDialog( target ) {
 		// Is the user in the first time configuration tab?
-		var comingFromFTCTab = !! jQuery( "#wpseo-tabs" ).find( "a" ).filter( ".nav-tab-active" ).filter( "#first-time-configuration-tab" ).length;
+		var comingFromFTCTab = !! jQuery( "#first-time-configuration-tab" ).filter( ".nav-tab-active" ).length;
 		// Does the user wants to switch to the first time configuration tab?
 		var goingToFTCTab = !! target.filter( "#first-time-configuration-tab" ).length;
 

--- a/packages/js/src/initializers/admin.js
+++ b/packages/js/src/initializers/admin.js
@@ -381,20 +381,41 @@ export default function initAdmin( jQuery ) {
 
 		// Handle the settings pages tabs.
 		jQuery( "#wpseo-tabs" ).find( "a" ).on( "click", function() {
-			jQuery( "#wpseo-tabs" ).find( "a" ).removeClass( "nav-tab-active" );
-			jQuery( ".wpseotab" ).removeClass( "active" );
+			// Is the user in the first time configuration tab?
+			var comingFromFTCTab = !! jQuery( "#wpseo-tabs" ).find( "a" ).filter( ".nav-tab-active" ).filter( "#first-time-configuration-tab" ).length;
+			// Does the user wants to switch to the first time configuration tab?
+			var goingToFTCTab = !! jQuery( this ).filter( "#first-time-configuration-tab" ).length;
 
-			var id = jQuery( this ).attr( "id" ).replace( "-tab", "" );
-			var activeTab = jQuery( "#" + id );
-			activeTab.addClass( "active" );
-			jQuery( this ).addClass( "nav-tab-active" );
-			if ( activeTab.hasClass( "nosave" ) ) {
-				jQuery( "#wpseo-submit-container" ).hide();
-			} else {
-				jQuery( "#wpseo-submit-container" ).show();
+			var canChangeTab = true;
+
+			/**
+			 * Show the pop-up iff the user is in the first time configuration tab
+			 * and clicks on a tab which is different from the first time configuration tab
+			*/
+			if ( comingFromFTCTab && ! goingToFTCTab ) {
+				/* eslint-disable no-alert */
+				canChangeTab = confirm( "Are you sure you want to leave the page?" );
 			}
 
-			jQuery( window ).trigger( "yoast-seo-tab-change" );
+			if ( canChangeTab ) {
+				jQuery( "#wpseo-tabs" ).find( "a" ).removeClass( "nav-tab-active" );
+				jQuery( ".wpseotab" ).removeClass( "active" );
+
+				var id = jQuery( this ).attr( "id" ).replace( "-tab", "" );
+				var activeTab = jQuery( "#" + id );
+				activeTab.addClass( "active" );
+				jQuery( this ).addClass( "nav-tab-active" );
+				if ( activeTab.hasClass( "nosave" ) ) {
+					jQuery( "#wpseo-submit-container" ).hide();
+				} else {
+					jQuery( "#wpseo-submit-container" ).show();
+				}
+
+				jQuery( window ).trigger( "yoast-seo-tab-change" );
+			} else {
+				// Re-establish the focus on the first time configuration tab if the user clicks 'Cancel' on the pop-up
+				jQuery( "#first-time-configuration-tab" ).trigger( "focus" );
+			}
 
 			if ( id === "first-time-configuration" ) {
 				jQuery( "#yoast-first-time-configuration-notice" ).slideUp();

--- a/packages/js/src/initializers/admin.js
+++ b/packages/js/src/initializers/admin.js
@@ -301,6 +301,28 @@ export default function initAdmin( jQuery ) {
 		}
 	}
 
+	/**
+	 * Checks wether or not the confirmation dialog should be displayed upom switching tab.
+	 *
+	 * @param {object} target The clicked tab.
+	 *
+	 * @returns {bool} If the dialog should be displayed.
+	 */
+	function canShowConfirmDialog( target ) {
+		// Is the user in the first time configuration tab?
+		var comingFromFTCTab = !! jQuery( "#wpseo-tabs" ).find( "a" ).filter( ".nav-tab-active" ).filter( "#first-time-configuration-tab" ).length;
+		// Does the user wants to switch to the first time configuration tab?
+		var goingToFTCTab = !! target.filter( "#first-time-configuration-tab" ).length;
+
+
+		/**
+		 * Show the pop-up iff the user is in the first time configuration tab
+		 * and clicks on a tab which is different from the first time configuration tab
+		 * and the current step is being edited (set by first time configuration in React)
+		*/
+		return ( comingFromFTCTab && ( ! goingToFTCTab ) && window.isStepBeingEdited );
+	}
+
 	window.wpseoDetectWrongVariables = wpseoDetectWrongVariables;
 	window.setWPOption = setWPOption;
 	window.wpseoCopyHomeMeta = wpseoCopyHomeMeta;
@@ -381,18 +403,9 @@ export default function initAdmin( jQuery ) {
 
 		// Handle the settings pages tabs.
 		jQuery( "#wpseo-tabs" ).find( "a" ).on( "click", function() {
-			// Is the user in the first time configuration tab?
-			var comingFromFTCTab = !! jQuery( "#wpseo-tabs" ).find( "a" ).filter( ".nav-tab-active" ).filter( "#first-time-configuration-tab" ).length;
-			// Does the user wants to switch to the first time configuration tab?
-			var goingToFTCTab = !! jQuery( this ).filter( "#first-time-configuration-tab" ).length;
-
 			var canChangeTab = true;
 
-			/**
-			 * Show the pop-up iff the user is in the first time configuration tab
-			 * and clicks on a tab which is different from the first time configuration tab
-			*/
-			if ( comingFromFTCTab && ! goingToFTCTab ) {
+			if ( canShowConfirmDialog( jQuery( this ) ) ) {
 				/* eslint-disable no-alert */
 				canChangeTab = confirm( "Are you sure you want to leave the page?" );
 			}

--- a/packages/js/src/initializers/admin.js
+++ b/packages/js/src/initializers/admin.js
@@ -412,6 +412,7 @@ export default function initAdmin( jQuery ) {
 			}
 
 			if ( canChangeTab ) {
+				window.isStepBeingEdited = false;
 				jQuery( "#wpseo-tabs" ).find( "a" ).removeClass( "nav-tab-active" );
 				jQuery( ".wpseotab" ).removeClass( "active" );
 
@@ -426,15 +427,14 @@ export default function initAdmin( jQuery ) {
 				}
 
 				jQuery( window ).trigger( "yoast-seo-tab-change" );
+				if ( id === "first-time-configuration" ) {
+					jQuery( "#yoast-first-time-configuration-notice" ).slideUp();
+				} else {
+					jQuery( "#yoast-first-time-configuration-notice" ).slideDown();
+				}
 			} else {
 				// Re-establish the focus on the first time configuration tab if the user clicks 'Cancel' on the pop-up
 				jQuery( "#first-time-configuration-tab" ).trigger( "focus" );
-			}
-
-			if ( id === "first-time-configuration" ) {
-				jQuery( "#yoast-first-time-configuration-notice" ).slideUp();
-			} else {
-				jQuery( "#yoast-first-time-configuration-notice" ).slideDown();
 			}
 		} );
 

--- a/packages/js/src/initializers/admin.js
+++ b/packages/js/src/initializers/admin.js
@@ -1,5 +1,6 @@
 /* global wpseoAdminGlobalL10n, ajaxurl, wpseoScriptData, ClipboardJS */
 
+import { __ } from "@wordpress/i18n";
 import a11ySpeak from "a11y-speak";
 import { debounce } from "lodash-es";
 
@@ -407,7 +408,7 @@ export default function initAdmin( jQuery ) {
 
 			if ( canShowConfirmDialog( jQuery( this ) ) ) {
 				/* eslint-disable no-alert */
-				canChangeTab = confirm( "Are you sure you want to leave the page?" );
+				canChangeTab = confirm( __( "There are unsaved changes in one or more steps. Leaving means that those changes will be lost. Are you sure you want to leave?", "wordpress-seo" ) );
 			}
 
 			if ( canChangeTab ) {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Moving the First-time configuration inside a tab of the `General` section introduced the need to manage tabs switching when the current step is being edited. 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Shows a confirmation modal pup-up when the user tries to switch tab and there are unsaved changes in the current step

## Relevant technical choices:

* Please note the First-time configuration notice could keep popping up when you switch tabs until the page is refreshed. This is expected and will be fixed [in another PR](https://github.com/Yoast/wordpress-seo/pull/18419).

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Start with a freshly-installed Yoast SEO instance
* Navigate to `General` -> `First-time configuration` tab
* Click on Start SEO data optimization and switch tab before the process is completed
* Verity a modal pop-up appears asking for confirmation
* Click on `OK` and verify the tab changes
* Go back to the `First-time configuration` tab and advance to the `Site representation` step
* Make some changes and switch tab
* Verity a modal pop-up appears asking for confirmation
* Click on `Cancel` and verify you're still in the `First-time configuration` tab
* Complete the first-time configuration and click the `Edit` button aside the `Social profiles` step
* Without changing anything click on a tab and verify no pop-up is shown
* Edit some fields and try to change tab
* Verity a modal pop-up appears asking for confirmation

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes [DUPP-465](https://yoast.atlassian.net/browse/DUPP-465)
