### PR TITLE
Improve archive template / CollectionPage schema properties

### DIFF
--- a/src/context/meta-tags-context.php
+++ b/src/context/meta-tags-context.php
@@ -604,8 +604,7 @@ class Meta_Tags_Context extends Abstract_Presentation {
 	public function generate_main_image_id() {
 		switch ( true ) {
 			case is_singular():
-				$this->get_singular_post_image( $this->id );
-				break;
+				return $this->get_singular_post_image( $this->id );
 			case is_author():
 			case is_tax():
 			case is_tag():
@@ -691,6 +690,10 @@ class Meta_Tags_Context extends Abstract_Presentation {
 			if ( \is_int( $thumbnail_id ) && $thumbnail_id > 0 ) {
 				return $thumbnail_id;
 			}
+		}
+
+		if ( \is_singular( 'attachment' ) ) {
+			return \get_query_var( 'attachment_id' );
 		}
 
 		return null;

--- a/src/context/meta-tags-context.php
+++ b/src/context/meta-tags-context.php
@@ -615,6 +615,7 @@ class Meta_Tags_Context extends Abstract_Presentation {
 			case is_category():
 			case is_search():
 			case is_date():
+			case is_post_type_archive():
 				return $this->get_singular_post_image( $GLOBALS['wp_query']->posts[0]->ID );
 			default:
 				return null;

--- a/src/context/meta-tags-context.php
+++ b/src/context/meta-tags-context.php
@@ -4,7 +4,6 @@ namespace Yoast\WP\SEO\Context;
 
 use WP_Block_Parser_Block;
 use WP_Post;
-use WPSEO_Image_Utils;
 use WPSEO_Replace_Vars;
 use Yoast\WP\SEO\Config\Schema_IDs;
 use Yoast\WP\SEO\Config\Schema_Types;
@@ -614,8 +613,6 @@ class Meta_Tags_Context extends Abstract_Presentation {
 			case is_search():
 			case is_date():
 				return $this->get_singular_post_image( $GLOBALS['wp_query']->posts[0]->ID );
-			case is_404():
-				return $this->options->get( 'og_default_image_id', null );
 			default:
 				return null;
 		}

--- a/src/context/meta-tags-context.php
+++ b/src/context/meta-tags-context.php
@@ -588,6 +588,10 @@ class Meta_Tags_Context extends Abstract_Presentation {
 			return $this->image->get_attachment_image_url( $this->main_image_id, 'full' );
 		}
 
+		if ( ! \is_singular() ) {
+			return null;
+		}
+
 		$url = $this->image->get_post_content_image( $this->id );
 		if ( $url === '' ) {
 			return null;

--- a/src/generators/schema/main-image.php
+++ b/src/generators/schema/main-image.php
@@ -15,7 +15,7 @@ class Main_Image extends Abstract_Schema_Piece {
 	 * @return bool
 	 */
 	public function is_needed() {
-		return $this->context->indexable->object_type !== 'user';
+		return true;
 	}
 
 	/**

--- a/src/generators/schema/main-image.php
+++ b/src/generators/schema/main-image.php
@@ -15,7 +15,7 @@ class Main_Image extends Abstract_Schema_Piece {
 	 * @return bool
 	 */
 	public function is_needed() {
-		return $this->context->indexable->object_type === 'post';
+		return $this->context->indexable->object_type !== 'user';
 	}
 
 	/**

--- a/src/generators/schema/webpage.php
+++ b/src/generators/schema/webpage.php
@@ -45,9 +45,9 @@ class WebPage extends Abstract_Schema_Piece {
 			}
 		}
 
-		if ( $this->context->indexable->object_type === 'post' ) {
-			$this->add_image( $data );
+		$this->add_image( $data );
 
+		if ( $this->context->indexable->object_type === 'post' ) {
 			$data['datePublished'] = $this->helpers->date->format( $this->context->post->post_date_gmt );
 			$data['dateModified']  = $this->helpers->date->format( $this->context->post->post_modified_gmt );
 
@@ -100,6 +100,8 @@ class WebPage extends Abstract_Schema_Piece {
 	public function add_image( &$data ) {
 		if ( $this->context->has_image ) {
 			$data['primaryImageOfPage'] = [ '@id' => $this->context->canonical . Schema_IDs::PRIMARY_IMAGE_HASH ];
+			$data['image']              = [ '@id' => $this->context->canonical . Schema_IDs::PRIMARY_IMAGE_HASH ];
+			$data['thumbnailUrl']       = $this->context->main_image_url;
 		}
 	}
 
@@ -125,8 +127,8 @@ class WebPage extends Abstract_Schema_Piece {
 	 */
 	private function add_potential_action( $data ) {
 		$url = $this->context->canonical;
-		if ( empty( $url ) && \is_search() ) {
-			$url = $this->build_search_url();
+		if ( $data['@type'] === 'CollectionPage' || ( is_array( $data['@type'] ) && in_array( 'CollectionPage', $data['@type'], true ) ) ) {
+			return $data;
 		}
 
 		/**

--- a/tests/unit/generators/schema-generator-test.php
+++ b/tests/unit/generators/schema-generator-test.php
@@ -223,6 +223,7 @@ class Schema_Generator_Test extends TestCase {
 	 */
 	public function test_generate_with_no_blocks() {
 		$this->context->indexable->object_sub_type = 'super-custom-post-type';
+		$this->context->has_image                  = false;
 		$this->current_page->expects( 'is_paged' )->andReturns( false );
 
 		Monkey\Functions\expect( 'is_search' )
@@ -832,6 +833,7 @@ class Schema_Generator_Test extends TestCase {
 	 */
 	public function test_generate_with_search_page() {
 		$this->context->indexable->object_sub_type = 'super-custom-post-type';
+		$this->context->has_image                  = false;
 		$this->context->site_url                   = 'https://fake.url/';
 		$this->context->main_schema_id             = 'https://fake.url/?s=searchterm';
 
@@ -893,14 +895,6 @@ class Schema_Generator_Test extends TestCase {
 						],
 						'inLanguage'      => 'English',
 						'breadcrumb'      => [ '@id' => '#breadcrumb' ],
-						'potentialAction' => [
-							[
-								'@type'  => 'ReadAction',
-								'target' => [
-									0 => 'https://fake.url/?s=searchterm',
-								],
-							],
-						],
 					],
 				],
 			],

--- a/tests/unit/generators/schema/main-image-test.php
+++ b/tests/unit/generators/schema/main-image-test.php
@@ -158,28 +158,6 @@ class Main_Image_Test extends TestCase {
 	}
 
 	/**
-	 * Tests is needed.
-	 *
-	 * @covers ::is_needed
-	 */
-	public function test_is_needed() {
-		$this->meta_tags_context->indexable->object_type = 'post';
-
-		self::assertTrue( $this->instance->is_needed() );
-	}
-
-	/**
-	 * Tests to see output is not needed on a user page.
-	 *
-	 * @covers ::is_needed
-	 */
-	public function test_is_needed_object_type_user() {
-		$this->meta_tags_context->indexable->object_type = 'user';
-
-		self::assertFalse( $this->instance->is_needed() );
-	}
-
-	/**
 	 * Generates the image id as the main image class would.
 	 *
 	 * @return string The image id.

--- a/tests/unit/generators/schema/main-image-test.php
+++ b/tests/unit/generators/schema/main-image-test.php
@@ -169,11 +169,11 @@ class Main_Image_Test extends TestCase {
 	}
 
 	/**
-	 * Tests is not needed.
+	 * Tests to see output is not needed on a user page.
 	 *
 	 * @covers ::is_needed
 	 */
-	public function test_is_not_needed() {
+	public function test_is_needed_object_type_user() {
 		$this->meta_tags_context->indexable->object_type = 'user';
 
 		self::assertFalse( $this->instance->is_needed() );

--- a/tests/unit/generators/schema/webpage-test.php
+++ b/tests/unit/generators/schema/webpage-test.php
@@ -195,6 +195,10 @@ class WebPage_Test extends TestCase {
 	public function test_generate_with_provider( $values_to_test, $expected, $message ) {
 		$this->meta_tags_context->has_image = $values_to_test['has_image'];
 
+		if ( $this->meta_tags_context->has_image ) {
+			$this->meta_tags_context->main_image_url = $values_to_test['image_url'];
+		}
+
 		$this->id->primary_image_hash = '#primaryimage';
 		$this->id->breadcrumb_hash    = '#breadcrumb';
 
@@ -457,7 +461,7 @@ class WebPage_Test extends TestCase {
 			'CollectionPage',
 			0,
 			0,
-			1
+			0
 		);
 
 		$expected = [
@@ -469,14 +473,6 @@ class WebPage_Test extends TestCase {
 				'@id' => 'https://example.com/#website',
 			],
 			'inLanguage'      => 'the-language',
-			'potentialAction' => [
-				[
-					'@type'  => 'ReadAction',
-					'target' => [
-						'https://example.com/the-post/',
-					],
-				],
-			],
 			'breadcrumb'      => [ '@id' => 'https://example.com/the-post/#breadcrumb' ],
 		];
 
@@ -498,7 +494,7 @@ class WebPage_Test extends TestCase {
 			'CollectionPage',
 			1,
 			1,
-			1
+			0
 		);
 
 		$expected = [
@@ -513,14 +509,6 @@ class WebPage_Test extends TestCase {
 				'@id' => 'https://example.com/#website',
 			],
 			'inLanguage'      => 'the-language',
-			'potentialAction' => [
-				[
-					'@type'  => 'ReadAction',
-					'target' => [
-						'https://example.com/the-post/',
-					],
-				],
-			],
 		];
 
 		$this->assertEquals( $expected, $this->instance->generate() );
@@ -581,6 +569,7 @@ class WebPage_Test extends TestCase {
 			[
 				'values_to_test' => [
 					'has_image'           => true,
+					'image_url'           => 'https://example.com/image.jpg',
 				],
 				'expected'       => [
 					'@type'              => [ 'WebPage' ],
@@ -594,6 +583,8 @@ class WebPage_Test extends TestCase {
 					'dateModified'       => '2345-12-12 23:23:23',
 					'breadcrumb'         => [ '@id' => 'https://example.com/the-post/#breadcrumb' ],
 					'primaryImageOfPage' => [ '@id' => 'https://example.com/the-post/#primaryimage' ],
+					'image'              => [ '@id' => 'https://example.com/the-post/#primaryimage' ],
+					'thumbnailUrl'       => 'https://example.com/image.jpg',
 					'inLanguage'         => 'the-language',
 					'potentialAction'    => [
 						[


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves Schema for archive pages by using the featured image of the first post as `primaryImageOfPage` and removing `potentialAction`.
* Improves Schema for attachment pages by setting the proper `primaryImage` attribute.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:
_Tip: to verify the results of this PR, I found the [diffchecker](https://www.diffchecker.com/diff) tool to be very effective. You can use it to compare the schema produced by Yoast SEO before and after applying the PR.
However, you should still use a schema validator tool s.a. [this](https://classyschema.org/Visualisation) to ensure a valid schema is produced._
* Go to `Yoast SEO` -> `Search Appearance` -> `Media` tab and verify that the `Redirect attachment URLs to the attachment itself?` toggle is set to `No`
* Visit an attachment page: 
  * go to `Media` -> `Library` 
  * Select an image and click on the link `View attachment page`
* Inspect the page source, copy the generated schema and verify:
  * Without this PR, the `WebPage` schema piece has no `primaryImageOfPage` element
  * With this PR , the  `WebPage` schema piece has the `primaryImageOfPage` element whose `@id` is set to the `ImageObject` schema piece `@id`, an `image` property with the same `@id` and a `thumbnailUrl` set to the image URL.

* Visit a tag archive page, e.g. [http://basic.wordpress.test/tag/customizable-clear-thinking-challenge/](http://basic.wordpress.test/tag/customizable-clear-thinking-challenge/)
* Verify that the first (the most recent) post has a featured image; if it has no feature image, add it and visit the tag archive page again
* Inspect the page source, copy the generated schema and verify:
  * Without this PR:
    * the `CollectionPage` schema piece has no `primaryImageOfPage` element
    * the `CollectionPage` schema piece has a `potentialAction` element
  * With this PR:
    * the `CollectionPage` schema piece has the `primaryImageOfPage` element whose `@id` is set to the `ImageObject`
    * the `CollectionPage` schema piece has the `image` element whose `@id` is set to the `ImageObject`
    * the `CollectionPage` schema piece has the `thumbnailUrl` element set to the URL of the image
    * the `CollectionPage` schema piece has no `potentialAction` element
* Now edit again the first (the most recent) post: remove the featured image and add an image to the post's content (if it hasn't already one)
* (With this PR) verify the `CollectionPage` schema piece has no `primaryImageOfPage` element

* Perform the checks above for a category archive, a custom taxonomy archive, a date archive and a custom post type archive (note that, for custom post types, you will have to create a new custom post type through the CPT UI plugin, and set in its settings `Has archive` to `True` and tick the `Featured image` box)

* Perform the checks above for an author archive: you will find a `ProfilePage` instead of a `CollectionPage`
 
### Test instructions for QA when the code is in the RC
* [x] QA should use the same steps as above.

## Documentation

* [x] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes PC-21
