### PR TITLE
Prevent fatal error when `php_uname()` is disabled

### DIFF
--- a/admin/tracking/class-tracking-server-data.php
+++ b/admin/tracking/class-tracking-server-data.php
@@ -36,7 +36,10 @@ class WPSEO_Tracking_Server_Data implements WPSEO_Collection {
 			$server_data['Hostname'] = gethostbyaddr( $ipaddress );
 		}
 
-		$server_data['os']            = php_uname();
+		if ( function_exists( 'php_uname' ) ) {
+			$server_data['os'] = php_uname();
+		}
+
 		$server_data['PhpVersion']    = PHP_VERSION;
 		$server_data['CurlVersion']   = $this->get_curl_info();
 		$server_data['PhpExtensions'] = $this->get_php_extensions();

--- a/admin/tracking/class-tracking-server-data.php
+++ b/admin/tracking/class-tracking-server-data.php
@@ -36,10 +36,7 @@ class WPSEO_Tracking_Server_Data implements WPSEO_Collection {
 			$server_data['Hostname'] = gethostbyaddr( $ipaddress );
 		}
 
-		if ( function_exists( 'php_uname' ) ) {
-			$server_data['os'] = php_uname();
-		}
-
+		$server_data['os']            = function_exists( 'php_uname' ) ? php_uname() : PHP_OS;
 		$server_data['PhpVersion']    = PHP_VERSION;
 		$server_data['CurlVersion']   = $this->get_curl_info();
 		$server_data['PhpExtensions'] = $this->get_php_extensions();


### PR DESCRIPTION
## Context

* There are many web hosting providers that disable a number of built-in PHP functions due to security reasons. When the `php_uname()` function is disabled on a web host, activating Yoast SEO causes a fatal error when the tracking is enabled. The PR checks whether the relevant function exists and if it does, it adds the OS information to the tracking data. If the relevant function is disabled, the `PHP_OS` constant is being used as a fallback as the relevant constant will work even when the relevant function is disabled by the web hosting provider.

## Summary

This PR can be summarized in the following changelog entry:

* Prevent PHP fatal error when `php_uname()` function is disabled by the web hosting provider.

## Relevant technical choices:

* Used an additional `if()` condition to check whether the `php_uname()` function is enabled on the server. If yes, it will fallback to the `PHP_OS` constant to get the relevant information.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Disable the `php_uname()` functions from the `php.ini` file by adding the `disable_functions = "php_uname"`.
* Enable the usage tracking option from the Yoast SEO → Search Appearance → Features (tab).
* Activate the Yoast SEO plugin to check whether you see any errors. Note that we received a report in support where a customer sees a fatal error but I didn't get the fatal error. If there's no fatal error, it still makes sense to use the PR to avoid the error if anyone is seeing that.
* Use the PR and activate the plugin.
* Check whether you are seeing any fatal error.
* Alternatively, use the following code snippet to theme `functions.php` file to see whether the OS information appears even when the `php_uname()` function is disabled:
```php
add_filter('wpseo_metadesc', function () {
    $name = function_exists('php_uname') ? php_uname() : PHP_OS;

    die($name);
});
```

### Test instructions for QA when the code is in the RC

* [x] QA should use the same steps as above.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes https://yoast.atlassian.net/browse/IM-1884
