### PR TITLE
DUPP-533 show redirects upsell to editors

### DIFF
--- a/src/integrations/admin/redirects-integration.php
+++ b/src/integrations/admin/redirects-integration.php
@@ -48,7 +48,7 @@ class Redirects_Integration implements Integration_Interface {
 			'wpseo_dashboard',
 			'',
 			__( 'Redirects', 'wordpress-seo' ) . ' <span class="yoast-badge yoast-premium-badge"></span>',
-			'wpseo_manage_options',
+			'edit_others_posts',
 			'wpseo_redirects',
 			[ $this, 'display' ],
 		];

--- a/tests/unit/integrations/admin/redirects-integration-test.php
+++ b/tests/unit/integrations/admin/redirects-integration-test.php
@@ -73,7 +73,7 @@ class Redirects_Integration_Test extends TestCase {
 				'wpseo_dashboard',
 				'',
 				'Redirects <span class="yoast-badge yoast-premium-badge"></span>',
-				'wpseo_manage_options',
+				'edit_others_posts',
 				'wpseo_redirects',
 				[ $this->instance, 'display' ],
 			],


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where the `Redirects` upsell wouldn't be displayed to the roles that access the same page on Premium.

## Relevant technical choices:

* in Premium the target capability for `Redirects` is `wpseo_manage_redirects` which is not present at all in Free. We want to avoid conflicts so we're not introducing that cap, targeting `edit_others_posts` instead.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install and activate without Premium
* Make sure you have at least a user with `Editor` role and a user with `SEO Editor` role.
* Switch to the Editor user
* Check that you can see only 2 subpages under `Yoast SEO` in the sidebar (both with `Premium` badge)
  * Workouts
  * Redirects
* visit the Redirects page and check it looks as per the original PR: #18431 
* Check the same with the SEO Editor user
* install+activate Premium and check that the *actual* Redirects page is visible for both users.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes [DUPP-533]


[DUPP-533]: https://yoast.atlassian.net/browse/DUPP-533?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ