### PR TITLE
When local is enabled, hide text in Social page

### DIFF
--- a/admin/class-config.php
+++ b/admin/class-config.php
@@ -149,6 +149,8 @@ class WPSEO_Admin_Pages {
 			];
 
 			$script_data['search_appearance_link'] = admin_url( 'admin.php?page=wpseo_titles' );
+
+			$script_data['force_organization'] = ( defined( 'WPSEO_LOCAL_FILE' ) );
 		}
 
 		$this->asset_manager->localize_script( 'settings', 'wpseoScriptData', $script_data );

--- a/packages/js/src/initializers/social-settings.js
+++ b/packages/js/src/initializers/social-settings.js
@@ -205,18 +205,22 @@ function SocialProfilesWrapper() {
 							{ __( "Saved!", "wordpress-seo" ) }
 						</span> }
 					</div>
-					<p className="yst-mt-8 yst-text-gray-500">{
-						addLinkToString(
-							sprintf(
-								/* translators: 1: link tag to the relevant WPSEO admin page; 2: link close tag. */
-								__( "Your website is currently configured to represent an Organization. If you want your site to represent a Person, please select 'Person' in the 'Knowledge Graph & Schema.org' section of the %1$sSearch Appearance%2$s settings.", "wordpress-seo" ),
-								"<a>",
-								"</a>"
-							),
-							window.wpseoScriptData.search_appearance_link,
-							"yoast-search-appearance-link"
-						)
-					}</p>
+					{
+						! window.wpseoScriptData.force_organization && <p className="yst-mt-8 yst-text-gray-500">
+							{
+								addLinkToString(
+									sprintf(
+										/* translators: 1: link tag to the relevant WPSEO admin page; 2: link close tag. */
+										__( "Your website is currently configured to represent an Organization. If you want your site to represent a Person, please select 'Person' in the 'Knowledge Graph & Schema.org' section of the %1$sSearch Appearance%2$s settings.", "wordpress-seo" ),
+										"<a>",
+										"</a>"
+									),
+									window.wpseoScriptData.search_appearance_link,
+									"yoast-search-appearance-link"
+								)
+							}
+						</p>
+					}
 				</Fragment>
 			}
 			<SocialHiddenFields


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Hides the `Site represents an Organization` text in the Social page when Local SEO is enabled

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* When Local is not installed, and the site represents an Organization, going into the Yoast SEO->Social page, the `Your website is currently configured to represent an Organization, .... ` text should appear likeso:
![image](https://user-images.githubusercontent.com/12400734/167401395-9824ada8-8d84-4ce7-98ca-4a5cb61c3ca5.png)

* When Local is installed, the `Your website is currently configured to represent an Organization, .... ` text should NOT appear there, likeso:
![image](https://user-images.githubusercontent.com/12400734/167401201-abc833d2-61be-4d2b-922d-2b39e5b00cd5.png)

* When Local is not installed, and the site represents a person, going into the Yoast SEO->Social page, the `Your website is currently configured to represent a Person, .... ` text should appear likeso:
![image](https://user-images.githubusercontent.com/12400734/167400969-7b4537ef-31a9-45d2-b9c8-84bd1bdf5f8a.png)


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes #
