### PR TITLE
PC-90 - Do not show Flesch reading ease inside of the insights tab when it is not available.

### DIFF
--- a/packages/js/src/insights/components/insights-collapsible.js
+++ b/packages/js/src/insights/components/insights-collapsible.js
@@ -1,4 +1,5 @@
 import { __ } from "@wordpress/i18n";
+import { useSelect } from "@wordpress/data";
 import PropTypes from "prop-types";
 import MetaboxCollapsible from "../../components/MetaboxCollapsible";
 import EstimatedReadingTime from "./estimated-reading-time";
@@ -12,6 +13,8 @@ import WordCount from "./word-count";
  * @returns {JSX.Element} The element.
  */
 const InsightsCollapsible = ( { location } ) => {
+	const isFleschReadingEaseAvailable = useSelect( select => select( "yoast-seo/editor" ).isFleschReadingEaseAvailable(), [] );
+
 	return (
 		<MetaboxCollapsible
 			title={ __( "Insights", "wordpress-seo" ) }
@@ -20,9 +23,9 @@ const InsightsCollapsible = ( { location } ) => {
 		>
 			<ProminentWords location={ location } />
 			<div>
-				<div className="yoast-insights-row">
+				{ isFleschReadingEaseAvailable && <div className="yoast-insights-row">
 					<FleschReadingEase />
-				</div>
+				</div> }
 				<div className="yoast-insights-row yoast-insights-row--columns">
 					<EstimatedReadingTime />
 					<WordCount />

--- a/packages/js/src/insights/components/insights-modal.js
+++ b/packages/js/src/insights/components/insights-modal.js
@@ -14,6 +14,7 @@ import WordCount from "./word-count";
  */
 const InsightsModal = ( { location } ) => {
 	const isElementorEditor = useSelect( select => select( "yoast-seo/editor" ).getIsElementorEditor(), [] );
+	const isFleschReadingEaseAvailable = useSelect( select => select( "yoast-seo/editor" ).isFleschReadingEaseAvailable(), [] );
 
 	return (
 		<EditorModal
@@ -25,9 +26,9 @@ const InsightsModal = ( { location } ) => {
 			<div className="yoast-insights yoast-modal-content--columns">
 				<ProminentWords location={ location } />
 				<div>
-					<div className="yoast-insights-row">
+					{ isFleschReadingEaseAvailable && <div className="yoast-insights-row">
 						<FleschReadingEase />
-					</div>
+					</div> }
 					<div className="yoast-insights-row yoast-insights-row--columns">
 						<EstimatedReadingTime />
 						<WordCount />

--- a/packages/js/src/insights/initializer.js
+++ b/packages/js/src/insights/initializer.js
@@ -26,7 +26,14 @@ const createUpdater = () => {
 		const paper = Paper.parse( collectData() );
 
 		runResearch( "readingTime", paper ).then( response => setEstimatedReadingTime( response.result ) );
-		runResearch( "getFleschReadingScore", paper ).then( response => setFleschReadingEase( response.result ) );
+		runResearch( "getFleschReadingScore", paper ).then( response => {
+			/*
+			 * For languages that do not have Flesch reading ease support, `false` is returned.
+			 */
+			if ( response.result ) {
+				setFleschReadingEase( response.result );
+			}
+		} );
 		runResearch( "wordCountInText", paper ).then( response => setWordCount( response.result ) );
 	};
 };

--- a/packages/js/src/insights/redux/reducer.js
+++ b/packages/js/src/insights/redux/reducer.js
@@ -2,8 +2,6 @@ import { LOAD_ESTIMATED_READING_TIME, SET_ESTIMATED_READING_TIME, SET_FLESCH_REA
 
 const INITIAL_STATE = {
 	estimatedReadingTime: 0,
-	fleschReadingEaseScore: 0,
-	fleschReadingEaseDifficulty: 0,
 	wordCount: 0,
 };
 

--- a/packages/js/src/insights/redux/selectors.js
+++ b/packages/js/src/insights/redux/selectors.js
@@ -1,5 +1,4 @@
 import { get } from "lodash";
-import { DIFFICULTY } from "yoastseo";
 
 /**
  * Gets the Estimated Reading Time from the store.
@@ -15,18 +14,29 @@ export const getEstimatedReadingTime = state => get( state, "insights.estimatedR
  *
  * @param {Object} state The state.
  *
- * @returns {number} The flesch reading ease score.
+ * @returns {number|null} The flesch reading ease score.
  */
-export const getFleschReadingEaseScore = state => get( state, "insights.fleschReadingEaseScore", 0 );
+export const getFleschReadingEaseScore = state => get( state, "insights.fleschReadingEaseScore", null );
 
 /**
  * Gets the flesch reading ease difficulty from the store.
  *
  * @param {Object} state The state.
  *
- * @returns {DIFFICULTY} The flesch reading ease difficulty.
+ * @returns {DIFFICULTY|null} The flesch reading ease difficulty.
  */
-export const getFleschReadingEaseDifficulty = state => get( state, "insights.fleschReadingEaseDifficulty", DIFFICULTY.VERY_DIFFICULT );
+export const getFleschReadingEaseDifficulty = state => get( state, "insights.fleschReadingEaseDifficulty", null );
+
+/**
+ * Checks if the flesch reading ease score and difficulty are available.
+ *
+ * @param {Object} state The state.
+ *
+ * @returns {boolean} Whether the flesch reading ease score and difficulty are available.
+ */
+export const isFleschReadingEaseAvailable = state => {
+	return getFleschReadingEaseScore( state ) !== null && getFleschReadingEaseDifficulty( state ) !== null;
+};
 
 /**
  * Gets the word count from the store.

--- a/packages/js/tests/insights/components/insights-collapsible.test.js
+++ b/packages/js/tests/insights/components/insights-collapsible.test.js
@@ -1,0 +1,47 @@
+import React from "react";
+import { useSelect } from "@wordpress/data";
+import InsightsCollapsible from "../../../src/insights/components/insights-collapsible";
+import { shallow } from "enzyme";
+import FleschReadingEase from "../../../src/insights/components/flesch-reading-ease";
+
+jest.mock( "@wordpress/data", () => (
+	{
+		useSelect: jest.fn(),
+	}
+) );
+
+/**
+ * Mocks the WordPress `useSelect` hook.
+ *
+ * @param {boolean} isFleschReadingEaseAvailable Whether FRE is available
+ *
+ * @returns {void}
+ */
+function mockSelect( isFleschReadingEaseAvailable ) {
+	const select = jest.fn(
+		() => (
+			{
+				isFleschReadingEaseAvailable: jest.fn( () => isFleschReadingEaseAvailable ),
+			}
+		)
+	);
+
+	useSelect.mockImplementation(
+		selectFunction => selectFunction( select )
+	);
+}
+
+describe( "The insights collapsible component", () => {
+	it( "renders the Flesch reading ease (FRE) component if the FRE score and difficulty are available", () => {
+		mockSelect( true );
+		const render = shallow( <InsightsCollapsible location={ "sidebar" } /> );
+
+		expect( render.find( FleschReadingEase ) ).toHaveLength( 1 );
+	} );
+	it( "does not render the FRE component if the FRE score and difficulty are not available", () => {
+		mockSelect( false );
+		const render = shallow( <InsightsCollapsible location={ "sidebar" } /> );
+
+		expect( render.find( FleschReadingEase ) ).toHaveLength( 0 );
+	} );
+} );

--- a/packages/js/tests/insights/components/insights-modal.test.js
+++ b/packages/js/tests/insights/components/insights-modal.test.js
@@ -1,0 +1,54 @@
+import React from "react";
+import { useSelect } from "@wordpress/data";
+import { shallow } from "enzyme";
+import FleschReadingEase from "../../../src/insights/components/flesch-reading-ease";
+import InsightsModal from "../../../src/insights/components/insights-modal";
+
+
+jest.mock( "@wordpress/data", () => (
+	{
+		withSelect: jest.fn(),
+		withDispatch: jest.fn(),
+		useSelect: jest.fn(),
+	}
+) );
+
+jest.mock( "../../../src/containers/EditorModal", () => jest.fn() );
+
+/**
+ * Mocks the WordPress `useSelect` hook.
+ *
+ * @param {boolean} isFleschReadingEaseAvailable Whether FRE is available
+ * @param {boolean} isElementorEditor Whether the editor is the Elementor editor
+ *
+ * @returns {void}
+ */
+function mockSelect( isFleschReadingEaseAvailable, isElementorEditor ) {
+	const select = jest.fn(
+		() => (
+			{
+				isFleschReadingEaseAvailable: jest.fn( () => isFleschReadingEaseAvailable ),
+				getIsElementorEditor: jest.fn( () => isElementorEditor ),
+			}
+		)
+	);
+
+	useSelect.mockImplementation(
+		selectFunction => selectFunction( select )
+	);
+}
+
+describe( "The insights collapsible component", () => {
+	it( "renders the Flesch reading ease (FRE) component if the FRE score and difficulty are available", () => {
+		mockSelect( true, false );
+		const render = shallow( <InsightsModal location={ "sidebar" } /> );
+
+		expect( render.find( FleschReadingEase ) ).toHaveLength( 1 );
+	} );
+	it( "does not render the FRE component if the FRE score and difficulty are not available", () => {
+		mockSelect( false, false );
+		const render = shallow( <InsightsModal location={ "sidebar" } /> );
+
+		expect( render.find( FleschReadingEase ) ).toHaveLength( 0 );
+	} );
+} );

--- a/packages/js/tests/insights/redux/selectors.test.js
+++ b/packages/js/tests/insights/redux/selectors.test.js
@@ -4,17 +4,47 @@ import {
 	getFleschReadingEaseDifficulty,
 	getFleschReadingEaseScore,
 	getWordCount,
+	isFleschReadingEaseAvailable,
 } from "../../../src/insights/redux/selectors";
 import { DIFFICULTY } from "yoastseo";
 
 describe( "The insights selectors", () => {
-	it( "gets the Flesch reading ease score from the store", () => {
-		const state = set( {}, "insights.fleschReadingEaseScore", 42 );
-		expect( getFleschReadingEaseScore( state ) ).toEqual( 42 );
+	describe( "The Flesch reading ease score selector", () => {
+		it( "gets the score from the store", () => {
+			const state = set( {}, "insights.fleschReadingEaseScore", 42 );
+			expect( getFleschReadingEaseScore( state ) ).toEqual( 42 );
+		} );
+		it( "returns `null` when no score is available", () => {
+			const state = {};
+			expect( getFleschReadingEaseScore( state ) ).toEqual( null );
+		} );
 	} );
-	it( "gets the Flesch reading ease score from the store", () => {
-		const state = set( {}, "insights.fleschReadingEaseDifficulty", DIFFICULTY.EASY );
-		expect( getFleschReadingEaseDifficulty( state ) ).toEqual( DIFFICULTY.EASY );
+	describe( "The Flesch reading ease difficulty selector", () => {
+		it( "gets the difficulty from the store", () => {
+			const state = set( {}, "insights.fleschReadingEaseDifficulty", DIFFICULTY.EASY );
+			expect( getFleschReadingEaseDifficulty( state ) ).toEqual( DIFFICULTY.EASY );
+		} );
+		it( "returns `null` when no difficulty is available", () => {
+			const state = {};
+			expect( getFleschReadingEaseDifficulty( state ) ).toEqual( null );
+		} );
+	} );
+	describe( "the Flesch reading ease availability selector", () => {
+		it( "returns `true` when a score and difficulty are available", () => {
+			const state = {
+				insights: {
+					fleschReadingEaseScore: 42,
+					fleschReadingEaseDifficulty: DIFFICULTY.OKAY,
+				},
+			};
+			expect( isFleschReadingEaseAvailable( state ) ).toEqual( true );
+		} );
+		it( "returns `false` when score or difficulty are not available", () => {
+			const state = {
+				insights: {},
+			};
+			expect( isFleschReadingEaseAvailable( state ) ).toEqual( false );
+		} );
 	} );
 	it( "gets the estimated reading time from the store", () => {
 		const state = set( {}, "insights.estimatedReadingTime", 31 );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* For some languages, like Japanese, we do not support the Flesch reading ease calculation. When it is not available, we do not want to show it in the insights.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the Flesch reading ease insight was shown in the insights, even if the user's language does not support Flesch reading ease score calculation.

## Relevant technical choices:

* Created a new selector to check whether the Flesch reading ease score and difficulty are available.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Japanese (language with no FRE support)
* Set your site language to Japanese.
* Create a new post.
* Add some content.
* Check the insights tab inside of the metabox.
   * **Note**: Even though the site's language is set to Japanese, the insights tab will still be in English since the insights tab has not been translated yet. 
* No Flesch reading ease score and description should be shown.
* Check the insights modal inside of the Yoast SEO sidebar.
* No Flesch reading ease score and description should be shown.

#### English (or other language with FRE support)
* Set your site language to Japanese.
* Create a new post.
* Add some content.
* Check the insights tab inside of the metabox.
* Flesch reading ease score and description should be shown.
* Check the insights modal inside of the Yoast SEO sidebar.
* Flesch reading ease score and description should be shown.

Also check in classic / Elementor / Gutenberg and in pages / custom post type / category / WooCommerce product.

**Note**: The insights modal or tab may not be available in every editor. E.g. we do not show the metabox in Elementor and do not show the sidebar in the classic editor.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes #
