### PR TITLE
Add block template support to tracking

### DIFF
--- a/admin/tracking/class-tracking-theme-data.php
+++ b/admin/tracking/class-tracking-theme-data.php
@@ -20,14 +20,15 @@ class WPSEO_Tracking_Theme_Data implements WPSEO_Collection {
 
 		return [
 			'theme' => [
-				'name'        => $theme->get( 'Name' ),
-				'url'         => $theme->get( 'ThemeURI' ),
-				'version'     => $theme->get( 'Version' ),
-				'author'      => [
+				'name'                 => $theme->get( 'Name' ),
+				'url'                  => $theme->get( 'ThemeURI' ),
+				'version'              => $theme->get( 'Version' ),
+				'author'               => [
 					'name' => $theme->get( 'Author' ),
 					'url'  => $theme->get( 'AuthorURI' ),
 				],
-				'parentTheme' => $this->get_parent_theme( $theme ),
+				'parentTheme'          => $this->get_parent_theme( $theme ),
+				'blockTemplateSupport' => current_theme_supports( 'block-templates' ),
 			],
 		];
 	}

--- a/admin/tracking/class-tracking-theme-data.php
+++ b/admin/tracking/class-tracking-theme-data.php
@@ -29,6 +29,7 @@ class WPSEO_Tracking_Theme_Data implements WPSEO_Collection {
 				],
 				'parentTheme'          => $this->get_parent_theme( $theme ),
 				'blockTemplateSupport' => current_theme_supports( 'block-templates' ),
+				'isBlockTheme'         => function_exists( 'wp_is_block_theme' ) && wp_is_block_theme(),
 			],
 		];
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Adds block template support to tracking

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds block template support to our tracking data.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Make sure tracking is enabled.
* Delete the `wpseo_tracking_last_request` option.
* Visit the WordPress Admin.
* The tracking data send should include `blockTemplateSupport` in the theme tracking data.
* I recommend setting a breakpoint in the `WPSEO_Tracking::send` method to validate this.


### Test instructions for QA when the code is in the RC
<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Make sure tracking is enabled.
* Delete the `wpseo_tracking_last_request` option.
* Visit the WordPress Admin.
* The `wpseo_tracking_last_request` should be filled with a timestamp near the current time.
* There should have been no fatals.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Tracking data

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
