### PR TITLE
[PC-73] Add notice for premium deactivated

### DIFF
--- a/css/src/admin-global.css
+++ b/css/src/admin-global.css
@@ -782,12 +782,19 @@ body.folded .wpseo-admin-submit-fixed {
 	display: flex;
 }
 
-.notice-yoast img,
 .notice-yoast .notice-yoast__container > svg {
 	line-height: 1;
 	margin-left: 10px;
 	height: 60px;
 	width: auto;
+}
+
+.notice-yoast img {
+	line-height: 1;
+	margin-left: 16px;
+	height: 60px;
+	width: auto;
+	margin-bottom: 5px;
 }
 
 .notice-yoast p {

--- a/inc/options/class-wpseo-option-wpseo.php
+++ b/inc/options/class-wpseo-option-wpseo.php
@@ -85,6 +85,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 		'workouts_data'                            => [ 'configuration' => [ 'finishedSteps' => [] ] ],
 		'configuration_finished_steps'             => [],
 		'dismiss_configuration_workout_notice'     => false,
+		'dismiss_premium_deactivated_notice'       => false,
 		'importing_completed'                      => [],
 		'wincher_integration_active'               => true,
 		'wincher_tokens'                           => [],

--- a/src/integrations/admin/deactivated-premium-integration.php
+++ b/src/integrations/admin/deactivated-premium-integration.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\SEO\Integrations\Admin;
 
 use WPSEO_Admin_Asset_Manager;
 use Yoast\WP\SEO\Conditionals\Admin_Conditional;
+use Yoast\WP\SEO\Conditionals\Non_Multisite_Conditional;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
 use Yoast\WP\SEO\Presenters\Admin\Notice_Presenter;
@@ -31,7 +32,7 @@ class Deactivated_Premium_Integration implements Integration_Interface {
 	 * {@inheritDoc}
 	 */
 	public static function get_conditionals() {
-		return [ Admin_Conditional::class ];
+		return [ Admin_Conditional::class, Non_Multisite_Conditional::class ];
 	}
 
 	/**
@@ -84,7 +85,8 @@ class Deactivated_Premium_Integration implements Integration_Interface {
 			);
             // phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped -- Output escaped above.
 			echo new Notice_Presenter(
-				\__( 'Yoast SEO Premium is installed but not activated!', 'wordpress-seo' ),
+				/* translators: 1: Yoast SEO Premium */
+				\sprintf( \__( '%1$s is installed but not activated!', 'wordpress-seo' ), 'Yoast SEO Premium' ),
 				$content,
 				'support-team.svg',
 				null,
@@ -115,11 +117,11 @@ class Deactivated_Premium_Integration implements Integration_Interface {
 	}
 
 	/**
-	 * Dismisses the First-time configuration notice.
+	 * Dismisses the premium deactivated notice.
 	 *
 	 * @return bool
 	 */
-	public function dismiss_first_time_configuration_notice() {
+	public function dismiss_premium_deactivated_notice() {
 		return $this->options_helper->set( 'dismiss_premium_deactivated_notice', true );
 	}
 

--- a/src/integrations/admin/deactivated-premium-integration.php
+++ b/src/integrations/admin/deactivated-premium-integration.php
@@ -62,7 +62,7 @@ class Deactivated_Premium_Integration implements Integration_Interface {
 	 * @return void
 	 */
 	public function premium_deactivated_notice() {
-		if ( ! $this->options_helper->get( 'dismiss_premium_deactivated_notice', false ) === false ) {
+		if ( ! $this->options_helper->get( 'dismiss_premium_deactivated_notice', false ) === true ) {
 			return;
 		}
 

--- a/src/integrations/admin/deactivated-premium-integration.php
+++ b/src/integrations/admin/deactivated-premium-integration.php
@@ -78,7 +78,7 @@ class Deactivated_Premium_Integration implements Integration_Interface {
 
 			$content = \sprintf(
 				/* translators: 1: Yoast SEO Premium 2: Link start tag to activate premium, 3: Link closing tag. */
-				\__( 'You have %1$s installed but not activated. %2$sActivate %1$s now!%3$s', 'wordpress-seo' ),
+				\__( 'You\'ve installed %1$s but it\'s not activated yet. %2$sActivate %1$s now!%3$s', 'wordpress-seo' ),
 				'Yoast SEO Premium',
 				'<a href="' . \esc_url( \wp_nonce_url( 'plugins.php?action=activate&plugin=' . $premium_file, 'activate-plugin_' . $premium_file ) ) . '">',
 				'</a>'
@@ -86,7 +86,7 @@ class Deactivated_Premium_Integration implements Integration_Interface {
             // phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped -- Output escaped above.
 			echo new Notice_Presenter(
 				/* translators: 1: Yoast SEO Premium */
-				\sprintf( \__( '%1$s is installed but not activated!', 'wordpress-seo' ), 'Yoast SEO Premium' ),
+				\sprintf( \__( 'Activate %1$s!', 'wordpress-seo' ), 'Yoast SEO Premium' ),
 				$content,
 				'support-team.svg',
 				null,

--- a/src/integrations/admin/deactivated-premium-integration.php
+++ b/src/integrations/admin/deactivated-premium-integration.php
@@ -77,7 +77,7 @@ class Deactivated_Premium_Integration implements Integration_Interface {
 			$this->admin_asset_manager->enqueue_style( 'monorepo' );
 
 			$content = \sprintf(
-				/* translators: 1: Yoast SEO Premium 2: Link start tag to tactivate premium, 3: Link closing tag. */
+				/* translators: 1: Yoast SEO Premium 2: Link start tag to activate premium, 3: Link closing tag. */
 				\__( 'You have %1$s installed but not activated. %2$sActivate %1$s now!%3$s', 'wordpress-seo' ),
 				'Yoast SEO Premium',
 				'<a href="' . \esc_url( \wp_nonce_url( 'plugins.php?action=activate&plugin=' . $premium_file, 'activate-plugin_' . $premium_file ) ) . '">',

--- a/src/integrations/admin/deactivated-premium-integration.php
+++ b/src/integrations/admin/deactivated-premium-integration.php
@@ -57,25 +57,22 @@ class Deactivated_Premium_Integration implements Integration_Interface {
 	}
 
 	/**
-	 * Undocumented function
+	 * Shows a notice if premium is installed but not activated.
 	 *
 	 * @return void
 	 */
 	public function premium_deactivated_notice() {
-		if ( ! $this->options_helper->get( 'dismiss_premium_deactivated_notice', false ) === true ) {
+		if ( $this->options_helper->get( 'dismiss_premium_deactivated_notice', false ) === true ) {
 			return;
 		}
 
 		$premium_file = 'wordpress-seo-premium/wp-seo-premium.php';
 
-		if ( ! current_user_can( 'activate_plugin', $premium_file ) ) {
+		if ( ! \current_user_can( 'activate_plugin', $premium_file ) ) {
 			return;
 		}
 
-		if (
-			! defined( 'WPSEO_PREMIUM_FILE' )
-			&& \file_exists( \WP_PLUGIN_DIR . '/' . $premium_file )
-		) {
+		if ( $this->premium_is_installed_not_activated( $premium_file ) ) {
 			$this->admin_asset_manager->enqueue_style( 'monorepo' );
 
 			$content = \sprintf(
@@ -124,5 +121,19 @@ class Deactivated_Premium_Integration implements Integration_Interface {
 	 */
 	public function dismiss_first_time_configuration_notice() {
 		return $this->options_helper->set( 'dismiss_premium_deactivated_notice', true );
+	}
+
+	/**
+	 * Returns whether or not premium is installed and not activated.
+	 *
+	 * @param string $premium_file The premium file.
+	 *
+	 * @return boolean Whether or not premium is installed and not activated.
+	 */
+	protected function premium_is_installed_not_activated( $premium_file ) {
+		return (
+			! \defined( 'WPSEO_PREMIUM_FILE' )
+			&& \file_exists( \WP_PLUGIN_DIR . '/' . $premium_file )
+		);
 	}
 }

--- a/src/integrations/admin/deactivated-premium-integration.php
+++ b/src/integrations/admin/deactivated-premium-integration.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Yoast\WP\SEO\Integrations\Admin;
+
+use WPSEO_Admin_Asset_Manager;
+use Yoast\WP\SEO\Conditionals\Admin_Conditional;
+use Yoast\WP\SEO\Helpers\Options_Helper;
+use Yoast\WP\SEO\Integrations\Integration_Interface;
+use Yoast\WP\SEO\Presenters\Admin\Notice_Presenter;
+
+/**
+ * Deactivated_Premium_Integration class
+ */
+class Deactivated_Premium_Integration implements Integration_Interface {
+
+	/**
+	 * The options' helper.
+	 *
+	 * @var Options_Helper
+	 */
+	private $options_helper;
+
+	/**
+	 * The admin asset manager.
+	 *
+	 * @var WPSEO_Admin_Asset_Manager
+	 */
+	private $admin_asset_manager;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_conditionals() {
+		return [ Admin_Conditional::class ];
+	}
+
+	/**
+	 * First_Time_Configuration_Notice_Integration constructor.
+	 *
+	 * @param Options_Helper            $options_helper      The options helper.
+	 * @param WPSEO_Admin_Asset_Manager $admin_asset_manager The admin asset manager.
+	 */
+	public function __construct(
+		Options_Helper $options_helper,
+		WPSEO_Admin_Asset_Manager $admin_asset_manager
+	) {
+		$this->options_helper      = $options_helper;
+		$this->admin_asset_manager = $admin_asset_manager;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function register_hooks() {
+		\add_action( 'admin_notices', [ $this, 'premium_deactivated_notice' ] );
+		\add_action( 'wp_ajax_dismiss_premium_deactivated_notice', [ $this, 'dismiss_premium_deactivated_notice' ] );
+	}
+
+	/**
+	 * Undocumented function
+	 *
+	 * @return void
+	 */
+	public function premium_deactivated_notice() {
+		if ( ! $this->options_helper->get( 'dismiss_premium_deactivated_notice', false ) === false ) {
+			return;
+		}
+
+		$premium_file = 'wordpress-seo-premium/wp-seo-premium.php';
+		if (
+			! defined( 'WPSEO_PREMIUM_FILE' )
+			&& \file_exists( \WP_PLUGIN_DIR . '/' . $premium_file )
+		) {
+			$this->admin_asset_manager->enqueue_style( 'monorepo' );
+
+			$content = \sprintf(
+				/* translators: 1: Yoast SEO Premium 2: Link start tag to tactivate premium, 3: Link closing tag. */
+				\__( 'You have %1$s installed but not activated. %2$sActivate %1$s now!%3$s', 'wordpress-seo' ),
+				'Yoast SEO Premium',
+				'<a href="' . \esc_url( \wp_nonce_url( 'plugins.php?action=activate&plugin=' . $premium_file, 'activate-plugin_' . $premium_file ) ) . '">',
+				'</a>'
+			);
+            // phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped -- Output escaped above.
+			echo new Notice_Presenter(
+				\__( 'Yoast SEO Premium is installed but not activated!', 'wordpress-seo' ),
+				$content,
+				'support-team.svg',
+				null,
+				true,
+				'yoast-premium-deactivated-notice'
+			);
+            // phpcs:enable
+
+			// Enable permanently dismissing the notice.
+			echo "<script>
+                function dismiss_premium_deactivated_notice(){
+                    var data = {
+                    'action': 'dismiss_premium_deactivated_notice',
+                    };
+
+                    jQuery.post( ajaxurl, data, function( response ) {
+                        jQuery( '#yoast-premium-deactivated-notice' ).hide();
+                    });
+                }
+
+                jQuery( document ).ready( function() {
+                    jQuery( 'body' ).on( 'click', '#yoast-premium-deactivated-notice .notice-dismiss', function() {
+                        dismiss_premium_deactivated_notice();
+                    } );
+                } );
+                </script>";
+		}
+	}
+
+	/**
+	 * Dismisses the First-time configuration notice.
+	 *
+	 * @return bool
+	 */
+	public function dismiss_first_time_configuration_notice() {
+		return $this->options_helper->set( 'dismiss_premium_deactivated_notice', true );
+	}
+}

--- a/src/integrations/admin/deactivated-premium-integration.php
+++ b/src/integrations/admin/deactivated-premium-integration.php
@@ -80,7 +80,12 @@ class Deactivated_Premium_Integration implements Integration_Interface {
 				/* translators: 1: Yoast SEO Premium 2: Link start tag to activate premium, 3: Link closing tag. */
 				\__( 'You\'ve installed %1$s but it\'s not activated yet. %2$sActivate %1$s now!%3$s', 'wordpress-seo' ),
 				'Yoast SEO Premium',
-				'<a href="' . \esc_url( \wp_nonce_url( 'plugins.php?action=activate&plugin=' . $premium_file, 'activate-plugin_' . $premium_file ) ) . '">',
+				'<a href="' . \esc_url(
+					\wp_nonce_url(
+						\self_admin_url( 'plugins.php?action=activate&plugin=' . $premium_file ),
+						'activate-plugin_' . $premium_file
+					)
+				) . '">',
 				'</a>'
 			);
             // phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped -- Output escaped above.

--- a/src/integrations/admin/deactivated-premium-integration.php
+++ b/src/integrations/admin/deactivated-premium-integration.php
@@ -113,7 +113,7 @@ class Deactivated_Premium_Integration implements Integration_Interface {
                         dismiss_premium_deactivated_notice();
                     } );
                 } );
-                </script>";
+            </script>";
 		}
 	}
 

--- a/src/integrations/admin/deactivated-premium-integration.php
+++ b/src/integrations/admin/deactivated-premium-integration.php
@@ -67,6 +67,11 @@ class Deactivated_Premium_Integration implements Integration_Interface {
 		}
 
 		$premium_file = 'wordpress-seo-premium/wp-seo-premium.php';
+
+		if ( ! current_user_can( 'activate_plugin', $premium_file ) ) {
+			return;
+		}
+
 		if (
 			! defined( 'WPSEO_PREMIUM_FILE' )
 			&& \file_exists( \WP_PLUGIN_DIR . '/' . $premium_file )

--- a/tests/unit/integrations/admin/deactivated-premium-integration-test.php
+++ b/tests/unit/integrations/admin/deactivated-premium-integration-test.php
@@ -94,7 +94,8 @@ class Deactivated_Premium_Integration_Test extends TestCase {
 
 		$this->asset_manager->expects( 'enqueue_style' )->with( 'monorepo' );
 
-		Monkey\Functions\expect( 'wp_nonce_url' )->with( 'plugins.php?action=activate&plugin=' . $premium_file, 'activate-plugin_' . $premium_file )->andReturnFirstArg();
+		Monkey\Functions\expect( 'self_admin_url' )->with( 'plugins.php?action=activate&plugin=' . $premium_file, 'activate-plugin_' . $premium_file )->andReturn( 'https://example.org/wp-admin/plugins.php?action=activate&plugin=' . $premium_file );
+		Monkey\Functions\expect( 'wp_nonce_url' )->with( 'https://example.org/wp-admin/plugins.php?action=activate&plugin=' . $premium_file, 'activate-plugin_' . $premium_file )->andReturnFirstArg();
 		Monkey\Functions\expect( 'wp_enqueue_style' )->with( 'yoast-seo-notifications' );
 		Monkey\Functions\expect( 'plugin_dir_url' )->andReturn( 'https://example.org/wp-content/plugins/' );
 

--- a/tests/unit/integrations/admin/deactivated-premium-integration-test.php
+++ b/tests/unit/integrations/admin/deactivated-premium-integration-test.php
@@ -67,7 +67,7 @@ class Deactivated_Premium_Integration_Test extends TestCase {
 	}
 
 	/**
-	 * Tests the registratation of the hooks.
+	 * Tests the registration of the hooks.
 	 *
 	 * @covers ::register_hooks
 	 */

--- a/tests/unit/integrations/admin/deactivated-premium-integration-test.php
+++ b/tests/unit/integrations/admin/deactivated-premium-integration-test.php
@@ -6,6 +6,7 @@ use Brain\Monkey;
 use Mockery;
 use WPSEO_Admin_Asset_Manager;
 use Yoast\WP\SEO\Conditionals\Admin_Conditional;
+use Yoast\WP\SEO\Conditionals\Non_Multisite_Conditional;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Integrations\Admin\Deactivated_Premium_Integration;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
@@ -62,7 +63,7 @@ class Deactivated_Premium_Integration_Test extends TestCase {
 	 * @covers ::get_conditionals
 	 */
 	public function test_get_conditionals() {
-		$this->assertEquals( [ Admin_Conditional::class ], Deactivated_Premium_Integration::get_conditionals() );
+		$this->assertEquals( [ Admin_Conditional::class, Non_Multisite_Conditional::class ], Deactivated_Premium_Integration::get_conditionals() );
 	}
 
 	/**
@@ -168,5 +169,15 @@ class Deactivated_Premium_Integration_Test extends TestCase {
 		// Nothing should be output.
 		$this->expectOutputString( '' );
 		$this->instance->premium_deactivated_notice();
+	}
+
+	/**
+	 * Tests dimsissing the notice.
+	 *
+	 * @covers ::dismiss_premium_deactivated_notice
+	 */
+	public function test_dismiss_premium_deactivated_notice() {
+		$this->options_helper->expects( 'set' )->with( 'dismiss_premium_deactivated_notice', true );
+		$this->instance->dismiss_premium_deactivated_notice();
 	}
 }

--- a/tests/unit/integrations/admin/deactivated-premium-integration-test.php
+++ b/tests/unit/integrations/admin/deactivated-premium-integration-test.php
@@ -1,0 +1,172 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Integrations\Admin;
+
+use Brain\Monkey;
+use Mockery;
+use WPSEO_Admin_Asset_Manager;
+use Yoast\WP\SEO\Conditionals\Admin_Conditional;
+use Yoast\WP\SEO\Helpers\Options_Helper;
+use Yoast\WP\SEO\Integrations\Admin\Deactivated_Premium_Integration;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Class Deactivated_Premium_Integration_Test.
+ *
+ * @group integrations
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Integrations\Admin\Deactivated_Premium_Integration
+ */
+class Deactivated_Premium_Integration_Test extends TestCase {
+
+	/**
+	 * Mock of the options helper.
+	 *
+	 * @var Mockery\MockInterface|Options_Helper
+	 */
+	protected $options_helper;
+
+	/**
+	 * Mock of the asset manager.
+	 *
+	 * @var Mockery\MockInterface|WPSEO_Admin_Asset_Manager
+	 */
+	protected $asset_manager;
+
+	/**
+	 * Mock of the instance.
+	 *
+	 * @var Mockery\MockInterface|Deactivated_Premium_Integration
+	 */
+	protected $instance;
+
+	/**
+	 * Sets up the test fixtures.
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->stubTranslationFunctions();
+		$this->stubEscapeFunctions();
+
+		$this->options_helper = Mockery::mock( Options_Helper::class );
+		$this->asset_manager  = Mockery::mock( WPSEO_Admin_Asset_Manager::class );
+		$this->instance       = Mockery::mock( Deactivated_Premium_Integration::class, [ $this->options_helper, $this->asset_manager ] )
+			->makePartial()
+			->shouldAllowMockingProtectedMethods();
+	}
+
+	/**
+	 * Tests if the expected conditionals are given.
+	 *
+	 * @covers ::get_conditionals
+	 */
+	public function test_get_conditionals() {
+		$this->assertEquals( [ Admin_Conditional::class ], Deactivated_Premium_Integration::get_conditionals() );
+	}
+
+	/**
+	 * Tests the registratation of the hooks.
+	 *
+	 * @covers ::register_hooks
+	 */
+	public function test_register_hooks() {
+		$this->instance->register_hooks();
+
+		$this->assertNotFalse( \has_action( 'admin_notices', [ $this->instance, 'premium_deactivated_notice' ] ) );
+		$this->assertNotFalse( \has_action( 'wp_ajax_dismiss_premium_deactivated_notice', [ $this->instance, 'dismiss_premium_deactivated_notice' ] ) );
+	}
+
+	/**
+	 * Tests showing the notice.
+	 *
+	 * @covers ::premium_deactivated_notice
+	 */
+	public function test_premium_deactivated_notice() {
+		$premium_file = 'wordpress-seo-premium/wp-seo-premium.php';
+
+		$this->options_helper->expects( 'get' )->with( 'dismiss_premium_deactivated_notice', false )->andReturnFalse();
+
+		Monkey\Functions\expect( 'current_user_can' )->with( 'activate_plugin', $premium_file )->andReturnTrue();
+
+		$this->instance->expects( 'premium_is_installed_not_activated' )->with( $premium_file )->andReturnTrue();
+
+		$this->asset_manager->expects( 'enqueue_style' )->with( 'monorepo' );
+
+		Monkey\Functions\expect( 'wp_nonce_url' )->with( 'plugins.php?action=activate&plugin=' . $premium_file, 'activate-plugin_' . $premium_file )->andReturnFirstArg();
+		Monkey\Functions\expect( 'wp_enqueue_style' )->with( 'yoast-seo-notifications' );
+		Monkey\Functions\expect( 'plugin_dir_url' )->andReturn( 'https://example.org/wp-content/plugins/' );
+
+		// Output should contain the nonce URL.
+		$this->expectOutputContains( 'plugins.php?action=activate&plugin=' . $premium_file );
+
+		// Output should contain the ajax action script.
+		$this->expectOutputContains(
+			"<script>
+                function dismiss_premium_deactivated_notice(){
+                    var data = {
+                    'action': 'dismiss_premium_deactivated_notice',
+                    };
+
+                    jQuery.post( ajaxurl, data, function( response ) {
+                        jQuery( '#yoast-premium-deactivated-notice' ).hide();
+                    });
+                }
+
+                jQuery( document ).ready( function() {
+                    jQuery( 'body' ).on( 'click', '#yoast-premium-deactivated-notice .notice-dismiss', function() {
+                        dismiss_premium_deactivated_notice();
+                    } );
+                } );
+            </script>"
+		);
+
+		$this->instance->premium_deactivated_notice();
+	}
+
+	/**
+	 * Tests showing the notice.
+	 *
+	 * @covers ::premium_deactivated_notice
+	 */
+	public function test_premium_deactivated_notice_if_dismissed() {
+		$this->options_helper->expects( 'get' )->with( 'dismiss_premium_deactivated_notice', false )->andReturnTrue();
+
+		// Nothing should be output.
+		$this->expectOutputString( '' );
+		$this->instance->premium_deactivated_notice();
+	}
+
+	/**
+	 * Tests showing the notice.
+	 *
+	 * @covers ::premium_deactivated_notice
+	 */
+	public function test_premium_deactivated_notice_if_no_capabilities() {
+		$premium_file = 'wordpress-seo-premium/wp-seo-premium.php';
+
+		$this->options_helper->expects( 'get' )->with( 'dismiss_premium_deactivated_notice', false )->andReturnFalse();
+		Monkey\Functions\expect( 'current_user_can' )->with( 'activate_plugin', $premium_file )->andReturnFalse();
+
+		// Nothing should be output.
+		$this->expectOutputString( '' );
+		$this->instance->premium_deactivated_notice();
+	}
+
+	/**
+	 * Tests showing the notice.
+	 *
+	 * @covers ::premium_deactivated_notice
+	 */
+	public function test_premium_deactivated_notice_if_no_premium_installed() {
+		$premium_file = 'wordpress-seo-premium/wp-seo-premium.php';
+
+		$this->options_helper->expects( 'get' )->with( 'dismiss_premium_deactivated_notice', false )->andReturnFalse();
+		Monkey\Functions\expect( 'current_user_can' )->with( 'activate_plugin', $premium_file )->andReturnTrue();
+		$this->instance->expects( 'premium_is_installed_not_activated' )->with( $premium_file )->andReturnFalse();
+
+		// Nothing should be output.
+		$this->expectOutputString( '' );
+		$this->instance->premium_deactivated_notice();
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Adds a notice if premium is installed but not activated.
* This notice is shown on all admin pages if and only if the current user has the capability to activate plugins.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds a notice that displays when Yoast SEO Premium is installed but not activated prompting the user to activate it.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Have Yoast SEO Premium installed but not activated.
* You should see a notice if and only if you have permission to activate plugins.
* The notice should be present on all admin pages.
* The notice should look like this:
![image](https://user-images.githubusercontent.com/12400734/175258399-fc151208-d37b-4e7a-9bb9-6e10d515419c.png)

* Click the link in the notice.
* Premium should be activated.
* Deactivate premium again
* Uninstall Premium and reload any admin page.
* The notice should not be visible anymore.
* Now install Premium again but don't activate it. The notice should re-appear.
* Dismiss the notice.
* Reload the page
* The notice should not be shown again.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* A notice that is always shown in the admin but only when premium is installed but not activated.
* Some small styling changes were added in the FTC notice, it should now look like this:
![image](https://user-images.githubusercontent.com/12400734/175258611-aa756496-12e8-403f-9521-ea0dae5556d0.png)
* No styling changes for the webinar notice, it should still look like this:
![image](https://user-images.githubusercontent.com/12400734/175258702-54b85025-dd76-4ce9-83f2-a208e6994649.png)


## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes https://yoast.atlassian.net/browse/PC-73