### PR TITLE
Bring several small improvements to WordPress RSS feeds

### DIFF
--- a/src/integrations/front-end/feed-improvements.php
+++ b/src/integrations/front-end/feed-improvements.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace Yoast\YoastCom\Core\WordPress\Integration\YoastSEO;
+
+use Yoast\WP\SEO\Integrations\Integration_Interface;
+use Yoast\WP\SEO\Conditionals\Front_End_Conditional;
+use Yoast\WP\SEO\Helpers\Options_Helper;
+use Yoast\WP\SEO\Surfaces\Meta_Surface;
+
+/**
+ * Class Feed_Improvements
+ */
+class Feed_Improvements implements Integration_Interface {
+
+	/**
+	 * Holds the options helper.
+	 *
+	 * @var Options_Helper
+	 */
+	private $options;
+
+	/**
+	 * Holds the meta helper surface.
+	 *
+	 * @var Meta_Surface
+	 */
+	private $meta;
+
+	/**
+	 * Canonical_Header constructor.
+	 *
+	 * @codeCoverageIgnore It only sets depedencies.
+	 *
+	 * @param Options_Helper $options The options helper.
+	 * @param Meta_Surface   $meta    The meta surface.
+	 */
+	public function __construct(
+		Options_Helper $options,
+		Meta_Surface $meta
+	) {
+		$this->options = $options;
+		$this->meta    = $meta;
+	}
+
+	/**
+	 * Returns the conditionals based in which this loadable should be active.
+	 *
+	 * @return array
+	 */
+	public static function get_conditionals() {
+		return [ Front_End_Conditional::class ];
+	}
+
+	/**
+	 * Registers hooks to WordPress.
+	 *
+	 * @return void
+	 */
+	public function register_hooks() {
+		add_filter( 'get_bloginfo_rss', [ $this, 'filter_bloginfo_rss' ], 10, 2 );
+		add_filter( 'document_title_separator', [ $this, 'filter_document_title_separator' ] );
+
+		add_action( 'do_feed_rss', [ $this, 'send_canonical_header' ], 9 );
+		add_action( 'do_feed_rss2', [ $this, 'send_canonical_header' ], 9 );
+	}
+
+	/**
+	 * Filter `bloginfo_rss` output to give the URL for what's being shown instead of just always the homepage.
+	 *
+	 * @param string $show The output so far.
+	 * @param string $what What is being shown.
+	 *
+	 * @return string
+	 */
+	public function filter_bloginfo_rss( $show, $what ) {
+		if ( $what === 'url' ) {
+			return $this->get_url_for_queried_object( $show );
+		}
+
+		return $show;
+	}
+
+	/**
+	 * Adds a canonical link header to the main canonical URL for the requested feed object.
+	 */
+	public function send_canonical_header() {
+		if ( headers_sent() ) {
+			return;
+		}
+
+		$url = $this->get_url_for_queried_object( $this->meta->for_home_page()->canonical );
+		if ( ! empty( $url ) ) {
+			header( sprintf( 'Link: <%s>; rel="canonical"', $url ), false );
+		}
+	}
+
+	/**
+	 * Makes sure the title separator set in Yoast SEO is used for all feeds.
+	 *
+	 * @param string $separator The separator from WordPress.
+	 *
+	 * @return string The separator from Yoast SEO's settings.
+	 */
+	public function filter_document_title_separator( $separator ) {
+		return html_entity_decode( $this->options->get_title_separator() );
+	}
+
+	/**
+	 * Determines the main URL for the queried object.
+	 *
+	 * @param string $url The URL determined so far.
+	 *
+	 * @return string The canonical URL for the queried object.
+	 */
+	protected function get_url_for_queried_object( $url = '' ) {
+		$queried_object = get_queried_object();
+		// Don't call get_class with null. This gives a warning.
+		$class = ( $queried_object !== null ) ? get_class( $queried_object ) : null;
+
+		switch ( $class ) {
+			// Post type archive feeds.
+			case 'WP_Post_Type':
+				$url = $this->meta->for_post_type_archive( $queried_object->name )->canonical;
+				break;
+			// Post comment feeds.
+			case 'WP_Post':
+				$url = $this->meta->for_post( $queried_object->ID )->canonical;
+				break;
+			// Term feeds.
+			case 'WP_Term':
+				$url = $this->meta->for_term( $queried_object->term_id )->canonical;
+				break;
+			// Author feeds.
+			case 'WP_User':
+				$url = $this->meta->for_author( $queried_object->ID )->canonical;
+				break;
+			// This would be NULL on the home page and on date archive feeds.
+			case null:
+				$url = $this->meta->for_home_page()->canonical;
+				break;
+			default:
+				break;
+		}
+
+		return $url;
+	}
+}

--- a/src/integrations/front-end/feed-improvements.php
+++ b/src/integrations/front-end/feed-improvements.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Yoast\YoastCom\Core\WordPress\Integration\YoastSEO;
+namespace Yoast\WP\SEO\Integrations\Front_End;
 
 use Yoast\WP\SEO\Integrations\Integration_Interface;
 use Yoast\WP\SEO\Conditionals\Front_End_Conditional;
@@ -57,11 +57,11 @@ class Feed_Improvements implements Integration_Interface {
 	 * @return void
 	 */
 	public function register_hooks() {
-		add_filter( 'get_bloginfo_rss', [ $this, 'filter_bloginfo_rss' ], 10, 2 );
-		add_filter( 'document_title_separator', [ $this, 'filter_document_title_separator' ] );
+		\add_filter( 'get_bloginfo_rss', [ $this, 'filter_bloginfo_rss' ], 10, 2 );
+		\add_filter( 'document_title_separator', [ $this, 'filter_document_title_separator' ] );
 
-		add_action( 'do_feed_rss', [ $this, 'send_canonical_header' ], 9 );
-		add_action( 'do_feed_rss2', [ $this, 'send_canonical_header' ], 9 );
+		\add_action( 'do_feed_rss', [ $this, 'send_canonical_header' ], 9 );
+		\add_action( 'do_feed_rss2', [ $this, 'send_canonical_header' ], 9 );
 	}
 
 	/**
@@ -84,13 +84,13 @@ class Feed_Improvements implements Integration_Interface {
 	 * Adds a canonical link header to the main canonical URL for the requested feed object.
 	 */
 	public function send_canonical_header() {
-		if ( headers_sent() ) {
+		if ( \headers_sent() ) {
 			return;
 		}
 
 		$url = $this->get_url_for_queried_object( $this->meta->for_home_page()->canonical );
 		if ( ! empty( $url ) ) {
-			header( sprintf( 'Link: <%s>; rel="canonical"', $url ), false );
+			\header( \sprintf( 'Link: <%s>; rel="canonical"', $url ), false );
 		}
 	}
 
@@ -102,7 +102,7 @@ class Feed_Improvements implements Integration_Interface {
 	 * @return string The separator from Yoast SEO's settings.
 	 */
 	public function filter_document_title_separator( $separator ) {
-		return html_entity_decode( $this->options->get_title_separator() );
+		return \html_entity_decode( $this->options->get_title_separator() );
 	}
 
 	/**
@@ -113,9 +113,9 @@ class Feed_Improvements implements Integration_Interface {
 	 * @return string The canonical URL for the queried object.
 	 */
 	protected function get_url_for_queried_object( $url = '' ) {
-		$queried_object = get_queried_object();
+		$queried_object = \get_queried_object();
 		// Don't call get_class with null. This gives a warning.
-		$class = ( $queried_object !== null ) ? get_class( $queried_object ) : null;
+		$class = ( $queried_object !== null ) ? \get_class( $queried_object ) : null;
 
 		switch ( $class ) {
 			// Post type archive feeds.


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Brings some of the RSS feed enhancements we've long done on yoast.com to Yoast SEO.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds canonical HTTP headers from RSS feeds to their parent URLs (for instance your homepage, or specific categories or tags), so the feeds themselves don't show up in search results.
* Makes sure the title separator chosen in Yoast SEO is used for RSS feed titles too.
* Makes sure the `link` tag in the RSS feeds' `channel` section links to the most specific URL possible (for instance the category or tag the RSS feed is for) instead of the homepage.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Make sure that feeds are enabled
* Repeat the checks below for all these types of feeds:
  * category feeds e.g. http://basic.wordpress.test/category/configurable-responsive-framework/feed/
  * tag feeds e.g. http://basic.wordpress.test/tag/assimilated-dedicated-flexibility/feed/
  * custom taxonomy feeds e.g. http://basic.wordpress.test/yoast-test-book-genre/crime/feed/
  * custom post type feeds e.g. http://basic.wordpress.test/my-books/feed/
  * post author feeds e.g. http://basic.wordpress.test/author/ansel73/feed/
  * post comment feed e.g. http://basic.wordpress.test/2022/06/adaptive-homogeneous-challenge/feed
* In the Network tab of your inspector, see that there is a `Link` HTTP header with `rel="canonical"` for every RSS feed, that has the URL of the page related to the feed (i.e. without `/feed` in the end)
* See that the `<link>` element in the `<channel>` section links to the same URL
* See that the separator used in the title is the one selected in Yoast SEO > Search Appearance

* Repeat the above check
  * for the home page [global comment feed] e.g. http://basic.wordpress.test/feed/
  * for date archives feeds e.g. http://basic.wordpress.test/2022/feed/
  * for search results feeds e.g. http://basic.wordpress.test/?s=and&feed=feed
* In the Network tab of your inspector, see that there is a `Link` HTTP header with `rel="canonical"` for every RSS feed, that has the URL of the home page
* See that the `<link>` element in the `<channel>` section links to the URL of the home page
* See that the separator used in the title is the one selected in Yoast SEO > Search Appearance

* If you test feeds that have multiple pages and add `?paged=2` to them, e.g.  http://basic.wordpress.test/category/configurable-responsive-framework/feed/?paged=2, the URL in the `<link>` tag and in the `Link` header should be e.g. http://basic.wordpress.test/category/configurable-responsive-framework/page/2

**When testing this on yoast.com, be sure to delete `site/core-yoastcom/WordPress/Integration/YoastSEO/Feeds.php` first.**

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes PRODUCT-179
