### PR TITLE
DUPP-496 Disable the usage tracking step in the FTC when it's not allowed at network level

### DIFF
--- a/packages/js/src/first-time-configuration/tailwind-components/steps/personal-preferences/personal-preferences-step.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/steps/personal-preferences/personal-preferences-step.js
@@ -26,17 +26,20 @@ export default function PersonalPreferencesStep( { state, setTracking } ) {
 				sprintf( __( "%s usage tracking", "wordpress-seo" ), "Yoast SEO" )
 			}
 		</h4>
-		{ ! state.isTrackingAllowedMultisite && <Alert type={ "warning" } className="yst-mt-2">
+		{ !! state.isMainSite && ! state.isTrackingAllowedMultisite && <Alert type={ "warning" } className="yst-mt-2">
 			{ __( "This feature has been disabled by the network admin.", "wordpress-seo" ) }
 		</Alert> }
-		<p className={ classNames( "yst-text-normal yst-mt-2 yst-mb-4", state.isTrackingAllowedMultisite ? "" : "yst-opacity-50" ) }>{ __( "We need your help to improve Yoast SEO. Can we collect anonymous information about your website and how you use it?", "wordpress-seo" ) }</p>
+		{ ! state.isMainSite && <Alert type={ "warning" } className="yst-mt-2">
+			{ __( "This feature has been disabled since subsites never send tracking data.", "wordpress-seo" ) }
+		</Alert> }
+		<p className={ classNames( "yst-text-normal yst-mt-2 yst-mb-4", state.isMainSite && state.isTrackingAllowedMultisite ? "" : "yst-opacity-50" ) }>{ __( "We need your help to improve Yoast SEO. Can we collect anonymous information about your website and how you use it?", "wordpress-seo" ) }</p>
 		{ <RadioGroup
 			id="yoast-configuration-tracking-radio-button"
 			name="yoast-configuration-tracking"
 			value={ state.tracking }
 			onChange={ setTracking }
-			className={ state.isTrackingAllowedMultisite ? "" : "yst-opacity-50" }
-			disabled={ ! state.isTrackingAllowedMultisite }
+			className={ state.isMainSite && state.isTrackingAllowedMultisite ? "" : "yst-opacity-50" }
+			disabled={ ! state.isMainSite || ! state.isTrackingAllowedMultisite }
 			options={ [
 				{
 					value: 0,
@@ -48,7 +51,7 @@ export default function PersonalPreferencesStep( { state, setTracking } ) {
 				},
 			] }
 		/> }
-		{ !! state.isTrackingAllowedMultisite && <Fragment>
+		{ !! state.isMainSite && !! state.isTrackingAllowedMultisite && <Fragment>
 			<Link
 				className="yst-inline-block yst-mt-4"
 				href={ "https://yoa.st/config-workout-tracking" }

--- a/packages/js/src/first-time-configuration/tailwind-components/steps/personal-preferences/personal-preferences-step.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/steps/personal-preferences/personal-preferences-step.js
@@ -1,10 +1,12 @@
 import { Fragment } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
 import PropTypes from "prop-types";
+import classNames from "classnames";
 
+import Alert from "../../base/alert";
 import { makeOutboundLink } from "@yoast/helpers";
-import RadioGroup from "../../base/radio-group";
 import { NewsletterSignup } from "./newsletter-signup";
+import RadioGroup from "../../base/radio-group";
 
 const Link = makeOutboundLink();
 
@@ -24,12 +26,17 @@ export default function PersonalPreferencesStep( { state, setTracking } ) {
 				sprintf( __( "%s usage tracking", "wordpress-seo" ), "Yoast SEO" )
 			}
 		</h4>
-		<p className="yst-text-normal yst-mt-2 yst-mb-4">{ __( "We need your help to improve Yoast SEO. Can we collect anonymous information about your website and how you use it?", "wordpress-seo" ) }</p>
+		{ ! state.isTrackingAllowedMultisite && <Alert type={ "warning" } className="yst-mt-2">
+			{ __( "This feature has been disabled by the network admin.", "wordpress-seo" ) }
+		</Alert> }
+		<p className={ classNames( "yst-text-normal yst-mt-2 yst-mb-4", state.isTrackingAllowedMultisite ? "" : "yst-opacity-50" ) }>{ __( "We need your help to improve Yoast SEO. Can we collect anonymous information about your website and how you use it?", "wordpress-seo" ) }</p>
 		{ <RadioGroup
 			id="yoast-configuration-tracking-radio-button"
 			name="yoast-configuration-tracking"
 			value={ state.tracking }
 			onChange={ setTracking }
+			className={ state.isTrackingAllowedMultisite ? "" : "yst-opacity-50" }
+			disabled={ ! state.isTrackingAllowedMultisite }
 			options={ [
 				{
 					value: 0,
@@ -41,17 +48,19 @@ export default function PersonalPreferencesStep( { state, setTracking } ) {
 				},
 			] }
 		/> }
-		<Link
-			className="yst-inline-block yst-mt-4"
-			href={ "https://yoa.st/config-workout-tracking" }
-		>
-			{ __( "What data will be tracked and for what reasons?", "wordpress-seo" ) }
-		</Link>
-		<p className="yst-my-2">
-			<i>{
-				__( "Important: We will never sell this data. And of course, as always, we won't collect any personal data about you or your visitors.", "wordpress-seo" )
-			}</i>
-		</p>
+		{ !! state.isTrackingAllowedMultisite && <Fragment>
+			<Link
+				className="yst-inline-block yst-mt-4"
+				href={ "https://yoa.st/config-workout-tracking" }
+			>
+				{ __( "What data will be tracked and for what reasons?", "wordpress-seo" ) }
+			</Link>
+			<p className="yst-my-2">
+				<i>{
+					__( "Important: We will never sell this data. And of course, as always, we won't collect any personal data about you or your visitors.", "wordpress-seo" )
+				}</i>
+			</p>
+		</Fragment> }
 		{ ( ! state.isPremium ) && <Fragment>
 			<br />
 			<NewsletterSignup gdprLink={ window.wpseoFirstTimeConfigurationData.shortlinks.gdpr } />

--- a/src/integrations/admin/first-time-configuration-integration.php
+++ b/src/integrations/admin/first-time-configuration-integration.php
@@ -199,6 +199,7 @@ class First_Time_Configuration_Integration implements Integration_Interface {
 					"isPremium": %d,
 					"tracking": %d,
 					"isTrackingAllowedMultisite": %d,
+					"isMainSite": %d,
 					"companyOrPersonOptions": %s,
 					"shouldForceCompany": %d,
 					"knowledgeGraphMessage": "%s",
@@ -226,6 +227,7 @@ class First_Time_Configuration_Integration implements Integration_Interface {
 				$this->product_helper->is_premium(),
 				$this->has_tracking_enabled(),
 				$this->is_tracking_enabled_multisite(),
+				$this->is_main_site(),
 				WPSEO_Utils::format_json_encode( $options ),
 				$this->should_force_company(),
 				$knowledge_graph_message,
@@ -398,6 +400,15 @@ class First_Time_Configuration_Integration implements Integration_Interface {
 		}
 
 		return $this->options_helper->get( 'allow_tracking', $default );
+	}
+
+	/**
+	 * Checks whether we are in a main site.
+	 *
+	 * @return bool True if it's the main site or a single site, false if it's a subsite.
+	 */
+	private function is_main_site() {
+		return \is_main_site();
 	}
 
 	/**

--- a/src/integrations/admin/first-time-configuration-integration.php
+++ b/src/integrations/admin/first-time-configuration-integration.php
@@ -198,6 +198,7 @@ class First_Time_Configuration_Integration implements Integration_Interface {
 					},
 					"isPremium": %d,
 					"tracking": %d,
+					"isTrackingAllowedMultisite": %d,
 					"companyOrPersonOptions": %s,
 					"shouldForceCompany": %d,
 					"knowledgeGraphMessage": "%s",
@@ -224,6 +225,7 @@ class First_Time_Configuration_Integration implements Integration_Interface {
 				WPSEO_Utils::format_json_encode( $social_profiles['other_social_urls'] ),
 				$this->product_helper->is_premium(),
 				$this->has_tracking_enabled(),
+				$this->is_tracking_enabled_multisite(),
 				WPSEO_Utils::format_json_encode( $options ),
 				$this->should_force_company(),
 				$knowledge_graph_message,
@@ -381,6 +383,21 @@ class First_Time_Configuration_Integration implements Integration_Interface {
 		}
 
 		return $this->options_helper->get( 'tracking', $default );
+	}
+
+	/**
+	 * Checks whether tracking option is allowed at network level.
+	 *
+	 * @return bool True if option change is allowed, false otherwise.
+	 */
+	private function is_tracking_enabled_multisite() {
+		$default = true;
+
+		if ( ! \is_multisite() ) {
+			return $default;
+		}
+
+		return $this->options_helper->get( 'allow_tracking', $default );
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to gray out the usage tracking step in the FTC when it's not allowed at network level, as it happens already in the features tab.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Disables the usage tracking step in the FTC when it's not allowed at network level

## Relevant technical choices:

* Note that _the "sending" part of the step is not disabled_. Prior to this PR, saving the step to set a choice of "yes" in a network where tracking is disabled would have resulted in a `500` error. In this case, instead, the value is always forced to be `No`, the request is sent but gets a `200`. I don't think it would worth the hassle to prevent that request, adding complexity.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Multisite Free on a main site with usage tracking disallowed
* install on a multisite environment
* network activate the plugin
* visit the SEO > General page *in the network dashboard* and _disallow_ usage tracking in the Features tab.
* visit the dashboard of the main subsite, go to the FTC
* navigate to the Personal preferences step
* Check that the usage tracking part is greyed out, there is an Alert, the radiobutton is disabled, and the link + disclaimer are not there (to unclutter the UI a bit):
![Screenshot 2022-05-12 at 09-07-20 General - Yoast SEO ‹ multisite — WordPress](https://user-images.githubusercontent.com/15989132/168012015-222c6c52-109f-4657-a161-1b4d16ef322f.png)
* open the JS or Network console to check the following
* save the step and see that you have a XHR request that gets a 200 and no errors in the console

#### Multisite Premium on a main site with usage tracking disallowed
* install on a multisite environment, also with the latest Premium RC/release branch
* network activate Free + Premium
* visit the SEO > General page *in the network dashboard* and _disallow_ usage tracking in the Features tab.
* visit the dashboard of the main subsite, go to the FTC
* navigate to the Personal preferences step
* Check that the usage tracking part is greyed out, there is an Alert, the radiobutton is disabled, and the link + disclaimer are not there (to unclutter the UI a bit):
![Screenshot 2022-05-12 at 09-11-27 General - Yoast SEO ‹ multisite — WordPress](https://user-images.githubusercontent.com/15989132/168012710-fbf8cc8c-c083-4183-9431-8e793473b8ff.png)
* open the JS or Network console to check the following
* save the step and see that you have a XHR request that gets a 200 and no errors in the console

#### Multisite on a main site with usage tracking allowed
* install on a multisite environment
* network activate the plugin without Premium
* visit the SEO > General page *in the network dashboard* and _allow_ usage tracking in the Features tab.
* visit the dashboard of the main subsite, go to the FTC
* navigate to the Personal preferences step
* Check that you see the step not greyed out/disabled, with all the parts expected from the design
* Change the value of the radiobutton to Yes, save and reload to check that it's working
* Change the value of the radiobutton to No, save and reload to check that it's working
* Network-activate Premium and re-check the above

#### Multisite on a subsite with usage tracking allowed
* install on a multisite environment
* network activate the plugin without Premium
* visit the SEO > General page *in the network dashboard* and _allow_ usage tracking in the Features tab.
* visit the dashboard of a subsite which is not the main one, go to the FTC
* navigate to the Personal preferences step
* Check that the usage tracking part is greyed out, there is an Alert, the radiobutton is disabled, and the link + disclaimer are not there (to unclutter the UI a bit):
![Screenshot 2022-05-12 at 11-19-35 General - Yoast SEO ‹ Test — WordPress](https://user-images.githubusercontent.com/15989132/168037311-5c76a0de-b9da-4ad8-9eed-26f89f1478dc.png)
* open the JS or Network console to check the following
* save the step and see that you have a XHR request that gets a 200 and no errors in the console
* Network-activate Premium and re-check the above

#### Regression test on single site
* install on a single site environment
* activate the plugin without Premium
* go to the FTC
* navigate to the Personal preferences step
* Check that you see the step not greyed out/disabled, with all the parts expected from the design
* Change the value of the radiobutton to Yes, save and reload to check that it's working
* Change the value of the radiobutton to No, save and reload to check that it's working
* Aactivate Premium and re-check the above

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes [DUPP-496]


[DUPP-496]: https://yoast.atlassian.net/browse/DUPP-496?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ