### PR TITLE
Return `noindex, nofollow` when `wpseo_robots` is `false`

### DIFF
--- a/src/presentations/indexable-presentation.php
+++ b/src/presentations/indexable-presentation.php
@@ -336,6 +336,13 @@ class Indexable_Presentation extends Abstract_Presentation {
 			$robots = $robots_new;
 		}
 
+		if ( \is_bool( $robots_filtered ) && ( $robots_filtered === false ) ) {
+			return [
+				'index'  => 'noindex',
+				'follow' => 'nofollow'
+			];
+		}
+
 		if ( ! $robots_filtered ) {
 			return [];
 		}

--- a/src/presentations/indexable-presentation.php
+++ b/src/presentations/indexable-presentation.php
@@ -339,7 +339,7 @@ class Indexable_Presentation extends Abstract_Presentation {
 		if ( \is_bool( $robots_filtered ) && ( $robots_filtered === false ) ) {
 			return [
 				'index'  => 'noindex',
-				'follow' => 'nofollow'
+				'follow' => 'nofollow',
 			];
 		}
 

--- a/tests/unit/presentations/indexable-presentation/robots-test.php
+++ b/tests/unit/presentations/indexable-presentation/robots-test.php
@@ -58,9 +58,15 @@ class Robots_Test extends TestCase {
 		Monkey\Filters\expectApplied( 'wpseo_robots' )
 			->once()
 			->with( 'index, follow, max-snippet:-1, max-image-preview:large, max-video-preview:-1', $this->instance )
-			->andReturn( false );
+			->andReturn( 'noindex, nofollow' );
 
-		$this->assertEquals( [], $this->instance->generate_robots() );
+		$this->assertEquals(
+			[
+				'index'  => 'noindex',
+				'follow' => 'nofollow',
+			],
+			$this->instance->generate_robots()
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Context

* When `add_filter( 'wpseo_robots', '__false' );` is set, `noindex, nofllow` isn't shown but only `max-image-preview:large` is being shown, which is wrong. When the relevant filter is set to `false`, it shall output `noindex, nofollow` to discourage search engine crawling the entire site.

## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where `noindex, nofollow` would not be displayed when `wpseo_robots` filter is set to `false`.


## Test instructions
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Set `add_filter('wpseo_robots', '__return_false');` on `functions.php` file.
* Check the robots meta output on the front-end of the website to look for `noindex, nofllow`.


### Test instructions for QA when the code is in the RC
* [x] QA should use the same steps as above.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #18483
