### PR TITLE
Fixes a bug where the focus keyphrase was not recognized in the Wincher table (and thus did not get marked with an asterisk).

### DIFF
--- a/packages/js/src/components/WincherKeyphrasesTable.js
+++ b/packages/js/src/components/WincherKeyphrasesTable.js
@@ -340,7 +340,7 @@ const WincherKeyphrasesTable = ( props ) => {
 									onTrackKeyphrase={ onTrackKeyphrase }
 									onUntrackKeyphrase={ onUntrackKeyphrase }
 									rowData={ getKeyphraseData( keyphrase ) }
-									isFocusKeyphrase={ keyphrase === focusKeyphrase.trim() }
+									isFocusKeyphrase={ keyphrase === focusKeyphrase.trim().toLowerCase() }
 									websiteId={ websiteId }
 									isDisabled={ ! isLoggedIn }
 									isLoading={ isDataLoading || loadingKeyphrases.indexOf( keyphrase.toLowerCase() ) >= 0 }

--- a/packages/js/tests/components/WincherKeyphrasesTable.test.js
+++ b/packages/js/tests/components/WincherKeyphrasesTable.test.js
@@ -12,7 +12,7 @@ import { trackKeyphrases } from "../../src/helpers/wincherEndpoints";
 
 jest.mock( "../../src/helpers/wincherEndpoints" );
 trackKeyphrases.mockImplementation( async fn => {
-	await fn();
+	return fn;
 } );
 
 const keyphrases = [ "yoast seo" ];
@@ -107,5 +107,27 @@ describe( "WincherKeyphrasesTable", () => {
 		} );
 
 		expect( trackKeyphrases ).toHaveBeenCalledWith( keyphrases );
+	} );
+
+	it( "should add an asterisk after the focus keyphrase, even if the keyphrase contains capital letters", () => {
+		const component = shallow( <WincherKeyphrasesTable
+			keyphrases={ keyphrases }
+			trackedKeyphrases={ keyphrasesData }
+			onAuthentication={ noop }
+			addTrackingKeyphrase={ noop }
+			newRequest={ noop }
+			setKeyphraseLimitReached={ noop }
+			setTrackedKeyphrases={ noop }
+			setRequestFailed={ noop }
+			setRequestSucceeded={ noop }
+			addTrackedKeyphrase={ noop }
+			removeTrackedKeyphrase={ noop }
+			setHasTrackedAll={ noop }
+			permalink=""
+			focusKeyphrase={ "Yoast SEO" }
+		/> );
+
+		const rows = component.find( WincherTableRow );
+		expect( rows.first().props().isFocusKeyphrase ).toEqual( true );
 	} );
 } );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug in the Wincher integration table on posts and terms where the focus keyphrase was not marked with an asterisk.

## Relevant technical choices:

* Also fixes a minor error inside of the Wincher table unit tests:
   ```js
   console.error
      fn is not a function
     ```

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

Note: this should be tested in the block editor, classic editor and Elementor.
* Install and activate the latest version of Yoast SEO Premium.
* Create a post.
* Enter a focus keyphrase that includes capital letters (for example _Yoast SEO_).
* Enter a related keyphrase.
* Look in the Wincher integration table inside of the metabox (In the collapsible labeled _Track SEO performance_). The focus keyphrase should have an asterisk next to it.
  * Although Wincher may not be connected to Yoast SEO, you should still be able to see the (greyed out) table with the keyphrases. 

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* 

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes #
