### PR TITLE
DUPP-436 Add a Redirects with an upsell to Premium

### DIFF
--- a/admin/pages/redirects.php
+++ b/admin/pages/redirects.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * WPSEO plugin file.
+ *
+ * @package WPSEO\Admin
+ * @since   19.0
+ */
+
+if ( ! defined( 'WPSEO_VERSION' ) ) {
+	header( 'Status: 403 Forbidden' );
+	header( 'HTTP/1.1 403 Forbidden' );
+	exit();
+}
+
+require WPSEO_PATH . 'admin/views/redirects.php';

--- a/admin/views/redirects.php
+++ b/admin/views/redirects.php
@@ -16,9 +16,7 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 <div class="wrap yoast wpseo-admin-page page-wpseo_redirects">
 	<h1 id="wpseo-title"><?php echo \esc_html( \get_admin_page_title() ); ?></h1>
 	<div class="wpseo_content_wrapper" style="position: relative;">
-		<div style="position: absolute;border: solid 1px #cccccc;top: 0;bottom: 0;left: 0;right: 0;z-index: 100; display: flex;
-justify-content: center;
-align-items: center;">
+		<div style="position: absolute;top: 0;bottom: 0;left: 0;right: 0;z-index: 100; display: flex;justify-content: center;align-items: center;background: radial-gradient(#ffffffcf 20%, #ffffff00 50%);">
 			<a class="yoast-button-upsell" href="<?php echo \esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/4e0/' ) ); ?>" target="_blank">
 				<?php
 				echo \esc_html__( 'Unlock with Premium', 'wordpress-seo' )
@@ -27,7 +25,7 @@ align-items: center;">
 				?>
 				<span aria-hidden="true" class="yoast-button-upsell__caret"></span></a>
 		</div>
-		<div class="wpseo_content_cell" id="wpseo_content_top" style="filter: blur(3px);opacity: 01;padding: 16px;box-sizing: border-box;">
+		<div class="wpseo_content_cell" id="wpseo_content_top" style="opacity: 0.5;">
 			<h2 class="nav-tab-wrapper" id="wpseo-tabs">
 				<a class="nav-tab nav-tab-active" id="tab-url-tab" href="#" tabindex="-1">Redirects</a>
 				<a class="nav-tab" id="tab-url-tab" href="" tabindex="-1">Regex Redirects</a>

--- a/admin/views/redirects.php
+++ b/admin/views/redirects.php
@@ -19,7 +19,7 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 		<div style="position: absolute;top: 0;bottom: 0;left: 0;right: 0;z-index: 100; display: flex;justify-content: center;align-items: center;background: radial-gradient(#ffffffcf 20%, #ffffff00 50%);">
 			<a class="yoast-button-upsell" href="<?php echo \esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/4e0/' ) ); ?>" target="_blank">
 				<?php
-				\esc_html_e( 'Unlock with Premium', 'wordpress-seo' )
+				echo \esc_html__( 'Unlock with Premium', 'wordpress-seo' )
 					// phpcs:ignore WordPress.Security.EscapeOutput -- Already escapes correctly.
 					. WPSEO_Admin_Utils::get_new_tab_message();
 				?>
@@ -138,7 +138,7 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 								?>
 							</option>
 						</select>
-						<input type="submit" name="filter_action" id="post-query-submit" class="button" value="<?php \esc_attr_e( 'Filter', 'wordpress-seo' ); ?>" tabindex="-1">
+						<input type="button" name="filter_action" id="post-query-submit" class="button" value="<?php \esc_attr_e( 'Filter', 'wordpress-seo' ); ?>" tabindex="-1">
 					</div>
 						<br class="clear">
 					</div>

--- a/admin/views/redirects.php
+++ b/admin/views/redirects.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * WPSEO plugin file.
+ *
+ * @package WPSEO\Admin
+ * @since   19.0
+ */
+
+if ( ! defined( 'WPSEO_VERSION' ) ) {
+	header( 'Status: 403 Forbidden' );
+	header( 'HTTP/1.1 403 Forbidden' );
+	exit();
+}
+
+?>
+<div class="wrap yoast wpseo-admin-page page-wpseo_redirects">
+	<h1 id="wpseo-title"><?php echo \esc_html( \get_admin_page_title() ); ?></h1>
+	<div class="wpseo_content_wrapper" style="position: relative;">
+		<div style="position: absolute;border: solid 1px #cccccc;top: 0;bottom: 0;left: 0;right: 0;z-index: 100; display: flex;
+justify-content: center;
+align-items: center;">
+			<a class="yoast-button-upsell" href="<?php echo \esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/4e0/' ) ); ?>" target="_blank">
+				<?php
+				echo \esc_html__( 'Unlock with Premium', 'wordpress-seo' )
+					// phpcs:ignore WordPress.Security.EscapeOutput -- Already escapes correctly.
+					. WPSEO_Admin_Utils::get_new_tab_message();
+				?>
+				<span aria-hidden="true" class="yoast-button-upsell__caret"></span></a>
+		</div>
+		<div class="wpseo_content_cell" id="wpseo_content_top" style="filter: blur(3px);opacity: 01;padding: 16px;box-sizing: border-box;">
+			<h2 class="nav-tab-wrapper" id="wpseo-tabs">
+				<a class="nav-tab nav-tab-active" id="tab-url-tab" href="#">Redirects</a><a class="nav-tab" id="tab-url-tab" href="">Regex Redirects</a><a class="nav-tab" id="tab-url-tab" href="#">Settings</a></h2>
+
+
+			<div id="table-plain" class="tab-url redirect-table-tab">
+				<h2>Plain redirects</h2>	<form class="wpseo-new-redirect-form" method="post">
+					<div class="wpseo_redirect_form">
+						<div class="redirect_form_row" id="row-wpseo_redirects_type">
+							<label class="textinput" for="wpseo_redirects_type">
+								<span class="title">Type</span>
+							</label>
+							<select name="wpseo_redirects_type" id="wpseo_redirects_type" class="select select2-hidden-accessible" data-select2-id="wpseo_redirects_type" tabindex="-1" aria-hidden="true">
+								<option value="301" data-select2-id="2">301 Moved Permanently</option>
+								<option value="302">302 Found</option>
+								<option value="307">307 Temporary Redirect</option>
+								<option value="410">410 Content Deleted</option>
+								<option value="451">451 Unavailable For Legal Reasons</option>
+							</select><span class="select2 select2-container select2-container--default" dir="ltr" data-select2-id="1" style="width: 400px;"><span class="selection"><span class="select2-selection select2-selection--single" role="combobox" aria-haspopup="true" aria-expanded="false" tabindex="0" aria-disabled="false" aria-labelledby="select2-wpseo_redirects_type-container"><span class="select2-selection__rendered" id="select2-wpseo_redirects_type-container" role="textbox" aria-readonly="true" title="301 Moved Permanently">301 Moved Permanently</span><span class="select2-selection__arrow" role="presentation"><b role="presentation"></b></span></span></span><span class="dropdown-wrapper" aria-hidden="true"></span></span>
+						</div>
+
+						<p class="label desc description wpseo-redirect-clear">
+							The redirect type is the HTTP response code sent to the browser telling the browser what type of redirect is served. <a href="https://yoa.st/2jb?php_version=7.4&amp;platform=wordpress&amp;platform_version=5.9.3&amp;software=premium&amp;software_version=18.9-RC4&amp;days_active=2-5&amp;user_language=en_US&amp;screen=wpseo_redirects" target="_blank">Learn more about redirect types</a>.</p>
+
+						<div class="redirect_form_row" id="row-wpseo_redirects_origin">
+							<label class="textinput" for="wpseo_redirects_origin">
+								<span class="title">Old URL</span>
+							</label>
+							<input type="text" class="textinput" name="wpseo_redirects_origin" id="wpseo_redirects_origin" value="">
+						</div>
+						<br class="clear">
+
+						<div class="redirect_form_row wpseo_redirect_target_holder" id="row-wpseo_redirects_target">
+							<label class="textinput" for="wpseo_redirects_target">
+								<span class="title">URL</span>
+							</label>
+							<input type="text" class="textinput" name="wpseo_redirects_target" id="wpseo_redirects_target" value="">
+						</div>
+						<br class="clear">
+
+						<button type="button" class="button button-primary">Add Redirect</button>
+					</div>
+				</form>
+
+				<form id="plain" class="wpseo-redirects-table-form" method="post" action="">
+					<input type="hidden" class="wpseo_redirects_ajax_nonce" name="wpseo_redirects_ajax_nonce" value="6ccb86df42">
+					<input type="hidden" id="_wpnonce" name="_wpnonce" value="4b02cca185"><input type="hidden" name="_wp_http_referer" value="/wp-admin/admin.php?page=wpseo_redirects">	<div class="tablenav top">
+
+						<div class="alignleft actions">
+							<label for="filter-by-redirect" class="screen-reader-text">Filter by redirect type</label>
+							<select name="redirect-type" id="filter-by-redirect">
+								<option selected="selected" value="0">All redirect types</option>
+								<option value="301">301 Moved Permanently</option>
+								<option value="302">302 Found</option>
+								<option value="307">307 Temporary Redirect</option>
+								<option value="410">410 Content Deleted</option>
+								<option value="451">451 Unavailable For Legal Reasons</option>
+							</select>
+							<input type="submit" name="filter_action" id="post-query-submit" class="button" value="Filter">		</div>
+						<div class="tablenav-pages no-pages"><span class="displaying-num">0 items</span>
+							<span class="pagination-links"><span class="tablenav-pages-navspan button disabled" aria-hidden="true">«</span>
+<span class="tablenav-pages-navspan button disabled" aria-hidden="true">‹</span>
+<span class="paging-input"><label for="current-page-selector" class="screen-reader-text">Current Page</label><input class="current-page" id="current-page-selector" type="text" name="paged" value="1" size="1" aria-describedby="table-paging"><span class="tablenav-paging-text"> of <span class="total-pages">0</span></span></span>
+<a class="next-page button" href="#"><span class="screen-reader-text">Next page</span><span aria-hidden="true">›</span></a>
+<a class="last-page button" href="#"><span class="screen-reader-text">Last page</span><span aria-hidden="true">»</span></a></span></div>
+						<br class="clear">
+					</div>
+					<table class="wp-list-table widefat fixed striped table-view-list plain">
+						<thead>
+						<tr>
+							<td id="cb" class="manage-column column-cb check-column"><label class="screen-reader-text" for="cb-select-all-1">Select All</label><input id="cb-select-all-1" type="checkbox"></td><th scope="col" id="type" class="manage-column column-type column-primary sortable desc"><a href="#"><span>Type</span><span class="sorting-indicator"></span></a></th><th scope="col" id="old" class="manage-column column-old sortable desc"><a href="#"><span>Old URL</span><span class="sorting-indicator"></span></a></th><th scope="col" id="new" class="manage-column column-new sortable desc"><a href="#"><span>New URL</span><span class="sorting-indicator"></span></a></th>	</tr>
+						</thead>
+
+						<tbody id="the-list">
+						<tr class="no-items"><td class="colspanchange" colspan="4">No items found.</td></tr>	</tbody>
+
+						<tfoot>
+						<tr>
+							<td class="manage-column column-cb check-column"><label class="screen-reader-text" for="cb-select-all-2">Select All</label><input id="cb-select-all-2" type="checkbox"></td><th scope="col" class="manage-column column-type column-primary sortable desc"><a href="#"><span>Type</span><span class="sorting-indicator"></span></a></th><th scope="col" class="manage-column column-old sortable desc"><a href="#"><span>Old URL</span><span class="sorting-indicator"></span></a></th><th scope="col" class="manage-column column-new sortable desc"><a href="#"><span>New URL</span><span class="sorting-indicator"></span></a></th>	</tr>
+						</tfoot>
+
+					</table>
+					<div class="tablenav bottom">
+
+						<div class="tablenav-pages no-pages"><span class="displaying-num">0 items</span>
+							<span class="pagination-links"><span class="tablenav-pages-navspan button disabled" aria-hidden="true">«</span>
+<span class="tablenav-pages-navspan button disabled" aria-hidden="true">‹</span>
+<span class="screen-reader-text">Current Page</span><span id="table-paging" class="paging-input"><span class="tablenav-paging-text">1 of <span class="total-pages">0</span></span></span>
+<a class="next-page button" href="#"><span class="screen-reader-text">Next page</span><span aria-hidden="true">›</span></a>
+<a class="last-page button" href="#"><span class="screen-reader-text">Last page</span><span aria-hidden="true">»</span></a></span></div>
+						<br class="clear">
+					</div>
+				</form>
+			</div>
+
+			<br class="clear">
+
+		</div><!-- end of div wpseo_content_top --></div><!-- end of div wpseo_content_wrapper -->
+</div>

--- a/admin/views/redirects.php
+++ b/admin/views/redirects.php
@@ -29,11 +29,14 @@ align-items: center;">
 		</div>
 		<div class="wpseo_content_cell" id="wpseo_content_top" style="filter: blur(3px);opacity: 01;padding: 16px;box-sizing: border-box;">
 			<h2 class="nav-tab-wrapper" id="wpseo-tabs">
-				<a class="nav-tab nav-tab-active" id="tab-url-tab" href="#">Redirects</a><a class="nav-tab" id="tab-url-tab" href="">Regex Redirects</a><a class="nav-tab" id="tab-url-tab" href="#">Settings</a></h2>
+				<a class="nav-tab nav-tab-active" id="tab-url-tab" href="#" tabindex="-1">Redirects</a>
+				<a class="nav-tab" id="tab-url-tab" href="" tabindex="-1">Regex Redirects</a>
+				<a class="nav-tab" id="tab-url-tab" href="#" tabindex="-1">Settings</a></h2>
 
 
 			<div id="table-plain" class="tab-url redirect-table-tab">
-				<h2>Plain redirects</h2>	<form class="wpseo-new-redirect-form" method="post">
+				<h2>Plain redirects</h2>
+				<form class="wpseo-new-redirect-form" method="post">
 					<div class="wpseo_redirect_form">
 						<div class="redirect_form_row" id="row-wpseo_redirects_type">
 							<label class="textinput" for="wpseo_redirects_type">
@@ -45,17 +48,17 @@ align-items: center;">
 								<option value="307">307 Temporary Redirect</option>
 								<option value="410">410 Content Deleted</option>
 								<option value="451">451 Unavailable For Legal Reasons</option>
-							</select><span class="select2 select2-container select2-container--default" dir="ltr" data-select2-id="1" style="width: 400px;"><span class="selection"><span class="select2-selection select2-selection--single" role="combobox" aria-haspopup="true" aria-expanded="false" tabindex="0" aria-disabled="false" aria-labelledby="select2-wpseo_redirects_type-container"><span class="select2-selection__rendered" id="select2-wpseo_redirects_type-container" role="textbox" aria-readonly="true" title="301 Moved Permanently">301 Moved Permanently</span><span class="select2-selection__arrow" role="presentation"><b role="presentation"></b></span></span></span><span class="dropdown-wrapper" aria-hidden="true"></span></span>
+							</select><span class="select2 select2-container select2-container--default" dir="ltr" data-select2-id="1" style="width: 400px;"><span class="selection"><span class="select2-selection select2-selection--single" role="combobox" aria-haspopup="true" aria-expanded="false" tabindex="-1" aria-disabled="false" aria-labelledby="select2-wpseo_redirects_type-container"><span class="select2-selection__rendered" id="select2-wpseo_redirects_type-container" role="textbox" aria-readonly="true" title="301 Moved Permanently">301 Moved Permanently</span><span class="select2-selection__arrow" role="presentation"><b role="presentation"></b></span></span></span><span class="dropdown-wrapper" aria-hidden="true"></span></span>
 						</div>
 
 						<p class="label desc description wpseo-redirect-clear">
-							The redirect type is the HTTP response code sent to the browser telling the browser what type of redirect is served. <a href="https://yoa.st/2jb?php_version=7.4&amp;platform=wordpress&amp;platform_version=5.9.3&amp;software=premium&amp;software_version=18.9-RC4&amp;days_active=2-5&amp;user_language=en_US&amp;screen=wpseo_redirects" target="_blank">Learn more about redirect types</a>.</p>
+							The redirect type is the HTTP response code sent to the browser telling the browser what type of redirect is served. <a href="#" target="_blank" tabindex="-1">Learn more about redirect types</a>.</p>
 
 						<div class="redirect_form_row" id="row-wpseo_redirects_origin">
 							<label class="textinput" for="wpseo_redirects_origin">
 								<span class="title">Old URL</span>
 							</label>
-							<input type="text" class="textinput" name="wpseo_redirects_origin" id="wpseo_redirects_origin" value="">
+							<input type="text" class="textinput" name="wpseo_redirects_origin" id="wpseo_redirects_origin" value="" tabindex="-1">
 						</div>
 						<br class="clear">
 
@@ -63,49 +66,78 @@ align-items: center;">
 							<label class="textinput" for="wpseo_redirects_target">
 								<span class="title">URL</span>
 							</label>
-							<input type="text" class="textinput" name="wpseo_redirects_target" id="wpseo_redirects_target" value="">
+							<input type="text" class="textinput" name="wpseo_redirects_target" id="wpseo_redirects_target" value="" tabindex="-1">
 						</div>
 						<br class="clear">
 
-						<button type="button" class="button button-primary">Add Redirect</button>
+						<button type="button" class="button button-primary" tabindex="-1">Add Redirect</button>
 					</div>
 				</form>
 
 				<form id="plain" class="wpseo-redirects-table-form" method="post" action="">
 					<input type="hidden" class="wpseo_redirects_ajax_nonce" name="wpseo_redirects_ajax_nonce" value="6ccb86df42">
-					<input type="hidden" id="_wpnonce" name="_wpnonce" value="4b02cca185"><input type="hidden" name="_wp_http_referer" value="/wp-admin/admin.php?page=wpseo_redirects">	<div class="tablenav top">
+					<input type="hidden" id="_wpnonce" name="_wpnonce" value="4b02cca185">
+					<input type="hidden" name="_wp_http_referer" value="/wp-admin/admin.php?page=wpseo_redirects">	<div class="tablenav top">
 
-						<div class="alignleft actions">
-							<label for="filter-by-redirect" class="screen-reader-text">Filter by redirect type</label>
-							<select name="redirect-type" id="filter-by-redirect">
-								<option selected="selected" value="0">All redirect types</option>
-								<option value="301">301 Moved Permanently</option>
-								<option value="302">302 Found</option>
-								<option value="307">307 Temporary Redirect</option>
-								<option value="410">410 Content Deleted</option>
-								<option value="451">451 Unavailable For Legal Reasons</option>
-							</select>
-							<input type="submit" name="filter_action" id="post-query-submit" class="button" value="Filter">		</div>
-						<div class="tablenav-pages no-pages"><span class="displaying-num">0 items</span>
-							<span class="pagination-links"><span class="tablenav-pages-navspan button disabled" aria-hidden="true">«</span>
-<span class="tablenav-pages-navspan button disabled" aria-hidden="true">‹</span>
-<span class="paging-input"><label for="current-page-selector" class="screen-reader-text">Current Page</label><input class="current-page" id="current-page-selector" type="text" name="paged" value="1" size="1" aria-describedby="table-paging"><span class="tablenav-paging-text"> of <span class="total-pages">0</span></span></span>
-<a class="next-page button" href="#"><span class="screen-reader-text">Next page</span><span aria-hidden="true">›</span></a>
-<a class="last-page button" href="#"><span class="screen-reader-text">Last page</span><span aria-hidden="true">»</span></a></span></div>
+					<div class="alignleft actions">
+						<select name="redirect-type" id="filter-by-redirect" tabindex="-1">
+							<option selected="selected" value="0">All redirect types</option>
+							<option value="301">301 Moved Permanently</option>
+							<option value="302">302 Found</option>
+							<option value="307">307 Temporary Redirect</option>
+							<option value="410">410 Content Deleted</option>
+							<option value="451">451 Unavailable For Legal Reasons</option>
+						</select>
+						<input type="submit" name="filter_action" id="post-query-submit" class="button" value="Filter" tabindex="-1">
+					</div>
+					<div class="tablenav-pages no-pages"><span class="displaying-num">0 items</span>
+						<span class="pagination-links"><span class="tablenav-pages-navspan button disabled" aria-hidden="true">«</span>
+						<span class="tablenav-pages-navspan button disabled" aria-hidden="true">‹</span>
+						<span class="paging-input">
+							<input class="current-page" id="current-page-selector" type="text" name="paged" value="1" size="1" aria-describedby="table-paging"><span class="tablenav-paging-text"> of <span class="total-pages">0</span></span></span>
+							<a class="next-page button" href="#"><span aria-hidden="true">›</span></a>
+							<a class="last-page button" href="#"><span aria-hidden="true">»</span></a>
+						</span>
+					</div>
 						<br class="clear">
 					</div>
 					<table class="wp-list-table widefat fixed striped table-view-list plain">
 						<thead>
-						<tr>
-							<td id="cb" class="manage-column column-cb check-column"><label class="screen-reader-text" for="cb-select-all-1">Select All</label><input id="cb-select-all-1" type="checkbox"></td><th scope="col" id="type" class="manage-column column-type column-primary sortable desc"><a href="#"><span>Type</span><span class="sorting-indicator"></span></a></th><th scope="col" id="old" class="manage-column column-old sortable desc"><a href="#"><span>Old URL</span><span class="sorting-indicator"></span></a></th><th scope="col" id="new" class="manage-column column-new sortable desc"><a href="#"><span>New URL</span><span class="sorting-indicator"></span></a></th>	</tr>
+							<tr>
+								<td id="cb" class="manage-column column-cb check-column">
+									<input id="cb-select-all-1" type="checkbox"  tabindex="-1">
+								</td>
+								<th scope="col" id="type" class="manage-column column-type column-primary sortable desc">
+									<a href="#" tabindex="-1"><span>Type</span><span class="sorting-indicator"></span></a>
+								</th>
+								<th scope="col" id="old" class="manage-column column-old sortable desc">
+									<a href="#" tabindex="-1"><span>Old URL</span><span class="sorting-indicator"></span></a>
+								</th>
+								<th scope="col" id="new" class="manage-column column-new sortable desc">
+									<a href="#" tabindex="-1"><span>New URL</span><span class="sorting-indicator"></span></a>
+								</th>
+							</tr>
 						</thead>
 
 						<tbody id="the-list">
-						<tr class="no-items"><td class="colspanchange" colspan="4">No items found.</td></tr>	</tbody>
+							<tr class="no-items"><td class="colspanchange" colspan="4">No items found.</td></tr>
+						</tbody>
 
 						<tfoot>
-						<tr>
-							<td class="manage-column column-cb check-column"><label class="screen-reader-text" for="cb-select-all-2">Select All</label><input id="cb-select-all-2" type="checkbox"></td><th scope="col" class="manage-column column-type column-primary sortable desc"><a href="#"><span>Type</span><span class="sorting-indicator"></span></a></th><th scope="col" class="manage-column column-old sortable desc"><a href="#"><span>Old URL</span><span class="sorting-indicator"></span></a></th><th scope="col" class="manage-column column-new sortable desc"><a href="#"><span>New URL</span><span class="sorting-indicator"></span></a></th>	</tr>
+							<tr>
+								<td class="manage-column column-cb check-column">
+									<input id="cb-select-all-2" type="checkbox" tabindex="-1">
+								</td>
+								<th scope="col" class="manage-column column-type column-primary sortable desc">
+									<a href="#" tabindex="-1"><span>Type</span><span class="sorting-indicator"></span></a>
+								</th>
+								<th scope="col" class="manage-column column-old sortable desc">
+									<a href="#" tabindex="-1"><span>Old URL</span><span class="sorting-indicator"></span></a>
+								</th>
+								<th scope="col" class="manage-column column-new sortable desc">
+									<a href="#" tabindex="-1"><span>New URL</span><span class="sorting-indicator"></span></a>
+								</th>
+							</tr>
 						</tfoot>
 
 					</table>
@@ -114,9 +146,9 @@ align-items: center;">
 						<div class="tablenav-pages no-pages"><span class="displaying-num">0 items</span>
 							<span class="pagination-links"><span class="tablenav-pages-navspan button disabled" aria-hidden="true">«</span>
 <span class="tablenav-pages-navspan button disabled" aria-hidden="true">‹</span>
-<span class="screen-reader-text">Current Page</span><span id="table-paging" class="paging-input"><span class="tablenav-paging-text">1 of <span class="total-pages">0</span></span></span>
-<a class="next-page button" href="#"><span class="screen-reader-text">Next page</span><span aria-hidden="true">›</span></a>
-<a class="last-page button" href="#"><span class="screen-reader-text">Last page</span><span aria-hidden="true">»</span></a></span></div>
+<span id="table-paging" class="paging-input"><span class="tablenav-paging-text">1 of <span class="total-pages">0</span></span></span>
+<a class="next-page button" href="#"><span aria-hidden="true">›</span></a>
+<a class="last-page button" href="#"><span aria-hidden="true">»</span></a></span></div>
 						<br class="clear">
 					</div>
 				</form>

--- a/admin/views/redirects.php
+++ b/admin/views/redirects.php
@@ -19,7 +19,7 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 		<div style="position: absolute;top: 0;bottom: 0;left: 0;right: 0;z-index: 100; display: flex;justify-content: center;align-items: center;background: radial-gradient(#ffffffcf 20%, #ffffff00 50%);">
 			<a class="yoast-button-upsell" href="<?php echo \esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/4e0/' ) ); ?>" target="_blank">
 				<?php
-				echo \esc_html__( 'Unlock with Premium', 'wordpress-seo' )
+				\esc_html_e( 'Unlock with Premium', 'wordpress-seo' )
 					// phpcs:ignore WordPress.Security.EscapeOutput -- Already escapes correctly.
 					. WPSEO_Admin_Utils::get_new_tab_message();
 				?>
@@ -27,34 +27,79 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 		</div>
 		<div class="wpseo_content_cell" id="wpseo_content_top" style="opacity: 0.5;">
 			<h2 class="nav-tab-wrapper" id="wpseo-tabs">
-				<a class="nav-tab nav-tab-active" id="tab-url-tab" href="#" tabindex="-1">Redirects</a>
-				<a class="nav-tab" id="tab-url-tab" href="" tabindex="-1">Regex Redirects</a>
-				<a class="nav-tab" id="tab-url-tab" href="#" tabindex="-1">Settings</a></h2>
-
+				<a class="nav-tab nav-tab-active" id="tab-url-tab" href="#" tabindex="-1">
+					<?php
+					\esc_html_e( 'Redirects', 'wordpress-seo' )
+					?>
+				</a>
+				<a class="nav-tab" id="tab-url-tab" href="" tabindex="-1">
+					<?php
+					\esc_html_e( 'Regex Redirects', 'wordpress-seo' )
+					?>
+				</a>
+				<a class="nav-tab" id="tab-url-tab" href="#" tabindex="-1">
+					<?php
+					\esc_html_e( 'Settings', 'wordpress-seo' )
+					?>
+					</a>
+			</h2>
 
 			<div id="table-plain" class="tab-url redirect-table-tab">
-				<h2>Plain redirects</h2>
+				<h2>
+					<?php
+					\esc_html_e( 'Plain redirects', 'wordpress-seo' )
+					?>
+				</h2>
 				<form class="wpseo-new-redirect-form" method="post">
 					<div class="wpseo_redirect_form">
 						<div class="redirect_form_row" id="row-wpseo_redirects_type">
 							<label class="textinput" for="wpseo_redirects_type">
-								<span class="title">Type</span>
+								<span class="title">
+									<?php
+									\esc_html_e( 'Type', 'wordpress-seo' )
+									?>
+								</span>
 							</label>
 							<select name="wpseo_redirects_type" id="wpseo_redirects_type" class="select select2-hidden-accessible" data-select2-id="wpseo_redirects_type" tabindex="-1" aria-hidden="true">
-								<option value="301" data-select2-id="2">301 Moved Permanently</option>
-								<option value="302">302 Found</option>
-								<option value="307">307 Temporary Redirect</option>
-								<option value="410">410 Content Deleted</option>
-								<option value="451">451 Unavailable For Legal Reasons</option>
-							</select><span class="select2 select2-container select2-container--default" dir="ltr" data-select2-id="1" style="width: 400px;"><span class="selection"><span class="select2-selection select2-selection--single" role="combobox" aria-haspopup="true" aria-expanded="false" tabindex="-1" aria-disabled="false" aria-labelledby="select2-wpseo_redirects_type-container"><span class="select2-selection__rendered" id="select2-wpseo_redirects_type-container" role="textbox" aria-readonly="true" title="301 Moved Permanently">301 Moved Permanently</span><span class="select2-selection__arrow" role="presentation"><b role="presentation"></b></span></span></span><span class="dropdown-wrapper" aria-hidden="true"></span></span>
+								<option value="301" data-select2-id="2">
+									<?php
+									\esc_html_e( '301 Moved Permanently', 'wordpress-seo' )
+									?>
+								</option>
+							</select>
+							<span class="select2 select2-container select2-container--default" dir="ltr" data-select2-id="1" style="width: 400px;">
+								<span class="selection">
+									<span class="select2-selection select2-selection--single" role="combobox" aria-haspopup="true" aria-expanded="false" tabindex="-1" aria-disabled="false" aria-labelledby="select2-wpseo_redirects_type-container">
+										<span class="select2-selection__rendered" id="select2-wpseo_redirects_type-container" role="textbox" aria-readonly="true" title="301 Moved Permanently">
+											<?php
+											\esc_html_e( '301 Moved Permanently', 'wordpress-seo' )
+											?>
+										</span>
+										<span class="select2-selection__arrow" role="presentation">
+											<b role="presentation"></b>
+										</span>
+									</span>
+								</span>
+								<span class="dropdown-wrapper" aria-hidden="true"></span>
+							</span>
 						</div>
 
 						<p class="label desc description wpseo-redirect-clear">
-							The redirect type is the HTTP response code sent to the browser telling the browser what type of redirect is served. <a href="#" target="_blank" tabindex="-1">Learn more about redirect types</a>.</p>
-
+							<?php
+							printf(
+								/* translators: 1: opens a link. 2: closes the link. */
+								esc_html__( 'The redirect type is the HTTP response code sent to the browser telling the browser what type of redirect is served. %1$sLearn more about redirect types%2$s.', 'wordpress-seo' ),
+								'<a href="#" target="_blank">',
+								'</a>'
+							);
+							?>
 						<div class="redirect_form_row" id="row-wpseo_redirects_origin">
 							<label class="textinput" for="wpseo_redirects_origin">
-								<span class="title">Old URL</span>
+								<span class="title">
+									<?php
+									\esc_html_e( 'Old URL', 'wordpress-seo' )
+									?>
+								</span>
 							</label>
 							<input type="text" class="textinput" name="wpseo_redirects_origin" id="wpseo_redirects_origin" value="" tabindex="-1">
 						</div>
@@ -62,16 +107,24 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 
 						<div class="redirect_form_row wpseo_redirect_target_holder" id="row-wpseo_redirects_target">
 							<label class="textinput" for="wpseo_redirects_target">
-								<span class="title">URL</span>
+								<span class="title">
+									<?php
+									\esc_html_e( 'URL', 'wordpress-seo' )
+									?>
+								</span>
 							</label>
 							<input type="text" class="textinput" name="wpseo_redirects_target" id="wpseo_redirects_target" value="" tabindex="-1">
 						</div>
 						<br class="clear">
 
-						<button type="button" class="button button-primary" tabindex="-1">Add Redirect</button>
+						<button type="button" class="button button-primary" tabindex="-1">
+							<?php
+							\esc_html_e( 'Add Redirect', 'wordpress-seo' )
+							?>
+						</button>
 					</div>
 				</form>
-
+				<p class="desc">&nbsp;</p>
 				<form id="plain" class="wpseo-redirects-table-form" method="post" action="">
 					<input type="hidden" class="wpseo_redirects_ajax_nonce" name="wpseo_redirects_ajax_nonce" value="6ccb86df42">
 					<input type="hidden" id="_wpnonce" name="_wpnonce" value="4b02cca185">
@@ -79,23 +132,13 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 
 					<div class="alignleft actions">
 						<select name="redirect-type" id="filter-by-redirect" tabindex="-1">
-							<option selected="selected" value="0">All redirect types</option>
-							<option value="301">301 Moved Permanently</option>
-							<option value="302">302 Found</option>
-							<option value="307">307 Temporary Redirect</option>
-							<option value="410">410 Content Deleted</option>
-							<option value="451">451 Unavailable For Legal Reasons</option>
+							<option selected="selected" value="0">
+								<?php
+								\esc_html_e( 'All redirect types', 'wordpress-seo' )
+								?>
+							</option>
 						</select>
-						<input type="submit" name="filter_action" id="post-query-submit" class="button" value="Filter" tabindex="-1">
-					</div>
-					<div class="tablenav-pages no-pages"><span class="displaying-num">0 items</span>
-						<span class="pagination-links"><span class="tablenav-pages-navspan button disabled" aria-hidden="true">«</span>
-						<span class="tablenav-pages-navspan button disabled" aria-hidden="true">‹</span>
-						<span class="paging-input">
-							<input class="current-page" id="current-page-selector" type="text" name="paged" value="1" size="1" aria-describedby="table-paging"><span class="tablenav-paging-text"> of <span class="total-pages">0</span></span></span>
-							<a class="next-page button" href="#"><span aria-hidden="true">›</span></a>
-							<a class="last-page button" href="#"><span aria-hidden="true">»</span></a>
-						</span>
+						<input type="submit" name="filter_action" id="post-query-submit" class="button" value="<?php \esc_attr_e( 'Filter', 'wordpress-seo' ); ?>" tabindex="-1">
 					</div>
 						<br class="clear">
 					</div>
@@ -106,19 +149,46 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 									<input id="cb-select-all-1" type="checkbox"  tabindex="-1">
 								</td>
 								<th scope="col" id="type" class="manage-column column-type column-primary sortable desc">
-									<a href="#" tabindex="-1"><span>Type</span><span class="sorting-indicator"></span></a>
+									<a href="#" tabindex="-1">
+										<span>
+										<?php
+										\esc_html_e( 'Type', 'wordpress-seo' )
+										?>
+										</span>
+										<span class="sorting-indicator"></span>
+									</a>
 								</th>
 								<th scope="col" id="old" class="manage-column column-old sortable desc">
-									<a href="#" tabindex="-1"><span>Old URL</span><span class="sorting-indicator"></span></a>
+									<a href="#" tabindex="-1">
+										<span>
+											<?php
+											\esc_html_e( 'Old URL', 'wordpress-seo' )
+											?>
+										</span>
+										<span class="sorting-indicator"></span>
+									</a>
 								</th>
 								<th scope="col" id="new" class="manage-column column-new sortable desc">
-									<a href="#" tabindex="-1"><span>New URL</span><span class="sorting-indicator"></span></a>
+									<a href="#" tabindex="-1">
+										<span>
+											<?php
+											\esc_html_e( 'New URL', 'wordpress-seo' )
+											?>
+										</span>
+										<span class="sorting-indicator"></span>
+									</a>
 								</th>
 							</tr>
 						</thead>
 
 						<tbody id="the-list">
-							<tr class="no-items"><td class="colspanchange" colspan="4">No items found.</td></tr>
+							<tr class="no-items">
+								<td class="colspanchange" colspan="4">
+									<?php
+									\esc_html_e( 'No items found.', 'wordpress-seo' )
+									?>
+								</td>
+							</tr>
 						</tbody>
 
 						<tfoot>
@@ -127,28 +197,37 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 									<input id="cb-select-all-2" type="checkbox" tabindex="-1">
 								</td>
 								<th scope="col" class="manage-column column-type column-primary sortable desc">
-									<a href="#" tabindex="-1"><span>Type</span><span class="sorting-indicator"></span></a>
+									<a href="#" tabindex="-1">
+										<span>
+											<?php
+											\esc_html_e( 'Type', 'wordpress-seo' )
+											?>
+										</span>
+										<span class="sorting-indicator"></span></a>
 								</th>
 								<th scope="col" class="manage-column column-old sortable desc">
-									<a href="#" tabindex="-1"><span>Old URL</span><span class="sorting-indicator"></span></a>
+									<a href="#" tabindex="-1">
+										<span>
+											<?php
+											\esc_html_e( 'Old URL', 'wordpress-seo' )
+											?>
+										</span>
+										<span class="sorting-indicator"></span>
+									</a>
 								</th>
 								<th scope="col" class="manage-column column-new sortable desc">
-									<a href="#" tabindex="-1"><span>New URL</span><span class="sorting-indicator"></span></a>
+									<a href="#" tabindex="-1">
+										<span>
+											<?php
+											\esc_html_e( 'New URL', 'wordpress-seo' )
+											?>
+										</span>
+										<span class="sorting-indicator"></span></a>
 								</th>
 							</tr>
 						</tfoot>
 
 					</table>
-					<div class="tablenav bottom">
-
-						<div class="tablenav-pages no-pages"><span class="displaying-num">0 items</span>
-							<span class="pagination-links"><span class="tablenav-pages-navspan button disabled" aria-hidden="true">«</span>
-<span class="tablenav-pages-navspan button disabled" aria-hidden="true">‹</span>
-<span id="table-paging" class="paging-input"><span class="tablenav-paging-text">1 of <span class="total-pages">0</span></span></span>
-<a class="next-page button" href="#"><span aria-hidden="true">›</span></a>
-<a class="last-page button" href="#"><span aria-hidden="true">»</span></a></span></div>
-						<br class="clear">
-					</div>
 				</form>
 			</div>
 

--- a/src/integrations/admin/redirects-integration.php
+++ b/src/integrations/admin/redirects-integration.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Yoast\WP\SEO\Integrations\Admin;
+
+use WPSEO_Admin_Utils;
+use WPSEO_Shortlinker;
+use Yoast\WP\SEO\Conditionals\Admin_Conditional;
+use Yoast\WP\SEO\Conditionals\Premium_Inactive_Conditional;
+use Yoast\WP\SEO\Integrations\Integration_Interface;
+
+/**
+ * Redirects_Integration class.
+ */
+class Redirects_Integration implements Integration_Interface {
+
+	/**
+	 * Sets up the hooks.
+	 *
+	 * @return void
+	 */
+	public function register_hooks() {
+		\add_filter( 'wpseo_submenu_pages', [ $this, 'add_submenu_page' ], 9 );
+	}
+
+	/**
+	 * Returns the conditionals based on which this loadable should be active.
+	 *
+	 * In this case: only when on an admin page and Premium is not active.
+	 *
+	 * @return array The conditionals.
+	 */
+	public static function get_conditionals() {
+		return [
+			Admin_Conditional::class,
+			Premium_Inactive_Conditional::class,
+		];
+	}
+
+	/**
+	 * Adds the redirects submenu page.
+	 *
+	 * @param array $submenu_pages The Yoast SEO submenu pages.
+	 *
+	 * @return array The filtered submenu pages.
+	 */
+	public function add_submenu_page( $submenu_pages ) {
+		$submenu_pages[] = [
+			'wpseo_dashboard',
+			'',
+			__( 'Redirects', 'wordpress-seo' ) . ' <span class="yoast-badge yoast-premium-badge"></span>',
+			'wpseo_manage_options',
+			'wpseo_redirects',
+			[ $this, 'display' ],
+		];
+
+		return $submenu_pages;
+	}
+
+	/**
+	 * Displays the redirects page.
+	 *
+	 * @return void
+	 */
+	public function display() {
+		require WPSEO_PATH . 'admin/pages/redirects.php';
+	}
+}

--- a/tests/unit/integrations/admin/redirects-integration-test.php
+++ b/tests/unit/integrations/admin/redirects-integration-test.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Integrations\Admin;
+
+use Brain\Monkey;
+use Mockery;
+use Yoast\WP\SEO\Conditionals\Admin_Conditional;
+use Yoast\WP\SEO\Conditionals\Premium_Inactive_Conditional;
+use Yoast\WP\SEO\Integrations\Admin\Redirects_Integration;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Class Redirects_Integration_Test
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Integrations\Admin\Redirects_Integration
+ *
+ * @group integrations
+ */
+class Redirects_Integration_Test extends TestCase {
+
+	/**
+	 * Represents the instance to test.
+	 *
+	 * @var Redirects_Integration|Mockery\Mock
+	 */
+	protected $instance;
+
+	/**
+	 * Set up the fixtures for the tests.
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->instance = new Redirects_Integration();
+	}
+
+	/**
+	 * Tests the retrieval of the conditionals.
+	 *
+	 * @covers ::get_conditionals
+	 */
+	public function test_get_conditionals() {
+		static::assertEquals(
+			[
+				Admin_Conditional::class,
+				Premium_Inactive_Conditional::class,
+			],
+			Redirects_Integration::get_conditionals()
+		);
+	}
+
+	/**
+	 * Tests the registration of the hooks.
+	 *
+	 * @covers ::register_hooks
+	 */
+	public function test_register_hooks() {
+		$this->instance->register_hooks();
+		$this->assertNotFalse( Monkey\Filters\has( 'wpseo_submenu_pages', [ $this->instance, 'add_submenu_page' ] ), 'Does not have expected wpseo_submenu_pages filter' );
+	}
+
+	/**
+	 * Tests the addition of a submenu page.
+	 *
+	 * @covers ::add_submenu_page
+	 */
+	public function test_add_submenu_page() {
+		Monkey\Functions\expect( '__' )
+			->andReturnFirstArg();
+
+		$submenu_pages = [
+			[
+				'wpseo_dashboard',
+				'',
+				'Redirects <span class="yoast-badge yoast-premium-badge"></span>',
+				'wpseo_manage_options',
+				'wpseo_redirects',
+				[ $this->instance, 'display' ],
+			],
+		];
+
+		$this->assertSame( $submenu_pages, $this->instance->add_submenu_page( [] ) );
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to add a Redirects page in Free with an Upsell to Premium

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds a Redirects page with an upsell to Premium.

## Relevant technical choices:

* 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Check the page
* install & activate this PR or the RC containing it
* make sure Premium is not active
* check that there is a `Redirects` menu item in the sidebar and it has a `Premium` badge
* visit the page and check it's according to this screenshot:
![Screenshot 2022-05-17 at 10-46-10 Redirects - Yoast SEO ‹ Basic — WordPress](https://user-images.githubusercontent.com/15989132/168770171-afc737a0-08eb-4fe0-a3ad-14017b552c85.png)
* Check that navigating with the `TAB` key skips all the form elements in the background
* Check that different screen sizes are handled well.
* Look at the upsell button link destination and see it contains the expected info (version number, etc.)
* Click on the button and see a new tab opens on the same page as the upsells in the Search Appearance upsells
* Switch to a new language in `Setting` > `General` and visit `Dashboard` > `Updates` to look for available translations, install them if they're there (they should be)
* visit the Redirects page again and see the Upsell button is translated
  * strings in the page are translatable as well, but all the strings were in Premium so no translation is available in Free at the moment.

#### Check with Premium
* Install and activate Premium
* See that you have only one `Redirects` menu item in the sidebar
* visit the Page and see that you don't get any upsell and it's the regular (and working) Redirects page.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes [DUPP-436]


[DUPP-436]: https://yoast.atlassian.net/browse/DUPP-436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ