### PR TITLE
LINGO-1462 - Marking a post as cornerstone content does not change the readability analysis

### DIFF
--- a/packages/js/src/classic-editor/components/cornerstone-content.js
+++ b/packages/js/src/classic-editor/components/cornerstone-content.js
@@ -19,8 +19,8 @@ const LearnMoreLink = makeOutboundLink();
  * @returns {JSX.Element} The collapsible cornerstone toggle component.
  */
 const CornerstoneContent = ( { cornerstoneContentInfoLink } ) => {
-	const isCornerstone  = useSelect( select => select( SEO_STORE_NAME ).selectIsCornerstone() );
-	const { updateIsCornerstone } = useDispatch( SEO_STORE_NAME );
+	const isCornerstone  = useSelect( select => select( SEO_STORE_NAME ).shouldApplyCornerstoneAnalysis() );
+	const { updateShouldApplyCornerstoneAnalysis } = useDispatch( SEO_STORE_NAME );
 
 	return (
 		<MetaboxCollapsible
@@ -36,7 +36,7 @@ const CornerstoneContent = ( { cornerstoneContentInfoLink } ) => {
 			<CornerstoneToggle
 				id="yoast-cornerstone-metabox"
 				isEnabled={ isCornerstone }
-				onToggle={ updateIsCornerstone }
+				onToggle={ updateShouldApplyCornerstoneAnalysis }
 			/>
 			<Slot name="YoastAfterCornerstoneToggle" />
 		</MetaboxCollapsible>

--- a/packages/js/src/classic-editor/components/cornerstone-content.js
+++ b/packages/js/src/classic-editor/components/cornerstone-content.js
@@ -19,7 +19,7 @@ const LearnMoreLink = makeOutboundLink();
  * @returns {JSX.Element} The collapsible cornerstone toggle component.
  */
 const CornerstoneContent = ( { cornerstoneContentInfoLink } ) => {
-	const isCornerstone  = useSelect( select => select( SEO_STORE_NAME ).shouldApplyCornerstoneAnalysis() );
+	const isCornerstone  = useSelect( select => select( SEO_STORE_NAME ).selectShouldApplyCornerstoneAnalysis() );
 	const { updateShouldApplyCornerstoneAnalysis } = useDispatch( SEO_STORE_NAME );
 
 	return (

--- a/packages/js/src/classic-editor/initial-state.js
+++ b/packages/js/src/classic-editor/initial-state.js
@@ -15,6 +15,7 @@ export const getInitialPostState = () => ( {
 			analysisType: "post",
 			isSeoActive: isSeoAnalysisActive(),
 			isReadabilityActive: isReadabilityAnalysisActive(),
+			shouldApplyCornerstoneAnalysis: dom.getPostIsCornerstone(),
 		},
 	},
 	editor: {
@@ -38,7 +39,6 @@ export const getInitialPostState = () => ( {
 				window.wpseoScriptData.metabox.title_template,
 			description: dom.getPostMetaDescription() || window.wpseoScriptData.metabox.metadesc_template,
 			slug: dom.getPostSlug(),
-			isCornerstone: dom.getPostIsCornerstone(),
 		},
 		keyphrases: {
 			[ FOCUS_KEYPHRASE_ID ]: {
@@ -82,6 +82,7 @@ export const getInitialTermState = () => ( {
 			analysisType: "term",
 			isSeoActive: isSeoAnalysisActive(),
 			isReadabilityActive: isReadabilityAnalysisActive(),
+			shouldApplyCornerstoneAnalysis: dom.getTermIsCornerstone(),
 		},
 	},
 	editor: {
@@ -97,7 +98,6 @@ export const getInitialTermState = () => ( {
 				window.wpseoScriptData.metabox.title_template,
 			description: dom.getTermMetaDescription() || window.wpseoScriptData.metabox.metadesc_template,
 			slug: dom.getTermSlug(),
-			isCornerstone: dom.getTermIsCornerstone(),
 		},
 		keyphrases: {
 			[ FOCUS_KEYPHRASE_ID ]: {

--- a/packages/js/src/classic-editor/watcher.js
+++ b/packages/js/src/classic-editor/watcher.js
@@ -377,7 +377,7 @@ const syncStoreToPost = () => {
 	createDomSync( selectors.selectSeoTitle, { domGet: dom.getPostSeoTitle, domSet: dom.setPostSeoTitle }, "seoTitle" );
 	createDomSync( selectors.selectMetaDescription, { domGet: dom.getPostMetaDescription, domSet: dom.setPostMetaDescription }, "metaDescription" );
 	createDomSync( selectors.selectKeyphrase, { domGet: dom.getPostFocusKeyphrase, domSet: dom.setPostFocusKeyphrase }, "focusKeyphrase" );
-	createDomSync( selectors.selectIsCornerstone, { domGet: dom.getPostIsCornerstone, domSet: dom.setPostIsCornerstone }, "isCornerstone" );
+	createDomSync( selectors.shouldApplyCornerstoneAnalysis, { domGet: dom.getPostIsCornerstone, domSet: dom.setPostIsCornerstone }, "isCornerstone" );
 	createDomSync(
 		selectors.selectSeoScore,
 		{
@@ -434,7 +434,7 @@ const syncStoreToTerm = () => {
 	createDomSync( selectors.selectSeoTitle, { domGet: dom.getTermSeoTitle, domSet: dom.setTermSeoTitle }, "seoTitle" );
 	createDomSync( selectors.selectMetaDescription, { domGet: dom.getTermMetaDescription, domSet: dom.setTermMetaDescription }, "metaDescription" );
 	createDomSync( selectors.selectKeyphrase, { domGet: dom.getTermFocusKeyphrase, domSet: dom.setTermFocusKeyphrase }, "focusKeyphrase" );
-	createDomSync( selectors.selectIsCornerstone, { domGet: dom.getTermIsCornerstone, domSet: dom.setTermIsCornerstone }, "isCornerstone" );
+	createDomSync( selectors.shouldApplyCornerstoneAnalysis, { domGet: dom.getTermIsCornerstone, domSet: dom.setTermIsCornerstone }, "isCornerstone" );
 	createDomSync(
 		selectors.selectSeoScore,
 		{

--- a/packages/js/tests/classic-editor/initial-state.test.js
+++ b/packages/js/tests/classic-editor/initial-state.test.js
@@ -79,6 +79,7 @@ self.wpseoScriptData = {
 describe( "a test for getting the initial state of a post or a term", () => {
 	it( "returns the initial state of a post", () => {
 		const actual = getInitialPostState();
+		expect( actual.analysis.config.shouldApplyCornerstoneAnalysis ).toEqual( false );
 		expect( actual.editor.title ).toEqual( "Tortoiseshell cat" );
 		expect( actual.editor.date ).toEqual( "18 January 2022 12:17" );
 		expect( actual.editor.permalink ).toEqual( "www.example.com/123" );
@@ -89,7 +90,6 @@ describe( "a test for getting the initial state of a post or a term", () => {
 		expect( actual.form.seo.title ).toEqual( "Tortoiseshell cat - All about cats" );
 		expect( actual.form.seo.description ).toEqual( "Cats with tortoiseshell coloration are believed to bring good luck." );
 		expect( actual.form.seo.slug ).toEqual( "www.example.com/tortoiseshell-cat" );
-		expect( actual.form.seo.isCornerstone ).toEqual( false );
 		expect( actual.form.keyphrases ).toEqual( { focus: { id: "focus", keyphrase: "tortoiseshell cat" } } );
 		expect( actual.editor.taxonomies.categories ).toEqual( [
 			{
@@ -127,6 +127,7 @@ describe( "a test for getting the initial state of a post or a term", () => {
 
 	it( "returns the initial state of a term", () => {
 		const actual = getInitialTermState();
+		expect( actual.analysis.config.shouldApplyCornerstoneAnalysis ).toEqual( false );
 		expect( actual.editor.title ).toEqual( "cat" );
 		expect( actual.editor.permalink ).toEqual( "www.example.com/categories" );
 		expect( actual.editor.content ).toEqual( "This is to describe a cat, that deserves only good attributes to them." );
@@ -134,7 +135,6 @@ describe( "a test for getting the initial state of a post or a term", () => {
 		expect( actual.form.seo.title ).toEqual( "A title befitting a beautiful cat" );
 		expect( actual.form.seo.description ).toEqual( "An example of a description for a cat." );
 		expect( actual.form.seo.slug ).toEqual( "www.example.com/categories/cat" );
-		expect( actual.form.seo.isCornerstone ).toEqual( false );
 		expect( actual.form.social.facebook.title ).toEqual( "An FB title for term" );
 		expect( actual.form.social.facebook.description ).toEqual( "An FB meta description for term" );
 		expect( actual.form.social.facebook.image.id ).toEqual( 4 );

--- a/packages/seo-integration/src/analysis/analysis.js
+++ b/packages/seo-integration/src/analysis/analysis.js
@@ -1,9 +1,8 @@
-import { applyFilters } from "@wordpress/hooks";
 import { __ } from "@wordpress/i18n";
-import { isObject, omit } from "lodash";
 import { AnalysisWorkerWrapper, createWorker } from "yoastseo";
 
 import createAnalyzeFunction from "./analyze";
+import createAnalysisConfiguration from "./createAnalysisConfiguration";
 
 /**
  * Creates the analysis worker.
@@ -19,25 +18,6 @@ const createAnalysisWorkerWrapper = ( { workerUrl, dependencies } ) => {
 	worker.postMessage( { dependencies: dependencies } );
 
 	return new AnalysisWorkerWrapper( worker );
-};
-
-/**
- * Creates the analysis configuration.
- *
- * @param {Object} configuration The base configuration of the analysis worker.
- *
- * @returns {Object} The analysis configuration.
- */
-const createAnalysisConfiguration = ( configuration = {} ) => {
-	const config = {
-		...omit( configuration, [ "isReadabilityActive", "isSeoActive" ] ),
-		isContentAnalysisActive: configuration.isReadabilityActive,
-		isKeywordAnalysisActive: configuration.isSeoActive,
-	};
-
-	const processedConfig = applyFilters( "yoast.seoIntegration.analysis.configuration", config );
-
-	return isObject( processedConfig ) ? processedConfig : config;
 };
 
 /**

--- a/packages/seo-integration/src/analysis/createAnalysisConfiguration.js
+++ b/packages/seo-integration/src/analysis/createAnalysisConfiguration.js
@@ -1,0 +1,24 @@
+import { isObject, omit } from "lodash";
+import { applyFilters } from "@wordpress/hooks";
+
+/**
+ * Creates the analysis configuration.
+ *
+ * @param {Object} configuration The base configuration of the analysis worker.
+ *
+ * @returns {Object} The analysis configuration.
+ */
+const createAnalysisConfiguration = ( configuration = {} ) => {
+	const config = {
+		...omit( configuration, [ "isReadabilityActive", "isSeoActive", "shouldApplyCornerstoneAnalysis" ] ),
+		isContentAnalysisActive: configuration.isReadabilityActive,
+		isKeywordAnalysisActive: configuration.isSeoActive,
+		useCornerstone: configuration.shouldApplyCornerstoneAnalysis,
+	};
+
+	const processedConfig = applyFilters( "yoast.seoIntegration.analysis.configuration", config );
+
+	return isObject( processedConfig ) ? processedConfig : config;
+};
+
+export default createAnalysisConfiguration;

--- a/packages/seo-integration/src/google-preview/containers/google-preview-container.js
+++ b/packages/seo-integration/src/google-preview/containers/google-preview-container.js
@@ -52,7 +52,7 @@ const GooglePreviewContainer = ( { as: Component, ...restProps } ) => {
 	let date = useSelect( select => select( SEO_STORE_NAME ).selectDate() );
 	const focusKeyphrase = useSelect( select => select( SEO_STORE_NAME ).selectKeyphrase() );
 	const morphologyResults = useSelect( select => select( SEO_STORE_NAME ).selectResearchResults( "morphology" ) );
-	const isCornerstone = useSelect( select => select( SEO_STORE_NAME ).selectIsCornerstone() );
+	const isCornerstone = useSelect( select => select( SEO_STORE_NAME ).shouldApplyCornerstoneAnalysis() );
 	const permalink = useSelect( select => select( SEO_STORE_NAME ).selectPermalink() );
 	const [ previewMode, setPreviewMode ] = useState( "mobile" );
 	const { updateSlug, updateSeoTitle, updateMetaDescription } = useDispatch( SEO_STORE_NAME );

--- a/packages/seo-integration/src/google-preview/containers/google-preview-container.js
+++ b/packages/seo-integration/src/google-preview/containers/google-preview-container.js
@@ -52,7 +52,7 @@ const GooglePreviewContainer = ( { as: Component, ...restProps } ) => {
 	let date = useSelect( select => select( SEO_STORE_NAME ).selectDate() );
 	const focusKeyphrase = useSelect( select => select( SEO_STORE_NAME ).selectKeyphrase() );
 	const morphologyResults = useSelect( select => select( SEO_STORE_NAME ).selectResearchResults( "morphology" ) );
-	const isCornerstone = useSelect( select => select( SEO_STORE_NAME ).shouldApplyCornerstoneAnalysis() );
+	const isCornerstone = useSelect( select => select( SEO_STORE_NAME ).selectShouldApplyCornerstoneAnalysis() );
 	const permalink = useSelect( select => select( SEO_STORE_NAME ).selectPermalink() );
 	const [ previewMode, setPreviewMode ] = useState( "mobile" );
 	const { updateSlug, updateSeoTitle, updateMetaDescription } = useDispatch( SEO_STORE_NAME );

--- a/packages/seo-store/src/analysis/slice/config.js
+++ b/packages/seo-store/src/analysis/slice/config.js
@@ -5,6 +5,7 @@ export const defaultConfigState = {
 	analysisType: "post",
 	isSeoActive: true,
 	isReadabilityActive: true,
+	shouldApplyCornerstoneAnalysis: false,
 	researches: [ "morphology" ],
 };
 
@@ -21,6 +22,9 @@ const configSlice = createSlice( {
 		updateIsReadabilityActive: ( state, { payload } ) => {
 			state.isReadabilityActive = Boolean( payload );
 		},
+		updateShouldApplyCornerstoneAnalysis: ( state, { payload } ) => {
+			state.shouldApplyCornerstoneAnalysis = Boolean( payload );
+		},
 		addResearch: ( state, { payload } ) => {
 			state.researches.push( payload );
 		},
@@ -35,6 +39,7 @@ export const configSelectors = {
 	selectAnalysisType: state => get( state, "analysis.config.analysisType" ),
 	selectIsSeoAnalysisActive: state => get( state, "analysis.config.isSeoActive" ),
 	selectIsReadabilityAnalysisActive: state => get( state, "analysis.config.isReadabilityActive" ),
+	shouldApplyCornerstoneAnalysis: state => get( state, "analysis.config.shouldApplyCornerstoneAnalysis" ),
 	selectResearches: state => get( state, "analysis.config.researches" ),
 };
 

--- a/packages/seo-store/src/analysis/slice/config.js
+++ b/packages/seo-store/src/analysis/slice/config.js
@@ -39,7 +39,7 @@ export const configSelectors = {
 	selectAnalysisType: state => get( state, "analysis.config.analysisType" ),
 	selectIsSeoAnalysisActive: state => get( state, "analysis.config.isSeoActive" ),
 	selectIsReadabilityAnalysisActive: state => get( state, "analysis.config.isReadabilityActive" ),
-	shouldApplyCornerstoneAnalysis: state => get( state, "analysis.config.shouldApplyCornerstoneAnalysis" ),
+	selectShouldApplyCornerstoneAnalysis: state => get( state, "analysis.config.shouldApplyCornerstoneAnalysis" ),
 	selectResearches: state => get( state, "analysis.config.researches" ),
 };
 

--- a/packages/seo-store/src/form/slice/seo.js
+++ b/packages/seo-store/src/form/slice/seo.js
@@ -5,7 +5,6 @@ export const defaultSeoState = {
 	title: "",
 	description: "",
 	slug: "",
-	isCornerstone: false,
 };
 
 const seoSlice = createSlice( {
@@ -21,9 +20,6 @@ const seoSlice = createSlice( {
 		updateSlug: ( state, action ) => {
 			state.slug = action.payload;
 		},
-		updateIsCornerstone: ( state, action ) => {
-			state.isCornerstone = Boolean( action.payload );
-		},
 	},
 } );
 
@@ -32,7 +28,6 @@ export const seoSelectors = {
 	selectSeoTitle: state => get( state, "form.seo.title" ),
 	selectMetaDescription: state => get( state, "form.seo.description" ),
 	selectSlug: state => get( state, "form.seo.slug" ),
-	selectIsCornerstone: state => get( state, "form.seo.isCornerstone" ),
 };
 
 export const seoActions = seoSlice.actions;

--- a/packages/seo-store/tests/analysis/hooks.test.js
+++ b/packages/seo-store/tests/analysis/hooks.test.js
@@ -25,6 +25,7 @@ describe( "Hooks", () => {
 			isSeoActive: true,
 			isReadabilityActive: true,
 			researches: [ "morphology" ],
+			shouldApplyCornerstoneAnalysis: false,
 		};
 
 		let analyze;

--- a/packages/seo-store/tests/analysis/slice/config.test.js
+++ b/packages/seo-store/tests/analysis/slice/config.test.js
@@ -72,6 +72,17 @@ describe( "Config slice", () => {
 				researches: [],
 			} );
 		} );
+
+		test( "should update whether the cornerstone analysis is active", () => {
+			const { updateShouldApplyCornerstoneAnalysis } = configActions;
+
+			const result = configReducer( previousState, updateShouldApplyCornerstoneAnalysis( true ) );
+
+			expect( result ).toEqual( {
+				...initialState,
+				shouldApplyCornerstoneAnalysis: true,
+			} );
+		} );
 	} );
 
 	describe( "Selectors", () => {
@@ -119,6 +130,15 @@ describe( "Config slice", () => {
 			const result = selectResearches( createStoreState( state ) );
 
 			expect( result ).toEqual( [ "morphology", "test" ] );
+		} );
+
+		test( "should select whether the cornerstone analysis should be active", () => {
+			const { selectShouldApplyCornerstoneAnalysis } = configSelectors;
+
+			const state = { ...initialState, shouldApplyCornerstoneAnalysis: true };
+			const result = selectShouldApplyCornerstoneAnalysis( createStoreState( state ) );
+
+			expect( result ).toBe( true );
 		} );
 	} );
 } );

--- a/packages/seo-store/tests/analysis/slice/config.test.js
+++ b/packages/seo-store/tests/analysis/slice/config.test.js
@@ -10,6 +10,7 @@ describe( "Config slice", () => {
 		isSeoActive: true,
 		isReadabilityActive: true,
 		researches: [ "morphology" ],
+		shouldApplyCornerstoneAnalysis: false,
 	};
 
 	describe( "Reducer", () => {

--- a/packages/seo-store/tests/analysis/slice/results.test.js
+++ b/packages/seo-store/tests/analysis/slice/results.test.js
@@ -277,6 +277,7 @@ describe( "Results slice", () => {
 				isSeoActive: true,
 				isReadabilityActive: true,
 				researches: [ "morphology" ],
+				shouldApplyCornerstoneAnalysis: false,
 			} );
 
 			// 5. Prepared paper.

--- a/packages/seo-store/tests/form/slice/seo.test.js
+++ b/packages/seo-store/tests/form/slice/seo.test.js
@@ -8,7 +8,6 @@ describe( "Seo slice", () => {
 		title: "",
 		description: "",
 		slug: "",
-		isCornerstone: false,
 	};
 
 	describe( "Reducer", () => {
@@ -46,17 +45,6 @@ describe( "Seo slice", () => {
 			expect( result ).toEqual( {
 				...initialState,
 				slug: "test",
-			} );
-		} );
-
-		test( "should update the isCornerstone", () => {
-			const { updateIsCornerstone } = seoActions;
-
-			const result = seoReducer( initialState, updateIsCornerstone( false ) );
-
-			expect( result ).toEqual( {
-				...initialState,
-				isCornerstone: false,
 			} );
 		} );
 	} );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where marking a post as cornerstone content did not influence the SEO or readability analysis.

## Relevant technical choices:

* Moved the `isCornerstone` state to the analysis configuration state, since we treat it as analysis configuration in the analysis (and thus need it to re-initialize the analysis).

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Make sure that the Classic Editor plugin is installed and activated.
* Create a post.
* Add a focus keyphrase.
* Check the results of the SEO analysis, it should have a red bullet for the _Text length_ assessment saying:
  > [Text length](https://yoa.st/34n?php_version=7.4&platform=wordpress&platform_version=6.0&software=free&software_version=19.0&days_active=6-30&user_language=en_US): The text contains 0 words. This is far below the recommended minimum of 300 words. [Add more content](https://yoa.st/34o?php_version=7.4&platform=wordpress&platform_version=6.0&software=free&software_version=19.0&days_active=6-30&user_language=en_US).
   * (The 300 words is the minimum length for non-cornerstone content).
* Enable the cornerstone analysis by toggling the _Mark as cornerstone content_ toggle to on.
* Check the results of the SEO analysis, it should have a red bullet for the _Text length_ assessment saying:
  > [Text length](https://yoa.st/34n?php_version=7.4&platform=wordpress&platform_version=6.0&software=free&software_version=19.0&days_active=6-30&user_language=en_US): The text contains 0 words. This is far below the recommended minimum of 900 words. [Add more content](https://yoa.st/34o?php_version=7.4&platform=wordpress&platform_version=6.0&software=free&software_version=19.0&days_active=6-30&user_language=en_US).
   * (The 900 words is the minimum length for non-cornerstone content).

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes #
