### PR TITLE
DUPP-550 disable taxonomy feeds

### DIFF
--- a/admin/tracking/class-tracking-settings-data.php
+++ b/admin/tracking/class-tracking-settings-data.php
@@ -185,6 +185,9 @@ class WPSEO_Tracking_Settings_Data implements WPSEO_Collection {
 		'remove_feed_post_comments',
 		'remove_atom_rdf_feeds',
 		'remove_feed_global',
+		'remove_feed_categories',
+		'remove_feed_tags',
+		'remove_feed_custom_taxonomies',
 	];
 
 	/**

--- a/admin/views/tabs/dashboard/crawl-settings.php
+++ b/admin/views/tabs/dashboard/crawl-settings.php
@@ -51,6 +51,33 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 	);
 
 	$yform->toggle_switch(
+		'remove_feed_categories',
+		[
+			'off' => __( 'Keep', 'wordpress-seo' ),
+			'on'  => __( 'Remove', 'wordpress-seo' ),
+		],
+		__( 'Category feeds', 'wordpress-seo' )
+	);
+
+	$yform->toggle_switch(
+		'remove_feed_tags',
+		[
+			'off' => __( 'Keep', 'wordpress-seo' ),
+			'on'  => __( 'Remove', 'wordpress-seo' ),
+		],
+		__( 'Tag feeds', 'wordpress-seo' )
+	);
+
+	$yform->toggle_switch(
+		'remove_feed_custom_taxonomies',
+		[
+			'off' => __( 'Keep', 'wordpress-seo' ),
+			'on'  => __( 'Remove', 'wordpress-seo' ),
+		],
+		__( 'Custom taxonomy feeds', 'wordpress-seo' )
+	);
+
+	$yform->toggle_switch(
 		'remove_atom_rdf_feeds',
 		[
 			'off' => __( 'Keep', 'wordpress-seo' ),

--- a/admin/views/tabs/network/crawl-settings.php
+++ b/admin/views/tabs/network/crawl-settings.php
@@ -52,6 +52,34 @@ $feature_toggles = Yoast_Feature_Toggles::instance()->get_all();
 		__( 'Post comment feeds', 'wordpress-seo' )
 	);
 
+
+	$yform->toggle_switch(
+		WPSEO_Option::ALLOW_KEY_PREFIX . 'remove_feed_categories',
+		[
+			'on'  => __( 'Allow Control', 'wordpress-seo' ),
+			'off' => __( 'Disable', 'wordpress-seo' ),
+		],
+		__( 'Category feeds', 'wordpress-seo' )
+	);
+
+	$yform->toggle_switch(
+		WPSEO_Option::ALLOW_KEY_PREFIX . 'remove_feed_tags',
+		[
+			'on'  => __( 'Allow Control', 'wordpress-seo' ),
+			'off' => __( 'Disable', 'wordpress-seo' ),
+		],
+		__( 'Tag feeds', 'wordpress-seo' )
+	);
+
+	$yform->toggle_switch(
+		WPSEO_Option::ALLOW_KEY_PREFIX . 'remove_feed_custom_taxonomies',
+		[
+			'on'  => __( 'Allow Control', 'wordpress-seo' ),
+			'off' => __( 'Disable', 'wordpress-seo' ),
+		],
+		__( 'Custom taxonomy feeds', 'wordpress-seo' )
+	);
+
 	$yform->toggle_switch(
 		WPSEO_Option::ALLOW_KEY_PREFIX . 'remove_atom_rdf_feeds',
 		[

--- a/inc/options/class-wpseo-option-ms.php
+++ b/inc/options/class-wpseo-option-ms.php
@@ -104,6 +104,9 @@ class WPSEO_Option_MS extends WPSEO_Option {
 			"{$allow_prefix}remove_feed_post_comments"      => true,
 			"{$allow_prefix}remove_atom_rdf_feeds"          => true,
 			"{$allow_prefix}remove_feed_global"             => true,
+			"{$allow_prefix}remove_feed_categories"         => true,
+			"{$allow_prefix}remove_feed_tags"               => true,
+			"{$allow_prefix}remove_feed_custom_taxonomies"  => true,
 		];
 
 		if ( is_multisite() ) {

--- a/inc/options/class-wpseo-option-wpseo.php
+++ b/inc/options/class-wpseo-option-wpseo.php
@@ -94,6 +94,9 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 		'remove_feed_post_comments'                => false,
 		'remove_atom_rdf_feeds'                    => false,
 		'remove_feed_global'                       => false,
+		'remove_feed_categories'                   => false,
+		'remove_feed_tags'                         => false,
+		'remove_feed_custom_taxonomies'            => false,
 	];
 
 	/**
@@ -400,6 +403,9 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 				 *  'remove_feed_post_comments'
 				 *  'remove_atom_rdf_feeds'
 				 *  'remove_feed_global'
+				 * 	'remove_feed_categories'
+				 *  'remove_feed_tags'
+				 *  'remove_feed_custom_taxonomies'
 				 *  'should_redirect_after_install_free'
 				 *  and most of the feature variables.
 				 */
@@ -445,6 +451,9 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 			'remove_feed_post_comments'      => false,
 			'remove_atom_rdf_feeds'          => false,
 			'remove_feed_global'             => false,
+			'remove_feed_categories'         => false,
+			'remove_feed_tags'               => false,
+			'remove_feed_custom_taxonomies'  => false,
 		];
 
 		// We can reuse this logic from the base class with the above defaults to parse with the correct feature values.

--- a/src/integrations/front-end/crawl-cleanup-rss.php
+++ b/src/integrations/front-end/crawl-cleanup-rss.php
@@ -42,7 +42,7 @@ class Crawl_Cleanup_Rss implements Integration_Interface {
 	 * Register our RSS related hooks.
 	 */
 	public function register_hooks() {
-		if ( $this->options_helper->get( 'remove_feed_global' ) === true ) {
+		if ( $this->is_true( 'remove_feed_global' ) ) {
 			\add_action( 'feed_links_show_posts_feed', '__return_false' );
 		}
 		\add_action( 'wp', [ $this, 'maybe_disable_feeds' ] );
@@ -53,7 +53,7 @@ class Crawl_Cleanup_Rss implements Integration_Interface {
 	 * Disable feeds on selected cases.
 	 */
 	public function maybe_disable_feeds() {
-		if ( \is_singular() && $this->options_helper->get( 'remove_feed_post_comments' ) === true ) {
+		if ( \is_singular() && $this->is_true( 'remove_feed_post_comments' ) ) {
 			\remove_action( 'wp_head', 'feed_links_extra', 3 );
 		}
 	}
@@ -68,14 +68,14 @@ class Crawl_Cleanup_Rss implements Integration_Interface {
 			return;
 		}
 
-		if ( \in_array( \get_query_var( 'feed' ), [ 'atom', 'rdf' ], true ) && $this->options_helper->get( 'remove_atom_rdf_feeds' ) === true ) {
+		if ( \in_array( \get_query_var( 'feed' ), [ 'atom', 'rdf' ], true ) && $this->is_true( 'remove_atom_rdf_feeds' ) ) {
 			$this->redirect_feed( \home_url(), 'We disable Atom/RDF feeds for performance reasons.' );
 		}
 		// Only if we're on the global feed, the query is _just_ `'feed' => 'feed'`, hence this check.
-		elseif ( $wp_query->query === [ 'feed' => 'feed' ] && $this->options_helper->get( 'remove_feed_global' ) === true ) {
+		elseif ( $wp_query->query === [ 'feed' => 'feed' ] && $this->is_true( 'remove_feed_global' ) ) {
 			$this->redirect_feed( \home_url(), 'We disable the RSS feed for performance reasons.' );
 		}
-		elseif ( \is_comment_feed() && \is_singular() && $this->options_helper->get( 'remove_feed_post_comments' ) === true ) {
+		elseif ( \is_comment_feed() && \is_singular() && $this->is_true( 'remove_feed_post_comments' ) ) {
 			$url = \get_permalink( \get_queried_object() );
 			$this->redirect_feed( $url, 'We disable post comment feeds for performance reasons.' );
 		}
@@ -116,5 +116,16 @@ class Crawl_Cleanup_Rss implements Integration_Interface {
 
 		\wp_safe_redirect( $url, 301, 'Yoast SEO: ' . $reason );
 		exit;
+	}
+
+	/**
+	 * Checks if the value of an option is set to true.
+	 *
+	 * @param string $option_name The option name.
+	 *
+	 * @return bool
+	 */
+	private function is_true( $option_name ) {
+		return $this->options_helper->get( $option_name ) === true;
 	}
 }

--- a/src/integrations/front-end/crawl-cleanup-rss.php
+++ b/src/integrations/front-end/crawl-cleanup-rss.php
@@ -56,6 +56,13 @@ class Crawl_Cleanup_Rss implements Integration_Interface {
 		if ( \is_singular() && $this->is_true( 'remove_feed_post_comments' ) ) {
 			\remove_action( 'wp_head', 'feed_links_extra', 3 );
 		}
+		elseif (
+			( \is_category() && $this->is_true( 'remove_feed_categories' ) )
+			|| ( \is_tag() && $this->is_true( 'remove_feed_tags' ) )
+			|| ( \is_tax() && $this->is_true( 'remove_feed_custom_taxonomies' ) )
+		) {
+			\remove_action( 'wp_head', 'feed_links_extra', 3 );
+		}
 	}
 
 	/**
@@ -78,6 +85,18 @@ class Crawl_Cleanup_Rss implements Integration_Interface {
 		elseif ( \is_comment_feed() && \is_singular() && $this->is_true( 'remove_feed_post_comments' ) ) {
 			$url = \get_permalink( \get_queried_object() );
 			$this->redirect_feed( $url, 'We disable post comment feeds for performance reasons.' );
+		}
+		elseif (
+			( \is_category() && $this->is_true( 'remove_feed_categories' ) )
+			|| ( \is_tag() && $this->is_true( 'remove_feed_tags' ) )
+			|| ( \is_tax() && $this->is_true( 'remove_feed_custom_taxonomies' ) )
+		) {
+			$term = \get_queried_object();
+			$url  = \get_term_link( $term, $term->taxonomy );
+			if ( \is_wp_error( $url ) ) {
+				$url = \home_url();
+			}
+			$this->redirect_feed( $url, 'We disable taxonomy feeds for performance reasons.' );
 		}
 	}
 

--- a/tests/unit/integrations/front-end/crawl-cleanup-rss-test.php
+++ b/tests/unit/integrations/front-end/crawl-cleanup-rss-test.php
@@ -104,6 +104,18 @@ class Crawl_Cleanup_Rss_Test extends TestCase {
 			->once()
 			->andReturn( true );
 
+		Monkey\Functions\expect( 'is_category' )
+			->once()
+			->andReturnFalse();
+
+		Monkey\Functions\expect( 'is_tag' )
+			->once()
+			->andReturnFalse();
+
+		Monkey\Functions\expect( 'is_tax' )
+			->once()
+			->andReturnFalse();
+
 		$this->options_helper
 			->expects( 'get' )
 			->once()
@@ -124,7 +136,19 @@ class Crawl_Cleanup_Rss_Test extends TestCase {
 	public function test_maybe_disable_feeds_when_not_singular() {
 		Monkey\Functions\expect( 'is_singular' )
 			->once()
-			->andReturn( false );
+			->andReturnFalse();
+
+		Monkey\Functions\expect( 'is_category' )
+			->once()
+			->andReturnFalse();
+
+		Monkey\Functions\expect( 'is_tag' )
+			->once()
+			->andReturnFalse();
+
+		Monkey\Functions\expect( 'is_tax' )
+			->once()
+			->andReturnFalse();
 
 		$this->options_helper
 			->expects( 'get' )


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to add new toggle switches to the `Crawl settings` tab to let users disable the category, tag and custom taxonomy feeds by redirecting the request to the relative archives.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds a feature to disable the category, tag and custom taxonomy feeds.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* TBA


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes [DUPP-550]


[DUPP-550]: https://yoast.atlassian.net/browse/DUPP-550?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ