### PR TITLE
Post overview: sortable SEO and readability score columns

### DIFF
--- a/admin/class-meta-columns.php
+++ b/admin/class-meta-columns.php
@@ -614,24 +614,28 @@ class WPSEO_Meta_Columns {
 		switch ( $order_by ) {
 			case 'wpseo-metadesc':
 				return [
+					// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- Reason: Only used when user requests sorting.
 					'meta_key' => WPSEO_Meta::$meta_prefix . 'metadesc',
 					'orderby'  => 'meta_value',
 				];
 
 			case 'wpseo-focuskw':
 				return [
+					// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- Reason: Only used when user requests sorting.
 					'meta_key' => WPSEO_Meta::$meta_prefix . 'focuskw',
 					'orderby'  => 'meta_value',
 				];
 
 			case 'wpseo-score':
 				return [
+					// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- Reason: Only used when user requests sorting.
 					'meta_key' => WPSEO_Meta::$meta_prefix . 'linkdex',
 					'orderby'  => 'meta_value_num',
 				];
 
 			case 'wpseo-score-readability':
 				return [
+					// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- Reason: Only used when user requests sorting.
 					'meta_key' => WPSEO_Meta::$meta_prefix . 'content_score',
 					'orderby'  => 'meta_value_num',
 				];

--- a/admin/class-meta-columns.php
+++ b/admin/class-meta-columns.php
@@ -88,11 +88,11 @@ class WPSEO_Meta_Columns {
 		$added_columns = [];
 
 		if ( $this->analysis_seo->is_enabled() ) {
-			$added_columns['wpseo-score'] = '<span class="yoast-tooltip yoast-tooltip-n yoast-tooltip-alt" data-label="' . esc_attr__( 'SEO score', 'wordpress-seo' ) . '"><span class="yoast-column-seo-score yoast-column-header-has-tooltip"><span class="screen-reader-text">' . __( 'SEO score', 'wordpress-seo' ) . '</span></span></span>';
+			$added_columns['wpseo-score'] = '<span class="yoast-column-seo-score yoast-column-header-has-tooltip" data-tooltip-text="' . esc_attr__( 'SEO score', 'wordpress-seo' ) . '"><span class="screen-reader-text">' . __( 'SEO score', 'wordpress-seo' ) . '</span></span></span>';
 		}
 
 		if ( $this->analysis_readability->is_enabled() ) {
-			$added_columns['wpseo-score-readability'] = '<span class="yoast-tooltip yoast-tooltip-n yoast-tooltip-alt" data-label="' . esc_attr__( 'Readability score', 'wordpress-seo' ) . '"><span class="yoast-column-readability yoast-column-header-has-tooltip"><span class="screen-reader-text">' . __( 'Readability score', 'wordpress-seo' ) . '</span></span></span>';
+			$added_columns['wpseo-score-readability'] = '<span class="yoast-column-readability yoast-column-header-has-tooltip" data-tooltip-text="' . esc_attr__( 'Readability score', 'wordpress-seo' ) . '"><span class="screen-reader-text">' . __( 'Readability score', 'wordpress-seo' ) . '</span></span></span>';
 		}
 
 		$added_columns['wpseo-title']    = __( 'SEO Title', 'wordpress-seo' );
@@ -175,6 +175,11 @@ class WPSEO_Meta_Columns {
 
 		if ( $this->analysis_seo->is_enabled() ) {
 			$columns['wpseo-focuskw'] = 'wpseo-focuskw';
+			$columns['wpseo-score']   = [ 'wpseo-score', 'desc' ];
+		}
+
+		if ( $this->analysis_readability->is_enabled() ) {
+			$columns['wpseo-score-readability'] = [ 'wpseo-score-readability', 'desc' ];
 		}
 
 		return $columns;
@@ -617,6 +622,18 @@ class WPSEO_Meta_Columns {
 				return [
 					'meta_key' => WPSEO_Meta::$meta_prefix . 'focuskw',
 					'orderby'  => 'meta_value',
+				];
+
+			case 'wpseo-score':
+				return [
+					'meta_key' => WPSEO_Meta::$meta_prefix . 'linkdex',
+					'orderby'  => 'meta_value_num',
+				];
+
+			case 'wpseo-score-readability':
+				return [
+					'meta_key' => WPSEO_Meta::$meta_prefix . 'content_score',
+					'orderby'  => 'meta_value_num',
 				];
 		}
 

--- a/composer.json
+++ b/composer.json
@@ -85,7 +85,7 @@
 		],
 		"check-cs-thresholds": [
 			"@putenv YOASTCS_THRESHOLD_ERRORS=243",
-			"@putenv YOASTCS_THRESHOLD_WARNINGS=219",
+			"@putenv YOASTCS_THRESHOLD_WARNINGS=217",
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_cs_thresholds"
 		],
 		"check-cs": [

--- a/css/src/admin-global.css
+++ b/css/src/admin-global.css
@@ -218,6 +218,11 @@ td .wpseo-score-icon {
   padding: 0;
 }
 
+.fixed th.column-wpseo-score,
+.fixed th.column-wpseo-score-readability {
+  width: 3.5em;
+}
+
 /* Don't use selectors related to classes added with JavaScript to avoid flickering. */
 th.column-wpseo-links a,
 th.column-wpseo-linked a,
@@ -235,6 +240,14 @@ th.column-wpseo-score .yoast-tooltip,
 th.column-wpseo-score-readability .yoast-tooltip {
   /* 11+20+11=42px */
   padding: 8px 11px;
+}
+
+th.column-wpseo-score.sortable .yoast-tooltip,
+th.column-wpseo-score-readability.sortable .yoast-tooltip,
+th.column-wpseo-score.sorted .yoast-tooltip,
+th.column-wpseo-score-readability.sorted .yoast-tooltip {
+  /* Remove padding-right so that sorting arrow aligns to right and not bottom */
+  padding-right: 0px;
 }
 
 .column-wpseo-links .yoast-tooltip-multiline::after {

--- a/css/src/admin-global.css
+++ b/css/src/admin-global.css
@@ -218,8 +218,10 @@ td .wpseo-score-icon {
   padding: 0;
 }
 
-.fixed th.column-wpseo-score,
-.fixed th.column-wpseo-score-readability {
+.fixed th.column-wpseo-score.sortable,
+.fixed th.column-wpseo-score-readability.sortable,
+.fixed th.column-wpseo-score.sorted,
+.fixed th.column-wpseo-score-readability.sorted {
   width: 3.5em;
 }
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Enables sorting on the SEO and readability score columns on the post overview page.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Go to the post overview page
* Verify the SEO score & readability score columns can now be sorted (first click should sort descending, from green to red)
* Note an unchanged "quirk": the posts without a saved score will be filtered out. Unchanged because this works the same way for the meta description and keyphrase columns

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes P1-1370
