### PR TITLE
Add support for subdirectory XML sitemaps in robots.txt

### DIFF
--- a/src/integrations/front-end/robots-txt-integration.php
+++ b/src/integrations/front-end/robots-txt-integration.php
@@ -120,15 +120,18 @@ class Robots_Txt_Integration implements Integration_Interface {
 		}
 
 		$criteria = [
-			'public'     => 1,
+			'archived'   => 0,
 			'deleted'    => 0,
+			'public'     => 1,
+			'spam'       => 0,
+			'fields'     => 'ids',
 			'network_id' => \get_current_network_id(),
 		];
 		$sites    = \get_sites( $criteria );
 
 		$sitemaps = "\n\n";
-		foreach ( $sites as $site ) {
-			$sitemap = 'Sitemap: ' . \esc_url( \get_home_url( $site->blog_id, 'sitemap_index.xml' ) );
+		foreach ( $sites as $blog_id ) {
+			$sitemap = 'Sitemap: ' . \esc_url( \get_home_url( $blog_id, 'sitemap_index.xml' ) );
 
 			// If our sitemap is already output, bail.
 			if ( \strpos( $robots_txt, $sitemap ) !== false ) {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Each site on a subdirectory multisite install has its own sitemap index. Therefore the robots.txt should have all sitemaps.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Add support for subdirectory XML sitemaps in robots.txt.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Have a `Subdirectory` multisite installation and have not activated the plugin yet
* Verify that a `robots.txt` file exists; e.g. `http://multisite.wordpress.test/robots.txt`
* Verify it contains:
```
User-agent: *
Disallow: /wp-admin/
Allow: /wp-admin/admin-ajax.php

Sitemap: http://multisite.wordpress.test/wp-sitemap.xml
```
- Activate the plugin
- Reload the `robots.txt`; e.g. `http://multisite.wordpress.test/robots.txt`
- * Verify it contains:
```
User-agent: *
Disallow:

Sitemap: http://multisite.wordpress.test/sitemap_index.xml

Sitemap: http://multisite.wordpress.test/site2/sitemap_index.xml
```

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes P1-1373
Addition to #18445 
