### PR TITLE
Handle step level errors

### DIFF
--- a/packages/js/src/first-time-configuration/first-time-configuration-steps.js
+++ b/packages/js/src/first-time-configuration/first-time-configuration-steps.js
@@ -181,7 +181,7 @@ function calculateInitialState( windowObject, isStepFinished ) {
 		companyOrPersonOptions,
 		personSocialProfiles: {},
 		errorFields: [],
-		errorSteps: [],
+		stepErrors: {},
 		editedSteps: [],
 		savedSteps: [],
 	};

--- a/packages/js/src/first-time-configuration/first-time-configuration-steps.js
+++ b/packages/js/src/first-time-configuration/first-time-configuration-steps.js
@@ -218,7 +218,7 @@ export default function FirstTimeConfigurationSteps() {
 	const [ showRunIndexationAlert, setShowRunIndexationAlert ] = useState( false );
 
 	const setErrorSteps = useCallback( ( step, message ) => {
-		dispatch( { type: "SET_ERROR_STEPS", payload: { step, message } } );
+		dispatch( { type: "SET_STEP_ERROR", payload: { step, message } } );
 	}, [] );
 
 	/* Briefly override window variable and remove indexing notices, because indexingstate is reinitialized when navigating back and forth
@@ -310,7 +310,7 @@ export default function FirstTimeConfigurationSteps() {
 					return false;
 				}
 				if ( e.message ) {
-					setErrorFields( [ "site_representation", e.message ] );
+					setErrorSteps( STEPS.siteRepresentation, e.message );
 				}
 				return false;
 			} );
@@ -347,6 +347,9 @@ export default function FirstTimeConfigurationSteps() {
 						if ( e.failures ) {
 							setErrorFields( e.failures );
 						}
+						if ( e.message ) {
+							setErrorSteps( STEPS.socialProfiles, e.message );
+						}
 						return false;
 					}
 				);
@@ -373,6 +376,9 @@ export default function FirstTimeConfigurationSteps() {
 					if ( e.failures ) {
 						setErrorFields( e.failures );
 					}
+					if ( e.message ) {
+						setErrorSteps( STEPS.socialProfiles, e.message );
+					}
 					return false;
 				}
 			);
@@ -396,6 +402,12 @@ export default function FirstTimeConfigurationSteps() {
 			.then( () => finishSteps( STEPS.personalPreferences ) )
 			.then( () => {
 				return true;
+			} )
+			.catch( e => {
+				if ( e.message ) {
+					setErrorSteps( STEPS.personalPreferences, e.message );
+				}
+				return false;
 			} );
 	}
 
@@ -582,7 +594,6 @@ export default function FirstTimeConfigurationSteps() {
 						</Step.Header>
 						<Step.Content>
 							<IndexationStep setIndexingState={ setIndexingState } indexingState={ indexingState } showRunIndexationAlert={ showRunIndexationAlert } isStepperFinished={ isStepperFinished } />
-							<Step.Error id="yoast-indexation-step-error" message="test" />
 							<ContinueButton
 								additionalClasses="yst-mt-12"
 								beforeGo={ beforeContinueIndexationStep }
@@ -612,7 +623,7 @@ export default function FirstTimeConfigurationSteps() {
 								state={ state }
 								siteRepresentationEmpty={ siteRepresentationEmpty }
 							/>
-							<Step.Error id="yoast-site-representation-step-error" message="test" />
+							<Step.Error id="yoast-site-representation-step-error" message={ state.stepErrors[ STEPS.siteRepresentation ] || "" } />
 							<ConfigurationStepButtons
 								stepperFinishedOnce={ stepperFinishedOnce }
 								saveFunction={ updateOnFinishSiteRepresentation }
@@ -635,7 +646,7 @@ export default function FirstTimeConfigurationSteps() {
 						</Step.Header>
 						<Step.Content>
 							<SocialProfilesStep state={ state } dispatch={ dispatch } setErrorFields={ setErrorFields } />
-							<Step.Error id="yoast-social-profiles-step-error" message="test" />
+							<Step.Error id="yoast-social-profiles-step-error" message={ state.stepErrors[ STEPS.socialProfiles ] || "" } />
 							<ConfigurationStepButtons stepperFinishedOnce={ stepperFinishedOnce } saveFunction={ updateOnFinishSocialProfiles } setEditState={ setIsStepBeingEdited } />
 						</Step.Content>
 					</Step>
@@ -654,7 +665,7 @@ export default function FirstTimeConfigurationSteps() {
 						</Step.Header>
 						<Step.Content>
 							<PersonalPreferencesStep state={ state } setTracking={ setTracking } />
-							<Step.Error id="yoast-personal-preferences-step-error" message="test" />
+							<Step.Error id="yoast-personal-preferences-step-error" message={ state.stepErrors[ STEPS.personalPreferences ] || "" } />
 							<ConfigurationStepButtons stepperFinishedOnce={ stepperFinishedOnce } saveFunction={ updateOnFinishPersonalPreferences } setEditState={ setIsStepBeingEdited } />
 						</Step.Content>
 					</Step>

--- a/packages/js/src/first-time-configuration/first-time-configuration-steps.js
+++ b/packages/js/src/first-time-configuration/first-time-configuration-steps.js
@@ -217,8 +217,12 @@ export default function FirstTimeConfigurationSteps() {
 	const [ siteRepresentationEmpty, setSiteRepresentationEmpty ] = useState( false );
 	const [ showRunIndexationAlert, setShowRunIndexationAlert ] = useState( false );
 
-	const setErrorSteps = useCallback( ( step, message ) => {
+	const setStepError = useCallback( ( step, message ) => {
 		dispatch( { type: "SET_STEP_ERROR", payload: { step, message } } );
+	}, [] );
+
+	const removeStepError = useCallback( ( step ) => {
+		dispatch( { type: "REMOVE_STEP_ERROR", payload: step } );
 	}, [] );
 
 	/* Briefly override window variable and remove indexing notices, because indexingstate is reinitialized when navigating back and forth
@@ -301,6 +305,7 @@ export default function FirstTimeConfigurationSteps() {
 			.then( () => setStepIsSaved( 2 ) )
 			.then( () => {
 				setErrorFields( [] );
+				removeStepError( STEPS.siteRepresentation );
 				finishSteps( STEPS.siteRepresentation );
 				return true;
 			} )
@@ -310,7 +315,7 @@ export default function FirstTimeConfigurationSteps() {
 					return false;
 				}
 				if ( e.message ) {
-					setErrorSteps( STEPS.siteRepresentation, e.message );
+					setStepError( STEPS.siteRepresentation, e.message );
 				}
 				return false;
 			} );
@@ -337,6 +342,7 @@ export default function FirstTimeConfigurationSteps() {
 				.then( () => setStepIsSaved( 3 ) )
 				.then( () => {
 					setErrorFields( [] );
+					removeStepError( STEPS.socialProfiles );
 					finishSteps( STEPS.socialProfiles );
 				} )
 				.then( () => {
@@ -348,7 +354,7 @@ export default function FirstTimeConfigurationSteps() {
 							setErrorFields( e.failures );
 						}
 						if ( e.message ) {
-							setErrorSteps( STEPS.socialProfiles, e.message );
+							setStepError( STEPS.socialProfiles, e.message );
 						}
 						return false;
 					}
@@ -366,6 +372,7 @@ export default function FirstTimeConfigurationSteps() {
 			.then( () => setStepIsSaved( 3 ) )
 			.then( () => {
 				setErrorFields( [] );
+				removeStepError( STEPS.socialProfiles );
 				finishSteps( STEPS.socialProfiles );
 			} )
 			.then( () => {
@@ -377,7 +384,7 @@ export default function FirstTimeConfigurationSteps() {
 						setErrorFields( e.failures );
 					}
 					if ( e.message ) {
-						setErrorSteps( STEPS.socialProfiles, e.message );
+						setStepError( STEPS.socialProfiles, e.message );
 					}
 					return false;
 				}
@@ -401,11 +408,12 @@ export default function FirstTimeConfigurationSteps() {
 			.then( () => setStepIsSaved( 4 ) )
 			.then( () => finishSteps( STEPS.personalPreferences ) )
 			.then( () => {
+				removeStepError( STEPS.personalPreferences );
 				return true;
 			} )
 			.catch( e => {
 				if ( e.message ) {
-					setErrorSteps( STEPS.personalPreferences, e.message );
+					setStepError( STEPS.personalPreferences, e.message );
 				}
 				return false;
 			} );

--- a/packages/js/src/first-time-configuration/first-time-configuration-steps.js
+++ b/packages/js/src/first-time-configuration/first-time-configuration-steps.js
@@ -181,6 +181,7 @@ function calculateInitialState( windowObject, isStepFinished ) {
 		companyOrPersonOptions,
 		personSocialProfiles: {},
 		errorFields: [],
+		errorSteps: [],
 		editedSteps: [],
 		savedSteps: [],
 	};
@@ -215,6 +216,10 @@ export default function FirstTimeConfigurationSteps() {
 	const [ indexingState, setIndexingState ] = useState( () => window.yoastIndexingData.amount === "0" ? "already_done" : "idle" );
 	const [ siteRepresentationEmpty, setSiteRepresentationEmpty ] = useState( false );
 	const [ showRunIndexationAlert, setShowRunIndexationAlert ] = useState( false );
+
+	const setErrorSteps = useCallback( ( step, message ) => {
+		dispatch( { type: "SET_ERROR_STEPS", payload: { step, message } } );
+	}, [] );
 
 	/* Briefly override window variable and remove indexing notices, because indexingstate is reinitialized when navigating back and forth
 	without triggering a reload, whereas the window variable remains stale. */
@@ -576,7 +581,8 @@ export default function FirstTimeConfigurationSteps() {
 							</EditButton>
 						</Step.Header>
 						<Step.Content>
-							<IndexationStep setIndexingState={ setIndexingState } indexingState={ indexingState } showRunIndexationAlert={ showRunIndexationAlert }  isStepperFinished={ isStepperFinished } />
+							<IndexationStep setIndexingState={ setIndexingState } indexingState={ indexingState } showRunIndexationAlert={ showRunIndexationAlert } isStepperFinished={ isStepperFinished } />
+							<Step.Error id="yoast-indexation-step-error" message="test" />
 							<ContinueButton
 								additionalClasses="yst-mt-12"
 								beforeGo={ beforeContinueIndexationStep }
@@ -606,6 +612,7 @@ export default function FirstTimeConfigurationSteps() {
 								state={ state }
 								siteRepresentationEmpty={ siteRepresentationEmpty }
 							/>
+							<Step.Error id="yoast-site-representation-step-error" message="test" />
 							<ConfigurationStepButtons
 								stepperFinishedOnce={ stepperFinishedOnce }
 								saveFunction={ updateOnFinishSiteRepresentation }
@@ -628,6 +635,7 @@ export default function FirstTimeConfigurationSteps() {
 						</Step.Header>
 						<Step.Content>
 							<SocialProfilesStep state={ state } dispatch={ dispatch } setErrorFields={ setErrorFields } />
+							<Step.Error id="yoast-social-profiles-step-error" message="test" />
 							<ConfigurationStepButtons stepperFinishedOnce={ stepperFinishedOnce } saveFunction={ updateOnFinishSocialProfiles } setEditState={ setIsStepBeingEdited } />
 						</Step.Content>
 					</Step>
@@ -646,6 +654,7 @@ export default function FirstTimeConfigurationSteps() {
 						</Step.Header>
 						<Step.Content>
 							<PersonalPreferencesStep state={ state } setTracking={ setTracking } />
+							<Step.Error id="yoast-personal-preferences-step-error" message="test" />
 							<ConfigurationStepButtons stepperFinishedOnce={ stepperFinishedOnce } saveFunction={ updateOnFinishPersonalPreferences } setEditState={ setIsStepBeingEdited } />
 						</Step.Content>
 					</Step>

--- a/packages/js/src/first-time-configuration/tailwind-components/helpers/index.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/helpers/index.js
@@ -214,6 +214,9 @@ export function configurationReducer( state, action ) {
 		case "SET_ERROR_FIELDS":
 			newState.errorFields = action.payload;
 			return newState;
+		case "SET_ERROR_STEPS":
+			newState.errorSteps = action.payload;
+			return newState;
 		case "SET_TRACKING":
 			newState = handleStepEdit( newState, 4 );
 			newState.tracking = action.payload;

--- a/packages/js/src/first-time-configuration/tailwind-components/helpers/index.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/helpers/index.js
@@ -1,5 +1,5 @@
 import { __ } from "@wordpress/i18n";
-import { cloneDeep } from "lodash";
+import { cloneDeep, pickBy } from "lodash";
 
 import classNames from "classnames";
 
@@ -214,8 +214,11 @@ export function configurationReducer( state, action ) {
 		case "SET_ERROR_FIELDS":
 			newState.errorFields = action.payload;
 			return newState;
-		case "SET_ERROR_STEPS":
-			newState.errorSteps = action.payload;
+		case "SET_STEP_ERROR":
+			newState.stepErrors[ action.payload.step ] = action.payload.message;
+			return newState;
+		case "REMOVE_STEP_ERROR":
+			newState.stepErrors = pickBy( newState.stepErrors, ( _value, key ) => key !== action.payload );
 			return newState;
 		case "SET_TRACKING":
 			newState = handleStepEdit( newState, 4 );

--- a/packages/js/src/first-time-configuration/tailwind-components/stepper.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/stepper.js
@@ -1,9 +1,10 @@
 import { Fragment, useCallback, useState, useEffect, useContext, createContext } from "@wordpress/element";
-import { __ } from "@wordpress/i18n";
+import { __, sprintf } from "@wordpress/i18n";
 import AnimateHeight from "react-animate-height";
 import PropTypes from "prop-types";
 import { stepperTimings, stepperTimingClasses } from "../stepper-helper";
 import StepHeader from "./step-header";
+import { FadeInAlert } from "../tailwind-components/base/alert";
 
 /* eslint-disable complexity */
 const {
@@ -152,6 +153,42 @@ Step.propTypes = {
 };
 
 /**
+ * Provides a way to provide error messages at the Step level.
+ * @param {Object} props The props.
+ *
+ * @returns {WPElement} The StepError component.
+ */
+export function StepError( { id, message, className } ) {
+	return <FadeInAlert
+		id={ id }
+		type="error"
+		isVisible={ message !== "" }
+		className={ className }
+	>
+		{
+			/* translators: %1$s expands to the error message returned by the server */
+			sprintf(
+				__(
+					"An error has occurred: %1$s",
+					"wordpress-seo"
+				),
+				message
+			)
+		}
+	</FadeInAlert>;
+}
+
+StepError.propTypes = {
+	id: PropTypes.string.isRequired,
+	message: PropTypes.string.isRequired,
+	className: PropTypes.string,
+};
+
+StepError.defaultProps = {
+	className: "",
+};
+
+/**
  * The (Tailwind) Step component
  *
  * @param {Object} props The props.
@@ -233,6 +270,7 @@ Stepper.defaultProps = {
 };
 
 Step.Content = Content;
+Step.Error = StepError;
 Step.Header = StepHeader;
 Step.GoButton = GoButton;
 Step.EditButton = EditButton;

--- a/packages/js/src/first-time-configuration/tailwind-components/stepper.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/stepper.js
@@ -162,7 +162,7 @@ export function StepError( { id, message, className } ) {
 	return <FadeInAlert
 		id={ id }
 		type="error"
-		isVisible={ message !== "" }
+		isVisible={ !! message }
 		className={ className }
 	>
 		{

--- a/packages/js/src/first-time-configuration/tailwind-components/steps/site-representation/site-representation-step.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/steps/site-representation/site-representation-step.js
@@ -108,23 +108,6 @@ export default function SiteRepresentationStep( { onOrganizationOrPersonChange, 
 				)
 			}
 		</FadeInAlert>
-		<FadeInAlert
-			id="site-representaton-error-alert"
-			type="error"
-			isVisible={ state.errorFields[ 0 ] === "site_representation" }
-			className="yst-mt-6"
-		>
-			{
-				/* translators: %1$s expands to the error message returned by the server */
-				sprintf(
-					__(
-						"An error has occurred: %1$s",
-						"wordpress-seo"
-					),
-					state.errorFields[ 1 ]
-				)
-			}
-		</FadeInAlert>
 	</Fragment>;
 }
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* To add errors on a step-saving level (so unrelated to specific input fields).

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds an informative error message to the steps of the First-time configuration should an error occur.

## Relevant technical choices:

* Only added errors to steps with advancing criteria that can fail (e.g. they have `.then().catch()` statements upon saving.
* Only showing the error alert if there was a message field in the server error response.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* In the stepper, go to either the site representation, social profiles, or personal preferences step.
* In the network tab in Chrome, under the `throttling` drop down, set throttling to "offline".
* Press save. An error should appear about you being offline.
* Set throttling to online again.
* Press save again. You should continue to the next step, and on pressing back, the error should be gone.
* QA: you cannot do this step, sorry.
	* In the first-time-configuration-steps component, change the endpoints of the site-representaiton/social-profiles/personal-preferences steps to your taste.
	* Upon saving the step corresponding to the endpoint, an error should appear about the missing route.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes DUPP-515
