### PR TITLE
Opengraph/twitter image filters shouldn't encode ampersands

### DIFF
--- a/inc/sitemaps/class-sitemap-image-parser.php
+++ b/inc/sitemaps/class-sitemap-image-parser.php
@@ -208,7 +208,7 @@ class WPSEO_Sitemap_Image_Parser {
 				continue;
 			}
 
-			if ( $src !== esc_url( $src ) ) {
+			if ( $src !== esc_url_raw( $src ) ) {
 				continue;
 			}
 

--- a/inc/sitemaps/class-sitemaps-renderer.php
+++ b/inc/sitemaps/class-sitemaps-renderer.php
@@ -39,6 +39,13 @@ class WPSEO_Sitemaps_Renderer {
 	protected $needs_conversion = false;
 
 	/**
+	 * Holds the Url_Helper instance.
+	 *
+	 * @var \Yoast\WP\SEO\Helpers\Url_Helper
+	 */
+	protected $url_helper;
+
+	/**
 	 * Set up object properties.
 	 */
 	public function __construct() {
@@ -56,6 +63,8 @@ class WPSEO_Sitemaps_Renderer {
 		}
 
 		$this->needs_conversion = $this->output_charset !== $this->charset;
+
+		$this->url_helper = YoastSEO()->helpers->url;
 	}
 
 	/**
@@ -249,13 +258,15 @@ class WPSEO_Sitemaps_Renderer {
 	/**
 	 * Ensure the URL is encoded per RFC3986 and correctly escaped for use in an XML sitemap.
 	 *
-	 * This method works around a two quirks in esc_url():
+	 * This method works around a few quirks in esc_url():
 	 * 1. `esc_url()` leaves schema-relative URLs alone, while according to the sitemap specs,
 	 *    the URL must always begin with a protocol.
 	 * 2. `esc_url()` escapes ampersands as `&#038;` instead of the more common `&amp;`.
 	 *    According to the specs, `&amp;` should be used, and even though this shouldn't
 	 *    really make a difference in practice, to quote Jono: "I'd be nervous about &#038;
 	 *    given how many weird and wonderful things eat sitemaps", so better safe than sorry.
+	 * 3. `esc_url()` escapes ampersands as `&#039;` instead of the more common `&apos;`.
+	 *    According to the specs, `&apos;` should be used.
 	 *
 	 * @link https://www.sitemaps.org/protocol.html#xmlTagDefinitions
 	 * @link https://www.sitemaps.org/protocol.html#escaping
@@ -267,8 +278,7 @@ class WPSEO_Sitemaps_Renderer {
 	 */
 	protected function encode_and_escape( $url ) {
 		$url = $this->encode_url_rfc3986( $url );
-		$url = esc_url( $url );
-		$url = str_replace( '&#038;', '&amp;', $url );
+		$url = $this->url_helper->escape_for_sitemap( $url );
 
 		if ( strpos( $url, '//' ) === 0 ) {
 			// Schema-relative URL for which esc_url() does not add a scheme.

--- a/src/helpers/url-helper.php
+++ b/src/helpers/url-helper.php
@@ -218,4 +218,20 @@ class Url_Helper {
 
 		return ( $is_image ) ? SEO_Links::TYPE_EXTERNAL_IMAGE : SEO_Links::TYPE_EXTERNAL;
 	}
+
+	/**
+	 * Escapes the URL for use in an XML sitemap.
+	 *
+	 * @see WPSEO_Sitemaps_Renderer::encode_and_escape
+	 *
+	 * @param string $url The URL to escape.
+	 *
+	 * @return string The escaped URL.
+	 */
+	public function escape_for_sitemap( $url ) {
+		$output = \esc_url( $url );
+		$output = \str_replace( '&#038;', '&amp;', $output );
+
+		return \str_replace( '&#039;', '&apos;', $output );
+	}
 }

--- a/src/presenters/open-graph/image-presenter.php
+++ b/src/presenters/open-graph/image-presenter.php
@@ -23,9 +23,9 @@ class Image_Presenter extends Abstract_Indexable_Presenter {
 	 * @var array
 	 */
 	protected static $image_tags = [
-		'width'     => 'width',
-		'height'    => 'height',
-		'type'      => 'type',
+		'width'  => 'width',
+		'height' => 'height',
+		'type'   => 'type',
 	];
 
 	/**
@@ -42,16 +42,16 @@ class Image_Presenter extends Abstract_Indexable_Presenter {
 
 		$return = '';
 		foreach ( $images as $image_index => $image_meta ) {
-			$image_url = $image_meta['url'];
+			$image_url = $this->helpers->url->escape_for_sitemap( $image_meta['url'] );
 
-			$return .= '<meta property="og:image" content="' . \esc_url( $image_url ) . '" />';
+			$return .= '<meta property="og:image" content="' . $image_url . '" />';
 
 			foreach ( static::$image_tags as $key => $value ) {
 				if ( empty( $image_meta[ $key ] ) ) {
 					continue;
 				}
 
-				$return .= \PHP_EOL . "\t" . '<meta property="og:image:' . \esc_attr( $key ) . '" content="' . $image_meta[ $key ] . '" />';
+				$return .= \PHP_EOL . "\t" . '<meta property="og:image:' . \esc_attr( $key ) . '" content="' . \esc_attr( $image_meta[ $key ] ) . '" />';
 			}
 		}
 

--- a/src/presenters/twitter/image-presenter.php
+++ b/src/presenters/twitter/image-presenter.php
@@ -18,13 +18,6 @@ class Image_Presenter extends Abstract_Indexable_Tag_Presenter {
 	protected $key = 'twitter:image';
 
 	/**
-	 * The method of escaping to use.
-	 *
-	 * @var string
-	 */
-	protected $escaping = 'attribute';
-
-	/**
 	 * Run the Twitter image value through the `wpseo_twitter_image` filter.
 	 *
 	 * @return string The filtered Twitter image.
@@ -38,5 +31,16 @@ class Image_Presenter extends Abstract_Indexable_Tag_Presenter {
 		 * @api string $twitter_image Image URL string.
 		 */
 		return (string) \apply_filters( 'wpseo_twitter_image', $this->presentation->twitter_image, $this->presentation );
+	}
+
+	/**
+	 * Escaped the output.
+	 *
+	 * @param string $value The desired method of escaping; 'html', 'url' or 'attribute'.
+	 *
+	 * @return string The escaped value.
+	 */
+	protected function escape_value( $value ) {
+		return $this->helpers->url->escape_for_sitemap( $value );
 	}
 }

--- a/tests/integration/sitemaps/test-class-wpseo-sitemaps-renderer.php
+++ b/tests/integration/sitemaps/test-class-wpseo-sitemaps-renderer.php
@@ -131,6 +131,10 @@ class WPSEO_Sitemaps_Renderer_Test extends WPSEO_UnitTestCase {
 				'loc'      => 'http://example.com/page-name?s=keyword&#038;p=2#anchor',
 				'expected' => 'http://example.com/page-name?s=keyword&amp;p=2#anchor',
 			],
+			'Full URL which will validate with the filter - contains &#039;' => [
+				'loc'      => 'http://example.com/page-name?s=keyword&p=\'2\'#anchor',
+				'expected' => 'http://example.com/page-name?s=keyword&amp;p=&apos;2&apos;#anchor',
+			],
 
 			/*
 			 * All the below URLs will not validate with `FILTER_VALIDATE_URL` and will therefore

--- a/tests/unit/presenters/open-graph/image-presenter-test.php
+++ b/tests/unit/presenters/open-graph/image-presenter-test.php
@@ -4,8 +4,10 @@ namespace Yoast\WP\SEO\Tests\Unit\Presenters\Open_Graph;
 
 use Brain\Monkey;
 use Mockery;
+use Yoast\WP\SEO\Helpers\Url_Helper;
 use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 use Yoast\WP\SEO\Presenters\Open_Graph\Image_Presenter;
+use Yoast\WP\SEO\Surfaces\Helpers_Surface;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
@@ -43,6 +45,8 @@ class Image_Presenter_Test extends TestCase {
 		$this->presentation = new Indexable_Presentation();
 
 		$this->instance->presentation = $this->presentation;
+		$this->instance->helpers      = Mockery::mock( Helpers_Surface::class );
+		$this->instance->helpers->url = Mockery::mock( Url_Helper::class );
 	}
 
 	/**
@@ -71,6 +75,8 @@ class Image_Presenter_Test extends TestCase {
 		];
 
 		$this->presentation->open_graph_images = [ $image ];
+
+		$this->instance->helpers->url->expects( 'escape_for_sitemap' )->andReturnArg( 0 );
 
 		$this->assertEquals(
 			'<meta property="og:image" content="https://example.com/image.jpg" />' . \PHP_EOL . "\t" . '<meta property="og:image:width" content="100" />' . \PHP_EOL . "\t" . '<meta property="og:image:height" content="100" />',

--- a/tests/unit/presenters/twitter/image-presenter-test.php
+++ b/tests/unit/presenters/twitter/image-presenter-test.php
@@ -3,8 +3,11 @@
 namespace Yoast\WP\SEO\Tests\Unit\Presenters\Twitter;
 
 use Brain\Monkey;
+use Mockery;
+use Yoast\WP\SEO\Helpers\Url_Helper;
 use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 use Yoast\WP\SEO\Presenters\Twitter\Image_Presenter;
+use Yoast\WP\SEO\Surfaces\Helpers_Surface;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
@@ -43,6 +46,8 @@ class Image_Presenter_Test extends TestCase {
 		$this->instance               = new Image_Presenter();
 		$this->instance->presentation = new Indexable_Presentation();
 		$this->presentation           = $this->instance->presentation;
+		$this->instance->helpers      = Mockery::mock( Helpers_Surface::class );
+		$this->instance->helpers->url = Mockery::mock( Url_Helper::class );
 
 		Monkey\Functions\expect( 'post_password_required' )->andReturn( false );
 	}
@@ -51,9 +56,12 @@ class Image_Presenter_Test extends TestCase {
 	 * Tests whether the presenter returns the correct image.
 	 *
 	 * @covers ::present
+	 * @covers ::escape_value
 	 */
 	public function test_present() {
 		$this->presentation->twitter_image = 'relative_image.jpg';
+
+		$this->instance->helpers->url->expects( 'escape_for_sitemap' )->andReturnArg( 0 );
 
 		$expected = '<meta name="twitter:image" content="relative_image.jpg" />';
 		$actual   = $this->instance->present();
@@ -81,6 +89,8 @@ class Image_Presenter_Test extends TestCase {
 	 */
 	public function test_present_filter() {
 		$this->presentation->twitter_image = 'relative_image.jpg';
+
+		$this->instance->helpers->url->expects( 'escape_for_sitemap' )->andReturnArg( 0 );
 
 		Monkey\Filters\expectApplied( 'wpseo_twitter_image' )
 			->once()


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

*

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

*


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes #
