### PR TITLE
Dupp 490 error in network admin

### DIFF
--- a/packages/js/src/first-time-configuration.js
+++ b/packages/js/src/first-time-configuration.js
@@ -4,5 +4,8 @@ import { renderReactRoot } from "./helpers/reactRoot";
 import FirstTimeConfigurationSteps from "./first-time-configuration/first-time-configuration-steps";
 
 domReady( () => {
-	renderReactRoot( "wpseo-first-time-configuration", <FirstTimeConfigurationSteps /> );
+	const rootId = "wpseo-first-time-configuration";
+	if ( document.getElementById( rootId ) ) {
+		renderReactRoot( rootId, <FirstTimeConfigurationSteps /> );
+	}
 } );

--- a/src/integrations/admin/first-time-configuration-integration.php
+++ b/src/integrations/admin/first-time-configuration-integration.php
@@ -124,7 +124,7 @@ class First_Time_Configuration_Integration implements Integration_Interface {
 	 */
 	public function enqueue_assets() {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Date is not processed or saved.
-		if ( ! isset( $_GET['page'] ) || $_GET['page'] !== 'wpseo_dashboard' ) {
+		if ( ! isset( $_GET['page'] ) || $_GET['page'] !== 'wpseo_dashboard' || is_network_admin() ) {
 			return;
 		}
 

--- a/src/integrations/admin/first-time-configuration-integration.php
+++ b/src/integrations/admin/first-time-configuration-integration.php
@@ -124,7 +124,7 @@ class First_Time_Configuration_Integration implements Integration_Interface {
 	 */
 	public function enqueue_assets() {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Date is not processed or saved.
-		if ( ! isset( $_GET['page'] ) || $_GET['page'] !== 'wpseo_dashboard' || is_network_admin() ) {
+		if ( ! isset( $_GET['page'] ) || $_GET['page'] !== 'wpseo_dashboard' || \is_network_admin() ) {
 			return;
 		}
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to avoid throwing a console error in the SEO dashboard page when on the network admin

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where a console error would appear in the network admin.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Go to the http://multisite.wordpress.test/wp-admin/network/admin.php?page=wpseo_dashboard page of a multisite setup
Without this PR:
* We would have gotten a `Uncaught Error: Target container is not a DOM element` console error
With this PR:
* We dont get that console error

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Go to the SEO->Dashboard page of a subsite in a multisite setup and smoke test that the FTC tab appears there with the normal UX
* Go to the SEO->Dashboard page of a single site setup and smoke test that the FTC tab appears there with the normal UX

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes #
