### PR TITLE
Improve UX

### DIFF
--- a/css/src/admin-global.css
+++ b/css/src/admin-global.css
@@ -701,7 +701,7 @@ body.folded .wpseo-admin-submit-fixed {
 }
 
 .yoast p[class*="yoast-extra-variables-label"] {
-  padding-left: 240px!important;
+  padding-left: 243px!important;
 }
 
 @media screen and (max-width: 782px) {

--- a/css/src/admin-global.css
+++ b/css/src/admin-global.css
@@ -665,7 +665,8 @@ body.folded .wpseo-admin-submit-fixed {
 
 .yoast #crawl-settings fieldset[id$="_free"] ,
 .yoast label[for="search_character_limit_free"],
-.yoast label[for="clean_permalinks_extra_variables_free"] {
+.yoast label[for="clean_permalinks_extra_variables_free"],
+.yoast p.yoast-extra-variables-label-free {
 	opacity: 0.5;
 }
 
@@ -675,20 +676,39 @@ body.folded .wpseo-admin-submit-fixed {
 }
 
 .yoast label[for^="search_character_limit"] {
-  width: 280px!important;
+  width: 320px!important;
   margin-bottom: 10px!important;
-}
-
-.yoast label[for^="clean_permalinks_extra_variables"] {
-  width: 220px!important;
+  font-weight: 600;
+  padding-left: 2px;
 }
 
 .yoast input[id^="search_character_limit"] {
   width: 70px!important;
 }
 
+.yoast label[for^="clean_permalinks_extra_variables"] {
+  width: 240px!important;
+  font-weight: 600;
+  padding-left: 2px;
+}
+
 .yoast input[id^="clean_permalinks_extra_variables"] {
-  width: 380px!important;
+  width: 358px!important;
+}
+
+.yoast .yoast-crawl-single-setting {
+  margin-top: 18px;
+}
+
+.yoast p[class*="yoast-extra-variables-label"] {
+  padding-left: 240px!important;
+}
+
+@media screen and (max-width: 782px) {
+  .yoast p[class*="yoast-extra-variables-label"] {
+    padding-left: 0px!important;
+    margin-top: -20px!important;
+  }
 }
 
 .yoast .yoast-global-comments-feed-help,

--- a/src/integrations/admin/crawl-settings-integration.php
+++ b/src/integrations/admin/crawl-settings-integration.php
@@ -200,6 +200,7 @@ class Crawl_Settings_Integration implements Integration_Interface {
 		$this->print_toggles( $first_search_setting, $yform, $is_network, \__( 'Search cleanup settings', 'wordpress-seo' ), \__( 'Clean up and filter searches to prevent search spam.', 'wordpress-seo' ), $search_settings_toggles );
 
 		if ( ! $is_network ) {
+			echo '<div class="yoast-crawl-single-setting">';
 			$yform->number(
 				'search_character_limit_free',
 				\__( 'Max number of characters to allow in searches', 'wordpress-seo' ),
@@ -210,6 +211,7 @@ class Crawl_Settings_Integration implements Integration_Interface {
 				]
 			);
 			$yform->hidden( 'search_character_limit', 'search_character_limit' );
+			echo '</div>';
 		}
 
 		$this->print_toggles( $rest_search_settings, $yform, $is_network, '', '', $search_settings_toggles );
@@ -217,6 +219,7 @@ class Crawl_Settings_Integration implements Integration_Interface {
 		$this->print_toggles( $this->permalink_cleanup_settings, $yform, $is_network, \__( 'Permalink cleanup settings', 'wordpress-seo' ), \__( 'Remove unwanted URL parameters from your URLs.', 'wordpress-seo' ) );
 
 		if ( ! $is_network ) {
+			echo '<div class="yoast-crawl-single-setting">';
 			$yform->textinput(
 				'clean_permalinks_extra_variables_free',
 				\__( 'Additional URL parameters to allow', 'wordpress-seo' ),
@@ -225,6 +228,10 @@ class Crawl_Settings_Integration implements Integration_Interface {
 				]
 			);
 			$yform->hidden( 'clean_permalinks_extra_variables', 'clean_permalinks_extra_variables' );
+			echo '<p class="desc label yoast-extra-variables-label-free">';
+			esc_html_e( 'Please use a comma to separate multiple URL parameters.', 'wordpress-seo' );
+			echo '</p>';
+			echo '</div>';
 		}
 	}
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Minor UX tweaks, as per @uxkai 's feedback
* To be tested alongside https://github.com/Yoast/wordpress-seo-premium/pull/3576

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves UX for the unreleased feature of the additional Crawl Cleanup settings

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* When Premium is not enabled, the Crawl Cleanup tab should look like this:
![image](https://user-images.githubusercontent.com/12400734/173780092-9f5701ce-9dcb-4b7a-8efe-ff9c40ff3611.png)
* When Premium is enabled, follow Test Instructions of https://github.com/Yoast/wordpress-seo-premium/pull/3576


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes #
