### PR TITLE
Add apply replacement variables prop to google preview

### DIFF
--- a/packages/search-metadata-previews/src/snippet-editor/SnippetEditor.js
+++ b/packages/search-metadata-previews/src/snippet-editor/SnippetEditor.js
@@ -125,6 +125,7 @@ class SnippetEditor extends React.Component {
 	 * @param {Object}   props.titleLengthProgress               The values for the title length assessment.
 	 * @param {Object}   props.descriptionLengthProgress         The values for the description length assessment.
 	 * @param {Function} props.mapEditorDataToPreview            Function to map the editor data to data for the preview.
+	 * @param {Function} props.applyReplacementVariables         Function that overrides default replacement variables application with a custom one.
 	 * @param {string}   props.locale                            The locale of the page.
 	 * @param {string}   props.mobileImageSrc                    Mobile Image source for snippet preview.
 	 * @param {bool}     props.hasPaperStyle                     Whether or not it has paper style.
@@ -399,6 +400,10 @@ class SnippetEditor extends React.Component {
 	 * @returns {string} The processed content.
 	 */
 	processReplacementVariables( content, replacementVariables = this.props.replacementVariables ) {
+		if ( this.props.applyReplacementVariables ) {
+			return this.props.applyReplacementVariables( content );
+		}
+
 		for ( const { name, value } of replacementVariables ) {
 			content = content.replace( new RegExp( "%%" + name + "%%", "g" ), value );
 		}
@@ -599,6 +604,7 @@ SnippetEditor.propTypes = {
 	onChangeAnalysisData: PropTypes.func,
 	titleLengthProgress: lengthProgressShape,
 	descriptionLengthProgress: lengthProgressShape,
+	applyReplacementVariables: PropTypes.func,
 	mapEditorDataToPreview: PropTypes.func,
 	keyword: PropTypes.string,
 	wordsToHighlight: PropTypes.array,
@@ -629,6 +635,7 @@ SnippetEditor.defaultProps = {
 		actual: 0,
 		score: 0,
 	},
+	applyReplacementVariables: null,
 	mapEditorDataToPreview: null,
 	keyword: "",
 	locale: "en",


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Replacement variable application in the Google preview or `SnipperEditor` component needs to be more flexible to fit the needs of different products.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [@yoast/search-metadata-previews] Adds a prop to the `SnippetEditor` for overriding default replacement variable application.

## Relevant technical choices:

* Implemented the most flexible solution possible: either leave it to the component to handle replacement variable application based on the `replacementVariables` prop or take over the functionality completely using the new `applyReplacementVariables` prop.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* In `packages/js/src/containers/SnippetEditor.js`, in the `SnippetEditorWrapper` component, add a dummy `applyReplacementVariables` prop like so:
```js
<SnippetEditor
    applyReplacementVariables={ ( content ) => {
        console.warn( "content", content );
        return "replaced";
    } }
/>
```
* Run a JS or full build using `grunt build:js` or `grunt build` in the root.
* Visit a post or page and navigate to the Google preview.
* Verify that the replacement variables in the preview have been applied as per your custom function (everything reads "replaced" in case of above example).


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* A simple replacement variable verification in the Google preview should suffice to check that nothing was broken.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [x] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes https://yoast.atlassian.net/browse/PC-280
