### PR TITLE
Don't encode ampersands in URLs

### DIFF
--- a/inc/sitemaps/class-sitemap-image-parser.php
+++ b/inc/sitemaps/class-sitemap-image-parser.php
@@ -208,7 +208,7 @@ class WPSEO_Sitemap_Image_Parser {
 				continue;
 			}
 
-			if ( $src !== esc_url( $src ) ) {
+			if ( $src !== esc_url( $src, null, 'attribute' ) ) {
 				continue;
 			}
 

--- a/inc/sitemaps/class-sitemaps-renderer.php
+++ b/inc/sitemaps/class-sitemaps-renderer.php
@@ -269,6 +269,7 @@ class WPSEO_Sitemaps_Renderer {
 		$url = $this->encode_url_rfc3986( $url );
 		$url = esc_url( $url );
 		$url = str_replace( '&#038;', '&amp;', $url );
+		$url = str_replace( '&#039;', '&apos;', $url );
 
 		if ( strpos( $url, '//' ) === 0 ) {
 			// Schema-relative URL for which esc_url() does not add a scheme.

--- a/tests/integration/sitemaps/test-class-wpseo-sitemaps-renderer.php
+++ b/tests/integration/sitemaps/test-class-wpseo-sitemaps-renderer.php
@@ -131,6 +131,10 @@ class WPSEO_Sitemaps_Renderer_Test extends WPSEO_UnitTestCase {
 				'loc'      => 'http://example.com/page-name?s=keyword&#038;p=2#anchor',
 				'expected' => 'http://example.com/page-name?s=keyword&amp;p=2#anchor',
 			],
+			'Full URL which will validate with the filter - contains &#039;' => [
+				'loc'      => 'http://example.com/page-name?s=keyword&p=\'2&#039;#anchor',
+				'expected' => 'http://example.com/page-name?s=keyword&amp;p=&apos;2&apos;#anchor',
+			],
 
 			/*
 			 * All the below URLs will not validate with `FILTER_VALIDATE_URL` and will therefore


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the sitemap `image:loc` URLs containing ampersands would lead to encoding issues.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

-- **Make sure you test this with images uploaded to the current WordPress installation** --

* Add an images to a post, containing query attributes. E.g. `https://www.example.com/path/?query=value&cats=cool`.
* Open the sitemap source and verify that:
  * the images are present 
  * the ampersand did not get transformed (to `&#038;`)
* Add an images to a post, containing single quotes in some forms. E.g. `https://www.example.com/path/?query='value&apos;`
* Open the sitemap source and verify that:
  * the images are present 
  * the single quote did get transformed to `&apos;`
  * the `&apos;` did not get transformed (to `&#039;`)

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes P1-1426
