### PR TITLE
Updates shortlinks in the FTC SEO data optimization step

### DIFF
--- a/packages/js/src/first-time-configuration/first-time-configuration-steps.js
+++ b/packages/js/src/first-time-configuration/first-time-configuration-steps.js
@@ -492,7 +492,7 @@ export default function FirstTimeConfigurationSteps() {
 							"Yoast SEO",
 							"</a>"
 						),
-						window.wpseoFirstTimeConfigurationData.shortlinks.workoutGuide,
+						window.wpseoFirstTimeConfigurationData.shortlinks.configIndexables,
 						"yoast-configuration-guide-link"
 					)
 				}

--- a/packages/js/src/first-time-configuration/tailwind-components/steps/indexation/indexation-step.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/steps/indexation/indexation-step.js
@@ -32,7 +32,7 @@ export default function IndexationStep( { indexingState, setIndexingState, showR
 						"<a>",
 						"</a>"
 					),
-					window.wpseoFirstTimeConfigurationData.shortlinks.indexData,
+					window.wpseoFirstTimeConfigurationData.shortlinks.configIndexablesBenefits,
 					"yoast-configuration-workout-index-data-link"
 				)
 				}

--- a/src/integrations/admin/first-time-configuration-integration.php
+++ b/src/integrations/admin/first-time-configuration-integration.php
@@ -202,9 +202,9 @@ class First_Time_Configuration_Integration implements Integration_Interface {
 					"shouldForceCompany": %d,
 					"knowledgeGraphMessage": "%s",
 					"shortlinks": {
-						"workoutGuide": "%s",
-						"indexData": "%s",
 						"gdpr": "%s",
+						"configIndexables": "%s",
+						"configIndexablesBenefits": "%s",
 					},
 				};',
 				$this->social_profiles_helper->can_edit_profile( $person_id ),
@@ -227,9 +227,9 @@ class First_Time_Configuration_Integration implements Integration_Interface {
 				WPSEO_Utils::format_json_encode( $options ),
 				$this->should_force_company(),
 				$knowledge_graph_message,
-				$this->shortlinker->build_shortlink( 'https://yoa.st/config-workout-guide' ),
-				$this->shortlinker->build_shortlink( 'https://yoa.st/config-workout-index-data' ),
-				$this->shortlinker->build_shortlink( 'https://yoa.st/gdpr-config-workout' )
+				$this->shortlinker->build_shortlink( 'https://yoa.st/gdpr-config-workout' ),
+				$this->shortlinker->build_shortlink( 'http://yoa.st/config-indexables' ),
+				$this->shortlinker->build_shortlink( 'http://yoa.st/config-indexables-benefits' )
 			),
 			'before'
 		);

--- a/src/integrations/admin/first-time-configuration-integration.php
+++ b/src/integrations/admin/first-time-configuration-integration.php
@@ -228,8 +228,8 @@ class First_Time_Configuration_Integration implements Integration_Interface {
 				$this->should_force_company(),
 				$knowledge_graph_message,
 				$this->shortlinker->build_shortlink( 'https://yoa.st/gdpr-config-workout' ),
-				$this->shortlinker->build_shortlink( 'http://yoa.st/config-indexables' ),
-				$this->shortlinker->build_shortlink( 'http://yoa.st/config-indexables-benefits' )
+				$this->shortlinker->build_shortlink( 'https://yoa.st/config-indexables' ),
+				$this->shortlinker->build_shortlink( 'https://yoa.st/config-indexables-benefits' )
 			),
 			'before'
 		);


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Updates links in the FTC SEO data optimization step

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* In the 1st step of the FTC, check the link of the `Yoast SEO indexables squad` text. It should be `http://yoa.st/config-indexables?` plus the information about your setup:
![image](https://user-images.githubusercontent.com/12400734/167871487-31a7a5e4-df20-4a39-8cee-c55f7da82b7b.png)
* In the 1st step of the FTC, check the link of the `check out the benefits of the indexables squad` text. It should be `http://yoa.st/config-indexables-benefits?` plus the information about your setup:
![image](https://user-images.githubusercontent.com/12400734/167870320-fcee4794-5982-4da9-bbb1-6ed87c4f6a75.png)

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* In the PERSONAL PREFERENCES step of the FTC, check the link of the `our privacy policy` text. It should be `https://yoa.st/gdpr-config-workout?` plus the information about your setup:
![image](https://user-images.githubusercontent.com/12400734/167870640-367e894e-034b-43dd-9574-fe36d8b30afb.png)


## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes #
