### PR TITLE
Adds localization to steps titles

### DIFF
--- a/packages/js/src/first-time-configuration/first-time-configuration-steps.js
+++ b/packages/js/src/first-time-configuration/first-time-configuration-steps.js
@@ -551,7 +551,7 @@ export default function FirstTimeConfigurationSteps() {
 				>
 					<Step>
 						<Step.Header
-							name="SEO data optimization"
+							name={ __( "SEO data optimization", "wordpress-seo" ) }
 							isFinished={ isIndexationStepFinished }
 						>
 							<EditButton
@@ -575,7 +575,7 @@ export default function FirstTimeConfigurationSteps() {
 					</Step>
 					<Step>
 						<Step.Header
-							name="Site representation"
+							name={ __( "Site representation", "wordpress-seo" ) }
 							isFinished={ isStep2Finished }
 						>
 							<EditButton
@@ -602,7 +602,7 @@ export default function FirstTimeConfigurationSteps() {
 					</Step>
 					<Step>
 						<Step.Header
-							name="Social profiles"
+							name={ __( "Social profiles", "wordpress-seo" ) }
 							isFinished={ isStep3Finished }
 						>
 							<EditButton
@@ -620,7 +620,7 @@ export default function FirstTimeConfigurationSteps() {
 					</Step>
 					<Step>
 						<Step.Header
-							name="Personal preferences"
+							name={ __( "Personal preferences", "wordpress-seo" ) }
 							isFinished={ isStep4Finished }
 						>
 							<EditButton
@@ -638,7 +638,7 @@ export default function FirstTimeConfigurationSteps() {
 					</Step>
 					<Step>
 						<Step.Header
-							name="Finish configuration"
+							name={ __( "Finish configuration", "wordpress-seo" ) }
 							isFinished={ isStepperFinished }
 						/>
 						<Step.Content>


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* In the First-time configuration the titles of the steps are not localized

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Add localization to the First-time configuration steps' titles

## Relevant technical choices:

* N/A

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Navigate to `General` -> `First-time configuration tab`
* Verify each steps' title is properly localized (or displayed in english if the string is not translated to the current locale)

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.

Fixes [DUPP-513](https://yoast.atlassian.net/browse/DUPP-513)
