### PR TITLE
LR-6 Make morphology work for hyphenated keyphrases in Keyphrase in slug assessment

### DIFF
--- a/packages/yoastseo/spec/languageProcessing/helpers/morphology/getAllWordsFromPaperSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/helpers/morphology/getAllWordsFromPaperSpec.js
@@ -30,7 +30,8 @@ describe( "Test for getting all words found in the text, title, slug and meta de
 			"envisages", "the", "vehicle", "travelling", "to", "the", "Moon", "and", "Mars", "The", "SpaceX", "CEO", "praised",
 			"his", "team", "adding", "that", "the", "demonstration", "had", "acquired", "all", "the", "data", "we", "needed",
 			"Mars", "here", "we", "come", "he", "tweeted", "Elon", "Musk's", "Starship", "prototype", "makes", "a",
-			"big", "impact", "science", "environment", "55239628", "US", "entrepreneur", "Elon", "Musk", "has", "launched",
-			"the", "latest", "prototype", "of", "his", "Starship", "vehicle", "from", "Texas", "a", "test" ] );
+			"big", "impact", "science-environment-55239628", "science", "environment", "55239628", "US", "entrepreneur",
+			"Elon", "Musk", "has", "launched", "the", "latest", "prototype", "of", "his", "Starship", "vehicle", "from",
+			"Texas", "a", "test" ] );
 	} );
 } );

--- a/packages/yoastseo/spec/languageProcessing/researches/keywordCountInUrlSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/keywordCountInUrlSpec.js
@@ -213,6 +213,35 @@ describe( "test to check slug for keyword", function() {
 		researcher.addResearchData( "morphology", morphologyData );
 		expect( slugKeyword( paper, researcher ) ).toEqual( { keyphraseLength: 3, percentWordMatches: 100 } );
 	} );
+
+	it( "morphology works for hyphenated keyphrases", function() {
+		const paper = new Paper( "", { slug: "ex-husband", keyword: "ex-husbands" } );
+		const researcher = new EnglishResearcher( paper );
+		researcher.addResearchData( "morphology", morphologyData );
+		expect( slugKeyword( paper, researcher ) ).toEqual( { keyphraseLength: 2, percentWordMatches: 100 } );
+	} );
+
+	it( "morphology works for partially hyphenated keyphrases", function() {
+		const paper = new Paper( "", { slug: "modern pop art", keyword: "modern pop-art" } );
+		const researcher = new EnglishResearcher( paper );
+		researcher.addResearchData( "morphology", morphologyData );
+		expect( slugKeyword( paper, researcher ) ).toEqual( { keyphraseLength: 3, percentWordMatches: 100 } );
+	} );
+
+	it( "morphology works for hyphenated keyphrases with function words", function() {
+		const paper = new Paper( "", { slug: "two-year-old", keyword: "two-year-olds" } );
+		const researcher = new EnglishResearcher( paper );
+		researcher.addResearchData( "morphology", morphologyData );
+		expect( slugKeyword( paper, researcher ) ).toEqual( { keyphraseLength: 3, percentWordMatches: 100 } );
+	} );
+
+	// Does not work yet.
+	xit( "morphology works for partially hyphenated keyphrases with function words", function() {
+		const paper = new Paper( "", { slug: "two-years-anniversary", keyword: "two-year anniversary" } );
+		const researcher = new EnglishResearcher( paper );
+		researcher.addResearchData( "morphology", morphologyData );
+		expect( slugKeyword( paper, researcher ) ).toEqual( { keyphraseLength: 3, percentWordMatches: 100 } );
+	} );
 } );
 
 describe( "tests proper deprecation", function() {

--- a/packages/yoastseo/spec/languageProcessing/researches/keywordCountInUrlSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/keywordCountInUrlSpec.js
@@ -222,7 +222,7 @@ describe( "test to check slug for keyword", function() {
 	} );
 
 	it( "morphology works for partially hyphenated keyphrases", function() {
-		const paper = new Paper( "", { slug: "modern pop art", keyword: "modern pop-art" } );
+		const paper = new Paper( "", { slug: "modern-pop-art", keyword: "modern pop-art" } );
 		const researcher = new EnglishResearcher( paper );
 		researcher.addResearchData( "morphology", morphologyData );
 		expect( slugKeyword( paper, researcher ) ).toEqual( { keyphraseLength: 3, percentWordMatches: 100 } );

--- a/packages/yoastseo/spec/languageProcessing/researches/keywordCountInUrlSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/keywordCountInUrlSpec.js
@@ -221,13 +221,6 @@ describe( "test to check slug for keyword", function() {
 		expect( slugKeyword( paper, researcher ) ).toEqual( { keyphraseLength: 2, percentWordMatches: 100 } );
 	} );
 
-	it( "morphology works for partially hyphenated keyphrases", function() {
-		const paper = new Paper( "", { slug: "modern-pop-art", keyword: "modern pop-art" } );
-		const researcher = new EnglishResearcher( paper );
-		researcher.addResearchData( "morphology", morphologyData );
-		expect( slugKeyword( paper, researcher ) ).toEqual( { keyphraseLength: 3, percentWordMatches: 100 } );
-	} );
-
 	it( "morphology works for hyphenated keyphrases with function words", function() {
 		const paper = new Paper( "", { slug: "two-year-old", keyword: "two-year-olds" } );
 		const researcher = new EnglishResearcher( paper );
@@ -236,11 +229,11 @@ describe( "test to check slug for keyword", function() {
 	} );
 
 	// Does not work yet.
-	xit( "morphology works for partially hyphenated keyphrases with function words", function() {
-		const paper = new Paper( "", { slug: "two-years-anniversary", keyword: "two-year anniversary" } );
+	xit( "morphology works for partially hyphenated keyphrases", function() {
+		const paper = new Paper( "", { slug: "how-to-entertain-two-year-old", keyword: "how to entertain two-year-olds" } );
 		const researcher = new EnglishResearcher( paper );
 		researcher.addResearchData( "morphology", morphologyData );
-		expect( slugKeyword( paper, researcher ) ).toEqual( { keyphraseLength: 3, percentWordMatches: 100 } );
+		expect( slugKeyword( paper, researcher ) ).toEqual( { keyphraseLength: 6, percentWordMatches: 100 } );
 	} );
 } );
 

--- a/packages/yoastseo/src/languageProcessing/helpers/morphology/getAllWordsFromPaper.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/morphology/getAllWordsFromPaper.js
@@ -19,6 +19,7 @@ export default function( paper ) {
 	const paperContent = [
 		paperText,
 		paper.getTitle(),
+		paper.getSlug(),
 		parseSlug( paper.getSlug() ),
 		paper.getDescription(),
 		altTagsInText.join( " " ),

--- a/packages/yoastseo/src/languageProcessing/researches/keywordCountInUrl.js
+++ b/packages/yoastseo/src/languageProcessing/researches/keywordCountInUrl.js
@@ -24,7 +24,7 @@ function dehyphenateWordsWithOneForm( wordForms, dehyphenatedForms ) {
  * word forms. Splits each word form on the hyphen and puts each compound into its corresponding array (i.e. the first
  * compound into the first array, the second compound into the second array, etc.). The result is that compounds that are
  * forms of the same word are grouped together (e.g. if the hyphenated keyphrase forms are 'ex-husband' and 'ex-husbands',
- * 'husband' and 'husbands' are grouped together as forms of the same word.
+ * 'husband' and 'husbands' are grouped together as forms of the same word).
  *
  * @param {string[]}	wordForms		The array with the word forms.
  * @param {Array[]}		dehyphenatedForms	The array with the dehyphenated word forms.
@@ -37,7 +37,7 @@ function dehyphenateWordsWithMultipleForms( wordForms, dehyphenatedForms ) {
 	 * Create one array per compound in the array of dehyphenated word forms.
 	 * Put a number corresponding to the compound index inside the array so that later we can put the compound in the correct
 	 * array by looking for the array that contains the compound index.
-	* */
+	 */
 	const numberOfCompounds = firstWordFormSplit.length;
 	for ( let i = 0; i < numberOfCompounds; i++ ) {
 		dehyphenatedForms.push( [ i ] );

--- a/packages/yoastseo/src/languageProcessing/researches/keywordCountInUrl.js
+++ b/packages/yoastseo/src/languageProcessing/researches/keywordCountInUrl.js
@@ -107,7 +107,7 @@ function keywordCountInSlug( paper, researcher ) {
 	const parsedSlug = parseSlug( paper.getSlug() );
 	const locale = paper.getLocale();
 
-	const keyphraseInSlug = findTopicFormsInString( topicForms, parsedSlug, false, locale );
+	const keyphraseInSlug = findTopicFormsInString( topicForms, parsedSlug, false, locale, false );
 
 	return {
 		keyphraseLength: topicForms.keyphraseForms.length,

--- a/packages/yoastseo/src/languageProcessing/researches/keywordCountInUrl.js
+++ b/packages/yoastseo/src/languageProcessing/researches/keywordCountInUrl.js
@@ -1,6 +1,7 @@
 /** @module researches/keywordCountInSlug */
 import parseSlug from "../helpers/url/parseSlug";
 import { findTopicFormsInString } from "../helpers/match/findKeywordFormsInString.js";
+import { uniq } from "lodash-es";
 
 /**
  * Splits the word form on the hyphen and adds each compound into a separate array inside the array of word forms.
@@ -52,10 +53,13 @@ function dehyphenateWordsWithMultipleForms( wordForms, dehyphenatedForms ) {
 		}
 	} );
 
-	// Remove numbers from the array of word forms.
-	dehyphenatedForms.forEach( function( arrayOfForms ) {
-		arrayOfForms.shift();
-	} );
+	// Remove numbers and duplicates from the array of word forms.
+	for ( let i = 0; i < dehyphenatedForms.length; i++ ) {
+		dehyphenatedForms[ i ] = uniq( dehyphenatedForms[ i ] );
+		// Remove the numbers indicating the compound index.
+		dehyphenatedForms[ i ].shift();
+	}
+
 	return dehyphenatedForms;
 }
 

--- a/packages/yoastseo/src/languageProcessing/researches/keywordCountInUrl.js
+++ b/packages/yoastseo/src/languageProcessing/researches/keywordCountInUrl.js
@@ -4,7 +4,7 @@ import { findTopicFormsInString } from "../helpers/match/findKeywordFormsInStrin
 import { uniq } from "lodash-es";
 
 /**
- * Splits the word form on the hyphen and adds each compound into a separate array inside the array of word forms.
+ * Splits the word form on the hyphen and adds each part into a separate array inside the array of word forms.
  *
  * @param {string[]}	wordForms			The array with the word form.
  * @param {Array[]}		dehyphenatedForms	The array with the dehyphenated word forms.
@@ -20,9 +20,9 @@ function dehyphenateWordsWithOneForm( wordForms, dehyphenatedForms ) {
 }
 
 /**
- * Checks how many compounds the hyphenated word has. Creates an array for each compound inside the array of dehyphenated
- * word forms. Splits each word form on the hyphen and puts each compound into its corresponding array (i.e. the first
- * compound into the first array, the second compound into the second array, etc.). The result is that compounds that are
+ * Checks how many parts the hyphenated word has. Creates an array for each part inside the array of dehyphenated
+ * word forms. Splits each word form on the hyphen and puts each part into its corresponding array (i.e. the first
+ * part into the first array, the second part into the second array, etc.). The result is that parts that are
  * forms of the same word are grouped together (e.g. if the hyphenated keyphrase forms are 'ex-husband' and 'ex-husbands',
  * 'husband' and 'husbands' are grouped together as forms of the same word).
  *
@@ -32,31 +32,30 @@ function dehyphenateWordsWithOneForm( wordForms, dehyphenatedForms ) {
  * @returns {Array[]}	The array of dehyphenated word forms.
  */
 function dehyphenateWordsWithMultipleForms( wordForms, dehyphenatedForms ) {
-	const firstWordFormSplit = wordForms[ 0 ].split( "-" );
 	/*
-	 * Create one array per compound in the array of dehyphenated word forms.
-	 * Put a number corresponding to the compound index inside the array so that later we can put the compound in the correct
-	 * array by looking for the array that contains the compound index.
+	 * Create one array for each part of the dehyphenated word in the array of dehyphenated word forms.
+	 * Put a number corresponding to the index of the part inside the array so that later we can put the part in the correct
+	 * array by looking for the array that contains the part index.
 	 */
-	const numberOfCompounds = firstWordFormSplit.length;
-	for ( let i = 0; i < numberOfCompounds; i++ ) {
+	const firstWordFormSplit = wordForms[ 0 ].split( "-" );
+	const numberOfParts = firstWordFormSplit.length;
+	for ( let i = 0; i < numberOfParts; i++ ) {
 		dehyphenatedForms.push( [ i ] );
 	}
 
-	// Split each word form on the hyphen and put each compound into the corresponding array based on the index.
+	// Split each word form on the hyphen and put each part into the corresponding array based on the index.
 	wordForms.forEach( function( wordForm ) {
 		const splitWordForm = wordForm.split( "-" );
 
-		for ( let i = 0; i < numberOfCompounds; i++ ) {
-			const indexInArrayOfForms = dehyphenatedForms.findIndex( element => element.includes( i ) );
-			dehyphenatedForms[ indexInArrayOfForms ].push( splitWordForm[ i ] );
+		for ( let i = 0; i < numberOfParts; i++ ) {
+			dehyphenatedForms[ i ].push( splitWordForm[ i ] );
 		}
 	} );
 
 	// Remove numbers and duplicates from the array of word forms.
 	for ( let i = 0; i < dehyphenatedForms.length; i++ ) {
 		dehyphenatedForms[ i ] = uniq( dehyphenatedForms[ i ] );
-		// Remove the numbers indicating the compound index.
+		// Remove the numbers indicating the part index.
 		dehyphenatedForms[ i ].shift();
 	}
 
@@ -64,7 +63,7 @@ function dehyphenateWordsWithMultipleForms( wordForms, dehyphenatedForms ) {
 }
 
 /**
- * Splits hyphenated keyphrases so that each compound is an individual word, e.g. 'pop-art' becomes 'pop' and 'art'.
+ * Splits hyphenated keyphrases so that each part is an individual word, e.g. 'pop-art' becomes 'pop' and 'art'.
  * Splitting the keyphrase forms allows for hyphenated keyphrases to be detected in the slug. The slug is parsed on hyphens, and the words from
  * the keyphrase are compared with the words from the slug to find a match. Without dehyphenating the keyphrase, the word from the keyphrase would be
  * 'pop-art' while the words from the slug would be 'pop' and 'art', and a match would not be detected.

--- a/packages/yoastseo/src/languageProcessing/researches/keywordCountInUrl.js
+++ b/packages/yoastseo/src/languageProcessing/researches/keywordCountInUrl.js
@@ -3,6 +3,63 @@ import parseSlug from "../helpers/url/parseSlug";
 import { findTopicFormsInString } from "../helpers/match/findKeywordFormsInString.js";
 
 /**
+ * Splits the word form on the hyphen and adds each compound into a separate array inside the array of word forms.
+ *
+ * @param {string[]}	wordForms			The array with the word form.
+ * @param {Array[]}		dehyphenatedForms	The array with the dehyphenated word forms.
+ *
+ * @returns {Array[]}	The array of dehyphenated word forms.
+ */
+function dehyphenateWordsWithOneForm( wordForms, dehyphenatedForms ) {
+	wordForms.forEach( function( wordForm ) {
+		const splitWordForm = wordForm.split( "-" );
+		splitWordForm.forEach( compound => dehyphenatedForms.push( [ compound ] ) );
+	} );
+	return dehyphenatedForms;
+}
+
+/**
+ * Checks how many compounds the hyphenated word has. Creates an array for each compound inside the array of dehyphenated
+ * word forms. Splits each word form on the hyphen and puts each compound into its corresponding array (i.e. the first
+ * compound into the first array, the second compound into the second array, etc.). The result is that compounds that are
+ * forms of the same word are grouped together (e.g. if the hyphenated keyphrase forms are 'ex-husband' and 'ex-husbands',
+ * 'husband' and 'husbands' are grouped together as forms of the same word.
+ *
+ * @param {string[]}	wordForms		The array with the word forms.
+ * @param {Array[]}		dehyphenatedForms	The array with the dehyphenated word forms.
+ *
+ * @returns {Array[]}	The array of dehyphenated word forms.
+ */
+function dehyphenateWordsWithMultipleForms( wordForms, dehyphenatedForms ) {
+	const firstWordFormSplit = wordForms[ 0 ].split( "-" );
+	/*
+	 * Create one array per compound in the array of dehyphenated word forms.
+	 * Put a number corresponding to the compound index inside the array so that later we can put the compound in the correct
+	 * array by looking for the array that contains the compound index.
+	* */
+	const numberOfCompounds = firstWordFormSplit.length;
+	for ( let i = 0; i < numberOfCompounds; i++ ) {
+		dehyphenatedForms.push( [ i ] );
+	}
+
+	// Split each word form on the hyphen and put each compound into the corresponding array based on the index.
+	wordForms.forEach( function( wordForm ) {
+		const splitWordForm = wordForm.split( "-" );
+
+		for ( let i = 0; i < numberOfCompounds; i++ ) {
+			const indexInArrayOfForms = dehyphenatedForms.findIndex( element => element.includes( i ) );
+			dehyphenatedForms[ indexInArrayOfForms ].push( splitWordForm[ i ] );
+		}
+	} );
+
+	// Remove numbers from the array of word forms.
+	dehyphenatedForms.forEach( function( arrayOfForms ) {
+		arrayOfForms.shift();
+	} );
+	return dehyphenatedForms;
+}
+
+/**
  * Splits hyphenated keyphrases so that each compound is an individual word, e.g. 'pop-art' becomes 'pop' and 'art'.
  * Splitting the keyphrase forms allows for hyphenated keyphrases to be detected in the slug. The slug is parsed on hyphens, and the words from
  * the keyphrase are compared with the words from the slug to find a match. Without dehyphenating the keyphrase, the word from the keyphrase would be
@@ -13,7 +70,7 @@ import { findTopicFormsInString } from "../helpers/match/findKeywordFormsInStrin
  * @returns {Array} topicForms with split compounds.
  */
 function dehyphenateKeyphraseForms( topicForms ) {
-	const dehyphenatedKeyphraseForms = [];
+	let dehyphenatedKeyphraseForms = [];
 
 	topicForms.keyphraseForms.forEach( function( wordForms ) {
 		// If a word doesn't contain hyphens, don't split it.
@@ -22,12 +79,13 @@ function dehyphenateKeyphraseForms( topicForms ) {
 			return;
 		}
 
-		// Split each form of a hyphenated word and add each compound to the array of dehyphenated keyphrase forms.
-		wordForms.forEach( function( wordForm ) {
-			const splitWordForm = wordForm.split( "-" );
-			splitWordForm.forEach( compound => dehyphenatedKeyphraseForms.push( [ compound ] ) );
-		} );
+		if ( wordForms.length === 1 ) {
+			dehyphenatedKeyphraseForms = dehyphenateWordsWithOneForm( wordForms, dehyphenatedKeyphraseForms );
+		} else {
+			dehyphenatedKeyphraseForms = dehyphenateWordsWithMultipleForms( wordForms, dehyphenatedKeyphraseForms );
+		}
 	} );
+
 	topicForms.keyphraseForms = dehyphenatedKeyphraseForms;
 
 	return topicForms;
@@ -44,8 +102,9 @@ function dehyphenateKeyphraseForms( topicForms ) {
 function keywordCountInSlug( paper, researcher ) {
 	const topicForms = dehyphenateKeyphraseForms( researcher.getResearch( "morphology" ) );
 	const parsedSlug = parseSlug( paper.getSlug() );
+	const locale = paper.getLocale();
 
-	const keyphraseInSlug = findTopicFormsInString( topicForms, parsedSlug, false, paper.getLocale() );
+	const keyphraseInSlug = findTopicFormsInString( topicForms, parsedSlug, false, locale );
 
 	return {
 		keyphraseLength: topicForms.keyphraseForms.length,


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* In other assessments, we recognize word forms of hyphenated keyphrases (e.g. `two-year-old` and `two-year-olds`) but we do not filter out function words (e.g. `two`, `year`, and `old` are all function words but they don't get filtered out from the phrase `two-year-old`). We want to achieve the same behavior for the Keyphrase in slug assessment. Before implementing the change in this PR, both morphology and function words weren't working in the Keyphrase in slug assessment for hyphenated keyphrases.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [wordpress-seo-premium] Improves the accuracy of the Keyphrase in slug assessment by recognizing different word forms of hyphenated keyphrases in the slug (e.g. if keyphrase is `ex-husband` and slug is `ex-husbands`). 
* [shopify-seo] Improves the accuracy of the Keyphrase in slug assessment by recognizing different word forms of hyphenated keyphrases in the slug (e.g. if keyphrase is `ex-husband` and slug is `ex-husbands`). 
* [yoastseo] Adds the full slug (in addition to each part of the slug divided on the hyphen/underscore) to the list of words from the paper.
* [yoastseo] Adds a step to the `dehyphenateKeyphrase` function in the `keywordCountInUrl` research that allows to generate an array of dehyphenated keyphrase forms for keyphrases with multiple word forms.

## Relevant technical choices:

* In order to create word forms, we get all words from the paper, stem them, and recognize word forms with the same stem as belonging to the same word. To get words from the slug, we split the slug on the hyphen/underscore and add each part as a separate word. In this PR, we also add the full slug to the list of words from the paper. This makes it possible to recognize the slug as a word form of a hyphenated keyphrase (e.g. if keyphrase is `ex-husband` and slug is `ex-husbands`).
* An extra step is added to the `dehyphenateKeyphrase` function inside the `keywordCountInUrl` research. This step makes sure that for keyphrases with multiple forms, the forms of the same compound/word are grouped together in the array of dehyphenated keyphrase forms.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Test in Yoast SEO Premium
* Open a new post, set your keyphrase to `ex-husband` and your slug to `ex-husbands`
* Confirm that the Keyphrase in slug assessment returns a green bullet
* Switch the slug and the keyphrase around (so that keyphrase is `ex-husbands` and slug `ex-husband`
* Confirm that the Keyphrase in slug assessment still returns a green bullet
* Change your site language to French
* Go back to the post, change your keyphrase to `non-fumeurs` and your slug to `non-fumeur`
* Confirm that the Keyphrase in slug assessment returns a green bullet
* Repeat the steps for English also in Shopify


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [x] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes https://yoast.atlassian.net/browse/LR-6
