### PR TITLE
Changes to IndexNow and pinging search engines

### DIFF
--- a/inc/options/class-wpseo-option-wpseo.php
+++ b/inc/options/class-wpseo-option-wpseo.php
@@ -55,7 +55,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 		'enable_cornerstone_content'               => true,
 		'enable_xml_sitemap'                       => true,
 		'enable_text_link_counter'                 => true,
-		'enable_index_now'                         => false,
+		'enable_index_now'                         => true,
 		'show_onboarding_notice'                   => false,
 		'first_activated_on'                       => false,
 		'myyoast-oauth'                            => [

--- a/inc/sitemaps/class-sitemaps-admin.php
+++ b/inc/sitemaps/class-sitemaps-admin.php
@@ -100,6 +100,10 @@ class WPSEO_Sitemaps_Admin {
 
 		// Ping Google about our sitemap change.
 		wp_remote_get( 'https://www.google.com/ping?sitemap=' . $url, [ 'blocking' => false ] );
+
+		if ( ! defined( 'WPSEO_PREMIUM_FILE' ) || WPSEO_Options::get( 'enable_index_now' ) === false ) {
+			wp_remote_get( 'https://www.bing.com/ping?sitemap=' . $url, [ 'blocking' => false ] );
+		}
 	}
 
 	/**

--- a/inc/sitemaps/class-sitemaps-admin.php
+++ b/inc/sitemaps/class-sitemaps-admin.php
@@ -66,15 +66,6 @@ class WPSEO_Sitemaps_Admin {
 			return;
 		}
 
-		/**
-		 * Filter: 'wpseo_allow_xml_sitemap_ping' - Check if pinging is not allowed (allowed by default).
-		 *
-		 * @api boolean $allow_ping The boolean that is set to true by default.
-		 */
-		if ( apply_filters( 'wpseo_allow_xml_sitemap_ping', true ) === false ) {
-			return;
-		}
-
 		$this->ping_search_engines();
 	}
 

--- a/inc/sitemaps/class-sitemaps-admin.php
+++ b/inc/sitemaps/class-sitemaps-admin.php
@@ -79,7 +79,7 @@ class WPSEO_Sitemaps_Admin {
 		}
 
 		/**
-		 * Filter: 'wpseo_allow_xml_sitemap_ping' - Check if pinging is not allowed (allowed by default)
+		 * Filter: 'wpseo_allow_xml_sitemap_ping' - Check if pinging is not allowed (allowed by default).
 		 *
 		 * @api boolean $allow_ping The boolean that is set to true by default.
 		 */

--- a/inc/sitemaps/class-sitemaps-admin.php
+++ b/inc/sitemaps/class-sitemaps-admin.php
@@ -75,12 +75,31 @@ class WPSEO_Sitemaps_Admin {
 			return;
 		}
 
-		if ( defined( 'YOAST_SEO_PING_IMMEDIATELY' ) && YOAST_SEO_PING_IMMEDIATELY ) {
-			WPSEO_Sitemaps::ping_search_engines();
+		$this->ping_search_engines();
+	}
+
+	/**
+	 * Notify Google of the updated sitemap.
+	 */
+	public function ping_search_engines() {
+
+		if ( get_option( 'blog_public' ) === '0' ) { // Don't ping if blog is not public.
+			return;
 		}
-		elseif ( ! wp_next_scheduled( 'wpseo_ping_search_engines' ) ) {
-			wp_schedule_single_event( ( time() + 300 ), 'wpseo_ping_search_engines' );
+
+		/**
+		 * Filter: 'wpseo_allow_xml_sitemap_ping' - Check if pinging is not allowed (allowed by default)
+		 *
+		 * @api boolean $allow_ping The boolean that is set to true by default.
+		 */
+		if ( apply_filters( 'wpseo_allow_xml_sitemap_ping', true ) === false ) {
+			return;
 		}
+
+		$url = rawurlencode( WPSEO_Sitemaps_Router::get_base_url( 'sitemap_index.xml' ) );
+
+		// Ping Google about our sitemap change.
+		wp_remote_get( 'https://www.google.com/ping?sitemap=' . $url, [ 'blocking' => false ] );
 	}
 
 	/**
@@ -134,6 +153,6 @@ class WPSEO_Sitemaps_Admin {
 			do_action( 'wpseo_hit_sitemap_index' );
 		}
 
-		WPSEO_Sitemaps::ping_search_engines();
+		$this->ping_search_engines();
 	}
 }

--- a/inc/sitemaps/class-sitemaps.php
+++ b/inc/sitemaps/class-sitemaps.php
@@ -101,7 +101,6 @@ class WPSEO_Sitemaps {
 		add_action( 'after_setup_theme', [ $this, 'reduce_query_load' ], 99 );
 		add_action( 'pre_get_posts', [ $this, 'redirect' ], 1 );
 		add_action( 'wpseo_hit_sitemap_index', [ $this, 'hit_sitemap_index' ] );
-		add_action( 'wpseo_ping_search_engines', [ __CLASS__, 'ping_search_engines' ] );
 
 		$this->router   = new WPSEO_Sitemaps_Router();
 		$this->renderer = new WPSEO_Sitemaps_Renderer();
@@ -543,30 +542,15 @@ class WPSEO_Sitemaps {
 	/**
 	 * Notify search engines of the updated sitemap.
 	 *
+	 * @deprecated 19.2
+	 *
 	 * @param string|null $url Optional URL to make the ping for.
 	 */
 	public static function ping_search_engines( $url = null ) {
+		_deprecated_function( __METHOD__, 'WPSEO 19.2', 'WPSEO_Sitemaps_Admin::ping_search_engines' );
 
-		/**
-		 * Filter: 'wpseo_allow_xml_sitemap_ping' - Check if pinging is not allowed (allowed by default)
-		 *
-		 * @api boolean $allow_ping The boolean that is set to true by default.
-		 */
-		if ( apply_filters( 'wpseo_allow_xml_sitemap_ping', true ) === false ) {
-			return;
-		}
-
-		if ( get_option( 'blog_public' ) === '0' ) { // Don't ping if blog is not public.
-			return;
-		}
-
-		if ( empty( $url ) ) {
-			$url = rawurlencode( WPSEO_Sitemaps_Router::get_base_url( 'sitemap_index.xml' ) );
-		}
-
-		// Ping Google and Bing.
-		wp_remote_get( 'https://www.google.com/ping?sitemap=' . $url, [ 'blocking' => false ] );
-		wp_remote_get( 'https://www.bing.com/ping?sitemap=' . $url, [ 'blocking' => false ] );
+		$admin = new WPSEO_Sitemaps_Admin();
+		$admin->ping_search_engines();
 	}
 
 	/**

--- a/inc/sitemaps/class-sitemaps.php
+++ b/inc/sitemaps/class-sitemaps.php
@@ -509,7 +509,7 @@ class WPSEO_Sitemaps {
 					ORDER BY date DESC
 				";
 
-				// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- They are prepared on the lines above.
+				// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery -- They are prepared on the lines above and a direct query is required.
 				foreach ( $wpdb->get_results( $sql ) as $obj ) {
 					$post_type_dates[ $obj->post_type ] = $obj->date;
 				}
@@ -540,6 +540,8 @@ class WPSEO_Sitemaps {
 		return YoastSEO()->helpers->date->format( self::get_last_modified_gmt( $post_types ) );
 	}
 
+	// phpcs:disable Generic.CodeAnalysis.UnusedFunctionParameter.Found -- Argument is kept for documentation purposes.
+
 	/**
 	 * Notify search engines of the updated sitemap.
 	 *
@@ -555,6 +557,8 @@ class WPSEO_Sitemaps {
 		$admin = new WPSEO_Sitemaps_Admin();
 		$admin->ping_search_engines();
 	}
+
+	// phpcs:enable
 
 	/**
 	 * Get the maximum number of entries per XML sitemap.

--- a/inc/sitemaps/class-sitemaps.php
+++ b/inc/sitemaps/class-sitemaps.php
@@ -509,6 +509,7 @@ class WPSEO_Sitemaps {
 					ORDER BY date DESC
 				";
 
+				// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- They are prepared on the lines above.
 				foreach ( $wpdb->get_results( $sql ) as $obj ) {
 					$post_type_dates[ $obj->post_type ] = $obj->date;
 				}
@@ -543,6 +544,8 @@ class WPSEO_Sitemaps {
 	 * Notify search engines of the updated sitemap.
 	 *
 	 * @deprecated 19.2
+	 *
+	 * @codeCoverageIgnore
 	 *
 	 * @param string|null $url Optional URL to make the ping for.
 	 */

--- a/tests/unit/inc/sitemaps/sitemaps-admin-test.php
+++ b/tests/unit/inc/sitemaps/sitemaps-admin-test.php
@@ -86,6 +86,11 @@ class WPSEO_Sitemaps_Admin_Test extends TestCase {
 	 * @covers WPSEO_Sitemaps_Admin::status_transition
 	 */
 	public function test_status_transition_on_production() {
+		global $wp_rewrite;
+
+		$wp_rewrite = Mockery::mock();
+		$wp_rewrite->expects( 'using_index_permalinks' )->andReturnFalse();
+
 		Monkey\Functions\stubs(
 			[
 				'wp_get_environment_type' => 'production',
@@ -107,22 +112,16 @@ class WPSEO_Sitemaps_Admin_Test extends TestCase {
 			->once()
 			->andReturn( true );
 
-		Monkey\Functions\expect( 'wp_next_scheduled' )
+		Monkey\Functions\expect( 'home_url' )
 			->once()
-			->andReturn( false );
+			->andReturn( 'https://example.com' );
 
-		$start = \time();
-
-		Monkey\Functions\expect( 'wp_schedule_single_event' )
+		Monkey\Functions\expect( 'wp_parse_url' )
 			->once()
-			->withArgs(
-				static function( $timestamp, $function_name ) use ( $start ) {
-					if ( $function_name === 'wpseo_ping_search_engines' ) {
-						return ( $timestamp < $start + 600 );
-					}
-					return false;
-				}
-			);
+			->andReturn( 'https' );
+
+		Monkey\Functions\expect( 'wp_remote_get' )
+			->twice();
 
 		$this->instance->status_transition( 'publish', 'draft', $this->mock_post );
 	}

--- a/tests/unit/inc/sitemaps/sitemaps-admin-test.php
+++ b/tests/unit/inc/sitemaps/sitemaps-admin-test.php
@@ -120,8 +120,7 @@ class WPSEO_Sitemaps_Admin_Test extends TestCase {
 			->once()
 			->andReturn( 'https' );
 
-		Monkey\Functions\expect( 'wp_remote_get' )
-			->twice();
+		Monkey\Functions\expect( 'wp_remote_get' );
 
 		$this->instance->status_transition( 'publish', 'draft', $this->mock_post );
 	}

--- a/tests/unit/integrations/front-end/category-term-description-test.php
+++ b/tests/unit/integrations/front-end/category-term-description-test.php
@@ -11,7 +11,6 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  * Class Category_Term_Description_Test.
  *
  * @coversDefaultClass \Yoast\WP\SEO\Integrations\Front_End\Category_Term_Description
- * @covers ::<!public>
  *
  * @group integrations
  * @group front-end

--- a/tests/unit/integrations/front-end/comment-link-fixer-test.php
+++ b/tests/unit/integrations/front-end/comment-link-fixer-test.php
@@ -14,7 +14,6 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  * Class Comment_Link_Fixer_Test.
  *
  * @coversDefaultClass \Yoast\WP\SEO\Integrations\Front_End\Comment_Link_Fixer
- * @covers ::<!public>
  *
  * @group integrations
  * @group front-end

--- a/tests/unit/integrations/front-end/indexing-controls-test.php
+++ b/tests/unit/integrations/front-end/indexing-controls-test.php
@@ -13,7 +13,6 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  * Class Indexing_Controls_Test.
  *
  * @coversDefaultClass \Yoast\WP\SEO\Integrations\Front_End\Indexing_Controls
- * @covers ::<!public>
  *
  * @group integrations
  * @group front-end

--- a/tests/unit/integrations/front-end/redirects-test.php
+++ b/tests/unit/integrations/front-end/redirects-test.php
@@ -16,7 +16,6 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  * Class Redirects_Test.
  *
  * @coversDefaultClass \Yoast\WP\SEO\Integrations\Front_End\Redirects
- * @covers ::<!public>
  *
  * @group integrations
  * @group front-end

--- a/tests/unit/integrations/front-end/robots-txt-integration-test.php
+++ b/tests/unit/integrations/front-end/robots-txt-integration-test.php
@@ -93,17 +93,24 @@ class Robots_Txt_Integration_Test extends TestCase {
 	 * @param string $expected The expected output/sitemap.
 	 */
 	public function test_public_site_with_sitemaps( $sitemap, $expected ) {
+		global $wp_rewrite;
+
+		$wp_rewrite = Mockery::mock();
+		$wp_rewrite->expects( 'using_index_permalinks' )->andReturnFalse();
+
+		Monkey\Functions\expect( 'home_url' )
+			->once()
+			->andReturn( 'https://example.com/sitemap_index.xml' );
+
+		Monkey\Functions\expect( 'wp_parse_url' )
+			->once()
+			->andReturn( 'https' );
+
 		$this->options_helper
 			->expects( 'get' )
 			->once()
 			->with( 'enable_xml_sitemap', false )
 			->andReturnTrue();
-
-		Mockery::mock( 'overload:WPSEO_Sitemaps_Router' )
-			->expects( 'get_base_url' )
-			->once()
-			->with( 'sitemap_index.xml' )
-			->andReturn( 'https://example.com/sitemap_index.xml' );
 
 		$this->assertEquals(
 			$expected,
@@ -137,11 +144,18 @@ class Robots_Txt_Integration_Test extends TestCase {
 			->with( 'enable_xml_sitemap', false )
 			->andReturnTrue();
 
-		Mockery::mock( 'overload:WPSEO_Sitemaps_Router' )
-			->expects( 'get_base_url' )
+		global $wp_rewrite;
+
+		$wp_rewrite = Mockery::mock();
+		$wp_rewrite->expects( 'using_index_permalinks' )->andReturnFalse();
+
+		Monkey\Functions\expect( 'home_url' )
 			->once()
-			->with( 'sitemap_index.xml' )
 			->andReturn( 'https://example.com/sitemap_index.xml' );
+
+		Monkey\Functions\expect( 'wp_parse_url' )
+			->once()
+			->andReturn( 'https' );
 
 		Monkey\Functions\when( 'is_multisite' )->justReturn( true );
 		Monkey\Functions\when( 'is_subdomain_install' )->justReturn( ! $multisite['is_subdirectory'] );
@@ -186,17 +200,24 @@ class Robots_Txt_Integration_Test extends TestCase {
 	 * @covers ::is_yoast_active_for_network
 	 */
 	public function test_multisite_sitemaps_without_yoast_seo_active() {
+		global $wp_rewrite;
+
+		$wp_rewrite = Mockery::mock();
+		$wp_rewrite->expects( 'using_index_permalinks' )->andReturnFalse();
+
+		Monkey\Functions\expect( 'home_url' )
+			->once()
+			->andReturn( 'https://example.com/sitemap_index.xml' );
+
+		Monkey\Functions\expect( 'wp_parse_url' )
+			->once()
+			->andReturn( 'https' );
+
 		$this->options_helper
 			->expects( 'get' )
 			->once()
 			->with( 'enable_xml_sitemap', false )
 			->andReturnTrue();
-
-		Mockery::mock( 'overload:WPSEO_Sitemaps_Router' )
-			->expects( 'get_base_url' )
-			->once()
-			->with( 'sitemap_index.xml' )
-			->andReturn( 'https://example.com/sitemap_index.xml' );
 
 		Monkey\Functions\when( 'is_multisite' )->justReturn( true );
 		Monkey\Functions\when( 'is_subdomain_install' )->justReturn( false );
@@ -241,17 +262,24 @@ class Robots_Txt_Integration_Test extends TestCase {
 	 * @covers ::is_yoast_active_for_network
 	 */
 	public function test_multisite_sitemaps_option_not_found() {
+		global $wp_rewrite;
+
+		$wp_rewrite = Mockery::mock();
+		$wp_rewrite->expects( 'using_index_permalinks' )->andReturnFalse();
+
+		Monkey\Functions\expect( 'home_url' )
+			->once()
+			->andReturn( 'https://example.com/sitemap_index.xml' );
+
+		Monkey\Functions\expect( 'wp_parse_url' )
+			->once()
+			->andReturn( 'https' );
+
 		$this->options_helper
 			->expects( 'get' )
 			->once()
 			->with( 'enable_xml_sitemap', false )
 			->andReturnTrue();
-
-		Mockery::mock( 'overload:WPSEO_Sitemaps_Router' )
-			->expects( 'get_base_url' )
-			->once()
-			->with( 'sitemap_index.xml' )
-			->andReturn( 'https://example.com/sitemap_index.xml' );
 
 		Monkey\Functions\when( 'is_multisite' )->justReturn( true );
 		Monkey\Functions\when( 'is_subdomain_install' )->justReturn( false );

--- a/tests/unit/integrations/front-end/rss-footer-embed-test.php
+++ b/tests/unit/integrations/front-end/rss-footer-embed-test.php
@@ -13,7 +13,6 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  * Class RSS_Footer_Embed_Test.
  *
  * @coversDefaultClass \Yoast\WP\SEO\Integrations\Front_End\RSS_Footer_Embed
- * @covers ::<!public>
  *
  * @group integrations
  * @group front-end

--- a/tests/unit/integrations/front-end/theme-titles-test.php
+++ b/tests/unit/integrations/front-end/theme-titles-test.php
@@ -11,7 +11,6 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  * Class Theme_Titles_Test.
  *
  * @coversDefaultClass \Yoast\WP\SEO\Integrations\Front_End\Theme_Titles
- * @covers ::<!public>
  *
  * @group integrations
  * @group front-end

--- a/tests/unit/integrations/third-party/amp-test.php
+++ b/tests/unit/integrations/third-party/amp-test.php
@@ -12,7 +12,6 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  * AMP integration test.
  *
  * @coversDefaultClass \Yoast\WP\SEO\Integrations\Third_Party\AMP
- * @covers ::<!public>
  *
  * @group integrations
  * @group third-party

--- a/tests/unit/integrations/third-party/bbpress-test.php
+++ b/tests/unit/integrations/third-party/bbpress-test.php
@@ -12,7 +12,6 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  * Class BbPress_Test.
  *
  * @coversDefaultClass \Yoast\WP\SEO\Integrations\Third_Party\BbPress
- * @covers ::<!public>
  *
  * @group integrations
  * @group third-party

--- a/tests/unit/integrations/third-party/jetpack-test.php
+++ b/tests/unit/integrations/third-party/jetpack-test.php
@@ -12,7 +12,6 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  * Class Jetpack_Test.
  *
  * @coversDefaultClass \Yoast\WP\SEO\Integrations\Third_Party\Jetpack
- * @covers ::<!public>
  *
  * @group integrations
  * @group third-party

--- a/tests/unit/integrations/third-party/wpml-test.php
+++ b/tests/unit/integrations/third-party/wpml-test.php
@@ -10,7 +10,6 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  * Class WPML_Test.
  *
  * @coversDefaultClass \Yoast\WP\SEO\Integrations\Third_Party\WPML
- * @covers ::<!public>
  *
  * @group integrations
  * @group third-party

--- a/tests/unit/loader-test.php
+++ b/tests/unit/loader-test.php
@@ -16,7 +16,6 @@ use YoastSEO_Vendor\Symfony\Component\DependencyInjection\ContainerInterface;
  * @group loader
  *
  * @coversDefaultClass \Yoast\WP\SEO\Loader
- * @covers ::<!public>
  */
 class Loader_Test extends TestCase {
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Set IndexNow to on by default (in premium);
* Simplify XML sitemap ping towards Google
* Remove Bing XML sitemap ping

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Ensures the Bing XML sitemap ping is only made if IndexNow is disabled.
* Prevents XML sitemap pings for blogs that aren't public.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Place a breakpoint in the ping search engines function.
* It should be called when you publish a post.


### Test instructions for QA when the code is in the RC
<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Publish a post.
* There should be no errors in the network tab or console ( compared to before clicking publish ).

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Pinging search engines after a post has been published or otherwise transitioned in status.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes #
