### PR TITLE
Fix small bug in the WordProof certificate

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@typescript-eslint/parser": "^4.24.0",
     "@wordpress/dependency-extraction-webpack-plugin": "^3.1.0",
     "@wordpress/scripts": "^14.1.1",
-    "@wordproof/uikit": "^1.0.40",
+    "@wordproof/uikit": "1.0.41",
     "@yoast/babel-preset": "^1.0.0",
     "@yoast/browserslist-config": "^1.2.2",
     "@yoast/grunt-plugin-tasks": "^2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6957,10 +6957,10 @@
     "@babel/runtime" "^7.13.10"
     lodash "^4.17.19"
 
-"@wordproof/uikit@^1.0.40":
-  version "1.0.40"
-  resolved "https://registry.yarnpkg.com/@wordproof/uikit/-/uikit-1.0.40.tgz#34fba00181a5b37cb912204e74a635b6802401ef"
-  integrity sha512-FyS8DiKKWZUiAer2eGquzYwmwbUPrOOYLqxS4U0v9cHvEHB7K/R6JQPqvcGQmZhR0Za3r5mei6P6BmbgSsRx7g==
+"@wordproof/uikit@1.0.41":
+  version "1.0.41"
+  resolved "https://registry.yarnpkg.com/@wordproof/uikit/-/uikit-1.0.41.tgz#0aefba14bec5abe494c388b6c4f6936711c6a58a"
+  integrity sha512-AjavDDgZOSvrXVObRTHdVV82gQvGO9ceDDUaAOPRufFZjBwJatdWYQ9AMCXhd07uabNHnVZXeRijsAB80vPIZA==
   dependencies:
     "@stencil/core" "2.9.0"
     autoprefixer "^10.2.3"


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Fixes small bug in the WordProof certificate

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fix small bug in the WordProof certificate
<img width="982" alt="image" src="https://user-images.githubusercontent.com/11903095/174721237-721e8670-a089-40ca-8836-bb447ef7dc58.png">


## Relevant technical choices:

* New version of @wordproof/uikit.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Timestamp a page
* Open the certificate
* Click on "Compare Versions"
* Make sure the line breaks are not as funky as in the image below.
<img width="562" alt="image" src="https://user-images.githubusercontent.com/11903095/174721505-a6ee54d4-5f1f-42da-a139-7c9f86ce8775.png">



### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->


## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The WordProof certificate

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes #
