### PR TITLE
Dupp 542 ftc adjust copy and alert in Social profiles step

### DIFF
--- a/packages/js/src/first-time-configuration/tailwind-components/steps/personal-preferences/newsletter-signup.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/steps/personal-preferences/newsletter-signup.js
@@ -89,8 +89,8 @@ export function NewsletterSignup( { gdprLink } ) {
 			<p className="yst-my-2">
 				{
 					sprintf(
+						// translators: %1$s expands to "Yoast", %2$s expands to "Yoast SEO"
 						__(
-							// translators: %1$s expands to "Yoast", %2$s expands to "Yoast SEO"
 							"Sign up for the %1$s newsletter to receive best-practice tips on how to rank, stay up-to-date with the latest SEO news and get guidance on how to use %2$s to the fullest!",
 							"wordpress-seo"
 						),

--- a/packages/js/src/first-time-configuration/tailwind-components/steps/social-profiles/social-input-person-section.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/steps/social-profiles/social-input-person-section.js
@@ -63,8 +63,8 @@ function SocialInputPersonSection( { socialProfiles, errorFields, dispatch, canE
 					{
 						createInterpolateElement(
 							sprintf(
+								// translators: %1$s is replaced by the selected person's username
 								__(
-									// translators: %1$s is replaced by the selected person's username
 									"You're not allowed to edit the social profiles of the user %1$s. Please ask this user or an admin to do this.",
 									"wordpress-seo"
 								),

--- a/packages/js/src/first-time-configuration/tailwind-components/steps/social-profiles/social-input-person-section.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/steps/social-profiles/social-input-person-section.js
@@ -1,5 +1,5 @@
 import apiFetch from "@wordpress/api-fetch";
-import { createInterpolateElement, useCallback, useEffect, Fragment } from "@wordpress/element";
+import { createInterpolateElement, useCallback, useEffect } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
 import PropTypes from "prop-types";
 

--- a/packages/js/src/first-time-configuration/tailwind-components/steps/social-profiles/social-input-person-section.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/steps/social-profiles/social-input-person-section.js
@@ -3,8 +3,7 @@ import { createInterpolateElement, useCallback, useEffect, Fragment } from "@wor
 import { __, sprintf } from "@wordpress/i18n";
 import PropTypes from "prop-types";
 
-import { Alert } from "@yoast/components";
-import { addLinkToString } from "../../../../helpers/stringHelpers.js";
+import Alert from "../../base/alert";
 import { socialMedia } from "../../helpers";
 import SocialInput from "./social-input";
 
@@ -47,63 +46,17 @@ function SocialInputPersonSection( { socialProfiles, errorFields, dispatch, canE
 		<div>
 			{
 				// No person has been selected in step 2
-				personId === 0 && <Fragment>
-					<Alert type="info">
-						{
-							createInterpolateElement(
-								sprintf(
-									__(
-										// translators: %1$s and %2$s are replaced by opening and closing <b> tags, %3$s and %4$s are replaced by opening and closing anchor tags
-										"%1$sImportant%2$s: Please select a name in step 2 for this step to be effective.",
-										"wordpress-seo"
-									),
-									"<b>",
-									"</b>"
-								),
-								{
-									b: <b />,
-								}
+				personId === 0 && <Alert type="info" className="yst-mt-5">
+					{
+						sprintf(
+							__(
+								// translators: %1$s and %2$s are replaced by opening and closing <b> tags, %3$s and %4$s are replaced by opening and closing anchor tags
+								"Please select a name in step 2 for this step to be effective.",
+								"wordpress-seo"
 							)
-						}
-					</Alert>
-					<p>
-						{
-							createInterpolateElement(
-								sprintf(
-									__(
-										// translators: %1$s and %2$s are replaced by opening and closing anchor tags
-										"In this step, you need to add the personal social profiles of the person your site represents. To do that, you should go to the %1$sUsers%2$s > Profile page in a new browser tab. Alternatively, ask the user or an admin to do it if you are not allowed.",
-										"wordpress-seo"
-									),
-									"<a>",
-									"</a>"
-								),
-								{
-									b: <b />,
-									// eslint-disable-next-line jsx-a11y/anchor-has-content
-									a: <a id="yoast-configuration-workout-user-page-link-1" href={ window.wpseoFirstTimeConfigurationData.usersPageUrl } target="_blank" rel="noopener noreferrer" />,
-								}
-							)
-						}
-					</p>
-					<p>
-						{
-							addLinkToString(
-								sprintf(
-									__(
-										// translators: %1$s and %2$s are replaced by opening and closing anchor tags.
-										"On the %1$sUsers%2$s page, hover your mouse over the username you want to edit. Click ‘Edit’ to access the user’s profile. Then, scroll down to the ‘Contact info’ section (see screenshot below) and fill in the URLs of the personal social profiles you want to add.",
-										"wordpress-seo"
-									),
-									"<a>",
-									"</a>"
-								),
-								window.wpseoFirstTimeConfigurationData.usersPageUrl,
-								"yoast-configuration-workout-user-page-link-2"
-							)
-						}
-					</p>
-				</Fragment>
+						)
+					}
+				</Alert>
 			}
 			{
 				( ( personId !== 0 ) && ( ! canEditUser ) ) &&

--- a/packages/js/src/first-time-configuration/tailwind-components/steps/social-profiles/social-input-person-section.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/steps/social-profiles/social-input-person-section.js
@@ -48,7 +48,7 @@ function SocialInputPersonSection( { socialProfiles, errorFields, dispatch, canE
 				// No person has been selected in step 2
 				personId === 0 && <Alert type="info" className="yst-mt-5">
 					{
-						// translators: please note that "Site representation" here refers to the name of the previous step, so this occurnce needs to be translated accordingly to the previous step header's translation
+						// translators: please note that "Site representation" here refers to the name of the previous step, so this occurrence needs to be translated accordingly to the previous step header's translation
 						__(
 							"Please select a name in the Site representation step for this step to be effective.",
 							"wordpress-seo"

--- a/packages/js/src/first-time-configuration/tailwind-components/steps/social-profiles/social-input-person-section.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/steps/social-profiles/social-input-person-section.js
@@ -48,12 +48,11 @@ function SocialInputPersonSection( { socialProfiles, errorFields, dispatch, canE
 				// No person has been selected in step 2
 				personId === 0 && <Alert type="info" className="yst-mt-5">
 					{
-						sprintf(
-							__(
-								// translators: %1$s and %2$s are replaced by opening and closing <b> tags, %3$s and %4$s are replaced by opening and closing anchor tags
-								"Please select a name in step 2 for this step to be effective.",
-								"wordpress-seo"
-							)
+						// translators: please note that "Site representation" here refers to the name of the previous step, so this occurnce needs to be translated accordingly to the previous step header's translation
+						__(
+							"Please select a name in the Site representation step for this step to be effective.",
+							"wordpress-seo"
+
 						)
 					}
 				</Alert>

--- a/packages/js/src/first-time-configuration/tailwind-components/steps/social-profiles/social-input-person-section.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/steps/social-profiles/social-input-person-section.js
@@ -48,9 +48,9 @@ function SocialInputPersonSection( { socialProfiles, errorFields, dispatch, canE
 				// No person has been selected in step 2
 				personId === 0 && <Alert type="info" className="yst-mt-5">
 					{
-						// translators: please note that "Site representation" here refers to the name of the previous step, so this occurrence needs to be translated accordingly to the previous step header's translation
+						// translators: please note that "Site representation" here refers to the name of a step in the first-time configuration, so this occurrence needs to be translated in the same manner as that step's heading.
 						__(
-							"Please select a name in the Site representation step for this step to be effective.",
+							"Please select a name in the site representation step for this step to be effective.",
 							"wordpress-seo"
 
 						)

--- a/packages/js/src/workouts/components/SocialInputPersonSection.js
+++ b/packages/js/src/workouts/components/SocialInputPersonSection.js
@@ -39,7 +39,7 @@ function SocialInputPersonSection( { personId } ) {
 					</Alert>
 					<p>
 						{
-							createInterpolateElement(
+							addLinkToString(
 								sprintf(
 									__(
 										// translators: %1$s and %2$s are replaced by opening and closing anchor tags
@@ -49,11 +49,8 @@ function SocialInputPersonSection( { personId } ) {
 									"<a>",
 									"</a>"
 								),
-								{
-									b: <b />,
-									// eslint-disable-next-line jsx-a11y/anchor-has-content
-									a: <a id="yoast-configuration-workout-user-page-link-1" href={ window.wpseoWorkoutsData.usersPageUrl } target="_blank" rel="noopener noreferrer" />,
-								}
+								window.wpseoFirstTimeConfigurationData.usersPageUrl,
+								"yoast-configuration-workout-user-page-link-1"
 							)
 						}
 					</p>
@@ -69,7 +66,7 @@ function SocialInputPersonSection( { personId } ) {
 									"<a>",
 									"</a>"
 								),
-								window.wpseoWorkoutsData.usersPageUrl,
+								window.wpseoFirstTimeConfigurationData.usersPageUrl,
 								"yoast-configuration-workout-user-page-link-2"
 							)
 						}

--- a/packages/js/src/workouts/components/SocialInputPersonSection.js
+++ b/packages/js/src/workouts/components/SocialInputPersonSection.js
@@ -23,8 +23,8 @@ function SocialInputPersonSection( { personId } ) {
 						{
 							createInterpolateElement(
 								sprintf(
+									// translators: %1$s and %2$s are replaced by opening and closing <b> tags, %3$s and %4$s are replaced by opening and closing anchor tags
 									__(
-										// translators: %1$s and %2$s are replaced by opening and closing <b> tags, %3$s and %4$s are replaced by opening and closing anchor tags
 										"%1$sImportant%2$s: Please select a name in step 2 for this step to be effective.",
 										"wordpress-seo"
 									),
@@ -41,8 +41,8 @@ function SocialInputPersonSection( { personId } ) {
 						{
 							addLinkToString(
 								sprintf(
+									// translators: %1$s and %2$s are replaced by opening and closing anchor tags
 									__(
-										// translators: %1$s and %2$s are replaced by opening and closing anchor tags
 										"In this step, you need to add the personal social profiles of the person your site represents. To do that, you should go to the %1$sUsers%2$s > Profile page in a new browser tab. Alternatively, ask the user or an admin to do it if you are not allowed.",
 										"wordpress-seo"
 									),
@@ -58,8 +58,8 @@ function SocialInputPersonSection( { personId } ) {
 						{
 							addLinkToString(
 								sprintf(
+									// translators: %1$s and %2$s are replaced by opening and closing anchor tags.
 									__(
-										// translators: %1$s and %2$s are replaced by opening and closing anchor tags.
 										"On the %1$sUsers%2$s page, hover your mouse over the username you want to edit. Click ‘Edit’ to access the user’s profile. Then, scroll down to the ‘Contact info’ section (see screenshot below) and fill in the URLs of the personal social profiles you want to add.",
 										"wordpress-seo"
 									),
@@ -79,8 +79,8 @@ function SocialInputPersonSection( { personId } ) {
 						{
 							addLinkToString(
 								sprintf(
+									// translators: %1$s and %2$s are replaced by opening and closing <b> tags, %3$s and %4$s are replaced by opening and closing anchor tags
 									__(
-										// translators: %1$s and %2$s are replaced by opening and closing <b> tags, %3$s and %4$s are replaced by opening and closing anchor tags
 										"In this step, you need to add the personal social profiles of the person your site represents. To do that, you should go to the user’s %1$sProfile page%2$s (opens in a new browser tab). Then, scroll down to the ‘Contact info’ section (see screenshot below) and fill in the URLs of the personal social profiles you want to add. Alternatively, ask the user or an admin to do it if you are not allowed.",
 										"wordpress-seo"
 									),

--- a/src/integrations/admin/first-time-configuration-integration.php
+++ b/src/integrations/admin/first-time-configuration-integration.php
@@ -208,7 +208,6 @@ class First_Time_Configuration_Integration implements Integration_Interface {
 						"configIndexables": "%s",
 						"configIndexablesBenefits": "%s",
 					},
-					"usersPageUrl": "%s",
 				};',
 				$this->social_profiles_helper->can_edit_profile( $person_id ),
 				$this->is_company_or_person(),
@@ -234,8 +233,7 @@ class First_Time_Configuration_Integration implements Integration_Interface {
 				$knowledge_graph_message,
 				$this->shortlinker->build_shortlink( 'https://yoa.st/gdpr-config-workout' ),
 				$this->shortlinker->build_shortlink( 'https://yoa.st/config-indexables' ),
-				$this->shortlinker->build_shortlink( 'https://yoa.st/config-indexables-benefits' ),
-				\esc_url( \admin_url( 'users.php' ) )
+				$this->shortlinker->build_shortlink( 'https://yoa.st/config-indexables-benefits' )
 			),
 			'before'
 		);

--- a/src/integrations/admin/first-time-configuration-integration.php
+++ b/src/integrations/admin/first-time-configuration-integration.php
@@ -208,6 +208,7 @@ class First_Time_Configuration_Integration implements Integration_Interface {
 						"configIndexables": "%s",
 						"configIndexablesBenefits": "%s",
 					},
+					"usersPageUrl": "%s",
 				};',
 				$this->social_profiles_helper->can_edit_profile( $person_id ),
 				$this->is_company_or_person(),
@@ -233,7 +234,8 @@ class First_Time_Configuration_Integration implements Integration_Interface {
 				$knowledge_graph_message,
 				$this->shortlinker->build_shortlink( 'https://yoa.st/gdpr-config-workout' ),
 				$this->shortlinker->build_shortlink( 'https://yoa.st/config-indexables' ),
-				$this->shortlinker->build_shortlink( 'https://yoa.st/config-indexables-benefits' )
+				$this->shortlinker->build_shortlink( 'https://yoa.st/config-indexables-benefits' ),
+				\esc_url( \admin_url( 'users.php' ) )
 			),
 			'before'
 		);

--- a/src/integrations/admin/first-time-configuration-integration.php
+++ b/src/integrations/admin/first-time-configuration-integration.php
@@ -120,7 +120,7 @@ class First_Time_Configuration_Integration implements Integration_Interface {
 	}
 
 	/**
-	 * Adds the data for the configuration workout to the wpseoWorkoutsData object.
+	 * Adds the data for the first-time configuration to the wpseoFirstTimeConfigurationData object.
 	 */
 	public function enqueue_assets() {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Date is not processed or saved.

--- a/src/routes/first-time-configuration-route.php
+++ b/src/routes/first-time-configuration-route.php
@@ -82,7 +82,7 @@ class First_Time_Configuration_Route implements Route_Interface {
 	/**
 	 * First_Time_Configuration_Route constructor.
 	 *
-	 * @param First_Time_Configuration_Action $first_time_configuration_action The configuration workout action.
+	 * @param First_Time_Configuration_Action $first_time_configuration_action The first-time configuration action.
 	 */
 	public function __construct(
 		First_Time_Configuration_Action $first_time_configuration_action


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* In the `Site representation` step, if a user chooses _Person_ but doesn’t select the user the site represents, in the following `Social profiles` step a text paragraph is shown with outdated information and an alert is displayed with wrong styling
 
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where outdated information is shown in the First-time configuration Social profiles step

## Relevant technical choices:

* N/A

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Start with a fresh installation of  Yoast SEO 
* Navigate to `General` -> `First-time configuration` tab
* In the `Site Representation`step, choose the site to represent a person from the drop-down but leave the _Name_ input field empty. Press `Save and Continue` and advance to the next step
* Verify the content of the step looks as follows:

<img width="655" alt="Screenshot 2022-05-24 at 15 34 02" src="https://user-images.githubusercontent.com/68744851/170047985-53baa774-26a6-4aaa-86e1-6cd7cef15609.png">

* Click `Go back` and select a user name in the  _Name_ input field, then press `Save and continue`
* Verify the content of the step looks as follows:

<img width="702" alt="Screenshot 2022-05-24 at 15 37 17" src="https://user-images.githubusercontent.com/68744851/170048724-5ad0e79d-7b08-4f89-934b-1a8fa5693a63.png">

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.

Fixes [DUPP-542](https://yoast.atlassian.net/browse/DUPP-542)
