### PR TITLE
Return initial behavior for free users in first time configuration

### DIFF
--- a/packages/js/src/first-time-configuration/tailwind-components/steps/finish/finish-step.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/steps/finish/finish-step.js
@@ -59,12 +59,11 @@ function webinarPromoContent() {
  */
 export default function FinishStep() {
 	const isPremium = useSelect( select => select( "yoast-seo/settings" ).getIsPremium() );
-	const isAlertDismissed = useSelect( select => select( "yoast-seo/settings" ).isAlertDismissed( "webinar-promo-notification" ) );
 
 	return (
 		<div className="yst-flex yst-flex-row yst-justify-between yst-items-center yst--mt-4">
 			<div className="yst-mr-6">
-				{ isPremium || isAlertDismissed ? regularContent() : webinarPromoContent() }
+				{ isPremium ? regularContent() : webinarPromoContent() }
 			</div>
 			<ConfigurationFinishImage className="yst-shrink-0 yst-h-28" />
 		</div>


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Keep the webinar promo on the final step of the first time configuration for free users

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Return initial behavior for free users in first time configuration

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Test with free
* Have a clean environment & activate the plugin
* Go to the first time configuration and click on continue until you’re at the final step
* Verify you’ll see the webinar promo content

#### Test with premium active

* Have a clean environment & activate premium
* Go to the first time configuration and click on continue until you're at the final step
* Verify the the last step has non webinar promo related content

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes P1-1416
