### PR TITLE
Dupp 489 ftc seo optimization error dissapears

### DIFF
--- a/packages/js/src/first-time-configuration/tailwind-components/steps/indexation/indexation.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/steps/indexation/indexation.js
@@ -377,6 +377,7 @@ export class Indexation extends Component {
 		return <IndexingError
 			message={ yoastIndexingData.errorMessage }
 			error={ this.state.error }
+			className={ "yst-mb-4" }
 		/>;
 	}
 
@@ -396,7 +397,9 @@ export class Indexation extends Component {
 				{ this.props.children }
 				<Transition
 					unmount={ false }
-					show={ this.isState( STATE.IN_PROGRESS ) || ( this.isState( STATE.IDLE ) && this.state.amount > 0 ) }
+					show={ this.isState( STATE.ERRORED ) ||
+						this.isState( STATE.IN_PROGRESS ) ||
+						( this.isState( STATE.IDLE ) && this.state.amount > 0 ) }
 					leave="yst-transition-opacity yst-duration-1000"
 					leaveFrom="yst-opacity-100"
 					leaveTo="yst-opacity-0"

--- a/packages/js/src/first-time-configuration/tailwind-components/steps/indexation/indexing-error.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/steps/indexation/indexing-error.js
@@ -71,8 +71,11 @@ ErrorBox.defaultProps = {
  *
  * @returns {JSX.Element} The indexation error component.
  */
-export default function IndexingError( { message, error } ) {
-	return <Alert type={ "error" }>
+export default function IndexingError( { message, error, className} ) {
+	return <Alert
+		type={ "error" }
+		className={ className }
+	>
 		<div dangerouslySetInnerHTML={ { __html: message } } />
 		<details>
 			<summary>{ __( "Error details", "wordpress-seo" ) }</summary>
@@ -94,4 +97,9 @@ IndexingError.propTypes = {
 		PropTypes.instanceOf( Error ),
 		PropTypes.instanceOf( RequestError ),
 	] ).isRequired,
+	className: PropTypes.string,
+};
+
+IndexingError.defaultProps = {
+	className: "",
 };


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* In the `SEO Data Optimization` step of the First-time configuration, if an error occurs, the alert appears and disappears shortly after

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes the error alert box to stay on screen when an error occurs

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Start with a freshly-installed Yoast SEO instance
* Simulate an error in the indexing process (for devs, change `packages/js/src/first-time-configuration/tailwind-components/steps/indexation/indexation.js` line 134 from:
```
let url = this.settings.restApi.root + this.settings.restApi.indexing_endpoints[ endpoint ];
```
to:
```
let url = this.settings.restApi.root + this.settings.restApi.indexing_endpoints[ endpoint ] + "error!";
```
or similar)

* Navigate to `General` -> `First-time configuration tab` and click on `Start SEO data optimization`
* Verify that an error alert appears and stays on the screen

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes [DUPP-489](https://yoast.atlassian.net/browse/DUPP-478)
