### PR TITLE
LINGO-1448 decrease analysis result discrepancy of Block and Elementor editor

### DIFF
--- a/packages/yoastseo/spec/fullTextTests/testTexts/ca/catalanPaper.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/ca/catalanPaper.js
@@ -1,7 +1,7 @@
 import Paper from "../../../../src/values/Paper.js";
 import content from "./catalanPaper.html";
 
-const name = "catalanPaper1";
+const name = "catalanPaper";
 
 const paper = new Paper( content, {
 	keyword: "Clàssic",
@@ -126,7 +126,7 @@ const expectedResults = {
 	textTransitionWords: {
 		isApplicable: true,
 		score: 3,
-		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 12.1% of the sentences contain transition words, " +
+		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 13.8% of the sentences contain transition words, " +
 			"which is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more of them</a>.",
 	},
 	passiveVoice: {

--- a/packages/yoastseo/spec/fullTextTests/testTexts/cs/czechPaper.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/cs/czechPaper.js
@@ -1,7 +1,7 @@
 import Paper from "../../../../src/values/Paper.js";
 import content from "./czechPaper.html";
 
-const name = "czechPaper1";
+const name = "czechPaper";
 
 const paper = new Paper( content, {
 	keyword: "Nikifor Černigovskij",

--- a/packages/yoastseo/spec/fullTextTests/testTexts/de/germanPaper.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/de/germanPaper.js
@@ -1,7 +1,7 @@
 import Paper from "../../../../src/values/Paper.js";
 import content from "./germanPaper.html";
 
-const name = "germanPaper1";
+const name = "germanPaper";
 
 const paper = new Paper( content, {
 	keyword: "Flughafen London Heathrow",
@@ -98,7 +98,7 @@ const expectedResults = {
 	fleschReadingEase: {
 		isApplicable: true,
 		score: 6,
-		resultText: "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 52.4 in the test, which is considered fairly difficult to read. <a href='https://yoa.st/34s' target='_blank'>Try to make shorter sentences to improve readability</a>.",
+		resultText: "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 51.5 in the test, which is considered fairly difficult to read. <a href='https://yoa.st/34s' target='_blank'>Try to make shorter sentences to improve readability</a>.",
 	},
 	subheadingsTooLong: {
 		isApplicable: true,
@@ -117,13 +117,13 @@ const expectedResults = {
 	},
 	textTransitionWords: {
 		isApplicable: true,
-		score: 3,
-		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 19.3% of the sentences contain transition words, which is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more of them</a>.",
+		score: 6,
+		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 21.6% of the sentences contain transition words, which is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more of them</a>.",
 	},
 	passiveVoice: {
 		isApplicable: true,
-		score: 9,
-		resultText: "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: You're using enough active voice. That's great!",
+		score: 6,
+		resultText: "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: 10.8% of the sentences contain passive voice, which is more than the recommended maximum of 10%. <a href='https://yoa.st/34u' target='_blank'>Try to use their active counterparts</a>.",
 	},
 	textPresence: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/fullTextTests/testTexts/el/greekPaper.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/el/greekPaper.js
@@ -128,13 +128,13 @@ const expectedResults = {
 	textTransitionWords: {
 		isApplicable: true,
 		score: 3,
-		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 15.9% of the sentences contain" +
+		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 17.4% of the sentences contain" +
 			" transition words, which is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more of them</a>.",
 	},
 	passiveVoice: {
 		isApplicable: true,
 		score: 3,
-		resultText: "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: 20.9% of the sentences contain passive voice," +
+		resultText: "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: 22.8% of the sentences contain passive voice," +
 			" which is more than the recommended maximum of 10%. <a href='https://yoa.st/34u' target='_blank'>" +
 			"Try to use their active counterparts</a>.",
 	},

--- a/packages/yoastseo/spec/fullTextTests/testTexts/en/englishPaper.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/en/englishPaper.js
@@ -1,7 +1,7 @@
 import Paper from "../../../../src/values/Paper.js";
 import content from "./englishPaper.html";
 
-const name = "englishPaper1";
+const name = "englishPaper";
 
 const paper = new Paper( content, {
 	keyword: "voice search",

--- a/packages/yoastseo/spec/fullTextTests/testTexts/en/englishPaperForPerformanceTest.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/en/englishPaperForPerformanceTest.js
@@ -122,7 +122,7 @@ const expectedResults = {
 	textTransitionWords: {
 		isApplicable: true,
 		score: 3,
-		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 2.6% of the sentences contain transition words, which is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more of them</a>.",
+		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 2.8% of the sentences contain transition words, which is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more of them</a>.",
 	},
 	passiveVoice: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/fullTextTests/testTexts/es/spanishPaper.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/es/spanishPaper.js
@@ -1,7 +1,7 @@
 import Paper from "../../../../src/values/Paper.js";
 import content from "./spanishPaper.html";
 
-const name = "spanishPaper1";
+const name = "spanishPaper";
 
 const paper = new Paper( content, {
 	keyword: "«Hey Jude»",
@@ -97,7 +97,7 @@ const expectedResults = {
 	fleschReadingEase: {
 		isApplicable: true,
 		score: 9,
-		resultText: "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 79.9 in the test, which is considered fairly easy to read. Good job!",
+		resultText: "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 78.3 in the test, which is considered fairly easy to read. Good job!",
 	},
 	subheadingsTooLong: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/fullTextTests/testTexts/fa/farsiPaper.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/fa/farsiPaper.js
@@ -1,7 +1,7 @@
 import Paper from "../../../../src/values/Paper.js";
 import content from "./farsiPaper.html";
 
-const name = "farsiPaper1";
+const name = "farsiPaper";
 
 const paper = new Paper( content, {
 	keyword: "فرانکاروم",
@@ -127,8 +127,8 @@ const expectedResults = {
 	},
 	textTransitionWords: {
 		isApplicable: true,
-		score: 6,
-		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 28.9% of the sentences contain transition words, which is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more of them</a>.",
+		score: 9,
+		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Well done!",
 	},
 	passiveVoice: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/fullTextTests/testTexts/fr/frenchPaper.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/fr/frenchPaper.js
@@ -1,7 +1,7 @@
 import Paper from "../../../../src/values/Paper.js";
 import content from "./frenchPaper.html";
 
-const name = "frenchPaper2";
+const name = "frenchPaper";
 
 const paper = new Paper( content, {
 	keyword: "syntaxe (linguistique)",
@@ -54,7 +54,7 @@ const expectedResults = {
 	textLength: {
 		isApplicable: true,
 		score: 9,
-		resultText: "<a href='https://yoa.st/34n' target='_blank'>Text length</a>: The text contains 845 words. Good job!",
+		resultText: "<a href='https://yoa.st/34n' target='_blank'>Text length</a>: The text contains 844 words. Good job!",
 	},
 	externalLinks: {
 		isApplicable: true,
@@ -97,7 +97,7 @@ const expectedResults = {
 	fleschReadingEase: {
 		isApplicable: true,
 		score: 9,
-		resultText: "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 72.6 in the test, which is considered fairly easy to read. Good job!",
+		resultText: "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 72.5 in the test, which is considered fairly easy to read. Good job!",
 	},
 	subheadingsTooLong: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/fullTextTests/testTexts/he/hebrewPaper.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/he/hebrewPaper.js
@@ -1,7 +1,7 @@
 import Paper from "../../../../src/values/Paper.js";
 import content from "./hebrewPaper.html";
 
-const name = "hebrewPaper1";
+const name = "hebrewPaper";
 
 const paper = new Paper( content, {
 	keyword: "נאפולי",
@@ -128,7 +128,7 @@ const expectedResults = {
 	passiveVoice: {
 		isApplicable: true,
 		score: 6,
-		resultText: "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: 13.6% of the sentences contain passive voice, which is more than the recommended maximum of 10%. <a href='https://yoa.st/34u' target='_blank'>Try to use their active counterparts</a>.",
+		resultText: "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: 14.3% of the sentences contain passive voice, which is more than the recommended maximum of 10%. <a href='https://yoa.st/34u' target='_blank'>Try to use their active counterparts</a>.",
 	},
 	textPresence: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/fullTextTests/testTexts/id/indonesianPaper.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/id/indonesianPaper.js
@@ -1,7 +1,7 @@
 import Paper from "../../../../src/values/Paper.js";
 import content from "./indonesianPaper.html";
 
-const name = "indonesianPaper1";
+const name = "indonesianPaper";
 
 const paper = new Paper( content, {
 	keyword: "Franka-Mongol",
@@ -115,12 +115,12 @@ const expectedResults = {
 	textTransitionWords: {
 		isApplicable: true,
 		score: 6,
-		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 20.1% of the sentences contain transition words, which is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more of them</a>.",
+		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 21.4% of the sentences contain transition words, which is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more of them</a>.",
 	},
 	passiveVoice: {
 		isApplicable: true,
 		score: 6,
-		resultText: "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: 11.3% of the sentences contain passive voice, which is more than the recommended maximum of 10%. <a href='https://yoa.st/34u' target='_blank'>Try to use their active counterparts</a>.",
+		resultText: "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: 12% of the sentences contain passive voice, which is more than the recommended maximum of 10%. <a href='https://yoa.st/34u' target='_blank'>Try to use their active counterparts</a>.",
 	},
 	textPresence: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/fullTextTests/testTexts/it/italianPaper.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/it/italianPaper.js
@@ -1,7 +1,7 @@
 import Paper from "../../../../src/values/Paper.js";
 import content from "./italianPaper.html";
 
-const name = "italianPaper1";
+const name = "italianPaper";
 
 const paper = new Paper( content, {
 	keyword: "Shinji Ikari",
@@ -97,7 +97,7 @@ const expectedResults = {
 	fleschReadingEase: {
 		isApplicable: true,
 		score: 9,
-		resultText: "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 76.4 in the test, which is considered fairly easy to read. Good job!",
+		resultText: "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 76 in the test, which is considered fairly easy to read. Good job!",
 	},
 	subheadingsTooLong: {
 		isApplicable: true,
@@ -117,7 +117,7 @@ const expectedResults = {
 	textTransitionWords: {
 		isApplicable: true,
 		score: 3,
-		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 16.9% of the sentences contain transition words, which is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more of them</a>.",
+		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 17.5% of the sentences contain transition words, which is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more of them</a>.",
 	},
 	passiveVoice: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/fullTextTests/testTexts/nb/norwegianPaper.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/nb/norwegianPaper.js
@@ -1,7 +1,7 @@
 import Paper from "../../../../src/values/Paper.js";
 import content from "./norwegianPaper.html";
 
-const name = "norwegianPaper1";
+const name = "norwegianPaper";
 
 const paper = new Paper( content, {
 	keyword: "Maine coon",

--- a/packages/yoastseo/spec/fullTextTests/testTexts/nl/dutchPaper.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/nl/dutchPaper.js
@@ -1,7 +1,7 @@
 import Paper from "../../../../src/values/Paper.js";
 import content from "./dutchPaper.html";
 
-const name = "dutchPaper1";
+const name = "dutchPaper";
 
 const paper = new Paper( content, {
 	keyword: "schaap",
@@ -96,7 +96,7 @@ const expectedResults = {
 	fleschReadingEase: {
 		isApplicable: true,
 		score: 9,
-		resultText: "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 61.7 in the test, which is considered ok to read. Good job!",
+		resultText: "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 60 in the test, which is considered ok to read. Good job!",
 	},
 	subheadingsTooLong: {
 		isApplicable: true,
@@ -120,8 +120,8 @@ const expectedResults = {
 	},
 	passiveVoice: {
 		isApplicable: true,
-		score: 6,
-		resultText: "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: 14.6% of the sentences contain passive voice, which is more than the recommended maximum of 10%. <a href='https://yoa.st/34u' target='_blank'>Try to use their active counterparts</a>.",
+		score: 3,
+		resultText: "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: 17.1% of the sentences contain passive voice, which is more than the recommended maximum of 10%. <a href='https://yoa.st/34u' target='_blank'>Try to use their active counterparts</a>.",
 	},
 	textPresence: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/fullTextTests/testTexts/pl/polishPaper.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/pl/polishPaper.js
@@ -1,7 +1,7 @@
 import Paper from "../../../../src/values/Paper.js";
 import content from "./polishPaper.html";
 
-const name = "polishPaper1";
+const name = "polishPaper";
 
 const paper = new Paper( content, {
 	keyword: "Google (firma)",
@@ -115,13 +115,13 @@ const expectedResults = {
 	},
 	textTransitionWords: {
 		isApplicable: true,
-		score: 6,
-		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 25.9% of the sentences contain transition words, which is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more of them</a>.",
+		score: 9,
+		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Well done!",
 	},
 	passiveVoice: {
 		isApplicable: true,
-		score: 6,
-		resultText: "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: 13.6% of the sentences contain passive voice, which is more than the recommended maximum of 10%. <a href='https://yoa.st/34u' target='_blank'>Try to use their active counterparts</a>.",
+		score: 3,
+		resultText: "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: 16.7% of the sentences contain passive voice, which is more than the recommended maximum of 10%. <a href='https://yoa.st/34u' target='_blank'>Try to use their active counterparts</a>.",
 	},
 	textPresence: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/fullTextTests/testTexts/pt/portuguesePaper.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/pt/portuguesePaper.js
@@ -1,7 +1,7 @@
 import Paper from "../../../../src/values/Paper.js";
 import content from "./portuguesePaper.html";
 
-const name = "portuguesePaper1";
+const name = "portuguesePaper";
 
 const paper = new Paper( content, {
 	keyword: "História de Portugal",
@@ -109,7 +109,7 @@ const expectedResults = {
 	fleschReadingEase: {
 		isApplicable: true,
 		score: 3,
-		resultText: "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 43.3 in the test, which is considered" +
+		resultText: "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 41.9 in the test, which is considered" +
 			" difficult to read. <a href='https://yoa.st/34s' target='_blank'>Try to make shorter sentences, using less difficult words to improve" +
 			" readability</a>.",
 	},
@@ -133,7 +133,7 @@ const expectedResults = {
 	textTransitionWords: {
 		isApplicable: true,
 		score: 3,
-		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 6.3% of the sentences contain transition words," +
+		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 7.1% of the sentences contain transition words," +
 			" which is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more of them</a>.",
 	},
 	passiveVoice: {

--- a/packages/yoastseo/spec/fullTextTests/testTexts/ru/russianPaper.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/ru/russianPaper.js
@@ -1,7 +1,7 @@
 import Paper from "../../../../src/values/Paper.js";
 import content from "./russianPaper.html";
 
-const name = "russianPaper1";
+const name = "russianPaper";
 
 const paper = new Paper( content, {
 	keyword: "Роти-буайя",
@@ -97,7 +97,7 @@ const expectedResults = {
 	fleschReadingEase: {
 		isApplicable: true,
 		score: 3,
-		resultText: "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 33.1 in the test, which is considered difficult to read. <a href='https://yoa.st/34s' target='_blank'>Try to make shorter sentences, using less difficult words to improve readability</a>.",
+		resultText: "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 31.9 in the test, which is considered difficult to read. <a href='https://yoa.st/34s' target='_blank'>Try to make shorter sentences, using less difficult words to improve readability</a>.",
 	},
 	subheadingsTooLong: {
 		isApplicable: true,
@@ -117,7 +117,7 @@ const expectedResults = {
 	textTransitionWords: {
 		isApplicable: true,
 		score: 3,
-		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 15.7% of the sentences contain transition words, which is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more of them</a>.",
+		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 17.5% of the sentences contain transition words, which is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more of them</a>.",
 	},
 	passiveVoice: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/fullTextTests/testTexts/sk/slovakPaper.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/sk/slovakPaper.js
@@ -1,7 +1,7 @@
 import Paper from "../../../../src/values/Paper.js";
 import content from "./slovakPaper.html";
 
-const name = "slovakPaper1";
+const name = "slovakPaper";
 
 const paper = new Paper( content, {
 	keyword: "Britská mačka",

--- a/packages/yoastseo/spec/fullTextTests/testTexts/sv/swedishPaper.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/sv/swedishPaper.js
@@ -1,7 +1,7 @@
 import Paper from "../../../../src/values/Paper.js";
 import content from "./swedishPaper.html";
 
-const name = "swedishPaper1";
+const name = "swedishPaper";
 
 const paper = new Paper( content, {
 	keyword: "Ester Nordström",
@@ -112,13 +112,13 @@ const expectedResults = {
 	},
 	textTransitionWords: {
 		isApplicable: true,
-		score: 6,
-		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 25.5% of the sentences contain transition words, which is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more of them</a>.",
+		score: 9,
+		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Well done!",
 	},
 	passiveVoice: {
 		isApplicable: true,
-		score: 6,
-		resultText: "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: 13.7% of the sentences contain passive voice, which is more than the recommended maximum of 10%. <a href='https://yoa.st/34u' target='_blank'>Try to use their active counterparts</a>.",
+		score: 3,
+		resultText: "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: 17.1% of the sentences contain passive voice, which is more than the recommended maximum of 10%. <a href='https://yoa.st/34u' target='_blank'>Try to use their active counterparts</a>.",
 	},
 	textPresence: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/fullTextTests/testTexts/tr/turkishPaper.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/tr/turkishPaper.js
@@ -1,7 +1,7 @@
 import Paper from "../../../../src/values/Paper.js";
 import content from "./turkishPaper.html";
 
-const name = "turkishPaper1";
+const name = "turkishPaper";
 
 const paper = new Paper( content, {
 	keyword: "Nektar",

--- a/packages/yoastseo/spec/languageProcessing/helpers/sanitize/sanitizeStringSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/helpers/sanitize/sanitizeStringSpec.js
@@ -10,4 +10,32 @@ describe( "Test for removing unwanted characters.", function() {
 		expect( sanitizeString( "50/50" ) ).toBe( "50/50" );
 		expect( sanitizeString( "<p>50/50</p>" ) ).toBe( "50/50" );
 	} );
+	it( "excludes Table of Content from the text", () => {
+		const text = "<p></p> <div class='wp-block-yoast-seo-table-of-contents yoast-table-of-contents'> <h2>Table of contents</h2> " +
+			"<a href='#h-food-that-are-raw' data-level='2'>Food that are raw</a> <a href='#h-food-from-fresh-meat'" +
+			" data-level='3'>Food from fresh meat</a> <a href='#h-food-that-contains-vegetables' " +
+			"data-level='3'>Food that contains vegetables</a> <a href='#h-food-that-are-cooked' " +
+			"data-level='2'>Food that are cooked</a> </div> <p>Here is the list of food you can give your cat.</p>" +
+			" <h2 id='h-food-that-are-raw'>Food that are raw</h2> " +
+			"<p>Lorem ipsum dolor sit amet, est minim reprimique et, impetus interpretaris eos ea.</p> " +
+			"<h3 id='h-food-from-fresh-meat'>Food from fresh meat</h3> " +
+			"<p>Aperiri scripserit per cu, at mea graeci numquam.</p> " +
+			"<h3 id='h-food-that-contains-vegetables'>Food that contains vegetables</h3> " +
+			"<p>Ne vix clita soluta persecuti, vel at fugit labores, mentitum intellegebat ius ex. " +
+			"Cu semper comprehensam duo, pro fugit animal reprehendunt et.</p> " +
+			"<h2 id='h-food-that-are-cooked'>Food that are cooked</h2> " +
+			"<p>Has an natum errem, vix oratio mediocrem an, pro ponderum senserit dignissim ut.</p>";
+
+		expect( sanitizeString( text ) ).toEqual(  "Here is the list of food you can give your cat. Food that are raw Lorem ipsum dolor sit amet, " +
+			"est minim reprimique et, impetus interpretaris eos ea. Food from fresh meat Aperiri scripserit per cu, at mea graeci numquam." +
+			" Food that contains vegetables Ne vix clita soluta persecuti, vel at fugit labores, mentitum intellegebat ius ex. " +
+			"Cu semper comprehensam duo, pro fugit animal reprehendunt et. Food that are cooked Has an natum errem, vix oratio mediocrem an, " +
+			"pro ponderum senserit dignissim ut."
+		);
+	} );
+	it( "unifies whitespaces and non-breaking spaces", () => {
+		const text = "A&nbsp;text\u0020string.";
+
+		expect( sanitizeString( text ) ).toEqual( "A text string." );
+	} );
 } );

--- a/packages/yoastseo/spec/languageProcessing/helpers/sentence/getSentencesSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/helpers/sentence/getSentencesSpec.js
@@ -256,6 +256,25 @@ describe( "Get sentences from text", function() {
 		expect( actual ).toEqual( expected );
 	} );
 
+	it( "should split a text with excessive paragraph tags correctly into sentences", () => {
+		const text = "<p>\n" +
+			"</p>\n" +
+			"<p>Tempeh or tempe (/ˈtɛmpeɪ/; Javanese: ꦠꦺꦩ꧀ꦥꦺ, romanized: témpé, pronounced [tempe]) is a traditional Indonesian food " +
+			"made from fermented soybeans. " +
+			"It is made by a natural culturing and controlled fermentation process that binds soybeans into a cake form. " +
+			"A fungus, Rhizopus oligosporus or Rhizopus oryzae, is used in the fermentation process and is also known as tempeh starter. </p>\n" +
+			"<p>\n" +
+			"</p>\n";
+
+		expect( getSentences( text ) ).toEqual( [
+			"Tempeh or tempe (/ˈtɛmpeɪ/;",
+			"Javanese: ꦠꦺꦩ꧀ꦥꦺ, romanized: témpé, pronounced [tempe]) is a traditional Indonesian food made from fermented soybeans.",
+			"It is made by a natural culturing and controlled fermentation process that binds soybeans into a cake form.",
+			"A fungus, Rhizopus oligosporus or Rhizopus oryzae, is used in the fermentation process and is also known as tempeh starter.",
+		]
+		);
+	} );
+
 	it( "should match correctly with quotation", function() {
 		const testCases = [
 			{
@@ -376,7 +395,7 @@ describe( "Get sentences from text", function() {
 		testGetSentences( testCases );
 	} );
 
-	it( "Correctly gets sentences with a '<' signs in the middle or at the start.", function() {
+	it( "correctly gets sentences with a '<' signs in the middle or at the start.", function() {
 		const testCases = [
 			{
 				input: "This is a sentence with a < and is still one sentence.",

--- a/packages/yoastseo/spec/languageProcessing/helpers/word/getWordsSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/helpers/word/getWordsSpec.js
@@ -47,6 +47,13 @@ describe( "a test for getting words from a sentence", function() {
 			"words",
 		] );
 	} );
+
+	it( "doesn't return non-breaking space &nbsp; in the result", () => {
+		const text = "<p>Sri Tandjung noted that Javanese had been eating cooked (native black) soybeans since the 12th&nbsp;century.</p>\n";
+
+		expect( getWords( text ) ).toEqual(  [ "Sri", "Tandjung", "noted", "that", "Javanese", "had", "been", "eating", "cooked", "native", "black",
+			"soybeans", "since", "the", "12th", "century" ] );
+	} );
 } );
 
 describe( "language-specific tests for getting words", function() {

--- a/packages/yoastseo/spec/scoring/collectionPages/fullTextTests/testTexts/en/englishPaper2.js
+++ b/packages/yoastseo/spec/scoring/collectionPages/fullTextTests/testTexts/en/englishPaper2.js
@@ -51,7 +51,7 @@ const expectedResults = {
 	textLength: {
 		isApplicable: true,
 		score: 9,
-		resultText: "<a href='https://yoa.st/shopify58' target='_blank'>Text length</a>: The text contains 167 words. Good job!",
+		resultText: "<a href='https://yoa.st/shopify58' target='_blank'>Text length</a>: The text contains 168 words. Good job!",
 	},
 	titleKeyword: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/scoring/productPages/fullTextTests/testTexts/en/englishPaper1.js
+++ b/packages/yoastseo/spec/scoring/productPages/fullTextTests/testTexts/en/englishPaper1.js
@@ -57,7 +57,7 @@ const expectedResults = {
 	textLength: {
 		isApplicable: true,
 		score: 9,
-		resultText: "<a href='https://yoa.st/shopify58' target='_blank'>Text length</a>: The text contains 218 words. Good job!",
+		resultText: "<a href='https://yoa.st/shopify58' target='_blank'>Text length</a>: The text contains 217 words. Good job!",
 	},
 	titleKeyword: {
 		isApplicable: true,

--- a/packages/yoastseo/src/languageProcessing/helpers/sanitize/sanitizeString.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/sanitize/sanitizeString.js
@@ -14,7 +14,7 @@ export default function( text ) {
 	text = unifyAllSpaces( text );
 	// Remove Table of Contents.
 	text = excludeTableOfContentsTag( text );
-	// Strips the tags and multiple spaces.
+	// Strip the tags and multiple spaces.
 	text = stripTags( text );
 
 	return text;

--- a/packages/yoastseo/src/languageProcessing/helpers/sanitize/sanitizeString.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/sanitize/sanitizeString.js
@@ -1,5 +1,6 @@
 import excludeTableOfContentsTag from "./excludeTableOfContentsTag";
 import { stripFullTags as stripTags } from "./stripHTMLTags.js";
+import { unifyAllSpaces } from "./unifyWhitespace";
 
 /**
  * Sanitizes the text before we use the text for the analysis.
@@ -9,7 +10,11 @@ import { stripFullTags as stripTags } from "./stripHTMLTags.js";
  * @returns {String} The sanitized text.
  */
 export default function( text ) {
+	// Unify whitespaces and non-breaking spaces.
+	text = unifyAllSpaces( text );
+	// Remove Table of Contents.
 	text = excludeTableOfContentsTag( text );
+	// Strips the tags and multiple spaces.
 	text = stripTags( text );
 
 	return text;

--- a/packages/yoastseo/src/languageProcessing/helpers/sentence/getSentences.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/sentence/getSentences.js
@@ -7,9 +7,8 @@ import { memoize } from "lodash-es";
 
 // Internal dependencies.
 import { getBlocks } from "../html/html.js";
-import { unifyNonBreakingSpace as unifyWhitespace } from "../sanitize/unifyWhitespace.js";
+import sanitizeString from "../sanitize/sanitizeString";
 import SentenceTokenizer from "./SentenceTokenizer";
-import excludeTableOfContentsTag from "../sanitize/excludeTableOfContentsTag";
 
 // Character classes.
 const newLines = "\n\r|\n|\r";
@@ -39,8 +38,8 @@ const getSentencesFromBlockCached = memoize( getSentenceTokenizer );
  * @returns {Array} Sentences found in the text.
  */
 export default function( text ) {
-	text = excludeTableOfContentsTag( text );
-	text = unifyWhitespace( text );
+	// Unify whitespaces and non-breaking spaces, remove table of content and strip the tags and multiple spaces.
+	text = sanitizeString( text );
 	let blocks = getBlocks( text );
 
 	// Split each block on newlines.

--- a/packages/yoastseo/src/languageProcessing/helpers/sentence/getSentences.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/sentence/getSentences.js
@@ -35,9 +35,10 @@ const getSentencesFromBlockCached = memoize( getSentenceTokenizer );
  * @returns {Array} Sentences found in the text.
  */
 export default function( text ) {
+	// We don't remove the other HTML tags here since removing them might lead to incorrect results when running the sentence tokenizer.
 	// Remove Table of Contents.
 	text = excludeTableOfContentsTag( text );
-	// Unify whitespaces and non-breaking spaces.
+	// Unify only non-breaking spaces and not the other whitespaces since a whitespace could signify a sentence break or a new line.
 	text = unifyNonBreakingSpace( text );
 
 	let blocks = getBlocks( text );

--- a/packages/yoastseo/src/languageProcessing/helpers/word/getWords.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/word/getWords.js
@@ -1,9 +1,5 @@
 /** @module stringProcessing/countWords */
-
-import { stripFullTags as stripTags } from "../sanitize/stripHTMLTags.js";
-import excludeTableOfContentsTag from "../sanitize/excludeTableOfContentsTag.js";
-
-import stripSpaces from "../sanitize/stripSpaces.js";
+import sanitizeString from "../sanitize/sanitizeString";
 import removePunctuation from "../sanitize/removePunctuation.js";
 import { map, filter } from "lodash-es";
 
@@ -15,8 +11,9 @@ import { map, filter } from "lodash-es";
  * @returns {Array} The array with all words.
  */
 export default function( text ) {
-	text = excludeTableOfContentsTag( text );
-	text = stripSpaces( stripTags( text ) );
+	// Unify whitespaces and non-breaking spaces, remove table of content and strip the tags and multiple spaces.
+	text = sanitizeString( text );
+
 	if ( text === "" ) {
 		return [];
 	}

--- a/packages/yoastseo/src/values/Paper.js
+++ b/packages/yoastseo/src/values/Paper.js
@@ -1,4 +1,5 @@
 import { defaults, isEmpty, isEqual } from "lodash-es";
+import { unifyAllSpaces } from "../languageProcessing/helpers/sanitize/unifyWhitespace";
 
 /**
  * Default attributes to be used by the Paper if they are left undefined.
@@ -36,6 +37,8 @@ const defaultAttributes = {
  */
 function Paper( text, attributes ) {
 	this._text = text || "";
+	// Unify whitespaces and non-breaking spaces.
+	this._text = unifyAllSpaces( this._text );
 
 	attributes = attributes || {};
 	defaults( attributes, defaultAttributes );

--- a/packages/yoastseo/src/values/Paper.js
+++ b/packages/yoastseo/src/values/Paper.js
@@ -1,5 +1,5 @@
 import { defaults, isEmpty, isEqual } from "lodash-es";
-import { unifyAllSpaces } from "../languageProcessing/helpers/sanitize/unifyWhitespace";
+import { unifyNonBreakingSpace } from "../languageProcessing/helpers/sanitize/unifyWhitespace";
 
 /**
  * Default attributes to be used by the Paper if they are left undefined.
@@ -38,7 +38,7 @@ const defaultAttributes = {
 function Paper( text, attributes ) {
 	this._text = text || "";
 	// Unify whitespaces and non-breaking spaces.
-	this._text = unifyAllSpaces( this._text );
+	this._text = unifyNonBreakingSpace( this._text );
 
 	attributes = attributes || {};
 	defaults( attributes, defaultAttributes );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Editing an existing post (created in Block editor) in Elementor, will lead to an analysis result discrepancy when exiting the Elementor editor.

<img width="1083" alt="Screenshot 2022-05-11 at 11 59 24" src="https://user-images.githubusercontent.com/48715883/167824059-fdcc92e8-ddcd-4e08-abb7-753c2a1cc6e0.png">

* One of the reasons of the result discrepancy is the fact that in the above case, additional paragraph tags were added when exiting the Elementor editor. The tags were not properly sanitized inside the Paper at this point.
* Another potential problem is the fact that in some cases an `&nbsp;` tag is also added when editing in Elementor editor. The tag is sanitized when retrieving the sentences from the text, but not when retrieving the words.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [yoastseo] Adds a step to unify all whitespaces and non-breaking spaces in `sanitizeString.js` helper.
* [yoastseo] Adds a step to unify non-breaking spaces in `Paper.js` and before splitting it into words.
* [yoastseo] Adds a step to filter out blocks that only contain paragraph tags in `getSentences.js`.
* [shopify-seo] Improves word recognition by unifying the non-breaking spaces `&nbsp;` which increases the accuracy of words segmentation.
* Fixes a bug where editing an existing post created in Block editor in Elementor would result in an analysis result discrepancy.

## Relevant technical choices:

* The step to unify all white spaces and non-breaking spaces is added to `sanitizeString.js` helper, in which the helper is used in `getWords.js`. The sanitation steps are: 1. unifying the whitespaces and non-breaking spaces, 2. excluding Table of Contents, 3. stripping tags and multiple spaces. Hence, by using this helper inside `getWords`, we make sure that the non-breaking spaces are also unified before the text is split into words.
* Inside `getSentences.js`, the sentences that contains only paragraph tags are filtered out. This is necessary since the added paragraph tags when exiting Elementor editor after an edit, are incorrectly converted into separate blocks and further split into separate sentences.
* Adding the step to unify non-breaking spaces inside `Paper.js` is a way to ensure that the assessments that don't use `getWords.js` and `getSentences.js` helper, receives a text with unified non-breaking spaces.
* The changelog item for [shopify-seo] is an improvement.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

**Requirements:**
* Install and activate Elementor editor
* Enable the Yoast analysis worker debugger by adding these two lines inside a wordpress config file:
````
define( 'YOAST_SEO_DEBUG', true );
define( 'YOAST_SEO_DEBUG_ANALYSIS_WORKER', 'DEBUG' );
````
   * If testing using Docker/Rancher, add the codes above inside `plugin-development-docker/config/basic-wordpress-config.php`
   * If testing using Local by Flywheel:
      * Go to `wp-config.php` file from Finder. From root folder, go to Local Sites > basicwordpresstest > app> public > wp-config.php
      * Open the config file in your IDE
      * Add the two lines of code inside the config file

**Tips:**
* To check if the overall score of the analysis result change, check out the `AnalysisWebWorker` logger in the console, e.g.
<img width="566" alt="Screenshot 2022-05-11 at 16 51 51" src="https://user-images.githubusercontent.com/48715883/167879851-cf5dd059-1df0-4083-8b17-4050cd30d8cf.png">


**Testing steps in WordPress**
* Create a post in Block editor
* Copy and paste the text from [this article](https://yoast.com/10-copywriting-tips-for-social-media/) and save the changes
* Open the post in Elementor
* Confirm that the analysis results are the same
* Make some changes to the posts, e.g. add more words or sentences
* Save the changes and notice the analysis result
* Exit the Elementor editor
* In the "limbo"/in between editors space, confirm that the analysis result stays the same
* Create a new post in Elementor and paste the same text from the article
* Check the analysis results, then exit the Elementor editor
* Confirm that the results are the same in the "limbo"/in between editors space

**Testing steps in Shopify**
Note for developers: Link `wordpress-seo` in `shopify-seo/app` before building the app.
* Create a product in Shopify editor
* Add 300 words
* Add `May&nbsp;12th` to the text (tip: use the html editor so that the `&nbsp;` is picked up as a space)
   
<img width="628" alt="Screenshot 2022-05-12 at 11 03 54" src="https://user-images.githubusercontent.com/48715883/168034331-3689ec38-c257-43f3-9b98-9214846696c1.png">

* Go to Yoast SEO editor
* Confirm that the text length assessment returns with 302 words

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [x] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes https://yoast.atlassian.net/browse/LINGO-1448
