### PR TITLE
WordProof endpoint fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
 		"symfony/polyfill-intl-normalizer": "1.19.0",
 		"symfony/polyfill-php70": "1.19.0",
 		"symfony/polyfill-php72": "1.19.0",
-		"wordproof/wordpress-sdk": "1.3"
+		"wordproof/wordpress-sdk": "1.3.1"
 	},
 	"minimum-stability": "dev",
 	"prefer-stable": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "933f38a68d0ef6536aa67780ea3c5edc",
+    "content-hash": "bd84705c345c5be7b5d5d3d73fba6bf0",
     "packages": [
         {
             "name": "composer/installers",
@@ -4381,16 +4381,16 @@
         },
         {
             "name": "wordproof/wordpress-sdk",
-            "version": "1.3.0",
+            "version": "1.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wordproof/wordpress-sdk.git",
-                "reference": "457f521cac04ed4de13316b5568783e1548013c7"
+                "reference": "e9c1008e3de9b3601592ac1c7e04d116bc444f50"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wordproof/wordpress-sdk/zipball/457f521cac04ed4de13316b5568783e1548013c7",
-                "reference": "457f521cac04ed4de13316b5568783e1548013c7",
+                "url": "https://api.github.com/repos/wordproof/wordpress-sdk/zipball/e9c1008e3de9b3601592ac1c7e04d116bc444f50",
+                "reference": "e9c1008e3de9b3601592ac1c7e04d116bc444f50",
                 "shasum": ""
             },
             "require": {
@@ -4427,9 +4427,9 @@
             "description": "WordPress SDK",
             "support": {
                 "issues": "https://github.com/wordproof/wordpress-sdk/issues",
-                "source": "https://github.com/wordproof/wordpress-sdk/tree/1.3.0"
+                "source": "https://github.com/wordproof/wordpress-sdk/tree/1.3.1"
             },
-            "time": "2022-06-10T13:05:15+00:00"
+            "time": "2022-06-17T07:40:34+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",

--- a/src/conditionals/third-party/wordproof-integration-active-conditional.php
+++ b/src/conditionals/third-party/wordproof-integration-active-conditional.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Yoast\WP\SEO\Conditionals\Third_Party;
+
+use Yoast\WP\SEO\Conditionals\Conditional;
+use Yoast\WP\SEO\Helpers\Wordproof_Helper;
+
+/**
+ * Conditional that is met when the WordProof integration is toggled on.
+ */
+class Wordproof_Integration_Active_Conditional implements Conditional {
+
+	/**
+	 * The WordProof helper.
+	 *
+	 * @var Wordproof_Helper
+	 */
+	private $wordproof;
+
+	/**
+	 * WordProof integration active constructor.
+	 *
+	 * @param Wordproof_Helper $wordproof The options helper.
+	 */
+	public function __construct( Wordproof_Helper $wordproof ) {
+		$this->wordproof = $wordproof;
+	}
+
+	/**
+	 * Returns whether or not the WordProof Timestamp plugin is active.
+	 *
+	 * @return bool Whether or not the WordProof Timestamp plugin is active.
+	 */
+	public function is_met() {
+		return $this->wordproof->integration_is_active();
+	}
+}

--- a/src/integrations/third-party/wordproof.php
+++ b/src/integrations/third-party/wordproof.php
@@ -3,6 +3,7 @@
 namespace Yoast\WP\SEO\Integrations\Third_Party;
 
 use WPSEO_Admin_Asset_Manager;
+use Yoast\WP\SEO\Conditionals\Third_Party\Wordproof_Integration_Active_Conditional;
 use YoastSEO_Vendor\WordProof\SDK\Helpers\CertificateHelper;
 use YoastSEO_Vendor\WordProof\SDK\Helpers\PostMetaHelper;
 use YoastSEO_Vendor\WordProof\SDK\WordPressSDK;
@@ -62,7 +63,11 @@ class Wordproof implements Integration_Interface {
 	 * @return array
 	 */
 	public static function get_conditionals() {
-		return [ Wordproof_Plugin_Inactive_Conditional::class, Non_Multisite_Conditional::class ];
+		return [
+			Wordproof_Plugin_Inactive_Conditional::class,
+			Non_Multisite_Conditional::class,
+			Wordproof_Integration_Active_Conditional::class,
+		];
 	}
 
 	/**
@@ -104,7 +109,7 @@ class Wordproof implements Integration_Interface {
 		\add_filter( 'wordproof_timestamp_post_meta_key_overrides', [ $this, 'add_post_meta_key' ] );
 
 		/**
-		 * Called by the WordProof WordPress SDK to determine if the certficate should be shown.
+		 * Called by the WordProof WordPress SDK to determine if the certificate should be shown.
 		 */
 		\add_filter( 'wordproof_timestamp_show_certificate', [ $this, 'show_certificate' ], 10, 2 );
 


### PR DESCRIPTION
## Context

* Fix for [QA-3346](https://yoast.atlassian.net/browse/QA-3346)

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* WordProof endpoint security vulnerability fix

## Relevant technical choices:

* Added a Wordproof_integration_active conditional to the main WordProof integration file that prevents registering the hooks. With the integration disabled, none of the hooks in `integrations/third-party/wordproof.php` are registered. This includes the init of the SDK which in turn registers webhooks.
* Webhooks are only accepted when the site is authenticated preventing others to access webhook endpoints.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Go to /wp-json
* wordproof/v1 should not be listed in the namespaces
* enable the WordProof integration
* wordproof/v1 should be listed in the namespaces

Test the extra check on `isValidWebhookRequest`.
* Enable the integration
* Be unauthenticated
* Send a post request to the webhook endpoint (/wordproof/v1/webhook) with the signature set to e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.
* You shouldn't have permission to access this resource.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* See https://yoast.atlassian.net/browse/QA-3346

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes #
