### PR TITLE
Make sure component state is not accessed after unmounting

### DIFF
--- a/packages/js/src/first-time-configuration/tailwind-components/steps/site-representation/user-selector.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/steps/site-representation/user-selector.js
@@ -1,5 +1,5 @@
 /* global wpApiSettings */
-import { useState, useCallback } from "@wordpress/element";
+import { useState, useCallback, useRef, useEffect } from "@wordpress/element";
 import PropTypes from "prop-types";
 import { debounce, noop } from "lodash";
 import { __ } from "@wordpress/i18n";
@@ -43,6 +43,14 @@ export default function UserSelector( { initialValue, onChangeCallback, placehol
 		label: initialValue.name,
 	} );
 	const [ isLoading, setIsLoading ] = useState( false );
+	const isMounted = useRef( true );
+
+	// On unmounting, set isMounted to false
+	useEffect( () => {
+		return () => {
+			isMounted.current = false;
+		};
+	}, [] );
 
 	const handleSelectChange = useCallback( ( event ) => {
 		setSelectedPerson( event );
@@ -52,6 +60,10 @@ export default function UserSelector( { initialValue, onChangeCallback, placehol
 	const loadUsers = useCallback( debounce( async( searchQuery ) => {
 		setIsLoading( true );
 		const usersResponse = await fetchUsers( searchQuery );
+		// If the component is being unmounted, stop executing the callback
+		if ( ! isMounted.current ) {
+			return;
+		}
 		setIsLoading( false );
 		setUsers( usersResponse.map( ( user ) => {
 			return {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* in the `Site representation` step of the First-time configuration, toggling back and forth the select combobox outputs an error in the browser console

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where switching back and forth the combobox in the Site representation steps causes an error to be displayed in the browser console

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Navigate to `General` -> `First-time configuration tab` -> `Site representation` step
* Open the browser's  console
* Toggle back and forth the select combobox labelled `Does your site represent an Organization or Person?`, selecting `Person` and `Organization` alternatively
* Verify no error appears in the console

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes [DUPP-441](https://yoast.atlassian.net/browse/DUPP-441)
