### PR TITLE
DUPP-573 Allow changing the check url for the Ryte integration

### DIFF
--- a/src/integrations/admin/ryte-integration.php
+++ b/src/integrations/admin/ryte-integration.php
@@ -182,8 +182,15 @@ class Ryte_Integration implements Integration_Interface {
 			$parameters['wf_strict'] = 1;
 		}
 
-		$request  = new WPSEO_Ryte_Request();
-		$response = $request->do_request( get_option( 'home' ), $parameters );
+		$request = new WPSEO_Ryte_Request();
+
+		/**
+		 * Filter: 'wpseo_ryte_change_url' - Allow filtering the URL that the Ryte integration checks.
+		 *
+		 * @api string $site_url The site URL that Ryte checks for indexability.
+		 */
+		$site_url = apply_filters( 'wpseo_ryte_change_url', get_option( 'home' ) );
+		$response = $request->do_request( $site_url, $parameters );
 
 		// Populate the ryte_response property.
 		$this->ryte_response = $response;

--- a/src/integrations/admin/ryte-integration.php
+++ b/src/integrations/admin/ryte-integration.php
@@ -185,11 +185,11 @@ class Ryte_Integration implements Integration_Interface {
 		$request = new WPSEO_Ryte_Request();
 
 		/**
-		 * Filter: 'wpseo_ryte_change_url' - Allow filtering the URL that the Ryte integration checks.
+		 * Filter: 'wpseo_change_home_url' - Allow filtering the home URL that is used by our integrations, eg. the Ryte integration for indexability.
 		 *
-		 * @api string $site_url The site URL that Ryte checks for indexability.
+		 * @api string $site_url The home URL that is used by our integrations, eg. the Ryte integration for indexability.
 		 */
-		$site_url = apply_filters( 'wpseo_ryte_change_url', get_option( 'home' ) );
+		$site_url = apply_filters( 'wpseo_change_home_url', get_option( 'home' ) );
 		$response = $request->do_request( $site_url, $parameters );
 
 		// Populate the ryte_response property.

--- a/src/integrations/admin/ryte-integration.php
+++ b/src/integrations/admin/ryte-integration.php
@@ -189,7 +189,7 @@ class Ryte_Integration implements Integration_Interface {
 		 *
 		 * @api string $site_url The home URL that is used by our integrations, eg. the Ryte integration for indexability.
 		 */
-		$site_url = apply_filters( 'wpseo_change_home_url', get_option( 'home' ) );
+		$site_url = \apply_filters( 'wpseo_change_home_url', get_option( 'home' ) );
 		$response = $request->do_request( $site_url, $parameters );
 
 		// Populate the ryte_response property.

--- a/src/integrations/admin/ryte-integration.php
+++ b/src/integrations/admin/ryte-integration.php
@@ -187,7 +187,7 @@ class Ryte_Integration implements Integration_Interface {
 		/**
 		 * Filter: 'wpseo_change_home_url' - Allow filtering the home URL that is used by our integrations, eg. the Ryte integration for indexability.
 		 *
-		 * @api string $site_url The home URL that is used by our integrations, eg. the Ryte integration for indexability.
+		 * @param string $site_url The home URL that is used by our integrations, eg. the Ryte integration for indexability.
 		 */
 		$site_url = \apply_filters( 'wpseo_change_home_url', get_option( 'home' ) );
 		$response = $request->do_request( $site_url, $parameters );


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds a new filter `wpseo_change_home_url` that allows changing the URL the Ryte integration checks, to allow for more versatile hosting setups.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* If you're on a test environment like the Yoast's docker one, you have to add this filter in a mu-plugin (or in the functions.php file of your active theme:
```
add_filter( 'yoast_seo_development_mode', 'yoast_seo_development_mode_change', 1 );
function yoast_seo_development_mode_change() {
    return false;
}
```
so that the Ryte integration can be active and running when checking the Site Health tool
* If you're on a local environment, the site should not be able to be indexed, so if you go to the Site Health tool, you should see a `An error occurred while checking whether your site can be found by search engines` entry there.
* The above message should show both with this PR and without.
* With this PR you are able to add a filter to change the URL that the Ryte indexability check is performed with:
```
add_filter( 'wpseo_change_home_url', 'change_home_url', 1 );
function change_home_url() {
    return 'https://yoast.com';
}
```
* With the above filter, we instruct Ryte to perform the indexability check for yoast.com
* If you refresh the Site Health tool, it should now show a `Your site can be found by search engines` entry instead.
* If you add in that filter a URL of a non-accessible site again (or a non-existent site) and refresh the Site Health tool, it should again show the `An error occurred while checking whether your site can be found by search engines` entry.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.


## Impact Check
* Check in a site where the previous RC was showing that a site was indexable (in the Site Health Tool), that it still shows as indexable there 
## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
