### PR TITLE
Fix 'Skip' anchor placement in mobile view

### DIFF
--- a/packages/js/src/installation-success.js
+++ b/packages/js/src/installation-success.js
@@ -118,13 +118,13 @@ function InstallationSuccessPage() {
 						</div>
 					</div>
 				</div>
+				<a id="installation-success-skip-link" className="yst-self-end yst-text-base yst-bottom-12 yst-right-0 yst-absolute yst-mr-5" href={ "/wp-admin/admin.php?page=wpseo_dashboard" }>
+					{
+						/* translators: %s expands to ' »'. */
+						sprintf( __( "Skip%s", "wordpress-seo" ), " »" )
+					}
+				</a>
 			</div>
-			<a id="installation-success-skip-link" className="yst-self-end yst-text-base yst-bottom-12 yst-right-0 yst-absolute yst-mr-5" href={ "/wp-admin/admin.php?page=wpseo_dashboard" }>
-				{
-					/* translators: %s expands to ' »'. */
-					sprintf( __( "Skip%s", "wordpress-seo" ), " »" )
-				}
-			</a>
 		</div>
 	);
 }

--- a/packages/js/src/installation-success.js
+++ b/packages/js/src/installation-success.js
@@ -117,13 +117,13 @@ function InstallationSuccessPage() {
 							</a>
 						</div>
 					</div>
+					<a id="installation-success-skip-link" className="yst-bottom-12 yst-right-0 yst-mr-5 yst-self-end yst-text-base md:yst-absolute" href={ "/wp-admin/admin.php?page=wpseo_dashboard" }>
+						{
+							/* translators: %s expands to ' »'. */
+							sprintf( __( "Skip%s", "wordpress-seo" ), " »" )
+						}
+					</a>
 				</div>
-				<a id="installation-success-skip-link" className="yst-self-end yst-text-base yst-bottom-12 yst-right-0 yst-absolute yst-mr-5" href={ "/wp-admin/admin.php?page=wpseo_dashboard" }>
-					{
-						/* translators: %s expands to ' »'. */
-						sprintf( __( "Skip%s", "wordpress-seo" ), " »" )
-					}
-				</a>
 			</div>
 		</div>
 	);


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The mobile version of the _installation successful_ page does not render correctly the `Skip` anchor

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes the placement of the `Skip` anchor in mobile view

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install and activate Yoast SEO: you will be redirected to the _Installation successful_ page (if you have it already installed and activated visit the  page directly, e.g. http://basic.wordpress.test/wp-admin/admin.php?page=wpseo_installation_successful_free
* In the browser's developer tools switch to the mobile view and verify the `Skip` anchor is right below the purple block:
<img width="449" alt="Screenshot 2022-05-10 at 11 42 18" src="https://user-images.githubusercontent.com/68744851/167599756-81499ae5-358d-4fd0-b72f-a254425e2239.png">


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes [DUPP-484](https://yoast.atlassian.net/browse/DUPP-484)
