### PR TITLE
DUPP-510 - DUPP-510-handle-network-failure-in-ftc-site-representation-step

### DIFF
--- a/packages/js/src/first-time-configuration/first-time-configuration-steps.js
+++ b/packages/js/src/first-time-configuration/first-time-configuration-steps.js
@@ -292,10 +292,17 @@ export default function FirstTimeConfigurationSteps() {
 			return false;
 		}
 		setSiteRepresentationEmpty( state.companyOrPerson === "emptyChoice" || isCompanyAndEmpty || isPersonAndEmpty );
-		updateSiteRepresentation( state )
+		return updateSiteRepresentation( state )
 			.then( () => setStepIsSaved( 2 ) )
-			.then( () => finishSteps( STEPS.siteRepresentation ) );
-		return true;
+			.then( () => {
+				setErrorFields( [] );
+				finishSteps( STEPS.siteRepresentation );
+				return true;
+			} )
+			.catch( ( e ) => {
+				setErrorFields( [ "site_representation", e.message ] );
+				return false;
+			} );
 	}
 
 	/**

--- a/packages/js/src/first-time-configuration/first-time-configuration-steps.js
+++ b/packages/js/src/first-time-configuration/first-time-configuration-steps.js
@@ -300,7 +300,9 @@ export default function FirstTimeConfigurationSteps() {
 				return true;
 			} )
 			.catch( ( e ) => {
-				setErrorFields( [ "site_representation", e.message ] );
+				if ( e.message ) {
+					setErrorFields( [ "site_representation", e.message ] );
+				}
 				return false;
 			} );
 	}

--- a/packages/js/src/first-time-configuration/tailwind-components/configuration-stepper-buttons.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/configuration-stepper-buttons.js
@@ -153,8 +153,8 @@ StepButtons.defaultProps = {
  * @returns {WPElement} The most common stepper buttons: continue and back.
  */
 export function ConfigurationStepButtons( { stepperFinishedOnce, saveFunction, setEditState } ) {
-	const onSaveClick = useCallback( () => {
-		const saveSuccesful = saveFunction();
+	const onSaveClick = useCallback( async() => {
+		const saveSuccesful = await saveFunction();
 
 		// If save is not succesful: we are still editing
 		setEditState( ! saveSuccesful );

--- a/packages/js/src/first-time-configuration/tailwind-components/steps/site-representation/site-representation-step.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/steps/site-representation/site-representation-step.js
@@ -106,6 +106,23 @@ export default function SiteRepresentationStep( { onOrganizationOrPersonChange, 
 				)
 			}
 		</FadeInAlert>
+		<FadeInAlert
+			id="site-representaton-error-alert"
+			type="error"
+			isVisible={ state.errorFields[ 0 ] === "site_representation" }
+			className="yst-mt-6"
+		>
+			{
+				/* translators: %1$s expands to the error message returned by the server */
+				sprintf(
+					__(
+						"An error has occurred: %1$s",
+						"wordpress-seo"
+					),
+					state.errorFields[ 1 ]
+				)
+			}
+		</FadeInAlert>
 	</Fragment>;
 }
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* When a network error (or another generic error) occurs when the user is in the Site Representation step of the First-time configuration, no notice is given to the user and s/he is still be able to advance to the next step

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where an error in saving the Site representation step of the First-time configuration would not block the advancement to the next step.

## Relevant technical choices:

* The management of this error exploits the already-existing _setErrorFields_ function by creating an array in which the first element is the string "site_representation", and the second element is the actual error message. This is sub-optimal and should be addressed by swapping the _setErrorFields_ function to a more general function allowing to manage all the FTC-related errors.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Navigate to `General` -> `First-time configuration tab` -> `Site representation` step
* Make some changes and do not save them
* Simulate a network error (by, e.g. disconnecting from the Internet of through the browser's developers tools)
* Press `Save and continue`
* Verify an error alert appears as follows:

<img width="631" alt="Screenshot 2022-05-17 at 11 47 42" src="https://user-images.githubusercontent.com/68744851/168782991-f3c71078-bf20-43de-90e1-8bcd5693c54e.png">

* check that you cannot progress in the FTC
* re-enable network 
* edit `\Yoast\WP\SEO\Routes\First_Time_Configuration_Route::set_site_representation` by adding a `die()` at the beginning;
* Press `Save and continue`
* Verify an error alert appears as above, with a different error message ("The response is not a valid JSON response")
* check that you cannot progress in the FTC
* remove the `die()` call
* Press `Save and continue`
* See that the alert goes away and you progress to the next step.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* N/A

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.

Fixes [DUPP-510](https://yoast.atlassian.ent/browse/DUPP-510)
