### PR TITLE
only return the yoast meta key to be timestamped

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
 		"symfony/polyfill-intl-normalizer": "1.19.0",
 		"symfony/polyfill-php70": "1.19.0",
 		"symfony/polyfill-php72": "1.19.0",
-		"wordproof/wordpress-sdk": "1.3.1"
+		"wordproof/wordpress-sdk": "1.3.2"
 	},
 	"minimum-stability": "dev",
 	"prefer-stable": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4385,12 +4385,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/wordproof/wordpress-sdk.git",
-                "reference": "8d20e759e37fa4e6ebc66ddc8bf20e5387dbed3c"
+                "reference": "48d5c6dcea1bc23174b7ce27230dbaacd7cb173f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wordproof/wordpress-sdk/zipball/8d20e759e37fa4e6ebc66ddc8bf20e5387dbed3c",
-                "reference": "8d20e759e37fa4e6ebc66ddc8bf20e5387dbed3c",
+                "url": "https://api.github.com/repos/wordproof/wordpress-sdk/zipball/48d5c6dcea1bc23174b7ce27230dbaacd7cb173f",
+                "reference": "48d5c6dcea1bc23174b7ce27230dbaacd7cb173f",
                 "shasum": ""
             },
             "require": {
@@ -4429,7 +4429,7 @@
                 "issues": "https://github.com/wordproof/wordpress-sdk/issues",
                 "source": "https://github.com/wordproof/wordpress-sdk/tree/1.3.2"
             },
-            "time": "2022-06-22T13:36:51+00:00"
+            "time": "2022-06-23T06:45:38+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2a060b05147eee02d7c65d14c61ba7fe",
+    "content-hash": "9b44de2f95717f6d1a93aa038bd7b9f6",
     "packages": [
         {
             "name": "composer/installers",
@@ -4381,16 +4381,16 @@
         },
         {
             "name": "wordproof/wordpress-sdk",
-            "version": "1.3.1",
+            "version": "1.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wordproof/wordpress-sdk.git",
-                "reference": "e9c1008e3de9b3601592ac1c7e04d116bc444f50"
+                "reference": "8d20e759e37fa4e6ebc66ddc8bf20e5387dbed3c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wordproof/wordpress-sdk/zipball/e9c1008e3de9b3601592ac1c7e04d116bc444f50",
-                "reference": "e9c1008e3de9b3601592ac1c7e04d116bc444f50",
+                "url": "https://api.github.com/repos/wordproof/wordpress-sdk/zipball/8d20e759e37fa4e6ebc66ddc8bf20e5387dbed3c",
+                "reference": "8d20e759e37fa4e6ebc66ddc8bf20e5387dbed3c",
                 "shasum": ""
             },
             "require": {
@@ -4427,9 +4427,9 @@
             "description": "WordPress SDK",
             "support": {
                 "issues": "https://github.com/wordproof/wordpress-sdk/issues",
-                "source": "https://github.com/wordproof/wordpress-sdk/tree/1.3.1"
+                "source": "https://github.com/wordproof/wordpress-sdk/tree/1.3.2"
             },
-            "time": "2022-06-17T07:40:34+00:00"
+            "time": "2022-06-22T13:36:51+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",
@@ -4718,5 +4718,5 @@
         "php": "^5.6.20 || ^7.0 || ^8.0"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4385,12 +4385,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/wordproof/wordpress-sdk.git",
-                "reference": "48d5c6dcea1bc23174b7ce27230dbaacd7cb173f"
+                "reference": "8d20e759e37fa4e6ebc66ddc8bf20e5387dbed3c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wordproof/wordpress-sdk/zipball/48d5c6dcea1bc23174b7ce27230dbaacd7cb173f",
-                "reference": "48d5c6dcea1bc23174b7ce27230dbaacd7cb173f",
+                "url": "https://api.github.com/repos/wordproof/wordpress-sdk/zipball/8d20e759e37fa4e6ebc66ddc8bf20e5387dbed3c",
+                "reference": "8d20e759e37fa4e6ebc66ddc8bf20e5387dbed3c",
                 "shasum": ""
             },
             "require": {
@@ -4429,7 +4429,7 @@
                 "issues": "https://github.com/wordproof/wordpress-sdk/issues",
                 "source": "https://github.com/wordproof/wordpress-sdk/tree/1.3.2"
             },
-            "time": "2022-06-23T06:45:38+00:00"
+            "time": "2022-06-22T13:36:51+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",

--- a/src/integrations/third-party/wordproof.php
+++ b/src/integrations/third-party/wordproof.php
@@ -146,14 +146,13 @@ class Wordproof implements Integration_Interface {
 	}
 
 	/**
-	 * Add the Yoast post meta key for the included WordProof SDK to determine if the post should be timestamped.
+	 * Return the Yoast post meta key for the SDK to determine if the post should be timestamped.
 	 *
 	 * @param array $array The array containing meta keys that should be used.
 	 * @return array
 	 */
 	public function add_post_meta_key( $array ) {
-		$array[] = $this->post_meta_key;
-		return $array;
+		return [ $this->post_meta_key ];
 	}
 
 	/**

--- a/src/integrations/third-party/wordproof.php
+++ b/src/integrations/third-party/wordproof.php
@@ -109,6 +109,11 @@ class Wordproof implements Integration_Interface {
 		\add_filter( 'wordproof_timestamp_post_meta_key_overrides', [ $this, 'add_post_meta_key' ] );
 
 		/**
+		 * Called by the WordProof WordPress SDK to determine if the post should be automatically timestamped.
+		 */
+		\add_filter( 'wordproof_timestamp_post_types', [ $this, 'remove_post_type_timestamping' ] );
+
+		/**
 		 * Called by the WordProof WordPress SDK to determine if the certificate should be shown.
 		 */
 		\add_filter( 'wordproof_timestamp_show_certificate', [ $this, 'show_certificate' ], 10, 2 );
@@ -153,6 +158,16 @@ class Wordproof implements Integration_Interface {
 	 */
 	public function add_post_meta_key( $array ) {
 		return [ $this->post_meta_key ];
+	}
+
+	/**
+	 * Return an empty array to disable automatically timestamping selected post types.
+	 *
+	 * @param array $array The array containing post types that should be automatically timestamped.
+	 * @return array
+	 */
+	public function wordproof_timestamp_post_types( $array ) {
+		return [];
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Prevent Yoast timestamping posts that contain the default WordProof timestamp meta or 'selected_post_types' from authenticating with the WordProof timestamp plugin.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where all previously timestamped pages through the WordProof Timestamp plugin would continue to be timestamped through the Yoast SEO WordProof integration with the WordProof Timestamp plugin deactivated.

## Relevant technical choices:

* We only return the Yoast meta key and return an empty array for the auto timestamping feature.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

- Activate WordProof Timestamp plugin, authenticate (or logout and authenticate again) and timestamp a few pages
- Activate Yoast SEO plugin with WordProof integration
- Deactivate WordProof Timestamp plugin
- Update some of the previous timestamped pages. In your WordProof dashboard the available timestamps are not decreasing.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->

The WordProof integration with the WordProof plugin.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes #
