### PR TITLE
Also validate company_name failure

### DIFF
--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "test": "jest -u",
-    "lint": "eslint src tests --max-warnings=141"
+    "lint": "eslint src tests --max-warnings=122"
   },
   "dependencies": {
     "@draft-js-plugins/mention": "^5.0.0",

--- a/packages/js/src/first-time-configuration/first-time-configuration-steps.js
+++ b/packages/js/src/first-time-configuration/first-time-configuration-steps.js
@@ -300,6 +300,10 @@ export default function FirstTimeConfigurationSteps() {
 				return true;
 			} )
 			.catch( ( e ) => {
+				if ( e.failures ) {
+					setErrorFields( e.failures );
+					return false;
+				}
 				if ( e.message ) {
 					setErrorFields( [ "site_representation", e.message ] );
 				}

--- a/packages/js/src/first-time-configuration/first-time-configuration-steps.js
+++ b/packages/js/src/first-time-configuration/first-time-configuration-steps.js
@@ -278,7 +278,7 @@ export default function FirstTimeConfigurationSteps() {
 	/**
 	 * Runs checks of finishing the site representation step.
 	 *
-	 * @returns {void}
+	 * @returns {Boolean|Promise} Returns either a Boolean for success/failure or a Promise that will resolve into a Boolean.
 	 */
 	function updateOnFinishSiteRepresentation() {
 		if ( ! siteRepresentationEmpty && isCompanyAndEmpty ) {

--- a/packages/js/src/first-time-configuration/tailwind-components/steps/site-representation/organization-section.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/steps/site-representation/organization-section.js
@@ -41,7 +41,7 @@ export function OrganizationSection( { dispatch, imageUrl, organizationName, err
 				onChange={ handleChange }
 				feedback={ {
 					isVisible: errorFields.includes( "company_name" ),
-					message: [ __( "We could not save the company name. Please check the value.", "wordpress-seo" ) ],
+					message: [ __( "We could not save the organization name. Please check the value.", "wordpress-seo" ) ],
 					type: "error",
 				} }
 			/>

--- a/packages/js/src/first-time-configuration/tailwind-components/steps/site-representation/organization-section.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/steps/site-representation/organization-section.js
@@ -15,7 +15,7 @@ import { openMedia } from "../../../../helpers/selectMedia";
  * @param {bool}     isDisabled       A flag to disable the field.
  * @returns {WPElement} The organization section.
  */
-export function OrganizationSection( { dispatch, imageUrl, organizationName } ) {
+export function OrganizationSection( { dispatch, imageUrl, organizationName, errorFields } ) {
 	const openImageSelect = useCallback( () => {
 		openMedia( ( selectedImage ) => {
 			dispatch( { type: "SET_COMPANY_LOGO", payload: { ...selectedImage } } );
@@ -39,6 +39,11 @@ export function OrganizationSection( { dispatch, imageUrl, organizationName } ) 
 				label={ __( "Organization name", "wordpress-seo" ) }
 				value={ organizationName }
 				onChange={ handleChange }
+				feedback={ {
+					isVisible: errorFields.includes( "company_name" ),
+					message: [ __( "We could not save the company name. Please check the value.", "wordpress-seo" ) ],
+					type: "error",
+				} }
 			/>
 			<ImageSelect
 				className="yst-mt-6"
@@ -58,9 +63,11 @@ OrganizationSection.propTypes = {
 	dispatch: PropTypes.func.isRequired,
 	imageUrl: PropTypes.string,
 	organizationName: PropTypes.string,
+	errorFields: PropTypes.array,
 };
 
 OrganizationSection.defaultProps = {
 	imageUrl: "",
 	organizationName: "",
+	errorFields: [],
 };

--- a/packages/js/src/first-time-configuration/tailwind-components/steps/site-representation/site-representation-step.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/steps/site-representation/site-representation-step.js
@@ -74,6 +74,7 @@ export default function SiteRepresentationStep( { onOrganizationOrPersonChange, 
 					dispatch={ dispatch }
 					imageUrl={ state.companyLogo }
 					organizationName={ state.companyName }
+					errorFields={ state.errorFields }
 				/> }
 				{ state.companyOrPerson === "person" && <PersonSection
 					dispatch={ dispatch }
@@ -83,6 +84,7 @@ export default function SiteRepresentationStep( { onOrganizationOrPersonChange, 
 						name: state.personName,
 					} }
 					canEditUser={ !! state.canEditUser }
+					errorFields={ state.errorFields }
 				/> }
 			</div>
 		</ReactAnimateHeight>


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug in the First-time Configuration where saving an invalid organization name would fail without feedback.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* In the FTC, go to Site representation, select organization, and enter an invalid name (e.g. `<script>blablabla</script>`
* Press save.
* You should see error feedback in the company name field.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes DUPP-514
