### PR TITLE
LINGO 1459 - focus keyphrase is not previewed in bold in meta description preview desktop result

### DIFF
--- a/packages/seo-store/src/analysis/slice/results.js
+++ b/packages/seo-store/src/analysis/slice/results.js
@@ -108,7 +108,7 @@ export const resultsSelectors = {
 	selectSeoResults: ( state, id = FOCUS_KEYPHRASE_ID ) => get( state, `analysis.results.seo.${ id }.results` ),
 	selectReadabilityScore: ( state ) => get( state, "analysis.results.readability.score" ),
 	selectReadabilityResults: ( state ) => get( state, "analysis.results.readability.results" ),
-	selectResearchResults: ( state, id ) => get( state, `analysis.results.research.${ id }` ),
+	selectResearchResults: ( state, id ) => get( state, `analysis.results.research.${ id }.result` ),
 	selectActiveMarker: ( state ) => get( state, "analysis.results.activeMarker" ),
 	selectActiveMarkerId: ( state ) => get( state, "analysis.results.activeMarker.id" ),
 	selectActiveMarks: ( state ) => get( state, "analysis.results.activeMarker.marks" ),

--- a/packages/seo-store/tests/analysis/slice/results.test.js
+++ b/packages/seo-store/tests/analysis/slice/results.test.js
@@ -152,7 +152,12 @@ describe( "Results slice", () => {
 			const { selectResearchResults } = resultsSelectors;
 
 			const state = {
-				research: { morphology: "test" },
+				research: {
+					morphology: {
+						data: {},
+						result: "test",
+					},
+				},
 			};
 			const result = selectResearchResults( createStoreState( state ), "morphology" );
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug in the classic editor agnostic analysis integration where the focus keyphrase forms were not highlighted inside of the Google preview desktop result.

## Relevant technical choices:

* Since the results of a research are always set on the `result` key, I decided to add this path to the `getResearchResults` selector.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Create a post.
* Set a focus keyphrase.
* Add a meta description and add your focus keyphrase in the description.
* Inside Google Preview, preview the meta description in “Desktop result”.
* Confirm that the focus keyphrase is in bold in the preview.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Smoke test if the Google preview still works as expected.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes LINGO-1459
