### PR TITLE
LINGO-1487 - Exclude list items in the sentence beginnings assessment.

### DIFF
--- a/packages/yoastseo/spec/fullTextTests/testTexts/fr/frenchPaper.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/fr/frenchPaper.js
@@ -131,8 +131,8 @@ const expectedResults = {
 	},
 	sentenceBeginnings: {
 		isApplicable: true,
-		score: 3,
-		resultText: "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: The text contains 3 consecutive sentences starting with the same word. <a href='https://yoa.st/35g' target='_blank'>Try to mix things up</a>!",
+		score: 9,
+		resultText: "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: There is enough variety in your sentences. That's great!",
 	},
 	imageKeyphrase: {
 		// This is not applicable to this paper since the text doesn't have any image in it.

--- a/packages/yoastseo/spec/languageProcessing/researches/getSentenceBeginningsSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/getSentenceBeginningsSpec.js
@@ -73,11 +73,16 @@ describe( "gets the sentence beginnings and the count of consecutive duplicates.
 		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 3 );
 	} );
 
-	it( "returns an object with English sentence beginnings in lists", function() {
-		mockPaper = new Paper( "<ul><li>item 1</li><li>item 2</li><li>item 3</li><li>item 4</li></ul>" );
+	it( "removes list items", function() {
+		mockPaper = new Paper( "<ul><li>item 1</li><li class='list-item'>item 2</li><li>item 3</li><li>item 4</li></ul>" +
+							   "<p>Hello. Hello. Hello.</p>" );
 		researcher = new EnglishResearcher( mockPaper );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "item" );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 4 );
+
+		const sentenceBeginnings = getSentenceBeginnings( mockPaper, researcher );
+
+		expect( sentenceBeginnings ).toHaveLength( 1 );
+		expect( sentenceBeginnings[ 0 ].count ).toBe( 3 );
+		expect( sentenceBeginnings[ 0 ].word ).toBe( "hello" );
 	} );
 
 	it( "does not count consecutive sentences in tables", function() {

--- a/packages/yoastseo/src/languageProcessing/researches/getSentenceBeginnings.js
+++ b/packages/yoastseo/src/languageProcessing/researches/getSentenceBeginnings.js
@@ -98,6 +98,9 @@ export default function( paper, researcher ) {
 	// Exclude text inside tables.
 	text = text.replace( /<figure class='wp-block-table'>.*<\/figure>/sg, "" );
 
+	// Exclude text inside list items.
+	text = text.replace( /<li(?:[^>]+)?>(.*?)<\/li>/ig, "" );
+
 	let sentences = getSentences( text );
 
 	let sentenceBeginnings = sentences.map( function( sentence ) {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to exclude list items from the assessment that checks whether consecutive sentences begin with the same word(s), since items in lists often do (they enumerate things, for example).

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where items in lists were not excluded for the readability assessment that checks whether consecutive sentences do not begin with the same words.
* [shopify-seo] Fixes a bug where items in lists were not excluded for the readability assessment that checks whether consecutive sentences do not begin with the same words in Collections, Posts and Pages.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### WordPress
* Create a post.
* Add a list.
* Add items that start with the same words to the list.
* Check the results of the readability analysis, it should give a green bullet on the _Consecutive sentences_ assessment:
  > Consecutive sentences: There is enough variety in your sentences. That's great!

#### Shopify
* Create a collection/blog post/page.
* Optimize the product in Yoast SEO.
* Add a list to the product description.
* Add items that start with the same words to the list.
* Check the results of the readability analysis, it should give a green bullet on the _Consecutive sentences_ assessment:
  > Consecutive sentences: There is enough variety in your sentences. That's great!

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The _Consecutive sentences_ assessment as a whole. We could do a quick smoke test whether consecutive sentences that start with the same words, but are outside list items, are still recognised.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [x] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [x] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes #
