### PR TITLE
Don't encode ampersands in URLs

### DIFF
--- a/src/presenters/abstract-indexable-tag-presenter.php
+++ b/src/presenters/abstract-indexable-tag-presenter.php
@@ -59,7 +59,7 @@ abstract class Abstract_Indexable_Tag_Presenter extends Abstract_Indexable_Prese
 			case 'html':
 				return \esc_html( $value );
 			case 'url':
-				return \esc_url( $value );
+				return \esc_url( $value, null, 'attribute' );
 			case 'attribute':
 			default:
 				return \esc_attr( $value );

--- a/src/presenters/open-graph/image-presenter.php
+++ b/src/presenters/open-graph/image-presenter.php
@@ -18,6 +18,13 @@ class Image_Presenter extends Abstract_Indexable_Presenter {
 	protected $key = 'og:image';
 
 	/**
+	 * The method of escaping to use.
+	 *
+	 * @var string
+	 */
+	protected $escaping = 'url';
+
+	/**
 	 * Image tags that we output for each image.
 	 *
 	 * @var array
@@ -44,7 +51,7 @@ class Image_Presenter extends Abstract_Indexable_Presenter {
 		foreach ( $images as $image_index => $image_meta ) {
 			$image_url = $image_meta['url'];
 
-			$return .= '<meta property="og:image" content="' . \esc_url( $image_url ) . '" />';
+			$return .= '<meta property="og:image" content="' . \esc_url( $image_url, null, 'attribute' ) . '" />';
 
 			foreach ( static::$image_tags as $key => $value ) {
 				if ( empty( $image_meta[ $key ] ) ) {

--- a/src/presenters/open-graph/image-presenter.php
+++ b/src/presenters/open-graph/image-presenter.php
@@ -18,13 +18,6 @@ class Image_Presenter extends Abstract_Indexable_Presenter {
 	protected $key = 'og:image';
 
 	/**
-	 * The method of escaping to use.
-	 *
-	 * @var string
-	 */
-	protected $escaping = 'url';
-
-	/**
 	 * Image tags that we output for each image.
 	 *
 	 * @var array

--- a/src/presenters/twitter/image-presenter.php
+++ b/src/presenters/twitter/image-presenter.php
@@ -22,7 +22,7 @@ class Image_Presenter extends Abstract_Indexable_Tag_Presenter {
 	 *
 	 * @var string
 	 */
-	protected $escaping = 'attribute';
+	protected $escaping = 'url';
 
 	/**
 	 * Run the Twitter image value through the `wpseo_twitter_image` filter.


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixed a bug where filtering the OpenGraph and Twitter image to a URL containing ampersands would lead to encoding issues.

## Relevant technical choices:

* Made sure we don't use the `display` escaping for URLs.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Create a small plugin like so:

```php
<?php
/**
* Plugin Name: test plugin
*/

add_filter( 'wpseo_opengraph_image', 'return_wrong_image' );
add_filter( 'wpseo_twitter_image', 'return_wrong_image' );

function return_wrong_image() {
	return 'https://www.example.com/path/?query=value&cats=cool';
}
```

* See that with the patch this gets displayed properly in the Twitter and `og:` meta-tags with the `&` unencoded.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes P1-1414
