### PR TITLE
PC-94 Fix permalink generation for date archives

### DIFF
--- a/src/presentations/indexable-presentation.php
+++ b/src/presentations/indexable-presentation.php
@@ -229,6 +229,10 @@ class Indexable_Presentation extends Abstract_Presentation {
 			return $this->permalink_helper->get_permalink_for_indexable( $this->model );
 		}
 
+		if ( \is_date() ) {
+			return $this->current_page->get_date_archive_permalink();
+		}
+
 		return $this->model->permalink;
 	}
 

--- a/tests/unit/presentations/archive-adjacent-test.php
+++ b/tests/unit/presentations/archive-adjacent-test.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\WP\SEO\Tests\Unit\Presentations;
 
+use Brain\Monkey;
 use Mockery;
 use Yoast\WP\SEO\Helpers\Pagination_Helper;
 use Yoast\WP\SEO\Tests\Unit\Presentations\Indexable_Post_Type_Archive_Presentation\Presentation_Instance_Builder;
@@ -94,6 +95,10 @@ class Archive_Adjacent_Test extends TestCase {
 			->once()
 			->andReturn( 2 );
 
+		Monkey\Functions\expect( 'is_date' )
+			->once()
+			->andReturn( false );
+
 		$this->assertEquals( 'https://example.com/permalink/', $this->instance->generate_rel_prev() );
 	}
 
@@ -125,6 +130,10 @@ class Archive_Adjacent_Test extends TestCase {
 			->with( 'https://example.com/permalink/', 2 )
 			->once()
 			->andReturn( 'https://example.com/permalink/page/2/' );
+
+		Monkey\Functions\expect( 'is_date' )
+			->once()
+			->andReturn( false );
 
 		$this->assertEquals( 'https://example.com/permalink/page/2/', $this->instance->generate_rel_prev() );
 	}
@@ -200,6 +209,10 @@ class Archive_Adjacent_Test extends TestCase {
 			->with( 'https://example.com/permalink/', 6 )
 			->once()
 			->andReturn( 'https://example.com/permalink/page/6/' );
+
+		Monkey\Functions\expect( 'is_date' )
+			->once()
+			->andReturn( false );
 
 		$this->assertEquals( 'https://example.com/permalink/page/6/', $this->instance->generate_rel_next() );
 	}

--- a/tests/unit/presentations/indexable-author-archive-presentation/canonical-test.php
+++ b/tests/unit/presentations/indexable-author-archive-presentation/canonical-test.php
@@ -3,7 +3,6 @@
 namespace Yoast\WP\SEO\Tests\Unit\Presentations\Indexable_Author_Archive_Presentation;
 
 use Brain\Monkey;
-
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**

--- a/tests/unit/presentations/indexable-author-archive-presentation/canonical-test.php
+++ b/tests/unit/presentations/indexable-author-archive-presentation/canonical-test.php
@@ -2,6 +2,8 @@
 
 namespace Yoast\WP\SEO\Tests\Unit\Presentations\Indexable_Author_Archive_Presentation;
 
+use Brain\Monkey;
+
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
@@ -47,6 +49,10 @@ class Canonical_Test extends TestCase {
 			->once()
 			->andReturn( false );
 
+		Monkey\Functions\expect( 'is_date' )
+			->once()
+			->andReturn( false );
+
 		$this->assertEmpty( $this->instance->generate_canonical() );
 	}
 
@@ -67,6 +73,10 @@ class Canonical_Test extends TestCase {
 			->expects( 'get_current_archive_page_number' )
 			->once()
 			->andReturn( 0 );
+
+		Monkey\Functions\expect( 'is_date' )
+			->once()
+			->andReturn( false );
 
 		$this->assertEquals( 'https://example.com/author/', $this->instance->generate_canonical() );
 	}
@@ -94,6 +104,10 @@ class Canonical_Test extends TestCase {
 			->with( $this->indexable->permalink, 2 )
 			->once()
 			->andReturn( 'https://example.com/author/page/2/' );
+
+		Monkey\Functions\expect( 'is_date' )
+			->once()
+			->andReturn( false );
 
 		$this->assertEquals( 'https://example.com/author/page/2/', $this->instance->generate_canonical() );
 	}

--- a/tests/unit/presentations/indexable-author-archive-presentation/presentation-instance-builder-trait.php
+++ b/tests/unit/presentations/indexable-author-archive-presentation/presentation-instance-builder-trait.php
@@ -57,7 +57,7 @@ trait Presentation_Instance_Builder {
 	/**
 	 * Holds the Pagination_Helper instance.
 	 *
-	 * @var Pagination_Helper
+	 * @var Pagination_Helper|Mockery\MockInterface
 	 */
 	protected $pagination;
 

--- a/tests/unit/presentations/indexable-home-page-presentation/canonical-test.php
+++ b/tests/unit/presentations/indexable-home-page-presentation/canonical-test.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\WP\SEO\Tests\Unit\Presentations\Indexable_Home_Page_Presentation;
 
+use Brain\Monkey;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
@@ -47,6 +48,10 @@ class Canonical_Test extends TestCase {
 			->once()
 			->andReturn( false );
 
+		Monkey\Functions\expect( 'is_date' )
+			->once()
+			->andReturn( false );
+
 		$this->assertEmpty( $this->instance->generate_canonical() );
 	}
 
@@ -60,6 +65,10 @@ class Canonical_Test extends TestCase {
 
 		$this->indexable_helper
 			->expects( 'dynamic_permalinks_enabled' )
+			->once()
+			->andReturn( false );
+
+		Monkey\Functions\expect( 'is_date' )
 			->once()
 			->andReturn( false );
 
@@ -81,6 +90,10 @@ class Canonical_Test extends TestCase {
 
 		$this->indexable_helper
 			->expects( 'dynamic_permalinks_enabled' )
+			->once()
+			->andReturn( false );
+
+		Monkey\Functions\expect( 'is_date' )
 			->once()
 			->andReturn( false );
 

--- a/tests/unit/presentations/indexable-post-type-archive-presentation/canonical-test.php
+++ b/tests/unit/presentations/indexable-post-type-archive-presentation/canonical-test.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\WP\SEO\Tests\Unit\Presentations\Indexable_Post_Type_Archive_Presentation;
 
+use Brain\Monkey;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
@@ -36,6 +37,10 @@ class Canonical_Test extends TestCase {
 			->once()
 			->andReturn( false );
 
+		Monkey\Functions\expect( 'is_date' )
+			->once()
+			->andReturn( false );
+
 		$this->assertEmpty( $this->instance->generate_canonical() );
 	}
 
@@ -49,6 +54,10 @@ class Canonical_Test extends TestCase {
 
 		$this->indexable_helper
 			->expects( 'dynamic_permalinks_enabled' )
+			->once()
+			->andReturn( false );
+
+		Monkey\Functions\expect( 'is_date' )
 			->once()
 			->andReturn( false );
 
@@ -70,6 +79,10 @@ class Canonical_Test extends TestCase {
 
 		$this->indexable_helper
 			->expects( 'dynamic_permalinks_enabled' )
+			->once()
+			->andReturn( false );
+
+		Monkey\Functions\expect( 'is_date' )
 			->once()
 			->andReturn( false );
 

--- a/tests/unit/presentations/indexable-post-type-archive-presentation/presentation-instance-builder-trait.php
+++ b/tests/unit/presentations/indexable-post-type-archive-presentation/presentation-instance-builder-trait.php
@@ -32,7 +32,7 @@ trait Presentation_Instance_Builder {
 	/**
 	 * Holds the Pagination_Helper instance.
 	 *
-	 * @var Pagination_Helper
+	 * @var Pagination_Helper|Mockery\MockInterface
 	 */
 	protected $pagination;
 

--- a/tests/unit/presentations/indexable-post-type-presentation/canonical-test.php
+++ b/tests/unit/presentations/indexable-post-type-presentation/canonical-test.php
@@ -2,6 +2,8 @@
 
 namespace Yoast\WP\SEO\Tests\Unit\Presentations\Indexable_Post_Type_Presentation;
 
+use Brain\Monkey;
+
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
@@ -64,6 +66,10 @@ class Canonical_Test extends TestCase {
 				}
 			);
 
+		Monkey\Functions\expect( 'is_date' )
+			->once()
+			->andReturn( false );
+
 		$this->assertEquals( 'https://example.com/permalink/', $this->instance->generate_canonical() );
 	}
 
@@ -100,6 +106,10 @@ class Canonical_Test extends TestCase {
 					return $val;
 				}
 			);
+
+		Monkey\Functions\expect( 'is_date' )
+			->once()
+			->andReturn( false );
 
 		$this->assertEquals( 'https://example.com/permalink/2/', $this->instance->generate_canonical() );
 	}

--- a/tests/unit/presentations/indexable-post-type-presentation/canonical-test.php
+++ b/tests/unit/presentations/indexable-post-type-presentation/canonical-test.php
@@ -3,7 +3,6 @@
 namespace Yoast\WP\SEO\Tests\Unit\Presentations\Indexable_Post_Type_Presentation;
 
 use Brain\Monkey;
-
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**

--- a/tests/unit/presentations/indexable-presentation/canonical-test.php
+++ b/tests/unit/presentations/indexable-presentation/canonical-test.php
@@ -3,7 +3,6 @@
 namespace Yoast\WP\SEO\Tests\Unit\Presentations\Indexable_Presentation;
 
 use Brain\Monkey;
-
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**

--- a/tests/unit/presentations/indexable-presentation/canonical-test.php
+++ b/tests/unit/presentations/indexable-presentation/canonical-test.php
@@ -96,4 +96,28 @@ class Canonical_Test extends TestCase {
 
 		$this->assertEquals( 'https://example.com/dynamic-permalink/', $this->instance->generate_canonical() );
 	}
+
+	/**
+	 * Tests the situation where the permalink is given and we are in a date archive.
+	 *
+	 * @covers ::generate_canonical
+	 */
+	public function test_with_permalink_on_date_archive() {
+		$this->indexable->permalink = '';
+
+		$this->indexable_helper
+			->expects( 'dynamic_permalinks_enabled' )
+			->once()
+			->andReturn( false );
+
+		Monkey\Functions\expect( 'is_date' )
+			->once()
+			->andReturnTrue();
+
+		$this->current_page
+			->expects( 'get_date_archive_permalink' )
+			->andReturn( 'https://example.com/2022/06' );
+
+		$this->assertEquals( 'https://example.com/2022/06', $this->instance->generate_canonical() );
+	}
 }

--- a/tests/unit/presentations/indexable-presentation/canonical-test.php
+++ b/tests/unit/presentations/indexable-presentation/canonical-test.php
@@ -2,6 +2,8 @@
 
 namespace Yoast\WP\SEO\Tests\Unit\Presentations\Indexable_Presentation;
 
+use Brain\Monkey;
+
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
@@ -49,6 +51,10 @@ class Canonical_Test extends TestCase {
 			->once()
 			->andReturn( false );
 
+		Monkey\Functions\expect( 'is_date' )
+			->once()
+			->andReturn( false );
+
 		$this->assertEquals( 'https://example.com/permalink/', $this->instance->generate_canonical() );
 	}
 
@@ -60,6 +66,10 @@ class Canonical_Test extends TestCase {
 	public function test_without_canonical_or_permalink() {
 		$this->indexable_helper
 			->expects( 'dynamic_permalinks_enabled' )
+			->once()
+			->andReturn( false );
+
+		Monkey\Functions\expect( 'is_date' )
 			->once()
 			->andReturn( false );
 

--- a/tests/unit/presentations/indexable-presentation/open-graph-url-test.php
+++ b/tests/unit/presentations/indexable-presentation/open-graph-url-test.php
@@ -2,6 +2,8 @@
 
 namespace Yoast\WP\SEO\Tests\Unit\Presentations\Indexable_Presentation;
 
+use Brain\Monkey;
+
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
@@ -47,6 +49,10 @@ class Open_Graph_URL_Test extends TestCase {
 
 		$this->indexable_helper
 			->expects( 'dynamic_permalinks_enabled' )
+			->once()
+			->andReturn( false );
+
+		Monkey\Functions\expect( 'is_date' )
 			->once()
 			->andReturn( false );
 

--- a/tests/unit/presentations/indexable-presentation/open-graph-url-test.php
+++ b/tests/unit/presentations/indexable-presentation/open-graph-url-test.php
@@ -3,7 +3,6 @@
 namespace Yoast\WP\SEO\Tests\Unit\Presentations\Indexable_Presentation;
 
 use Brain\Monkey;
-
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**

--- a/tests/unit/presentations/indexable-presentation/permalink-test.php
+++ b/tests/unit/presentations/indexable-presentation/permalink-test.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\WP\SEO\Tests\Unit\Presentations\Indexable_Presentation;
 
+use Brain\Monkey;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
@@ -34,6 +35,10 @@ class Permalink_Test extends TestCase {
 
 		$this->indexable_helper
 			->expects( 'dynamic_permalinks_enabled' )
+			->once()
+			->andReturn( false );
+
+		Monkey\Functions\expect( 'is_date' )
 			->once()
 			->andReturn( false );
 

--- a/tests/unit/presentations/indexable-static-home-page-presentation/canonical-test.php
+++ b/tests/unit/presentations/indexable-static-home-page-presentation/canonical-test.php
@@ -3,7 +3,6 @@
 namespace Yoast\WP\SEO\Tests\Unit\Presentations\Indexable_Static_Home_Page_Presentation;
 
 use Brain\Monkey;
-
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**

--- a/tests/unit/presentations/indexable-static-home-page-presentation/canonical-test.php
+++ b/tests/unit/presentations/indexable-static-home-page-presentation/canonical-test.php
@@ -2,6 +2,8 @@
 
 namespace Yoast\WP\SEO\Tests\Unit\Presentations\Indexable_Static_Home_Page_Presentation;
 
+use Brain\Monkey;
+
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
@@ -64,6 +66,10 @@ class Canonical_Test extends TestCase {
 				}
 			);
 
+		Monkey\Functions\expect( 'is_date' )
+			->once()
+			->andReturn( false );
+
 		$this->assertEquals( 'https://example.com/permalink/', $this->instance->generate_canonical() );
 	}
 
@@ -101,6 +107,10 @@ class Canonical_Test extends TestCase {
 					return $val;
 				}
 			);
+
+		Monkey\Functions\expect( 'is_date' )
+			->once()
+			->andReturn( false );
 
 		$this->assertEquals( 'https://example.com/permalink/2/', $this->instance->generate_canonical() );
 	}

--- a/tests/unit/presentations/indexable-static-posts-page-presentation/canonical-test.php
+++ b/tests/unit/presentations/indexable-static-posts-page-presentation/canonical-test.php
@@ -3,7 +3,6 @@
 namespace Yoast\WP\SEO\Tests\Unit\Presentations\Indexable_Static_Posts_Page_Presentation;
 
 use Brain\Monkey;
-
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**

--- a/tests/unit/presentations/indexable-static-posts-page-presentation/canonical-test.php
+++ b/tests/unit/presentations/indexable-static-posts-page-presentation/canonical-test.php
@@ -2,6 +2,8 @@
 
 namespace Yoast\WP\SEO\Tests\Unit\Presentations\Indexable_Static_Posts_Page_Presentation;
 
+use Brain\Monkey;
+
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
@@ -54,6 +56,10 @@ class Canonical_Test extends TestCase {
 			->once()
 			->andReturn( 1 );
 
+		Monkey\Functions\expect( 'is_date' )
+			->once()
+			->andReturn( false );
+
 		$this->assertEquals( 'https://example.com/permalink/', $this->instance->generate_canonical() );
 	}
 
@@ -72,6 +78,10 @@ class Canonical_Test extends TestCase {
 			->expects( 'get_current_archive_page_number' )
 			->once()
 			->andReturn( 1 );
+
+		Monkey\Functions\expect( 'is_date' )
+			->once()
+			->andReturn( false );
 
 		$this->assertEmpty( $this->instance->generate_canonical() );
 	}
@@ -99,6 +109,10 @@ class Canonical_Test extends TestCase {
 			->once()
 			->with( 'https://example.com/permalink/', 2 )
 			->andReturn( 'https://example.com/permalink/page/2/' );
+
+		Monkey\Functions\expect( 'is_date' )
+			->once()
+			->andReturn( false );
 
 		$this->assertEquals( 'https://example.com/permalink/page/2/', $this->instance->generate_canonical() );
 	}

--- a/tests/unit/presentations/indexable-static-posts-page-presentation/open-graph-url-test.php
+++ b/tests/unit/presentations/indexable-static-posts-page-presentation/open-graph-url-test.php
@@ -2,6 +2,8 @@
 
 namespace Yoast\WP\SEO\Tests\Unit\Presentations\Indexable_Static_Posts_Page_Presentation;
 
+use Brain\Monkey;
+
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
@@ -34,6 +36,10 @@ class Open_Graph_URL_Test extends TestCase {
 
 		$this->indexable_helper
 			->expects( 'dynamic_permalinks_enabled' )
+			->once()
+			->andReturn( false );
+
+		Monkey\Functions\expect( 'is_date' )
 			->once()
 			->andReturn( false );
 

--- a/tests/unit/presentations/indexable-static-posts-page-presentation/open-graph-url-test.php
+++ b/tests/unit/presentations/indexable-static-posts-page-presentation/open-graph-url-test.php
@@ -3,7 +3,6 @@
 namespace Yoast\WP\SEO\Tests\Unit\Presentations\Indexable_Static_Posts_Page_Presentation;
 
 use Brain\Monkey;
-
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**

--- a/tests/unit/presentations/indexable-term-archive-presentation/canonical-test.php
+++ b/tests/unit/presentations/indexable-term-archive-presentation/canonical-test.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\WP\SEO\Tests\Unit\Presentations\Indexable_Term_Archive_Presentation;
 
+use Brain\Monkey;
 use Mockery;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
@@ -66,6 +67,10 @@ class Canonical_Test extends TestCase {
 			->once()
 			->andReturn( false );
 
+		Monkey\Functions\expect( 'is_date' )
+			->once()
+			->andReturn( false );
+
 		$this->assertEmpty( $this->instance->generate_canonical() );
 	}
 
@@ -89,6 +94,10 @@ class Canonical_Test extends TestCase {
 			->expects( 'get_current_archive_page_number' )
 			->once()
 			->andReturn( 0 );
+
+		Monkey\Functions\expect( 'is_date' )
+			->once()
+			->andReturn( false );
 
 		$this->assertEquals( 'https://example.com/term-archive/', $this->instance->generate_canonical() );
 	}
@@ -119,6 +128,10 @@ class Canonical_Test extends TestCase {
 			->with( $this->indexable->permalink, 2 )
 			->once()
 			->andReturn( 'https://example.com/term-archive/page/2/' );
+
+		Monkey\Functions\expect( 'is_date' )
+			->once()
+			->andReturn( false );
 
 		$this->assertEquals( 'https://example.com/term-archive/page/2/', $this->instance->generate_canonical() );
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to fix the `main_schema_id` for date archives after https://github.com/Yoast/wordpress-seo/pull/18558

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where the `WebPage` piece would get a blank ID for date archives.

## Relevant technical choices:

* 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Visit a date archive page, e.g.:
  * http://basic.wordpress.test/2022/06/23/
  * http://basic.wordpress.test/2022/06/
  * http://basic.wordpress.test/2022/
* Inspect the schema (e.g. with [this](https://classyschema.org/Visualisation) tool)
* Look for the `CollectionPage` schema piece:
  *  Without this PR, the `@id` is set to `null`
  *  With this PR, the `@id` is set to the page's permalink
* Now go to `Settings` -> `Permalinks` and choose `Numeric` from the `Common Settings` section
* Perform the same check by specifying the date archive page URL in the format:
  * http://basic.wordpress.test/archives/date/2022/06/23
  * http://basic.wordpress.test/archives/date/2022/06
  * http://basic.wordpress.test/archives/date/2022
  
### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes [PC-94]


[PC-94]: https://yoast.atlassian.net/browse/PC-94?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ