### PR TITLE
LINGO-1506 Splits text on sentence delimiter only if the next character is a valid sentence beginning

### DIFF
--- a/packages/yoastseo/spec/languageProcessing/helpers/sentence/getSentencesSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/helpers/sentence/getSentencesSpec.js
@@ -474,6 +474,36 @@ describe( "Get sentences from text", function() {
 	} );
 } );
 
+describe( "a test for when texts containing sentence delimiter", () => {
+	it( "should break on ;, ? and ! only when it's followed by a valid sentence beginning", function() {
+		let text = "First sentence; second sentence! third sentence? fourth sentence";
+
+		expect( getSentences( text ) ).toEqual( [ "First sentence; second sentence! third sentence? fourth sentence" ] );
+
+		text = "First sentence; second sentence! Third sentence? Fourth sentence";
+		expect( getSentences( text ) ).toEqual( [
+			"First sentence; second sentence!",
+			"Third sentence?",
+			"Fourth sentence" ] );
+	} );
+	it( "should accept the horizontal ellipsis as sentence terminator, when the next character is valid sentence beginning", function() {
+		const text = "This is the first sentence… Followed by a second one.";
+
+		expect( getSentences( text ) ).toEqual( [ "This is the first sentence…", "Followed by a second one." ] );
+	} );
+	it( "should not split text into sentences if the next character after an ellipsis is not a valid sentence beginning", () => {
+		let text = "This house is built in 1990&#x2026; a nice house.";
+		expect( getSentences( text ) ).toEqual( [
+			"This house is built in 1990&#x2026; a nice house.",
+		] );
+
+		text = "This house is built in 1990… a nice house.";
+		expect( getSentences( text ) ).toEqual( [
+			"This house is built in 1990… a nice house.",
+		] );
+	} );
+} );
+
 describe( "parses Japanese text", () => {
 	it( "parses a Japanese text.", function() {
 		const text = "東海道新幹線の開業前、東西の大動脈である東海道本線は高度経済成長下で線路容量が逼迫しており、抜本的な輸送力増強を迫られていた。" +

--- a/packages/yoastseo/src/languageProcessing/helpers/sentence/SentenceTokenizer.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/sentence/SentenceTokenizer.js
@@ -462,9 +462,32 @@ export default class SentenceTokenizer {
 	}
 
 	/**
+	 * Gets the current sentence when:
+	 * a) There is a next sentence, and the next character is a valid sentence beginning preceded by a white space, OR
+	 * b) The next token is a sentence start
+	 *
+	 * @param {boolean} hasNextSentence     Whether the next characters are more than two.
+	 * @param {string} nextSentenceStart    The second character of the next characters.
+	 * @param {string} nextCharacters       The string values of the next two tokens.
+	 * @param {object} nextToken            The next token object.
+	 * @param {array} tokenSentences        The array of pushed valid sentences.
+	 * @param {string} currentSentence      The current sentence.
+	 *
+	 * @returns {string} The current sentence.
+	 */
+	getValidSentence( hasNextSentence, nextSentenceStart, nextCharacters, nextToken, tokenSentences, currentSentence ) {
+		if ( ( hasNextSentence && this.isValidSentenceBeginning( nextSentenceStart ) && this.isCharacterASpace( nextCharacters[ 0 ] ) ) ||
+			this.isSentenceStart( nextToken ) ) {
+			tokenSentences.push( currentSentence );
+			currentSentence = "";
+		}
+		return currentSentence;
+	}
+
+	/**
 	 * Checks if the character is a whitespace.
 	 *
-	 * @param {string} character    The chracter to check.
+	 * @param {string} character    The character to check.
 	 * @returns {boolean}   Whether the character is a whitespace.
 	 */
 	isCharacterASpace( character ) {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where a text was split on sentence delimiter regardless of whether the next character is a valid sentence beginning or not.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

*


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes #
