### PR TITLE
Update error fields upon input actions

### DIFF
--- a/packages/js/src/first-time-configuration/first-time-configuration-steps.js
+++ b/packages/js/src/first-time-configuration/first-time-configuration-steps.js
@@ -2,9 +2,10 @@
 import apiFetch from "@wordpress/api-fetch";
 import { useCallback, useReducer, useState, useEffect, useRef } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
-import { cloneDeep, uniq } from "lodash";
+import { uniq } from "lodash";
 
 import { addLinkToString } from "../helpers/stringHelpers.js";
+import { configurationReducer } from "./tailwind-components/helpers/index.js";
 import SocialProfilesStep from "./tailwind-components/steps/social-profiles/social-profiles-step";
 import Stepper, { Step } from "./tailwind-components/stepper";
 import { ContinueButton, EditButton, ConfigurationStepButtons } from "./tailwind-components/configuration-stepper-buttons";
@@ -27,149 +28,7 @@ const STEPS = {
 	personalPreferences: "personalPreferences",
 };
 
-/**
- * Adds a step to editedSteps if not there already.
- *
- * @param {Array} editedSteps Steps that have been edited.
- * @param {number} stepNumber  The number of the field that was edited.
- *
- * @returns {Array} The new array of editedSteps.
- */
-function addStepToEditedSteps( editedSteps, stepNumber ) {
-	if ( editedSteps.includes( stepNumber ) ) {
-		return [ ...editedSteps ];
-	}
-	return [ ...editedSteps, stepNumber ];
-}
-
-/**
- * Removes a step from savedSteps.
- *
- * @param {Array} savedSteps Steps that have been saved.
- * @param {number} stepNumber  The number of the step that was edited.
- *
- * @returns {Array} The new array of savedSteps
- */
-function removeStepFromSavedSteps( savedSteps, stepNumber ) {
-	return savedSteps.filter( step => step !== stepNumber );
-}
-
-/**
- * Adjusts the editedSteps and savedSteps and returns the full state;
- *
- * @param {Object} state      The state.
- * @param {number} stepNumber The number of the step that was edited.
- *
- * @returns {Object} The new state;
- */
-function handleStepEdit( state, stepNumber ) {
-	const newEditedSteps = addStepToEditedSteps( state.editedSteps, stepNumber );
-	const newSavedSteps = removeStepFromSavedSteps( state.savedSteps, stepNumber );
-	return {
-		...state,
-		editedSteps: newEditedSteps,
-		savedSteps: newSavedSteps,
-	};
-}
-
 /* eslint-disable complexity */
-/**
- * A reducer for the configuration's internal state.
- *
- * @param {Object} state  The "current" state.
- * @param {Object} action The action with which to mutate the state.
- *
- * @returns {Object} The state as altered by the action.
- */
-function configurationReducer( state, action ) {
-	let newState = cloneDeep( state );
-	switch ( action.type ) {
-		case "SET_COMPANY_OR_PERSON":
-			newState = handleStepEdit( newState, 2 );
-			newState.companyOrPerson = action.payload;
-			newState.companyOrPersonLabel = newState.companyOrPersonOptions.filter( ( item ) => {
-				return item.value === action.payload;
-			} ).pop().label;
-			return newState;
-		case "CHANGE_COMPANY_NAME":
-			newState = handleStepEdit( newState, 2 );
-			newState.companyName = action.payload;
-			return newState;
-		case "SET_COMPANY_LOGO":
-			newState = handleStepEdit( newState, 2 );
-			newState.companyLogo = action.payload.url;
-			newState.companyLogoId = action.payload.id;
-			return newState;
-		case "REMOVE_COMPANY_LOGO":
-			newState = handleStepEdit( newState, 2 );
-			newState.companyLogo = "";
-			newState.companyLogoId = "";
-			return newState;
-		case "SET_PERSON_LOGO":
-			newState = handleStepEdit( newState, 2 );
-			newState.personLogo = action.payload.url;
-			newState.personLogoId = action.payload.id;
-			return newState;
-		case "REMOVE_PERSON_LOGO":
-			newState = handleStepEdit( newState, 2 );
-			newState.personLogo = "";
-			newState.personLogoId = "";
-			return newState;
-		case "SET_PERSON":
-			newState = handleStepEdit( newState, 2 );
-			newState.personId = action.payload.value;
-			newState.personName = action.payload.label;
-			return newState;
-		case "CHANGE_PERSON_SOCIAL_PROFILE":
-			newState = handleStepEdit( newState, 3 );
-			newState.personSocialProfiles[ action.payload.socialMedium ] = action.payload.value;
-			return newState;
-		case "INIT_PERSON_SOCIAL_PROFILES":
-			newState.personSocialProfiles = action.payload.socialProfiles;
-			return newState;
-		case "SET_CAN_EDIT_USER":
-			newState = handleStepEdit( newState, 2 );
-			newState.canEditUser = ( action.payload === true ) ? 1 : 0;
-			return newState;
-		case "CHANGE_SOCIAL_PROFILE":
-			newState = handleStepEdit( newState, 3 );
-			newState.socialProfiles[ action.payload.socialMedium ] = action.payload.value;
-			return newState;
-		case "CHANGE_OTHERS_SOCIAL_PROFILE":
-			newState = handleStepEdit( newState, 3 );
-			newState.socialProfiles.otherSocialUrls[ action.payload.index ] = action.payload.value;
-			return newState;
-		case "ADD_OTHERS_SOCIAL_PROFILE":
-			newState = handleStepEdit( newState, 3 );
-			newState.socialProfiles.otherSocialUrls = [ ...newState.socialProfiles.otherSocialUrls, action.payload.value ];
-			return newState;
-		case "REMOVE_OTHERS_SOCIAL_PROFILE":
-			newState = handleStepEdit( newState, 3 );
-			newState.socialProfiles.otherSocialUrls.splice( action.payload.index, 1 );
-			return newState;
-		case "SET_ERROR_FIELDS":
-			newState.errorFields = action.payload;
-			return newState;
-		case "SET_TRACKING":
-			newState = handleStepEdit( newState, 4 );
-			newState.tracking = action.payload;
-			return newState;
-		case "SET_STEP_SAVED":
-			if ( ! newState.savedSteps.includes( action.payload ) ) {
-				newState.savedSteps = [ ...newState.savedSteps, action.payload ];
-			}
-			newState.editedSteps = newState.editedSteps.filter( step => step !== action.payload );
-			return newState;
-		case "SET_STEP_NOT_SAVED":
-			newState.savedSteps = newState.savedSteps.filter( step => step !== action.payload );
-			return newState;
-		case "SET_ALL_STEPS_NOT_SAVED":
-			newState.savedSteps = [];
-			return newState;
-		default:
-			return newState;
-	}
-}
 
 /**
  * Updates the site representation in the database.

--- a/packages/js/src/first-time-configuration/tailwind-components/helpers/index.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/helpers/index.js
@@ -163,6 +163,14 @@ export function configurationReducer( state, action ) {
 		case "CHANGE_SOCIAL_PROFILE":
 			newState = handleStepEdit( newState, 3 );
 			newState.socialProfiles[ action.payload.socialMedium ] = action.payload.value;
+			newState.errorFields = newState.errorFields.filter( errorField => {
+				if ( action.payload.socialMedium === "facebookUrl" ) {
+					return errorField !== "facebook_site";
+				} else if ( action.payload.socialMedium === "twitterUsername" ) {
+					return errorField !== "twitter_site";
+				}
+				return true;
+			} );
 			return newState;
 		case "CHANGE_OTHERS_SOCIAL_PROFILE":
 			newState = handleStepEdit( newState, 3 );

--- a/packages/js/src/first-time-configuration/tailwind-components/helpers/index.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/helpers/index.js
@@ -101,6 +101,31 @@ function handleStepEdit( state, stepNumber ) {
 	};
 }
 
+/**
+ * Manages updating of the error notices when one (or more) field are removed from the user
+ *
+ * @param {object} prevState An array of fields names with errors
+ * @param {int} index The index of the field to be removed
+ *
+ * @returns {Array} The filtered list of fields with errors
+ */
+export function removeFieldAndUpdateErrors( prevState, index ) {
+	// Map through all the fields with errors
+	return prevState.map( ( errorField ) => {
+		// Find the index of the current error
+		const errorFieldIndex = parseInt( errorField.replace( "other_social_urls-", "" ), 10 );
+		// If the error occurs on the field to be removed, mark it for removal
+		if ( errorFieldIndex === index ) {
+			return "remove";
+		// If the field index is past the field to be removed, decrease it by one since we'll remove the previous field
+		} else if ( errorFieldIndex > index ) {
+			return `other_social_urls-${ errorFieldIndex - 1 }`;
+		}
+		return errorField;
+	// Keep all the errors not marked to be removed
+	} ).filter( errorField => errorField !== "remove" );
+}
+
 /* eslint-disable complexity */
 /**
  * A reducer for the configuration's internal state.
@@ -184,15 +209,7 @@ export function configurationReducer( state, action ) {
 		case "REMOVE_OTHERS_SOCIAL_PROFILE":
 			newState = handleStepEdit( newState, 3 );
 			newState.socialProfiles.otherSocialUrls.splice( action.payload.index, 1 );
-			newState.errorFields = newState.errorFields.map( ( errorField ) => {
-				const errorFieldIndex = parseInt( errorField.replace( "other_social_urls-", "" ), 10 );
-				if ( errorFieldIndex === action.payload.index ) {
-					return "remove";
-				} else if ( errorFieldIndex > action.payload.index ) {
-					return `other_social_urls-${ errorFieldIndex - 1 }`;
-				}
-				return errorField;
-			} ).filter( errorField => errorField !== "remove" );
+			newState.errorFields = removeFieldAndUpdateErrors( newState.errorFields, action.payload.index );
 			return newState;
 		case "SET_ERROR_FIELDS":
 			newState.errorFields = action.payload;

--- a/packages/js/src/initializers/social-settings.js
+++ b/packages/js/src/initializers/social-settings.js
@@ -73,6 +73,11 @@ function SocialProfilesWrapper() {
 	const [ isSaved, setIsSaved ] = useState( false );
 
 	/* eslint-disable max-len */
+	// Clear isSaved when values are edited.
+	useEffect( () => {
+		setIsSaved( false );
+	}, [ facebookValue, twitterValue, otherSocialUrls ] );
+
 	useEffect( () => {
 		/**
 		 * Prevents the submission of the form upon pressing enter.
@@ -146,11 +151,11 @@ function SocialProfilesWrapper() {
 				return errorField;
 			} ).filter( errorField => errorField !== "remove" );
 		} );
-	}, [ setOtherSocialUrls ] );
+	}, [ setOtherSocialUrls, setErrorFields ] );
 
 	const onAddProfileHandler = useCallback( () => {
 		setOtherSocialUrls( prevState => [ ...prevState, "" ] );
-	}, [ setOtherSocialUrls ] );
+	}, [ setOtherSocialUrls, setErrorFields ] );
 	return (
 		<div
 			className="yst-root yst-bg-white yst-rounded-lg yst-p-6 yst-shadow-md yst-max-w-2xl yst-mt-6"

--- a/packages/js/src/initializers/social-settings.js
+++ b/packages/js/src/initializers/social-settings.js
@@ -72,12 +72,6 @@ function SocialProfilesWrapper() {
 	const [ errorFields, setErrorFields ] = useState( [] );
 	const [ isSaved, setIsSaved ] = useState( false );
 
-	// Clear errorFields and isSaved when values are edited.
-	useEffect( () => {
-		setErrorFields( [] );
-		setIsSaved( false );
-	}, [ facebookValue, twitterValue, otherSocialUrls ] );
-
 	/* eslint-disable max-len */
 	useEffect( () => {
 		/**
@@ -123,8 +117,10 @@ function SocialProfilesWrapper() {
 	const onChangeHandler = useCallback( ( value, socialMedium ) => {
 		if ( socialMedium === "facebookUrl" ) {
 			setFacebookValue( value );
+			setErrorFields( prevState => prevState.filter( errorField => errorField !== "facebook_site" ) );
 		} else if ( socialMedium === "twitterUsername" ) {
 			setTwitterValue( value );
+			setErrorFields( prevState => prevState.filter( errorField => errorField !== "twitter_site" ) );
 		}
 	}, [ setFacebookValue, setTwitterValue ] );
 
@@ -134,10 +130,22 @@ function SocialProfilesWrapper() {
 			nextState[ index ] = value;
 			return nextState;
 		} );
+		setErrorFields( prevState => prevState.filter( errorField => errorField !== `other_social_urls-${ index }` ) );
 	}, [ setOtherSocialUrls ] );
 
 	const onRemoveProfileHandler = useCallback( ( index ) => {
 		setOtherSocialUrls( prevState => prevState.filter( ( _, prevStateIndex ) => prevStateIndex !== index ) );
+		setErrorFields( prevState => {
+			return prevState.map( ( errorField ) => {
+				const errorFieldIndex = parseInt( errorField.replace( "other_social_urls-", "" ), 10 );
+				if ( errorFieldIndex === index ) {
+					return "remove";
+				} else if ( errorFieldIndex > index ) {
+					return `other_social_urls-${ errorFieldIndex - 1 }`;
+				}
+				return errorField;
+			} ).filter( errorField => errorField !== "remove" );
+		} );
 	}, [ setOtherSocialUrls ] );
 
 	const onAddProfileHandler = useCallback( () => {

--- a/packages/js/src/initializers/social-settings.js
+++ b/packages/js/src/initializers/social-settings.js
@@ -6,6 +6,7 @@ import ImageSelectPortal from "../components/portals/ImageSelectPortal";
 import Portal from "../components/portals/Portal";
 import { __, sprintf } from "@wordpress/i18n";
 import { addLinkToString } from "../helpers/stringHelpers.js";
+import { removeFieldAndUpdateErrors } from "../first-time-configuration/tailwind-components/helpers/index.js";
 import { SocialInputSection } from "../first-time-configuration/tailwind-components/steps/social-profiles/social-input-section";
 
 /**
@@ -136,22 +137,14 @@ function SocialProfilesWrapper() {
 			return nextState;
 		} );
 		setErrorFields( prevState => prevState.filter( errorField => errorField !== `other_social_urls-${ index }` ) );
-	}, [ setOtherSocialUrls ] );
+	}, [ setOtherSocialUrls, setErrorFields ] );
 
 	const onRemoveProfileHandler = useCallback( ( index ) => {
 		setOtherSocialUrls( prevState => prevState.filter( ( _, prevStateIndex ) => prevStateIndex !== index ) );
 		setErrorFields( prevState => {
-			return prevState.map( ( errorField ) => {
-				const errorFieldIndex = parseInt( errorField.replace( "other_social_urls-", "" ), 10 );
-				if ( errorFieldIndex === index ) {
-					return "remove";
-				} else if ( errorFieldIndex > index ) {
-					return `other_social_urls-${ errorFieldIndex - 1 }`;
-				}
-				return errorField;
-			} ).filter( errorField => errorField !== "remove" );
+			return removeFieldAndUpdateErrors( prevState, index );
 		} );
-	}, [ setOtherSocialUrls, setErrorFields ] );
+	}, [ setOtherSocialUrls, setErrorFields, removeFieldAndUpdateErrors ] );
 
 	const onAddProfileHandler = useCallback( () => {
 		setOtherSocialUrls( prevState => [ ...prevState, "" ] );


### PR DESCRIPTION


## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where error feedback in the social profiles step and social accounts tab would be misplaced upon deletion of another input.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* In the FTC have organization set and go to social profiles. Add 5 or so empty other social profiles, and in the 3rd and the last one enter a bad value (e.g. "bla"). Also enter bad values for facebook and twitter.
* Press save and continue.
* Errors should appear at all bad values.
* Edit Facebook. Only facebook error should disappear.
* Edit Twitter. Only Twitter error should disappear.
* Remove some of the empty other urls. The erroring inputs should have its error move along with it.
* Edit the last erroring other url. Only that error should disappear.
* Remove (one of) the erroring other url(s), only that one should disappear.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* 

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes DUPP-471
