### PR TITLE
Delete cached logos from the db when Site Representation is stored

### DIFF
--- a/src/actions/configuration/first-time-configuration-action.php
+++ b/src/actions/configuration/first-time-configuration-action.php
@@ -77,6 +77,10 @@ class First_Time_Configuration_Action {
 			}
 		}
 
+		// Delete cached logos in the db.
+		$this->options_helper->set( 'company_logo_meta', false );
+		$this->options_helper->set( 'person_logo_meta', false );
+
 		if ( \count( $failures ) === 0 ) {
 			return (object) [
 				'success' => true,

--- a/tests/unit/actions/configuration/first-time-configuration-action-test.php
+++ b/tests/unit/actions/configuration/first-time-configuration-action-test.php
@@ -116,8 +116,8 @@ class First_Time_Configuration_Action_Test extends TestCase {
 				'company_logo_id'   => 123,
 				'description'       => 'A nice tagline',
 			],
-			'times'                 => 4,
-			'yoast_options_results' => [ true, true, true, true ],
+			'times'                 => 6,
+			'yoast_options_results' => [ true, true, true, true, true, true ],
 			'wp_option_result'      => true,
 			'expected'              => (object) [
 				'success' => true,
@@ -133,8 +133,8 @@ class First_Time_Configuration_Action_Test extends TestCase {
 				'company_or_person_user_id' => 321,
 				'description'               => 'A nice tagline',
 			],
-			'times'                 => 4,
-			'yoast_options_results' => [ true, true, true, true ],
+			'times'                 => 6,
+			'yoast_options_results' => [ true, true, true, true, true, true ],
 			'wp_option_result'      => true,
 			'expected'              => (object) [
 				'success' => true,
@@ -150,8 +150,8 @@ class First_Time_Configuration_Action_Test extends TestCase {
 				'company_or_person_user_id' => 321,
 				'description'               => 'A tagline that will fail for some reason',
 			],
-			'times'                 => 4,
-			'yoast_options_results' => [ true, true, true, true ],
+			'times'                 => 6,
+			'yoast_options_results' => [ true, true, true, true, true, true ],
 			'wp_option_result'      => false,
 			'expected'              => (object) [
 				'success'  => false,
@@ -169,8 +169,8 @@ class First_Time_Configuration_Action_Test extends TestCase {
 				'company_logo_id'   => 123,
 				'description'       => 'A nice tagline',
 			],
-			'times'                 => 4,
-			'yoast_options_results' => [ true, false, false, true ],
+			'times'                 => 6,
+			'yoast_options_results' => [ true, false, false, true, true, true ],
 			'wp_option_result'      => true,
 			'expected'              => (object) [
 				'success'  => false,


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the schema would not be updated with the new logo when the user changed it via the First Time Configuration

## Relevant technical choices:

* We now deleted the cached `company_logo_meta` and `person_logo_meta` db entries that take precedent when on the frontend, whenever we save the Site Represents step in the First Time Configuratio.
* Which means that every time the Site Representation step is saved in the FTC, the next page load of the frontend will also produce again the cached `company_logo_meta` and `person_logo_meta` values.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Go to the First Time Configuration's Site Representation step
* Select Organization and set a Organization Logo
* Visit the frontend
* Now go again to the First Time Configuration and edit the Site Representation step
* Change the Organization Logo and visit the frontend

**Without this PR:**
* The `url` and `contentUrl` attributes of the site's logo are not updated to the new image

**With this PR:**
* The `url` and `contentUrl` attributes of the site's logo are updated to the new image

Also:
* Test the same but for Person/Person's logo
### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes #
