### PR TITLE
Add capability on seo manager

### DIFF
--- a/admin/capabilities/class-register-capabilities.php
+++ b/admin/capabilities/class-register-capabilities.php
@@ -92,7 +92,7 @@ class WPSEO_Register_Capabilities implements WPSEO_WordPress_Integration {
 		$user = wp_get_current_user();
 
 		if ( in_array( 'wpseo_manager', $user->roles, true ) ) {
-			add_filter( 'map_meta_cap', [ $this, 'add_manage_privacy_options_capability' ], 1, 2 );
+			add_action( 'map_meta_cap', [ $this, 'add_manage_privacy_options_capability' ], 1, 2 );
 		}
 	}
 

--- a/admin/capabilities/class-register-capabilities.php
+++ b/admin/capabilities/class-register-capabilities.php
@@ -27,7 +27,7 @@ class WPSEO_Register_Capabilities implements WPSEO_WordPress_Integration {
 		 * a potential privacy leak.
 		 */
 		if ( ! is_multisite() ) {
-			add_filter( 'map_meta_cap', [ $this, 'add_manage_privacy_options_capability' ], 1, 4 );
+			add_filter( 'map_meta_cap', [ $this, 'add_manage_privacy_options_capability' ], 1, 2 );
 		}
 	}
 
@@ -100,7 +100,7 @@ class WPSEO_Register_Capabilities implements WPSEO_WordPress_Integration {
 		if ( $cap === 'manage_privacy_options' ) {
 			$caps = array_diff( $caps, [ 'manage_options' ] );
 		}
-		
+
 		return $caps;
 	}
 }

--- a/admin/capabilities/class-register-capabilities.php
+++ b/admin/capabilities/class-register-capabilities.php
@@ -27,7 +27,7 @@ class WPSEO_Register_Capabilities implements WPSEO_WordPress_Integration {
 		 * a potential privacy leak.
 		 */
 		if ( ! is_multisite() ) {
-			add_action( 'admin_init', [ $this, 'extend_wpseo_manager_capabilities' ], 10 );
+			add_filter( 'map_meta_cap', [ $this, 'add_manage_privacy_options_capability' ], 1, 4 );
 		}
 	}
 
@@ -84,19 +84,6 @@ class WPSEO_Register_Capabilities implements WPSEO_WordPress_Integration {
 	}
 
 	/**
-	 * Action on admin_init that checks if the current user should have added capabilities to.
-	 *
-	 * @return void
-	 */
-	public function extend_wpseo_manager_capabilities() {
-		$user = wp_get_current_user();
-
-		if ( in_array( 'wpseo_manager', $user->roles, true ) ) {
-			add_action( 'map_meta_cap', [ $this, 'add_manage_privacy_options_capability' ], 1, 2 );
-		}
-	}
-
-	/**
 	 * Action on map_meta_cap that allows SEO Managers to edit the privacy page.
 	 *
 	 * @param array  $caps The capabilities for the current user.
@@ -104,9 +91,16 @@ class WPSEO_Register_Capabilities implements WPSEO_WordPress_Integration {
 	 * @return array|mixed
 	 */
 	public function add_manage_privacy_options_capability( $caps, $cap ) {
+		$user = wp_get_current_user();
+
+		if ( ! in_array( 'wpseo_manager', $user->roles, true ) ) {
+			return $caps;
+		}
+
 		if ( $cap === 'manage_privacy_options' ) {
 			$caps = array_diff( $caps, [ 'manage_options' ] );
 		}
+		
 		return $caps;
 	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Uses add_filter for `map_meta_cap` to properly add the `manage_privacy_options` capability to the seo manager role.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* SEO Managers are now allowed to edit the privacy page. But not on multisites.

## Relevant technical choices:

* we use map_meta_cap to dynamically add the capability

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Create a privacy page as an admin.
* Login as an SEO manager.
* Make sure you can edit the privacy page.
* Above should not be the case for multisites.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The `manage_privacy_options` capability for the SEO manager.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes #
