### PR TITLE
Unauthenticate WordProof user on login with invalid token

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
 		"symfony/polyfill-intl-normalizer": "1.19.0",
 		"symfony/polyfill-php70": "1.19.0",
 		"symfony/polyfill-php72": "1.19.0",
-		"wordproof/wordpress-sdk": "1.3.2"
+		"wordproof/wordpress-sdk": "1.3.3"
 	},
 	"minimum-stability": "dev",
 	"prefer-stable": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9b44de2f95717f6d1a93aa038bd7b9f6",
+    "content-hash": "79f290f37114cb4c378fd650fe900847",
     "packages": [
         {
             "name": "composer/installers",
@@ -4381,16 +4381,16 @@
         },
         {
             "name": "wordproof/wordpress-sdk",
-            "version": "1.3.2",
+            "version": "1.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wordproof/wordpress-sdk.git",
-                "reference": "8d20e759e37fa4e6ebc66ddc8bf20e5387dbed3c"
+                "reference": "6a20d409b26d6aa986e0f0e44620a0644c14e33b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wordproof/wordpress-sdk/zipball/8d20e759e37fa4e6ebc66ddc8bf20e5387dbed3c",
-                "reference": "8d20e759e37fa4e6ebc66ddc8bf20e5387dbed3c",
+                "url": "https://api.github.com/repos/wordproof/wordpress-sdk/zipball/6a20d409b26d6aa986e0f0e44620a0644c14e33b",
+                "reference": "6a20d409b26d6aa986e0f0e44620a0644c14e33b",
                 "shasum": ""
             },
             "require": {
@@ -4427,9 +4427,9 @@
             "description": "WordPress SDK",
             "support": {
                 "issues": "https://github.com/wordproof/wordpress-sdk/issues",
-                "source": "https://github.com/wordproof/wordpress-sdk/tree/1.3.2"
+                "source": "https://github.com/wordproof/wordpress-sdk/tree/1.3.3"
             },
-            "time": "2022-06-22T13:36:51+00:00"
+            "time": "2022-06-23T07:35:43+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Unauthenticate a user when a invalid token is used to login with the current environment.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* /

## Relevant technical choices:

* The user is authenticated if the MY send a wordproof:oauth:invalid_token post message.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

- Activate Yoast SEO plugin and authenticate with WordProof
- Make sure you can open the WordProof settings (Manage WordProof settings)
- Change to a different environment
- Click Manage WordProof Settings
- You should be logged out and ready to authenticate again.

To change environments go to the src/config/wordproof-app-config.php and add the following functions.

```
	
	public function getOauthClient() {
		return 78;
	}

	public function getWordProofUrl() {
		return 'https://staging.wordproof.com';
	}
```

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->

The WordProof integration with the WordProof plugin.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes #
