### PR TITLE
Add info link

### DIFF
--- a/admin/views/tabs/dashboard/crawl-settings.php
+++ b/admin/views/tabs/dashboard/crawl-settings.php
@@ -23,6 +23,15 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 		'Yoast SEO'
 	);
 
+	echo '<p style="margin: 0.5em 0 1em;">';
+	echo sprintf(
+		/* translators: %1$s opens the link to the Yoast.com article about Crawl settings, %2$s closes the link, */
+		esc_html__( '%1$sLearn more about crawl settings and how they could benefit your site.%2$s', 'wordpress-seo' ),
+		'<a href="' . esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/crawl-settings' ) ) . '" target="_blank" rel="noopener noreferrer">',
+		'</a>'
+	);
+	echo '</p>';
+
 	$help_text  = esc_html__( 'This removes the Post Comment Feed link.', 'wordpress-seo' );
 	$help_text .= ' ';
 	$help_text .= sprintf(

--- a/admin/views/tabs/network/crawl-settings.php
+++ b/admin/views/tabs/network/crawl-settings.php
@@ -25,6 +25,15 @@ $feature_toggles = Yoast_Feature_Toggles::instance()->get_all();
 		'Yoast SEO'
 	);
 
+	echo '<p style="margin: 0.5em 0 1em;">';
+	echo sprintf(
+		/* translators: %1$s opens the link to the Yoast.com article about Crawl settings, %2$s closes the link, */
+		esc_html__( '%1$sLearn more about crawl settings and how they could benefit your site.%2$s', 'wordpress-seo' ),
+		'<a href="' . esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/crawl-settings' ) ) . '" target="_blank" rel="noopener noreferrer">',
+		'</a>'
+	);
+	echo '</p>';
+
 	$help_text  = esc_html__( 'This removes the Post Comment Feed link.', 'wordpress-seo' );
 	$help_text .= ' ';
 	$help_text .= sprintf(


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds an info link in the Crawl settings.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Go to Yoast SEO->General in the Crawl settings tab
* Confirm that an info link was added there likeso:
![image](https://user-images.githubusercontent.com/12400734/169802753-62ab81a9-b7c1-4e7b-89a6-df0939e64faa.png)
* Confirm that the link directs to https://yoa.st/crawl-settings in a new tab and that the shortlink args are added in the url, eg. `?php_version=7.4&platform=wordpress&platform_version=5.9.3` etc.

For multisites:
* Go to Yoast SEO->General in the Crawl settings tab of the network admin
* Confirm that an info link was added there likeso:
![image](https://user-images.githubusercontent.com/12400734/169807902-16b4b787-d00d-4563-9dea-0002d461684d.png)
* Confirm that the link directs to https://yoa.st/crawl-settings in a new tab and that the shortlink args are added in the url, eg. `?php_version=7.4&platform=wordpress&platform_version=5.9.3` etc.
* Note, the copy of the network tab will probably be finalized later in the day and will be taken care of with a later PR.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes #
