### PR TITLE
Wincher: improve refresh token handling

### DIFF
--- a/packages/js/src/components/WincherPerformanceReport.js
+++ b/packages/js/src/components/WincherPerformanceReport.js
@@ -150,7 +150,7 @@ const GetUserMessage = ( props ) => {
 		return <NotConnectedMessage { ...props } />;
 	}
 
-	if ( ! isEmpty( data ) && data.status === 404 ) {
+	if ( data && [ 401, 403, 404 ].includes( data.status ) ) {
 		return <WincherReconnectAlert
 			onReconnect={ onConnectAction }
 		/>;

--- a/packages/js/src/components/WincherSEOPerformance.js
+++ b/packages/js/src/components/WincherSEOPerformance.js
@@ -34,7 +34,7 @@ import WincherNoPermalinkAlert from "./modals/WincherNoPermalinkAlert";
  * @returns {wp.Element} The error message component.
  */
 const GetErrorMessage = ( { response, onLogin } ) => {
-	if ( response.status === 403 || response.status === 404 ) {
+	if ( [ 401, 403, 404 ].includes( response.status ) ) {
 		return <WincherReconnectAlert onReconnect={ onLogin } />;
 	}
 

--- a/packages/js/src/components/modals/WincherReconnectAlert.js
+++ b/packages/js/src/components/modals/WincherReconnectAlert.js
@@ -31,7 +31,12 @@ const WincherReconnectAlert = ( props ) => {
 					mixedString: message,
 					components: {
 						// eslint-disable-next-line jsx-a11y/anchor-is-valid
-						reconnectToWincher: <a href="#" onClick={ props.onReconnect }>
+						reconnectToWincher: <a
+							href="#" onClick={ e => { // eslint-disable-line react/jsx-no-bind
+								e.preventDefault();
+								props.onReconnect();
+							} }
+						>
 							{
 								sprintf(
 									/* translators: %s : Expands to "Wincher". */

--- a/packages/js/src/dashboard-widget.js
+++ b/packages/js/src/dashboard-widget.js
@@ -165,6 +165,13 @@ class DashboardWidget extends Component {
 					status: keyphraseChartData.status,
 				},
 			} );
+		} else {
+			this.setState( {
+				wincherData: {
+					results: [],
+					status: keyphraseChartData.status,
+				},
+			} );
 		}
 	}
 

--- a/src/values/oauth/oauth-token.php
+++ b/src/values/oauth/oauth-token.php
@@ -46,6 +46,13 @@ class OAuth_Token {
 	public $created_at;
 
 	/**
+	 * The number of times we've gotten an error trying to refresh this token.
+	 *
+	 * @var int
+	 */
+	public $error_count;
+
+	/**
 	 * OAuth_Token constructor.
 	 *
 	 * @param string $access_token  The access token.
@@ -53,10 +60,11 @@ class OAuth_Token {
 	 * @param int    $expires       The date and time at which the token will expire.
 	 * @param bool   $has_expired   Whether or not the token has expired.
 	 * @param int    $created_at    The timestamp of when the token was created.
+	 * @param int    $error_count   The number of times we've gotten an error trying to refresh this token.
 	 *
 	 * @throws Empty_Property_Exception Exception thrown if a token property is empty.
 	 */
-	public function __construct( $access_token, $refresh_token, $expires, $has_expired, $created_at ) {
+	public function __construct( $access_token, $refresh_token, $expires, $has_expired, $created_at, $error_count = 0 ) {
 
 		if ( empty( $access_token ) ) {
 			throw new Empty_Property_Exception( 'access_token' );
@@ -82,6 +90,7 @@ class OAuth_Token {
 
 		$this->has_expired = $has_expired;
 		$this->created_at  = $created_at;
+		$this->error_count = $error_count;
 	}
 
 	/**
@@ -124,6 +133,7 @@ class OAuth_Token {
 			'expires'       => $this->expires,
 			'has_expired'   => $this->has_expired(),
 			'created_at'    => $this->created_at,
+			'error_count'   => $this->error_count,
 		];
 	}
 }

--- a/tests/unit/config/oauth-client-test.php
+++ b/tests/unit/config/oauth-client-test.php
@@ -140,6 +140,7 @@ class OAuth_Client_Test extends TestCase {
 					'expires'       => 604800,
 					'has_expired'   => true,
 					'created_at'    => $this->time,
+					'error_count'   => 0,
 				]
 			);
 
@@ -213,6 +214,7 @@ class OAuth_Client_Test extends TestCase {
 					'expires'       => 604800,
 					'has_expired'   => true,
 					'created_at'    => $this->time,
+					'error_count'   => 0,
 				]
 			)
 			->andReturns( $this->token );
@@ -250,6 +252,7 @@ class OAuth_Client_Test extends TestCase {
 					'expires'       => 604800,
 					'has_expired'   => true,
 					'created_at'    => $this->time,
+					'error_count'   => 0,
 				]
 			);
 
@@ -292,6 +295,7 @@ class OAuth_Client_Test extends TestCase {
 				'expires'       => 604800,
 				'has_expired'   => true,
 				'created_at'    => $this->time,
+				'error_count'   => 0,
 			]
 		);
 
@@ -305,6 +309,7 @@ class OAuth_Client_Test extends TestCase {
 					'expires'       => 604800,
 					'has_expired'   => true,
 					'created_at'    => $this->time,
+					'error_count'   => 0,
 				]
 			)
 			->once()
@@ -348,6 +353,7 @@ class OAuth_Client_Test extends TestCase {
 				'expires'       => 604800,
 				'has_expired'   => true,
 				'created_at'    => $this->time,
+				'error_count'   => 0,
 			]
 		);
 
@@ -361,6 +367,7 @@ class OAuth_Client_Test extends TestCase {
 					'expires'       => 604800,
 					'has_expired'   => true,
 					'created_at'    => $this->time,
+					'error_count'   => 0,
 				]
 			)
 			->once()
@@ -412,6 +419,7 @@ class OAuth_Client_Test extends TestCase {
 					'expires'       => ( $this->time + 604800 ),
 					'has_expired'   => false,
 					'created_at'    => $this->time,
+					'error_count'   => 0,
 				]
 			);
 
@@ -518,6 +526,7 @@ class OAuth_Client_Test extends TestCase {
 					'expires'       => 604800,
 					'has_expired'   => true,
 					'created_at'    => $this->time,
+					'error_count'   => 0,
 				]
 			);
 
@@ -577,6 +586,7 @@ class OAuth_Client_Test extends TestCase {
 					'expires'       => ( $this->time + 604800 ),
 					'has_expired'   => false,
 					'created_at'    => $this->time,
+					'error_count'   => 0,
 				]
 			);
 
@@ -652,6 +662,7 @@ class OAuth_Client_Test extends TestCase {
 					'expires'       => 604800,
 					'has_expired'   => true,
 					'created_at'    => $this->time,
+					'error_count'   => 0,
 				]
 			);
 
@@ -675,10 +686,10 @@ class OAuth_Client_Test extends TestCase {
 			->with( 'refresh_token', [ 'refresh_token' => '000001' ] )
 			->andReturn( $this->response );
 
-		Functions\expect('get_transient')
+		Functions\expect( 'get_transient' )
 			->once();
 
-		Functions\expect('delete_transient')
+		Functions\expect( 'delete_transient' )
 			->once();
 
 		$this->assertInstanceOf( OAuth_Token::class, $instance->get_tokens() );
@@ -703,6 +714,7 @@ class OAuth_Client_Test extends TestCase {
 					'expires'       => ( $this->time + 604800 ),
 					'has_expired'   => false,
 					'created_at'    => $this->time,
+					'error_count'   => 0,
 				]
 			);
 
@@ -737,6 +749,7 @@ class OAuth_Client_Test extends TestCase {
 					'expires'       => 604800,
 					'has_expired'   => true,
 					'created_at'    => $this->time,
+					'error_count'   => 0,
 				]
 			);
 
@@ -769,10 +782,10 @@ class OAuth_Client_Test extends TestCase {
 			->expects( 'store_token' )
 			->once();
 
-		Functions\expect('get_transient')
+		Functions\expect( 'get_transient' )
 			->once();
 
-		Functions\expect('delete_transient')
+		Functions\expect( 'delete_transient' )
 			->once();
 
 		$instance->refresh_tokens( $this->token );
@@ -804,6 +817,7 @@ class OAuth_Client_Test extends TestCase {
 					'expires'       => 604800,
 					'has_expired'   => true,
 					'created_at'    => $this->time,
+					'error_count'   => 0,
 				]
 			);
 
@@ -832,15 +846,15 @@ class OAuth_Client_Test extends TestCase {
 			->expects( 'clear_token' )
 			->never();
 
-		Functions\expect('get_transient')
+		Functions\expect( 'get_transient' )
 			->once()
-			->andReturn(false);
+			->andReturn( false );
 
-		Functions\expect('set_transient')
+		Functions\expect( 'set_transient' )
 			->once()
-			->andReturn(true);
+			->andReturn( true );
 
-		Functions\expect('delete_transient')
+		Functions\expect( 'delete_transient' )
 			->once();
 
 		$instance->refresh_tokens( $this->token );
@@ -867,6 +881,7 @@ class OAuth_Client_Test extends TestCase {
 					'expires'       => 604800,
 					'has_expired'   => true,
 					'created_at'    => $this->time,
+					'error_count'   => 0,
 				]
 			);
 
@@ -895,17 +910,20 @@ class OAuth_Client_Test extends TestCase {
 			->expects( 'clear_token' )
 			->once();
 
-		Functions\expect('get_transient')
+		Functions\expect( 'get_transient' )
 			->once()
-			->andReturn(false);
+			->andReturn( false );
 
-		Functions\expect('set_transient')
+		Functions\expect( 'set_transient' )
 			->once()
-			->andReturn(true);
+			->andReturn( true );
 
-		Functions\expect('delete_transient')
+		Functions\expect( 'delete_transient' )
 			->once();
 
-		$instance->refresh_tokens( $this->token );
+		$token              = clone $this->token;
+		$token->error_count = 1;
+
+		$instance->refresh_tokens( $token );
 	}
 }

--- a/tests/unit/values/oauth/oauth-token-test.php
+++ b/tests/unit/values/oauth/oauth-token-test.php
@@ -69,6 +69,7 @@ class OAuth_Token_Test extends TestCase {
 		$this->assertEquals( ( $this->created_at + 604800 ), $instance->expires );
 		$this->assertFalse( $instance->has_expired() );
 		$this->assertEquals( $this->created_at, $instance->created_at );
+		$this->assertEquals( 0, $instance->error_count );
 	}
 
 	/**
@@ -92,6 +93,7 @@ class OAuth_Token_Test extends TestCase {
 				'expires'       => ( $this->created_at + 604800 ),
 				'has_expired'   => false,
 				'created_at'    => $this->created_at,
+				'error_count'   => 0,
 			],
 			$instance->to_array()
 		);


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

Wincher is currently getting about 500-800 requests per minute from Yoast installations that have somehow ended up with a corrupt / invalid refresh token. 
It's unclear exactly how the installations have ended up in this state, but it could be because of:

* Storage errors when saving the new token.
* Response errors, like network errors after our server has already processed the request.
* Race conditions and refresh token rotation (on our end).

This problem also has negative consequences for the performance of WordPress on installations caught in this state, since on every single admin page load they'll have to wait for the refresh request to Wincher as well. It also likely also affects the SEMRush integration.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves handling of OAuth errors in the Wincher integration and clears refresh tokens that seem to be invalid.

## Relevant technical choices:

* Introduction of a basic "locking" mechanism to `OAuth_Client::refresh_tokens`. This mechanism is currently based on transients, which isn't ideal since it's still somewhat susceptible to race conditions. I was not certain whether it is worth it to create a new Lock class to handle this in a less error-prone way using custom SQL queries?
* Clearing of the token is only done when an invalid_grant error has been seen twice for the same token. Don't want to do it the first time due to the danger of race conditions.


## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

It's very difficult to test this new behavior since you need to manually edit the stored tokens in the DB, and they're stored as serialized values... But here goes:

1. Connect to Wincher
2. Head into your favorite DB client and edit find this row: `SELECT * FROM wp_options WHERE option_name = "wpseo";`
3. Edit the `option_value` column and find the value `wincher_tokens.has_expired` and change it from 0 to 1. Also find the value `wincher_tokens.refresh_token` and change one letter to something else. This creates the state of having an expired token with an invalid refresh token.
4. Refresh any page in the admin a couple of times.
5. Go back into the DB client and ensure that the `wincher_tokens` value is now empty.

Also good to test:

1. Connect to Wincher
2. Wait 1-2 hours for the access token to expire. Or inspect the options in the DB as described above and set `has_expired` from 0 to 1, then save.
3. Refresh any page in the admin and ensure that you're still connected.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Wincher integration
* Indirectly: Semrush integration

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes [DUPP-534]


[DUPP-534]: https://yoast.atlassian.net/browse/DUPP-534?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ