### PR TITLE
PHPCS: Increase ObjectNameDepth limit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -84,7 +84,7 @@
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_coding_standards"
 		],
 		"check-cs-thresholds": [
-			"@putenv YOASTCS_THRESHOLD_ERRORS=241",
+			"@putenv YOASTCS_THRESHOLD_ERRORS=173",
 			"@putenv YOASTCS_THRESHOLD_WARNINGS=217",
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_cs_thresholds"
 		],

--- a/config/dependency-injection/inject-from-registry-pass.php
+++ b/config/dependency-injection/inject-from-registry-pass.php
@@ -13,8 +13,6 @@ use Yoast\WP\SEO\Loadable_Interface;
 
 /**
  * Inject_From_Registry_Pass class
- *
- * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded -- 4 words is fine.
  */
 class Inject_From_Registry_Pass extends AbstractRecursivePass {
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -112,6 +112,13 @@
 		</properties>
 	</rule>
 
+	<rule ref="Yoast.NamingConventions.ObjectNameDepth">
+		<properties>
+			<property name="max_words" value="5" />
+			<property name="recommended_max_words" value="5" />
+		</properties>
+	</rule>
+
 	<rule ref="Yoast.NamingConventions.NamespaceName">
 		<properties>
 			<!-- Indicate which directories should be treated as project root directories for
@@ -174,10 +181,7 @@
 
 	<!-- Exclude select directories from the object depth naming convention check. -->
 	<rule ref="Yoast.NamingConventions.ObjectNameDepth.MaxExceeded">
-		<exclude-pattern>/config/php-codeshift/*</exclude-pattern>
-		<exclude-pattern>/src/conditionals/*</exclude-pattern>
 		<exclude-pattern>/src/config/migrations/*</exclude-pattern>
-		<exclude-pattern>/src/generators/schema/third-party/*</exclude-pattern>
 	</rule>
 
 	<!-- Exclude third-party from being checked too roughly. -->

--- a/src/actions/configuration/first-time-configuration-action.php
+++ b/src/actions/configuration/first-time-configuration-action.php
@@ -5,7 +5,6 @@ namespace Yoast\WP\SEO\Actions\Configuration;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Integrations\Admin\Social_Profiles_Helper;
 
-// phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded -- First time configuration simply has a lot of words.
 /**
  * Class First_Time_Configuration_Action.
  */

--- a/src/actions/importing/abstract-aioseo-importing-action.php
+++ b/src/actions/importing/abstract-aioseo-importing-action.php
@@ -13,8 +13,6 @@ use Yoast\WP\SEO\Services\Importing\Aioseo\Aioseo_Robots_Transformer_Service;
 
 /**
  * Importing action interface.
- *
- * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
 abstract class Abstract_Aioseo_Importing_Action implements Importing_Action_Interface {
 

--- a/src/actions/importing/aioseo/abstract-aioseo-settings-importing-action.php
+++ b/src/actions/importing/aioseo/abstract-aioseo-settings-importing-action.php
@@ -9,8 +9,6 @@ use Yoast\WP\SEO\Helpers\Import_Helper;
 
 /**
  * Abstract class for importing AIOSEO settings.
- *
- * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
 abstract class Abstract_Aioseo_Settings_Importing_Action extends Abstract_Aioseo_Importing_Action {
 

--- a/src/actions/importing/aioseo/aioseo-cleanup-action.php
+++ b/src/actions/importing/aioseo/aioseo-cleanup-action.php
@@ -9,8 +9,6 @@ use Yoast\WP\SEO\Helpers\Options_Helper;
 
 /**
  * Importing action for cleaning up AIOSEO data.
- *
- * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
 class Aioseo_Cleanup_Action extends Abstract_Aioseo_Importing_Action {
 

--- a/src/actions/importing/aioseo/aioseo-general-settings-importing-action.php
+++ b/src/actions/importing/aioseo/aioseo-general-settings-importing-action.php
@@ -13,8 +13,6 @@ use Yoast\WP\SEO\Services\Importing\Aioseo\Aioseo_Robots_Transformer_Service;
 
 /**
  * Importing action for AIOSEO general settings.
- *
- * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
 class Aioseo_General_Settings_Importing_Action extends Abstract_Aioseo_Settings_Importing_Action {
 

--- a/src/actions/importing/aioseo/aioseo-posts-importing-action.php
+++ b/src/actions/importing/aioseo/aioseo-posts-importing-action.php
@@ -20,8 +20,6 @@ use Yoast\WP\SEO\Services\Importing\Aioseo\Aioseo_Social_Images_Provider_Service
 
 /**
  * Importing action for AIOSEO post data.
- *
- * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
 class Aioseo_Posts_Importing_Action extends Abstract_Aioseo_Importing_Action {
 

--- a/src/actions/importing/aioseo/aioseo-taxonomy-settings-importing-action.php
+++ b/src/actions/importing/aioseo/aioseo-taxonomy-settings-importing-action.php
@@ -5,8 +5,6 @@ namespace Yoast\WP\SEO\Actions\Importing\Aioseo;
 
 /**
  * Importing action for AIOSEO taxonomies settings data.
- *
- * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
 class Aioseo_Taxonomy_Settings_Importing_Action extends Abstract_Aioseo_Settings_Importing_Action {
 

--- a/src/actions/importing/aioseo/aioseo-validate-data-action.php
+++ b/src/actions/importing/aioseo/aioseo-validate-data-action.php
@@ -10,8 +10,6 @@ use Yoast\WP\SEO\Actions\Importing\Abstract_Aioseo_Importing_Action;
 
 /**
  * Importing action for validating AIOSEO data before the import occurs.
- *
- * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
 class Aioseo_Validate_Data_Action extends Abstract_Aioseo_Importing_Action {
 

--- a/src/actions/importing/deactivate-conflicting-plugins-action.php
+++ b/src/actions/importing/deactivate-conflicting-plugins-action.php
@@ -14,8 +14,6 @@ use Yoast\WP\SEO\Services\Importing\Conflicting_Plugins_Service;
 
 /**
  * Deactivates plug-ins that cause conflicts with Yoast SEO.
- *
- * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
 class Deactivate_Conflicting_Plugins_Action extends Abstract_Aioseo_Importing_Action {
 

--- a/src/actions/indexing/abstract-link-indexing-action.php
+++ b/src/actions/indexing/abstract-link-indexing-action.php
@@ -9,8 +9,6 @@ use Yoast\WP\SEO\Repositories\Indexable_Repository;
 
 /**
  * Reindexing action for link indexables.
- *
- * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
 abstract class Abstract_Link_Indexing_Action extends Abstract_Indexing_Action {
 

--- a/src/actions/indexing/indexable-general-indexation-action.php
+++ b/src/actions/indexing/indexable-general-indexation-action.php
@@ -7,8 +7,6 @@ use Yoast\WP\SEO\Repositories\Indexable_Repository;
 
 /**
  * General reindexing action for indexables.
- *
- * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
 class Indexable_General_Indexation_Action implements Indexation_Action_Interface, Limited_Indexing_Action_Interface {
 

--- a/src/actions/indexing/indexable-indexing-complete-action.php
+++ b/src/actions/indexing/indexable-indexing-complete-action.php
@@ -6,8 +6,6 @@ use Yoast\WP\SEO\Helpers\Indexable_Helper;
 
 /**
  * Indexing action to call when the indexable indexing process is completed.
- *
- * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
 class Indexable_Indexing_Complete_Action {
 

--- a/src/actions/indexing/indexable-post-indexation-action.php
+++ b/src/actions/indexing/indexable-post-indexation-action.php
@@ -12,8 +12,6 @@ use Yoast\WP\SEO\Values\Indexables\Indexable_Builder_Versions;
 
 /**
  * Reindexing action for post indexables.
- *
- * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
 class Indexable_Post_Indexation_Action extends Abstract_Indexing_Action {
 

--- a/src/actions/indexing/indexable-term-indexation-action.php
+++ b/src/actions/indexing/indexable-term-indexation-action.php
@@ -11,8 +11,6 @@ use Yoast\WP\SEO\Values\Indexables\Indexable_Builder_Versions;
 
 /**
  * Reindexing action for term indexables.
- *
- * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
 class Indexable_Term_Indexation_Action extends Abstract_Indexing_Action {
 

--- a/src/actions/indexing/limited-indexing-action-interface.php
+++ b/src/actions/indexing/limited-indexing-action-interface.php
@@ -4,8 +4,6 @@ namespace Yoast\WP\SEO\Actions\Indexing;
 
 /**
  * Interface definition of a reindexing action for indexables that have a limited unindexed count.
- *
- * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
 interface Limited_Indexing_Action_Interface {
 

--- a/src/actions/indexing/post-link-indexing-action.php
+++ b/src/actions/indexing/post-link-indexing-action.php
@@ -7,8 +7,6 @@ use Yoast\WP\SEO\Helpers\Post_Type_Helper;
 
 /**
  * Reindexing action for post link indexables.
- *
- * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
 class Post_Link_Indexing_Action extends Abstract_Link_Indexing_Action {
 

--- a/src/actions/indexing/term-link-indexing-action.php
+++ b/src/actions/indexing/term-link-indexing-action.php
@@ -7,8 +7,6 @@ use Yoast\WP\SEO\Helpers\Taxonomy_Helper;
 
 /**
  * Reindexing action for term link indexables.
- *
- * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
 class Term_Link_Indexing_Action extends Abstract_Link_Indexing_Action {
 

--- a/src/builders/indexable-date-archive-builder.php
+++ b/src/builders/indexable-date-archive-builder.php
@@ -10,8 +10,6 @@ use Yoast\WP\SEO\Values\Indexables\Indexable_Builder_Versions;
  * Date Archive Builder for the indexables.
  *
  * Formats the date archive meta to indexable format.
- *
- * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
 class Indexable_Date_Archive_Builder {
 

--- a/src/builders/indexable-home-page-builder.php
+++ b/src/builders/indexable-home-page-builder.php
@@ -13,8 +13,6 @@ use Yoast\WP\SEO\Values\Indexables\Indexable_Builder_Versions;
  * Homepage Builder for the indexables.
  *
  * Formats the homepage meta to indexable format.
- *
- * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
 class Indexable_Home_Page_Builder {
 

--- a/src/builders/indexable-post-type-archive-builder.php
+++ b/src/builders/indexable-post-type-archive-builder.php
@@ -12,8 +12,6 @@ use Yoast\WP\SEO\Values\Indexables\Indexable_Builder_Versions;
  * Post type archive builder for the indexables.
  *
  * Formats the post type archive meta to indexable format.
- *
- * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
 class Indexable_Post_Type_Archive_Builder {
 

--- a/src/builders/indexable-social-image-trait.php
+++ b/src/builders/indexable-social-image-trait.php
@@ -12,8 +12,6 @@ use Yoast\WP\SEO\Models\Indexable;
  * Trait for determine the social image to use in the indexable.
  *
  * Represents the trait used in builders for handling social images.
- *
- * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
 trait Indexable_Social_Image_Trait {
 

--- a/src/builders/indexable-system-page-builder.php
+++ b/src/builders/indexable-system-page-builder.php
@@ -10,8 +10,6 @@ use Yoast\WP\SEO\Values\Indexables\Indexable_Builder_Versions;
  * System page builder for the indexables.
  *
  * Formats system pages ( search and error ) meta to indexable format.
- *
- * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
 class Indexable_System_Page_Builder {
 

--- a/src/conditionals/admin/doing-post-quick-edit-save-conditional.php
+++ b/src/conditionals/admin/doing-post-quick-edit-save-conditional.php
@@ -4,10 +4,10 @@ namespace Yoast\WP\SEO\Conditionals\Admin;
 
 use Yoast\WP\SEO\Conditionals\Conditional;
 
-// phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded -- Base class can't be written shorter without abbreviating.
-
 /**
  * Checks if the post is saved by inline-save. This is the case when doing quick edit.
+ *
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded -- Base class can't be written shorter without abbreviating.
  */
 class Doing_Post_Quick_Edit_Save_Conditional implements Conditional {
 
@@ -35,4 +35,3 @@ class Doing_Post_Quick_Edit_Save_Conditional implements Conditional {
 		return ( $sanitized_action === 'inline-save' );
 	}
 }
-// phpcs:enable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded -- Base class can't be written shorter without abbreviating.

--- a/src/conditionals/user-can-manage-wpseo-options-conditional.php
+++ b/src/conditionals/user-can-manage-wpseo-options-conditional.php
@@ -4,6 +4,8 @@ namespace Yoast\WP\SEO\Conditionals;
 
 /**
  * Conditional that is only met when the current user has the `wpseo_manage_options` capability.
+ *
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
 class User_Can_Manage_Wpseo_Options_Conditional implements Conditional {
 

--- a/src/conditionals/yoast-admin-and-dashboard-conditional.php
+++ b/src/conditionals/yoast-admin-and-dashboard-conditional.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore Yoast.Files.FileName.InvalidClassFileName -- Reason: this explicitly concerns the Yoast admin and dashboard.
 
 namespace Yoast\WP\SEO\Conditionals;
 

--- a/src/conditionals/yoast-tools-page-conditional.php
+++ b/src/conditionals/yoast-tools-page-conditional.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore Yoast.Files.FileName.InvalidClassFileName -- Reason: this explicitly concerns the Yoast tools page.
 
 namespace Yoast\WP\SEO\Conditionals;
 

--- a/src/exceptions/addon-installation/addon-activation-error-exception.php
+++ b/src/exceptions/addon-installation/addon-activation-error-exception.php
@@ -1,7 +1,5 @@
 <?php
 
-// phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded -- Discussed in Tech Council, a better solution is being worked on.
-
 namespace Yoast\WP\SEO\Exceptions\Addon_Installation;
 
 use Exception;

--- a/src/exceptions/addon-installation/addon-already-installed-exception.php
+++ b/src/exceptions/addon-installation/addon-already-installed-exception.php
@@ -1,7 +1,5 @@
 <?php
 
-// phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded -- Discussed in Tech Council, a better solution is being worked on.
-
 namespace Yoast\WP\SEO\Exceptions\Addon_Installation;
 
 use Exception;

--- a/src/exceptions/addon-installation/addon-installation-error-exception.php
+++ b/src/exceptions/addon-installation/addon-installation-error-exception.php
@@ -1,7 +1,5 @@
 <?php
 
-// phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded -- Discussed in Tech Council, a better solution is being worked on.
-
 namespace Yoast\WP\SEO\Exceptions\Addon_Installation;
 
 use Exception;

--- a/src/exceptions/addon-installation/user-cannot-activate-plugins-exception.php
+++ b/src/exceptions/addon-installation/user-cannot-activate-plugins-exception.php
@@ -1,7 +1,5 @@
 <?php
 
-// phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded -- Discussed in Tech Council, a better solution is being worked on.
-
 namespace Yoast\WP\SEO\Exceptions\Addon_Installation;
 
 use Exception;

--- a/src/exceptions/addon-installation/user-cannot-install-plugins-exception.php
+++ b/src/exceptions/addon-installation/user-cannot-install-plugins-exception.php
@@ -1,7 +1,5 @@
 <?php
 
-// phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded -- Discussed in Tech Council, a better solution is being worked on.
-
 namespace Yoast\WP\SEO\Exceptions\Addon_Installation;
 
 use Exception;

--- a/src/helpers/import-cursor-helper.php
+++ b/src/helpers/import-cursor-helper.php
@@ -4,7 +4,6 @@ namespace Yoast\WP\SEO\Helpers;
 
 /**
  * The Import Cursor Helper.
- * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
 class Import_Cursor_Helper {
 

--- a/src/helpers/indexable-to-postmeta-helper.php
+++ b/src/helpers/indexable-to-postmeta-helper.php
@@ -6,7 +6,6 @@ use Yoast\WP\SEO\Models\Indexable;
 
 /**
  * A helper object to map indexable data to postmeta.
- * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
 class Indexable_To_Postmeta_Helper {
 

--- a/src/integrations/abstract-exclude-post-type.php
+++ b/src/integrations/abstract-exclude-post-type.php
@@ -4,8 +4,6 @@ namespace Yoast\WP\SEO\Integrations;
 
 /**
  * Abstract class for excluding certain post types from being indexed.
- *
- * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
 abstract class Abstract_Exclude_Post_Type implements Integration_Interface {
 

--- a/src/integrations/admin/first-time-configuration-integration.php
+++ b/src/integrations/admin/first-time-configuration-integration.php
@@ -15,7 +15,6 @@ use Yoast\WP\SEO\Integrations\Integration_Interface;
 use Yoast\WP\SEO\Integrations\Admin\Social_Profiles_Helper;
 use Yoast\WP\SEO\Routes\Indexing_Route;
 
-// phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded -- First time configuration simply has a lot of words.
 /**
  * First_Time_Configuration_Integration class
  */

--- a/src/integrations/admin/first-time-configuration-notice-integration.php
+++ b/src/integrations/admin/first-time-configuration-notice-integration.php
@@ -9,7 +9,6 @@ use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
 use Yoast\WP\SEO\Presenters\Admin\Notice_Presenter;
 
-// phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded -- First time configuration simply has a lot of words.
 /**
  * First_Time_Configuration_Notice_Integration class
  */

--- a/src/integrations/exclude-oembed-cache-post-type.php
+++ b/src/integrations/exclude-oembed-cache-post-type.php
@@ -8,8 +8,6 @@ use Yoast\WP\SEO\Conditionals\Migrations_Conditional;
  * Excludes certain oEmbed Cache-specific post types from the indexable table.
  *
  * Posts with these post types will not be saved to the indexable table.
- *
- * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
 class Exclude_Oembed_Cache_Post_Type extends Abstract_Exclude_Post_Type {
 

--- a/src/integrations/third-party/exclude-elementor-post-types.php
+++ b/src/integrations/third-party/exclude-elementor-post-types.php
@@ -9,8 +9,6 @@ use Yoast\WP\SEO\Integrations\Abstract_Exclude_Post_Type;
  * Excludes certain Elementor-specific post types from the indexable table.
  *
  * Posts with these post types will not be saved to the indexable table.
- *
- * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
 class Exclude_Elementor_Post_Types extends Abstract_Exclude_Post_Type {
 

--- a/src/integrations/third-party/exclude-woocommerce-post-types.php
+++ b/src/integrations/third-party/exclude-woocommerce-post-types.php
@@ -9,8 +9,6 @@ use Yoast\WP\SEO\Integrations\Abstract_Exclude_Post_Type;
  * Excludes certain WooCommerce-specific post types from the indexable table.
  *
  * Posts with these post types will not be saved to the indexable table.
- *
- * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
 class Exclude_WooCommerce_Post_Types extends Abstract_Exclude_Post_Type {
 

--- a/src/integrations/watchers/indexable-home-page-watcher.php
+++ b/src/integrations/watchers/indexable-home-page-watcher.php
@@ -11,8 +11,6 @@ use Yoast\WP\SEO\Repositories\Indexable_Repository;
  * Home page watcher to save the meta data to an Indexable.
  *
  * Watches the home page options to save the meta information when updated.
- *
- * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded -- 4 words is fine.
  */
 class Indexable_Home_Page_Watcher implements Integration_Interface {
 

--- a/src/integrations/watchers/indexable-post-type-archive-watcher.php
+++ b/src/integrations/watchers/indexable-post-type-archive-watcher.php
@@ -11,8 +11,6 @@ use Yoast\WP\SEO\Repositories\Indexable_Repository;
  * Post type archive watcher to save the meta data to an Indexable.
  *
  * Watches the home page options to save the meta information when updated.
- *
- * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
 class Indexable_Post_Type_Archive_Watcher implements Integration_Interface {
 

--- a/src/integrations/watchers/primary-category-quick-edit-watcher.php
+++ b/src/integrations/watchers/primary-category-quick-edit-watcher.php
@@ -14,8 +14,6 @@ use Yoast\WP\SEO\Models\Indexable;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
 use Yoast\WP\SEO\Repositories\Primary_Term_Repository;
 
-// phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded -- Base class can't be written shorter without abbreviating.
-
 /**
  * Class Primary_Category_Quick_Edit_Watcher
  */
@@ -189,4 +187,3 @@ class Primary_Category_Quick_Edit_Watcher implements Integration_Interface {
 		}
 	}
 }
-// phpcs:enable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded

--- a/src/memoizers/meta-tags-context-memoizer.php
+++ b/src/memoizers/meta-tags-context-memoizer.php
@@ -10,8 +10,6 @@ use Yoast\WP\SEO\Repositories\Indexable_Repository;
 
 /**
  * The meta tags context memoizer.
- *
- * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded -- 4 words is fine.
  */
 class Meta_Tags_Context_Memoizer {
 

--- a/src/presenters/abstract-indexable-tag-presenter.php
+++ b/src/presenters/abstract-indexable-tag-presenter.php
@@ -4,7 +4,7 @@ namespace Yoast\WP\SEO\Presenters;
 
 /**
  * Abstract presenter class for indexable tag presentations.
- * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
+ *
  * @phpcs:disable Yoast.Files.FileName.InvalidClassFileName
  */
 abstract class Abstract_Indexable_Tag_Presenter extends Abstract_Indexable_Presenter {

--- a/src/presenters/admin/indexing-failed-notification-presenter.php
+++ b/src/presenters/admin/indexing-failed-notification-presenter.php
@@ -1,5 +1,4 @@
 <?php
-// phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
 
 namespace Yoast\WP\SEO\Presenters\Admin;
 

--- a/src/presenters/open-graph/article-modified-time-presenter.php
+++ b/src/presenters/open-graph/article-modified-time-presenter.php
@@ -6,7 +6,6 @@ use Yoast\WP\SEO\Presenters\Abstract_Indexable_Tag_Presenter;
 
 /**
  * Presenter class for the Open Graph article modified time.
- * phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
 class Article_Modified_Time_Presenter extends Abstract_Indexable_Tag_Presenter {
 

--- a/src/presenters/open-graph/article-published-time-presenter.php
+++ b/src/presenters/open-graph/article-published-time-presenter.php
@@ -6,8 +6,6 @@ use Yoast\WP\SEO\Presenters\Abstract_Indexable_Tag_Presenter;
 
 /**
  * Presenter class for the Open Graph article published time.
- *
- * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
 class Article_Published_Time_Presenter extends Abstract_Indexable_Tag_Presenter {
 

--- a/src/routes/first-time-configuration-route.php
+++ b/src/routes/first-time-configuration-route.php
@@ -8,7 +8,6 @@ use Yoast\WP\SEO\Actions\Configuration\First_Time_Configuration_Action;
 use Yoast\WP\SEO\Conditionals\No_Conditionals;
 use Yoast\WP\SEO\Main;
 
-// phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded -- First time configuration simply has a lot of words.
 /**
  * First_Time_Configuration_Route class.
  */

--- a/src/routes/yoast-head-rest-field.php
+++ b/src/routes/yoast-head-rest-field.php
@@ -1,4 +1,4 @@
-<?php // @phpcs:ignore Yoast.Files.FileName.InvalidClassFileName -- reason: this explicitly concerns the Yoast head fields.
+<?php // phpcs:ignore Yoast.Files.FileName.InvalidClassFileName -- Reason: this explicitly concerns the Yoast head fields.
 
 namespace Yoast\WP\SEO\Routes;
 

--- a/src/routes/yoast-head-rest-field.php
+++ b/src/routes/yoast-head-rest-field.php
@@ -13,8 +13,6 @@ use Yoast\WP\SEO\Helpers\Taxonomy_Helper;
  *
  * Registers the yoast head REST field.
  * Not technically a route but behaves the same so is included here.
- *
- * @phpcs:ignore Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
 class Yoast_Head_REST_Field implements Route_Interface {
 

--- a/src/services/health-check/default-tagline-reports.php
+++ b/src/services/health-check/default-tagline-reports.php
@@ -4,8 +4,6 @@ namespace Yoast\WP\SEO\Services\Health_Check;
 
 /**
  * Presents a set of different messages for the Default_Tagline health check.
- *
- * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
 class Default_Tagline_Reports {
 	use Reports_Trait;

--- a/src/services/health-check/myyoast-api-request-factory.php
+++ b/src/services/health-check/myyoast-api-request-factory.php
@@ -4,7 +4,6 @@ namespace Yoast\WP\SEO\Services\Health_Check;
 
 use WPSEO_MyYoast_Api_Request;
 
-// phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
 /**
  * Creates WPSEO_MyYoast_Api_Request objects.
  */

--- a/src/services/importing/aioseo/aioseo-robots-provider-service.php
+++ b/src/services/importing/aioseo/aioseo-robots-provider-service.php
@@ -7,8 +7,6 @@ use Yoast\WP\SEO\Helpers\Aioseo_Helper;
 
 /**
  * Provides AISOEO search appearance robot settings.
- *
- * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
 class Aioseo_Robots_Provider_Service {
 

--- a/src/services/importing/aioseo/aioseo-robots-transformer-service.php
+++ b/src/services/importing/aioseo/aioseo-robots-transformer-service.php
@@ -5,8 +5,6 @@ namespace Yoast\WP\SEO\Services\Importing\Aioseo;
 
 /**
  * Transforms AISOEO search appearance robot settings.
- *
- * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
 class Aioseo_Robots_Transformer_Service {
 

--- a/src/services/importing/aioseo/aioseo-social-images-provider-service.php
+++ b/src/services/importing/aioseo/aioseo-social-images-provider-service.php
@@ -8,8 +8,6 @@ use Yoast\WP\SEO\Helpers\Image_Helper;
 
 /**
  * Provides AISOEO social images urls.
- *
- * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
 class Aioseo_Social_Images_Provider_Service {
 

--- a/src/surfaces/open-graph-helpers-surface.php
+++ b/src/surfaces/open-graph-helpers-surface.php
@@ -10,8 +10,6 @@ use YoastSEO_Vendor\Symfony\Component\DependencyInjection\ContainerInterface;
  *
  * Surface for the indexables.
  *
- * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded -- 4 words is fine.
- *
  * @property Open_Graph\Image_Helper $image
  */
 class Open_Graph_Helpers_Surface {

--- a/tests/unit/actions/configuration/first-time-configuration-action-test.php
+++ b/tests/unit/actions/configuration/first-time-configuration-action-test.php
@@ -9,7 +9,6 @@ use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Integrations\Admin\Social_Profiles_Helper;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
-// phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded -- First time configuration simply has a lot of words.
 /**
  * Class First_Time_Configuration_Action_Test
  *

--- a/tests/unit/actions/importing/abstract-aioseo-importing-action-test.php
+++ b/tests/unit/actions/importing/abstract-aioseo-importing-action-test.php
@@ -19,7 +19,6 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  * @group indexing
  *
  * @coversDefaultClass \Yoast\WP\SEO\Actions\Importing\Abstract_Aioseo_Importing_Action
- * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
 class Abstract_Aioseo_Importing_Action_Test extends TestCase {
 

--- a/tests/unit/actions/importing/aioseo-cleanup-action-test.php
+++ b/tests/unit/actions/importing/aioseo-cleanup-action-test.php
@@ -16,7 +16,6 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  * @group importing
  *
  * @coversDefaultClass \Yoast\WP\SEO\Actions\Importing\Aioseo\Aioseo_Cleanup_Action
- * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
 class Aioseo_Cleanup_Action_Test extends TestCase {
 

--- a/tests/unit/actions/importing/aioseo-posts-importing-action-test.php
+++ b/tests/unit/actions/importing/aioseo-posts-importing-action-test.php
@@ -30,7 +30,7 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  * @group importing
  *
  * @coversDefaultClass \Yoast\WP\SEO\Actions\Importing\Aioseo\Aioseo_Posts_Importing_Action
- * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded,Yoast.Yoast.AlternativeFunctions.json_encode_json_encode
+ * @phpcs:disable Yoast.Yoast.AlternativeFunctions.json_encode_json_encode
  */
 class Aioseo_Posts_Importing_Action_Test extends TestCase {
 

--- a/tests/unit/actions/importing/aioseo-validate-data-action-test.php
+++ b/tests/unit/actions/importing/aioseo-validate-data-action-test.php
@@ -22,7 +22,7 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  * @group importing
  *
  * @coversDefaultClass \Yoast\WP\SEO\Actions\Importing\Aioseo\Aioseo_Validate_Data_Action
- * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded, Yoast.Yoast.AlternativeFunctions.json_encode_json_encode
+ * @phpcs:disable Yoast.Yoast.AlternativeFunctions.json_encode_json_encode
  */
 class Aioseo_Validate_Data_Action_Test extends TestCase {
 

--- a/tests/unit/actions/importing/deactivate-conflicting-plugins-action-test.php
+++ b/tests/unit/actions/importing/deactivate-conflicting-plugins-action-test.php
@@ -20,7 +20,6 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  * @group importing
  *
  * @coversDefaultClass \Yoast\WP\SEO\Actions\Importing\Deactivate_Conflicting_Plugins_Action
- * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
 class Deactivate_Conflicting_Plugins_Action_Test extends TestCase {
 

--- a/tests/unit/actions/indexing/indexable-post-indexation-action-test.php
+++ b/tests/unit/actions/indexing/indexable-post-indexation-action-test.php
@@ -20,8 +20,6 @@ use Yoast\WP\SEO\Values\Indexables\Indexable_Builder_Versions;
  * @group indexing
  *
  * @coversDefaultClass \Yoast\WP\SEO\Actions\Indexing\Indexable_Post_Indexation_Action
- *
- * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
 class Indexable_Post_Indexation_Action_Test extends TestCase {
 

--- a/tests/unit/actions/indexing/indexable-post-type-archive-indexation-action-test.php
+++ b/tests/unit/actions/indexing/indexable-post-type-archive-indexation-action-test.php
@@ -21,6 +21,8 @@ use Yoast\WP\SEO\Values\Indexables\Indexable_Builder_Versions;
  * @group indexing
  *
  * @coversDefaultClass \Yoast\WP\SEO\Actions\Indexing\Indexable_Post_Type_Archive_Indexation_Action
+ *
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
 class Indexable_Post_Type_Archive_Indexation_Action_Test extends TestCase {
 

--- a/tests/unit/actions/indexing/indexable-term-indexation-action-test.php
+++ b/tests/unit/actions/indexing/indexable-term-indexation-action-test.php
@@ -19,8 +19,6 @@ use Yoast\WP\SEO\Values\Indexables\Indexable_Builder_Versions;
  * @group indexing
  *
  * @coversDefaultClass \Yoast\WP\SEO\Actions\Indexing\Indexable_Term_Indexation_Action
- *
- * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
 class Indexable_Term_Indexation_Action_Test extends TestCase {
 

--- a/tests/unit/admin/admin-gutenberg-compatibility-notification-test.php
+++ b/tests/unit/admin/admin-gutenberg-compatibility-notification-test.php
@@ -1,11 +1,4 @@
 <?php
-// phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded -- WPSEO_Admin_Gutenberg_Compatibility_Notification_Test.
-
-/**
- * WPSEO plugin test file.
- *
- * @package WPSEO\Tests\Admin
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Admin;
 
@@ -20,6 +13,8 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  * @group MyYoast
  *
  * @coversDefaultClass WPSEO_Admin_Gutenberg_Compatibility_Notification
+ *
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
 class WPSEO_Admin_Gutenberg_Compatibility_Notification_Test extends TestCase {
 

--- a/tests/unit/admin/import/plugins/import-aioseo-v4-test.php
+++ b/tests/unit/admin/import/plugins/import-aioseo-v4-test.php
@@ -12,8 +12,6 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  * Tests for the All-in-One SEO V4 import feature.
  *
  * @coversDefaultClass WPSEO_Import_AIOSEO_V4
- *
- * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
 class WPSEO_Import_AIOSEO_V4_Test extends TestCase {
 

--- a/tests/unit/builders/indexable-date-archive-builder-test.php
+++ b/tests/unit/builders/indexable-date-archive-builder-test.php
@@ -19,8 +19,6 @@ use Yoast\WP\SEO\Values\Indexables\Indexable_Builder_Versions;
  *
  * @coversDefaultClass \Yoast\WP\SEO\Builders\Indexable_Date_Archive_Builder
  * @covers \Yoast\WP\SEO\Builders\Indexable_Date_Archive_Builder
- *
- * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
 class Indexable_Date_Archive_Builder_Test extends TestCase {
 

--- a/tests/unit/builders/indexable-home-page-builder-test.php
+++ b/tests/unit/builders/indexable-home-page-builder-test.php
@@ -25,8 +25,6 @@ use Yoast\WP\SEO\Values\Indexables\Indexable_Builder_Versions;
  *
  * @coversDefaultClass \Yoast\WP\SEO\Builders\Indexable_Author_Builder
  * @covers \Yoast\WP\SEO\Builders\Indexable_Home_Page_Builder
- *
- * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded -- 5 words is fine.
  */
 class Indexable_Home_Page_Builder_Test extends TestCase {
 

--- a/tests/unit/builders/indexable-system-page-builder-test.php
+++ b/tests/unit/builders/indexable-system-page-builder-test.php
@@ -19,8 +19,6 @@ use Yoast\WP\SEO\Values\Indexables\Indexable_Builder_Versions;
  *
  * @coversDefaultClass \Yoast\WP\SEO\Builders\Indexable_System_Page_Builder
  * @covers \Yoast\WP\SEO\Builders\Indexable_System_Page_Builder
- *
- * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
 class Indexable_System_Page_Builder_Test extends TestCase {
 

--- a/tests/unit/conditionals/admin/doing-post-quick-edit-save-conditional-test.php
+++ b/tests/unit/conditionals/admin/doing-post-quick-edit-save-conditional-test.php
@@ -6,14 +6,14 @@ use Brain\Monkey;
 use Yoast\WP\SEO\Conditionals\Admin\Doing_Post_Quick_Edit_Save_Conditional;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
-// phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded -- Base class can't be written shorter without abbreviating.
-
 /**
  * Class Doing_Post_Quick_Edit_Save_Conditional
  *
  * @group conditionals
  *
  * @coversDefaultClass \Yoast\WP\SEO\Conditionals\Admin\Doing_Post_Quick_Edit_Save_Conditional
+ *
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded -- Base class can't be written shorter without abbreviating.
  */
 class Doing_Post_Quick_Edit_Save_Conditional_Test extends TestCase {
 
@@ -95,4 +95,3 @@ class Doing_Post_Quick_Edit_Save_Conditional_Test extends TestCase {
 		self::assertTrue( $this->instance->is_met() );
 	}
 }
-// phpcs:enable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded -- Base class can't be written shorter without abbreviating.

--- a/tests/unit/conditionals/estimated-reading-time-conditional-test.php
+++ b/tests/unit/conditionals/estimated-reading-time-conditional-test.php
@@ -9,8 +9,6 @@ use Yoast\WP\SEO\Conditionals\Admin\Post_Conditional;
 use Yoast\WP\SEO\Helpers\Input_Helper;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
-// phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded -- Base class can't be written shorter without abbreviating.
-
 /**
  * Class Estimated_Reading_Time_Conditional.
  *
@@ -147,4 +145,3 @@ class Estimated_Reading_Time_Conditional_Test extends TestCase {
 		$this->assertEquals( true, $this->instance->is_met() );
 	}
 }
-// phpcs:enable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded

--- a/tests/unit/conditionals/import-tool-selected-conditional-test.php
+++ b/tests/unit/conditionals/import-tool-selected-conditional-test.php
@@ -12,7 +12,6 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  * @group conditionals
  *
  * @coversDefaultClass \Yoast\WP\SEO\Conditionals\Import_Tool_Selected_Conditional
- * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
 class Import_Tool_Selected_Conditional_Test extends TestCase {
 

--- a/tests/unit/conditionals/third-party/coauthors-plus-activated-conditional-test.php
+++ b/tests/unit/conditionals/third-party/coauthors-plus-activated-conditional-test.php
@@ -12,7 +12,6 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  * @group third-party
  *
  * @coversDefaultClass \Yoast\WP\SEO\Conditionals\Third_Party\CoAuthors_Plus_Activated_Conditional
- * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
 class CoAuthors_Plus_Activated_Conditional_Test extends TestCase {
 

--- a/tests/unit/conditionals/wincher-automatically-track-conditional-test.php
+++ b/tests/unit/conditionals/wincher-automatically-track-conditional-test.php
@@ -7,8 +7,6 @@ use Yoast\WP\SEO\Conditionals\Wincher_Automatically_Track_Conditional;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
-// phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded -- Base class can't be written shorter without abbreviating.
-
 /**
  * Class Wincher_Automatically_Track_Conditional_Test.
  *

--- a/tests/unit/conditionals/yoast-admin-and-dashboard-conditional-test.php
+++ b/tests/unit/conditionals/yoast-admin-and-dashboard-conditional-test.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore Yoast.Files.FileName.InvalidClassFileName -- Reason: this explicitly concerns the Yoast admin and dashboard.
 
 namespace Yoast\WP\SEO\Tests\Unit\Conditionals;
 

--- a/tests/unit/conditionals/yoast-tools-page-conditional-test.php
+++ b/tests/unit/conditionals/yoast-tools-page-conditional-test.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore Yoast.Files.FileName.InvalidClassFileName -- Reason: this explicitly concerns the Yoast tools page.
 
 namespace Yoast\WP\SEO\Tests\Unit\Conditionals;
 

--- a/tests/unit/doubles/actions/importing/aioseo-posts-importing-action-double.php
+++ b/tests/unit/doubles/actions/importing/aioseo-posts-importing-action-double.php
@@ -6,8 +6,6 @@ use Yoast\WP\SEO\Actions\Importing\Aioseo\Aioseo_Posts_Importing_Action;
 
 /**
  * Class Aioseo_Posts_Importing_Action_Double
- *
- * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
 class Aioseo_Posts_Importing_Action_Double extends Aioseo_Posts_Importing_Action {
 

--- a/tests/unit/doubles/admin/admin-gutenberg-compatibility-notification-double.php
+++ b/tests/unit/doubles/admin/admin-gutenberg-compatibility-notification-double.php
@@ -1,5 +1,4 @@
 <?php
-// phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded -- WPSEO_Admin_Gutenberg_Compatibility_Notification_Double.
 
 namespace Yoast\WP\SEO\Tests\Unit\Doubles\Admin;
 
@@ -9,6 +8,8 @@ use WPSEO_Admin_Gutenberg_Compatibility_Notification;
  * Test helper class.
  *
  * Class WPSEO_Gutenberg_Compatibility_Double.
+ *
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
 class WPSEO_Admin_Gutenberg_Compatibility_Notification_Double extends WPSEO_Admin_Gutenberg_Compatibility_Notification {
 

--- a/tests/unit/doubles/admin/import/plugins/import-aioseo-v4-double.php
+++ b/tests/unit/doubles/admin/import/plugins/import-aioseo-v4-double.php
@@ -6,8 +6,6 @@ use WPSEO_Import_AIOSEO_V4;
 
 /**
  * Double for the WPSEO_Import_AIOSEO_V4 class, to be able to test its protected methods.
- *
- * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded -- the 'Double' suffix is there to communicate that this is a double, and not the real deal.
  */
 class WPSEO_Import_AIOSEO_V4_Double extends WPSEO_Import_AIOSEO_V4 {
 

--- a/tests/unit/doubles/memoizers/meta-tags-context-memoizer-double.php
+++ b/tests/unit/doubles/memoizers/meta-tags-context-memoizer-double.php
@@ -4,8 +4,6 @@ namespace Yoast\WP\SEO\Tests\Unit\Doubles\Memoizers;
 
 use Yoast\WP\SEO\Memoizers\Meta_Tags_Context_Memoizer;
 
-// phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded -- 'Double' suffix to communicates that it is a double to be used in tests.
-
 /**
  * Class Meta_Tags_Context_Memoizer_Double.
  */

--- a/tests/unit/doubles/services/importing/importable-detector-service-double.php
+++ b/tests/unit/doubles/services/importing/importable-detector-service-double.php
@@ -6,8 +6,6 @@ use Yoast\WP\SEO\Services\Importing\Importable_Detector_Service;
 
 /**
  * Class Importable_Detector_Service_Double
- *
- * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
 class Importable_Detector_Service_Double extends Importable_Detector_Service {
 

--- a/tests/unit/helpers/import-cursor-helper-test.php
+++ b/tests/unit/helpers/import-cursor-helper-test.php
@@ -16,7 +16,6 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  * @package Yoast\WP\SEO\Tests\Unit\Actions\Importing
  *
  * @coversDefaultClass Yoast\WP\SEO\Helpers\Import_Cursor_Helper
- * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
 class Import_Cursor_Helper_Test extends TestCase {
 

--- a/tests/unit/helpers/import-helper-test.php
+++ b/tests/unit/helpers/import-helper-test.php
@@ -14,7 +14,6 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  * @package Yoast\WP\SEO\Tests\Unit\Actions\Importing
  *
  * @coversDefaultClass Yoast\WP\SEO\Helpers\Import_Helper
- * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
 class Import_Helper_Test extends TestCase {
 

--- a/tests/unit/helpers/indexable-to-postmeta-helper-test.php
+++ b/tests/unit/helpers/indexable-to-postmeta-helper-test.php
@@ -13,7 +13,6 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  * @group helpers
  *
  * @coversDefaultClass \Yoast\WP\SEO\Helpers\Indexable_To_Postmeta_Helper
- * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
 class Indexable_To_Postmeta_Helper_Test extends TestCase {
 

--- a/tests/unit/integrations/abstract-exclude-post-type-test.php
+++ b/tests/unit/integrations/abstract-exclude-post-type-test.php
@@ -16,8 +16,6 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  * @group integrations
  *
  * @coversDefaultClass \Yoast\WP\SEO\Integrations\Abstract_Exclude_Post_Type
- *
- * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
 class Abstract_Exclude_Post_Type_Test extends TestCase {
 

--- a/tests/unit/integrations/third-party/exclude-elementor-post-types-test.php
+++ b/tests/unit/integrations/third-party/exclude-elementor-post-types-test.php
@@ -13,7 +13,6 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  * @group third-party
  *
  * @coversDefaultClass \Yoast\WP\SEO\Integrations\Third_Party\Exclude_Elementor_Post_Types
- * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
 class Exclude_Elementor_Post_Types_Test extends TestCase {
 

--- a/tests/unit/integrations/third-party/exclude-woocommerce-post-types-test.php
+++ b/tests/unit/integrations/third-party/exclude-woocommerce-post-types-test.php
@@ -13,7 +13,6 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  * @group third-party
  *
  * @coversDefaultClass \Yoast\WP\SEO\Integrations\Third_Party\Exclude_WooCommerce_Post_Types
- * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
 class Exclude_WooCommerce_Post_Types_Test extends TestCase {
 

--- a/tests/unit/integrations/watchers/indexable-home-page-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-home-page-watcher-test.php
@@ -20,8 +20,6 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  *
  * @coversDefaultClass \Yoast\WP\SEO\Integrations\Watchers\Indexable_Home_Page_Watcher
  * @covers \Yoast\WP\SEO\Integrations\Watchers\Indexable_Home_Page_Watcher
- *
- * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded -- 5 words is fine.
  */
 class Indexable_Home_Page_Watcher_Test extends TestCase {
 

--- a/tests/unit/integrations/watchers/indexable-post-meta-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-post-meta-watcher-test.php
@@ -17,8 +17,6 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  * @group watchers
  *
  * @coversDefaultClass \Yoast\WP\SEO\Integrations\Watchers\Indexable_Post_Meta_Watcher
- *
- * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
 class Indexable_Post_Meta_Watcher_Test extends TestCase {
 

--- a/tests/unit/integrations/watchers/primary-category-quick-edit-watcher-test.php
+++ b/tests/unit/integrations/watchers/primary-category-quick-edit-watcher-test.php
@@ -16,8 +16,6 @@ use Yoast\WP\SEO\Repositories\Primary_Term_Repository;
 use Yoast\WP\SEO\Tests\Unit\Doubles\Models\Indexable_Mock;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
-// phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded -- Base class can't be written shorter without abbreviating.
-
 /**
  * Class Admin_Columns_Cache_Integration_Test.
  *
@@ -25,6 +23,8 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  * @group watchers
  *
  * @coversDefaultClass \Yoast\WP\SEO\Integrations\Watchers\Primary_Category_Quick_Edit_Watcher
+ *
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded -- Base class can't be written shorter without abbreviating.
  */
 class Primary_Category_Quick_Edit_Watcher_Test extends TestCase {
 
@@ -390,4 +390,3 @@ class Primary_Category_Quick_Edit_Watcher_Test extends TestCase {
 		$this->instance->validate_primary_category( 1337, [], [ '1', '2' ], 'category' );
 	}
 }
-// phpcs:enable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded -- Base class can't be written shorter without abbreviating.

--- a/tests/unit/presenters/admin/indexing-failed-notification-presenter-test.php
+++ b/tests/unit/presenters/admin/indexing-failed-notification-presenter-test.php
@@ -1,5 +1,4 @@
 <?php
-// phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
 
 namespace Yoast\WP\SEO\Tests\Unit\Presenters\Admin;
 

--- a/tests/unit/routes/first-time-configuration-route-test.php
+++ b/tests/unit/routes/first-time-configuration-route-test.php
@@ -8,7 +8,6 @@ use Yoast\WP\SEO\Actions\Configuration\First_Time_Configuration_Action;
 use Yoast\WP\SEO\Routes\First_Time_Configuration_Route;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
-// phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded -- First time configuration simply has a lot of words.
 /**
  * Class First_Time_Configuration_Route_Test.
  *

--- a/tests/unit/routes/yoast-head-rest-field-test.php
+++ b/tests/unit/routes/yoast-head-rest-field-test.php
@@ -1,6 +1,5 @@
-<?php
+<?php // phpcs:ignore Yoast.Files.FileName.InvalidClassFileName -- Reason: this explicitly concerns the Yoast head fields.
 
-// phpcs:disable Yoast.Files.FileName.InvalidClassFileName
 namespace Yoast\WP\SEO\Tests\Unit\Routes;
 
 use Brain\Monkey;

--- a/tests/unit/routes/yoast-head-rest-field-test.php
+++ b/tests/unit/routes/yoast-head-rest-field-test.php
@@ -1,5 +1,6 @@
 <?php
 
+// phpcs:disable Yoast.Files.FileName.InvalidClassFileName
 namespace Yoast\WP\SEO\Tests\Unit\Routes;
 
 use Brain\Monkey;
@@ -19,9 +20,6 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  *
  * @group routes
  * @group indexables
- *
- * @phpcs:disable Yoast.Files.FileName.InvalidClassFileName
- * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
 class Yoast_Head_REST_Field_Test extends TestCase {
 

--- a/tests/unit/services/health-check/default-tagline-reports-test.php
+++ b/tests/unit/services/health-check/default-tagline-reports-test.php
@@ -9,8 +9,6 @@ use Yoast\WP\SEO\Services\Health_Check\Report_Builder;
 use Yoast\WP\SEO\Services\Health_Check\Report_Builder_Factory;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
-// phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
-
 /**
  * Default_Tagline_Reports
  *

--- a/tests/unit/services/health-check/links-table-reports-test.php
+++ b/tests/unit/services/health-check/links-table-reports-test.php
@@ -10,8 +10,6 @@ use Yoast\WP\SEO\Services\Health_Check\Report_Builder;
 use Yoast\WP\SEO\Services\Health_Check\Report_Builder_Factory;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
-// phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
-
 /**
  * Links_Table_Reports
  *

--- a/tests/unit/services/health-check/myyoast-api-request-factory-test.php
+++ b/tests/unit/services/health-check/myyoast-api-request-factory-test.php
@@ -10,8 +10,6 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  * MyYoast_Api_Request_Factory_Test
  *
  * @coversDefaultClass \Yoast\WP\SEO\Services\Health_Check\MyYoast_Api_Request_Factory
- *
- * phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
 class MyYoast_Api_Request_Factory_Test extends TestCase {
 

--- a/tests/unit/services/importing/aioseo-robots-provider-service-test.php
+++ b/tests/unit/services/importing/aioseo-robots-provider-service-test.php
@@ -14,7 +14,7 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  * @group importing
  *
  * @coversDefaultClass \Yoast\WP\SEO\Services\Importing\Aioseo\Aioseo_Robots_Provider_Service
- * @phpcs:disable Yoast.Yoast.AlternativeFunctions.json_encode_json_encode,Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
+ * @phpcs:disable Yoast.Yoast.AlternativeFunctions.json_encode_json_encode
  */
 class Aioseo_Robots_Provider_Service_Test extends TestCase {
 

--- a/tests/unit/services/importing/aioseo-robots-transformer-service-test.php
+++ b/tests/unit/services/importing/aioseo-robots-transformer-service-test.php
@@ -14,7 +14,7 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  * @group importing
  *
  * @coversDefaultClass \Yoast\WP\SEO\Services\Importing\Aioseo\Aioseo_Robots_Transformer_Service
- * @phpcs:disable Yoast.Yoast.AlternativeFunctions.json_encode_json_encode,Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
+ * @phpcs:disable Yoast.Yoast.AlternativeFunctions.json_encode_json_encode
  */
 class Aioseo_Robots_Transformer_Service_Test extends TestCase {
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* See https://yoast.slack.com/archives/C0361PEK4/p1655111883388949

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Increases the limit of the `Yoast.NamingConventions.ObjectNameDepth` sniff from 3 to 5.
* Adds some exceptions for the `Yoast.Files.FileName.InvalidClassFileName` sniff.

## Relevant technical choices:

* Removed the directory exceptions for all but the migrations.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Not needed to test by hand. This concerns PHPCS sniffs, the CI will determine if it is good to go.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes #
