### PR TITLE
Create defaultblog option validator for network admin 

### DIFF
--- a/src/exceptions/validation/invalid-blog-id-exception.php
+++ b/src/exceptions/validation/invalid-blog-id-exception.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Yoast\WP\SEO\Exceptions\Validation;
+
+/**
+ * Invalid blog ID validation exception class.
+ *
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded -- Exception is not part of the name.
+ */
+class Invalid_Blog_ID_Exception extends Abstract_Validation_Exception {
+
+	/**
+	 * Constructs an invalid blog ID validation exception instance.
+	 *
+	 * @param integer $value The value that is an invalid blog ID.
+	 */
+	public function __construct( $value ) {
+		parent::__construct(
+			\sprintf(
+			/* translators: %s expands to a not existing blog id. */
+				esc_html__( 'This must be an existing blog. Blog %s does not exist or has been marked as deleted.', 'wordpress-seo' ),
+				'<strong>' . \esc_html( $value ) . '</strong>'
+			)
+		);
+	}
+}

--- a/src/exceptions/validation/invalid-blog-id-exception.php
+++ b/src/exceptions/validation/invalid-blog-id-exception.php
@@ -18,7 +18,7 @@ class Invalid_Blog_ID_Exception extends Abstract_Validation_Exception {
 		parent::__construct(
 			\sprintf(
 			/* translators: %s expands to a not existing blog id. */
-				esc_html__( 'This must be an existing blog. Blog %s does not exist or has been marked as deleted.', 'wordpress-seo' ),
+				\esc_html__( 'This must be an existing blog. Blog %s does not exist or has been marked as deleted.', 'wordpress-seo' ),
 				'<strong>' . \esc_html( $value ) . '</strong>'
 			)
 		);

--- a/src/services/options/network-admin-options-service.php
+++ b/src/services/options/network-admin-options-service.php
@@ -49,7 +49,10 @@ class Network_Admin_Options_Service extends Abstract_Options_Service {
 		],
 		'defaultblog' => [
 			'default' => '',
-			'types'   => [ 'empty_string', 'integer' ],
+			'types'   => [
+				'empty_string',
+				'blog_id',
+			],
 		],
 	];
 

--- a/src/validators/blog-id-validator.php
+++ b/src/validators/blog-id-validator.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Yoast\WP\SEO\Validators;
+
+use Yoast\WP\SEO\Exceptions\Validation\Invalid_Blog_ID_Exception;
+
+
+/**
+ * The blog ID validator class.
+ */
+class Blog_ID_Validator extends Integer_Validator {
+
+	// phpcs:disable Squiz.Commenting.FunctionCommentThrowTag.WrongNumber -- Reason: The parent validate can throw too.
+
+	/**
+	 * Validates if a value is a valid blog ID.
+	 *
+	 * @param mixed $value    The value to validate.
+	 * @param array $settings Optional settings.
+	 *
+	 * @throws \Yoast\WP\SEO\Exceptions\Validation\Invalid_Type_Exception When the value is not an integer.
+	 * @throws Invalid_Blog_ID_Exception When the value is an invalid blog id.
+	 *
+	 * @return integer The blog ID.
+	 */
+	public function validate( $value, array $settings = null ) {
+		$blog_id = parent::validate( $value );
+
+		if ( $blog_id === 0 ) {
+			throw new Invalid_Blog_ID_Exception( $blog_id );
+		}
+
+		$blog_details = \get_blog_details( $blog_id, false );
+
+		if ( ! $blog_details || $blog_details->deleted === '1' ) {
+			throw new Invalid_Blog_ID_Exception( $blog_id );
+		}
+
+		return $blog_id;
+	}
+}

--- a/src/validators/blog-id-validator.php
+++ b/src/validators/blog-id-validator.php
@@ -38,4 +38,6 @@ class Blog_ID_Validator extends Integer_Validator {
 
 		return $blog_id;
 	}
+
+	// phpcs:enable Squiz.Commenting.FunctionCommentThrowTag.WrongNumber
 }

--- a/tests/unit/validators/blog-id-validator-test.php
+++ b/tests/unit/validators/blog-id-validator-test.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Validators;
+
+use Brain\Monkey;
+use Yoast\WP\SEO\Exceptions\Validation\Invalid_Blog_ID_Exception;
+use Yoast\WP\SEO\Exceptions\Validation\Invalid_Type_Exception;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+use Yoast\WP\SEO\Validators\Blog_ID_Validator;
+
+/**
+ * Tests the Blog_ID_Validator class.
+ *
+ * @group options
+ * @group validators
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Validators\Blog_ID_Validator
+ */
+class Blog_ID_Validator_Test extends TestCase {
+
+	/**
+	 * Holds the instance to test.
+	 *
+	 * @var Blog_ID_Validator
+	 */
+	protected $instance;
+
+	/**
+	 * Sets up the test fixtures.
+	 */
+	protected function set_up() {
+		parent::set_up();
+		$this->stubEscapeFunctions();
+		$this->stubTranslationFunctions();
+
+		$this->instance = new Blog_ID_Validator();
+	}
+
+	/**
+	 * Tests validation.
+	 *
+	 * @dataProvider blog_data_provider
+	 *
+	 * @covers ::validate
+	 *
+	 * @param mixed  $value     The value to test/validate.
+	 * @param mixed  $expected  The expected result.
+	 * @param string $exception The expected exception class. Optional, use when the expected result is false.
+	 *
+	 * @throws \Yoast\WP\SEO\Exceptions\Validation\Abstract_Validation_Exception When detecting an invalid value.
+	 */
+	public function test_validate( $value, $expected, $exception = '' ) {
+		if ( $exception !== '' ) {
+			Monkey\Functions\expect( 'get_blog_details' )->andReturn( (object) [ 'deleted' => '1' ] );
+
+			$this->expectException( $exception );
+			$this->instance->validate( $value );
+
+			return;
+		}
+
+		Monkey\Functions\expect( 'get_blog_details' )->andReturn( (object) [ 'deleted' => '0' ] );
+
+		$this->assertEquals( $expected, $this->instance->validate( $value ) );
+	}
+
+	/**
+	 * Data provider to test multiple "integers".
+	 *
+	 * @return array A mapping of methods and expected inputs.
+	 */
+	public function blog_data_provider() {
+		return [
+			'valid_id' => [
+				'value'    => 1,
+				'expected' => 1,
+			],
+			'invalid_id_0' => [
+				'value'     => 0,
+				'expected'  => false,
+				'exception' => Invalid_Blog_ID_Exception::class,
+			],
+			'invalid_id' => [
+				'value'     => 2,
+				'expected'  => false,
+				'exception' => Invalid_Blog_ID_Exception::class,
+			],
+			'invalid_type' => [
+				'value'     => '1abc23',
+				'expected'  => false,
+				'exception' => Invalid_Type_Exception::class,
+			],
+		];
+	}
+}


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds the blog ID validator.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Tests should make sense and cover the code
* Have a multisite wordpress installation running
* You can play around with requesting validations, using this code:
```php
function _test_validate( $value ) {
	/** @var \Yoast\WP\SEO\Validators\Blog_ID_Validator $validator */
	$validator = YoastSEO()->classes->get( \Yoast\WP\SEO\Validators\Blog_ID_Validator::class );
	echo 'Value: ';
	var_dump( $value );
	echo '<br>Result: ';
	try {
		var_dump( $validator->validate( $value ) );
	} catch ( \Yoast\WP\SEO\Exceptions\Validation\Abstract_Validation_Exception $exception ) {
		echo $exception->getMessage();
	}
	echo '<br>';
}
_test_validate( 1 );
_test_validate( 0 );
_test_validate( 'test' );

```
* You can play with the setting of the defaultblog ID, using this code:
```php
function _test_set( $value ) {
	/** @var \Yoast\WP\SEO\Services\Options\Network_Admin_Options_Service $options */
	$options = YoastSEO()->classes->get( \Yoast\WP\SEO\Services\Options\Network_Admin_Options_Service::class );
	echo '<br>Before: ';
	var_dump( $options->defaultblog );
	echo '<br>After: ';
	try {
		$options->defaultblog = $value;
		var_dump( $options->defaultblog );
	} catch ( \Yoast\WP\SEO\Exceptions\Validation\Abstract_Validation_Exception $exception ) {
		echo $exception->getMessage();
	}
	echo '<br>';
}
_test_set( 1 );
```

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Part of bigger feature, please test the whole feature when done.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes P1-1353
