### PR TITLE
DUPP-593 Use generic class for help text

### DIFF
--- a/css/src/admin-global.css
+++ b/css/src/admin-global.css
@@ -812,11 +812,9 @@ body.folded .wpseo-admin-submit-fixed {
 }
 
 
-
-.yoast .yoast-global-comments-feed-help-free {
+.yoast .yoast-crawl-settings-help-free {
   opacity: 0.5;
 }
-
 
 .yoast .yoast-crawl-settings-explanation-free {
   opacity: 0.5;

--- a/css/src/admin-global.css
+++ b/css/src/admin-global.css
@@ -691,8 +691,7 @@ body.folded .wpseo-admin-submit-fixed {
   width: 380px!important;
 }
 
-.yoast .yoast-global-comments-feed-help,
-.yoast .yoast-global-comments-feed-help-free {
+.yoast .yoast-crawl-settings-help {
 	font-style: italic;
 }
 /* Global notifications */

--- a/src/integrations/admin/crawl-settings-integration.php
+++ b/src/integrations/admin/crawl-settings-integration.php
@@ -277,8 +277,8 @@ class Crawl_Settings_Integration implements Integration_Interface {
 					'disabled' => true,
 				]
 			);
-			if ( $setting === 'remove_feed_global_comments_free' && ! $is_network ) {
-				echo '<p class="yoast-crawl-settings-help">';
+			if ( $setting === 'remove_feed_global_comments' && ! $is_network ) {
+				echo '<p class="yoast-crawl-settings-help yoast-crawl-settings-help-free ">';
 				echo \esc_html__( 'By removing Global comments feed, Post comments feeds will be removed too.', 'wordpress-seo' );
 				echo '</p>';
 			}

--- a/src/integrations/admin/crawl-settings-integration.php
+++ b/src/integrations/admin/crawl-settings-integration.php
@@ -278,7 +278,7 @@ class Crawl_Settings_Integration implements Integration_Interface {
 				]
 			);
 			if ( $setting === 'remove_feed_global_comments_free' && ! $is_network ) {
-				echo '<p class="yoast-global-comments-feed-help-free">';
+				echo '<p class="yoast-crawl-settings-help">';
 				echo \esc_html__( 'By removing Global comments feed, Post comments feeds will be removed too.', 'wordpress-seo' );
 				echo '</p>';
 			}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to use a generic class to style help text in the Crawl settings tab. 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Uses a generic CSS class to style help text in the Crawl settings tab.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Disable Premium
* Check that the help line `By removing Global comments feed, Post comments feeds will be removed too.` is visible and styled correctly (in _italic_ and 50% opacity)
* Enable Premium
* Check that the help line `By removing Global comments feed, Post comments feeds will be removed too.` is styled correctly (in _italic_)
* also check the matching Premium PR https://github.com/Yoast/wordpress-seo-premium/pull/3578



### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes [DUPP-593]


[DUPP-593]: https://yoast.atlassian.net/browse/DUPP-593?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ