### PR TITLE
Update notifications counters only when present

### DIFF
--- a/packages/js/src/first-time-configuration/first-time-configuration-steps.js
+++ b/packages/js/src/first-time-configuration/first-time-configuration-steps.js
@@ -227,15 +227,13 @@ export default function FirstTimeConfigurationSteps() {
 		if ( indexingState === "completed" ) {
 			const indexationNotice = document.getElementById( "wpseo-reindex" );
 			if ( indexationNotice ) {
-				let allCounters = document.querySelectorAll( ".yoast-issue-counter" );
+				const allCounters = document.querySelectorAll( ".yoast-issue-counter, #toplevel_page_wpseo_dashboard .update-plugins" );
 
-				// Update the notification counters
-				if ( allCounters ) {
+				// Update the notification counters if there are any (non-zero ones).
+				if ( allCounters.length > 0 && allCounters[ 0 ].firstChild.textContent !== "0" ) {
 					// Get the oldCount for easier targeting.
 					const oldCount = allCounters[ 0 ].firstChild.textContent;
 					const newCount = ( parseInt( oldCount, 10 ) - 1 ).toString();
-					// Find and add the sidebar counters
-					allCounters = [ ...allCounters, ...document.querySelectorAll( "#toplevel_page_wpseo_dashboard .update-plugins.count-" + oldCount ) ];
 					allCounters.forEach( ( counterNode => {
 						// The classList replace will return false if the class was not present (and thus an adminbar counter).
 						const isAdminBarCounter = ! counterNode.classList.replace( "count-" + oldCount, "count-" + newCount );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug that would cause the First-time configuration to crash when completing indexation with the Yoast admin bar menu hidden.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Have indexation set to not completed (using the Test helper => reset indexables tables and migations). Also reset notifications.
* Go to SEO-> General-> Feature and set Admin bar menu to Off
* Note the red notifaction in the sidebar.
* Go to SEO-> General-> FTC and Start SEO Data Optimization
* Wait until Start SEO Data Optimization is finished
* Note the count in the sidebar has gone down (or the red bubble is gone, if it was at 1 before).
* No errors in the console, FTC did not crash.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes DUPP-586
