### PR TITLE
Remove obsolete code

### DIFF
--- a/admin/views/tabs/dashboard/crawl-settings.php
+++ b/admin/views/tabs/dashboard/crawl-settings.php
@@ -39,13 +39,6 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 		esc_html__( 'Find out how removing feeds can improve performance.', 'wordpress-seo' )
 	);
 
-	$feature_help = new WPSEO_Admin_Help_Panel(
-		'remove_feed_post_comments',
-		/* translators: %s expands to a feature's name */
-		esc_html__( 'Help on: Post comment feeds', 'wordpress-seo' ),
-		$help_text
-	);
-
 	$yform->toggle_switch(
 		'remove_feed_post_comments',
 		[

--- a/admin/views/tabs/network/crawl-settings.php
+++ b/admin/views/tabs/network/crawl-settings.php
@@ -41,13 +41,6 @@ $feature_toggles = Yoast_Feature_Toggles::instance()->get_all();
 		esc_html__( 'Find out how removing feeds can improve performance.', 'wordpress-seo' )
 	);
 
-	$feature_help = new WPSEO_Admin_Help_Panel(
-		'remove_feed_post_comments',
-		/* translators: %s expands to a feature's name */
-		esc_html__( 'Help on: Post comment feeds', 'wordpress-seo' ),
-		$help_text
-	);
-
 	$yform->toggle_switch(
 		WPSEO_Option::ALLOW_KEY_PREFIX . 'remove_feed_post_comments',
 		[


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to clean some leftovers in the Crawl tab

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves technical debt in the Crawl tab

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* In a multisite, install SEO Free
* Go to a subsite and `Remove` the **Post comment feeds**
* Confirm in a post of that subsite that the feed have been removed
* Go to the network site and toggle the **Post comment feeds** from `Allow Control` to `Disable`
* Refresh the subsite settings and confirm that the setting has been disabled:
![image](https://user-images.githubusercontent.com/12400734/170011667-42336ae3-a5d4-4ec9-a653-3bc7d8081830.png)
* Confirm in the post of that subsite that the feed have returned.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes #
