### PR TITLE
Add the shortlinks to the webinar promo banner and notification

### DIFF
--- a/admin/class-config.php
+++ b/admin/class-config.php
@@ -135,7 +135,7 @@ class WPSEO_Admin_Pages {
 
 		if ( $page === 'wpseo_social' ) {
 			$user_id = WPSEO_Options::get( 'company_or_person_user_id', '' );
-			$user = \get_userdata( $user_id );
+			$user    = \get_userdata( $user_id );
 
 			$user_name = '';
 			if ( $user instanceof \WP_User ) {
@@ -148,7 +148,7 @@ class WPSEO_Admin_Pages {
 				'other_social_urls' => WPSEO_Options::get( 'other_social_urls', [] ),
 				'company_or_person' => WPSEO_Options::get( 'company_or_person', '' ),
 				'user_id'           => $user_id,
-				'user_name'         => $user_name
+				'user_name'         => $user_name,
 			];
 
 			$script_data['search_appearance_link'] = admin_url( 'admin.php?page=wpseo_titles' );

--- a/admin/class-config.php
+++ b/admin/class-config.php
@@ -82,10 +82,11 @@ class WPSEO_Admin_Pages {
 		$dismissed_alerts       = $alert_dismissal_action->all_dismissed();
 
 		$script_data = [
-			'userLanguageCode' => WPSEO_Language_Utils::get_language( \get_user_locale() ),
-			'dismissedAlerts'  => $dismissed_alerts,
-			'isRtl'            => is_rtl(),
-			'isPremium'        => YoastSEO()->helpers->product->is_premium(),
+			'userLanguageCode'        => WPSEO_Language_Utils::get_language( \get_user_locale() ),
+			'dismissedAlerts'         => $dismissed_alerts,
+			'isRtl'                   => is_rtl(),
+			'isPremium'               => YoastSEO()->helpers->product->is_premium(),
+			'webinarIntroSettingsUrl' => WPSEO_Shortlinker::get( 'https://yoa.st/webinar-intro-settings' ),
 		];
 
 		$page = filter_input( INPUT_GET, 'page' );

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -897,18 +897,19 @@ class WPSEO_Metabox extends WPSEO_Meta {
 
 		$script_data = [
 			// @todo replace this translation with JavaScript translations.
-			'media'            => [ 'choose_image' => __( 'Use Image', 'wordpress-seo' ) ],
-			'metabox'          => $this->get_metabox_script_data(),
-			'userLanguageCode' => WPSEO_Language_Utils::get_language( \get_user_locale() ),
-			'isPost'           => true,
-			'isBlockEditor'    => $is_block_editor,
-			'postStatus'       => get_post_status( $post_id ),
-			'analysis'         => [
+			'media'                    => [ 'choose_image' => __( 'Use Image', 'wordpress-seo' ) ],
+			'metabox'                  => $this->get_metabox_script_data(),
+			'userLanguageCode'         => WPSEO_Language_Utils::get_language( \get_user_locale() ),
+			'isPost'                   => true,
+			'isBlockEditor'            => $is_block_editor,
+			'postStatus'               => get_post_status( $post_id ),
+			'analysis'                 => [
 				'plugins'                     => $plugins_script_data,
 				'worker'                      => $worker_script_data,
 				'estimatedReadingTimeEnabled' => $this->estimated_reading_time_conditional->is_met(),
 			],
-			'dismissedAlerts'  => $dismissed_alerts,
+			'dismissedAlerts'          => $dismissed_alerts,
+			'webinarIntroBlockEditorUrl' => WPSEO_Shortlinker::get( 'https://yoa.st/webinar-intro-block-editor' ),
 		];
 
 		if ( post_type_supports( get_post_type(), 'thumbnail' ) ) {

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -897,18 +897,18 @@ class WPSEO_Metabox extends WPSEO_Meta {
 
 		$script_data = [
 			// @todo replace this translation with JavaScript translations.
-			'media'                    => [ 'choose_image' => __( 'Use Image', 'wordpress-seo' ) ],
-			'metabox'                  => $this->get_metabox_script_data(),
-			'userLanguageCode'         => WPSEO_Language_Utils::get_language( \get_user_locale() ),
-			'isPost'                   => true,
-			'isBlockEditor'            => $is_block_editor,
-			'postStatus'               => get_post_status( $post_id ),
-			'analysis'                 => [
+			'media'                      => [ 'choose_image' => __( 'Use Image', 'wordpress-seo' ) ],
+			'metabox'                    => $this->get_metabox_script_data(),
+			'userLanguageCode'           => WPSEO_Language_Utils::get_language( \get_user_locale() ),
+			'isPost'                     => true,
+			'isBlockEditor'              => $is_block_editor,
+			'postStatus'                 => get_post_status( $post_id ),
+			'analysis'                   => [
 				'plugins'                     => $plugins_script_data,
 				'worker'                      => $worker_script_data,
 				'estimatedReadingTimeEnabled' => $this->estimated_reading_time_conditional->is_met(),
 			],
-			'dismissedAlerts'          => $dismissed_alerts,
+			'dismissedAlerts'            => $dismissed_alerts,
 			'webinarIntroBlockEditorUrl' => WPSEO_Shortlinker::get( 'https://yoa.st/webinar-intro-block-editor' ),
 		];
 

--- a/composer.json
+++ b/composer.json
@@ -84,7 +84,7 @@
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_coding_standards"
 		],
 		"check-cs-thresholds": [
-			"@putenv YOASTCS_THRESHOLD_ERRORS=243",
+			"@putenv YOASTCS_THRESHOLD_ERRORS=241",
 			"@putenv YOASTCS_THRESHOLD_WARNINGS=219",
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_cs_thresholds"
 		],

--- a/packages/js/src/components/WebinarPromoNotification.js
+++ b/packages/js/src/components/WebinarPromoNotification.js
@@ -8,13 +8,14 @@ import { ReactComponent as DefaultImage } from "../../../../images/succes_mariek
 /**
  * @param {string} store The Redux store identifier from which to determine dismissed state.
  * @param {JSX.Element} image The image or null if no image.
+ * @param {string} url The URL for the register now link.
  *
  * @returns {JSX.Element} The WebinarPromoNotification component.
  */
 const WebinarPromoNotification = ( {
 	store = "yoast-seo/editor",
 	image: Image = DefaultImage,
-	url: url,
+	url,
 	...props
 } ) => {
 	const isPremium = useSelect( select => select( store ).getIsPremium() );

--- a/packages/js/src/components/WebinarPromoNotification.js
+++ b/packages/js/src/components/WebinarPromoNotification.js
@@ -14,6 +14,7 @@ import { ReactComponent as DefaultImage } from "../../../../images/succes_mariek
 const WebinarPromoNotification = ( {
 	store = "yoast-seo/editor",
 	image: Image = DefaultImage,
+	url: url,
 	...props
 } ) => {
 	const isPremium = useSelect( select => select( store ).getIsPremium() );
@@ -25,11 +26,12 @@ const WebinarPromoNotification = ( {
 			id="webinar-promo-notification"
 			title={ __( "Get the most out of Yoast SEO", "wordpress-seo" ) }
 			image={ Image }
+			url={ url }
 			{ ...props }
 		>
 			{ __( "Want to optimize even further with the help of our SEO experts? Sign up for our weekly webinar!", "wordpress-seo" ) }
 			<br />
-			<a href="https://yoast.com/" target="_blank" rel="noreferrer">
+			<a href={ url } target="_blank" rel="noreferrer">
 				{ __( "Register now!", "wordpress-seo" ) }
 			</a>
 		</PersistentDismissableNotification>
@@ -39,6 +41,7 @@ const WebinarPromoNotification = ( {
 WebinarPromoNotification.propTypes = {
 	store: PropTypes.string,
 	image: PropTypes.elementType,
+	url: PropTypes.string.isRequired,
 };
 
 export default WebinarPromoNotification;

--- a/packages/js/src/components/fills/SidebarFill.js
+++ b/packages/js/src/components/fills/SidebarFill.js
@@ -3,6 +3,7 @@ import { Fill } from "@wordpress/components";
 import { Fragment } from "@wordpress/element";
 import PropTypes from "prop-types";
 import { __ } from "@wordpress/i18n";
+import { get } from "lodash";
 
 /* Internal dependencies */
 import CollapsibleCornerstone from "../../containers/CollapsibleCornerstone";
@@ -31,13 +32,15 @@ import WebinarPromoNotification from "../WebinarPromoNotification";
  * @constructor
  */
 export default function SidebarFill( { settings } ) {
+	const webinarIntroBlockEditorUrl = get( window, "wpseoScriptData.webinarIntroBlockEditorUrl", "https://yoa.st/webinar-intro-block-editor" );
+
 	return (
 		<Fragment>
 			<Fill name="YoastSidebar">
 				<SidebarItem key="warning" renderPriority={ 1 }>
 					<Warning />
 					<div style={ { margin: "0 16px" } }>
-						<WebinarPromoNotification hasIcon={ false } image={ null } />
+						<WebinarPromoNotification hasIcon={ false } image={ null } url={ webinarIntroBlockEditorUrl } />
 					</div>
 				</SidebarItem>
 				{ settings.isKeywordAnalysisActive && <SidebarItem key="keyword-input" renderPriority={ 8 }>

--- a/packages/js/src/elementor/components/fills/ElementorFill.js
+++ b/packages/js/src/elementor/components/fills/ElementorFill.js
@@ -2,6 +2,7 @@
 import { Fill } from "@wordpress/components";
 import { useEffect } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
+import { get } from "lodash";
 import PropTypes from "prop-types";
 
 // Internal dependencies.
@@ -42,12 +43,14 @@ export default function ElementorFill( { isLoading, onLoad, settings } ) {
 		return null;
 	}
 
+	const webinarIntroElementorUrl = get( window, "wpseoScriptData.webinarIntroElementorUrl", "https://yoa.st/webinar-intro-elementor" );
+
 	return (
 		<>
 			<Fill name="YoastElementor">
 				<SidebarItem renderPriority={ 1 }>
 					<Alert />
-					<WebinarPromoNotification hasIcon={ false } image={ null } />
+					<WebinarPromoNotification hasIcon={ false } image={ null } url={ webinarIntroElementorUrl } />
 				</SidebarItem>
 				{ settings.isKeywordAnalysisActive && <SidebarItem renderPriority={ 8 }>
 					<KeywordInput

--- a/packages/js/src/first-time-configuration/tailwind-components/steps/finish/finish-step.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/steps/finish/finish-step.js
@@ -1,6 +1,6 @@
 import { useSelect } from "@wordpress/data";
 import { __ } from "@wordpress/i18n";
-import get from "lodash/get";
+import { get } from "lodash";
 import { ReactComponent as ConfigurationFinishImage } from "../../../../../images/indexables_2_left_bubble_optm.svg";
 
 /**

--- a/packages/js/src/first-time-configuration/tailwind-components/steps/finish/finish-step.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/steps/finish/finish-step.js
@@ -1,5 +1,6 @@
 import { useSelect } from "@wordpress/data";
 import { __ } from "@wordpress/i18n";
+import get from "lodash/get";
 import { ReactComponent as ConfigurationFinishImage } from "../../../../../images/indexables_2_left_bubble_optm.svg";
 
 /**
@@ -32,6 +33,8 @@ function regularContent() {
  * @returns {WPElement} The webinar promo content.
  */
 function webinarPromoContent() {
+	const webinarIntroSettingsUrl = get( window, "wpseoScriptData.webinarIntroSettingsUrl", "https://yoa.st/webinar-intro-settings" );
+
 	return (
 		<>
 			<p className="yst-text-sm yst-mb-4">
@@ -40,7 +43,7 @@ function webinarPromoContent() {
 			<p className="yst-text-sm yst-mb-6">
 				{ __( "Want to optimize even further and get the most out of Yoast SEO? Make sure you don't miss our weekly webinar!", "wordpress-seo" ) }
 			</p>
-			<a href="https://yoast.com/" target="_blank" rel="noreferrer" className="yst-button yst-button--primary yst-text-white">
+			<a href={ webinarIntroSettingsUrl } target="_blank" rel="noreferrer" className="yst-button yst-button--primary yst-text-white">
 				{ __( "Register now!", "wordpress-seo" ) }
 			</a>
 			<button

--- a/packages/js/src/initializers/settings-header.js
+++ b/packages/js/src/initializers/settings-header.js
@@ -11,11 +11,12 @@ import WebinarPromoNotification from "../components/WebinarPromoNotification";
 const initSettingsHeader = () => {
 	const reactRoot = document.getElementById( "yst-settings-header-root" );
 	const isRtl = Boolean( get( window, "wpseoScriptData.isRtl", false ) );
+	const webinarIntroSettingsUrl = get( window, "wpseoScriptData.webinarIntroSettingsUrl", "https://yoa.st/webinar-intro-settings" );
 
 	if ( reactRoot ) {
 		render(
 			<ThemeProvider theme={ { isRtl } }>
-				<WebinarPromoNotification store="yoast-seo/settings" />
+				<WebinarPromoNotification store="yoast-seo/settings" url={ webinarIntroSettingsUrl } />
 			</ThemeProvider>,
 			reactRoot
 		);

--- a/src/integrations/third-party/elementor.php
+++ b/src/integrations/third-party/elementor.php
@@ -15,6 +15,7 @@ use WPSEO_Metabox_Analysis_SEO;
 use WPSEO_Metabox_Formatter;
 use WPSEO_Post_Metabox_Formatter;
 use WPSEO_Replace_Vars;
+use WPSEO_Shortlinker;
 use WPSEO_Utils;
 use Yoast\WP\SEO\Actions\Alert_Dismissal_Action;
 use Yoast\WP\SEO\Conditionals\Admin\Estimated_Reading_Time_Conditional;
@@ -433,6 +434,7 @@ class Elementor implements Integration_Interface {
 				'estimatedReadingTimeEnabled' => $this->estimated_reading_time_conditional->is_met(),
 			],
 			'dismissedAlerts'   => $dismissed_alerts,
+			'webinarIntroElementorUrl' => WPSEO_Shortlinker::get( 'https://yoa.st/webinar-intro-elementor' ),
 		];
 
 		if ( \post_type_supports( $this->get_metabox_post()->post_type, 'thumbnail' ) ) {

--- a/src/integrations/third-party/elementor.php
+++ b/src/integrations/third-party/elementor.php
@@ -421,19 +421,19 @@ class Elementor implements Integration_Interface {
 		$dismissed_alerts       = $alert_dismissal_action->all_dismissed();
 
 		$script_data = [
-			'media'             => [ 'choose_image' => \__( 'Use Image', 'wordpress-seo' ) ],
-			'metabox'           => $this->get_metabox_script_data(),
-			'userLanguageCode'  => WPSEO_Language_Utils::get_language( \get_user_locale() ),
-			'isPost'            => true,
-			'isBlockEditor'     => WP_Screen::get()->is_block_editor(),
-			'isElementorEditor' => true,
-			'postStatus'        => \get_post_status( $post_id ),
-			'analysis'          => [
+			'media'                    => [ 'choose_image' => \__( 'Use Image', 'wordpress-seo' ) ],
+			'metabox'                  => $this->get_metabox_script_data(),
+			'userLanguageCode'         => WPSEO_Language_Utils::get_language( \get_user_locale() ),
+			'isPost'                   => true,
+			'isBlockEditor'            => WP_Screen::get()->is_block_editor(),
+			'isElementorEditor'        => true,
+			'postStatus'               => \get_post_status( $post_id ),
+			'analysis'                 => [
 				'plugins'                     => $plugins_script_data,
 				'worker'                      => $worker_script_data,
 				'estimatedReadingTimeEnabled' => $this->estimated_reading_time_conditional->is_met(),
 			],
-			'dismissedAlerts'   => $dismissed_alerts,
+			'dismissedAlerts'          => $dismissed_alerts,
 			'webinarIntroElementorUrl' => WPSEO_Shortlinker::get( 'https://yoa.st/webinar-intro-elementor' ),
 		];
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Add the shortlinks to the webinar promo banner and notifications

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Add the shortlinks to the webinar promo banner and notifications

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Testing webinar `settings url`
* Header banner notifications
  * Visit the 'General' admin page(`Yoast SEO -> General`)
  * You'll see the webinar promo notification
  * Inspect the `Register now!` link and verify the url: `https://yoa.st/webinar-intro-settings` with added query parameters 
* Final step of the FTC
  * Visit `Yoast SEO -> General -> First-time configuration(tab)`
  * Make it to the last step
  * Inspect the `Register now!` button and verify the added query parameters 

#### Testing webinar `block editor url` on the sidebar promo notification
* Add a new post
* You'll see the webinar promo notification in the sidebar
* Inspect the `Register now!` link and verify the url: `https://yoa.st/webinar-intro-block-editor` with added query parameters 

#### Testing webinar `elementor url` on the elementor promo notification
* Edit the post that was created at the previous step
* Click on `Edit with Elementor`
* Navigate to our plugin within Elementor (top left corner, click on the menu item and click on `Yoast SEO`)
* You'll see the webinar promo notification in the sidebar
* Inspect the `Register now!` link and verify the url: `https://yoa.st/webinar-intro-elementor` with added query parameters 

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes P1-1422