### PR TITLE
Show different button when Premium is not upgraded

### DIFF
--- a/admin/pages/network.php
+++ b/admin/pages/network.php
@@ -19,7 +19,9 @@ $network_tabs->add_tab( new WPSEO_Option_Tab( 'general', __( 'General', 'wordpre
 $network_tabs->add_tab( new WPSEO_Option_Tab( 'features', __( 'Features', 'wordpress-seo' ) ) );
 $network_tabs->add_tab( new WPSEO_Option_Tab( 'integrations', __( 'Integrations', 'wordpress-seo' ) ) );
 
-$premium = YoastSEO()->helpers->product->is_premium();
+$premium_installed = YoastSEO()->helpers->product->is_premium();
+$premium_version   = YoastSEO()->helpers->product->get_premium_version();
+$premium           = $premium_installed && $premium_version !== null && version_compare( $premium_version, '18.6-RC1', '>=' );
 $network_tabs->add_tab(
 	new WPSEO_Option_Tab(
 		'crawl-settings',

--- a/tests/unit/integrations/admin/crawl-settings-integration-test.php
+++ b/tests/unit/integrations/admin/crawl-settings-integration-test.php
@@ -69,6 +69,11 @@ class Crawl_Settings_Integration_Test extends TestCase {
 			->once()
 			->andReturn( true );
 
+		$this->product_helper
+			->expects( 'get_premium_version' )
+			->once()
+			->andReturn( '18.6' );
+
 		$this->instance->register_hooks();
 	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Show different button when Premium is not upgraded

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* When Premium is not installed, we should get this in the Yoast SEO-General for single sites and the network subsite respectively:
![image](https://user-images.githubusercontent.com/12400734/171007262-0ebd2c99-8845-4dae-ab98-409b4181bcd7.png)
![image](https://user-images.githubusercontent.com/12400734/171007299-9d17d641-efd8-4c49-afae-0157663fec8e.png)
* When Premium is installed but lower than 18.6, we should get these: 
![image](https://user-images.githubusercontent.com/12400734/171008629-b05b2112-3ceb-461d-9b25-f5c236090488.png)
![image](https://user-images.githubusercontent.com/12400734/171008324-b5de520b-a395-4ad7-80d9-8ce0072461d4.png)
* When Premium is installed and 18.6, we should get these: 
![image](https://user-images.githubusercontent.com/12400734/171008756-c3d6f18b-800b-476b-a0cc-6328c711e339.png)
![image](https://user-images.githubusercontent.com/12400734/171008770-6e0a13e4-1b5d-473a-a922-86cd087cd22f.png)
and the feature should be working as expected



### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes #
