### PR TITLE
LR-7 Improves sentence detection for sentences with initials

### DIFF
--- a/packages/yoastseo/spec/languageProcessing/helpers/sentence/SentenceTokenizerSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/helpers/sentence/SentenceTokenizerSpec.js
@@ -159,5 +159,114 @@ describe( "A test for tokenizing a (html) text into sentences", function() {
 
 		console.error.mockRestore();
 	} );
+	it( "does not break a sentence in two if there are initials within.", function() {
+		// The reprint was favourably reviewed by "A. B." in The Musical Times in 1935, who commented "Praise is due to Mr Mercer.
+		const tokens = [
+			{ type: "sentence", src: 'The reprint was favourably reviewed by "A' },
+			{ type: "full-stop", src: "." },
+			{ type: "sentence", src: " B" },
+			{ type: "full-stop", src: "." },
+			{ type: "sentence", src: '" in The Musical Times in , who commented "Praise is due to Mr Mercer' },
+			{ type: "full-stop", src: "." },
+		];
+		// eslint-disable-next-line max-len
+		expect( mockTokenizer.getSentencesFromTokens( tokens ) ).toEqual(   [ "The reprint was favourably reviewed by \"A. B.\" in The Musical Times in , who commented \"Praise is due to Mr Mercer." ]  );
+	} );
+
+	it( "recognizes sentence boundary when a sentence starts with initials", function() {
+		// 'This is a sentence. E.F. is a good writer. G. H. is a very very great personality.'
+		const tokens = [
+			{ type: "sentence", src: " This is a sentence" },
+			{ type: "full-stop", src: "." },
+			{ type: "sentence", src: " E" },
+			{ type: "full-stop", src: "." },
+			{ type: "sentence", src: "F" },
+			{ type: "full-stop", src: "." },
+			{ type: "sentence", src: " is a good writer" },
+			{ type: "full-stop", src: "." },
+			{ type: "sentence", src: " G" },
+			{ type: "full-stop", src: "." },
+			{ type: "sentence", src: " H" },
+			{ type: "full-stop", src: "." },
+			{ type: "sentence", src: " is a very very great personality" },
+			{ type: "full-stop", src: "." },
+
+		];
+		// eslint-disable-next-line max-len
+		expect( mockTokenizer.getSentencesFromTokens( tokens ) ).toEqual(   [ "This is a sentence.", "E.F. is a good writer.",  "G. H. is a very very great personality." ]  );
+	} );
+
+	it( "recognizes sentence boundary when a sentence ends with initials", function() {
+		// 'A cat is possessed by C. D. This is a sentence.'
+		const tokens = [
+			{ type: "sentence", src: " A cat is possessed by C" },
+			{ type: "full-stop", src: "." },
+			{ type: "sentence", src: " D" },
+			{ type: "full-stop", src: "." },
+			{ type: "sentence", src: " This is a sentence" },
+			{ type: "full-stop", src: "." },
+
+		];
+
+		expect( mockTokenizer.getSentencesFromTokens( tokens ) ).toEqual(   [ "A cat is possessed by C. D.", "This is a sentence." ]  );
+	} );
+
+	it( "recognizes when a full stop is part of a person's initials", function() {
+		const tokens = [
+			{ type: "sentence", src: " A cat is possessed by C" },
+			{ type: "full-stop", src: "." },
+			{ type: "sentence", src: " D" },
+			{ type: "full-stop", src: "." },
+			{ type: "sentence", src: " This is a sentence" },
+			{ type: "full-stop", src: "." },
+
+		];
+		const token = tokens[ 1 ];
+		const previousToken = tokens[ 0 ];
+		const nextToken = tokens[ 2 ];
+		const secondToNextToken = tokens[ 3 ];
+
+		expect( mockTokenizer.isPartOfPersonInitial( token, previousToken, nextToken, secondToNextToken ) ).toBeTruthy();
+	} );
+
+	it( "recognizes when a full stop is not part of a person's initials", function() {
+		const tokens = [
+			{ type: "sentence", src: "This is a sentence" },
+			{ type: "full-stop", src: "." },
+			{ type: "sentence", src: " This is a sentence" },
+			{ type: "full-stop", src: "." },
+
+		];
+		const token = tokens[ 1 ];
+		const previousToken = tokens[ 0 ];
+		const nextToken = tokens[ 2 ];
+		const secondToNextToken = tokens[ 3 ];
+
+		expect( mockTokenizer.isPartOfPersonInitial( token, previousToken, nextToken, secondToNextToken ) ).toBeFalsy();
+	} );
+
+	xit( "recognizes when a full stop is part of initials with multiple letters", function() {
+		const tokens = [
+			{ type: "sentence", src: "This is a sentence" },
+			{ type: "full-stop", src: "." },
+			{ type: "sentence", src: " A" },
+			{ type: "full-stop", src: "." },
+			{ type: "sentence", src: " F" },
+			{ type: "full-stop", src: "." },
+			{ type: "sentence", src: " Th" },
+			{ type: "full-stop", src: "." },
+			{ type: "sentence", src: " van der Heijden is a well known Dutch writer." },
+			{ type: "full-stop", src: "." },
+			{ type: "sentence", src: "This is a sentence" },
+			{ type: "full-stop", src: "." },
+		];
+
+		const token = tokens[ 5 ];
+		const previousToken = tokens[ 4 ];
+		const nextToken = tokens[ 6 ];
+		const secondToNextToken = tokens[ 7 ];
+
+		expect( mockTokenizer.isPartOfPersonInitial( token, previousToken, nextToken, secondToNextToken ) ).toBeTruthy();
+	} );
 } );
 

--- a/packages/yoastseo/spec/languageProcessing/helpers/sentence/SentenceTokenizerSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/helpers/sentence/SentenceTokenizerSpec.js
@@ -159,6 +159,7 @@ describe( "A test for tokenizing a (html) text into sentences", function() {
 
 		console.error.mockRestore();
 	} );
+
 	it( "does not break a sentence in two if there are initials within.", function() {
 		// The reprint was favourably reviewed by "A. B." in The Musical Times in 1935, who commented "Praise is due to Mr Mercer.
 		const tokens = [

--- a/packages/yoastseo/spec/scoring/collectionPages/fullTextTests/testTexts/en/englishPaper2.js
+++ b/packages/yoastseo/spec/scoring/collectionPages/fullTextTests/testTexts/en/englishPaper2.js
@@ -101,8 +101,8 @@ const expectedResults = {
 	},
 	passiveVoice: {
 		isApplicable: true,
-		score: 6,
-		resultText: "<a href='https://yoa.st/shopify42' target='_blank'>Passive voice</a>: 14.3% of the sentences contain passive voice, " +
+		score: 3,
+		resultText: "<a href='https://yoa.st/shopify42' target='_blank'>Passive voice</a>: 15.4% of the sentences contain passive voice, " +
 			"which is more than the recommended maximum of 10%. <a href='https://yoa.st/shopify43' target='_blank'>" +
 			"Try to use their active counterparts</a>.",
 	},

--- a/packages/yoastseo/src/languageProcessing/helpers/sentence/SentenceTokenizer.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/sentence/SentenceTokenizer.js
@@ -232,7 +232,6 @@ export default class SentenceTokenizer {
 	 * @returns {boolean} True if a full stop is part of a person's initials, False if the full stop is not part of a person's initials.
 	 */
 	isPartOfPersonInitial( token, previousToken, nextToken, secondToNextToken ) {
-		console.log( token );
 		return ( ! isUndefined( token ) &&
 			! isUndefined( nextToken ) &&
 			! isUndefined( secondToNextToken ) &&

--- a/packages/yoastseo/src/languageProcessing/helpers/sentence/SentenceTokenizer.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/sentence/SentenceTokenizer.js
@@ -6,6 +6,8 @@ import core from "tokenizer2/core";
 
 import { normalize as normalizeQuotes } from "../sanitize/quotes.js";
 
+import wordBoundaries from "../../../config/wordBoundaries";
+
 // All characters that indicate a sentence delimiter.
 const fullStop = ".";
 
@@ -16,6 +18,10 @@ const htmlEndRegex = /^<\/([^>\s]+)[^>]*>$/mi;
 
 const blockStartRegex = /^\s*[[({]\s*$/;
 const blockEndRegex = /^\s*[\])}]\s*$/;
+
+const wordBoundariesForRegex = "[" + wordBoundaries().map( ( boundary ) => "\\" + boundary ).join( "" ) + "]";
+const lastCharacterPartOfInitialsRegex = new RegExp( wordBoundariesForRegex + "[A-Za-z]$" );
+
 
 /**
  * Class for tokenizing a (html) text into sentences.
@@ -208,6 +214,35 @@ export default class SentenceTokenizer {
 		return (
 			! isUndefined( token ) &&
 			( token.type === "full-stop" || token.type === "sentence-delimiter" )
+		);
+	}
+
+	/**
+	 * Checks if a full stop is part of a person's initials.
+	 *
+	 * Tests if tokens exist. Then tests if the tokens are of the right type.
+	 * For previous token, it checks if the sentence ends with a single letter.
+	 * For nextToken it checks if it is a single letter.
+	 * Checks if next token is followed by a full stop.
+	 *
+	 * @param {object} token The current token (must be a full stop).
+	 * @param {object} previousToken The token before the full stop.
+	 * @param {object} nextToken The token following the full stop.
+	 * @param {object} secondToNextToken The second token after the full stop.
+	 * @returns {boolean} True if a full stop is part of a person's initials, False if the full stop is not part of a person's initials.
+	 */
+	isPartOfPersonInitial( token, previousToken, nextToken, secondToNextToken ) {
+		console.log( token );
+		return ( ! isUndefined( token ) &&
+			! isUndefined( nextToken ) &&
+			! isUndefined( secondToNextToken ) &&
+			! isUndefined( previousToken ) &&
+			token.type === "full-stop" &&
+			previousToken.type === "sentence" &&
+			lastCharacterPartOfInitialsRegex.test( previousToken.src ) &&
+			nextToken.type === "sentence" &&
+			nextToken.src.trim().length === 1 &&
+			secondToNextToken.type === "full-stop"
 		);
 	}
 
@@ -419,6 +454,11 @@ export default class SentenceTokenizer {
 
 					// It should not split the text if the first character of the potential next sentence is a number.
 					if ( hasNextSentence && this.isNumber( nextCharacters[ 0 ] ) ) {
+						break;
+					}
+
+					// If the full stop is part of a person's initials, don't split sentence.
+					if ( this.isPartOfPersonInitial( token, previousToken, nextToken, secondToNextToken ) ) {
 						break;
 					}
 					/*


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* This PR resolves [issue 640](https://github.com/Yoast/YoastSEO.js/issues/640) where initials in the sentence caused the sentence tokenizer to split up the sentence because the tokenizer thought that a fullstop followed by a space and a capitalized letter was a sentence break.
* Note that this PR is to a large extend a copy of https://github.com/Yoast/wordpress-seo/pull/18477. This I closed because it was too cluttered.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves the sentence recognition by disregarding initials as potential sentence boundaries.
* [yoastseo] Improves the sentence recognition by disregarding initials as potential sentence boundaries.
* [shopify-seo] Improves the sentence recognition by disregarding initials as potential sentence boundaries.

## Relevant technical choices:
* There is one edge case that still fails: multi letter initials, such as the Dutch writer "A. F. <ins>Th.</ins> van der Heijden". I will create an issue on this.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### For wordpress
1. Pull this branch and build yoastseo. Activate the yoast-seo plugin.
2. Create a new post. And fill in a title. For example "Frank Mercer"
3. Paste the text from [LR_7_test_text.txt](https://github.com/Yoast/wordpress-seo/files/8762162/LR_7_test_text.txt) in the post.
4. Expand readability analysis and toggle button to highlight the results of the passive voice analysis in the text (see arrow in the screenshot)
![wordpress_PV](https://user-images.githubusercontent.com/26040749/172412167-c4f272d6-4470-46a8-9475-d44369bc7dde.png)


5. The result should look like the screenshot.
6. Note that the following sentence is highlighted entirely, which is the desired outcome. "The reprint was favourably reviewed by "A. B." in The Musical Times in 1935, who commented "Praise is due to Mr Mercer."
7. Note that the following sentence is highlighted and the subsequent sentence is not, which is the desired outcome "A good way to do this is to see whether A cat is possessed by C.D. "
8.Note that the following sentence is highlighted and the subsequent sentence is not, which is the desired outcome "A sentence is written by me."


#### For shopify
1. install plugin to shopify
2. Open shop
3. Create a new product, and give it a name.
4. Paste the text from [LR_7_test_text.txt](https://github.com/Yoast/wordpress-seo/files/8762162/LR_7_test_text.txt) in the post.
5. Save
6. Go to apps --> Yoast SEO - Local Docker and open your product.
7. Expand readability analysis and toggle button to highlight the results of the passive voice analysis in the text (see arrow in the screenshot)
8. The results should look like the screenshot.
![shopify_PV](https://user-images.githubusercontent.com/26040749/172412318-5ef1ac4f-682f-47d1-bb87-cab4fd83e705.png)

9. Check points 6-8 from the wordpress test.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [x] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes https://github.com/Yoast/YoastSEO.js/issues/640
Fixes https://yoast.atlassian.net/browse/LR-7
