### PR TITLE
P1-1347 make yoast form use the new options framework

### DIFF
--- a/admin/class-option-tab.php
+++ b/admin/class-option-tab.php
@@ -74,9 +74,14 @@ class WPSEO_Option_Tab {
 	/**
 	 * Gets the option group.
 	 *
+	 * @deprecated xx.x
+	 * @codeCoverageIgnore
+	 *
 	 * @return string The option group.
 	 */
 	public function get_opt_group() {
+		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+
 		return $this->get_argument( 'opt_group' );
 	}
 

--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -6,7 +6,7 @@
  */
 
 use Yoast\WP\SEO\Exceptions\Option\Unknown_Exception;
-use Yoast\WP\SEO\Presenters\Admin\Light_Switch_Presenter;
+use Yoast\WP\SEO\Integrations\Options_Form_Integration;use Yoast\WP\SEO\Presenters\Admin\Light_Switch_Presenter;
 use Yoast\WP\SEO\Services\Options\Network_Admin_Options_Service;
 
 /**
@@ -82,7 +82,7 @@ class Yoast_Form {
 			}
 			else {
 				$action_url       = admin_url( 'options.php' );
-				$hidden_fields_cb = 'settings_fields';
+				$hidden_fields_cb = [ $this, 'form_fields' ];
 			}
 
 			echo '<form action="' .
@@ -94,6 +94,21 @@ class Yoast_Form {
 			call_user_func( $hidden_fields_cb, $option );
 		}
 		$this->set_option( $option );
+	}
+
+	/**
+	 * Outputs nonce, action and option group fields for an options page in the plugin.
+	 *
+	 * @param string $option The option name.
+	 *
+	 * @return void
+	 */
+	public function form_fields( $option ) {
+		?>
+		<input type="hidden" name="option" value="<?php echo esc_attr( $option ); ?>" />
+		<input type="hidden" name="action" value="<?php echo esc_attr( Options_Form_Integration::SET_OPTIONS_ACTION ); ?>" />
+		<?php
+		wp_nonce_field( Options_Form_Integration::SET_OPTIONS_ACTION . ":$option" );
 	}
 
 	/**

--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -52,15 +52,11 @@ class Yoast_Form {
 	 *
 	 * @since 2.0
 	 *
-	 * @param bool   $form             Whether or not the form start tag should be included.
-	 * @param string $option           The short name of the option to use for the current page.
-	 * @param bool   $contains_files   Whether the form should allow for file uploads.
-	 * @param bool   $option_long_name Group name of the option.
+	 * @param bool   $form           Whether the form start tag should be included.
+	 * @param string $option         The short name of the option to use for the current page.
+	 * @param bool   $contains_files Whether the form should allow for file uploads.
 	 */
-	public function admin_header( $form = true, $option = 'wpseo', $contains_files = false, $option_long_name = false ) {
-		if ( ! $option_long_name ) {
-			$option_long_name = WPSEO_Options::get_group_name( $option );
-		}
+	public function admin_header( $form = true, $option = 'wpseo_options', $contains_files = false ) {
 		?>
 		<div class="wrap yoast wpseo-admin-page <?php echo esc_attr( 'page-' . $option ); ?>">
 		<?php
@@ -95,7 +91,7 @@ class Yoast_Form {
 				$enctype . ' accept-charset="' .
 				esc_attr( get_bloginfo( 'charset' ) ) .
 				'" novalidate="novalidate">';
-			call_user_func( $hidden_fields_cb, $option_long_name );
+			call_user_func( $hidden_fields_cb, $option );
 		}
 		$this->set_option( $option );
 	}

--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -914,6 +914,20 @@ class Yoast_Form {
 			return false;
 		}
 
+		if ( \is_multisite() && \is_network_admin() ) {
+			/**
+			 * Indicates this variable is a Network_Admin_Options_Service.
+			 *
+			 * @var \Yoast\WP\SEO\Services\Options\Network_Admin_Options_Service $network_admin_options_service
+			 */
+			$network_admin_options_service = YoastSEO()->classes->get( Network_Admin_Options_Service::class );
+
+			try {
+				return $network_admin_options_service->__get( $field_name );
+			} catch ( Unknown_Exception $e ) {
+				return $default_value;
+			}
+		}
 		return WPSEO_Options::get( $field_name, $default_value );
 	}
 

--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -6,7 +6,8 @@
  */
 
 use Yoast\WP\SEO\Exceptions\Option\Unknown_Exception;
-use Yoast\WP\SEO\Integrations\Options_Form_Integration;use Yoast\WP\SEO\Presenters\Admin\Light_Switch_Presenter;
+use Yoast\WP\SEO\Integrations\Options_Form_Integration;
+use Yoast\WP\SEO\Presenters\Admin\Light_Switch_Presenter;
 use Yoast\WP\SEO\Services\Options\Network_Admin_Options_Service;
 
 /**
@@ -929,7 +930,7 @@ class Yoast_Form {
 			return false;
 		}
 
-		if ( \is_multisite() && \is_network_admin() ) {
+		if ( is_multisite() && is_network_admin() ) {
 			/**
 			 * Indicates this variable is a Network_Admin_Options_Service.
 			 *

--- a/admin/class-yoast-network-admin.php
+++ b/admin/class-yoast-network-admin.php
@@ -102,14 +102,14 @@ class Yoast_Network_Admin implements WPSEO_WordPress_AJAX_Integration, WPSEO_Wor
 	 * @return void
 	 */
 	public function handle_update_options_request() {
-		$option_group = filter_input( INPUT_POST, 'network_option_group', FILTER_SANITIZE_STRING );
+		$option = filter_input( INPUT_POST, 'network_option', FILTER_SANITIZE_STRING );
 
-		$this->verify_request( "{$option_group}-network-options" );
+		$this->verify_request( "{$option}-network-options" );
 
-		$whitelist_options = Yoast_Network_Settings_API::get()->get_whitelist_options( $option_group );
+		$whitelist_options = Yoast_Network_Settings_API::get()->get_whitelist_options( $option );
 
 		if ( empty( $whitelist_options ) ) {
-			add_settings_error( $option_group, 'settings_updated', __( 'You are not allowed to modify unregistered network settings.', 'wordpress-seo' ), 'error' );
+			add_settings_error( $option, 'settings_updated', __( 'You are not allowed to modify unregistered network settings.', 'wordpress-seo' ), 'error' );
 
 			$this->terminate_request();
 			return;
@@ -129,7 +129,7 @@ class Yoast_Network_Admin implements WPSEO_WordPress_AJAX_Integration, WPSEO_Wor
 
 		$settings_errors = get_settings_errors();
 		if ( empty( $settings_errors ) ) {
-			add_settings_error( $option_group, 'settings_updated', __( 'Settings Updated.', 'wordpress-seo' ), 'updated' );
+			add_settings_error( $option, 'settings_updated', __( 'Settings Updated.', 'wordpress-seo' ), 'updated' );
 		}
 
 		$this->terminate_request();
@@ -143,12 +143,13 @@ class Yoast_Network_Admin implements WPSEO_WordPress_AJAX_Integration, WPSEO_Wor
 	public function handle_restore_site_request() {
 		$this->verify_request( 'wpseo-network-restore', 'restore_site_nonce' );
 
-		$option_group = 'wpseo_ms';
+		// TODO: replace hardcoded string with network_admin_options_service->option_name.
+		$option = 'wpseo_network_admin_options';
 
 		// phpcs:ignore WordPress.Security.NonceVerification -- Nonce verified via `verify_request()` above.
-		$site_id = ! empty( $_POST[ $option_group ]['site_id'] ) ? (int) $_POST[ $option_group ]['site_id'] : 0;
+		$site_id = ! empty( $_POST[ $option ]['site_id'] ) ? (int) $_POST[ $option ]['site_id'] : 0;
 		if ( ! $site_id ) {
-			add_settings_error( $option_group, 'settings_updated', __( 'No site has been selected to restore.', 'wordpress-seo' ), 'error' );
+			add_settings_error( $option, 'settings_updated', __( 'No site has been selected to restore.', 'wordpress-seo' ), 'error' );
 
 			$this->terminate_request();
 			return;
@@ -157,13 +158,13 @@ class Yoast_Network_Admin implements WPSEO_WordPress_AJAX_Integration, WPSEO_Wor
 		$site = get_site( $site_id );
 		if ( ! $site ) {
 			/* translators: %s expands to the ID of a site within a multisite network. */
-			add_settings_error( $option_group, 'settings_updated', sprintf( __( 'Site with ID %d not found.', 'wordpress-seo' ), $site_id ), 'error' );
+			add_settings_error( $option, 'settings_updated', sprintf( __( 'Site with ID %d not found.', 'wordpress-seo' ), $site_id ), 'error' );
 		}
 		else {
 			YoastSEO()->classes->get( Network_Admin_Options_Service::class )->reset_options_for( $site_id );
 
 			/* translators: %s expands to the name of a site within a multisite network. */
-			add_settings_error( $option_group, 'settings_updated', sprintf( __( '%s restored to default SEO settings.', 'wordpress-seo' ), esc_html( $site->blogname ) ), 'updated' );
+			add_settings_error( $option, 'settings_updated', sprintf( __( '%s restored to default SEO settings.', 'wordpress-seo' ), esc_html( $site->blogname ) ), 'updated' );
 		}
 
 		$this->terminate_request();
@@ -172,16 +173,16 @@ class Yoast_Network_Admin implements WPSEO_WordPress_AJAX_Integration, WPSEO_Wor
 	/**
 	 * Outputs nonce, action and option group fields for a network settings page in the plugin.
 	 *
-	 * @param string $option_group Option group name for the current page.
+	 * @param string $option Option group name for the current page.
 	 *
 	 * @return void
 	 */
-	public function settings_fields( $option_group ) {
+	public function settings_fields( $option ) {
 		?>
-		<input type="hidden" name="network_option_group" value="<?php echo esc_attr( $option_group ); ?>" />
+		<input type="hidden" name="network_option" value="<?php echo esc_attr( $option ); ?>" />
 		<input type="hidden" name="action" value="<?php echo esc_attr( self::UPDATE_OPTIONS_ACTION ); ?>" />
 		<?php
-		wp_nonce_field( "$option_group-network-options" );
+		wp_nonce_field( "$option-network-options" );
 	}
 
 	/**

--- a/admin/class-yoast-network-admin.php
+++ b/admin/class-yoast-network-admin.php
@@ -35,8 +35,11 @@ class Yoast_Network_Admin implements WPSEO_WordPress_AJAX_Integration, WPSEO_Wor
 	 */
 	protected $network_admin_options_service;
 
-	function __construct(){
-		$this->network_admin_options_service  = YoastSEO()->classes->get( Network_Admin_Options_Service::class );
+	/**
+	 * Class constructor.
+	 */
+	public function __construct() {
+		$this->network_admin_options_service = YoastSEO()->classes->get( Network_Admin_Options_Service::class );
 	}
 
 	/**
@@ -133,6 +136,7 @@ class Yoast_Network_Admin implements WPSEO_WordPress_AJAX_Integration, WPSEO_Wor
 			$value = null;
 			if ( isset( $_POST[ $option_name ] ) ) {
 				// Adding sanitize_text_field around this will break the saving of settings because it expects a string: https://github.com/Yoast/wordpress-seo/issues/12440.
+				// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 				$value = wp_unslash( $_POST[ $option_name ] );
 			}
 

--- a/admin/google_search_console/class-gsc.php
+++ b/admin/google_search_console/class-gsc.php
@@ -11,13 +11,6 @@
 class WPSEO_GSC {
 
 	/**
-	 * The option where data will be stored.
-	 *
-	 * @var string
-	 */
-	const OPTION_WPSEO_GSC = 'wpseo-gsc';
-
-	/**
 	 * Outputs the HTML for the redirect page.
 	 *
 	 * @return void

--- a/admin/google_search_console/views/gsc-display.php
+++ b/admin/google_search_console/views/gsc-display.php
@@ -6,7 +6,7 @@
  */
 
 // Admin header.
-Yoast_Form::get_instance()->admin_header( false, 'wpseo-gsc', false, 'yoast_wpseo_gsc_options' );
+Yoast_Form::get_instance()->admin_header( false );
 
 // GSC Error notification.
 $gsc_url                 = 'https://search.google.com/search-console/index';

--- a/admin/pages/dashboard.php
+++ b/admin/pages/dashboard.php
@@ -21,7 +21,7 @@ if ( isset( $_GET['allow_tracking'] ) && check_admin_referer( 'wpseo_activate_tr
 }
 
 $yform = Yoast_Form::get_instance();
-$yform->admin_header( true, 'wpseo' );
+$yform->admin_header( true );
 
 do_action( 'wpseo_all_admin_notices' );
 

--- a/admin/pages/metas.php
+++ b/admin/pages/metas.php
@@ -12,7 +12,7 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 }
 
 $yform = Yoast_Form::get_instance();
-$yform->admin_header( true, 'wpseo_titles' );
+$yform->admin_header( true );
 
 $metas_tabs = new WPSEO_Option_Tabs( 'metas' );
 $metas_tabs->add_tab( new WPSEO_Option_Tab( 'general', __( 'General', 'wordpress-seo' ) ) );

--- a/admin/pages/network.php
+++ b/admin/pages/network.php
@@ -12,6 +12,7 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 }
 
 $yform = Yoast_Form::get_instance();
+// TODO: replace hardcoded string with network_admin_options_service->option_name.
 $yform->admin_header( true, 'wpseo_network_admin_options' );
 
 $network_tabs = new WPSEO_Option_Tabs( 'network' );

--- a/admin/pages/network.php
+++ b/admin/pages/network.php
@@ -12,7 +12,7 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 }
 
 $yform = Yoast_Form::get_instance();
-$yform->admin_header( true, 'wpseo_ms' );
+$yform->admin_header( true, 'wpseo_network_admin_options' );
 
 $network_tabs = new WPSEO_Option_Tabs( 'network' );
 $network_tabs->add_tab( new WPSEO_Option_Tab( 'general', __( 'General', 'wordpress-seo' ) ) );

--- a/admin/pages/network.php
+++ b/admin/pages/network.php
@@ -5,15 +5,23 @@
  * @package WPSEO\Admin
  */
 
+use Yoast\WP\SEO\Services\Options\Network_Admin_Options_Service;
+
 if ( ! defined( 'WPSEO_VERSION' ) ) {
 	header( 'Status: 403 Forbidden' );
 	header( 'HTTP/1.1 403 Forbidden' );
 	exit();
 }
 
+/**
+ * Indicates this variable is a Network_Admin_Options_Service.
+ *
+ * @var \Yoast\WP\SEO\Services\Options\Network_Admin_Options_Service $network_admin_options_service
+ */
+$network_admin_options_service = YoastSEO()->classes->get( Network_Admin_Options_Service::class );
+
 $yform = Yoast_Form::get_instance();
-// TODO: replace hardcoded string with network_admin_options_service->option_name.
-$yform->admin_header( true, 'wpseo_network_admin_options' );
+$yform->admin_header( true, $network_admin_options_service->option_name );
 
 $network_tabs = new WPSEO_Option_Tabs( 'network' );
 $network_tabs->add_tab( new WPSEO_Option_Tab( 'general', __( 'General', 'wordpress-seo' ) ) );

--- a/admin/pages/social.php
+++ b/admin/pages/social.php
@@ -12,7 +12,7 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 }
 
 $yform = Yoast_Form::get_instance();
-$yform->admin_header( true, 'wpseo_social' );
+$yform->admin_header( true,  );
 
 $social_tabs = new WPSEO_Option_Tabs( 'social' );
 $social_tabs->add_tab( new WPSEO_Option_Tab( 'accounts', __( 'Accounts', 'wordpress-seo' ), [ 'save_button' => false ] ) );

--- a/admin/pages/social.php
+++ b/admin/pages/social.php
@@ -12,7 +12,7 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 }
 
 $yform = Yoast_Form::get_instance();
-$yform->admin_header( true,  );
+$yform->admin_header( true );
 
 $social_tabs = new WPSEO_Option_Tabs( 'social' );
 $social_tabs->add_tab( new WPSEO_Option_Tab( 'accounts', __( 'Accounts', 'wordpress-seo' ), [ 'save_button' => false ] ) );

--- a/admin/views/tool-file-editor.php
+++ b/admin/views/tool-file-editor.php
@@ -93,6 +93,7 @@ if ( isset( $_POST['submithtaccess'] ) ) {
 
 if ( is_multisite() ) {
 	$action_url = network_admin_url( 'admin.php?page=wpseo_files' );
+	// TODO: replace hardcoded string with network_admin_options_service->option_name.
 	$yform->admin_header( false, 'wpseo_network_admin_options' );
 }
 else {

--- a/admin/views/tool-file-editor.php
+++ b/admin/views/tool-file-editor.php
@@ -93,7 +93,7 @@ if ( isset( $_POST['submithtaccess'] ) ) {
 
 if ( is_multisite() ) {
 	$action_url = network_admin_url( 'admin.php?page=wpseo_files' );
-	$yform->admin_header( false, 'wpseo_ms' );
+	$yform->admin_header( false, 'wpseo_network_admin_options' );
 }
 else {
 	$action_url = admin_url( 'admin.php?page=wpseo_tools&tool=file-editor' );

--- a/admin/views/tool-file-editor.php
+++ b/admin/views/tool-file-editor.php
@@ -5,6 +5,8 @@
  * @package WPSEO\Admin
  */
 
+use Yoast\WP\SEO\Services\Options\Network_Admin_Options_Service;
+
 if ( ! defined( 'WPSEO_VERSION' ) ) {
 	header( 'Status: 403 Forbidden' );
 	header( 'HTTP/1.1 403 Forbidden' );
@@ -93,8 +95,16 @@ if ( isset( $_POST['submithtaccess'] ) ) {
 
 if ( is_multisite() ) {
 	$action_url = network_admin_url( 'admin.php?page=wpseo_files' );
-	// TODO: replace hardcoded string with network_admin_options_service->option_name.
-	$yform->admin_header( false, 'wpseo_network_admin_options' );
+
+	/**
+	 * Indicates this variable is a Network_Admin_Options_Service.
+	 *
+	 * @var \Yoast\WP\SEO\Services\Options\Network_Admin_Options_Service $network_admin_options_service
+	 */
+	$network_admin_options_service = YoastSEO()->classes->get( Network_Admin_Options_Service::class );
+
+	$yform = Yoast_Form::get_instance();
+	$yform->admin_header( false, $network_admin_options_service->option_name );
 }
 else {
 	$action_url = admin_url( 'admin.php?page=wpseo_tools&tool=file-editor' );

--- a/composer.json
+++ b/composer.json
@@ -79,7 +79,7 @@
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_coding_standards"
 		],
 		"check-cs-thresholds": [
-			"@putenv YOASTCS_THRESHOLD_ERRORS=242",
+			"@putenv YOASTCS_THRESHOLD_ERRORS=241",
 			"@putenv YOASTCS_THRESHOLD_WARNINGS=218",
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_cs_thresholds"
 		],

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -1379,6 +1379,9 @@ SVG;
 	 *
 	 * @since 3.0.0
 	 *
+	 * @deprecated xx.x
+	 * @codeCoverageIgnore
+	 *
 	 * @return bool
 	 */
 	public static function is_development_mode() {

--- a/inc/options/class-wpseo-option.php
+++ b/inc/options/class-wpseo-option.php
@@ -147,7 +147,6 @@ abstract class WPSEO_Option {
 	 * Add all the actions and filters for the option.
 	 */
 	protected function __construct() {
-
 		/* Set option group name if not given */
 		if ( ! isset( $this->group_name ) || $this->group_name === '' ) {
 			$this->group_name = 'yoast_' . $this->option_name . '_options';

--- a/inc/options/class-wpseo-options.php
+++ b/inc/options/class-wpseo-options.php
@@ -285,6 +285,9 @@ class WPSEO_Options {
 	 * @param string $option        The option to retrieve.
 	 * @param mixed  $default_value A default value to return.
 	 *
+	 * @deprecated xx.x
+	 * @codeCoverageIgnore
+	 *
 	 * @return mixed
 	 */
 	public static function get_autoloaded_option( $option, $default_value = false ) {
@@ -464,6 +467,9 @@ class WPSEO_Options {
 	 * @param string $option_name              The name for the option to set.
 	 * @param mixed  $option_value             The value for the option.
 	 *
+	 * @deprecated xx.x
+	 * @codeCoverageIgnore
+	 *
 	 * @return bool Returns true if the option is successfully saved in the database.
 	 */
 	public static function save_option( $wpseo_options_group_name, $option_name, $option_value ) {
@@ -502,6 +508,9 @@ class WPSEO_Options {
 	/**
 	 * Retrieves a lookup table to find in which option_group a key is stored.
 	 *
+	 * @deprecated xx.x
+	 * @codeCoverageIgnore
+	 *
 	 * @return array The lookup table.
 	 */
 	private static function get_lookup_table() {
@@ -522,6 +531,9 @@ class WPSEO_Options {
 
 	/**
 	 * Retrieves a lookup table to find in which option_group a key is stored.
+	 *
+	 * @deprecated xx.x
+	 * @codeCoverageIgnore
 	 *
 	 * @return array The lookup table.
 	 */

--- a/inc/options/class-wpseo-taxonomy-meta.php
+++ b/inc/options/class-wpseo-taxonomy-meta.php
@@ -424,7 +424,7 @@ class WPSEO_Taxonomy_Meta extends WPSEO_Option {
 	 */
 	public static function set_values( $term_id, $taxonomy, array $meta_values ) {
 		try {
-			self::get_taxonomy_metadata_service()->set_options( $term_id, $taxonomy, $meta_values );
+			self::get_taxonomy_metadata_service()->set_term_options( $term_id, $taxonomy, $meta_values );
 		} catch ( Abstract_Option_Exception $exception ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- Deliberately left empty.
 		} catch ( Abstract_Validation_Exception $exception ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- Deliberately left empty.
 		}

--- a/src/actions/options/network-admin-options-action.php
+++ b/src/actions/options/network-admin-options-action.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Yoast\WP\SEO\Actions\Options;
+
+use Yoast\WP\SEO\Exceptions\Option\Form_Invalid_Exception;
+use Yoast\WP\SEO\Exceptions\Option\Save_Failed_Exception;
+use Yoast\WP\SEO\Services\Options\Network_Admin_Options_Service;
+
+class Network_Admin_Options_Action {
+
+	/**
+	 * Holds the Network_Admin_Options_Service instance.
+	 *
+	 * @var Network_Admin_Options_Service
+	 */
+	protected $network_admin_options_service;
+
+	/**
+	 * Constructs a Network_Admin_Options_Action instance.
+	 *
+	 * @param Network_Admin_Options_Service $network_admin_options_service The Network_Admin_Options_Service instance.
+	 */
+	public function __construct( Network_Admin_Options_Service $network_admin_options_service ) {
+		$this->network_admin_options_service = $network_admin_options_service;
+	}
+
+	/**
+	 * Retrieves the network admin options.
+	 *
+	 * @param string[] $keys Optionally request only these options.
+	 *
+	 * @return array The options.
+	 */
+	public function get( array $keys ) {
+		return $this->network_admin_options_service->get_options( $keys );
+	}
+
+	/**
+	 * Sets the network admin options.
+	 *
+	 * @param array $options The options.
+	 *
+	 * @return array The result, containing `success` and `error` keys.
+	 */
+	public function set( $options ) {
+		$result = $this->set_options( $options );
+
+		if ( $result['success'] ) {
+			return $result;
+		}
+
+		if ( $result['error'] instanceof Form_Invalid_Exception ) {
+			foreach ( $result['error']->get_field_exceptions() as $option => $field_exception ) {
+				$result['field_errors'][ $option ] = $field_exception->getMessage();
+			}
+		}
+		$result['error'] = $result['error']->getMessage();
+
+		return $result;
+	}
+
+	/**
+	 * Sets the network admin options.
+	 *
+	 * @param array $options The options.
+	 *
+	 * @return array The result, containing `success` and `error` keys.
+	 */
+	protected function set_options( array $options = [] ) {
+		$result = [ 'success' => false ];
+
+		try {
+			$this->network_admin_options_service->set_options( $options );
+			$result['success'] = true;
+		} catch ( Save_Failed_Exception $exception ) {
+			$result['error'] = $exception;
+		} catch ( Form_Invalid_Exception $exception ) {
+			$result['error'] = $exception;
+		}
+
+		return $result;
+	}
+}

--- a/src/actions/options/network-admin-options-action.php
+++ b/src/actions/options/network-admin-options-action.php
@@ -6,6 +6,11 @@ use Yoast\WP\SEO\Exceptions\Option\Form_Invalid_Exception;
 use Yoast\WP\SEO\Exceptions\Option\Save_Failed_Exception;
 use Yoast\WP\SEO\Services\Options\Network_Admin_Options_Service;
 
+/**
+ * Gets or sets the network admin options.
+ *
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded -- Action should not count.
+ */
 class Network_Admin_Options_Action {
 
 	/**

--- a/src/actions/options/options-action.php
+++ b/src/actions/options/options-action.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Yoast\WP\SEO\Actions\Options;
+
+use Yoast\WP\SEO\Exceptions\Option\Form_Invalid_Exception;
+use Yoast\WP\SEO\Helpers\Options_Helper;
+
+class Options_Action {
+
+	/**
+	 * Holds the Options_Helper instance.
+	 *
+	 * @var Options_Helper
+	 */
+	protected $options_helper;
+
+	/**
+	 * Constructs an Options_Action instance.
+	 *
+	 * @param Options_Helper $options_helper The Options_Helper instance.
+	 */
+	public function __construct( Options_Helper $options_helper ) {
+		$this->options_helper = $options_helper;
+	}
+
+	/**
+	 * Retrieves the options.
+	 *
+	 * @param string[] $keys Optionally request only these options.
+	 *
+	 * @return array The options.
+	 */
+	public function get( array $keys ) {
+		return $this->options_helper->get_options( $keys );
+	}
+
+	/**
+	 * Sets the options.
+	 *
+	 * @param array $options The options.
+	 *
+	 * @return array The result, containing `success` and `error` keys.
+	 */
+	public function set( $options ) {
+		$result = $this->options_helper->set_options( $options );
+
+		if ( $result['success'] ) {
+			return $result;
+		}
+
+		if ( $result['error'] instanceof Form_Invalid_Exception ) {
+			foreach ( $result['error']->get_field_exceptions() as $option => $field_exception ) {
+				$result['field_errors'][ $option ] = $field_exception->getMessage();
+			}
+		}
+		$result['error'] = $result['error']->getMessage();
+
+		return $result;
+	}
+}

--- a/src/actions/options/options-action.php
+++ b/src/actions/options/options-action.php
@@ -5,6 +5,9 @@ namespace Yoast\WP\SEO\Actions\Options;
 use Yoast\WP\SEO\Exceptions\Option\Form_Invalid_Exception;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 
+/**
+ * Gets or sets the options.
+ */
 class Options_Action {
 
 	/**

--- a/src/actions/options/options-action.php
+++ b/src/actions/options/options-action.php
@@ -33,7 +33,7 @@ class Options_Action {
 	 *
 	 * @return array The options.
 	 */
-	public function get( array $keys ) {
+	public function get( array $keys = [] ) {
 		return $this->options_helper->get_options( $keys );
 	}
 

--- a/src/exceptions/option/form-invalid-exception.php
+++ b/src/exceptions/option/form-invalid-exception.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Yoast\WP\SEO\Exceptions\Option;
+
+use Exception;
+
+/**
+ * Form invalid exception class.
+ */
+class Form_Invalid_Exception extends Abstract_Option_Exception {
+
+	/**
+	 * Holds the field exceptions.
+	 *
+	 * @var Exception[]
+	 */
+	protected $field_exceptions;
+
+	/**
+	 * Constructs a single exception for one or more field exceptions.
+	 *
+	 * @param Exception[] $field_exceptions The field exceptions.
+	 */
+	public function __construct( array $field_exceptions ) {
+		parent::__construct( \__( 'Form contains invalid fields.', 'wordpress-seo' ) );
+
+		$this->field_exceptions = $field_exceptions;
+	}
+
+	/**
+	 * Retrieves the field exceptions.
+	 *
+	 * @return Exception[] The field exceptions.
+	 */
+	public function get_field_exceptions() {
+		return $this->field_exceptions;
+	}
+}

--- a/src/helpers/input-helper.php
+++ b/src/helpers/input-helper.php
@@ -10,13 +10,14 @@ class Input_Helper {
 	/**
 	 * Returns the result of the filter_input. This is mostly a wrapper so we can test.
 	 *
-	 * @param int    $input_type    The type of input constant (e.g. INPUT_POST, INPUT_GET ).
-	 * @param string $search_string The property to get from the input.
-	 * @param int    $filter        Optional. The constant that defines the sanitization.
+	 * @param int       $input_type    The type of input constant (e.g. INPUT_POST, INPUT_GET ).
+	 * @param string    $search_string The property to get from the input.
+	 * @param int       $filter        Optional. The constant that defines the sanitization.
+	 * @param array|int $options       Optional. Associative array of options or bitwise disjunction of flags.
 	 *
-	 * @return string The result of the get input.
+	 * @return mixed The result of the get input.
 	 */
-	public function filter( $input_type, $search_string, $filter = \FILTER_DEFAULT ) {
-		return \filter_input( $input_type, $search_string, $filter );
+	public function filter( $input_type, $search_string, $filter = \FILTER_DEFAULT, $options = 0 ) {
+		return \filter_input( $input_type, $search_string, $filter, $options );
 	}
 }

--- a/src/helpers/options-helper.php
+++ b/src/helpers/options-helper.php
@@ -5,6 +5,7 @@ namespace Yoast\WP\SEO\Helpers;
 use WPSEO_Option_Social;
 use WPSEO_Option_Titles;
 use Yoast\WP\SEO\Exceptions\Option\Delete_Failed_Exception;
+use Yoast\WP\SEO\Exceptions\Option\Form_Invalid_Exception;
 use Yoast\WP\SEO\Exceptions\Option\Save_Failed_Exception;
 use Yoast\WP\SEO\Exceptions\Option\Unknown_Exception;
 use Yoast\WP\SEO\Exceptions\Validation\Abstract_Validation_Exception;
@@ -152,6 +153,29 @@ class Options_Helper {
 	 */
 	public function get_options( array $keys = [] ) {
 		return $this->get_options_service()->get_options( $keys );
+	}
+
+	/**
+	 * Sets the options.
+	 *
+	 * @param array $options The options.
+	 *
+	 * @return array The result, containing `success` and `error` keys.
+	 */
+	public function set_options( array $options = [] ) {
+		$result          = [ 'success' => false ];
+		$options_service = $this->get_options_service();
+
+		try {
+			$options_service->set_options( $options );
+			$result['success'] = true;
+		} catch ( Save_Failed_Exception $exception ) {
+			$result['error'] = $exception;
+		} catch ( Form_Invalid_Exception $exception ) {
+			$result['error'] = $exception;
+		}
+
+		return $result;
 	}
 
 	/**

--- a/src/helpers/options-helper.php
+++ b/src/helpers/options-helper.php
@@ -17,6 +17,8 @@ use Yoast\WP\SEO\Services\Options\Site_Options_Service;
  */
 class Options_Helper {
 
+	const INVALID_VALUE = 'YOAST_INVALID_VALUE';
+
 	/**
 	 * Holds the Site_Options_Service instance.
 	 *
@@ -121,6 +123,24 @@ class Options_Helper {
 		} catch ( Unknown_Exception $exception ) {
 			return null;
 		}
+	}
+
+	/**
+	 * Validates an option value.
+	 *
+	 * @param string $key   The option key.
+	 * @param mixed  $value The option value.
+	 *
+	 * @return mixed The valid value, or self::INVALID_VALUE if unknown or unfixable.
+	 */
+	public function validate( $key, $value ) {
+		try {
+			return $this->site_options_service->validate( $key, $value );
+		} catch ( Unknown_Exception $exception ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- Deliberately left empty.
+		} catch ( Abstract_Validation_Exception $exception ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- Deliberately left empty.
+		}
+
+		return self::INVALID_VALUE;
 	}
 
 	/**

--- a/src/helpers/options-helper.php
+++ b/src/helpers/options-helper.php
@@ -135,7 +135,7 @@ class Options_Helper {
 	 */
 	public function validate( $key, $value ) {
 		try {
-			return $this->site_options_service->validate( $key, $value );
+			return $this->get_options_service()->validate( $key, $value );
 		} catch ( Unknown_Exception $exception ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- Deliberately left empty.
 		} catch ( Abstract_Validation_Exception $exception ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- Deliberately left empty.
 		}

--- a/src/helpers/options-helper.php
+++ b/src/helpers/options-helper.php
@@ -203,6 +203,19 @@ class Options_Helper {
 	}
 
 	/**
+	 * Retrieves the appropriate options service for the current location.
+	 *
+	 * @return Site_Options_Service|Multisite_Options_Service The options service.
+	 */
+	public function get_options_service() {
+		if ( $this->site_helper->is_multisite() ) {
+			return $this->multisite_options_service;
+		}
+
+		return $this->site_options_service;
+	}
+
+	/**
 	 * Retrieves the title separator.
 	 *
 	 * @return string The title separator.
@@ -293,18 +306,5 @@ class Options_Helper {
 	 */
 	protected function get_separator_options() {
 		return WPSEO_Option_Titles::get_instance()->get_separator_options();
-	}
-
-	/**
-	 * Retrieves the appropriate options service for the current location.
-	 *
-	 * @return Site_Options_Service|Multisite_Options_Service The options service.
-	 */
-	protected function get_options_service() {
-		if ( $this->site_helper->is_multisite() ) {
-			return $this->multisite_options_service;
-		}
-
-		return $this->site_options_service;
 	}
 }

--- a/src/helpers/options-helper.php
+++ b/src/helpers/options-helper.php
@@ -162,7 +162,7 @@ class Options_Helper {
 	 *
 	 * @return array The result, containing `success` and `error` keys.
 	 */
-	public function set_options( array $options = [] ) {
+	public function set_options( array $options ) {
 		$result          = [ 'success' => false ];
 		$options_service = $this->get_options_service();
 

--- a/src/initializers/options-initializer.php
+++ b/src/initializers/options-initializer.php
@@ -3,7 +3,10 @@
 namespace Yoast\WP\SEO\Initializers;
 
 use Yoast\WP\SEO\Conditionals\No_Conditionals;
+use Yoast\WP\SEO\Helpers\Capability_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
+use Yoast\WP\SEO\Helpers\Site_Helper;
+use Yoast_Network_Settings_API;
 
 /**
  * Adds hooks for the options service.
@@ -20,12 +23,28 @@ class Options_Initializer implements Initializer_Interface {
 	protected $options_helper;
 
 	/**
+	 * Holds the capability helper instance.
+	 *
+	 * @var Capability_Helper
+	 */
+	protected $capability_helper;
+
+	/**
+	 * Holds the site helper instance.
+	 *
+	 * @var Site_Helper
+	 */
+	protected $site_helper;
+
+	/**
 	 * Constructs the options integration.
 	 *
 	 * @param Options_Helper $options_helper The options helper.
 	 */
-	public function __construct( Options_Helper $options_helper ) {
-		$this->options_helper = $options_helper;
+	public function __construct( Options_Helper $options_helper, Capability_Helper $capability_helper, Site_Helper $site_helper ) {
+		$this->options_helper    = $options_helper;
+		$this->capability_helper = $capability_helper;
+		$this->site_helper       = $site_helper;
 	}
 
 	/**
@@ -43,5 +62,55 @@ class Options_Initializer implements Initializer_Interface {
 		\add_action( 'unregistered_post_type', [ $this->options_helper, 'clear_cache' ] );
 		\add_action( 'registered_taxonomy', [ $this->options_helper, 'clear_cache' ] );
 		\add_action( 'unregistered_taxonomy', [ $this->options_helper, 'clear_cache' ] );
+
+		\add_action( 'admin_init', [ $this, 'register_options' ] );
+	}
+
+	/**
+	 * Registers the options for the configuration pages.
+	 *
+	 * @return void
+	 */
+	public function register_options() {
+		if ( ! $this->capability_helper->current_user_can( 'wpseo_manage_options' ) ) {
+			return;
+		}
+
+		// TODO: replace this with $this->site_helper->is_multisite() after P1-1156 is merged.
+		if ( \is_multisite() ) {
+			$network_settings_api = Yoast_Network_Settings_API::get();
+			if ( $network_settings_api->meets_requirements() ) {
+				// TODO: replace hardcoded string with network_admin_options_service->option_name.
+				$network_settings_api->register_setting( 'wpseo_network_admin_options', 'wpseo_network_admin_options' );
+			}
+		}
+
+		\register_setting(
+			'wpseo_options',
+			'wpseo_options',
+			[
+				'type'              => 'array',
+				'sanitize_callback' => [ $this, 'sanitize_options' ],
+			]
+		);
+	}
+
+	/**
+	 * Validates the option values. Invalid or unknown values will be removed.
+	 *
+	 * @param array $values The option values.
+	 *
+	 * @return array Valid values.
+	 */
+	public function sanitize_options( $values ) {
+		$valid_values = [];
+		foreach ( $values as $key => $value ) {
+			$valid_value = $this->options_helper->validate( $key, $value );
+			if ( $valid_value !== Options_Helper::INVALID_VALUE ) {
+				$valid_values[ $key ] = $valid_value;
+			}
+		}
+
+		return $valid_values;
 	}
 }

--- a/src/initializers/options-initializer.php
+++ b/src/initializers/options-initializer.php
@@ -94,33 +94,5 @@ class Options_Initializer implements Initializer_Interface {
 				$this->network_admin_options_service->option_name
 			);
 		}
-
-		\register_setting(
-			$this->options_helper->get_options_service()->option_name,
-			$this->options_helper->get_options_service()->option_name,
-			[
-				'type'              => 'array',
-				'sanitize_callback' => [ $this, 'sanitize_options' ],
-			]
-		);
-	}
-
-	/**
-	 * Validates the option values. Invalid or unknown values will be removed.
-	 *
-	 * @param array $values The option values.
-	 *
-	 * @return array Valid values.
-	 */
-	public function sanitize_options( $values ) {
-		$valid_values = [];
-		foreach ( $values as $key => $value ) {
-			$valid_value = $this->options_helper->validate( $key, $value );
-			if ( $valid_value !== Options_Helper::INVALID_VALUE ) {
-				$valid_values[ $key ] = $valid_value;
-			}
-		}
-
-		return $valid_values;
 	}
 }

--- a/src/initializers/options-initializer.php
+++ b/src/initializers/options-initializer.php
@@ -16,8 +16,6 @@ class Options_Initializer implements Initializer_Interface {
 
 	use No_Conditionals;
 
-	use No_Conditionals;
-
 	/**
 	 * Holds the network admin options service instance.
 	 *

--- a/src/initializers/options-initializer.php
+++ b/src/initializers/options-initializer.php
@@ -49,9 +49,17 @@ class Options_Initializer implements Initializer_Interface {
 	/**
 	 * Constructs the options integration.
 	 *
-	 * @param Options_Helper $options_helper The options helper.
+	 * @param Network_Admin_Options_Service $network_admin_options_service The network admin options service.
+	 * @param Options_Helper                $options_helper                The options helper.
+	 * @param Capability_Helper             $capability_helper             The capability helper.
+	 * @param Site_Helper                   $site_helper                   The site helper.
 	 */
-	public function __construct( Network_Admin_Options_Service $network_admin_options_service, Options_Helper $options_helper, Capability_Helper $capability_helper, Site_Helper $site_helper ) {
+	public function __construct(
+		Network_Admin_Options_Service $network_admin_options_service,
+		Options_Helper $options_helper,
+		Capability_Helper $capability_helper,
+		Site_Helper $site_helper
+	) {
 		$this->network_admin_options_service = $network_admin_options_service;
 		$this->options_helper                = $options_helper;
 		$this->capability_helper             = $capability_helper;

--- a/src/integrations/options-form-integration.php
+++ b/src/integrations/options-form-integration.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Yoast\WP\SEO\Integrations;
+
+use Yoast\WP\SEO\Actions\Options\Options_Action;
+use Yoast\WP\SEO\Conditionals\No_Conditionals;
+use Yoast\WP\SEO\Helpers\Capability_Helper;
+use Yoast\WP\SEO\Helpers\Options_Helper;
+
+/**
+ * Adds hooks for the Yoast Form.
+ */
+class Options_Form_Integration implements Integration_Interface {
+
+	use No_Conditionals;
+
+	/**
+	 * Holds the action identifier for setting options.
+	 *
+	 * @var string
+	 */
+	const SET_OPTIONS_ACTION = 'yoast_handle_set_options';
+
+	/**
+	 * Holds the options action instance.
+	 *
+	 * @var Options_Action
+	 */
+	protected $options_action;
+
+	/**
+	 * Holds the capability helper instance.
+	 *
+	 * @var Capability_Helper
+	 */
+	protected $capability_helper;
+
+	/**
+	 * Constructs the options integration.
+	 *
+	 * @param Options_Helper $options_helper The options helper.
+	 */
+	public function __construct( Options_Action $options_action, Capability_Helper $capability_helper ) {
+		$this->options_action    = $options_action;
+		$this->capability_helper = $capability_helper;
+	}
+
+	/**
+	 * Registers the hooks.
+	 *
+	 * @return void
+	 */
+	public function register_hooks() {
+		add_action( 'admin_action_' . self::SET_OPTIONS_ACTION, [ $this, 'handle_update_options_request' ] );
+	}
+
+	/**
+	 * Handles a request to update plugin network options.
+	 *
+	 * This method works similar to how option updates are handled in `wp-admin/options.php` and
+	 * `wp-admin/network/settings.php`.
+	 *
+	 * @return void
+	 */
+	public function handle_update_options_request() {
+		$option = filter_input( INPUT_POST, 'option', FILTER_SANITIZE_STRING );
+
+		$this->verify_request( self::SET_OPTIONS_ACTION . ":$option" );
+
+		$value = null;
+		if ( isset( $_POST[ $option ] ) ) {
+			// Adding sanitize_text_field around this will break the saving of settings because it expects a string: https://github.com/Yoast/wordpress-seo/issues/12440.
+			$value = \wp_unslash( $_POST[ $option ] );
+		}
+
+		$result = $this->options_action->set( $value );
+		if ( ! $result['success'] ) {
+			\add_settings_error( 'wpseo_options', 'settings_save_error', $result['error'], 'error' );
+			if ( \array_key_exists( 'field_errors', $result ) ) {
+				foreach ( $result['field_errors']->get_field_exceptions() as $option => $field_exception ) {
+					\add_settings_error( 'wpseo_options', $option, $field_exception, 'error' );
+				}
+			}
+		}
+
+		$settings_errors = \get_settings_errors();
+		if ( empty( $settings_errors ) ) {
+			\add_settings_error( $option, 'settings_updated', __( 'Settings Updated.', 'wordpress-seo' ), 'updated' );
+		}
+
+		$this->redirect_back( [ 'settings-updated' => 'true' ] );
+	}
+
+	/**
+	 * Verifies that the current request is valid.
+	 *
+	 * @param string $action    Nonce action.
+	 * @param string $query_arg Optional. Nonce query argument. Default '_wpnonce'.
+	 *
+	 * @return void
+	 */
+	public function verify_request( $action, $query_arg = '_wpnonce' ) {
+		$has_access = $this->capability_helper->current_user_can( 'wpseo_manage_options' );
+
+		\check_admin_referer( $action, $query_arg );
+
+		if ( ! $has_access ) {
+			\wp_die( \esc_html__( 'You are not allowed to perform this action.', 'wordpress-seo' ) );
+		}
+	}
+
+	/**
+	 * Redirects back to the referer URL, with optional query arguments.
+	 *
+	 * @param array $query_args Optional. Query arguments to add to the redirect URL. Default none.
+	 *
+	 * @return void
+	 */
+	protected function redirect_back( $query_args = [] ) {
+		$sendback = \wp_get_referer();
+
+		if ( ! empty( $query_args ) ) {
+			$sendback = \add_query_arg( $query_args, $sendback );
+		}
+
+		\wp_safe_redirect( $sendback );
+		exit;
+	}
+}

--- a/src/integrations/options-form-integration.php
+++ b/src/integrations/options-form-integration.php
@@ -51,7 +51,7 @@ class Options_Form_Integration implements Integration_Interface {
 	 * @return void
 	 */
 	public function register_hooks() {
-		add_action( 'admin_action_' . self::SET_OPTIONS_ACTION, [ $this, 'handle_update_options_request' ] );
+		\add_action( 'admin_action_' . self::SET_OPTIONS_ACTION, [ $this, 'handle_update_options_request' ] );
 	}
 
 	/**
@@ -63,7 +63,7 @@ class Options_Form_Integration implements Integration_Interface {
 	 * @return void
 	 */
 	public function handle_update_options_request() {
-		$option = filter_input( INPUT_POST, 'option', FILTER_SANITIZE_STRING );
+		$option = \filter_input( INPUT_POST, 'option', FILTER_SANITIZE_STRING );
 
 		$this->verify_request( self::SET_OPTIONS_ACTION . ":$option" );
 
@@ -77,7 +77,7 @@ class Options_Form_Integration implements Integration_Interface {
 		if ( ! $result['success'] ) {
 			\add_settings_error( 'wpseo_options', 'settings_save_error', $result['error'], 'error' );
 			if ( \array_key_exists( 'field_errors', $result ) ) {
-				foreach ( $result['field_errors']->get_field_exceptions() as $option => $field_exception ) {
+				foreach ( $result['field_errors'] as $option => $field_exception ) {
 					\add_settings_error( 'wpseo_options', $option, $field_exception, 'error' );
 				}
 			}

--- a/src/integrations/options-form-integration.php
+++ b/src/integrations/options-form-integration.php
@@ -5,6 +5,8 @@ namespace Yoast\WP\SEO\Integrations;
 use Yoast\WP\SEO\Actions\Options\Options_Action;
 use Yoast\WP\SEO\Conditionals\No_Conditionals;
 use Yoast\WP\SEO\Helpers\Capability_Helper;
+use Yoast\WP\SEO\Helpers\Input_Helper;
+use Yoast\WP\SEO\Helpers\Redirect_Helper;
 
 /**
  * Adds hooks for the Yoast Form.
@@ -18,7 +20,7 @@ class Options_Form_Integration implements Integration_Interface {
 	 *
 	 * @var string
 	 */
-	const SET_OPTIONS_ACTION = 'yoast_handle_set_options';
+	const SET_OPTIONS_ACTION = 'yoast_set_options';
 
 	/**
 	 * Holds the options action instance.
@@ -35,14 +37,37 @@ class Options_Form_Integration implements Integration_Interface {
 	protected $capability_helper;
 
 	/**
+	 * Holds the input helper instance.
+	 *
+	 * @var Input_Helper
+	 */
+	protected $input_helper;
+
+	/**
+	 * Holds the redirect helper instance.
+	 *
+	 * @var Redirect_Helper
+	 */
+	protected $redirect_helper;
+
+	/**
 	 * Constructs the options integration.
 	 *
 	 * @param Options_Action    $options_action    The options action.
 	 * @param Capability_Helper $capability_helper The capability helper.
+	 * @param Input_Helper      $input_helper      The input helper.
+	 * @param Redirect_Helper   $redirect_helper   The redirect helper.
 	 */
-	public function __construct( Options_Action $options_action, Capability_Helper $capability_helper ) {
+	public function __construct(
+		Options_Action $options_action,
+		Capability_Helper $capability_helper,
+		Input_Helper $input_helper,
+		Redirect_Helper $redirect_helper
+	) {
 		$this->options_action    = $options_action;
 		$this->capability_helper = $capability_helper;
+		$this->input_helper      = $input_helper;
+		$this->redirect_helper   = $redirect_helper;
 	}
 
 	/**
@@ -51,54 +76,43 @@ class Options_Form_Integration implements Integration_Interface {
 	 * @return void
 	 */
 	public function register_hooks() {
-		\add_action( 'admin_action_' . self::SET_OPTIONS_ACTION, [ $this, 'handle_update_options_request' ] );
+		\add_action( 'admin_action_' . self::SET_OPTIONS_ACTION, [ $this, 'handle_set_options_request' ] );
 	}
 
 	/**
-	 * Handles a request to update plugin network options.
+	 * Handles a request to set plugin options.
 	 *
-	 * This method works similar to how option updates are handled in `wp-admin/options.php` and
-	 * `wp-admin/network/settings.php`.
+	 * Heavy inspiration from Yoast_Network_Admin.
 	 *
 	 * @return void
 	 */
-	public function handle_update_options_request() {
-		$option = \filter_input( INPUT_POST, 'option', FILTER_SANITIZE_STRING );
-
+	public function handle_set_options_request() {
+		$option = $this->input_helper->filter( \INPUT_POST, 'option', \FILTER_SANITIZE_STRING, \FILTER_NULL_ON_FAILURE );
 		$this->verify_request( self::SET_OPTIONS_ACTION . ":$option" );
+		$values = $this->input_helper->filter( \INPUT_POST, $option, \FILTER_SANITIZE_STRING, ( \FILTER_REQUIRE_ARRAY | \FILTER_NULL_ON_FAILURE ) );
+		if ( $values === null ) {
+			\add_settings_error( 'wpseo_options', 'settings_error', \__( 'Please provide settings to save.', 'wordpress-seo' ), 'error' );
+			$this->terminate_request();
 
-		$value = null;
-		// phpcs:disable WordPress.Security.NonceVerification -- Nonce verified via `verify_request()` above.
-		if ( isset( $_POST[ $option ] ) ) {
-			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput -- Reason: Sanitized below.
-			$value = \wp_unslash( $_POST[ $option ] );
-			if ( \is_string( $value ) ) {
-				$value = \sanitize_text_field( $value );
-			}
-			else {
-				foreach ( $value as $key => $val ) {
-					$value[ \sanitize_key( $key ) ] = \sanitize_text_field( $val );
-				}
-			}
+			return;
 		}
-		// phpcs:enable WordPress.Security.NonceVerification
 
-		$result = $this->options_action->set( $value );
+		$result = $this->options_action->set( $values );
 		if ( ! $result['success'] ) {
 			\add_settings_error( 'wpseo_options', 'settings_save_error', $result['error'], 'error' );
 			if ( \array_key_exists( 'field_errors', $result ) ) {
-				foreach ( $result['field_errors'] as $option => $field_exception ) {
-					\add_settings_error( 'wpseo_options', $option, $field_exception, 'error' );
+				foreach ( $result['field_errors'] as $key => $field_exception ) {
+					\add_settings_error( 'wpseo_options', $key, $field_exception, 'error' );
 				}
 			}
 		}
 
 		$settings_errors = \get_settings_errors();
 		if ( empty( $settings_errors ) ) {
-			\add_settings_error( $option, 'settings_updated', __( 'Settings Updated.', 'wordpress-seo' ), 'updated' );
+			\add_settings_error( $option, 'settings_updated', \__( 'Settings Updated.', 'wordpress-seo' ), 'updated' );
 		}
 
-		$this->redirect_back( [ 'settings-updated' => 'true' ] );
+		$this->terminate_request( [ 'settings-updated' => 'true' ] );
 	}
 
 	/**
@@ -112,11 +126,60 @@ class Options_Form_Integration implements Integration_Interface {
 	public function verify_request( $action, $query_arg = '_wpnonce' ) {
 		$has_access = $this->capability_helper->current_user_can( 'wpseo_manage_options' );
 
+		if ( \wp_doing_ajax() ) {
+			\check_ajax_referer( $action, $query_arg );
+
+			if ( ! $has_access ) {
+				\wp_die( -1, 403 );
+			}
+
+			return;
+		}
+
 		\check_admin_referer( $action, $query_arg );
 
 		if ( ! $has_access ) {
 			\wp_die( \esc_html__( 'You are not allowed to perform this action.', 'wordpress-seo' ) );
 		}
+	}
+
+	/**
+	 * Terminates the current request by either redirecting back or sending an AJAX response.
+	 *
+	 * @param array $query_args Optional. Query arguments to add to the redirect URL. Default none.
+	 *
+	 * @return void
+	 */
+	public function terminate_request( $query_args = [] ) {
+		if ( \wp_doing_ajax() ) {
+			$settings_errors = \get_settings_errors();
+
+			if ( ! empty( $settings_errors ) && $settings_errors[0]['type'] === 'updated' ) {
+				\wp_send_json_success( $settings_errors, 200 );
+			}
+
+			\wp_send_json_error( $settings_errors, 400 );
+		}
+
+		$this->persist_settings_errors();
+		$this->redirect_back( $query_args );
+	}
+
+	/**
+	 * Persists settings errors.
+	 *
+	 * Settings errors are stored in a transient for 30 seconds so that this transient
+	 * can be retrieved on the next page load.
+	 *
+	 * @return void
+	 */
+	protected function persist_settings_errors() {
+		/*
+		 * A regular transient is used here, since it is automatically cleared right after the redirect.
+		 * A network transient would be cleaner, but would require a lot of copied code from core for
+		 * just a minor adjustment when displaying settings errors.
+		 */
+		\set_transient( 'settings_errors', \get_settings_errors(), 30 );
 	}
 
 	/**
@@ -133,7 +196,6 @@ class Options_Form_Integration implements Integration_Interface {
 			$sendback = \add_query_arg( $query_args, $sendback );
 		}
 
-		\wp_safe_redirect( $sendback );
-		exit;
+		$this->redirect_helper->do_safe_redirect( $sendback );
 	}
 }

--- a/src/routes/network-admin-options-route.php
+++ b/src/routes/network-admin-options-route.php
@@ -15,11 +15,18 @@ use Yoast\WP\SEO\Main;
 class Network_Admin_Options_Route implements Route_Interface {
 
 	/**
-	 * Holds the options route.
+	 * Holds the network admin options route.
 	 *
 	 * @var string
 	 */
 	const ROUTE = 'network-admin-options';
+
+	/**
+	 * Holds the full network admin options route.
+	 *
+	 * @var string
+	 */
+	const FULL_ROUTE = Main::API_V1_NAMESPACE . '/' . self::ROUTE;
 
 	/**
 	 * Holds the Network_Admin_Options_Action instance.

--- a/src/routes/network-admin-options-route.php
+++ b/src/routes/network-admin-options-route.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Yoast\WP\SEO\Routes;
+
+use WP_REST_Request;
+use WP_REST_Response;
+use Yoast\WP\SEO\Actions\Options\Network_Admin_Options_Action;
+use Yoast\WP\SEO\Conditionals\Multisite_Conditional;
+use Yoast\WP\SEO\Helpers\Capability_Helper;
+use Yoast\WP\SEO\Main;
+
+/**
+ * Network_Admin_Options_Route class.
+ */
+class Network_Admin_Options_Route implements Route_Interface {
+
+	/**
+	 * Holds the options route.
+	 *
+	 * @var string
+	 */
+	const ROUTE = 'network-admin-options';
+
+	/**
+	 * Holds the Network_Admin_Options_Action instance.
+	 *
+	 * @var Network_Admin_Options_Action
+	 */
+	protected $network_admin_options_action;
+
+	/**
+	 * Holds the Capability_Helper instance.
+	 *
+	 * @var Capability_Helper
+	 */
+	protected $capability_helper;
+
+	/**
+	 * Constructs a Network_Admin_Options_Route instance.
+	 *
+	 * @param Network_Admin_Options_Action $network_admin_options_action The Network_Admin_Options_Action instance.
+	 * @param Capability_Helper            $capability_helper            The Capability_Helper instance.
+	 */
+	public function __construct( Network_Admin_Options_Action $network_admin_options_action, Capability_Helper $capability_helper ) {
+		$this->network_admin_options_action = $network_admin_options_action;
+		$this->capability_helper            = $capability_helper;
+	}
+
+	/**
+	 * Returns the conditionals based on which this loadable should be active.
+	 *
+	 * @return array
+	 */
+	public static function get_conditionals() {
+		return [ Multisite_Conditional::class ];
+	}
+
+	/**
+	 * Registers routes with WordPress.
+	 *
+	 * @return void
+	 */
+	public function register_routes() {
+		\register_rest_route(
+			Main::API_V1_NAMESPACE,
+			self::ROUTE,
+			[
+				[
+					'methods'             => 'GET',
+					'callback'            => [ $this, 'get' ],
+					'permission_callback' => [ $this, 'can_get' ],
+				],
+				[
+					'methods'             => 'POST',
+					'callback'            => [ $this, 'set' ],
+					'permission_callback' => [ $this, 'can_set' ],
+				],
+			]
+		);
+	}
+
+	/**
+	 * Retrieves the requested options.
+	 *
+	 * @return WP_REST_Response The get response.
+	 */
+	public function get( WP_REST_Request $request ) {
+		$keys   = \array_keys( $request->get_params() );
+		$result = $this->network_admin_options_action->get( $keys );
+
+		return new WP_REST_Response( $result, 200 );
+	}
+
+	/**
+	 * Sets the options.
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 *
+	 * @return WP_REST_Response The set response.
+	 */
+	public function set( WP_REST_Request $request ) {
+		$options = $request->get_params();
+		$result  = $this->network_admin_options_action->set( $options );
+
+		if ( $result['success'] ) {
+			return new WP_REST_Response( $result, 200 );
+		}
+
+		return new WP_REST_Response( $result, 400 );
+	}
+
+	/**
+	 * Whether the current user is allowed to get.
+	 *
+	 * @return bool Whether the current user is allowed to get.
+	 */
+	public function can_get() {
+		return $this->capability_helper->current_user_can( 'read' );
+	}
+
+	/**
+	 * Whether the current user is allowed to set.
+	 *
+	 * @return bool Whether the current user is allowed to set.
+	 */
+	public function can_set() {
+		return $this->capability_helper->current_user_can( 'wpseo_manage_options' );
+	}
+}

--- a/src/routes/network-admin-options-route.php
+++ b/src/routes/network-admin-options-route.php
@@ -31,6 +31,13 @@ class Network_Admin_Options_Route implements Route_Interface {
 	const FULL_ROUTE = Main::API_V1_NAMESPACE . '/' . self::ROUTE;
 
 	/**
+	 * Holds the request argument name.
+	 *
+	 * @var string
+	 */
+	const ARGUMENT_NAME = 'options';
+
+	/**
 	 * Holds the Network_Admin_Options_Action instance.
 	 *
 	 * @var Network_Admin_Options_Action
@@ -78,6 +85,11 @@ class Network_Admin_Options_Route implements Route_Interface {
 					'methods'             => 'GET',
 					'callback'            => [ $this, 'get' ],
 					'permission_callback' => [ $this, 'can_get' ],
+					'args'                => [
+						self::ARGUMENT_NAME => [
+							'required' => false,
+						],
+					],
 				],
 				[
 					'methods'             => 'POST',
@@ -96,8 +108,12 @@ class Network_Admin_Options_Route implements Route_Interface {
 	 * @return WP_REST_Response The get response.
 	 */
 	public function get( WP_REST_Request $request ) {
-		$keys   = \array_keys( $request->get_params() );
-		$result = $this->network_admin_options_action->get( $keys );
+		$options = $request->get_param( self::ARGUMENT_NAME );
+		if ( $options === null ) {
+			// Change to requesting all options if no specific option was requested.
+			$options = [];
+		}
+		$result = $this->network_admin_options_action->get( $options );
 
 		return new WP_REST_Response( $result, 200 );
 	}
@@ -126,7 +142,7 @@ class Network_Admin_Options_Route implements Route_Interface {
 	 * @return bool Whether the current user is allowed to get.
 	 */
 	public function can_get() {
-		return $this->capability_helper->current_user_can( 'read' );
+		return $this->capability_helper->current_user_can( 'wpseo_manage_network_options' );
 	}
 
 	/**
@@ -135,6 +151,6 @@ class Network_Admin_Options_Route implements Route_Interface {
 	 * @return bool Whether the current user is allowed to set.
 	 */
 	public function can_set() {
-		return $this->capability_helper->current_user_can( 'wpseo_manage_options' );
+		return $this->capability_helper->current_user_can( 'wpseo_manage_network_options' );
 	}
 }

--- a/src/routes/network-admin-options-route.php
+++ b/src/routes/network-admin-options-route.php
@@ -11,6 +11,8 @@ use Yoast\WP\SEO\Main;
 
 /**
  * Network_Admin_Options_Route class.
+ *
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded -- Route should not count.
  */
 class Network_Admin_Options_Route implements Route_Interface {
 
@@ -88,6 +90,8 @@ class Network_Admin_Options_Route implements Route_Interface {
 
 	/**
 	 * Retrieves the requested options.
+	 *
+	 * @param WP_REST_Request $request The request.
 	 *
 	 * @return WP_REST_Response The get response.
 	 */

--- a/src/routes/options-route.php
+++ b/src/routes/options-route.php
@@ -24,6 +24,13 @@ class Options_Route implements Route_Interface {
 	const ROUTE = 'options';
 
 	/**
+	 * Holds the full options route.
+	 *
+	 * @var string
+	 */
+	const FULL_ROUTE = Main::API_V1_NAMESPACE . '/' . self::ROUTE;
+
+	/**
 	 * Holds the Options_Action instance.
 	 *
 	 * @var Options_Action

--- a/src/routes/options-route.php
+++ b/src/routes/options-route.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Yoast\WP\SEO\Routes;
+
+use WP_REST_Request;
+use WP_REST_Response;
+use Yoast\WP\SEO\Actions\Options\Options_Action;
+use Yoast\WP\SEO\Conditionals\No_Conditionals;
+use Yoast\WP\SEO\Helpers\Capability_Helper;
+use Yoast\WP\SEO\Main;
+
+/**
+ * Options_Route class.
+ */
+class Options_Route implements Route_Interface {
+
+	use No_Conditionals;
+
+	/**
+	 * Holds the options route.
+	 *
+	 * @var string
+	 */
+	const ROUTE = 'options';
+
+	/**
+	 * Holds the Options_Action instance.
+	 *
+	 * @var Options_Action
+	 */
+	protected $options_action;
+
+	/**
+	 * Holds the Capability_Helper instance.
+	 *
+	 * @var Capability_Helper
+	 */
+	protected $capability_helper;
+
+	/**
+	 * Constructs an Options_Route instance.
+	 *
+	 * @param Options_Action    $options_action    The Options_Action instance.
+	 * @param Capability_Helper $capability_helper The Capability_Helper instance.
+	 */
+	public function __construct( Options_Action $options_action, Capability_Helper $capability_helper ) {
+		$this->options_action    = $options_action;
+		$this->capability_helper = $capability_helper;
+	}
+
+	/**
+	 * Registers routes with WordPress.
+	 *
+	 * @return void
+	 */
+	public function register_routes() {
+		\register_rest_route(
+			Main::API_V1_NAMESPACE,
+			self::ROUTE,
+			[
+				[
+					'methods'             => 'GET',
+					'callback'            => [ $this, 'get' ],
+					'permission_callback' => [ $this, 'can_get' ],
+				],
+				[
+					'methods'             => 'POST',
+					'callback'            => [ $this, 'set' ],
+					'permission_callback' => [ $this, 'can_set' ],
+				],
+			]
+		);
+	}
+
+	/**
+	 * Retrieves the requested options.
+	 *
+	 * @return WP_REST_Response the registered options.
+	 */
+	public function get( WP_REST_Request $request ) {
+		$keys   = \array_keys( $request->get_params() );
+		$result = $this->options_action->get( $keys );
+
+		return new WP_REST_Response( $result, 200 );
+	}
+
+	/**
+	 * Sets the options.
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 *
+	 * @return WP_REST_Response the set options.
+	 */
+	public function set( WP_REST_Request $request ) {
+		$options = $request->get_params();
+		$result  = $this->options_action->set( $options );
+
+		if ( $result['success'] ) {
+			return new WP_REST_Response( $result, 200 );
+		}
+
+		return new WP_REST_Response( $result, 400 );
+	}
+
+	/**
+	 * Whether the current user is allowed to get.
+	 *
+	 * @return bool Whether the current user is allowed to get.
+	 */
+	public function can_get() {
+		return $this->capability_helper->current_user_can( 'read' );
+	}
+
+	/**
+	 * Whether the current user is allowed to set.
+	 *
+	 * @return bool Whether the current user is allowed to set.
+	 */
+	public function can_set() {
+		return $this->capability_helper->current_user_can( 'wpseo_manage_options' );
+	}
+}

--- a/src/routes/options-route.php
+++ b/src/routes/options-route.php
@@ -82,6 +82,8 @@ class Options_Route implements Route_Interface {
 	/**
 	 * Retrieves the requested options.
 	 *
+	 * @param WP_REST_Request $request The request.
+	 *
 	 * @return WP_REST_Response the registered options.
 	 */
 	public function get( WP_REST_Request $request ) {

--- a/src/routes/options-route.php
+++ b/src/routes/options-route.php
@@ -31,6 +31,13 @@ class Options_Route implements Route_Interface {
 	const FULL_ROUTE = Main::API_V1_NAMESPACE . '/' . self::ROUTE;
 
 	/**
+	 * Holds the request argument name.
+	 *
+	 * @var string
+	 */
+	const ARGUMENT_NAME = 'options';
+
+	/**
 	 * Holds the Options_Action instance.
 	 *
 	 * @var Options_Action
@@ -69,6 +76,11 @@ class Options_Route implements Route_Interface {
 					'methods'             => 'GET',
 					'callback'            => [ $this, 'get' ],
 					'permission_callback' => [ $this, 'can_get' ],
+					'args'                => [
+						self::ARGUMENT_NAME => [
+							'required' => false,
+						],
+					],
 				],
 				[
 					'methods'             => 'POST',
@@ -87,8 +99,12 @@ class Options_Route implements Route_Interface {
 	 * @return WP_REST_Response the registered options.
 	 */
 	public function get( WP_REST_Request $request ) {
-		$keys   = \array_keys( $request->get_params() );
-		$result = $this->options_action->get( $keys );
+		$options = $request->get_param( self::ARGUMENT_NAME );
+		if ( $options === null ) {
+			// Change to requesting all options if no specific option was requested.
+			$options = [];
+		}
+		$result = $this->options_action->get( $options );
 
 		return new WP_REST_Response( $result, 200 );
 	}

--- a/src/services/options/abstract-options-service.php
+++ b/src/services/options/abstract-options-service.php
@@ -138,14 +138,7 @@ abstract class Abstract_Options_Service {
 	 * @throws Save_Failed_Exception When the save failed.
 	 */
 	public function __set( $key, $value ) {
-		$valid_value = $this->validate( $key, $value );
-
-		// Only update when changed.
-		if ( $valid_value === $value ) {
-			return;
-		}
-
-		$this->update_option( $key, $valid_value );
+		$this->update_option( $key, $this->validate( $key, $value ) );
 	}
 
 	/**

--- a/src/services/options/abstract-options-service.php
+++ b/src/services/options/abstract-options-service.php
@@ -138,25 +138,43 @@ abstract class Abstract_Options_Service {
 	 * @throws Save_Failed_Exception When the save failed.
 	 */
 	public function __set( $key, $value ) {
+		$valid_value = $this->validate( $key, $value );
+
+		// Only update when changed.
+		if ( $valid_value === $value ) {
+			return;
+		}
+
+		$this->update_option( $key, $valid_value );
+	}
+
+	/**
+	 * Validates the option value.
+	 *
+	 * @param string $key   The option key.
+	 * @param mixed  $value The option value.
+	 *
+	 * @throws Unknown_Exception When the option does not exist.
+	 * @throws \Yoast\WP\SEO\Exceptions\Validation\Abstract_Validation_Exception When the value is invalid.
+	 *
+	 * @return mixed The valid option value.
+	 */
+	public function validate( $key, $value ) {
 		if ( ! \array_key_exists( $key, $this->get_configurations() ) ) {
 			throw Unknown_Exception::for_option( $key );
 		}
 
 		// Presuming the default is safe.
 		if ( $value === $this->get_configurations()[ $key ]['default'] ) {
-			$this->update_option( $key, $value );
-
-			return;
+			return $value;
 		}
-		// Only update when changed.
+		// Only validate when changed.
 		if ( $value === $this->get_values()[ $key ] ) {
-			return;
+			return $value;
 		}
 
 		// Validate, this can throw a Validation_Exception.
-		$value = $this->validation_helper->validate_as( $value, $this->get_configurations()[ $key ]['types'] );
-
-		$this->update_option( $key, $value );
+		return $this->validation_helper->validate_as( $value, $this->get_configurations()[ $key ]['types'] );
 	}
 
 	// phpcs:enable Squiz.Commenting.FunctionCommentThrowTag.WrongNumber

--- a/src/services/options/abstract-options-service.php
+++ b/src/services/options/abstract-options-service.php
@@ -197,6 +197,8 @@ abstract class Abstract_Options_Service {
 		);
 	}
 
+	// phpcs:disable Squiz.Commenting.FunctionCommentThrowTag.WrongNumber -- PHPCS doesn't take into account exceptions thrown in called methods.
+
 	/**
 	 * Sets the options.
 	 *
@@ -238,6 +240,8 @@ abstract class Abstract_Options_Service {
 			throw new Form_Invalid_Exception( $exceptions );
 		}
 	}
+
+	// phpcs:enable Squiz.Commenting.FunctionCommentThrowTag.WrongNumber
 
 	/**
 	 * Saves the options if the database row does not exist.

--- a/src/services/options/site-options-service.php
+++ b/src/services/options/site-options-service.php
@@ -754,6 +754,10 @@ class Site_Options_Service extends Abstract_Options_Service {
 			'default' => [ 'configuration' => [ 'finishedSteps' => [] ] ],
 			'types'   => [ 'string' ],
 		],
+		'configuration_finished_steps'                               => [
+			'default' => [],
+			'types'   => [ 'string' ],
+		],
 		'yandexverify'                                => [
 			'default' => '',
 			'types'   => [

--- a/src/services/options/site-options-service.php
+++ b/src/services/options/site-options-service.php
@@ -483,8 +483,9 @@ class Site_Options_Service extends Abstract_Options_Service {
 
 		// WPSEO.
 		'algolia_integration_active'                  => [
-			'default' => false,
-			'types'   => [ 'boolean' ],
+			'default'   => false,
+			'types'     => [ 'boolean' ],
+			'ms_verify' => false,
 		],
 		'baiduverify'                                 => [
 			'default' => '',
@@ -754,7 +755,7 @@ class Site_Options_Service extends Abstract_Options_Service {
 			'default' => [ 'configuration' => [ 'finishedSteps' => [] ] ],
 			'types'   => [ 'string' ],
 		],
-		'configuration_finished_steps'                               => [
+		'configuration_finished_steps'                => [
 			'default' => [],
 			'types'   => [ 'string' ],
 		],

--- a/src/services/options/site-options-service.php
+++ b/src/services/options/site-options-service.php
@@ -76,11 +76,12 @@ class Site_Options_Service extends Abstract_Options_Service {
 			'types'   => [ 'empty_string', 'url' ],
 		],
 		'pinterestverify'                             => [
-			'default' => '',
-			'types'   => [
+			'default'    => '',
+			'types'      => [
 				'empty_string',
 				'verification' => [ 'pattern' => '`^[A-Fa-f0-9_-]+$`' ],
 			],
+			'ms_exclude' => true,
 		],
 		'twitter'                                     => [
 			'default' => true,
@@ -488,11 +489,12 @@ class Site_Options_Service extends Abstract_Options_Service {
 			'ms_verify' => false,
 		],
 		'baiduverify'                                 => [
-			'default' => '',
-			'types'   => [
+			'default'    => '',
+			'types'      => [
 				'empty_string',
 				'verification' => [ 'pattern' => '`^[A-Za-z0-9_-]+$`' ],
 			],
+			'ms_exclude' => true,
 		],
 		'category_base_url'                           => [
 			'default' => '',
@@ -583,11 +585,12 @@ class Site_Options_Service extends Abstract_Options_Service {
 			'types'   => [ 'boolean' ],
 		],
 		'googleverify'                                => [
-			'default' => '',
-			'types'   => [
+			'default'    => '',
+			'types'      => [
 				'empty_string',
 				'verification' => [ 'pattern' => '`^[A-Za-z0-9_-]+$`' ],
 			],
+			'ms_exclude' => true,
 		],
 		'has_multiple_authors'                        => [
 			'default' => '',
@@ -645,11 +648,12 @@ class Site_Options_Service extends Abstract_Options_Service {
 			'types'   => [ 'boolean' ],
 		],
 		'msverify'                                    => [
-			'default' => '',
-			'types'   => [
+			'default'    => '',
+			'types'      => [
 				'empty_string',
 				'verification' => [ 'pattern' => '`^[A-Fa-f0-9_-]+$`' ],
 			],
+			'ms_exclude' => true,
 		],
 		'myyoast-oauth'                               => [
 			'default' => [
@@ -764,11 +768,12 @@ class Site_Options_Service extends Abstract_Options_Service {
 			'types'   => [ 'json-text-fields' ],
 		],
 		'yandexverify'                                => [
-			'default' => '',
-			'types'   => [
+			'default'    => '',
+			'types'      => [
 				'empty_string',
 				'verification' => [ 'pattern' => '`^[A-Fa-f0-9_-]+$`' ],
 			],
+			'ms_exclude' => true,
 		],
 		'zapier_api_key'                              => [
 			'default' => '',

--- a/src/services/options/site-options-service.php
+++ b/src/services/options/site-options-service.php
@@ -753,11 +753,15 @@ class Site_Options_Service extends Abstract_Options_Service {
 		],
 		'workouts_data'                               => [
 			'default' => [ 'configuration' => [ 'finishedSteps' => [] ] ],
-			'types'   => [ 'string' ],
+			'types'   => [ 'array' ],
 		],
 		'configuration_finished_steps'                => [
 			'default' => [],
-			'types'   => [ 'string' ],
+			'types'   => [ 'array' ],
+		],
+		'other_social_urls'                           => [
+			'default' => [],
+			'types'   => [ 'json-text-fields' ],
 		],
 		'yandexverify'                                => [
 			'default' => '',

--- a/src/services/options/taxonomy-metadata-service.php
+++ b/src/services/options/taxonomy-metadata-service.php
@@ -220,7 +220,7 @@ class Taxonomy_Metadata_Service extends Abstract_Options_Service {
 	 *
 	 * @return void
 	 */
-	public function set_options( $term, $taxonomy, $values ) {
+	public function set_term_options( $term, $taxonomy, $values ) {
 		$term_id = $this->get_term_id( $term, $taxonomy );
 		if ( $term_id === null ) {
 			throw Term_Not_Found_Exception::for_term( $term, $taxonomy );

--- a/src/services/options/taxonomy-metadata-service.php
+++ b/src/services/options/taxonomy-metadata-service.php
@@ -134,6 +134,17 @@ class Taxonomy_Metadata_Service extends Abstract_Options_Service {
 	}
 
 	/**
+	 * Sets the options.
+	 *
+	 * @param array $values The option values.
+	 *
+	 * @throws Method_Unimplemented_Exception Always, use set_term_options instead.
+	 */
+	public function set_options( array $values ) {
+		throw Method_Unimplemented_Exception::for_method( __METHOD__, __CLASS__ );
+	}
+
+	/**
 	 * Retrieves the option/metadata value for a term.
 	 *
 	 * @param mixed       $term     The term name, (int) term id or (object) term.

--- a/tests/integration/admin/test-class-option-tab.php
+++ b/tests/integration/admin/test-class-option-tab.php
@@ -33,28 +33,6 @@ class WPSEO_Option_Tab_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	 * Tests that the option group is returned properly.
-	 *
-	 * @covers WPSEO_Option_Tab::get_opt_group
-	 */
-	public function test_get_opt_group() {
-		$option_tab = new WPSEO_Option_Tab( 'name', 'label', [ 'opt_group' => 'opt_group' ] );
-
-		$this->assertEquals( 'opt_group', $option_tab->get_opt_group() );
-	}
-
-	/**
-	 * Tests that the option group is empty and does not error when it is not set.
-	 *
-	 * @covers WPSEO_Option_Tab::get_opt_group
-	 */
-	public function test_get_opt_group_WHEN_opt_group_is_not_set() {
-		$option_tab = new WPSEO_Option_Tab( 'name', 'label' );
-
-		$this->assertEquals( '', $option_tab->get_opt_group() );
-	}
-
-	/**
 	 * Tests that the save button argument set to false is detected correctly.
 	 *
 	 * @covers WPSEO_Option_Tab::has_save_button

--- a/tests/integration/admin/test-class-yoast-network-admin.php
+++ b/tests/integration/admin/test-class-yoast-network-admin.php
@@ -186,7 +186,7 @@ class Yoast_Network_Admin_Test extends WPSEO_UnitTestCase {
 		$admin->settings_fields( $group );
 		$output = ob_get_clean();
 
-		$this->assertTrue( (bool) strpos( $output, 'name="network_option_group" value="' . $group . '"' ) );
+		$this->assertTrue( (bool) strpos( $output, 'name="network_option" value="' . $group . '"' ) );
 		$this->assertTrue( (bool) strpos( $output, 'name="action" value="' . Yoast_Network_Admin::UPDATE_OPTIONS_ACTION . '"' ) );
 		$this->assertTrue( (bool) preg_match( '/name="_wpnonce" value="([a-z0-9]+)"/', $output, $matches ) );
 		$this->assertTrue( (bool) wp_verify_nonce( $matches[1], $group . '-network-options' ) );

--- a/tests/unit/actions/options/network-admin-options-action-test.php
+++ b/tests/unit/actions/options/network-admin-options-action-test.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Actions\Options;
+
+use Mockery;
+use Yoast\WP\SEO\Actions\Options\Network_Admin_Options_Action;
+use Yoast\WP\SEO\Exceptions\Option\Form_Invalid_Exception;
+use Yoast\WP\SEO\Exceptions\Option\Save_Failed_Exception;
+use Yoast\WP\SEO\Exceptions\Validation\Invalid_Empty_String_Exception;
+use Yoast\WP\SEO\Services\Options\Network_Admin_Options_Service;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Class Network_Admin_Options_Action_Test.
+ *
+ * @group actions
+ * @group options
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Actions\Options\Network_Admin_Options_Action
+ *
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
+ */
+class Network_Admin_Options_Action_Test extends TestCase {
+
+	/**
+	 * Holds the instance to test.
+	 *
+	 * @var Network_Admin_Options_Action
+	 */
+	protected $instance;
+
+	/**
+	 * Holds the Network_Admin_Options_Service instance.
+	 *
+	 * @var Network_Admin_Options_Service|Mockery\MockInterface
+	 */
+	protected $network_admin_options_service;
+
+	/**
+	 * Set up the test fixtures.
+	 */
+	protected function set_up() {
+		parent::set_up();
+		$this->stubTranslationFunctions();
+		$this->stubEscapeFunctions();
+
+		$this->network_admin_options_service = Mockery::mock( Network_Admin_Options_Service::class );
+		$this->instance                      = new Network_Admin_Options_Action( $this->network_admin_options_service );
+	}
+
+	/**
+	 * Tests the attributes after constructing.
+	 *
+	 * @covers ::__construct
+	 */
+	public function test_constructor() {
+		$this->assertInstanceOf( Network_Admin_Options_Action::class, $this->instance );
+		$this->assertInstanceOf(
+			Network_Admin_Options_Service::class,
+			$this->getPropertyValue( $this->instance, 'network_admin_options_service' )
+		);
+	}
+
+	/**
+	 * Tests the get action simply refers to the network admin options service' get_options.
+	 *
+	 * @covers ::get
+	 */
+	public function test_get() {
+		$keys   = [ 'foo', 'bar' ];
+		$result = 'value';
+		$this->network_admin_options_service->expects( 'get_options' )
+			->once()
+			->with( $keys )
+			->andReturn( $result );
+
+		$this->assertSame( $result, $this->instance->get( $keys ) );
+	}
+
+	/**
+	 * Tests the set action refers to the network admin options service' set_options.
+	 *
+	 * @covers ::set
+	 * @covers ::set_options
+	 */
+	public function test_set() {
+		$options = [ 'foo' => 'bar' ];
+		$result  = [ 'success' => true ];
+		$this->network_admin_options_service->expects( 'set_options' )
+			->once()
+			->with( $options )
+			->andReturn( $result );
+
+		$this->assertSame( $result, $this->instance->set( $options ) );
+	}
+
+	/**
+	 * Tests the set action error' exception to message.
+	 *
+	 * @covers ::set
+	 * @covers ::set_options
+	 */
+	public function test_set_with_error() {
+		$options = [ 'foo' => 'bar' ];
+		$this->network_admin_options_service->expects( 'set_options' )
+			->once()
+			->with( $options )
+			->andThrow( Save_Failed_Exception::for_option( 'foo' ) );
+
+		$this->assertSame(
+			[
+				'success' => false,
+				'error'   => 'Failed to save the option (foo).',
+			],
+			$this->instance->set( $options )
+		);
+	}
+
+	/**
+	 * Tests the set action error' form exception to message.
+	 *
+	 * @covers ::set
+	 * @covers ::set_options
+	 */
+	public function test_set_with_form_error() {
+		$options = [ 'foo' => 'bar' ];
+		$this->network_admin_options_service->expects( 'set_options' )
+			->once()
+			->with( $options )
+			->andThrow( new Form_Invalid_Exception( [ 'foo' => new Invalid_Empty_String_Exception( 'bar' ) ] ) );
+
+		$this->assertSame(
+			[
+				'success'      => false,
+				'error'        => 'Form contains invalid fields.',
+				'field_errors' => [
+					'foo' => '<strong>bar</strong> is not empty.',
+				],
+			],
+			$this->instance->set( $options )
+		);
+	}
+}

--- a/tests/unit/actions/options/options-action-test.php
+++ b/tests/unit/actions/options/options-action-test.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Actions\Options;
+
+use Mockery;
+use Yoast\WP\SEO\Actions\Options\Options_Action;
+use Yoast\WP\SEO\Exceptions\Option\Form_Invalid_Exception;
+use Yoast\WP\SEO\Exceptions\Option\Save_Failed_Exception;
+use Yoast\WP\SEO\Exceptions\Validation\Invalid_Empty_String_Exception;
+use Yoast\WP\SEO\Helpers\Options_Helper;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Class Options_Action_Test.
+ *
+ * @group actions
+ * @group options
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Actions\Options\Options_Action
+ */
+class Options_Action_Test extends TestCase {
+
+	/**
+	 * Holds the instance to test.
+	 *
+	 * @var Options_Action
+	 */
+	protected $instance;
+
+	/**
+	 * Holds the Options_Helper instance.
+	 *
+	 * @var Options_Helper|Mockery\MockInterface
+	 */
+	protected $options_helper;
+
+	/**
+	 * Set up the test fixtures.
+	 */
+	protected function set_up() {
+		parent::set_up();
+		$this->stubTranslationFunctions();
+		$this->stubEscapeFunctions();
+
+		$this->options_helper = Mockery::mock( Options_Helper::class );
+		$this->instance       = new Options_Action( $this->options_helper );
+	}
+
+	/**
+	 * Tests the attributes after constructing.
+	 *
+	 * @covers ::__construct
+	 */
+	public function test_constructor() {
+		$this->assertInstanceOf( Options_Action::class, $this->instance );
+		$this->assertInstanceOf(
+			Options_Helper::class,
+			$this->getPropertyValue( $this->instance, 'options_helper' )
+		);
+	}
+
+	/**
+	 * Tests the get action simply refers to the options helper' get_options.
+	 *
+	 * @covers ::get
+	 */
+	public function test_get() {
+		$keys   = [ 'foo', 'bar' ];
+		$result = 'value';
+		$this->options_helper->expects( 'get_options' )
+			->once()
+			->with( $keys )
+			->andReturn( $result );
+
+		$this->assertSame( $result, $this->instance->get( $keys ) );
+	}
+
+	/**
+	 * Tests the set action refers to the options helper' set_options.
+	 *
+	 * @covers ::set
+	 */
+	public function test_set() {
+		$options = [ 'foo' => 'bar' ];
+		$result  = [ 'success' => true ];
+		$this->options_helper->expects( 'set_options' )
+			->once()
+			->with( $options )
+			->andReturn( $result );
+
+		$this->assertSame( $result, $this->instance->set( $options ) );
+	}
+
+	/**
+	 * Tests the set action error' exception to message.
+	 *
+	 * @covers ::set
+	 */
+	public function test_set_with_error() {
+		$options = [ 'foo' => 'bar' ];
+		$this->options_helper->expects( 'set_options' )
+			->once()
+			->with( $options )
+			->andReturn(
+				[
+					'success' => false,
+					'error'   => Save_Failed_Exception::for_option( 'foo' ),
+				]
+			);
+
+		$this->assertSame(
+			[
+				'success' => false,
+				'error'   => 'Failed to save the option (foo).',
+			],
+			$this->instance->set( $options )
+		);
+	}
+
+	/**
+	 * Tests the set action error' form exception to message.
+	 *
+	 * @covers ::set
+	 */
+	public function test_set_with_form_error() {
+		$options = [ 'foo' => 'bar' ];
+		$this->options_helper->expects( 'set_options' )
+			->once()
+			->with( $options )
+			->andReturn(
+				[
+					'success' => false,
+					'error'   => new Form_Invalid_Exception( [ 'foo' => new Invalid_Empty_String_Exception( 'bar' ) ] ),
+				]
+			);
+
+		$this->assertSame(
+			[
+				'success'      => false,
+				'error'        => 'Form contains invalid fields.',
+				'field_errors' => [
+					'foo' => '<strong>bar</strong> is not empty.',
+				],
+			],
+			$this->instance->set( $options )
+		);
+	}
+}

--- a/tests/unit/helpers/options-helper-test.php
+++ b/tests/unit/helpers/options-helper-test.php
@@ -218,6 +218,12 @@ class Options_Helper_Test extends TestCase {
 			->with( 'twitter_site', 'yoast' )
 			->andReturn( 'yoast' );
 
+		$this->site_options_service->expects( 'get_defaults' )->andReturn( [ 'twitter_site' => '' ] );
+
+		Monkey\Functions\expect( 'update_option' )
+			->once()
+			->andReturn( true );
+
 		$this->assertTrue( $this->instance->set( 'twitter_site', 'yoast' ) );
 	}
 

--- a/tests/unit/helpers/options-helper-test.php
+++ b/tests/unit/helpers/options-helper-test.php
@@ -212,24 +212,11 @@ class Options_Helper_Test extends TestCase {
 	 */
 	public function test_set() {
 		$this->site_helper->expects( 'is_multisite' )->andReturn( false );
-		$this->site_options_service->expects( 'get_configurations' )
-			->times( 3 )
-			->andReturn(
-				[
-					'twitter_site' => [
-						'default' => '',
-						'types'   => [
-							'empty_string',
-							'twitter_username',
-						],
-					],
-				]
-			);
 
-		Monkey\Functions\expect( 'update_option' )->once()->andReturn( true );
-
-		$this->site_options_service->expects( 'get_defaults' )->andReturn( [ 'twitter_site' => '' ] );
-		$this->validation_helper->expects( 'validate_as' )->andReturn( 'yoast' );
+		$this->site_options_service->expects( 'validate' )
+			->once()
+			->with( 'twitter_site', 'yoast' )
+			->andReturn( 'yoast' );
 
 		$this->assertTrue( $this->instance->set( 'twitter_site', 'yoast' ) );
 	}
@@ -243,7 +230,11 @@ class Options_Helper_Test extends TestCase {
 	 */
 	public function test_set_catch_unknown() {
 		$this->site_helper->expects( 'is_multisite' )->andReturn( false );
-		$this->site_options_service->expects( 'get_configurations' )->andReturn( [] );
+
+		$this->site_options_service->expects( 'validate' )
+			->once()
+			->with( 'unknown', '' )
+			->andThrow( Unknown_Exception::class );
 
 		$this->assertFalse( $this->instance->set( 'unknown', '' ) );
 	}
@@ -257,23 +248,11 @@ class Options_Helper_Test extends TestCase {
 	 */
 	public function test_set_catch_validation() {
 		$this->site_helper->expects( 'is_multisite' )->andReturn( false );
-		$this->site_options_service->expects( 'get_configurations' )
-			->times( 3 )
-			->andReturn(
-				[
-					'twitter_site' => [
-						'default' => '',
-						'types'   => [
-							'empty_string',
-							'twitter_username',
-						],
-					],
-				]
-			);
 
-		$this->site_options_service->expects( 'get_defaults' )->andReturn( [ 'twitter_site' => '' ] );
-		$this->validation_helper->expects( 'validate_as' )
-			->andThrows( Invalid_Twitter_Username_Exception::class );
+		$this->site_options_service->expects( 'validate' )
+			->once()
+			->with( 'twitter_site', '#yoast' )
+			->andThrow( Invalid_Twitter_Username_Exception::class );
 
 		$this->assertFalse( $this->instance->set( 'twitter_site', '#yoast' ) );
 	}
@@ -287,24 +266,11 @@ class Options_Helper_Test extends TestCase {
 	 */
 	public function test_set_catch_save_failed() {
 		$this->site_helper->expects( 'is_multisite' )->andReturn( false );
-		$this->site_options_service->expects( 'get_configurations' )
-			->times( 3 )
-			->andReturn(
-				[
-					'twitter_site' => [
-						'default' => '',
-						'types'   => [
-							'empty_string',
-							'twitter_username',
-						],
-					],
-				]
-			);
 
-		Monkey\Functions\expect( 'update_option' )->once()->andReturn( false );
-
-		$this->site_options_service->expects( 'get_defaults' )->andReturn( [ 'twitter_site' => '' ] );
-		$this->validation_helper->expects( 'validate_as' )->andReturn( 'yoast' );
+		$this->site_options_service->expects( 'validate' )
+			->once()
+			->with( 'twitter_site', 'yoast' )
+			->andThrow( Save_Failed_Exception::class );
 
 		$this->assertFalse( $this->instance->set( 'twitter_site', 'yoast' ) );
 	}

--- a/tests/unit/helpers/options-helper-test.php
+++ b/tests/unit/helpers/options-helper-test.php
@@ -310,6 +310,48 @@ class Options_Helper_Test extends TestCase {
 	}
 
 	/**
+	 * Tests the validation of an option: valid.
+	 *
+	 * @covers ::validate
+	 *
+	 * @return void
+	 */
+	public function test_validate() {
+		$this->site_helper->expects( 'is_multisite' )->andReturn( false );
+		$this->site_options_service->expects( 'validate' )->andReturn( 'yoast' );
+
+		$this->assertEquals( 'yoast', $this->instance->validate( 'twitter_site', 'yoast' ) );
+	}
+
+	/**
+	 * Tests the validation of an option: invalid through validation.
+	 *
+	 * @covers ::validate
+	 *
+	 * @return void
+	 */
+	public function test_validate_invalid_through_validation() {
+		$this->site_helper->expects( 'is_multisite' )->andReturn( false );
+		$this->site_options_service->expects( 'validate' )->andThrow( Invalid_Twitter_Username_Exception::class );
+
+		$this->assertEquals( Options_Helper::INVALID_VALUE, $this->instance->validate( 'twitter_site', '#yoast' ) );
+	}
+
+	/**
+	 * Tests the validation of an option: invalid because unknown.
+	 *
+	 * @covers ::validate
+	 *
+	 * @return void
+	 */
+	public function test_validate_invalid_because_unknown() {
+		$this->site_helper->expects( 'is_multisite' )->andReturn( false );
+		$this->site_options_service->expects( 'validate' )->andThrow( Unknown_Exception::class );
+
+		$this->assertEquals( Options_Helper::INVALID_VALUE, $this->instance->validate( 'foo', 'bar' ) );
+	}
+
+	/**
 	 * Tests the retrieval of a couple of options.
 	 *
 	 * @covers ::get_options

--- a/tests/unit/initializers/options-initializer-test.php
+++ b/tests/unit/initializers/options-initializer-test.php
@@ -147,22 +147,27 @@ class Options_Initializer_Test extends TestCase {
 
 		$this->site_helper->expects( 'is_multisite' )
 			->once()
+			->andReturn( true );
+
+		$network_settings = Mockery::mock( 'overload:Yoast_Network_Settings_API' );
+		$network_settings->expects( 'register_setting' )->once()->with( 'wpseo_network_admin_options', 'wpseo_network_admin_options' );
+		$network_settings->expects( 'get' )->andReturn( $network_settings );
+
+		$this->instance->register_options();
+	}
+
+	/**
+	 * Tests that the expected options are not registered when not enough capabilities.
+	 *
+	 * @covers ::register_options
+	 */
+	public function test_register_options_unallowed() {
+		$this->capability_helper->expects( 'current_user_can' )
+			->once()
+			->with( 'wpseo_manage_options' )
 			->andReturn( false );
 
-		$this->options_helper->expects( 'get_options_service' )
-			->twice()
-			->andReturn( (object) [ 'option_name' => 'wpseo_options' ] );
-
-		Monkey\Functions\expect( 'register_setting' )
-			->once()
-			->with(
-				'wpseo_options',
-				'wpseo_options',
-				[
-					'type'              => 'array',
-					'sanitize_callback' => [ $this->instance, 'sanitize_options' ],
-				]
-			);
+		$this->site_helper->expects( 'is_multisite' )->never();
 
 		$this->instance->register_options();
 	}

--- a/tests/unit/initializers/options-initializer-test.php
+++ b/tests/unit/initializers/options-initializer-test.php
@@ -4,8 +4,11 @@ namespace Yoast\WP\SEO\Tests\Unit\Initializers;
 
 use Brain\Monkey;
 use Mockery;
+use Yoast\WP\SEO\Helpers\Capability_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
+use Yoast\WP\SEO\Helpers\Site_Helper;
 use Yoast\WP\SEO\Initializers\Options_Initializer;
+use Yoast\WP\SEO\Services\Options\Network_Admin_Options_Service;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
@@ -26,6 +29,13 @@ class Options_Initializer_Test extends TestCase {
 	protected $instance;
 
 	/**
+	 * Holds the network admin options service instance.
+	 *
+	 * @var Network_Admin_Options_Service|Mockery\Mock
+	 */
+	protected $network_admin_options_service;
+
+	/**
 	 * Holds the options helper instance.
 	 *
 	 * @var Options_Helper|Mockery\Mock
@@ -33,13 +43,35 @@ class Options_Initializer_Test extends TestCase {
 	protected $options_helper;
 
 	/**
+	 * Holds the capability helper instance.
+	 *
+	 * @var Capability_Helper|Mockery\Mock
+	 */
+	protected $capability_helper;
+
+	/**
+	 * Holds the site helper instance.
+	 *
+	 * @var Site_Helper|Mockery\Mock
+	 */
+	protected $site_helper;
+
+	/**
 	 * Set up the class which will be tested.
 	 */
 	protected function set_up() {
 		parent::set_up();
 
-		$this->options_helper = Mockery::mock( Options_Helper::class );
-		$this->instance       = new Options_Initializer( $this->options_helper );
+		$this->network_admin_options_service = Mockery::mock( Network_Admin_Options_Service::class );
+		$this->options_helper                = Mockery::mock( Options_Helper::class );
+		$this->capability_helper             = Mockery::mock( Capability_Helper::class );
+		$this->site_helper                   = Mockery::mock( Site_Helper::class );
+		$this->instance                      = new Options_Initializer(
+			$this->network_admin_options_service,
+			$this->options_helper,
+			$this->capability_helper,
+			$this->site_helper
+		);
 	}
 
 	/**
@@ -50,8 +82,20 @@ class Options_Initializer_Test extends TestCase {
 	public function test_constructor() {
 		$this->assertInstanceOf( Options_Initializer::class, $this->instance );
 		$this->assertInstanceOf(
+			Network_Admin_Options_Service::class,
+			$this->getPropertyValue( $this->instance, 'network_admin_options_service' )
+		);
+		$this->assertInstanceOf(
 			Options_Helper::class,
 			$this->getPropertyValue( $this->instance, 'options_helper' )
+		);
+		$this->assertInstanceOf(
+			Capability_Helper::class,
+			$this->getPropertyValue( $this->instance, 'capability_helper' )
+		);
+		$this->assertInstanceOf(
+			Site_Helper::class,
+			$this->getPropertyValue( $this->instance, 'site_helper' )
 		);
 	}
 
@@ -83,6 +127,43 @@ class Options_Initializer_Test extends TestCase {
 			->with( [ $this->options_helper, 'clear_cache' ] )
 			->once();
 
+		Monkey\Actions\expectAdded( 'admin_init' )
+			->with( [ $this->instance, 'register_options' ] )
+			->once();
+
 		$this->instance->initialize();
+	}
+
+	/**
+	 * Tests that the expected options are registered.
+	 *
+	 * @covers ::register_options
+	 */
+	public function test_register_options() {
+		$this->capability_helper->expects( 'current_user_can' )
+			->once()
+			->with( 'wpseo_manage_options' )
+			->andReturn( true );
+
+		$this->site_helper->expects( 'is_multisite' )
+			->once()
+			->andReturn( false );
+
+		$this->options_helper->expects( 'get_options_service' )
+			->twice()
+			->andReturn( (object) [ 'option_name' => 'wpseo_options' ] );
+
+		Monkey\Functions\expect( 'register_setting' )
+			->once()
+			->with(
+				'wpseo_options',
+				'wpseo_options',
+				[
+					'type'              => 'array',
+					'sanitize_callback' => [ $this->instance, 'sanitize_options' ],
+				]
+			);
+
+		$this->instance->register_options();
 	}
 }

--- a/tests/unit/integrations/options-form-integration-test.php
+++ b/tests/unit/integrations/options-form-integration-test.php
@@ -1,0 +1,396 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Integrations;
+
+use Brain\Monkey;
+use Mockery;
+use Yoast\WP\SEO\Actions\Options\Options_Action;
+use Yoast\WP\SEO\Helpers\Capability_Helper;
+use Yoast\WP\SEO\Helpers\Input_Helper;
+use Yoast\WP\SEO\Helpers\Redirect_Helper;
+use Yoast\WP\SEO\Integrations\Options_Form_Integration;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Class Options_Form_Integration_Test.
+ *
+ * @group integrations
+ * @group options
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Integrations\Options_Form_Integration
+ */
+class Options_Form_Integration_Test extends TestCase {
+
+	/**
+	 * Holds the instance of the class being tested.
+	 *
+	 * @var Options_Form_Integration
+	 */
+	protected $instance;
+
+	/**
+	 * Holds the options action instance.
+	 *
+	 * @var Options_Action|Mockery\MockInterface
+	 */
+	protected $options_action;
+
+	/**
+	 * Holds the capability helper instance.
+	 *
+	 * @var Capability_Helper|Mockery\MockInterface
+	 */
+	protected $capability_helper;
+
+	/**
+	 * Holds the input helper instance.
+	 *
+	 * @var Input_Helper|Mockery\MockInterface
+	 */
+	protected $input_helper;
+
+	/**
+	 * Holds the redirect helper instance.
+	 *
+	 * @var Redirect_Helper|Mockery\MockInterface
+	 */
+	protected $redirect_helper;
+
+	/**
+	 * Set up the class which will be tested.
+	 */
+	protected function set_up() {
+		parent::set_up();
+		$this->stubTranslationFunctions();
+
+		$this->options_action    = Mockery::mock( Options_Action::class );
+		$this->capability_helper = Mockery::mock( Capability_Helper::class );
+		$this->input_helper      = Mockery::mock( Input_Helper::class );
+		$this->redirect_helper   = Mockery::mock( Redirect_Helper::class );
+		$this->instance          = new Options_Form_Integration( $this->options_action, $this->capability_helper, $this->input_helper, $this->redirect_helper );
+	}
+
+	/**
+	 * Tests the attributes after constructing.
+	 *
+	 * @covers ::__construct
+	 */
+	public function test_constructor() {
+		$this->assertInstanceOf( Options_Form_Integration::class, $this->instance );
+		$this->assertInstanceOf(
+			Options_Action::class,
+			$this->getPropertyValue( $this->instance, 'options_action' )
+		);
+		$this->assertInstanceOf(
+			Capability_Helper::class,
+			$this->getPropertyValue( $this->instance, 'capability_helper' )
+		);
+		$this->assertInstanceOf(
+			Input_Helper::class,
+			$this->getPropertyValue( $this->instance, 'input_helper' )
+		);
+		$this->assertInstanceOf(
+			Redirect_Helper::class,
+			$this->getPropertyValue( $this->instance, 'redirect_helper' )
+		);
+	}
+
+	/**
+	 * Tests the get_conditionals functions.
+	 *
+	 * @covers ::get_conditionals
+	 */
+	public function test_get_conditionals() {
+		$this->assertEquals( [], Options_Form_Integration::get_conditionals() );
+	}
+
+	/**
+	 * Tests that the expected hooks are registered.
+	 *
+	 * @covers ::register_hooks
+	 */
+	public function test_register_hooks() {
+		Monkey\Actions\expectAdded( 'admin_action_yoast_set_options' )
+			->with( [ $this->instance, 'handle_set_options_request' ] )
+			->once();
+
+		$this->instance->register_hooks();
+	}
+
+	/**
+	 * Tests the set options request.
+	 *
+	 * @covers ::handle_set_options_request
+	 * @covers ::verify_request
+	 * @covers ::terminate_request
+	 * @covers ::persist_settings_errors
+	 * @covers ::redirect_back
+	 */
+	public function test_handle_set_options_request() {
+		$this->input_helper->expects( 'filter' )
+			->with( \INPUT_POST, 'option', \FILTER_SANITIZE_STRING, \FILTER_NULL_ON_FAILURE )
+			->andReturn( 'wpseo_options' );
+
+		$this->capability_helper->expects( 'current_user_can' )->with( 'wpseo_manage_options' )->andReturnTrue();
+		Monkey\Functions\expect( 'wp_doing_ajax' )->andReturn( false );
+		Monkey\Functions\expect( 'check_admin_referer' )->with( 'yoast_set_options:wpseo_options', '_wpnonce' );
+
+		$values = [ 'foo' => 'bar' ];
+		$this->input_helper->expects( 'filter' )
+			->with( \INPUT_POST, 'wpseo_options', \FILTER_SANITIZE_STRING, ( \FILTER_REQUIRE_ARRAY | \FILTER_NULL_ON_FAILURE ) )
+			->andReturn( $values );
+		$this->options_action->expects( 'set' )
+			->with( $values )
+			->andReturn( [ 'success' => true ] );
+
+		$updated_error = [
+			[
+				'setting' => 'wpseo_options',
+				'code'    => 'settings_updated',
+				'message' => 'Settings Updated.',
+				'type'    => 'updated',
+			],
+		];
+		Monkey\Functions\expect( 'get_settings_errors' )->andReturnValues( [ [], $updated_error ] );
+		Monkey\Functions\expect( 'add_settings_error' )->with( 'wpseo_options', 'settings_updated', 'Settings Updated.', 'updated' );
+
+		Monkey\Functions\expect( 'set_transient' )->with( 'settings_errors', $updated_error, 30 );
+		Monkey\Functions\expect( 'wp_get_referer' )->andReturn( 'https://example.com' );
+		Monkey\Functions\expect( 'add_query_arg' )
+			->with( [ 'settings-updated' => 'true' ], 'https://example.com' )
+			->andReturn( 'https://example.com?settings-updated=true' );
+		$this->redirect_helper->expects( 'do_safe_redirect' )->with( 'https://example.com?settings-updated=true' );
+
+		$this->instance->handle_set_options_request();
+	}
+
+	/**
+	 * Tests the set options request with errors.
+	 *
+	 * @covers ::handle_set_options_request
+	 */
+	public function test_handle_set_options_request_with_errors() {
+		$this->input_helper->expects( 'filter' )
+			->with( \INPUT_POST, 'option', \FILTER_SANITIZE_STRING, \FILTER_NULL_ON_FAILURE )
+			->andReturn( 'wpseo_options' );
+
+		$this->capability_helper->expects( 'current_user_can' )->with( 'wpseo_manage_options' )->andReturnTrue();
+		Monkey\Functions\expect( 'wp_doing_ajax' )->andReturn( false );
+		Monkey\Functions\expect( 'check_admin_referer' )->with( 'yoast_set_options:wpseo_options', '_wpnonce' );
+
+		$values = [ 'foo' => 'bar' ];
+		$this->input_helper->expects( 'filter' )
+			->with( \INPUT_POST, 'wpseo_options', \FILTER_SANITIZE_STRING, ( \FILTER_REQUIRE_ARRAY | \FILTER_NULL_ON_FAILURE ) )
+			->andReturn( $values );
+		$this->options_action->expects( 'set' )
+			->with( $values )
+			->andReturn(
+				[
+					'success'      => false,
+					'error'        => 'Message',
+					'field_errors' => [ 'foo' => 'Something' ],
+				]
+			);
+		Monkey\Functions\expect( 'add_settings_error' )->with( 'wpseo_options', 'settings_save_error', 'Message', 'error' );
+		Monkey\Functions\expect( 'add_settings_error' )->with( 'wpseo_options', 'foo', 'Something', 'error' );
+
+		$errors = [
+			[
+				'setting' => 'wpseo_options',
+				'code'    => 'settings_save_error',
+				'message' => 'Message',
+				'type'    => 'error',
+			],
+			[
+				'setting' => 'wpseo_options',
+				'code'    => 'foo',
+				'message' => 'Something',
+				'type'    => 'error',
+			],
+		];
+		Monkey\Functions\expect( 'get_settings_errors' )->andReturn( $errors );
+
+		Monkey\Functions\expect( 'set_transient' )->with( 'settings_errors', $errors, 30 );
+		Monkey\Functions\expect( 'wp_get_referer' )->andReturn( 'https://example.com' );
+		Monkey\Functions\expect( 'add_query_arg' )
+			->with( [ 'settings-updated' => 'true' ], 'https://example.com' )
+			->andReturn( 'https://example.com?settings-updated=true' );
+		$this->redirect_helper->expects( 'do_safe_redirect' )->with( 'https://example.com?settings-updated=true' );
+
+		$this->instance->handle_set_options_request();
+	}
+
+	/**
+	 * Tests the set options request without values.
+	 *
+	 * @covers ::handle_set_options_request
+	 */
+	public function test_handle_set_options_request_without_values() {
+		$this->input_helper->expects( 'filter' )
+			->with( \INPUT_POST, 'option', \FILTER_SANITIZE_STRING, \FILTER_NULL_ON_FAILURE )
+			->andReturn( 'wpseo_options' );
+
+		$this->capability_helper->expects( 'current_user_can' )->with( 'wpseo_manage_options' )->andReturnTrue();
+		Monkey\Functions\expect( 'wp_doing_ajax' )->andReturn( false );
+		Monkey\Functions\expect( 'check_admin_referer' )->with( 'yoast_set_options:wpseo_options', '_wpnonce' );
+
+		$this->input_helper->expects( 'filter' )
+			->with( \INPUT_POST, 'wpseo_options', \FILTER_SANITIZE_STRING, ( \FILTER_REQUIRE_ARRAY | \FILTER_NULL_ON_FAILURE ) )
+			->andReturnNull();
+		Monkey\Functions\expect( 'add_settings_error' )->with( 'wpseo_options', 'settings_error', 'Please provide settings to save.', 'error' );
+
+		Monkey\Functions\expect( 'get_settings_errors' )->andReturn( [] );
+
+		Monkey\Functions\expect( 'set_transient' )->with( 'settings_errors', [], 30 );
+		Monkey\Functions\expect( 'wp_get_referer' )->andReturn( 'https://example.com' );
+		$this->redirect_helper->expects( 'do_safe_redirect' )->with( 'https://example.com' );
+
+		$this->options_action->expects( 'set' )->never();
+
+		$this->instance->handle_set_options_request();
+	}
+
+	/**
+	 * Tests the set options request without capabilities.
+	 *
+	 * @covers ::handle_set_options_request
+	 * @covers ::verify_request
+	 */
+	public function test_handle_set_options_without_capabilities() {
+		$this->input_helper->expects( 'filter' )
+			->with( \INPUT_POST, 'option', \FILTER_SANITIZE_STRING, \FILTER_NULL_ON_FAILURE )
+			->andReturn( 'wpseo_options' );
+
+		$this->capability_helper->expects( 'current_user_can' )->with( 'wpseo_manage_options' )->andReturnFalse();
+		Monkey\Functions\expect( 'wp_doing_ajax' )->andReturn( false );
+		Monkey\Functions\expect( 'check_admin_referer' )->with( 'yoast_set_options:wpseo_options', '_wpnonce' );
+
+		$stop_test_continuing_on = new \Exception();
+		Monkey\Functions\expect( 'wp_die' )
+			->with( 'You are not allowed to perform this action.' )
+			->andThrow( $stop_test_continuing_on );
+		$this->expectExceptionObject( $stop_test_continuing_on );
+
+		$this->instance->handle_set_options_request();
+	}
+
+	/**
+	 * Tests the set options AJAX request.
+	 *
+	 * @covers ::handle_set_options_request
+	 * @covers ::verify_request
+	 * @covers ::terminate_request
+	 */
+	public function test_handle_set_options_ajax_request() {
+		$this->input_helper->expects( 'filter' )
+			->with( \INPUT_POST, 'option', \FILTER_SANITIZE_STRING, \FILTER_NULL_ON_FAILURE )
+			->andReturn( 'wpseo_options' );
+
+		$this->capability_helper->expects( 'current_user_can' )->with( 'wpseo_manage_options' )->andReturnTrue();
+		Monkey\Functions\expect( 'wp_doing_ajax' )->andReturn( true );
+		Monkey\Functions\expect( 'check_ajax_referer' )->with( 'yoast_set_options:wpseo_options', '_wpnonce' );
+
+		$values = [ 'foo' => 'bar' ];
+		$this->input_helper->expects( 'filter' )
+			->with( \INPUT_POST, 'wpseo_options', \FILTER_SANITIZE_STRING, ( \FILTER_REQUIRE_ARRAY | \FILTER_NULL_ON_FAILURE ) )
+			->andReturn( $values );
+		$this->options_action->expects( 'set' )
+			->with( $values )
+			->andReturn( [ 'success' => true ] );
+
+		$updated_error = [
+			[
+				'setting' => 'wpseo_options',
+				'code'    => 'settings_updated',
+				'message' => 'Settings Updated.',
+				'type'    => 'updated',
+			],
+		];
+		Monkey\Functions\expect( 'get_settings_errors' )->andReturnValues( [ [], $updated_error ] );
+		Monkey\Functions\expect( 'add_settings_error' )->with( 'wpseo_options', 'settings_updated', 'Settings Updated.', 'updated' );
+
+		$stop_test_continuing_on = new \Exception();
+		Monkey\Functions\expect( 'wp_send_json_success' )
+			->with( $updated_error, 200 )
+			->andThrow( $stop_test_continuing_on );
+		$this->expectExceptionObject( $stop_test_continuing_on );
+
+		$this->instance->handle_set_options_request();
+	}
+
+	/**
+	 * Tests the set options AJAX request with errors.
+	 *
+	 * @covers ::handle_set_options_request
+	 * @covers ::terminate_request
+	 */
+	public function test_handle_set_options_ajax_request_with_errors() {
+		$this->input_helper->expects( 'filter' )
+			->with( \INPUT_POST, 'option', \FILTER_SANITIZE_STRING, \FILTER_NULL_ON_FAILURE )
+			->andReturn( 'wpseo_options' );
+
+		$this->capability_helper->expects( 'current_user_can' )->with( 'wpseo_manage_options' )->andReturnTrue();
+		Monkey\Functions\expect( 'wp_doing_ajax' )->andReturn( true );
+		Monkey\Functions\expect( 'check_ajax_referer' )->with( 'yoast_set_options:wpseo_options', '_wpnonce' );
+
+		$values = [ 'foo' => 'bar' ];
+		$this->input_helper->expects( 'filter' )
+			->with( \INPUT_POST, 'wpseo_options', \FILTER_SANITIZE_STRING, ( \FILTER_REQUIRE_ARRAY | \FILTER_NULL_ON_FAILURE ) )
+			->andReturn( $values );
+		$this->options_action->expects( 'set' )
+			->with( $values )
+			->andReturn(
+				[
+					'success'      => false,
+					'error'        => 'Message',
+					'field_errors' => [ 'foo' => 'Something' ],
+				]
+			);
+		Monkey\Functions\expect( 'add_settings_error' )->with( 'wpseo_options', 'settings_save_error', 'Message', 'error' );
+		Monkey\Functions\expect( 'add_settings_error' )->with( 'wpseo_options', 'foo', 'Something', 'error' );
+
+		$errors = [
+			[
+				'setting' => 'wpseo_options',
+				'code'    => 'settings_save_error',
+				'message' => 'Message',
+				'type'    => 'error',
+			],
+			[
+				'setting' => 'wpseo_options',
+				'code'    => 'foo',
+				'message' => 'Something',
+				'type'    => 'error',
+			],
+		];
+		Monkey\Functions\expect( 'get_settings_errors' )->andReturn( $errors );
+
+		$stop_test_continuing_on = new \Exception();
+		Monkey\Functions\expect( 'wp_send_json_error' )->with( $errors, 400 )->andThrow( $stop_test_continuing_on );
+		$this->expectExceptionObject( $stop_test_continuing_on );
+
+		$this->instance->handle_set_options_request();
+	}
+
+	/**
+	 * Tests the set options AJAX request without capabilities.
+	 *
+	 * @covers ::handle_set_options_request
+	 * @covers ::verify_request
+	 */
+	public function test_handle_set_options_ajax_without_capabilities() {
+		$this->input_helper->expects( 'filter' )
+			->with( \INPUT_POST, 'option', \FILTER_SANITIZE_STRING, \FILTER_NULL_ON_FAILURE )
+			->andReturn( 'wpseo_options' );
+
+		$this->capability_helper->expects( 'current_user_can' )->with( 'wpseo_manage_options' )->andReturnFalse();
+		Monkey\Functions\expect( 'wp_doing_ajax' )->andReturn( true );
+		Monkey\Functions\expect( 'check_ajax_referer' )->with( 'yoast_set_options:wpseo_options', '_wpnonce' );
+
+		$stop_test_continuing_on = new \Exception();
+		Monkey\Functions\expect( 'wp_die' )->with( -1 )->andThrow( $stop_test_continuing_on );
+		$this->expectExceptionObject( $stop_test_continuing_on );
+
+		$this->instance->handle_set_options_request();
+	}
+}

--- a/tests/unit/integrations/third-party/wincher-test.php
+++ b/tests/unit/integrations/third-party/wincher-test.php
@@ -8,6 +8,8 @@ use Yoast\WP\SEO\Conditionals\Admin_Conditional;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Wincher_Helper;
 use Yoast\WP\SEO\Integrations\Third_Party\Wincher;
+use Yoast\WP\SEO\Services\Options\Network_Admin_Options_Service;
+use Yoast\WP\SEO\Surfaces\Classes_Surface;
 use Yoast\WP\SEO\Surfaces\Helpers_Surface;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
@@ -169,19 +171,18 @@ class Wincher_Test extends TestCase {
 			'disabled' => true,
 		];
 
-		$options_helper = Mockery::mock( Options_Helper::class );
-		$options_helper->expects( 'get' )
-			->with( 'wincher_website_id', '' )
-			->once()
-			->andReturn( 'some-id' );
+		$network_admin_options_service = Mockery::mock( Network_Admin_Options_Service::class );
+		$network_admin_options_service->expects( 'get_defaults' )->andReturn( [ 'wincher_website_id' => 'some-id' ] );
 
-		$helper_surface          = Mockery::mock( Helpers_Surface::class );
-		$helper_surface->options = $options_helper;
+		$classes_surface = Mockery::mock( Classes_Surface::class );
+		$classes_surface->expects( 'get' )
+			->with( Network_Admin_Options_Service::class )
+			->andReturn( $network_admin_options_service );
 
-		Monkey\Functions\expect( 'YoastSEO' )
-			->andReturn( (object) [ 'helpers' => $helper_surface ] );
+		Monkey\Functions\expect( 'YoastSEO' )->andReturn( (object) [ 'classes' => $classes_surface ] );
 
 		Monkey\Functions\stubs( [ 'is_multisite' => true ] );
+		Monkey\Functions\when( 'is_network_admin' )->justReturn( true );
 
 		$this->expectOutputContains( 'hidden_wincher_website_id' );
 

--- a/tests/unit/routes/network-admin-options-route-test.php
+++ b/tests/unit/routes/network-admin-options-route-test.php
@@ -1,0 +1,188 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Routes;
+
+use Brain\Monkey;
+use Mockery;
+use Yoast\WP\SEO\Actions\Options\Network_Admin_Options_Action;
+use Yoast\WP\SEO\Conditionals\Multisite_Conditional;
+use Yoast\WP\SEO\Helpers\Capability_Helper;
+use Yoast\WP\SEO\Routes\Network_Admin_Options_Route;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Class Network_Admin_Network_Admin_Options_Route_Test.
+ *
+ * @group routes
+ * @group options
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Routes\Network_Admin_Options_Route
+ *
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
+ */
+class Network_Admin_Options_Route_Test extends TestCase {
+
+	/**
+	 * Holds the instance of the class being tested.
+	 *
+	 * @var Network_Admin_Options_Route
+	 */
+	protected $instance;
+
+	/**
+	 * Holds the options action instance.
+	 *
+	 * @var Network_Admin_Options_Action|Mockery\MockInterface
+	 */
+	protected $network_admin_options_action;
+
+	/**
+	 * Holds the capability helper instance.
+	 *
+	 * @var Capability_Helper|Mockery\MockInterface
+	 */
+	protected $capability_helper;
+
+	/**
+	 * Set up the test fixtures.
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->network_admin_options_action = Mockery::mock( Network_Admin_Options_Action::class );
+		$this->capability_helper            = Mockery::mock( Capability_Helper::class );
+		$this->instance                     = new Network_Admin_Options_Route( $this->network_admin_options_action, $this->capability_helper );
+	}
+
+	/**
+	 * Tests the attributes after constructing.
+	 *
+	 * @covers ::__construct
+	 */
+	public function test_constructor() {
+		$this->assertInstanceOf( Network_Admin_Options_Route::class, $this->instance );
+		$this->assertInstanceOf(
+			Network_Admin_Options_Action::class,
+			$this->getPropertyValue( $this->instance, 'network_admin_options_action' )
+		);
+		$this->assertInstanceOf(
+			Capability_Helper::class,
+			$this->getPropertyValue( $this->instance, 'capability_helper' )
+		);
+	}
+
+	/**
+	 * Tests the retrieval of the conditionals.
+	 *
+	 * @covers ::get_conditionals
+	 */
+	public function test_get_conditionals() {
+		$this->assertEquals(
+			[ Multisite_Conditional::class ],
+			Network_Admin_Options_Route::get_conditionals()
+		);
+	}
+
+	/**
+	 * Tests the registration of the routes.
+	 *
+	 * @covers ::register_routes
+	 */
+	public function test_register_routes() {
+		Monkey\Functions\expect( 'register_rest_route' )->with(
+			'yoast/v1',
+			'network-admin-options',
+			[
+				[
+					'methods'             => 'GET',
+					'callback'            => [ $this->instance, 'get' ],
+					'permission_callback' => [ $this->instance, 'can_get' ],
+					'args'                => [
+						'options' => [
+							'required' => false,
+						],
+					],
+				],
+				[
+					'methods'             => 'POST',
+					'callback'            => [ $this->instance, 'set' ],
+					'permission_callback' => [ $this->instance, 'can_set' ],
+				],
+			]
+		);
+
+		$this->instance->register_routes();
+	}
+
+	/**
+	 * Tests the get.
+	 *
+	 * @covers ::get
+	 */
+	public function test_get() {
+		$this->network_admin_options_action->expects( 'get' )
+			->with( [] )
+			->andReturn( [ 'foo' => 'bar' ] );
+
+		$request = Mockery::mock( 'WP_Rest_Request' );
+		$request->expects( 'get_param' )
+			->with( 'options' )
+			->andReturnNull();
+
+		Mockery::mock( 'WP_Rest_Response' );
+
+		$this->assertInstanceOf( 'WP_Rest_Response', $this->instance->get( $request ) );
+	}
+
+	/**
+	 * Tests the set.
+	 *
+	 * @covers ::set
+	 */
+	public function test_set() {
+		$this->network_admin_options_action->expects( 'set' )
+			->twice()
+			->with( [ 'foo' => 'bar' ] )
+			->andReturn( [ 'success' => true ], [ 'success' => false ] );
+
+		$request = Mockery::mock( 'WP_Rest_Request' );
+		$request->expects( 'get_params' )
+			->twice()
+			->andReturn( [ 'foo' => 'bar' ] );
+
+		Mockery::mock( 'WP_Rest_Response' );
+
+		$this->assertInstanceOf( 'WP_Rest_Response', $this->instance->set( $request ) );
+		$this->assertInstanceOf( 'WP_Rest_Response', $this->instance->set( $request ) );
+	}
+
+	/**
+	 * Tests the get permissions.
+	 *
+	 * @covers ::can_get
+	 */
+	public function test_can_get() {
+		$this->capability_helper->expects( 'current_user_can' )
+			->twice()
+			->with( 'wpseo_manage_network_options' )
+			->andReturn( true, false );
+
+		$this->assertTrue( $this->instance->can_get() );
+		$this->assertFalse( $this->instance->can_get() );
+	}
+
+	/**
+	 * Tests the set permissions.
+	 *
+	 * @covers ::can_set
+	 */
+	public function test_can_set() {
+		$this->capability_helper->expects( 'current_user_can' )
+			->twice()
+			->with( 'wpseo_manage_network_options' )
+			->andReturn( true, false );
+
+		$this->assertTrue( $this->instance->can_set() );
+		$this->assertFalse( $this->instance->can_set() );
+	}
+}

--- a/tests/unit/routes/options-route-test.php
+++ b/tests/unit/routes/options-route-test.php
@@ -1,0 +1,173 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Routes;
+
+use Brain\Monkey;
+use Mockery;
+use Yoast\WP\SEO\Actions\Options\Options_Action;
+use Yoast\WP\SEO\Helpers\Capability_Helper;
+use Yoast\WP\SEO\Routes\Options_Route;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Class Options_Route_Test.
+ *
+ * @group routes
+ * @group options
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Routes\Options_Route
+ */
+class Options_Route_Test extends TestCase {
+
+	/**
+	 * Holds the instance of the class being tested.
+	 *
+	 * @var Options_Route
+	 */
+	protected $instance;
+
+	/**
+	 * Holds the options action instance.
+	 *
+	 * @var Options_Action|Mockery\MockInterface
+	 */
+	protected $options_action;
+
+	/**
+	 * Holds the capability helper instance.
+	 *
+	 * @var Capability_Helper|Mockery\MockInterface
+	 */
+	protected $capability_helper;
+
+	/**
+	 * Set up the test fixtures.
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->options_action    = Mockery::mock( Options_Action::class );
+		$this->capability_helper = Mockery::mock( Capability_Helper::class );
+		$this->instance          = new Options_Route( $this->options_action, $this->capability_helper );
+	}
+
+	/**
+	 * Tests the attributes after constructing.
+	 *
+	 * @covers ::__construct
+	 */
+	public function test_constructor() {
+		$this->assertInstanceOf( Options_Route::class, $this->instance );
+		$this->assertInstanceOf(
+			Options_Action::class,
+			$this->getPropertyValue( $this->instance, 'options_action' )
+		);
+		$this->assertInstanceOf(
+			Capability_Helper::class,
+			$this->getPropertyValue( $this->instance, 'capability_helper' )
+		);
+	}
+
+	/**
+	 * Tests the registration of the routes.
+	 *
+	 * @covers ::register_routes
+	 */
+	public function test_register_routes() {
+		Monkey\Functions\expect( 'register_rest_route' )->with(
+			'yoast/v1',
+			'options',
+			[
+				[
+					'methods'             => 'GET',
+					'callback'            => [ $this->instance, 'get' ],
+					'permission_callback' => [ $this->instance, 'can_get' ],
+					'args'                => [
+						'options' => [
+							'required' => false,
+						],
+					],
+				],
+				[
+					'methods'             => 'POST',
+					'callback'            => [ $this->instance, 'set' ],
+					'permission_callback' => [ $this->instance, 'can_set' ],
+				],
+			]
+		);
+
+		$this->instance->register_routes();
+	}
+
+	/**
+	 * Tests the get.
+	 *
+	 * @covers ::get
+	 */
+	public function test_get() {
+		$this->options_action->expects( 'get' )
+			->with( [] )
+			->andReturn( [ 'foo' => 'bar' ] );
+
+		$request = Mockery::mock( 'WP_Rest_Request' );
+		$request->expects( 'get_param' )
+			->with( 'options' )
+			->andReturnNull();
+
+		Mockery::mock( 'WP_Rest_Response' );
+
+		$this->assertInstanceOf( 'WP_Rest_Response', $this->instance->get( $request ) );
+	}
+
+	/**
+	 * Tests the set.
+	 *
+	 * @covers ::set
+	 */
+	public function test_set() {
+		$this->options_action->expects( 'set' )
+			->twice()
+			->with( [ 'foo' => 'bar' ] )
+			->andReturn( [ 'success' => true ], [ 'success' => false ] );
+
+		$request = Mockery::mock( 'WP_Rest_Request' );
+		$request->expects( 'get_params' )
+			->twice()
+			->andReturn( [ 'foo' => 'bar' ] );
+
+		Mockery::mock( 'WP_Rest_Response' );
+
+		$this->assertInstanceOf( 'WP_Rest_Response', $this->instance->set( $request ) );
+		$this->assertInstanceOf( 'WP_Rest_Response', $this->instance->set( $request ) );
+	}
+
+	/**
+	 * Tests the get permissions.
+	 *
+	 * @covers ::can_get
+	 */
+	public function test_can_get() {
+		$this->capability_helper->expects( 'current_user_can' )
+			->twice()
+			->with( 'read' )
+			->andReturn( true, false );
+
+		$this->assertTrue( $this->instance->can_get() );
+		$this->assertFalse( $this->instance->can_get() );
+	}
+
+	/**
+	 * Tests the set permissions.
+	 *
+	 * @covers ::can_set
+	 */
+	public function test_can_set() {
+		$this->capability_helper->expects( 'current_user_can' )
+			->twice()
+			->with( 'wpseo_manage_options' )
+			->andReturn( true, false );
+
+		$this->assertTrue( $this->instance->can_set() );
+		$this->assertFalse( $this->instance->can_set() );
+	}
+}

--- a/tests/unit/services/options/multisite-options-service-test.php
+++ b/tests/unit/services/options/multisite-options-service-test.php
@@ -23,28 +23,28 @@ class Multisite_Options_Service_Test extends TestCase {
 	/**
 	 * Holds the instance to test.
 	 *
-	 * @var Multisite_Options_Service|Mockery\Mock
+	 * @var Multisite_Options_Service
 	 */
 	protected $instance;
 
 	/**
 	 * Holds the validation helper instance.
 	 *
-	 * @var Validation_Helper|Mockery\Mock
+	 * @var Validation_Helper|Mockery\MockInterface
 	 */
 	protected $validation_helper;
 
 	/**
 	 * Holds the post type helper instance.
 	 *
-	 * @var Post_Type_Helper|Mockery\Mock
+	 * @var Post_Type_Helper|Mockery\MockInterface
 	 */
 	protected $post_type_helper;
 
 	/**
 	 * Holds the taxonomy helper instance.
 	 *
-	 * @var Taxonomy_Helper|Mockery\Mock
+	 * @var Taxonomy_Helper|Mockery\MockInterface
 	 */
 	protected $taxonomy_helper;
 

--- a/tests/unit/services/options/network-admin-options-service-test.php
+++ b/tests/unit/services/options/network-admin-options-service-test.php
@@ -28,35 +28,35 @@ class Network_Admin_Options_Service_Test extends TestCase {
 	/**
 	 * Holds the instance to test.
 	 *
-	 * @var Network_Admin_Options_Service|Mockery\Mock
+	 * @var Network_Admin_Options_Service
 	 */
 	protected $instance;
 
 	/**
 	 * Holds the multisite options service instance.
 	 *
-	 * @var Multisite_Options_Service|Mockery\Mock
+	 * @var Multisite_Options_Service|Mockery\MockInterface
 	 */
 	protected $multisite_options_service;
 
 	/**
 	 * Holds the validation helper instance.
 	 *
-	 * @var Validation_Helper|Mockery\Mock
+	 * @var Validation_Helper|Mockery\MockInterface
 	 */
 	protected $validation_helper;
 
 	/**
 	 * Holds the post type helper instance.
 	 *
-	 * @var Post_Type_Helper|Mockery\Mock
+	 * @var Post_Type_Helper|Mockery\MockInterface
 	 */
 	protected $post_type_helper;
 
 	/**
 	 * Holds the taxonomy helper instance.
 	 *
-	 * @var Taxonomy_Helper|Mockery\Mock
+	 * @var Taxonomy_Helper|Mockery\MockInterface
 	 */
 	protected $taxonomy_helper;
 

--- a/tests/unit/services/options/site-options-service-test.php
+++ b/tests/unit/services/options/site-options-service-test.php
@@ -27,28 +27,28 @@ class Site_Options_Service_Test extends TestCase {
 	/**
 	 * Holds the instance to test.
 	 *
-	 * @var Site_Options_Service|Mockery\Mock
+	 * @var Site_Options_Service
 	 */
 	protected $instance;
 
 	/**
 	 * Holds the validation helper instance.
 	 *
-	 * @var Validation_Helper|Mockery\Mock
+	 * @var Validation_Helper|Mockery\MockInterface
 	 */
 	protected $validation_helper;
 
 	/**
 	 * Holds the post type helper instance.
 	 *
-	 * @var Post_Type_Helper|Mockery\Mock
+	 * @var Post_Type_Helper|Mockery\MockInterface
 	 */
 	protected $post_type_helper;
 
 	/**
 	 * Holds the taxonomy helper instance.
 	 *
-	 * @var Taxonomy_Helper|Mockery\Mock
+	 * @var Taxonomy_Helper|Mockery\MockInterface
 	 */
 	protected $taxonomy_helper;
 

--- a/tests/unit/services/options/site-options-service-test.php
+++ b/tests/unit/services/options/site-options-service-test.php
@@ -254,6 +254,7 @@ class Site_Options_Service_Test extends TestCase {
 	 * Tests the magic set' happy path.
 	 *
 	 * @covers ::__set
+	 * @covers ::validate
 	 * @covers ::update_option
 	 * @covers ::update_wp_options
 	 */
@@ -285,6 +286,7 @@ class Site_Options_Service_Test extends TestCase {
 	 * Tests the magic set' setting the default without validating.
 	 *
 	 * @covers ::__set
+	 * @covers ::validate
 	 * @covers ::update_option
 	 */
 	public function test_set_default() {
@@ -313,6 +315,7 @@ class Site_Options_Service_Test extends TestCase {
 	 * Tests the magic set' not setting again.
 	 *
 	 * @covers ::__set
+	 * @covers ::validate
 	 * @covers ::update_option
 	 */
 	public function test_set_same() {
@@ -341,6 +344,7 @@ class Site_Options_Service_Test extends TestCase {
 	 * Tests the magic set' not setting again.
 	 *
 	 * @covers ::__set
+	 * @covers ::validate
 	 * @covers ::update_option
 	 */
 	public function test_set_same_after_sanitize() {
@@ -371,6 +375,7 @@ class Site_Options_Service_Test extends TestCase {
 	 * Tests the magic set' unknown exception.
 	 *
 	 * @covers ::__set
+	 * @covers ::validate
 	 */
 	public function test_set_unknown() {
 		Monkey\Filters\expectApplied( 'wpseo_options_additional_configurations' )
@@ -392,6 +397,7 @@ class Site_Options_Service_Test extends TestCase {
 	 * Tests the magic set' with invalid value.
 	 *
 	 * @covers ::__set
+	 * @covers ::validate
 	 */
 	public function test_set_invalid() {
 		Monkey\Functions\expect( 'get_option' )
@@ -423,6 +429,7 @@ class Site_Options_Service_Test extends TestCase {
 	 * Tests the magic set' with "database failure".
 	 *
 	 * @covers ::__set
+	 * @covers ::validate
 	 * @covers ::update_wp_options
 	 */
 	public function test_set_failed() {

--- a/tests/unit/services/options/taxonomy-metadata-service-test.php
+++ b/tests/unit/services/options/taxonomy-metadata-service-test.php
@@ -26,28 +26,28 @@ class Taxonomy_Metadata_Service_Test extends TestCase {
 	/**
 	 * Holds the instance to test.
 	 *
-	 * @var Taxonomy_Metadata_Service|Mockery\Mock
+	 * @var Taxonomy_Metadata_Service
 	 */
 	protected $instance;
 
 	/**
 	 * Holds the validation helper instance.
 	 *
-	 * @var Validation_Helper|Mockery\Mock
+	 * @var Validation_Helper|Mockery\MockInterface
 	 */
 	protected $validation_helper;
 
 	/**
 	 * Holds the post type helper instance.
 	 *
-	 * @var Post_Type_Helper|Mockery\Mock
+	 * @var Post_Type_Helper|Mockery\MockInterface
 	 */
 	protected $post_type_helper;
 
 	/**
 	 * Holds the taxonomy helper instance.
 	 *
-	 * @var Taxonomy_Helper|Mockery\Mock
+	 * @var Taxonomy_Helper|Mockery\MockInterface
 	 */
 	protected $taxonomy_helper;
 

--- a/tests/unit/services/options/taxonomy-metadata-service-test.php
+++ b/tests/unit/services/options/taxonomy-metadata-service-test.php
@@ -440,9 +440,9 @@ class Taxonomy_Metadata_Service_Test extends TestCase {
 	/**
 	 * Tests setting all option/metadata values for a term.
 	 *
-	 * @covers ::set_options
+	 * @covers ::set_term_options
 	 */
-	public function test_set_options() {
+	public function test_set_term_options() {
 		Monkey\Functions\expect( 'get_term_by' )
 			->once()
 			->with( 'id', 1, 'category' )
@@ -466,7 +466,7 @@ class Taxonomy_Metadata_Service_Test extends TestCase {
 
 		Monkey\Functions\expect( 'update_option' )->once()->andReturn( true );
 
-		$this->instance->set_options(
+		$this->instance->set_term_options(
 			1,
 			'category',
 			[
@@ -479,9 +479,9 @@ class Taxonomy_Metadata_Service_Test extends TestCase {
 	/**
 	 * Tests setting the same option/metadata values for a term.
 	 *
-	 * @covers ::set_options
+	 * @covers ::set_term_options
 	 */
-	public function test_set_options_same_values() {
+	public function test_set_term_options_same_values() {
 		Monkey\Functions\expect( 'get_term_by' )
 			->once()
 			->with( 'id', 1, 'category' )
@@ -507,15 +507,15 @@ class Taxonomy_Metadata_Service_Test extends TestCase {
 
 		Monkey\Functions\expect( 'update_option' )->never();
 
-		$this->instance->set_options( 1, 'category', $values );
+		$this->instance->set_term_options( 1, 'category', $values );
 	}
 
 	/**
 	 * Tests setting the option/metadata values for an unknown term.
 	 *
-	 * @covers ::set_options
+	 * @covers ::set_term_options
 	 */
-	public function test_set_options_unknown_term() {
+	public function test_set_term_options_unknown_term() {
 		Monkey\Functions\expect( 'get_term_by' )
 			->once()
 			->with( 'id', 1, 'category' )
@@ -524,7 +524,7 @@ class Taxonomy_Metadata_Service_Test extends TestCase {
 		$this->expectException( Term_Not_Found_Exception::class );
 		$this->expectExceptionMessage( Term_Not_Found_Exception::for_term( 1, 'category' )->getMessage() );
 
-		$this->instance->set_options( 1, 'category', [] );
+		$this->instance->set_term_options( 1, 'category', [] );
 	}
 
 	/**

--- a/tests/unit/services/options/taxonomy-metadata-service-test.php
+++ b/tests/unit/services/options/taxonomy-metadata-service-test.php
@@ -117,6 +117,17 @@ class Taxonomy_Metadata_Service_Test extends TestCase {
 	}
 
 	/**
+	 * Tests that set_options throws an exception.
+	 *
+	 * @covers ::set_options
+	 */
+	public function test_set_options() {
+		$this->expectException( Method_Unimplemented_Exception::class );
+
+		$this->instance->set_options( [] );
+	}
+
+	/**
 	 * Tests getting the option/metadata values for a term.
 	 *
 	 * @covers ::get


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Make Yoast Form use the new options services.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes the Yoast setting forms by making use of the options services.

## Relevant technical choices:

* Added get/set options and network options route and actions (only options actions are used here)
* Added a `set_options` for bulk setting
* Added Form_Invalid_Exception to hold one or more field exceptions
* Network admin options are "registered" (put on allow list) for the AJAX action to check in the Options Initializer
* Applied network admin options AJAX solution to the Yoast form in the form of the Options_Form_Integration
* Added some missing options after rebasing (from trunk via feature branch). Note that the validators might not be correct yet, the goal is to save the data
* 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Test the option forms
* Save without errors
* Reload the page and have the same data shown
* Cause validation errors (webmaster tools is easiest, insert `#!$#`) and verify invalid data did not save, but valid data did
* Ensure you have some custom post types and taxonomies active (you can use the Yoast Test helper for that)
* Bonus points for checking if the functionality is also correctly responding to the options
* Options to check on single and multisite:
  * General > Features
  * General > Integrations
  * General > Webmaster tools
  * General > First-time configuration
  * Search Appearance > General
  * Search Appearance > Content Types
    * Here the custom post types come into play 
  * Search Appearance > Media
  * Search Appearance > Taxonomies
    * Here the custom taxonomies come into play 
  * Search Appearance > Archives
  * Search Appearance > Breadcrumbs
  * Search Appearance > RSS
  * Social > Accounts
  * Social > Facebook
  * Social > Twitter
  * Social > Pinterest
* Options to check on multisite' network admin:
  * General > General
  * General > Features
    * If you disallow one, you should check a site under this multisite to verify they feature is now disabled
  * General > Integrations
    * If you disallow one, you should check a site under this multisite to verify they feature is now disabled

#### Test the multisite restore options
* In a multisite environment with at least 2 sites
* Change some options on site 1, including some privacy options that should not be copied over like the webmaster tools ones.
* Change some options on site 2 to ones differing from site 1 so you can check if it worked
* Go to multisite network admin options
* Save the inherit option under General > General to be site 1
* Go to General > Restore Site
* Restore the options of site 2
* Verify the options are as expected on site 2
  * Be sure to check none of the privacy options have values.

#### Test the option routes
* Install and active `JSON Basic Authentication` plugin to cheat the authentication a bit for easier testing (network activate)
* Fire some requests to the routes, we should have the following working:
  * GET yoast/v1/options -- retrieve all options
  * GET yoast/v1/options?options[]=facebook_site&options[]=twitter_site -- retrieve one or more options
  * POST yoast/v1/options -- with the data in the body: set one or more options
  * GET yoast/v1/network-admin-options -- retrieve all options
  * GET yoast/v1/network-admin-options?options[]=defaultblog&options[]=allow_content_analysis_active -- retrieve one or more options
  * POST yoast/v1/network-admin-options -- with the data in the body: set one or more options
* Example of curl POST request (that will produce failure), you should be able to figure out the other, right? I.e. change the domain to go to test single/multisite, change the last part of the URL to change network admin or normal options. Change the body to determine what to set. Remove the `-d "{}"` and change POST to GET for a GET request. Change the `admin:admin` part to be your user:password
```sh
curl -X POST --location "http://multisite.wordpress.test/wp-json/yoast/v1/network-admin-options" \
    -H "Content-Type: application/json" \
    -d "{
        	\"allow_content_analysis_active\": \"foo\",
        	\"allow_keyword_analysis_active\": \"bar\"
        }" \
    --basic --user admin:admin
```
* Do not forget to deactivate the `JSON Basic Authentication` plugin again after testing!

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Please test the feature branch as a whole instead of just this PR.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes [P1-1347](https://yoast.atlassian.net/browse/P1-1347)
Fixes [P1-1104](https://yoast.atlassian.net/browse/P1-1104)
