### PR TITLE
Replace date replace var with an empty string on terms.

### DIFF
--- a/inc/class-wpseo-replace-vars.php
+++ b/inc/class-wpseo-replace-vars.php
@@ -362,6 +362,13 @@ class WPSEO_Replace_Vars {
 	private function retrieve_date() {
 		$replacement = null;
 
+		/*
+		 * Terms do not have dates, so return an empty string.
+		 */
+		if ( self::is_a_term( $this->args ) ) {
+			return '';
+		}
+
 		if ( $this->args->post_date !== '' ) {
 			// Returns a string.
 			$replacement = YoastSEO()->helpers->date->format_translated( $this->args->post_date, get_option( 'date_format' ) );
@@ -384,6 +391,17 @@ class WPSEO_Replace_Vars {
 		}
 
 		return $replacement;
+	}
+
+	/**
+	 * Check whether the given object is a term.
+	 *
+	 * @param Object $object The object to check.
+	 *
+	 * @return bool Whether the current object is a term.
+	 */
+	private static function is_a_term( $object ) {
+		return ! empty( $object->taxonomy ) && ! empty( $object->term_id );
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Since terms do not have a published date, we do not want to output anything when a user enters a `%%date%%` replace var in the title or meta description of a term.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the `date` replacement variable would output `0` when used in categories or tags, instead of not outputting anything as shown in the Google preview.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

Please test this in a 'normal' term (either category or tag) and in a term from a custom taxonomy.
* Create a term.
* Add the `%%date%%` replace var in either the meta description or SEO title.
* See that the Google preview replaces the replace var with nothing.
* Publish the term.
* Go to the term page on the website.
* Check the source code of the term page. It should be the same as the one shown in the Google preview.
   * E.g. the `%%date%%` replace var should be replaced by nothing / the empty string.
   * **Note**: There is another existing bug where empty strings are replaced with a single space.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes #
