### PR TITLE
Avoid showing edit buttons if a step has an blocking error in it

### DIFF
--- a/packages/js/src/first-time-configuration/first-time-configuration-steps.js
+++ b/packages/js/src/first-time-configuration/first-time-configuration-steps.js
@@ -418,7 +418,7 @@ export default function FirstTimeConfigurationSteps() {
 	const [ stepperFinishedOnce, setStepperFinishedOnce ] = useState( isStepperFinished );
 	const [ isStepBeingEdited, setIsStepBeingEdited ] = useState( false );
 	const [ showEditButton, setShowEditButton ] = useState( stepperFinishedOnce && ! isStepBeingEdited && state.editedSteps.length === 0 );
-	
+
 	/**
 	 * Save and continue functionality for the Indexation step.
 	 *

--- a/packages/js/src/first-time-configuration/first-time-configuration-steps.js
+++ b/packages/js/src/first-time-configuration/first-time-configuration-steps.js
@@ -417,8 +417,8 @@ export default function FirstTimeConfigurationSteps() {
 
 	const [ stepperFinishedOnce, setStepperFinishedOnce ] = useState( isStepperFinished );
 	const [ isStepBeingEdited, setIsStepBeingEdited ] = useState( false );
-	const [ showEditButton, setShowEditButton ] = useState( stepperFinishedOnce && ! isStepBeingEdited );
-
+	const [ showEditButton, setShowEditButton ] = useState( stepperFinishedOnce && ! isStepBeingEdited && state.editedSteps.length === 0 );
+	
 	/**
 	 * Save and continue functionality for the Indexation step.
 	 *
@@ -466,8 +466,8 @@ export default function FirstTimeConfigurationSteps() {
 
 	// If stepperFinishedOnce changes or isStepBeingEdited changes, evaluate edit button state.
 	useEffect( () => {
-		setShowEditButton( stepperFinishedOnce && ! isStepBeingEdited );
-	}, [ stepperFinishedOnce, isStepBeingEdited ] );
+		setShowEditButton( stepperFinishedOnce && ! isStepBeingEdited && state.editedSteps.length === 0 );
+	}, [ stepperFinishedOnce, isStepBeingEdited, state.editedSteps ] );
 
 	/* eslint-disable max-len */
 	useEffect( () => {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Currently, when a user completes the First-time configuration an _Edit_ button appears beside each step title, so that the user could review the information s/he specified for that step. When a user edits a step by clicking on the Edit button, and the step being edited contains an error, pressing the _Save changes_ button makes the _edit_ buttons appear again, even if the error is still present. This allows users to exit the step regardless of any error.
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where users could leave a step containing errors by clicking another step's edit button

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:


* Navigate to `General` -> `First-time configuration tab`
* Finish the First-time configuration, the click on the `Edit` button beside the `Social profiles` step
* Insert an invalid url in one of the text fields
* Click `Save changes` and verify:
  *   An error message appears below the text field 
  *   No `Edit` button appears beside any step title
 * Now correct the error and click `Save changes` 
 * Verify the `Edit` buttons appear beside each step's title


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.

Fixes[DUPP-480](https://yoast.atlassian.net/browse/DUPP-480) 
