### PR TITLE
Add patcher to set idn_conversion to false

### DIFF
--- a/config/php-scoper/guzzlehttp.inc.php
+++ b/config/php-scoper/guzzlehttp.inc.php
@@ -4,7 +4,7 @@ declare( strict_types=1 );
 
 use Isolated\Symfony\Component\Finder\Finder;
 
-return array(
+return [
 
 	/*
 	 * By default when running php-scoper add-prefix, it will prefix all relevant code found in the current working
@@ -13,7 +13,7 @@ return array(
 	 *
 	 * For more see: https://github.com/humbug/php-scoper#finders-and-paths
 	 */
-	'finders'                    => [
+	'finders' => [
 		Finder::create()->files()->in( 'vendor/guzzlehttp/guzzle' )->name( [ '*.php', 'LICENSE', 'composer.json' ] ),
 		Finder::create()->files()->in( 'vendor/guzzlehttp/promises' )->name( [ '*.php', 'LICENSE', 'composer.json' ] ),
 		Finder::create()->files()->in( 'vendor/guzzlehttp/psr7' )->name( [ '*.php', 'LICENSE', 'composer.json' ] ),
@@ -27,7 +27,7 @@ return array(
 	 *
 	 * For more see: https://github.com/humbug/php-scoper#patchers
 	 */
-	'patchers'                   => [
+	'patchers' => [
 		/**
 		 * Replaces the Adapter string references with the prefixed versions.
 		 *
@@ -38,19 +38,26 @@ return array(
 		 * @return string The modified content.
 		 */
 		function( $file_path, $prefix, $content ) {
-			// 18 is the length of the GrantFactory.php file path.
-			if ( substr( $file_path, -18 ) !== 'src/Middleware.php' ) {
-				return $content;
+			// 18 is the length of the Middleware.php file path.
+			if ( substr( $file_path, -18 ) === 'src/Middleware.php' ) {
+				return str_replace(
+					sprintf( '%s\\\\cookies must be an instance of GuzzleHttp\\\\Cookie\\\\CookieJarInterface', $prefix ),
+					sprintf( 'cookies must be an instance of %s\\\\GuzzleHttp\\\\Cookie\\\\CookieJarInterface', $prefix ),
+					$content
+				);
 			}
 
-			$replaced = str_replace(
-				sprintf( '%s\\\\cookies must be an instance of GuzzleHttp\\\\Cookie\\\\CookieJarInterface', $prefix ),
-				sprintf( 'cookies must be an instance of %s\\\\GuzzleHttp\\\\Cookie\\\\CookieJarInterface', $prefix ),
-				$content
-			);
+			if ( substr( $file_path, -14 ) === 'src/Client.php' ) {
+				// A WordPress environment doesn't support idn_conversion so we disable it.
+				return str_replace(
+					"'idn_conversion' => \\true",
+					"'idn_conversion' => \\false",
+					$content
+				);
+			}
 
-			return $replaced;
+			return $content;
 		},
 	],
 
-);
+];


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where bumping Guzzle version would break authentication with integrations in PHP 5.6.

## Relevant technical choices:

* Guzzle now uses Symfony polyfills. However, those are not compatible with PHP 5.6. Therefor we are require the latest PHP 5.6 compatible versions of those polyfill packages.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Note: Guzzle is a dependency of the OAuth client we use (from League). I.e. it is the authentication that should be tested.
* Test that you can authenticate with Semrush
* Test that you can authenticate with Wincher

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Check with PHP 5.6

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes #
