### PR TITLE
DUPP-540 clean crawl settings integration

### DIFF
--- a/src/integrations/admin/crawl-settings-integration.php
+++ b/src/integrations/admin/crawl-settings-integration.php
@@ -3,11 +3,9 @@
 namespace Yoast\WP\SEO\Integrations\Admin;
 
 use WPSEO_Option_Tab;
-
+use WPSEO_Option_Tabs;
 use Yoast\WP\SEO\Conditionals\Admin_Conditional;
-use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
-use Yoast\WP\SEO\Presenters\Admin\Beta_Badge_Presenter;
 
 /**
  * Crawl_Settings_Integration class
@@ -15,32 +13,16 @@ use Yoast\WP\SEO\Presenters\Admin\Beta_Badge_Presenter;
 class Crawl_Settings_Integration implements Integration_Interface {
 
 	/**
-	 * The options' helper.
+	 * Returns the conditionals based in which this loadable should be active.
 	 *
-	 * @var Options_Helper
-	 */
-	private $options_helper;
-
-	/**
-	 * {@inheritDoc}
+	 * In this case: when on an admin page.
 	 */
 	public static function get_conditionals() {
 		return [ Admin_Conditional::class ];
 	}
 
 	/**
-	 * Crawl_Settings_Integration constructor.
-	 *
-	 * @param Options_Helper $options_helper The options helper.
-	 */
-	public function __construct(
-		Options_Helper $options_helper
-	) {
-		$this->options_helper = $options_helper;
-	}
-
-	/**
-	 * {@inheritDoc}
+	 * Registers an action to add a new tab to the General page.
 	 */
 	public function register_hooks() {
 		\add_action( 'wpseo_settings_tabs_dashboard', [ $this, 'add_crawl_settings_tab' ] );
@@ -49,13 +31,13 @@ class Crawl_Settings_Integration implements Integration_Interface {
 	/**
 	 * Adds a dedicated tab in the General sub-page.
 	 *
-	 * @param WPSEO_Options_Tabs $dashboard_tabs Object representing the tabs of the General sub-page.
+	 * @param WPSEO_Option_Tabs $dashboard_tabs Object representing the tabs of the General sub-page.
 	 */
 	public function add_crawl_settings_tab( $dashboard_tabs ) {
 		$dashboard_tabs->add_tab(
 			new WPSEO_Option_Tab(
 				'crawl-settings',
-				__( 'Crawl settings', 'wordpress-seo' ),
+				\__( 'Crawl settings', 'wordpress-seo' ),
 				[
 					'save_button' => true,
 					'beta'        => true,

--- a/tests/unit/integrations/admin/crawl-settings-integration-test.php
+++ b/tests/unit/integrations/admin/crawl-settings-integration-test.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Integrations\Admin;
+
+use Brain\Monkey;
+use Yoast\WP\SEO\Conditionals\Admin_Conditional;
+use Yoast\WP\SEO\Integrations\Admin\Crawl_Settings_Integration;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Class Cron_Integration_Test
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Integrations\Admin\Crawl_Settings_Integration
+ *
+ * @group integrations
+ */
+class Crawl_Settings_Integration_Test extends TestCase {
+
+	/**
+	 * Represents the instance to test.
+	 *
+	 * @var Crawl_Settings_Integration
+	 */
+	protected $instance;
+
+	/**
+	 * Set up the fixtures for the tests.
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->instance = new Crawl_Settings_Integration();
+	}
+
+	/**
+	 * Tests the retrieval of the conditionals.
+	 *
+	 * @covers ::get_conditionals
+	 */
+	public function test_get_conditionals() {
+		static::assertEquals(
+			[
+				Admin_Conditional::class,
+			],
+			Crawl_Settings_Integration::get_conditionals()
+		);
+	}
+
+	/**
+	 * Tests the registration of the hooks.
+	 *
+	 * @covers ::register_hooks
+	 */
+	public function test_register_hooks() {
+		Monkey\Actions\has( 'wpseo_settings_tabs_dashboard', [ $this->instance, 'add_crawl_settings_tab' ] );
+
+		$this->instance->register_hooks();
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to clean some leftovers in the Crawl settings integration.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves technical debt in the Crawl settings integration.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Smoke test the crawl settings tab: it should still be there and be working.
  * The feed removal should be unaffected 


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes [DUPP-540]


[DUPP-540]: https://yoast.atlassian.net/browse/DUPP-540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ