### PR TITLE
Dupp 487 ftc usage tracking not aligned between ftc tab and features tab

### DIFF
--- a/packages/js/src/first-time-configuration/first-time-configuration-steps.js
+++ b/packages/js/src/first-time-configuration/first-time-configuration-steps.js
@@ -350,8 +350,6 @@ export default function FirstTimeConfigurationSteps() {
 	const [ siteRepresentationEmpty, setSiteRepresentationEmpty ] = useState( false );
 	const [ showRunIndexationAlert, setShowRunIndexationAlert ] = useState( false );
 
-	const isTrackingOptionSelected = state.tracking === 0 || state.tracking === 1;
-
 	/* Briefly override window variable because indexingstate is reinitialized when navigating back and forth without triggering a reload,
 	whereas the window variable remains stale. */
 	useEffect( () => {
@@ -479,7 +477,7 @@ export default function FirstTimeConfigurationSteps() {
 	function updateOnFinishPersonalPreferences() {
 		return updateTracking( state )
 			.then( () => {
-				if ( isTrackingOptionSelected ) {
+				if ( !! state.tracking === true ) {
 					document.getElementById( "tracking-on" ).checked = true;
 				} else {
 					document.getElementById( "tracking-off" ).checked = true;
@@ -734,7 +732,7 @@ export default function FirstTimeConfigurationSteps() {
 							</EditButton>
 						</Step.Header>
 						<Step.Content>
-							<PersonalPreferencesStep state={ state } setTracking={ setTracking } isTrackingOptionSelected={ isTrackingOptionSelected } />
+							<PersonalPreferencesStep state={ state } setTracking={ setTracking } />
 							<ConfigurationStepButtons stepperFinishedOnce={ stepperFinishedOnce } saveFunction={ updateOnFinishPersonalPreferences } setEditState={ setIsStepBeingEdited } />
 						</Step.Content>
 					</Step>

--- a/packages/js/src/first-time-configuration/tailwind-components/steps/personal-preferences/personal-preferences-step.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/steps/personal-preferences/personal-preferences-step.js
@@ -13,7 +13,6 @@ const Link = makeOutboundLink();
  *
  * @param {Object}   state                    The state
  * @param {function} setTracking              Callback function to update tracking preference
- * @param {Boolean}  isTrackingOptionSelected Wether the tracking option is selected
  *
  * @returns {JSX.Element} Example step.
  */


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Some of the values that can be edited in the first-time configuration can be edited also in another parts of the plug-in: we want to keep the values of those variable aligned

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug which prevents keeping aligned the `Usage tracking` option value between the first-time configuration and the Features tab

## Relevant technical choices:

* N/A

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Start with a freshly-installed Yoast SEO instance
* Navigate to `General` -> `First-time configuration tab` -> `Personal preferences` step
* Toggle the radio button to `Yes, you can track my site data` and click on `Save and Continue`
* Switch to the `Features` tab and verify the `Usage tracking` radio button is set to `on`
* Toggle it to `off` and click on `Save changes`
* Switch to the `First-time configuration` tab and verify the radio button is set to `No, don’t track my site data`


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes [DUPP-487](https://yoast.atlassian.net/browse/DUPP-487)
