### PR TITLE
Revert to Allow Control for Post Comment feeds upon upgrade to 19.1

### DIFF
--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -79,6 +79,7 @@ class WPSEO_Upgrade {
 			'18.3-RC3'   => 'upgrade_183',
 			'18.6-RC0'   => 'upgrade_186',
 			'18.9-RC0'   => 'upgrade_189',
+			'19.1-RC0'   => 'upgrade_191',
 		];
 
 		array_walk( $routines, [ $this, 'run_upgrade_routine' ], $version );
@@ -914,6 +915,15 @@ class WPSEO_Upgrade {
 				'personalPreferences',
 			];
 			WPSEO_Options::set( 'configuration_finished_steps', $configuration_finished_steps );
+		}
+	}
+
+	/**
+	 * Performs the 19.1 upgrade routine.
+	 */
+	private function upgrade_191() {
+		if ( is_multisite() ) {
+			WPSEO_Options::set( 'allow_remove_feed_post_comments', true );
 		}
 	}
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* This is a follow-up fix for the https://github.com/Yoast/wordpress-seo/pull/18520 fix
* With this PR we want to ensure that users with no Premium when on 19.0, will get their `Post Comment Feed` setting set to `Allow Control` when the eventually install Premium
* Doing so requires setting `Post Comment Feed` to `Allow Control` upon upgrade to 19.0, even for people that have already set that setting to `Disable`
* We expect the users affected by the above point to be very few, if any.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where users on 19.0 and with no Premium would get the non-default value for `Post Comment Feeds` when eventually they install Premium

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Use clean docker multisite env
* Install and network activate Yoast Free 19.0
* Go to the network Yoast SEO->General page>Integrations tab
* Save changes
* Install and network activate the current RC
* Run the upgrade routine via the Yoast test helper
* Install Premium 18.7-RC
* Go to the network Yoast SEO->General page>Crawl settings tab
*  `Post Comment Feeds` should be set to `Allow Control` (like the rest of the settings in that tab)
* Go to a subsite's Yoast SEO->General page>Crawl settings tab
*  `Post Comment Feeds` should be set to `Keep` and not greyed-out (like the rest of the settings in that tab)


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Use clean docker multisite env
* Install and network activate Yoast Free 19.0
* Go to the network Yoast SEO->General page>Integrations tab
* Save changes
* Network upgrade Yoast Free with the current RC
* Install Premium 18.7-RC
* Go to the network Yoast SEO->General page>Crawl settings tab
*  `Post Comment Feeds` should be set to `Allow Control` (like the rest of the settings in that tab) - if you upgraded with the previous RC, it would be set to `Disable`
* Go to a subsite's Yoast SEO->General page>Crawl settings tab
*  `Post Comment Feeds` should be set to `Keep` and not greyed-out (like the rest of the settings in that tab) - if you upgraded with the previous RC, it would be greyed-out

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Yoast Free upgrade - Smoke test upgrading in single sites as well

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes #
