### PR TITLE
Small improvements to single-select and combo-box id's

### DIFF
--- a/packages/js/src/first-time-configuration/tailwind-components/base/combo-box.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/base/combo-box.js
@@ -23,6 +23,7 @@ function getDisplayValue( selectedOption ) {
  * The Yoast version of a Tailwind Combobox.
  *
  * @param {Object}   props               The props object.
+ * @param {string}   props.id            The id for this combo box.
  * @param {Object}   props.value         Selected option with shape {value, label}.
  * @param {*}        props.value.value   The id of the selected option
  * @param {string}   props.value.label   The display label of the selected option
@@ -34,7 +35,7 @@ function getDisplayValue( selectedOption ) {
  *
  * @returns {WPElement} The Yoast version of a Tailwind Combobox.
  */
-export default function YoastComboBox( { value, label, onChange, onQueryChange, options, placeholder, isLoading } ) {
+export default function YoastComboBox( { id, value, label, onChange, onQueryChange, options, placeholder, isLoading } ) {
 	const [ filteredOptions, setFilteredOptions ] = useState( options );
 	const [ query, setQuery ] = useState( "" );
 
@@ -80,7 +81,7 @@ export default function YoastComboBox( { value, label, onChange, onQueryChange, 
 		};
 	}, [] );
 
-	return <Combobox id="configuration-user-select" as="div" value={ value } onChange={ onChange } onBlur={ handleBlur }>
+	return <Combobox id={ id } as="div" value={ value } onChange={ onChange } onBlur={ handleBlur }>
 		{
 			( { open } ) => {
 				return <Fragment>
@@ -88,7 +89,6 @@ export default function YoastComboBox( { value, label, onChange, onQueryChange, 
 					<div className="yst-h-[45px] yst-max-w-sm yst-relative">
 						<Combobox.Button
 							role="button"
-							id="configuration-user-select-button"
 							className="yst-w-full yst-h-full yst-rounded-md yst-border yst-border-gray-300 yst-flex yst-items-center yst-rounded-r-md yst-pl-3 yst-pr-2 focus-within:yst-border-primary-500 focus-within:yst-outline-none focus-within:yst-ring-1 focus-within:yst-ring-primary-500"
 							as="div"
 						>
@@ -136,6 +136,7 @@ export default function YoastComboBox( { value, label, onChange, onQueryChange, 
 YoastComboBox.propTypes = {
 	onChange: PropTypes.func.isRequired,
 	options: PropTypes.array.isRequired,
+	id: PropTypes.string.isRequired,
 	value: PropTypes.shape( {
 		value: PropTypes.number,
 		label: PropTypes.string,

--- a/packages/js/src/first-time-configuration/tailwind-components/base/single-select.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/base/single-select.js
@@ -27,7 +27,7 @@ export default function Select( { id, value, choices, label, onChange, error, di
 	}, [ choices, value ] );
 
 	return (
-		<Listbox value={ value } onChange={ onChange } disabled={ disabled }>
+		<Listbox id={ id } as="div" value={ value } onChange={ onChange } disabled={ disabled }>
 			{ ( { open } ) => (
 				<>
 					{ label && <Listbox.Label className="yst-block yst-max-w-sm yst-mb-1 yst-text-sm yst-font-medium yst-text-gray-700">{ label }</Listbox.Label> }

--- a/packages/js/src/first-time-configuration/tailwind-components/steps/site-representation/user-selector.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/steps/site-representation/user-selector.js
@@ -74,6 +74,7 @@ export default function UserSelector( { initialValue, onChangeCallback, placehol
 	}, 500 ), [] );
 
 	return <YoastComboBox
+		id="yoast-configuration-user-select"
 		value={ selectedPerson }
 		label={ __( "Name", "wordpress-seo" ) }
 		onChange={ handleSelectChange }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* QA can always do with specific id's, as they provide better means of targeting UI. Unfortunately, headless-ui does not provide a way to override their semi-random internal id's. Therefore, I decided to at least make sure the wrapping div has an id.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds an id to the single-select and combo-box components to make automated tests easier.

## Relevant technical choices:

*  Unfortunately, headless-ui does not provide a way to override their semi-random internal id's. Therefore, I decided to at least make sure the wrapping div has an id.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Inspect the First-time configuration. Notice that the organisation-person-select and, after selecting person, the user-select, have a wrapping div with an id.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes DUPP-495
