### PR TITLE
Dupp 502 redirect to ftc

### DIFF
--- a/src/integrations/admin/old-configuration-integration.php
+++ b/src/integrations/admin/old-configuration-integration.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Yoast\WP\SEO\Integrations\Admin;
+
+use WPSEO_Admin_Asset_Manager;
+use Yoast\WP\SEO\Conditionals\Admin_Conditional;
+use Yoast\WP\SEO\Integrations\Integration_Interface;
+
+/**
+ * Old_Configuration_Integration class
+ */
+class Old_Configuration_Integration implements Integration_Interface {
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_conditionals() {
+		return [ Admin_Conditional::class ];
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function register_hooks() {
+		\add_filter( 'admin_menu', [ $this, 'add_submenu_page' ], 11 );
+		\add_action( 'admin_init', [ $this, 'redirect_to_new_configuration' ] );
+	}
+
+	/**
+	 * Adds the old configuration submenu page.
+	 *
+	 * @param array $submenu_pages The Yoast SEO submenu pages.
+	 *
+	 * @return array the filtered submenu pages.
+	 */
+	public function add_submenu_page( $submenu_pages ) {
+		\add_submenu_page(
+			null,
+			\__( 'Old Configuration Wizard', 'wordpress-seo' ),
+			null,
+			'manage_options',
+			'wpseo_configurator',
+			[ $this, 'render_page' ]
+		);
+
+		return $submenu_pages;
+	}
+
+	/**
+	 * Renders the old configuration page.
+	 */
+	public function render_page() {
+		// This page is never to be displayed.
+	}
+
+	/**
+	 * Redirects from the old configuration page to the new configuration page.
+	 */
+	public function redirect_to_new_configuration() {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Data is not processed or saved.
+		if ( ! isset( $_GET['page'] ) || $_GET['page'] !== 'wpseo_configurator' ) {
+			return;
+		}
+		\wp_safe_redirect( \admin_url( 'admin.php?page=wpseo_dashboard#top#first-time-configuration' ), 302, 'Yoast SEO' );
+		exit;
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to make sure that no 403 is thrown when a user tries to go to the old configuration wizard

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where a 403 error page would be thrown when a user tried to access the old configuration wizard.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Go to the http://basic.wordpress.test/wp-admin/?page=wpseo_configurator page (or http://multisite.wordpress.test/site2/wp-admin/admin.php?page=wpseo_dashboard#top#first-time-configuration for a subsite)
* Confirm that you are redirected to that site's new FTC


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Install and activate 17.6
* Open wizard but do nothing
* Install and activate 18.8 or 18.9-RC2
* Message regarding configuration wizard is displayed on the [dashboard](http://basic.wordpress.test/wp-admin/admin.php?page=wpseo_dashboard) which leads to http://basic.wordpress.test/wp-admin/?page=wpseo_configurator and the user gets 403 error there
* Now do the same with this current RC
* Message regarding configuration wizard is still displayed on the [dashboard](http://basic.wordpress.test/wp-admin/admin.php?page=wpseo_dashboard) but now when trying to go to http://basic.wordpress.test/wp-admin/?page=wpseo_configurator you get redirected to the FTC.
* Try the same with a subsite.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes #
