### PR TITLE
LINGO-1463 - Make previously used keyphrase available in agnostic analysis

### DIFF
--- a/packages/js/src/classic-editor.js
+++ b/packages/js/src/classic-editor.js
@@ -91,7 +91,7 @@ const initPost = async() => {
 	registerYoastApis( { analysisWorker } );
 	initializeUsedKeyphrasesAssessment(
 		"get_focus_keyword_usage",
-		window.YoastSEO.app.refresh,
+		window.YoastSEO.app.refresh
 	);
 	// Start watching for DOM/store changes.
 	initPostWatcher();

--- a/packages/js/src/classic-editor.js
+++ b/packages/js/src/classic-editor.js
@@ -19,6 +19,7 @@ import { initTermDescriptionTinyMce } from "./initializers/tiny-mce";
 import { initialize as initPublishBox } from "./ui/publishBox";
 import { registerFeaturedImagePlugin, registerMarkdownPlugin, registerSeoTitleWidthPlugin, registerShortcodePlugin } from "./classic-editor/plugins";
 import { getContentTypeReplacements } from "./classic-editor/content-types";
+import initializeUsedKeyphrasesAssessment from "./classic-editor/plugins/used-keyphrases-assessment";
 
 // These are either "1" or undefined.
 const isPost = Boolean( get( window, "wpseoScriptData.isPost" ) );
@@ -88,6 +89,10 @@ const initPost = async() => {
 	} );
 	// Register global Yoast APIs.
 	registerYoastApis( { analysisWorker } );
+	initializeUsedKeyphrasesAssessment(
+		"get_focus_keyword_usage",
+		window.YoastSEO.app.refresh,
+	);
 	// Start watching for DOM/store changes.
 	initPostWatcher();
 	// Render metabox with provider.
@@ -110,6 +115,10 @@ const initTerm = async() => {
 	} );
 	// Register global Yoast APIs.
 	registerYoastApis( { analysisWorker } );
+	initializeUsedKeyphrasesAssessment(
+		"get_term_keyword_usage",
+		window.YoastSEO.app.refresh
+	);
 	// Start watching for DOM/store changes.
 	initTermWatcher();
 	// Render metabox with provider.

--- a/packages/js/src/classic-editor/plugins/used-keyphrases-assessment.js
+++ b/packages/js/src/classic-editor/plugins/used-keyphrases-assessment.js
@@ -49,5 +49,5 @@ export default function initializeUsedKeyphrasesAssessment( usedKeyphrasesEndpoi
 
 			return results;
 		}
-	)
+	);
 }

--- a/packages/js/src/classic-editor/plugins/used-keyphrases-assessment.js
+++ b/packages/js/src/classic-editor/plugins/used-keyphrases-assessment.js
@@ -1,0 +1,53 @@
+import { get } from "lodash-es";
+import { addFilter } from "@wordpress/hooks";
+
+import getL10nObject from "../../analysis/getL10nObject";
+import UsedKeywords from "../../analysis/usedKeywords";
+
+/**
+ * Initializes the used keyphrases assessment.
+ *
+ * @param {string} usedKeyphrasesEndpoint The endpoint to call to retrieve previously used keyphrases.
+ * @param {function} refreshAnalysis The function to call to refresh the analysis.
+ *
+ * @returns {void}
+ */
+export default function initializeUsedKeyphrasesAssessment( usedKeyphrasesEndpoint, refreshAnalysis ) {
+	const localizedData = getL10nObject();
+
+	if ( ! localizedData.previouslyUsedKeywordActive ) {
+		return;
+	}
+
+	const scriptUrl = get(
+		window,
+		[ "wpseoScriptData", "analysis", "worker", "keywords_assessment_url" ],
+		"used-keywords-assessment.js"
+	);
+
+	const usedKeywords = new UsedKeywords(
+		usedKeyphrasesEndpoint,
+		localizedData,
+		refreshAnalysis,
+		scriptUrl
+	);
+	usedKeywords.init();
+
+	let lastFocusKeyphrase = null;
+
+	addFilter(
+		"yoast.seoStore.analysis.processResults",
+		"yoast/free/usedKeyphrasesAssessment",
+		( results, { keyphrases } ) => {
+			if ( keyphrases.focus === lastFocusKeyphrase ) {
+				return results;
+			}
+
+			usedKeywords.setKeyword( keyphrases.focus.keyphrase );
+
+			lastFocusKeyphrase = keyphrases.focus;
+
+			return results;
+		}
+	)
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want the previously used keyphrase assessment to be available in the classic editor agnostic analysis integration.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds the previously used keyphrases assessment to the classic editor agnostic analysis integration. 

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Posts
* Create a post.
* Set a focus keyphrase that you have not used in another post.
* Check the SEO analysis results. It should include this assessment result (green bullet):
  > [Previously used keyphrase](https://yoa.st/33x): You've not used this keyphrase before, very good.
* Publish the post.
* Create another post.
* Set the focus keyphrase to the same keyphrase you entered in the first post.
* Check the SEO analysis results. It should include this assessment result (orange bullet):
  > [Previously used keyphrase](https://yoa.st/33x): You've used this keyphrase [once before](http://basic.wordpress.test/wp-admin/term.php?action=edit&taxonomy=category&tag_ID=4). [Do not use your keyphrase more than once](https://yoa.st/33y).

#### Taxonomies
* Create a category or tag.
* Set a focus keyphrase that you have not used in another post.
* Check the SEO analysis results. It should include this assessment result (green bullet):
  > [Previously used keyphrase](https://yoa.st/33x): You've not used this keyphrase before, very good.
* Publish the post.
* Create another post.
* Set the focus keyphrase to the same keyphrase you entered in the first post.
* Check the SEO analysis results. It should include this assessment result (orange bullet):
  > [Previously used keyphrase](https://yoa.st/33x): You've used this keyphrase [once before](http://basic.wordpress.test/wp-admin/term.php?action=edit&taxonomy=category&tag_ID=4). [Do not use your keyphrase more than once](https://yoa.st/33y).

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Do a quick smoke test to test if the SEO analysis still works as expected.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes #
