### PR TITLE
DUPP-541 - DUPP-541-disable-atom-rdf-feeds

### DIFF
--- a/admin/tracking/class-tracking-settings-data.php
+++ b/admin/tracking/class-tracking-settings-data.php
@@ -183,6 +183,7 @@ class WPSEO_Tracking_Settings_Data implements WPSEO_Collection {
 		'first_time_install',
 		'other_social_urls',
 		'remove_feed_post_comments',
+		'remove_atom_rdf_feeds',
 	];
 
 	/**

--- a/admin/views/tabs/dashboard/crawl-settings.php
+++ b/admin/views/tabs/dashboard/crawl-settings.php
@@ -32,13 +32,6 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 	);
 	echo '</p>';
 
-	$help_text  = esc_html__( 'This removes the Post Comment Feed link.', 'wordpress-seo' );
-	$help_text .= ' ';
-	$help_text .= sprintf(
-		'<a href="#" target="_blank" rel="noopener noreferrer">%1$s</a>',
-		esc_html__( 'Find out how removing feeds can improve performance.', 'wordpress-seo' )
-	);
-
 	$yform->toggle_switch(
 		'remove_feed_post_comments',
 		[
@@ -46,6 +39,15 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 			'on'  => __( 'Remove', 'wordpress-seo' ),
 		],
 		__( 'Post comment feeds', 'wordpress-seo' )
+	);
+
+	$yform->toggle_switch(
+		'remove_atom_rdf_feeds',
+		[
+			'off' => __( 'Keep', 'wordpress-seo' ),
+			'on'  => __( 'Remove', 'wordpress-seo' ),
+		],
+		__( 'All Atom and RDF feeds', 'wordpress-seo' )
 	);
 	?>
 </div>

--- a/admin/views/tabs/network/crawl-settings.php
+++ b/admin/views/tabs/network/crawl-settings.php
@@ -34,13 +34,6 @@ $feature_toggles = Yoast_Feature_Toggles::instance()->get_all();
 	);
 	echo '</p>';
 
-	$help_text  = esc_html__( 'This removes the Post Comment Feed link.', 'wordpress-seo' );
-	$help_text .= ' ';
-	$help_text .= sprintf(
-		'<a href="#" target="_blank" rel="noopener noreferrer">%1$s</a>',
-		esc_html__( 'Find out how removing feeds can improve performance.', 'wordpress-seo' )
-	);
-
 	$yform->toggle_switch(
 		WPSEO_Option::ALLOW_KEY_PREFIX . 'remove_feed_post_comments',
 		[
@@ -48,6 +41,15 @@ $feature_toggles = Yoast_Feature_Toggles::instance()->get_all();
 			'off' => __( 'Disable', 'wordpress-seo' ),
 		],
 		__( 'Post comment feeds', 'wordpress-seo' )
+	);
+
+	$yform->toggle_switch(
+		WPSEO_Option::ALLOW_KEY_PREFIX . 'remove_atom_rdf_feeds',
+		[
+			'on'  => __( 'Allow Control', 'wordpress-seo' ),
+			'off' => __( 'Disable', 'wordpress-seo' ),
+		],
+		__( 'All Atom and RDF feeds', 'wordpress-seo' )
 	);
 	?>
 </div>

--- a/inc/options/class-wpseo-option-ms.php
+++ b/inc/options/class-wpseo-option-ms.php
@@ -102,6 +102,7 @@ class WPSEO_Option_MS extends WPSEO_Option {
 			"{$allow_prefix}zapier_integration_active"      => true,
 			"{$allow_prefix}wincher_integration_active"     => false,
 			"{$allow_prefix}remove_feed_post_comments"      => true,
+			"{$allow_prefix}remove_atom_rdf_feeds"          => true,
 		];
 
 		if ( is_multisite() ) {

--- a/inc/options/class-wpseo-option-wpseo.php
+++ b/inc/options/class-wpseo-option-wpseo.php
@@ -92,6 +92,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 		'should_redirect_after_install_free'       => false,
 		'activation_redirect_timestamp_free'       => 0,
 		'remove_feed_post_comments'                => false,
+		'remove_atom_rdf_feeds'                => false,
 	];
 
 	/**
@@ -396,6 +397,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 				 *  'indexing_first_time'
 				 *  'first_time_install'
 				 *  'remove_feed_post_comments'
+				 *  'remove_atom_rdf_feeds'
 				 *  'should_redirect_after_install_free'
 				 *  and most of the feature variables.
 				 */
@@ -439,6 +441,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 			'zapier_integration_active'      => false,
 			'wincher_integration_active'     => false,
 			'remove_feed_post_comments'      => false,
+			'remove_atom_rdf_feeds'          => false,
 		];
 
 		// We can reuse this logic from the base class with the above defaults to parse with the correct feature values.

--- a/inc/options/class-wpseo-option-wpseo.php
+++ b/inc/options/class-wpseo-option-wpseo.php
@@ -92,7 +92,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 		'should_redirect_after_install_free'       => false,
 		'activation_redirect_timestamp_free'       => 0,
 		'remove_feed_post_comments'                => false,
-		'remove_atom_rdf_feeds'                => false,
+		'remove_atom_rdf_feeds'                    => false,
 	];
 
 	/**

--- a/src/integrations/front-end/crawl-cleanup-rss.php
+++ b/src/integrations/front-end/crawl-cleanup-rss.php
@@ -63,7 +63,7 @@ class Crawl_Cleanup_Rss implements Integration_Interface {
 			return;
 		}
 
-		if ( in_array( \get_query_var( 'feed' ), [ 'atom', 'rdf' ], true ) && $this->options_helper->get( 'remove_atom_rdf_feeds' ) === true ) {
+		if ( \in_array( \get_query_var( 'feed' ), [ 'atom', 'rdf' ], true ) && $this->options_helper->get( 'remove_atom_rdf_feeds' ) === true ) {
 			$this->redirect_feed( \home_url(), 'We disable Atom/RDF feeds for performance reasons.' );
 		}
 

--- a/src/integrations/front-end/crawl-cleanup-rss.php
+++ b/src/integrations/front-end/crawl-cleanup-rss.php
@@ -62,6 +62,10 @@ class Crawl_Cleanup_Rss implements Integration_Interface {
 		if ( ! \is_feed() ) {
 			return;
 		}
+		
+		if ( in_array( \get_query_var( 'feed' ), [ 'atom', 'rdf' ] ) && $this->options_helper->get( 'remove_atom_rdf_feeds' ) === true ) {
+			$this->redirect_feed( \home_url(), 'We disable Atom/RDF feeds for performance reasons.' );
+		}
 
 		if ( \is_comment_feed() && \is_singular() && $this->options_helper->get( 'remove_feed_post_comments' ) === true ) {
 			$url = \get_permalink( \get_queried_object() );

--- a/src/integrations/front-end/crawl-cleanup-rss.php
+++ b/src/integrations/front-end/crawl-cleanup-rss.php
@@ -62,7 +62,7 @@ class Crawl_Cleanup_Rss implements Integration_Interface {
 		if ( ! \is_feed() ) {
 			return;
 		}
-		
+
 		if ( in_array( \get_query_var( 'feed' ), [ 'atom', 'rdf' ] ) && $this->options_helper->get( 'remove_atom_rdf_feeds' ) === true ) {
 			$this->redirect_feed( \home_url(), 'We disable Atom/RDF feeds for performance reasons.' );
 		}

--- a/src/integrations/front-end/crawl-cleanup-rss.php
+++ b/src/integrations/front-end/crawl-cleanup-rss.php
@@ -63,7 +63,7 @@ class Crawl_Cleanup_Rss implements Integration_Interface {
 			return;
 		}
 
-		if ( in_array( \get_query_var( 'feed' ), [ 'atom', 'rdf' ] ) && $this->options_helper->get( 'remove_atom_rdf_feeds' ) === true ) {
+		if ( in_array( \get_query_var( 'feed' ), [ 'atom', 'rdf' ], true ) && $this->options_helper->get( 'remove_atom_rdf_feeds' ) === true ) {
 			$this->redirect_feed( \home_url(), 'We disable Atom/RDF feeds for performance reasons.' );
 		}
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to add a new toggle switch to the `Crawl settings` tab to let users disable Atom/RDF URLs access by redirecting the request to their site homepage

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds a feature to redirect all the Atom/RDF feeds requests to the site homepage

## Relevant technical choices:

* N/A

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:


* Check that you can access the Atom and RDF feeds of the site, e.g.:
  * http://basic.wordpress.test/feed/atom
  * http://basic.wordpress.test/feed/rdf
  * http://basic.wordpress.test/comments/feed/atom
  * http://basic.wordpress.test/comments/feed/rdf
  * http://basic.wordpress.test/hello-world/feed/atom
  * http://basic.wordpress.test/hello-world/feed/rdf  
  * etc.
* Go to the admin area of your site, `Yoast SEO` -> `General` -> `Crawl settings` tab and toggle the `All Atom and RDF feeds` switch to `Remove`
* Now try to access the Atom and RDF feed again in the frontend and verify you're now redirected to the site's homepage
* check that the RSS feed are still accessible (provided that you haven't disabled them):
  * http://basic.wordpress.test/feed/
  * http://basic.wordpress.test/comments/feed/
  * http://basic.wordpress.test/hello-world/feed/
  * etc.

For multisites:
* Install the RC in a fresh multisite by activating the plugin at network level
* In Network admin go to `Yoast SEO` -> `General`-> `Crawl Settings` tab
* Confirm that the `All Atom and RDF feeds` toggle is set to `Allow Control` by default
* Go to the main sub-site's and another sub-site's `Yoast SEO` -> `General`-> `Crawl Settings` tab
* Confirm that the `All Atom and RDF feeds` toggle is set to `Keep` by default
* Check that you can access the Atom and RDF feeds of the main site, e.g.:
  * http://multisite.wordpress.test/feed/atom
  * http://multisite.wordpress.test/feed/rdf
  * http://multisite.wordpress.test/comments/feed/atom
  * http://multisite.wordpress.test/comments/feed/rdf
  * http://multisite.wordpress.test/hello-world/feed/atom
  * http://multisite.wordpress.test/hello-world/feed/rdf  
  * etc.
* Check that you can access the Atom and RDF feeds of a subsite, e.g.:
  * http://multisite.wordpress.test/site2/feed/atom
  * http://multisite.wordpress.test/site2/feed/rdf
  * http://multisite.wordpress.test/site2/comments/feed/atom
  * http://multisite.wordpress.test/site2/comments/feed/rdf
  * http://multisite.wordpress.test/site2/hello-world/feed/atom
  * http://multisite.wordpress.test/site2/hello-world/feed/rdf  
  * etc.
* Now, set the `All Atom and RDF feeds` to `remove` in one of the sub-site's settings
* Try to access the feeds URLs again for that sub-site and verify you're redirected to the sub-site's homepage
* Also confirm that the feeds URLs in the other sub-site is still available
* Now go to the network admin page and set the `All Atom and RDF feeds` toggle to `Disabled`.
* Confirm that in both sub-site's settings, the `All Atom and RDF feeds` toggle is set to  `Keep` with the `This feature has been disabled by the network admin` message displayed.
* Confirm that the Atom & RDF URLs for both sub-site are available
* Now go to the network admin page and set the `All Atom and RDF feeds` toggle to `Allow Control`.
* visit SEO > General for the subsite where you disabled the Atom & RDF feeds and check that the toggle is not greyed out anymore, and now it's set to `Remove` as it was before the network-level deactivation
* visit SEO > General for the main site and check that the toggle is not greyed out anymore, and now it's set to `Keep` as it was before the network-level deactivation


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [X] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.

Fixes [DUPP-541](https://yoast.atlassian.ne/browse/DUPP-541)
