### PR TITLE
Crawl cleanup: Settings should be set to Allow Control on Multisite after Premium installed and activated

### DIFF
--- a/src/integrations/admin/crawl-settings-integration.php
+++ b/src/integrations/admin/crawl-settings-integration.php
@@ -95,30 +95,30 @@ class Crawl_Settings_Integration implements Integration_Interface {
 	 */
 	private function register_setting_labels() {
 		$this->feed_settings = [
-			'remove_feed_global_free'            => \__( 'Global feed', 'wordpress-seo' ),
-			'remove_feed_global_comments_free'   => \__( 'Global comment feeds', 'wordpress-seo' ),
-			'remove_feed_post_comments_free'     => \__( 'Post comments feeds', 'wordpress-seo' ),
-			'remove_feed_authors_free'           => \__( 'Post authors feeds', 'wordpress-seo' ),
-			'remove_feed_post_types_free'        => \__( 'Post type feeds', 'wordpress-seo' ),
-			'remove_feed_categories_free'        => \__( 'Category feeds', 'wordpress-seo' ),
-			'remove_feed_tags_free'              => \__( 'Tag feeds', 'wordpress-seo' ),
-			'remove_feed_custom_taxonomies_free' => \__( 'Custom taxonomy feeds', 'wordpress-seo' ),
-			'remove_feed_search_free'            => \__( 'Search results feeds', 'wordpress-seo' ),
-			'remove_atom_rdf_feeds_free'         => \__( 'Atom/RDF feeds', 'wordpress-seo' ),
+			'remove_feed_global'            => \__( 'Global feed', 'wordpress-seo' ),
+			'remove_feed_global_comments'   => \__( 'Global comment feeds', 'wordpress-seo' ),
+			'remove_feed_post_comments'     => \__( 'Post comments feeds', 'wordpress-seo' ),
+			'remove_feed_authors'           => \__( 'Post authors feeds', 'wordpress-seo' ),
+			'remove_feed_post_types'        => \__( 'Post type feeds', 'wordpress-seo' ),
+			'remove_feed_categories'        => \__( 'Category feeds', 'wordpress-seo' ),
+			'remove_feed_tags'              => \__( 'Tag feeds', 'wordpress-seo' ),
+			'remove_feed_custom_taxonomies' => \__( 'Custom taxonomy feeds', 'wordpress-seo' ),
+			'remove_feed_search'            => \__( 'Search results feeds', 'wordpress-seo' ),
+			'remove_atom_rdf_feeds'         => \__( 'Atom/RDF feeds', 'wordpress-seo' ),
 		];
 
 		$this->basic_settings = [
-			'remove_shortlinks_free'     => \__( 'Shortlinks', 'wordpress-seo' ),
-			'remove_rest_api_links_free' => \__( 'REST API links', 'wordpress-seo' ),
-			'remove_rsd_wlw_links_free'  => \__( 'RSD / WLW links', 'wordpress-seo' ),
-			'remove_oembed_links_free'   => \__( 'oEmbed links', 'wordpress-seo' ),
-			'remove_generator_free'      => \__( 'Generator tag', 'wordpress-seo' ),
-			'remove_emoji_scripts_free'  => \__( 'Emoji scripts', 'wordpress-seo' ),
+			'remove_shortlinks'     => \__( 'Shortlinks', 'wordpress-seo' ),
+			'remove_rest_api_links' => \__( 'REST API links', 'wordpress-seo' ),
+			'remove_rsd_wlw_links'  => \__( 'RSD / WLW links', 'wordpress-seo' ),
+			'remove_oembed_links'   => \__( 'oEmbed links', 'wordpress-seo' ),
+			'remove_generator'      => \__( 'Generator tag', 'wordpress-seo' ),
+			'remove_emoji_scripts'  => \__( 'Emoji scripts', 'wordpress-seo' ),
 		];
 
 		$this->header_settings = [
-			'remove_pingback_header_free'   => \__( 'Pingback HTTP header', 'wordpress-seo' ),
-			'remove_powered_by_header_free' => \__( 'Powered by HTTP header', 'wordpress-seo' ),
+			'remove_pingback_header'   => \__( 'Pingback HTTP header', 'wordpress-seo' ),
+			'remove_powered_by_header' => \__( 'Powered by HTTP header', 'wordpress-seo' ),
 		];
 	}
 
@@ -165,37 +165,37 @@ class Crawl_Settings_Integration implements Integration_Interface {
 	 * Print the settings sections.
 	 *
 	 * @param Yoast_Form $yform        The Yoast form class.
-	 * @param boolean    $allow_prefix Whether to prefix options with the allow prefix or not.
+	 * @param boolean    $is_network   Whether we're on the network site.
 	 *
 	 * @return void
 	 */
-	private function add_crawl_settings( $yform, $allow_prefix ) {
+	private function add_crawl_settings( $yform, $is_network ) {
 		$this->display_premium_upsell_btn();
 
 		echo '<h3 class="yoast-crawl-settings-free">'
 			. \esc_html__( 'Basic crawl settings', 'wordpress-seo' )
 			. '</h3>';
 
-		if ( ! $allow_prefix ) {
+		if ( ! $is_network ) {
 			echo '<p class="yoast-crawl-settings-explanation-free">'
 				. \esc_html__( 'Remove links added by WordPress to the header and &lt;head&gt;.', 'wordpress-seo' )
 				. '</p>';
 		}
 
-		$this->print_toggles( $this->basic_settings, $yform, $allow_prefix );
-		$this->print_toggles( $this->header_settings, $yform, $allow_prefix );
+		$this->print_toggles( $this->basic_settings, $yform, $is_network );
+		$this->print_toggles( $this->header_settings, $yform, $is_network );
 
 		echo '<h3 class="yoast-crawl-settings-free">'
 			. \esc_html__( 'Feed crawl settings', 'wordpress-seo' )
 			. '</h3>';
 
-		if ( ! $allow_prefix ) {
+		if ( ! $is_network ) {
 			echo '<p class="yoast-crawl-settings-explanation-free">'
 				. \esc_html__( "Remove feed links added by WordPress that aren't needed for this site.", 'wordpress-seo' )
 				. '</p>';
 		}
 
-		$this->print_toggles( $this->feed_settings, $yform, $allow_prefix );
+		$this->print_toggles( $this->feed_settings, $yform, $is_network );
 	}
 
 	/**
@@ -203,18 +203,18 @@ class Crawl_Settings_Integration implements Integration_Interface {
 	 *
 	 * @param array      $settings     The settings being displayed.
 	 * @param Yoast_Form $yform        The Yoast form class.
-	 * @param boolean    $allow_prefix Whether we should prefix with the allow key.
+	 * @param boolean    $is_network   Whether we're on the network site.
 	 *
 	 * @return void
 	 */
-	private function print_toggles( array $settings, Yoast_Form $yform, $allow_prefix ) {
+	private function print_toggles( array $settings, Yoast_Form $yform, $is_network ) {
 		$setting_prefix = '';
 		$toggles        = [
 			'off' => __( 'Keep', 'wordpress-seo' ),
 			'on'  => __( 'Remove', 'wordpress-seo' ),
 		];
 
-		if ( $allow_prefix ) {
+		if ( $is_network ) {
 			$setting_prefix = WPSEO_Option::ALLOW_KEY_PREFIX;
 			$toggles        = [
 				// phpcs:ignore WordPress.WP.I18n.TextDomainMismatch -- Reason: text is originally from Yoast SEO.
@@ -225,7 +225,7 @@ class Crawl_Settings_Integration implements Integration_Interface {
 		}
 		foreach ( $settings as $setting => $label ) {
 			$yform->toggle_switch(
-				$setting_prefix . $setting,
+				$setting_prefix . $setting . '_free',
 				$toggles,
 				$label,
 				'',
@@ -233,11 +233,14 @@ class Crawl_Settings_Integration implements Integration_Interface {
 					'disabled' => true,
 				]
 			);
-			if ( $setting === 'remove_feed_global_comments_free' && ! $allow_prefix ) {
+			if ( $setting === 'remove_feed_global_comments_free' && ! $is_network ) {
 				echo '<p class="yoast-global-comments-feed-help-free">';
 				echo \esc_html__( 'By removing Global comments feed, Post comments feeds will be removed too.', 'wordpress-seo' );
 				echo '</p>';
 			}
+
+			$setting_name = $setting_prefix . $setting;
+			$yform->hidden( $setting_name, $setting_name );
 		}
 	}
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the network setting for the crawl cleanup feature would default to `Disable` when the super admin saved settings before upgrading/installing Premium.

## Relevant technical choices:

* Added a hidden field for all the newly-introduced options, so that they wouldnt default to false when saved while they didn't exist (so when Premium was not there)

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install Free and not Premium on a multisite
* Go to the network Yoast SEO->General page in the Integrations tab
* Save changes
* Install Premium now
* Go to the network Yoast SEO->General page in the Crawl settings tab

Without this RC:
* Crawl settings there, they would be `Disable` instead of `Allow Control` - wrong

With this RC:
* Crawl settings there, they would be `Allow Control` instead of `Disable` - correct

**Also, a more edge case scenario**:
* Install Free and Premium on a single site
* Go to Yoast SEO->General page in the Crawl settings tab and set every setting there as `Remove`
* Deactivate Premium 
* Go to the network Yoast SEO->General page in the Integrations tab
* Save changes
* Activate Premium again
* Go to Yoast SEO->General page in the Crawl settings tab

Without this RC:
* Crawl settings there, they would be reverted to  `Keep` instead of `Remove` - wrong

With this RC:
* Crawl settings there, they would still be `Remove` instead of `Keep` - correct, because we used to have them as `Remove`

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Crawl settings saving when Premium is enabled

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes #
