### PR TITLE
DUPP-547 Remove global feed

### DIFF
--- a/admin/tracking/class-tracking-settings-data.php
+++ b/admin/tracking/class-tracking-settings-data.php
@@ -184,6 +184,7 @@ class WPSEO_Tracking_Settings_Data implements WPSEO_Collection {
 		'other_social_urls',
 		'remove_feed_post_comments',
 		'remove_atom_rdf_feeds',
+		'remove_feed_global',
 	];
 
 	/**

--- a/admin/views/tabs/dashboard/crawl-settings.php
+++ b/admin/views/tabs/dashboard/crawl-settings.php
@@ -33,6 +33,15 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 	echo '</p>';
 
 	$yform->toggle_switch(
+		'remove_feed_global',
+		[
+			'off' => __( 'Keep', 'wordpress-seo' ),
+			'on'  => __( 'Remove', 'wordpress-seo' ),
+		],
+		__( 'Global feed', 'wordpress-seo' )
+	);
+
+	$yform->toggle_switch(
 		'remove_feed_post_comments',
 		[
 			'off' => __( 'Keep', 'wordpress-seo' ),

--- a/admin/views/tabs/network/crawl-settings.php
+++ b/admin/views/tabs/network/crawl-settings.php
@@ -35,6 +35,15 @@ $feature_toggles = Yoast_Feature_Toggles::instance()->get_all();
 	echo '</p>';
 
 	$yform->toggle_switch(
+		WPSEO_Option::ALLOW_KEY_PREFIX . 'remove_feed_global',
+		[
+			'on'  => __( 'Allow Control', 'wordpress-seo' ),
+			'off' => __( 'Disable', 'wordpress-seo' ),
+		],
+		__( 'Global feed', 'wordpress-seo' )
+	);
+
+	$yform->toggle_switch(
 		WPSEO_Option::ALLOW_KEY_PREFIX . 'remove_feed_post_comments',
 		[
 			'on'  => __( 'Allow Control', 'wordpress-seo' ),

--- a/inc/options/class-wpseo-option-ms.php
+++ b/inc/options/class-wpseo-option-ms.php
@@ -103,6 +103,7 @@ class WPSEO_Option_MS extends WPSEO_Option {
 			"{$allow_prefix}wincher_integration_active"     => false,
 			"{$allow_prefix}remove_feed_post_comments"      => true,
 			"{$allow_prefix}remove_atom_rdf_feeds"          => true,
+			"{$allow_prefix}remove_feed_global"             => true,
 		];
 
 		if ( is_multisite() ) {

--- a/inc/options/class-wpseo-option-wpseo.php
+++ b/inc/options/class-wpseo-option-wpseo.php
@@ -93,6 +93,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 		'activation_redirect_timestamp_free'       => 0,
 		'remove_feed_post_comments'                => false,
 		'remove_atom_rdf_feeds'                    => false,
+		'remove_feed_global'                       => false,
 	];
 
 	/**
@@ -398,6 +399,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 				 *  'first_time_install'
 				 *  'remove_feed_post_comments'
 				 *  'remove_atom_rdf_feeds'
+				 *  'remove_feed_global'
 				 *  'should_redirect_after_install_free'
 				 *  and most of the feature variables.
 				 */
@@ -442,6 +444,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 			'wincher_integration_active'     => false,
 			'remove_feed_post_comments'      => false,
 			'remove_atom_rdf_feeds'          => false,
+			'remove_feed_global'             => false,
 		];
 
 		// We can reuse this logic from the base class with the above defaults to parse with the correct feature values.

--- a/src/integrations/front-end/crawl-cleanup-rss.php
+++ b/src/integrations/front-end/crawl-cleanup-rss.php
@@ -42,6 +42,9 @@ class Crawl_Cleanup_Rss implements Integration_Interface {
 	 * Register our RSS related hooks.
 	 */
 	public function register_hooks() {
+		if ( $this->options_helper->get( 'remove_feed_global' ) === true ) {
+			\add_action( 'feed_links_show_posts_feed', '__return_false' );
+		}
 		\add_action( 'wp', [ $this, 'maybe_disable_feeds' ] );
 		\add_action( 'wp', [ $this, 'maybe_redirect_feeds' ], - 10000 );
 	}
@@ -59,6 +62,8 @@ class Crawl_Cleanup_Rss implements Integration_Interface {
 	 * Redirect feeds we don't want away.
 	 */
 	public function maybe_redirect_feeds() {
+		global $wp_query;
+
 		if ( ! \is_feed() ) {
 			return;
 		}
@@ -66,8 +71,11 @@ class Crawl_Cleanup_Rss implements Integration_Interface {
 		if ( \in_array( \get_query_var( 'feed' ), [ 'atom', 'rdf' ], true ) && $this->options_helper->get( 'remove_atom_rdf_feeds' ) === true ) {
 			$this->redirect_feed( \home_url(), 'We disable Atom/RDF feeds for performance reasons.' );
 		}
-
-		if ( \is_comment_feed() && \is_singular() && $this->options_helper->get( 'remove_feed_post_comments' ) === true ) {
+		// Only if we're on the global feed, the query is _just_ `'feed' => 'feed'`, hence this check.
+		elseif ( $wp_query->query === [ 'feed' => 'feed' ] && $this->options_helper->get( 'remove_feed_global' ) === true ) {
+			$this->redirect_feed( \home_url(), 'We disable the RSS feed for performance reasons.' );
+		}
+		elseif ( \is_comment_feed() && \is_singular() && $this->options_helper->get( 'remove_feed_post_comments' ) === true ) {
 			$url = \get_permalink( \get_queried_object() );
 			$this->redirect_feed( $url, 'We disable post comment feeds for performance reasons.' );
 		}

--- a/tests/unit/integrations/front-end/crawl-cleanup-rss-test.php
+++ b/tests/unit/integrations/front-end/crawl-cleanup-rss-test.php
@@ -61,8 +61,13 @@ class Crawl_Cleanup_Rss_Test extends TestCase {
 	 * @covers ::register_hooks
 	 */
 	public function test_register_hooks() {
+		$this->options_helper->expects( 'get' )
+			->with( 'remove_feed_global' )
+			->andReturnTrue();
+
 		$this->instance->register_hooks();
 
+		$this->assertNotFalse( Monkey\Actions\has( 'feed_links_show_posts_feed', '__return_false' ) );
 		$this->assertNotFalse( Monkey\Actions\has( 'wp', [ $this->instance, 'maybe_disable_feeds' ] ) );
 		$this->assertNotFalse( Monkey\Actions\has( 'wp', [ $this->instance, 'maybe_redirect_feeds' ] ) );
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to add a new toggle switch to the `Crawl settings` tab to let users disable the global feed by redirecting the request to their site homepage

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds a feature to disable the global RSS feed.

## Relevant technical choices:

* Disabling the RSS global feed doesn't disable the Atom and the RDF version of it: so http://basic.wordpress.test/feed/atom and http://basic.wordpress.test/feed/rdf will still be accessible until you disable the Atom/RDF feeds.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* inspect any page and see that you can see a  tag linking to the global feed, e,g,
`<link rel="alternate" type="application/rss+xml" title="Basic &raquo; Feed" href="http://basic.wordpress.test/feed/" />`
* Check that you can access the global feed of the site
* Go to the admin area of your site, `Yoast SEO` -> `General` -> `Crawl settings` tab and toggle the `Global feed` switch to `Remove`
* Inspect the source of any page and see the link tag is gone
* Now try to access the feed again http://basic.wordpress.test/feed/ and verify you're now redirected to the site's homepage
* check that the other RSS feed are still accessible (provided that you haven't disabled them):
  * http://basic.wordpress.test/comments/feed/
  * http://basic.wordpress.test/hello-world/feed/
  * etc.

For multisites:
* Install the RC in a fresh multisite by activating the plugin at network level
* In Network admin go to `Yoast SEO` -> `General`-> `Crawl Settings` tab
* Confirm that the `Global feed` toggle is set to `Allow Control` by default
* Go to the main sub-site's and another sub-site's `Yoast SEO` -> `General`-> `Crawl Settings` tab
* Confirm that the `Global feed` toggle is set to `Keep` by default
* inspect any page of the main site and see that you can see a  tag linking to the global feed, e,g,
`<link rel="alternate" type="application/rss+xml" title="Basic &raquo; Feed" href="http://multisite.wordpress.test/feed/" />`
* Check that you can access the global feed of the main site
* inspect any page of a site and see that you can see a  tag linking to the global feed, e,g,
`<link rel="alternate" type="application/rss+xml" title="Basic &raquo; Feed" href="http://multisite.wordpress.test/site2/feed/" />`
* Check that you can access the global feed of the subsite
* Now, set the `Global feed` to `Remove` in one of the sub-site's settings
* Try to access the feeds URL again for that sub-site and verify you're redirected to the sub-site's homepage
* Also confirm that the feeds URL in the other sub-site is still available
* Now go to the network admin page and set the `Global feed` toggle to `Disabled`.
* Confirm that in both sub-site's settings, the `Global feed` toggle is set to  `Keep` with the `This feature has been disabled by the network admin` message displayed.
* Confirm that the Global feed for both sub-site are available
* Now go to the network admin page and set the `Global feed` toggle to `Allow Control`.
* visit SEO > General for the subsite where you disabled the Global feed and check that the toggle is not greyed out anymore, and now it's set to `Remove` as it was before the network-level deactivation
* visit SEO > General for the main site and check that the toggle is not greyed out anymore, and now it's set to `Keep` as it was before the network-level deactivation


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes [DUPP-547]


[DUPP-547]: https://yoast.atlassian.net/browse/DUPP-547?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ