### PR TITLE
Fix yoast-premium-deactivated-notice when shown in privacy page

### DIFF
--- a/css/src/admin-global.css
+++ b/css/src/admin-global.css
@@ -839,8 +839,8 @@ body.folded .wpseo-admin-submit-fixed {
 }
 
 .privacy-settings #yoast-premium-deactivated-notice {
-	margin: 0 20px;
-  }
+  margin: 0 20px;
+}
 
 .yoast .yoast-crawl-settings-help-free {
   opacity: 0.5;

--- a/css/src/admin-global.css
+++ b/css/src/admin-global.css
@@ -838,6 +838,9 @@ body.folded .wpseo-admin-submit-fixed {
   color: #d63638;
 }
 
+.privacy-settings #yoast-premium-deactivated-notice {
+	margin: 0 20px;
+  }
 
 .yoast .yoast-crawl-settings-help-free {
   opacity: 0.5;

--- a/css/src/admin-global.css
+++ b/css/src/admin-global.css
@@ -838,7 +838,7 @@ body.folded .wpseo-admin-submit-fixed {
   color: #d63638;
 }
 
-.privacy-settings #yoast-premium-deactivated-notice {
+.privacy-settings .notice-yoast {
   margin: 0 20px;
 }
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* When in the `Settings` -> `Privacy` WordPress page,  Yoast SEO notices are shown without padding

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds padding around Yoast SEO notices when in WordPress Privacy page.

## Relevant technical choices:

* N/A

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install Yoast SEO
* Install but do not activate Yoast SEO Premium
* Go to `Settings` -> `Privacy` 
* Without this PR, the notice is shown as follows:

<img width="2270" alt="Screenshot 2022-06-24 at 15 11 24" src="https://user-images.githubusercontent.com/68744851/175543654-3054709d-c526-49a6-8d59-4cad0ec487c5.png">

* With this PR, it is shown as follows, instead:

<img width="1411" alt="Screenshot 2022-06-24 at 15 15 24" src="https://user-images.githubusercontent.com/68744851/175543669-a9b21e88-c069-4846-801a-467a21990b74.png">



### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->


## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes [PC-93](https://yoast.atlassian.net/browse/PC-93)
