### PR TITLE
Add multisite file editor location to robots conditional

### DIFF
--- a/src/conditionals/robots-txt-conditional.php
+++ b/src/conditionals/robots-txt-conditional.php
@@ -35,6 +35,10 @@ class Robots_Txt_Conditional implements Conditional {
 	/**
 	 * Returns whether the current page is the file editor page.
 	 *
+	 * This checks for two locations:
+	 * - Multisite network admin file editor page
+	 * - Single site file editor page (under tools)
+	 *
 	 * @return bool
 	 */
 	protected function is_file_editor_page() {
@@ -42,6 +46,11 @@ class Robots_Txt_Conditional implements Conditional {
 
 		if ( $pagenow !== 'admin.php' ) {
 			return false;
+		}
+
+		// phpcs:ignore WordPress.Security.NonceVerification -- This is not a form.
+		if ( isset( $_GET['page'] ) && $_GET['page'] === 'wpseo_files' && \is_multisite() && \is_network_admin() ) {
+			return true;
 		}
 
 		// phpcs:ignore WordPress.Security.NonceVerification -- This is not a form.


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where the robots txt integration was not active in the multisite file editor, resulting in the contents being the same as before our filters: no sitemap(s) and other allow/disallow.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Set up clean multisite subdomain env (or remove the `robots.txt` file from your WP root)
* Install and Network activate this branch
* Check `robots.txt` file (it shows the link to sitemaps)
* Go to Yoast SEO>Edit files> click create `robots.txt` file
* Check `robots.txt` file, it should have something like:
```
User-agent: *
Disallow:

Sitemap: http://multisite.wordpress.test/sitemap_index.xml
```
* Note that if you created the `robots.txt` as active file, the contents of the subdomain sites is then wrong!! I think this falls under the WP filter not running anymore and we can not filter its content. But this is very unfortunate.
* Repeat the steps but with a multisite subdirectory environment, where the expectation is that it has the sitemaps for every site

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes P1-1374
