### PR TITLE
Implement alternative to reloading for form-data refresh

### DIFF
--- a/packages/js/src/first-time-configuration/first-time-configuration-steps.js
+++ b/packages/js/src/first-time-configuration/first-time-configuration-steps.js
@@ -209,10 +209,14 @@ export default function FirstTimeConfigurationSteps() {
 	const [ siteRepresentationEmpty, setSiteRepresentationEmpty ] = useState( false );
 	const [ showRunIndexationAlert, setShowRunIndexationAlert ] = useState( false );
 
-	/* Briefly override window variable because indexingstate is reinitialized when navigating back and forth without triggering a reload,
-	whereas the window variable remains stale. */
+	/* Briefly override window variable and remove indexing notices, because indexingstate is reinitialized when navigating back and forth
+	without triggering a reload, whereas the window variable remains stale. */
 	useEffect( () => {
 		if ( indexingState === "completed" ) {
+			const indexationNotice = document.getElementById( "wpseo-reindex" );
+			if ( indexationNotice ) {
+				indexationNotice.remove();
+			}
 			window.yoastIndexingData.amount = "0";
 		}
 	}, [ indexingState ] );
@@ -415,19 +419,12 @@ export default function FirstTimeConfigurationSteps() {
 	/* In order to refresh data in the php form, once the stepper is done, we need to reload upon haschanges triggered by the tabswitching */
 	const isStepperFinishedAtBeginning = useRef( isStep2Finished && isStep3Finished && isStep4Finished );
 	useEffect( () => {
-		/**
-		 * Reloads the window.
-		 *
-		 * @returns {void}
-		 */
-		const reloadFunction = () => {
-			window.location.reload( true );
-		};
-
 		if ( isStepperFinished && ! isStepperFinishedAtBeginning.current ) {
-			window.addEventListener( "hashchange", reloadFunction );
+			const firstTimeConfigurationNotice = document.getElementById( "yoast-first-time-configuration-notice" );
+			if ( firstTimeConfigurationNotice ) {
+				firstTimeConfigurationNotice.remove();
+			}
 		}
-		return () => window.removeEventListener( "hashchange", reloadFunction );
 	}, [ isStepperFinished, isStepperFinishedAtBeginning ] );
 
 	// If stepperFinishedOnce changes or isStepBeingEdited changes, evaluate edit button state.

--- a/packages/js/src/first-time-configuration/first-time-configuration-steps.js
+++ b/packages/js/src/first-time-configuration/first-time-configuration-steps.js
@@ -215,6 +215,21 @@ export default function FirstTimeConfigurationSteps() {
 		if ( indexingState === "completed" ) {
 			const indexationNotice = document.getElementById( "wpseo-reindex" );
 			if ( indexationNotice ) {
+				// Update the notification counters
+				const allCounters = document.querySelectorAll( ".yoast-issue-counter" );
+				if ( allCounters ) {
+					allCounters.forEach( ( counterNode => {
+						const oldCount = counterNode.firstChild.textContent;
+						const newCount = ( parseInt( oldCount, 10 ) - 1 ).toString();
+						// If the count reaches zero because of this, remove the red dot alltogether.
+						if ( newCount === "0" ) {
+							counterNode.remove();
+						} else {
+							counterNode.firstChild.textContent = counterNode.firstChild.textContent.replace( oldCount, newCount );
+							counterNode.lastChild.textContent = counterNode.lastChild.textContent.replace( oldCount, newCount );
+						}
+					} ) );
+				}
 				indexationNotice.remove();
 			}
 			window.yoastIndexingData.amount = "0";


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Removes an unreleased feature that would cause a reload upon finishing the First-time Configuration in order to refresh form data and implements an alternative.

## Relevant technical choices:

* The reloading solution could not quickly be implemented in an elegant way, so instead we opted to manipulate the DOM using JS to fire corollary effects for the points of contact (covered by both FTC and general tab).
* The points of contact are:
	* First Time Configuration notice
	* SEO Optimization notification
	* Usage tracking radio button.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Using the test helper, reset indexables tables, and Configuration progress, and notifications.
* Go to Plugins and deactivate Yoast SEO. Then reactivate Yoast SEO.
* Go to General (or reload if you were already there).
* Verify that on the General > Dashboard tab there is a notification about doing indexation.
* Verify that there are at least some notices according to the red dot in the admin bar 
<img width="205" alt="image" src="https://user-images.githubusercontent.com/26220788/167872290-0889cf73-c79c-4c20-999d-bf9bb1165931.png">

* Verify that on each General tab _except_ FTC there is a notice about the FTC.
* Observe the position of the Usage Tracking on General -> features tab (On or Off)
* Go to the FTC.
* Finish indexation in step 1.
* Immediately upon finishing, the count in the red dots in the admin bar (also the drop down) should decrease by 1.
* Once indexation is finished, go to the dashboard tab, note that the notification is gone.
* Now reset indexables progress and notifications again in the test helper.
* Reload and verify the notifications and red dots are back.
* Hide all other notifications except for the one about indexation. The red dot count should now be 1.
* Finish indexation. Note that upon completion, the red dot does not go to 0, but in stead disappears completely.
* Indexation notice should still be gone from the dashboard.
* Go back to the FTC. In the Personal Preferences step, switch tracking option to the option it is not on currently.
* Save that step. The FTC now finishes.
* Go to features, observe there is NO reload happening.
* Observe the Usage Tracking is in the correct setting.
* Observe that there is no Notification about doing the FTC anymore.
* Reload and observe that the notification and the notice are still gone.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes DUPP-494
