### PR TITLE
DUPP-548 disable author feeds

### DIFF
--- a/admin/tracking/class-tracking-settings-data.php
+++ b/admin/tracking/class-tracking-settings-data.php
@@ -185,6 +185,7 @@ class WPSEO_Tracking_Settings_Data implements WPSEO_Collection {
 		'remove_feed_post_comments',
 		'remove_atom_rdf_feeds',
 		'remove_feed_global',
+		'remove_feed_authors',
 	];
 
 	/**

--- a/admin/views/tabs/dashboard/crawl-settings.php
+++ b/admin/views/tabs/dashboard/crawl-settings.php
@@ -51,6 +51,15 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 	);
 
 	$yform->toggle_switch(
+		'remove_feed_authors',
+		[
+			'off' => __( 'Keep', 'wordpress-seo' ),
+			'on'  => __( 'Remove', 'wordpress-seo' ),
+		],
+		__( 'Feeds per post author', 'wordpress-seo' )
+	);
+
+	$yform->toggle_switch(
 		'remove_atom_rdf_feeds',
 		[
 			'off' => __( 'Keep', 'wordpress-seo' ),

--- a/admin/views/tabs/network/crawl-settings.php
+++ b/admin/views/tabs/network/crawl-settings.php
@@ -53,6 +53,15 @@ $feature_toggles = Yoast_Feature_Toggles::instance()->get_all();
 	);
 
 	$yform->toggle_switch(
+		WPSEO_Option::ALLOW_KEY_PREFIX . 'remove_feed_authors',
+		[
+			'on'  => __( 'Allow Control', 'wordpress-seo' ),
+			'off' => __( 'Disable', 'wordpress-seo' ),
+		],
+		__( 'Feeds per post author', 'wordpress-seo' )
+	);
+
+	$yform->toggle_switch(
 		WPSEO_Option::ALLOW_KEY_PREFIX . 'remove_atom_rdf_feeds',
 		[
 			'on'  => __( 'Allow Control', 'wordpress-seo' ),

--- a/inc/options/class-wpseo-option-ms.php
+++ b/inc/options/class-wpseo-option-ms.php
@@ -104,6 +104,7 @@ class WPSEO_Option_MS extends WPSEO_Option {
 			"{$allow_prefix}remove_feed_post_comments"      => true,
 			"{$allow_prefix}remove_atom_rdf_feeds"          => true,
 			"{$allow_prefix}remove_feed_global"             => true,
+			"{$allow_prefix}remove_feed_authors"            => true,
 		];
 
 		if ( is_multisite() ) {

--- a/inc/options/class-wpseo-option-wpseo.php
+++ b/inc/options/class-wpseo-option-wpseo.php
@@ -94,6 +94,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 		'remove_feed_post_comments'                => false,
 		'remove_atom_rdf_feeds'                    => false,
 		'remove_feed_global'                       => false,
+		'remove_feed_authors'                      => false,
 	];
 
 	/**
@@ -400,6 +401,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 				 *  'remove_feed_post_comments'
 				 *  'remove_atom_rdf_feeds'
 				 *  'remove_feed_global'
+				 *  'remove_feed_authors'
 				 *  'should_redirect_after_install_free'
 				 *  and most of the feature variables.
 				 */
@@ -445,6 +447,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 			'remove_feed_post_comments'      => false,
 			'remove_atom_rdf_feeds'          => false,
 			'remove_feed_global'             => false,
+			'remove_feed_authors'            => false,
 		];
 
 		// We can reuse this logic from the base class with the above defaults to parse with the correct feature values.

--- a/src/integrations/front-end/crawl-cleanup-rss.php
+++ b/src/integrations/front-end/crawl-cleanup-rss.php
@@ -42,7 +42,7 @@ class Crawl_Cleanup_Rss implements Integration_Interface {
 	 * Register our RSS related hooks.
 	 */
 	public function register_hooks() {
-		if ( $this->options_helper->get( 'remove_feed_global' ) === true ) {
+		if ( $this->is_true( 'remove_feed_global' ) ) {
 			\add_action( 'feed_links_show_posts_feed', '__return_false' );
 		}
 		\add_action( 'wp', [ $this, 'maybe_disable_feeds' ] );
@@ -53,10 +53,10 @@ class Crawl_Cleanup_Rss implements Integration_Interface {
 	 * Disable feeds on selected cases.
 	 */
 	public function maybe_disable_feeds() {
-		if ( \is_singular() && $this->options_helper->get( 'remove_feed_post_comments' ) === true ) {
+		if ( \is_singular() && $this->is_true( 'remove_feed_post_comments' ) ) {
 			\remove_action( 'wp_head', 'feed_links_extra', 3 );
 		}
-		elseif ( \is_author() && $this->options_helper->get( 'remove_feed_authors' ) === true ) {
+		elseif ( \is_author() && $this->is_true( 'remove_feed_authors' ) ) {
 			\remove_action( 'wp_head', 'feed_links_extra', 3 );
 		}
 	}
@@ -71,18 +71,18 @@ class Crawl_Cleanup_Rss implements Integration_Interface {
 			return;
 		}
 
-		if ( \in_array( \get_query_var( 'feed' ), [ 'atom', 'rdf' ], true ) && $this->options_helper->get( 'remove_atom_rdf_feeds' ) === true ) {
+		if ( \in_array( \get_query_var( 'feed' ), [ 'atom', 'rdf' ], true ) && $this->is_true( 'remove_atom_rdf_feeds' ) ) {
 			$this->redirect_feed( \home_url(), 'We disable Atom/RDF feeds for performance reasons.' );
 		}
 		// Only if we're on the global feed, the query is _just_ `'feed' => 'feed'`, hence this check.
-		elseif ( $wp_query->query === [ 'feed' => 'feed' ] && $this->options_helper->get( 'remove_feed_global' ) === true ) {
+		elseif ( $wp_query->query === [ 'feed' => 'feed' ] && $this->is_true( 'remove_feed_global' ) ) {
 			$this->redirect_feed( \home_url(), 'We disable the RSS feed for performance reasons.' );
 		}
-		elseif ( \is_comment_feed() && \is_singular() && $this->options_helper->get( 'remove_feed_post_comments' ) === true ) {
+		elseif ( \is_comment_feed() && \is_singular() && $this->is_true( 'remove_feed_post_comments' ) ) {
 			$url = \get_permalink( \get_queried_object() );
 			$this->redirect_feed( $url, 'We disable post comment feeds for performance reasons.' );
 		}
-		elseif ( \is_author() && $this->options_helper->get( 'remove_feed_authors' ) === true ) {
+		elseif ( \is_author() && $this->is_true( 'remove_feed_authors' ) ) {
 			$author_id = (int) \get_query_var( 'author' );
 			$url       = \get_author_posts_url( $author_id );
 			$this->redirect_feed( $url, 'We disable author feeds for performance reasons.' );
@@ -124,5 +124,16 @@ class Crawl_Cleanup_Rss implements Integration_Interface {
 
 		\wp_safe_redirect( $url, 301, 'Yoast SEO: ' . $reason );
 		exit;
+	}
+
+	/**
+	 * Checks if the value of an option is set to true.
+	 *
+	 * @param string $option_name The option name.
+	 *
+	 * @return bool
+	 */
+	private function is_true( $option_name ) {
+		return $this->options_helper->get( $option_name ) === true;
 	}
 }

--- a/src/integrations/front-end/crawl-cleanup-rss.php
+++ b/src/integrations/front-end/crawl-cleanup-rss.php
@@ -56,6 +56,9 @@ class Crawl_Cleanup_Rss implements Integration_Interface {
 		if ( \is_singular() && $this->options_helper->get( 'remove_feed_post_comments' ) === true ) {
 			\remove_action( 'wp_head', 'feed_links_extra', 3 );
 		}
+		elseif ( \is_author() && $this->options_helper->get( 'remove_feed_authors' ) === true ) {
+			\remove_action( 'wp_head', 'feed_links_extra', 3 );
+		}
 	}
 
 	/**
@@ -78,6 +81,11 @@ class Crawl_Cleanup_Rss implements Integration_Interface {
 		elseif ( \is_comment_feed() && \is_singular() && $this->options_helper->get( 'remove_feed_post_comments' ) === true ) {
 			$url = \get_permalink( \get_queried_object() );
 			$this->redirect_feed( $url, 'We disable post comment feeds for performance reasons.' );
+		}
+		elseif ( \is_author() && $this->options_helper->get( 'remove_feed_authors' ) === true ) {
+			$author_id = (int) \get_query_var( 'author' );
+			$url       = \get_author_posts_url( $author_id );
+			$this->redirect_feed( $url, 'We disable author feeds for performance reasons.' );
 		}
 	}
 

--- a/tests/unit/integrations/front-end/crawl-cleanup-rss-test.php
+++ b/tests/unit/integrations/front-end/crawl-cleanup-rss-test.php
@@ -73,7 +73,7 @@ class Crawl_Cleanup_Rss_Test extends TestCase {
 	}
 
 	/**
-	 * Tests if the expected replacements are performed when a post is displayed and the RSS cleanup is enabled.
+	 * Tests if the expected replacements are performed when a post is displayed and the RSS feed is disabled.
 	 *
 	 * @covers ::maybe_disable_feeds
 	 */
@@ -95,14 +95,18 @@ class Crawl_Cleanup_Rss_Test extends TestCase {
 	}
 
 	/**
-	 * Tests if the expected replacements are performed when a post is displayed and the RSS cleanup is disabled.
+	 * Tests if the expected replacements are performed when a post is displayed and the RSS feed is enabled.
 	 *
 	 * @covers ::maybe_disable_feeds
 	 */
 	public function test_maybe_disable_feeds_when_is_singular_and_feeds_enabled() {
 		Monkey\Functions\expect( 'is_singular' )
 			->once()
-			->andReturn( true );
+			->andReturnTrue();
+
+		Monkey\Functions\expect( 'is_author' )
+			->once()
+			->andReturnFalse();
 
 		$this->options_helper
 			->expects( 'get' )
@@ -117,14 +121,70 @@ class Crawl_Cleanup_Rss_Test extends TestCase {
 	}
 
 	/**
-	 * Tests if the expected replacements are performed when a post is displayed and the RSS cleanup is disabled.
+	 * Tests if the expected replacements are performed when an author archive is displayed and the RSS feed is disabled.
 	 *
 	 * @covers ::maybe_disable_feeds
 	 */
-	public function test_maybe_disable_feeds_when_not_singular() {
+	public function test_maybe_disable_feeds_when_is_author_and_feed_disabled() {
+		Monkey\Functions\expect( 'is_singular' )
+			->once()
+			->andReturnFalse();
+
+		Monkey\Functions\expect( 'is_author' )
+			->once()
+			->andReturnTrue();
+
+		$this->options_helper
+			->expects( 'get' )
+			->once()
+			->with( 'remove_feed_authors' )
+			->andReturnTrue();
+
+		Monkey\Functions\expect( 'remove_action' )
+			->once();
+
+		$this->instance->maybe_disable_feeds();
+	}
+
+	/**
+	 * Tests if the expected replacements are performed when an author archive is displayed and the RSS feed is enabled.
+	 *
+	 * @covers ::maybe_disable_feeds
+	 */
+	public function test_maybe_disable_feeds_when_is_author_and_feeds_enabled() {
+		Monkey\Functions\expect( 'is_singular' )
+			->once()
+			->andReturnFalse();
+
+		Monkey\Functions\expect( 'is_author' )
+			->once()
+			->andReturnTrue();
+
+		$this->options_helper
+			->expects( 'get' )
+			->once()
+			->with( 'remove_feed_authors' )
+			->andReturnFalse();
+
+		Monkey\Functions\expect( 'remove_action' )
+			->never();
+
+		$this->instance->maybe_disable_feeds();
+	}
+
+	/**
+	 * Tests no replacements are performed when neither a post nor an author archive is displayed.
+	 *
+	 * @covers ::maybe_disable_feeds
+	 */
+	public function test_maybe_disable_feeds_when_not_matching() {
 		Monkey\Functions\expect( 'is_singular' )
 			->once()
 			->andReturn( false );
+
+		Monkey\Functions\expect( 'is_author' )
+			->once()
+			->andReturnFalse();
 
 		$this->options_helper
 			->expects( 'get' )


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to add a new toggle switch to the `Crawl settings` tab to let users disable the feed per post author by redirecting the request to the author archive.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds a feature to disable the feeds per post author.

## Relevant technical choices:

* When the author archives are disabled in Search Appearance, the feeds are disabled as a consequence. We may improve the feature by graying out the toggle (and setting it to "Remove") automatically.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* inspect any author archive page e.g. http://basic.wordpress.test/author/admin/ and see that you can see a tag linking to the author feed, e,g,
`<link rel="alternate" type="application/rss+xml" title="Basic &raquo; Posts by admin Feed" href="http://basic.wordpress.test/author/admin/feed/" />`
* Check that you can access the author feed
* Go to the admin area of your site, `Yoast SEO` -> `General` -> `Crawl settings` tab and toggle the `Feeds per post author` switch to `Remove`
* Inspect the source of any page and see the link tag is gone
* Now try to access the feed again http://basic.wordpress.test/author/admin/feed/ and verify you're now redirected to the author archive
* check that the other RSS feed are still accessible (provided that you haven't disabled them):
  * http://basic.wordpress.test/comments/feed/
  * http://basic.wordpress.test/hello-world/feed/
  * etc.

For multisites:
* Install the RC in a fresh multisite by activating the plugin at network level
* In Network admin go to `Yoast SEO` -> `General`-> `Crawl Settings` tab
* Confirm that the `Feeds per post author` toggle is set to `Allow Control` by default
* Go to the main sub-site's and another sub-site's `Yoast SEO` -> `General`-> `Crawl Settings` tab
* Confirm that the `Feeds per post author` toggle is set to `Keep` by default
* inspect any author archive page in the main site e.g. http://multisite.wordpress.test/author/admin/ and see that you can see a  tag linking to the author feed, e,g,
`<link rel="alternate" type="application/rss+xml" title="Basic &raquo; Posts by admin Feed" href="http://multisite.wordpress.test/author/admin/feed/" />`
* Check that you can access the author feeds of the main site
* inspect any author archive page in the subsite e.g. http://multisite.wordpress.test/site2/author/admin/ and see that you can see a  tag linking to the author feed, e,g,
`<link rel="alternate" type="application/rss+xml" title="Basic &raquo; Posts by admin Feed" href="http://multisite.wordpress.test/site2/author/admin/feed/" />`
* Check that you can access the author feeds of the subsite
* Now, set the `Feeds per post author`  to `Remove` in one of the sub-site's settings
* Try to access the feeds URL again for that sub-site and verify you're redirected to the sub-site's author archive
* Also confirm that the feeds URLs in the other sub-site is still available
* Now go to the network admin page and set the `Feeds per post author`  toggle to `Disabled`.
* Confirm that in both sub-site's settings, the `Feeds per post author`  toggle is set to  `Keep` with the `This feature has been disabled by the network admin` message displayed.
* Confirm that the author feeds for both sub-sites are available
* Now go to the network admin page and set the `Feeds per post author`  toggle to `Allow Control`.
* visit SEO > General for the subsite where you disabled the `Feeds per post author`  and check that the toggle is not greyed out anymore, and now it's set to `Remove` as it was before the network-level deactivation
* visit SEO > General for the main site and check that the toggle is not greyed out anymore, and now it's set to `Keep` as it was before the network-level deactivation


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes [DUPP-548]

[DUPP-548]: https://yoast.atlassian.net/browse/DUPP-548?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ