### PR TITLE
Show tweaked FTC notice to old users when they haven't dealt with SEO…

### DIFF
--- a/src/helpers/indexing-helper.php
+++ b/src/helpers/indexing-helper.php
@@ -232,6 +232,15 @@ class Indexing_Helper {
 	}
 
 	/**
+	 * Gets a boolean that indicates whether or not the indexing of the indexables has completed.
+	 *
+	 * @return bool Whether the indexing of the indexables has completed.
+	 */
+	public function is_finished_indexables_indexing() {
+		return $this->options_helper->get( 'indexables_indexing_completed', false );
+	}
+
+	/**
 	 * Returns the total number of unindexed objects.
 	 *
 	 * @return int The total number of unindexed objects.

--- a/src/integrations/admin/first-time-configuration-notice-integration.php
+++ b/src/integrations/admin/first-time-configuration-notice-integration.php
@@ -38,6 +38,13 @@ class First_Time_Configuration_Notice_Integration implements Integration_Interfa
 	private $admin_asset_manager;
 
 	/**
+	 * Whether we show the alternate mesage.
+	 *
+	 * @var bool
+	 */
+	private $show_alternate_message;
+
+	/**
 	 * {@inheritDoc}
 	 */
 	public static function get_conditionals() {
@@ -56,9 +63,10 @@ class First_Time_Configuration_Notice_Integration implements Integration_Interfa
 		Indexing_Helper $indexing_helper,
 		WPSEO_Admin_Asset_Manager $admin_asset_manager
 	) {
-		$this->options_helper      = $options_helper;
-		$this->indexing_helper     = $indexing_helper;
-		$this->admin_asset_manager = $admin_asset_manager;
+		$this->options_helper         = $options_helper;
+		$this->indexing_helper        = $indexing_helper;
+		$this->admin_asset_manager    = $admin_asset_manager;
+		$this->show_alternate_message = false;
 	}
 
 	/**
@@ -100,11 +108,21 @@ class First_Time_Configuration_Notice_Integration implements Integration_Interfa
 			return false;
 		}
 
-		if ( $this->options_helper->get( 'first_time_install', false ) === false ) {
+		if ( $this->options_helper->get( 'first_time_install', false ) !== false ) {
+			return ! $this->are_site_representation_name_and_logo_set() || $this->indexing_helper->get_unindexed_count() > 0;
+		}
+
+		if ( $this->indexing_helper->is_initial_indexing() === false ) {
 			return false;
 		}
 
-		return ! $this->are_site_representation_name_and_logo_set() || $this->indexing_helper->get_unindexed_count() > 0;
+		if ( $this->indexing_helper->is_finished_indexables_indexing() === true ) {
+			return false;
+		}
+
+		$this->show_alternate_message = true;
+
+		return ! $this->are_site_representation_name_and_logo_set();
 	}
 
 	/**
@@ -119,15 +137,28 @@ class First_Time_Configuration_Notice_Integration implements Integration_Interfa
 
 		$this->admin_asset_manager->enqueue_style( 'monorepo' );
 
-		$notice = new Notice_Presenter(
-			\__( 'First-time SEO configuration', 'wordpress-seo' ),
-			\sprintf(
-			/* translators: 1: Link start tag to the first-time configuration, 2: Yoast SEO, 3: Link closing tag. */
+		$title = ( ! $this->show_alternate_message ) ? \__( 'First-time SEO configuration', 'wordpress-seo' ) : \__( 'SEO configuration', 'wordpress-seo' );
+		if ( ! $this->show_alternate_message ) {
+			$content = \sprintf(
+				/* translators: 1: Link start tag to the first-time configuration, 2: Yoast SEO, 3: Link closing tag. */
 				\__( 'Get started quickly with the %1$s%2$s First-time configuration%3$s and configure Yoast SEO with the optimal SEO settings for your site!', 'wordpress-seo' ),
 				'<a href="' . \esc_url( \self_admin_url( 'admin.php?page=wpseo_dashboard#top#first-time-configuration' ) ) . '">',
 				'Yoast SEO',
 				'</a>'
-			),
+			);
+		}
+		else {
+			$content = \sprintf(
+				/* translators: 1: Link start tag to the first-time configuration, 2: Link closing tag. */
+				\__( 'We noticed that you haven\'t fully configured Yoast SEO yet. Optimize your SEO settings even further by using our improved %1$s First-time configuration%2$s.', 'wordpress-seo' ),
+				'<a href="' . \esc_url( \self_admin_url( 'admin.php?page=wpseo_dashboard#top#first-time-configuration' ) ) . '">',
+				'</a>'
+			);
+		}
+
+		$notice = new Notice_Presenter(
+			$title,
+			$content,
 			'mirrored_fit_bubble_woman_1_optim.svg',
 			null,
 			true,

--- a/src/integrations/admin/first-time-configuration-notice-integration.php
+++ b/src/integrations/admin/first-time-configuration-notice-integration.php
@@ -4,7 +4,6 @@ namespace Yoast\WP\SEO\Integrations\Admin;
 
 use WPSEO_Admin_Asset_Manager;
 use Yoast\WP\SEO\Conditionals\Admin_Conditional;
-use Yoast\WP\SEO\Conditionals\No_Conditionals;
 use Yoast\WP\SEO\Helpers\Indexing_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Integrations\Integration_Interface;


### PR DESCRIPTION
… optimization and site represents settings

## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to show the FTC notice to old users as well, when they have never dealt with SEO optimization and haven't completed the Site Represents settings
* In those cases, we tweak the FTC notice copy.
* In the cases of old users, we keep the past behavior.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Prompts users to set up their site in order to take advantage of all SEO features.

## Relevant technical choices:

* In order to not add heavy queries when checking if SEO optimization is completed in the site, we use the `indexing_first_time` and `indexables_indexing_completed` options instead.
* Only when both those options indicate no SEO optimization, then we allow that notice.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

**For old users:**
* You are regarded a new user if you activate any Yoast Free version from 17.7.1 and on.
* So, activate Yoast SEO 17.6 in a clean environment (make sure you have more than 25 posts there before activating Yoast) and upgrade to the new RC. (alternatively, you can activate the current version and set the `first_time_install` setting to false in the `wpseo` option in the db), thus making yourself an old user)
* You will now be presented with the FTC notice in the Yoast pages and the WordPress dashboard with this copy:
![image](https://user-images.githubusercontent.com/12400734/170217113-2bceafd2-d58a-4236-8d6b-dc4f620d6d26.png)
* That copy will stop be showing, if one of those things happen:
	* Start the SEO optimization (you dont have to finish it, just start it)
	* The background SEO optimization gets complete (I'm attaching a separate step for instructions for this)
	* The Site Represents settings are filled
	* The notice is dismissed
	* The FTC gets completed

so test those scenarios separately in a clean environment, by repeating the first steps from the `For old users` segment

**Testing the `background SEO optimization gets complete` scenario:**
* find the `should_index_on_shutdown()` function in the src/integrations/admin/background-indexing-integration.php file
* change it to:
```
	public function should_index_on_shutdown( $shutdown_limit ) {
		return true;
	}
```
* Visit a Yoast page
* At the end of that page load, the background indexation has been completed. So refresh the page and confirm that the notice no longer appears.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* FTC notice for new users should have the old behavior:

**For new users, the behavior should stay the same:**
* Activate Yoast Free in a clean environment.
* Since you activated, you're regarded as a first time user, so we expect the old FTC notice to appear in the Yoast pages and the WordPress dashboard:
![image](https://user-images.githubusercontent.com/12400734/170214922-3e6fe32d-e5f2-452b-b832-493a6c870d55.png)
* If you add the Site Represents settings (either from the FTC or the Search Appearance page) AND if you index your sites (either from the FTC or the Tools page), that FTC notice will not be displayed again.
* If you dismiss that FTC notice, it will not be displayed again. Test that in a clean environment.
* If you complete the FTC, it will not be displayed again. Test that in a clean environment.

## UI changes

* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes #
