### PR TITLE
Avoid syncing robots meta between multilingual contents

### DIFF
--- a/wpml-config.xml
+++ b/wpml-config.xml
@@ -4,9 +4,9 @@
         <custom-field action="translate">_yoast_wpseo_bctitle</custom-field>
         <custom-field action="translate">_yoast_wpseo_metadesc</custom-field>
         <custom-field action="translate">_yoast_wpseo_focuskw</custom-field>
-        <custom-field action="copy">_yoast_wpseo_meta-robots-noindex</custom-field>
-        <custom-field action="copy">_yoast_wpseo_meta-robots-nofollow</custom-field>
-        <custom-field action="copy">_yoast_wpseo_meta-robots-adv</custom-field>
+        <custom-field action="copy_once">_yoast_wpseo_meta-robots-noindex</custom-field>
+        <custom-field action="copy_once">_yoast_wpseo_meta-robots-nofollow</custom-field>
+        <custom-field action="copy_once">_yoast_wpseo_meta-robots-adv</custom-field>
         <custom-field action="ignore">_yoast_wpseo_canonical</custom-field>
         <custom-field action="ignore">_yoast_wpseo_redirect</custom-field>
         <custom-field action="translate">_yoast_wpseo_opengraph-description</custom-field>


### PR DESCRIPTION
## Context
It's quite very common to see that someone wants to set `noindex` to the translated content while the main content remains `index`. However, it wasn't possible at all due to the two-way robots meta synchronization. Setting up the `noindex` to the translated content will set the `noindex` to the parent content as well and vice-versa.

The PR resolves the two-way robots meta synchronization between the multilingual contents by applying the `copy_once` instead of `copy`. `wpml-config.xml` file is popular and used by various themes and plugins (i.e., Polylang) to make everything compatible with each other, and it offers the relevant action.

According to the [WPML documentation](https://wpml.org/documentation/support/language-configuration-files/#custom-fields):
> when using the `copy-once`, the value of the custom field is copied to the secondary language in the initial translation process. The custom fields that use the copy-once action will not appear on the Translation Editor screen. However, the user can change the custom field value of the secondary language to be different from the default language using the post editing screen. It is preferred to set the custom fields that hold settings like background color, font color, font size, and others, to `copy-once`. This allows the user to have different settings for translated content than those set for the posts and pages in the default language. For example, the user wants to set the background color of the same element to be yellow in the default language and blue in the secondary language. Please note that editing a field set to `copy-once` will not mark the field as needs update. This is because the field will not be copied to an existing translation, it is only copied when the translation is created.

## Summary

This PR can be summarized in the following changelog entry:
* Avoid syncing robots meta between multilingual contents when using a multilingual plugin like WPML or Polylang.

## Test instructions
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install and activate Yoast SEO
* Install a multilingual plugin like Polylang or WPML (I tested with Polylang, but WPML shall work as well)
* Configure Polylang or WPML for two separate langauge
* Create a post using the primary language
* Translate the relevant post using the secondary langauge
* Change the robots meta of the primary content to `noindex` from Yoast SEO meta box → Advanced → Allow search engines to show this Post in search results → No
* Check the relevant page source code and you shall see the `noindex` robots meta
* Now go to the translated content of the same page for the second language and check the source code. You shall see `index` robots meta


### Test instructions for QA when the code is in the RC

* [x] QA should use the same steps as above.

## Impact check

This PR affects the following parts of the plugin, which may require extra testing:

* Check the robots meta of multilingual content specially when using WPML.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes #18356, #6524, https://github.com/Yoast/bugreports/issues/811, https://yoast.atlassian.net/browse/IM-40
