### PR TITLE
Fix help link and copy of the IndexNow feature toggle

### DIFF
--- a/admin/views/class-yoast-feature-toggles.php
+++ b/admin/views/class-yoast-feature-toggles.php
@@ -185,9 +185,10 @@ class Yoast_Feature_Toggles {
 				'name'            => __( 'IndexNow', 'wordpress-seo' ),
 				'premium'         => true,
 				'setting'         => 'enable_index_now',
-				'label'           => __( 'This adds an IndexNow integration which will ping search engines like Bing and Yandex on site updates.', 'wordpress-seo' ),
+				'label'           => __( 'Automatically ping search engines like Bing and Yandex whenever you publish, update or delete a post.', 'wordpress-seo' ),
 				'read_more_label' => __( 'Find out how IndexNow can help your site.', 'wordpress-seo' ),
-				'read_more_url'   => 'https://yoa.st/index-now-feature',
+				'read_more_url'   => 'https://yoa.st/index-now-read-more',
+				'premium_url'     => 'https://yoa.st/index-now-feature',
 				'order'           => 110,
 			],
 		];


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where the shortlink of the Help text of the IndexNow feature toggle would be broken.
* Improves the unrleased copy of the IndexNow feature toggle.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Have Free enabled and Premium disabled.
* Go to a single site's or a subsite's Yoast SEO->General page in the Features tab
* The IndexNow toggle should have the following copy:
**Automatically ping search engines like Bing and Yandex whenever you publish, update or delete a post.**
* The `Find out how IndexNow can help your site.` link should point to the https://yoa.st/index-now-feature shortlink
* Go to the network site in the SEO->General page in the Features tab
* The IndexNow toggle should have the following copy:
**Automatically ping search engines like Bing and Yandex whenever you publish, update or delete a post.**
* The `Find out how IndexNow can help your site.` link should point to the https://yoa.st/index-now-read-more shortlink.
* Now enable Premium and repeat the above.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes #
