### PR TITLE
Lr 45 sentence tokenizer clash between initials and quotes

### DIFF
--- a/packages/yoastseo/spec/languageProcessing/helpers/sentence/SentenceTokenizerSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/helpers/sentence/SentenceTokenizerSpec.js
@@ -354,5 +354,41 @@ describe( "A test for tokenizing a (html) text into sentences", function() {
 
 		expect( mockTokenizer.isPartOfPersonInitial( token, previousToken, nextToken, secondToNextToken ) ).toBeTruthy();
 	} );
+
+	it( "recognizes initials in the edge case where there are quotes arouond the initials", function() {
+		const tokens = [
+			{ type: "sentence", src: "The reprint was favourably reviewed by" },
+			{ type: "sentence-delimiter", src: "\"" },
+			{ type: "sentence", src: "A" },
+			{ type: "full-stop", src: "." },
+			{ type: "sentence", src: " B" },
+			{ type: "full-stop", src: "." },
+			{ type: "sentence-delimiter", src: "\"" },
+			{ type: "full-stop", src: " in The Musical Times in 1935, who commented \"Praise is due to Mr Mercer." },
+		];
+
+		const token = tokens[ 3 ];
+		const previousToken = tokens[ 2 ];
+		const nextToken = tokens[ 4 ];
+		const secondToNextToken = tokens[ 5 ];
+
+		expect( mockTokenizer.isPartOfPersonInitial( token, previousToken, nextToken, secondToNextToken ) ).toBe( true );
+	} );
+
+	it( "correctly constructs the sentence in the edge case where there are quotes arouond the initials", function() {
+		const tokens = [
+			{ type: "sentence", src: "The reprint was favourably reviewed by" },
+			{ type: "sentence-delimiter", src: " \"" },
+			{ type: "sentence", src: "A" },
+			{ type: "full-stop", src: "." },
+			{ type: "sentence", src: " B" },
+			{ type: "full-stop", src: "." },
+			{ type: "sentence-delimiter", src: "\"" },
+			{ type: "full-stop", src: " in The Musical Times in 1935, who commented \"Praise is due to Mr Mercer." },
+		];
+
+		expect( mockTokenizer.getSentencesFromTokens( tokens ) ).toEqual( [
+			"The reprint was favourably reviewed by \"A. B.\" in The Musical Times in 1935, who commented \"Praise is due to Mr Mercer." ] );
+	} );
 } );
 

--- a/packages/yoastseo/spec/languageProcessing/helpers/sentence/getSentencesSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/helpers/sentence/getSentencesSpec.js
@@ -521,6 +521,11 @@ describe( "a test for when texts containing sentence delimiter", () => {
 			"東海道新幹線の開業前、東西の大動脈である東海道本線は高度経済成長下で線路容量が逼迫しており‥",
 			"抜本的な輸送力増強を迫られていた。" ] );
 	} );
+
+	it( "can deal with the edge case of quotes around initials.", ()=>{
+		expect( getSentences( "The reprint was favourably reviewed by \"A. B.\" in The Musical Times in 1935, who commented \"Praise is due to Mr Mercer." ) ).toEqual(
+			[ "The reprint was favourably reviewed by \"A. B.\" in The Musical Times in 1935, who commented \"Praise is due to Mr Mercer." ] );
+	} );
 } );
 
 describe( "parses Japanese text", () => {
@@ -1066,9 +1071,4 @@ describe( "Get sentences from texts that have been processed for the keyphrase d
 
 		testGetSentences( testCases );
 	} );
-
-	it("message", ()=>{
-		// const mockpaper = Paper("The reprint was favourably reviewed by \"A. B.\" in The Musical Times in 1935, who commented \"Praise is due to Mr Mercer.");
-		expect( getSentences("The reprint was favourably reviewed by \"A. B.\" in The Musical Times in 1935, who commented \"Praise is due to Mr Mercer.")).toEqual(["The reprint was favourably reviewed by \"A. B.\" in The Musical Times in 1935, who commented \"Praise is due to Mr Mercer."])
-	})
 } );

--- a/packages/yoastseo/spec/languageProcessing/helpers/sentence/getSentencesSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/helpers/sentence/getSentencesSpec.js
@@ -1066,4 +1066,9 @@ describe( "Get sentences from texts that have been processed for the keyphrase d
 
 		testGetSentences( testCases );
 	} );
+
+	it("message", ()=>{
+		// const mockpaper = Paper("The reprint was favourably reviewed by \"A. B.\" in The Musical Times in 1935, who commented \"Praise is due to Mr Mercer.");
+		expect( getSentences("The reprint was favourably reviewed by \"A. B.\" in The Musical Times in 1935, who commented \"Praise is due to Mr Mercer.")).toEqual(["The reprint was favourably reviewed by \"A. B.\" in The Musical Times in 1935, who commented \"Praise is due to Mr Mercer."])
+	})
 } );

--- a/packages/yoastseo/src/languageProcessing/helpers/sentence/SentenceTokenizer.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/sentence/SentenceTokenizer.js
@@ -25,7 +25,7 @@ const blockEndRegex = /^\s*[\])}]\s*$/;
 const abbreviationsPreparedForRegex = abbreviations.map( ( abbreviation ) => abbreviation.replace( ".", "\\." ) );
 const abbreviationsRegex = createRegexFromArray( abbreviationsPreparedForRegex );
 
-const wordBoundariesForRegex = "[" + wordBoundaries().map( ( boundary ) => "\\" + boundary ).join( "" ) + "]";
+const wordBoundariesForRegex = "(^|$|[" + wordBoundaries().map( ( boundary ) => "\\" + boundary ).join( "" ) + "])";
 const lastCharacterPartOfInitialsRegex = new RegExp( wordBoundariesForRegex + "[A-Za-z]$" );
 
 /**
@@ -411,7 +411,6 @@ export default class SentenceTokenizer {
 			const nextToken = tokenArray[ i + 1 ];
 			const previousToken = tokenArray[ i - 1 ];
 			const secondToNextToken = tokenArray[ i + 2 ];
-
 			nextCharacters = this.getNextTwoCharacters( [ nextToken, secondToNextToken ] );
 
 			// For a new sentence we need to check the next two characters.


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* LR-7 and LR-9 where both merged, but caused an issue when combined. This pr fixes this.
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [non-user-facing] Fixes a bug where two PRs on the sentence tokenizer clashed, which broke the fix of initials.

## Relevant technical choices:

* The `wordBoundariesForRegex` in `sentenceTokenizer.js` was expanded to also increase string boundaries.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

## Test [LR-7](https://github.com/Yoast/wordpress-seo/pull/18527) (I adapted it a little bit for easier testing):
## For wordpress
1. Create a new post. And fill in a title. For example "Frank Mercer"
2. Paste the text from [LR_7_test_text.txt](https://github.com/Yoast/wordpress-seo/files/8762162/LR_7_test_text.txt) in the post.
3. Expand readability analysis and toggle button to highlight the results of the passive voice analysis in the text (see arrow in the screenshot)
![wordpress_PV](https://user-images.githubusercontent.com/26040749/174072935-cd4f3d03-a766-4451-a5de-5d7b6dd17d7c.png)

4. The result should look like the screenshot.

5. Note that the following sentence is highlighted entirely, which is the desired outcome. "The reprint was favourably reviewed by "A. B." in The Musical Times in 1935, who commented "Praise is due to Mr Mercer."

6. Note that the following sentence is highlighted and the subsequent sentence is not, which is the desired outcome "A sentence is written by me."
7. Note that the following sentence is highlighted and the subsequent sentence is not, which is the desired outcome "A good way to do this is to see whether A cat is possessed by C.D. "

### For shopify
install plugin to shopify

1. Create a new product, and give it a name (e.g. Frank Mercer).

2. Paste the text from [LR_7_test_text.txt](https://github.com/Yoast/wordpress-seo/files/8762162/LR_7_test_text.txt) in the post.

3. In the yoast app. Expand readability analysis and toggle button to highlight the results of the passive voice analysis in the text (see arrow in the screenshot)

4. The results should look like the screenshot.
![shopify_PV](https://user-images.githubusercontent.com/26040749/174073439-83ee65b2-c9af-4a22-8949-d40b462a6d69.png)

5. Check points 5-7 from the wordpress test.

**Also check again the tests from [LR 9](https://github.com/Yoast/wordpress-seo/pull/18530):** (adapted a little)
1. In wordpress: add these sentences to the existing post (e.g. at the top of the page): `Add these sentences: Moreover, we expect the actor to be in the subject position, so we are slightly disoriented. This means constructing an image of what happens takes a tiny moment longer.`
2. Turn on highlighting for passive voice, Confirm that only the **first sentence** is highlighted (see screenshot.)
3. Put the first sentence in quotation marks, e.g. `"Moreover, we expect the actor to be in the subject position, so we are slightly disoriented."`
4. Confirm that only the first sentence is highlighted.
5. Put the first sentence in other quotation marks, e.g. `“”`. (Make sure there is a space between the sentences)
6. Confirm that only the first sentence is highlighted.
<img width="1473" alt="Screenshot 2022-06-16 at 15 04 06" src="https://user-images.githubusercontent.com/26040749/174076132-a8123089-c2b2-4b28-a0c5-4e6af2bd6d62.png">


## Shopify
To the existing shopify page:
1. Add these sentences: `Moreover, we expect the actor to be in the subject position, so we are slightly disoriented. This means constructing an image of what happens takes a tiny moment longer.`
2. Turn on highlighting for passive voice
3. Confirm that only the first sentence is highlighted.
4. Put the first sentence in quotation marks, e.g. `"Moreover, we expect the actor to be in the subject position, so we are slightly disoriented." This means constructing an image of what happens takes a tiny moment longer.`
5. Confirm that only the first sentence is highlighted.
6. Put the first sentence in other quotation marks, e.g. `“”`. (Make sure there is a space between the sentences)
7. Confirm that only the first sentence is highlighted.

<img width="1473" alt="Screenshot 2022-06-16 at 15 10 12" src="https://user-images.githubusercontent.com/26040749/174077209-4e99e234-100c-40e7-91e0-5df10c0a901f.png">


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* 

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes # https://yoast.atlassian.net/jira/software/c/projects/LR/boards/136?modal=detail&selectedIssue=LR-45
