### PR TITLE
Add an upgrade routine to help indentifying old users so that we don't show the Installation Success page then

### DIFF
--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -885,6 +885,10 @@ class WPSEO_Upgrade {
 	 * Performs the 18.9 upgrade routine.
 	 */
 	private function upgrade_189() {
+		// Make old users not get the Installation Success page after upgrading.
+		WPSEO_Options::set( 'should_redirect_after_install_free', false );
+		WPSEO_Options::set( 'activation_redirect_timestamp_free', 1652258756 );
+
 		// Transfer the Social URLs.
 		$other   = [];
 		$other[] = WPSEO_Options::get( 'instagram_url' );

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -887,6 +887,8 @@ class WPSEO_Upgrade {
 	private function upgrade_189() {
 		// Make old users not get the Installation Success page after upgrading.
 		WPSEO_Options::set( 'should_redirect_after_install_free', false );
+		// We're adding a hardcoded time here, so that in the future we can be able to identify whether the user did see the Installation Success page or not.
+		// If they did, they wouldn't have this hardcoded value in that option, but rather (roughly) the timestamp of the moment they saw it.
 		WPSEO_Options::set( 'activation_redirect_timestamp_free', 1652258756 );
 
 		// Transfer the Social URLs.


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want every user that upgrades into 18.9, to not be shown the new Installation Success page.
* We also want any old users that potentially deactivate/re-activate 18.9 to also not get the new Installation Success page.
* For that, we're adding two db entries upon upgrade to 18.9, that we check before the Installation Success page is shown.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Hides the installation success page for old users upgrading into 18.9

## Relevant technical choices:

* We're adding a hardcoded timestamp for `activation_redirect_timestamp_free` for users upgrading to 18.9.
* That way we will be able to know in the future if a user saw that Installation Success page or not. Maybe it won't ever be useful but maybe it will be.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Start with no Yoast SEO plug-in installed (brand new site)
* Install Yoast SEO 18.8 from wordpress UI
* Make some changes in settings (like Social Profile or Knowledge Graph)
* After the installation is successful, click on Plugins->Add new
* Upload the current RC (or if a dev, run the `grunt artifact` command on this branch to get a zip)
* Go to any page (or reload the page)
Without this PR:
* The installation successful page is shown - even though it shouldn't as we're "old" users.
With this PR:
* The installation successful page is NOT shown - as it should.
* After that, deactivate/re-activate Yoast Free
* Confirm that you *don't* get the installation successful page

Also:
* In a brand new site again, install this RC (or if a dev, the zip produced by the `grunt artifact` command on this branch)
* Confirm that you get the installation successful page after the installation
* After that, deactivate/re-activate Yoast Free
* Confirm that you *don't* get the installation successful page again

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes #
