### PR TITLE
[PC-87] Do not show premium deactivated notice on upload plugin pages

### DIFF
--- a/src/integrations/admin/deactivated-premium-integration.php
+++ b/src/integrations/admin/deactivated-premium-integration.php
@@ -63,6 +63,11 @@ class Deactivated_Premium_Integration implements Integration_Interface {
 	 * @return void
 	 */
 	public function premium_deactivated_notice() {
+		global $pagenow;
+		if ( $pagenow === 'update.php' ) {
+			return;
+		}
+
 		if ( $this->options_helper->get( 'dismiss_premium_deactivated_notice', false ) === true ) {
 			return;
 		}

--- a/tests/unit/integrations/admin/deactivated-premium-integration-test.php
+++ b/tests/unit/integrations/admin/deactivated-premium-integration-test.php
@@ -131,7 +131,24 @@ class Deactivated_Premium_Integration_Test extends TestCase {
 	 *
 	 * @covers ::premium_deactivated_notice
 	 */
+	public function test_premium_deactivated_notice_if_on_update_page() {
+		global $pagenow;
+		$pagenow = 'update.php';
+
+		// Nothing should be output.
+		$this->expectOutputString( '' );
+		$this->instance->premium_deactivated_notice();
+	}
+
+	/**
+	 * Tests showing the notice.
+	 *
+	 * @covers ::premium_deactivated_notice
+	 */
 	public function test_premium_deactivated_notice_if_dismissed() {
+		global $pagenow;
+		$pagenow = 'admin.php';
+
 		$this->options_helper->expects( 'get' )->with( 'dismiss_premium_deactivated_notice', false )->andReturnTrue();
 
 		// Nothing should be output.
@@ -145,6 +162,9 @@ class Deactivated_Premium_Integration_Test extends TestCase {
 	 * @covers ::premium_deactivated_notice
 	 */
 	public function test_premium_deactivated_notice_if_no_capabilities() {
+		global $pagenow;
+		$pagenow = 'admin.php';
+
 		$premium_file = 'wordpress-seo-premium/wp-seo-premium.php';
 
 		$this->options_helper->expects( 'get' )->with( 'dismiss_premium_deactivated_notice', false )->andReturnFalse();
@@ -161,6 +181,9 @@ class Deactivated_Premium_Integration_Test extends TestCase {
 	 * @covers ::premium_deactivated_notice
 	 */
 	public function test_premium_deactivated_notice_if_no_premium_installed() {
+		global $pagenow;
+		$pagenow = 'admin.php';
+
 		$premium_file = 'wordpress-seo-premium/wp-seo-premium.php';
 
 		$this->options_helper->expects( 'get' )->with( 'dismiss_premium_deactivated_notice', false )->andReturnFalse();


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Prevents showing the premium deactivated notice on upgrade pages.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Prevents showing the premium deactivated notice on upgrade pages.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* See https://yoast.atlassian.net/browse/PC-87


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The premium deactivated notice on upgrade pages.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes https://yoast.atlassian.net/browse/PC-87
