### PR TITLE
Introduce new meta author presenter

### DIFF
--- a/src/integrations/front-end-integration.php
+++ b/src/integrations/front-end-integration.php
@@ -101,6 +101,7 @@ class Front_End_Integration implements Integration_Interface {
 		'Open_Graph\Article_Published_Time',
 		'Open_Graph\Article_Modified_Time',
 		'Open_Graph\Image',
+		'Meta_Author',
 	];
 
 	/**
@@ -156,6 +157,7 @@ class Front_End_Integration implements Integration_Interface {
 	 * @var string[]
 	 */
 	protected $singular_presenters = [
+		'Meta_Author',
 		'Open_Graph\Article_Author',
 		'Open_Graph\Article_Publisher',
 		'Open_Graph\Article_Published_Time',

--- a/src/presenters/meta-author-presenter.php
+++ b/src/presenters/meta-author-presenter.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Yoast\WP\SEO\Presenters;
+
+/**
+ * Presenter class for the meta author tag.
+ */
+class Meta_Author_Presenter extends Abstract_Indexable_Tag_Presenter {
+
+	/**
+	 * The tag key name.
+	 *
+	 * @var string
+	 */
+	protected $key = 'author';
+
+	/**
+	 * Returns the author for a post in a meta author tag.
+	 *
+	 * @return string The meta author tag.
+	 */
+	public function present() {
+		$output = parent::present();
+
+		if ( ! empty( $output ) ) {
+			return $output;
+		}
+
+		return '';
+	}
+
+	/**
+	 * Get the author's display name.
+	 *
+	 * @return string The author's display name.
+	 */
+	public function get() {
+		$user_data = \get_userdata( $this->presentation->context->post->post_author );
+
+		return \trim( $this->helpers->schema->html->smart_strip_tags( $user_data->display_name ) );
+	}
+}

--- a/tests/unit/integrations/front-end-integration-test.php
+++ b/tests/unit/integrations/front-end-integration-test.php
@@ -229,6 +229,7 @@ class Front_End_Integration_Test extends TestCase {
 			'Yoast\WP\SEO\Presenters\Open_Graph\Article_Published_Time_Presenter',
 			'Yoast\WP\SEO\Presenters\Open_Graph\Article_Modified_Time_Presenter',
 			'Yoast\WP\SEO\Presenters\Open_Graph\Image_Presenter',
+			'Yoast\WP\SEO\Presenters\Meta_Author_Presenter',
 			'Yoast\WP\SEO\Presenters\Twitter\Card_Presenter',
 			'Yoast\WP\SEO\Presenters\Twitter\Title_Presenter',
 			'Yoast\WP\SEO\Presenters\Twitter\Description_Presenter',

--- a/tests/unit/presenters/meta-author-presenter-test.php
+++ b/tests/unit/presenters/meta-author-presenter-test.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Presenters;
+
+use Brain\Monkey;
+use Mockery;
+use Yoast\WP\SEO\Helpers\Schema\HTML_Helper;
+use Yoast\WP\SEO\Presentations\Indexable_Presentation;
+use Yoast\WP\SEO\Presenters\Meta_Author_Presenter;
+use Yoast\WP\SEO\Tests\Unit\Doubles\Context\Meta_Tags_Context_Mock;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Class Meta_Description_Presenter_Test
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Presenters\Meta_Description_Presenter
+ *
+ * @group presenters
+ * @group opengraph
+ */
+class Meta_Author_Presenter_Test extends TestCase {
+
+	/**
+	 * Holds the instance of the class being tested.
+	 *
+	 * @var Meta_Author_Presenter
+	 */
+	protected $instance;
+
+	/**
+	 * The indexable presentation.
+	 *
+	 * @var Indexable_Presentation
+	 */
+	protected $indexable_presentation;
+
+	/**
+	 * Setup of the tests.
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->stubEscapeFunctions();
+		$this->stubTranslationFunctions();
+
+		$this->html    = Mockery::mock( HTML_Helper::class );
+		$this->context = Mockery::mock( Meta_Tags_Context_Mock::class );
+
+		$this->instance          = new Meta_Author_Presenter();
+		$this->instance->helpers = (object) [
+			'schema' => (object) [
+				'html' => $this->html,
+			],
+		];
+
+		$this->context->post = (object) [
+			'post_author' => 123,
+		];
+
+		$this->indexable_presentation          = new Indexable_Presentation();
+		$this->indexable_presentation->context = $this->context;
+
+		$this->instance->presentation = $this->indexable_presentation;
+	}
+
+	/**
+	 * Tests the presenter of the meta description.
+	 *
+	 * @covers ::present
+	 * @covers ::get
+	 */
+	public function test_present_and_filter_happy_path() {
+		$this->indexable_presentation->meta_description = 'the_meta_description';
+
+		$this->html
+			->expects( 'smart_strip_tags' )
+			->once()
+			->with( 'John Doe' )
+			->andReturn( 'John Doe' );
+
+		Monkey\Functions\expect( 'get_userdata' )
+			->once()
+			->with( 123 )
+			->andReturn( (object) [ 'display_name' => 'John Doe' ] );
+
+		$output = '<meta name="author" content="John Doe" />';
+
+		$this->assertEquals( $output, $this->instance->present() );
+	}
+
+}

--- a/tests/unit/presenters/meta-author-presenter-test.php
+++ b/tests/unit/presenters/meta-author-presenter-test.php
@@ -87,5 +87,4 @@ class Meta_Author_Presenter_Test extends TestCase {
 
 		$this->assertEquals( $output, $this->instance->present() );
 	}
-
 }


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* By adding a `meta author` tag we're making sure LinkedIn picks up the name of a post author properly.

## Relevant technical choices:

* This uses `get_userdata`, which [this pull](https://github.com/Yoast/wordpress-seo/pull/18542) introduces in another place. Should we move this to the `Meta_Tags_Context` ? @herregroen what do you think?

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* install and activate latest Premium RC
* in SEO > General > Crawl settings, disable oEmbed links
* set up `ngrok` to make your site visible outside:
  * run `ngrok http 127.0.0.1 --host-header="basic.wordpress.test"` in a console
  * pick the https:// URL and use it as "Site URL" in the WP settings
* pick a post whose author is not `admin`, copy its URL
* Put the URL in the [LinkedIn's Post Inspector](https://www.linkedin.com/post-inspector/):
 * without this patch, see it doesn't pick up the author.
 * with this patch, it should. You should also see a tag such as `<meta name="author" content="Name Surname" />` in the page source.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Documentation

* [ ] I have _not_ written documentation for this change. @jonoalderson please do :)

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
