### PR TITLE
Remove date parameters from URLs when date archives are disabled

### DIFF
--- a/src/helpers/url-helper.php
+++ b/src/helpers/url-helper.php
@@ -218,4 +218,28 @@ class Url_Helper {
 
 		return ( $is_image ) ? SEO_Links::TYPE_EXTERNAL_IMAGE : SEO_Links::TYPE_EXTERNAL;
 	}
+
+	/**
+	 * Recreate current URL.
+	 *
+	 * @return string
+	 */
+	public function recreate_current_url() {
+		$current_url = 'http';
+		if ( isset( $_SERVER['HTTPS'] ) && $_SERVER['HTTPS'] === 'on' ) {
+			$current_url .= 's';
+		}
+		$current_url .= '://';
+
+		if ( isset( $_SERVER['SERVER_PORT'] ) && $_SERVER['SERVER_PORT'] !== '80' && $_SERVER['SERVER_PORT'] !== '443' ) {
+			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput -- We know this is scary.
+			$current_url .= $_SERVER['SERVER_NAME'] . ':' . $_SERVER['SERVER_PORT'] . $_SERVER['REQUEST_URI'];
+		}
+		else {
+			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput -- We know this is scary.
+			$current_url .= $_SERVER['SERVER_NAME'] . $_SERVER['REQUEST_URI'];
+		}
+
+		return $current_url;
+	}
 }

--- a/src/helpers/url-helper.php
+++ b/src/helpers/url-helper.php
@@ -222,22 +222,27 @@ class Url_Helper {
 	/**
 	 * Recreate current URL.
 	 *
+	 * @param bool $with_request_uri Whether we want the REQUEST_URI appended.
+	 *
 	 * @return string
 	 */
-	public function recreate_current_url() {
+	public function recreate_current_url( $with_request_uri = true ) {
 		$current_url = 'http';
 		if ( isset( $_SERVER['HTTPS'] ) && $_SERVER['HTTPS'] === 'on' ) {
 			$current_url .= 's';
 		}
 		$current_url .= '://';
 
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput -- We know this is scary.
+		$suffix = ( $with_request_uri ) ? $_SERVER['REQUEST_URI'] : '';
+
 		if ( isset( $_SERVER['SERVER_PORT'] ) && $_SERVER['SERVER_PORT'] !== '80' && $_SERVER['SERVER_PORT'] !== '443' ) {
 			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput -- We know this is scary.
-			$current_url .= $_SERVER['SERVER_NAME'] . ':' . $_SERVER['SERVER_PORT'] . $_SERVER['REQUEST_URI'];
+			$current_url .= $_SERVER['SERVER_NAME'] . ':' . $_SERVER['SERVER_PORT'] . $suffix;
 		}
 		else {
 			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput -- We know this is scary.
-			$current_url .= $_SERVER['SERVER_NAME'] . $_SERVER['REQUEST_URI'];
+			$current_url .= $_SERVER['SERVER_NAME'] . $suffix;
 		}
 
 		return $current_url;

--- a/src/integrations/front-end/indexing-controls.php
+++ b/src/integrations/front-end/indexing-controls.php
@@ -3,7 +3,6 @@
 namespace Yoast\WP\SEO\Integrations\Front_End;
 
 use Yoast\WP\SEO\Conditionals\Front_End_Conditional;
-use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Robots_Helper;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
 
@@ -34,11 +33,9 @@ class Indexing_Controls implements Integration_Interface {
 	 * @codeCoverageIgnore Sets the dependencies.
 	 *
 	 * @param Robots_Helper  $robots  The robots helper.
-	 * @param Options_Helper $options The options helper.
 	 */
-	public function __construct( Robots_Helper $robots, Options_Helper $options ) {
+	public function __construct( Robots_Helper $robots ) {
 		$this->robots  = $robots;
-		$this->options = $options;
 	}
 
 	/**

--- a/src/integrations/front-end/indexing-controls.php
+++ b/src/integrations/front-end/indexing-controls.php
@@ -2,7 +2,6 @@
 
 namespace Yoast\WP\SEO\Integrations\Front_End;
 
-use WP_Query;
 use Yoast\WP\SEO\Conditionals\Front_End_Conditional;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Robots_Helper;
@@ -19,13 +18,6 @@ class Indexing_Controls implements Integration_Interface {
 	 * @var Robots_Helper
 	 */
 	protected $robots;
-
-	/**
-	 * The options helper.
-	 *
-	 * @var Options_Helper
-	 */
-	private $options;
 
 	/**
 	 * Returns the conditionals based in which this loadable should be active.
@@ -74,26 +66,6 @@ class Indexing_Controls implements Integration_Interface {
 		\remove_action( 'wp_head', 'start_post_rel_link' );
 		\remove_action( 'wp_head', 'adjacent_posts_rel_link_wp_head' );
 		\remove_action( 'wp_head', 'noindex', 1 );
-
-		if ( $this->options->get( 'disable-date', false ) ) {
-			\add_action( 'pre_get_posts', [ $this, 'disable_date_queries' ] );
-		}
-	}
-
-	/**
-	 * Disable date queries, if they're disabled in Yoast SEO settings, to prevent indexing the wrong things.
-	 *
-	 * @param WP_Query $query The query object.
-	 *
-	 * @return void
-	 */
-	public function disable_date_queries( $query ) {
-		if ( ! is_admin() && $query->is_main_query() ) {
-			$query->set( 'year', '' );
-			$query->set( 'm', '' );
-			$query->set( 'monthnum', '' );
-			$query->set( 'day', '' );
-		}
 	}
 
 	/**

--- a/src/integrations/front-end/indexing-controls.php
+++ b/src/integrations/front-end/indexing-controls.php
@@ -32,10 +32,10 @@ class Indexing_Controls implements Integration_Interface {
 	 *
 	 * @codeCoverageIgnore Sets the dependencies.
 	 *
-	 * @param Robots_Helper  $robots  The robots helper.
+	 * @param Robots_Helper $robots The robots helper.
 	 */
 	public function __construct( Robots_Helper $robots ) {
-		$this->robots  = $robots;
+		$this->robots = $robots;
 	}
 
 	/**

--- a/src/integrations/front-end/indexing-controls.php
+++ b/src/integrations/front-end/indexing-controls.php
@@ -75,7 +75,9 @@ class Indexing_Controls implements Integration_Interface {
 		\remove_action( 'wp_head', 'adjacent_posts_rel_link_wp_head' );
 		\remove_action( 'wp_head', 'noindex', 1 );
 
-		\add_action( 'pre_get_posts', 'disable_date_queries' );
+		if ( $this->options->get( 'disable-date', false ) ) {
+			\add_action( 'pre_get_posts', [ $this, 'disable_date_queries' ] );
+		}
 	}
 
 	/**
@@ -86,11 +88,6 @@ class Indexing_Controls implements Integration_Interface {
 	 * @return void
 	 */
 	public function disable_date_queries( $query ) {
-		if ( ! $this->options->get( 'disable-date', false ) ) {
-			return;
-		}
-
-		// If Yoast SEO 'disable date archives' is set to YES.
 		if ( ! is_admin() && $query->is_main_query() ) {
 			$query->set( 'year', '' );
 			$query->set( 'm', '' );

--- a/src/integrations/front-end/redirects.php
+++ b/src/integrations/front-end/redirects.php
@@ -114,10 +114,10 @@ class Redirects implements Integration_Interface {
 	 */
 	public function disable_date_queries() {
 		if ( $this->options->get( 'disable-date', false ) ) {
-			list( $base_url, $query_string ) = \array_pad( \explode( '?', $this->url->recreate_current_url() ), 2, '' );
+			list( $base_url, $query_string ) = \array_pad( \explode( '?', $this->url->recreate_current_url(), 2 ), 2, '' );
 			\parse_str( $query_string, $query_vars );
 			foreach ( $this->date_query_variables as $variable ) {
-				if ( in_array( $variable, array_keys( $query_vars ), true ) ) {
+				if ( \in_array( $variable, \array_keys( $query_vars ), true ) ) {
 					$this->do_date_redirect( $query_vars, $base_url );
 				}
 			}

--- a/src/integrations/front-end/redirects.php
+++ b/src/integrations/front-end/redirects.php
@@ -114,7 +114,8 @@ class Redirects implements Integration_Interface {
 	 */
 	public function disable_date_queries() {
 		if ( $this->options->get( 'disable-date', false ) ) {
-			list( $base_url, $query_string ) = \array_pad( \explode( '?', $this->url->recreate_current_url(), 2 ), 2, '' );
+			$exploded_url                    = \explode( '?', $this->url->recreate_current_url(), 2 );
+			list( $base_url, $query_string ) = \array_pad( $exploded_url, 2, '' );
 			\parse_str( $query_string, $query_vars );
 			foreach ( $this->date_query_variables as $variable ) {
 				if ( \in_array( $variable, \array_keys( $query_vars ), true ) ) {

--- a/src/integrations/front-end/redirects.php
+++ b/src/integrations/front-end/redirects.php
@@ -7,6 +7,7 @@ use Yoast\WP\SEO\Helpers\Current_Page_Helper;
 use Yoast\WP\SEO\Helpers\Meta_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Redirect_Helper;
+use Yoast\WP\SEO\Helpers\Url_Helper;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
 
 /**
@@ -43,6 +44,28 @@ class Redirects implements Integration_Interface {
 	private $redirect;
 
 	/**
+	 * The URL helper.
+	 *
+	 * @var Url_Helper
+	 */
+	private $url;
+
+	/**
+	 * Holds the WP_Query variables we should get rid of.
+	 *
+	 * @var string[]
+	 */
+	private $date_query_variables = [
+		'year',
+		'm',
+		'monthnum',
+		'day',
+		'hour',
+		'minute',
+		'second',
+	];
+
+	/**
 	 * Sets the helpers.
 	 *
 	 * @codeCoverageIgnore
@@ -51,12 +74,14 @@ class Redirects implements Integration_Interface {
 	 * @param Meta_Helper         $meta         Meta helper.
 	 * @param Current_Page_Helper $current_page The current page helper.
 	 * @param Redirect_Helper     $redirect     The redirect helper.
+	 * @param Url_Helper          $url          The URL helper.
 	 */
-	public function __construct( Options_Helper $options, Meta_Helper $meta, Current_Page_Helper $current_page, Redirect_Helper $redirect ) {
+	public function __construct( Options_Helper $options, Meta_Helper $meta, Current_Page_Helper $current_page, Redirect_Helper $redirect, Url_Helper $url ) {
 		$this->options      = $options;
 		$this->meta         = $meta;
 		$this->current_page = $current_page;
 		$this->redirect     = $redirect;
+		$this->url          = $url;
 	}
 
 	/**
@@ -79,6 +104,24 @@ class Redirects implements Integration_Interface {
 		\add_action( 'wp', [ $this, 'archive_redirect' ] );
 		\add_action( 'wp', [ $this, 'page_redirect' ], 99 );
 		\add_action( 'template_redirect', [ $this, 'attachment_redirect' ], 1 );
+		\add_action( 'pre_get_posts', [ $this, 'disable_date_queries' ] );
+	}
+
+	/**
+	 * Disable date queries, if they're disabled in Yoast SEO settings, to prevent indexing the wrong things.
+	 *
+	 * @return void
+	 */
+	public function disable_date_queries() {
+		if ( $this->options->get( 'disable-date', false ) ) {
+			list( $base_url, $query_string ) = \array_pad( \explode( '?', $this->url->recreate_current_url() ), 2, '' );
+			\parse_str( $query_string, $query_vars );
+			foreach ( $this->date_query_variables as $variable ) {
+				if ( in_array( $variable, array_keys( $query_vars ), true ) ) {
+					$this->do_date_redirect( $query_vars, $base_url );
+				}
+			}
+		}
 	}
 
 	/**
@@ -175,5 +218,25 @@ class Redirects implements Integration_Interface {
 			\wp_get_attachment_url( \get_queried_object_id() ),
 			\get_queried_object()
 		);
+	}
+
+	/**
+	 * Redirects away query variables that shouldn't work.
+	 *
+	 * @param array  $query_vars   The query variables in the current URL.
+	 * @param string $base_url     The base URL without query string.
+	 *
+	 * @return void
+	 */
+	private function do_date_redirect( $query_vars, $base_url ) {
+		foreach ( $this->date_query_variables as $variable ) {
+			unset( $query_vars[ $variable ] );
+		}
+		$url = $base_url;
+		if ( count( $query_vars ) > 0 ) {
+			$url .= '?' . \http_build_query( $query_vars );
+		}
+
+		$this->redirect->do_safe_redirect( $url, 301 );
 	}
 }

--- a/tests/unit/integrations/front-end/redirects-test.php
+++ b/tests/unit/integrations/front-end/redirects-test.php
@@ -9,6 +9,7 @@ use Yoast\WP\SEO\Helpers\Current_Page_Helper;
 use Yoast\WP\SEO\Helpers\Meta_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Redirect_Helper;
+use Yoast\WP\SEO\Helpers\Url_Helper;
 use Yoast\WP\SEO\Integrations\Front_End\Redirects;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
@@ -59,6 +60,13 @@ class Redirects_Test extends TestCase {
 	private $redirect;
 
 	/**
+	 * The URL helper mock.
+	 *
+	 * @var Mockery\MockInterface|Url_Helper
+	 */
+	private $url;
+
+	/**
 	 * Sets an instance for test purposes.
 	 */
 	protected function set_up() {
@@ -68,7 +76,8 @@ class Redirects_Test extends TestCase {
 		$this->meta         = Mockery::mock( Meta_Helper::class );
 		$this->current_page = Mockery::mock( Current_Page_Helper::class );
 		$this->redirect     = Mockery::mock( Redirect_Helper::class );
-		$this->instance     = Mockery::mock( Redirects::class, [ $this->options, $this->meta, $this->current_page, $this->redirect ] )
+		$this->url          = Mockery::mock( Url_Helper::class );
+		$this->instance     = Mockery::mock( Redirects::class, [ $this->options, $this->meta, $this->current_page, $this->redirect, $this->url ] )
 			->shouldAllowMockingProtectedMethods()
 			->makePartial();
 	}


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* If you disable date archives in Yoast SEO, `/2022/` would redirect to your homepage, but a post, say `/hello-world/` with the parameter `?year=2022`, so `https://example.com/hello-world/?year=2022` would still show the 2022 archives. Yoast SEO now redirects those parameters away, so you'd be redirected to `https://example.com/hello-world/`.

## Relevant technical choices:

* Moved `recreate_current_url`, introduced in premium in the crawl cleanup clean permalinks changes, to the `Url_Helper` for easier access.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Try `https://example.com/hello-world/?year=2022` or something similar, and for the other variables touched too.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes PRODUCT-288
