### PR TITLE
PC-91 Output character counts for languages that use character count for text length calculation

### DIFF
--- a/packages/js/src/insights/components/insights-collapsible.js
+++ b/packages/js/src/insights/components/insights-collapsible.js
@@ -5,7 +5,7 @@ import MetaboxCollapsible from "../../components/MetaboxCollapsible";
 import EstimatedReadingTime from "./estimated-reading-time";
 import FleschReadingEase from "./flesch-reading-ease";
 import ProminentWords from "./prominent-words";
-import WordCount from "./word-count";
+import TextLength from "./text-length";
 
 /**
  * Insights collapsible component.
@@ -28,7 +28,7 @@ const InsightsCollapsible = ( { location } ) => {
 				</div> }
 				<div className="yoast-insights-row yoast-insights-row--columns">
 					<EstimatedReadingTime />
-					<WordCount />
+					<TextLength />
 				</div>
 			</div>
 		</MetaboxCollapsible>

--- a/packages/js/src/insights/components/insights-modal.js
+++ b/packages/js/src/insights/components/insights-modal.js
@@ -5,7 +5,7 @@ import EditorModal from "../../containers/EditorModal";
 import EstimatedReadingTime from "./estimated-reading-time";
 import FleschReadingEase from "./flesch-reading-ease";
 import ProminentWords from "./prominent-words";
-import WordCount from "./word-count";
+import TextLength from "./text-length";
 
 /**
  * Insights modal component.
@@ -31,7 +31,7 @@ const InsightsModal = ( { location } ) => {
 					</div> }
 					<div className="yoast-insights-row yoast-insights-row--columns">
 						<EstimatedReadingTime />
-						<WordCount />
+						<TextLength />
 					</div>
 				</div>
 			</div>

--- a/packages/js/src/insights/components/text-length.js
+++ b/packages/js/src/insights/components/text-length.js
@@ -8,14 +8,14 @@ import { get } from "lodash";
  * Text length component.
  * @returns {JSX.Element} The element.
  */
-const WordCount = () => {
+const TextLength = () => {
 	const textLength = useSelect( select => select( "yoast-seo/editor" ).getTextLength(), [] );
 	const textLengthLink = useMemo( () => get( window, "wpseoAdminL10n.shortlinks-insights-word_count", "" ), [] );
 
 	let unitString = _n( "word", "words", textLength.count, "wordpress-seo" );
 	let titleString = __( "Word count", "wordpress-seo" );
 	let linkText =  __( "Learn more about word count", "wordpress-seo" );
-	if ( textLength.wordOrCharacter === "character" ) {
+	if ( textLength.unit === "character" ) {
 		unitString = _n( "character", "characters", textLength.count, "wordpress-seo" );
 		titleString = __( "Character count", "wordpress-seo" );
 		linkText =  __( "Learn more about character count", "wordpress-seo" );
@@ -32,4 +32,4 @@ const WordCount = () => {
 	);
 };
 
-export default WordCount;
+export default TextLength;

--- a/packages/js/src/insights/components/word-count.js
+++ b/packages/js/src/insights/components/word-count.js
@@ -5,20 +5,29 @@ import { InsightsCard } from "@yoast/components";
 import { get } from "lodash";
 
 /**
- * Word count component.
+ * Text length component.
  * @returns {JSX.Element} The element.
  */
 const WordCount = () => {
-	const wordCount = useSelect( select => select( "yoast-seo/editor" ).getWordCount(), [] );
-	const wordCountLink = useMemo( () => get( window, "wpseoAdminL10n.shortlinks-insights-word_count", "" ), [] );
+	const textLength = useSelect( select => select( "yoast-seo/editor" ).getTextLength(), [] );
+	const textLengthLink = useMemo( () => get( window, "wpseoAdminL10n.shortlinks-insights-word_count", "" ), [] );
+
+	let unitString = _n( "word", "words", textLength.count, "wordpress-seo" );
+	let titleString = __( "Word count", "wordpress-seo" );
+	let linkText =  __( "Learn more about word count", "wordpress-seo" );
+	if ( textLength.wordOrCharacter === "character" ) {
+		unitString = _n( "character", "characters", textLength.count, "wordpress-seo" );
+		titleString = __( "Character count", "wordpress-seo" );
+		linkText =  __( "Learn more about character count", "wordpress-seo" );
+	}
 
 	return (
 		<InsightsCard
-			amount={ wordCount }
-			unit={ _n( "word", "words", wordCount, "wordpress-seo" ) }
-			title={ __( "Word count", "wordpress-seo" ) }
-			linkTo={ wordCountLink }
-			linkText={ __( "Learn more about word count", "wordpress-seo" ) }
+			amount={ textLength.count }
+			unit={ unitString }
+			title={ titleString }
+			linkTo={ textLengthLink }
+			linkText={ linkText }
 		/>
 	);
 };

--- a/packages/js/src/insights/initializer.js
+++ b/packages/js/src/insights/initializer.js
@@ -15,7 +15,7 @@ const isInsightsEnabled = () => select( "yoast-seo/editor" ).getPreference( "isI
  * @returns {function} The updater.
  */
 const createUpdater = () => {
-	const { setEstimatedReadingTime, setFleschReadingEase, setWordCount } = dispatch( "yoast-seo/editor" );
+	const { setEstimatedReadingTime, setFleschReadingEase, setTextLength } = dispatch( "yoast-seo/editor" );
 	const runResearch = get( window, "YoastSEO.analysis.worker.runResearch", noop );
 
 	/**
@@ -34,7 +34,7 @@ const createUpdater = () => {
 				setFleschReadingEase( response.result );
 			}
 		} );
-		runResearch( "wordCountInText", paper ).then( response => setWordCount( response.result ) );
+		runResearch( "wordCountInText", paper ).then( response => setTextLength( response.result ) );
 	};
 };
 

--- a/packages/js/src/insights/redux/actions.js
+++ b/packages/js/src/insights/redux/actions.js
@@ -5,7 +5,7 @@ export const SET_ESTIMATED_READING_TIME = "SET_ESTIMATED_READING_TIME";
 export const LOAD_ESTIMATED_READING_TIME = "LOAD_ESTIMATED_READING_TIME";
 export const SET_FLESCH_READING_EASE = "SET_FLESCH_READING_EASE";
 export const SET_PROMINENT_WORDS = "SET_PROMINENT_WORDS";
-export const SET_WORD_COUNT = "SET_WORD_COUNT";
+export const SET_TEXT_LENGTH = "SET_TEXT_LENGTH";
 
 /**
  * Sets the estimated reading time to the store.
@@ -60,13 +60,15 @@ export const setProminentWords = prominentWords => ( {
 } );
 
 /**
- * Sets the word count on the store.
+ * Sets the text length on the store.
  *
- * @param {number} wordCount The word count.
+ * @param {object} textLength The text length.
+ * @param {number} textLength.count The character or word count.
+ * @param {"character"|"word"} textLength.unit The unit in which the text length is measured.
  *
  * @returns {Object} The action.
  */
-export const setWordCount = wordCount => ( {
-	type: SET_WORD_COUNT,
-	payload: wordCount,
+export const setTextLength = textLength => ( {
+	type: SET_TEXT_LENGTH,
+	payload: textLength,
 } );

--- a/packages/js/src/insights/redux/reducer.js
+++ b/packages/js/src/insights/redux/reducer.js
@@ -1,8 +1,8 @@
-import { LOAD_ESTIMATED_READING_TIME, SET_ESTIMATED_READING_TIME, SET_FLESCH_READING_EASE, SET_WORD_COUNT } from "./actions";
+import { LOAD_ESTIMATED_READING_TIME, SET_ESTIMATED_READING_TIME, SET_FLESCH_READING_EASE, SET_TEXT_LENGTH } from "./actions";
 
 const INITIAL_STATE = {
 	estimatedReadingTime: 0,
-	wordCount: 0,
+	textLength: {},
 };
 
 /**
@@ -33,10 +33,10 @@ const reducer = ( state = INITIAL_STATE, { type, payload } ) => {
 				fleschReadingEaseScore: payload.score,
 				fleschReadingEaseDifficulty: payload.difficulty,
 			};
-		case SET_WORD_COUNT:
+		case SET_TEXT_LENGTH:
 			return {
 				...state,
-				wordCount: payload,
+				textLength: payload,
 			};
 		default:
 			return state;

--- a/packages/js/src/insights/redux/selectors.js
+++ b/packages/js/src/insights/redux/selectors.js
@@ -39,10 +39,10 @@ export const isFleschReadingEaseAvailable = state => {
 };
 
 /**
- * Gets the word count from the store.
+ * Gets the text length of the text, either based on the word length or the character length of the text.
  *
  * @param {Object} state The state.
  *
- * @returns {number} The word count.
+ * @returns {number} The text length.
  */
-export const getWordCount = state => get( state, "insights.wordCount", 0 );
+export const getTextLength = state => get( state, "insights.wordCount", 0 );

--- a/packages/js/src/insights/redux/selectors.js
+++ b/packages/js/src/insights/redux/selectors.js
@@ -43,6 +43,6 @@ export const isFleschReadingEaseAvailable = state => {
  *
  * @param {Object} state The state.
  *
- * @returns {{ count: string, unit: ("character"|"word") }} The text length.
+ * @returns {{ count: number, unit: ("character"|"word") }} The text length.
  */
 export const getTextLength = state => get( state, "insights.textLength", {} );

--- a/packages/js/src/insights/redux/selectors.js
+++ b/packages/js/src/insights/redux/selectors.js
@@ -39,10 +39,10 @@ export const isFleschReadingEaseAvailable = state => {
 };
 
 /**
- * Gets the text length of the text, either based on the word length or the character length of the text.
+ * Gets the length of the text, either based on the number of words or the number of characters in the text.
  *
  * @param {Object} state The state.
  *
- * @returns {number} The text length.
+ * @returns {{ count: string, unit: ("character"|"word") }} The text length.
  */
-export const getTextLength = state => get( state, "insights.wordCount", 0 );
+export const getTextLength = state => get( state, "insights.textLength", {} );

--- a/packages/js/tests/insights/components/insights-collapsible.test.js
+++ b/packages/js/tests/insights/components/insights-collapsible.test.js
@@ -3,6 +3,7 @@ import { useSelect } from "@wordpress/data";
 import InsightsCollapsible from "../../../src/insights/components/insights-collapsible";
 import { shallow } from "enzyme";
 import FleschReadingEase from "../../../src/insights/components/flesch-reading-ease";
+import TextLength from "../../../src/insights/components/text-length";
 
 jest.mock( "@wordpress/data", () => (
 	{
@@ -43,5 +44,10 @@ describe( "The insights collapsible component", () => {
 		const render = shallow( <InsightsCollapsible location={ "sidebar" } /> );
 
 		expect( render.find( FleschReadingEase ) ).toHaveLength( 0 );
+	} );
+	it( "renders the TextLength component", () => {
+		const render = shallow( <InsightsCollapsible location={ "sidebar" } /> );
+
+		expect( render.find( TextLength ) ).toHaveLength( 1 );
 	} );
 } );

--- a/packages/js/tests/insights/components/insights-modal.test.js
+++ b/packages/js/tests/insights/components/insights-modal.test.js
@@ -3,6 +3,7 @@ import { useSelect } from "@wordpress/data";
 import { shallow } from "enzyme";
 import FleschReadingEase from "../../../src/insights/components/flesch-reading-ease";
 import InsightsModal from "../../../src/insights/components/insights-modal";
+import TextLength from "../../../src/insights/components/text-length";
 
 
 jest.mock( "@wordpress/data", () => (
@@ -50,5 +51,10 @@ describe( "The insights collapsible component", () => {
 		const render = shallow( <InsightsModal location={ "sidebar" } /> );
 
 		expect( render.find( FleschReadingEase ) ).toHaveLength( 0 );
+	} );
+	it( "renders the TextLength component", () => {
+		const render = shallow( <InsightsModal location={ "sidebar" } /> );
+
+		expect( render.find( TextLength ) ).toHaveLength( 1 );
 	} );
 } );

--- a/packages/js/tests/insights/components/text-length.test.js
+++ b/packages/js/tests/insights/components/text-length.test.js
@@ -1,0 +1,60 @@
+import { shallow } from "enzyme";
+import React from "react";
+import { useSelect } from "@wordpress/data";
+import TextLength from "../../../src/insights/components/text-length";
+
+jest.mock( "@wordpress/data", () => (
+	{
+		useSelect: jest.fn(),
+	}
+) );
+
+
+/**
+ * Mocks the WordPress `useSelect` hook.
+ *
+ * @param {object} textLengthObject The result of text length research.
+ *
+ * @returns {void}
+ */
+function mockSelect( textLengthObject ) {
+	const select = jest.fn(
+		() => (
+			{
+				getTextLength: jest.fn( () => textLengthObject ),
+			}
+		)
+	);
+
+	useSelect.mockImplementation(
+		selectFunction => selectFunction( select )
+	);
+}
+
+describe( "a test for TextLength component", () => {
+	it( "returns the props for languages that use word as the unit for text length measurement", () => {
+		mockSelect( {
+			count: 300,
+			unit: "words",
+		} );
+		const render = shallow( <TextLength /> );
+
+		expect( render.props().amount ).toBe( 300 );
+		expect( render.props().linkText ).toBe( "Learn more about word count" );
+		expect( render.props().title ).toBe( "Word count" );
+		expect( render.props().unit ).toBe( "words" );
+	} );
+
+	it( "returns the props for languages that use character as the unit for text length measurement", () => {
+		mockSelect( {
+			count: 300,
+			unit: "character",
+		} );
+		const render = shallow( <TextLength /> );
+
+		expect( render.props().amount ).toBe( 300 );
+		expect( render.props().linkText ).toBe( "Learn more about character count" );
+		expect( render.props().title ).toBe( "Character count" );
+		expect( render.props().unit ).toBe( "characters" );
+	} );
+} );

--- a/packages/js/tests/insights/redux/reducer.test.js
+++ b/packages/js/tests/insights/redux/reducer.test.js
@@ -1,4 +1,4 @@
-import { setFleschReadingEase } from "../../../src/insights/redux/actions";
+import { setFleschReadingEase, setTextLength } from "../../../src/insights/redux/actions";
 import { DIFFICULTY } from "yoastseo";
 import reducer from "../../../src/insights/redux/reducer";
 
@@ -12,6 +12,22 @@ describe( "The insights reducer", () => {
 		expect( reducer( state, action ) ).toEqual( {
 			fleschReadingEaseScore: 10,
 			fleschReadingEaseDifficulty: DIFFICULTY.VERY_DIFFICULT,
+		} );
+	} );
+	it( "updates the state given an action to update the text length.", () => {
+		const state = {
+			estimatedReadingTime: 3.1,
+		};
+		const action = setTextLength( {
+			count: 42,
+			unit: "character",
+		} );
+		expect( reducer( state, action ) ).toEqual( {
+			estimatedReadingTime: 3.1,
+			textLength: {
+				count: 42,
+				unit: "character",
+			},
 		} );
 	} );
 } );

--- a/packages/js/tests/insights/redux/selectors.test.js
+++ b/packages/js/tests/insights/redux/selectors.test.js
@@ -51,7 +51,8 @@ describe( "The insights selectors", () => {
 		expect( getEstimatedReadingTime( state ) ).toEqual( 31 );
 	} );
 	it( "gets the word count from the store", () => {
-		const state = set( {}, "insights.wordCount", 420 );
-		expect( getTextLength( state ) ).toEqual( 420 );
+		const state = set( {}, "insights.textLength", { count: 420, unit: "word" } );
+		expect( getTextLength( state ).count ).toEqual( 420 );
+		expect( getTextLength( state ).unit ).toEqual( "word" );
 	} );
 } );

--- a/packages/js/tests/insights/redux/selectors.test.js
+++ b/packages/js/tests/insights/redux/selectors.test.js
@@ -50,7 +50,7 @@ describe( "The insights selectors", () => {
 		const state = set( {}, "insights.estimatedReadingTime", 31 );
 		expect( getEstimatedReadingTime( state ) ).toEqual( 31 );
 	} );
-	it( "gets the word count from the store", () => {
+	it( "gets the text length from the store", () => {
 		const state = set( {}, "insights.textLength", { count: 420, unit: "word" } );
 		expect( getTextLength( state ).count ).toEqual( 420 );
 		expect( getTextLength( state ).unit ).toEqual( "word" );

--- a/packages/js/tests/insights/redux/selectors.test.js
+++ b/packages/js/tests/insights/redux/selectors.test.js
@@ -3,7 +3,7 @@ import {
 	getEstimatedReadingTime,
 	getFleschReadingEaseDifficulty,
 	getFleschReadingEaseScore,
-	getWordCount,
+	getTextLength,
 	isFleschReadingEaseAvailable,
 } from "../../../src/insights/redux/selectors";
 import { DIFFICULTY } from "yoastseo";
@@ -52,6 +52,6 @@ describe( "The insights selectors", () => {
 	} );
 	it( "gets the word count from the store", () => {
 		const state = set( {}, "insights.wordCount", 420 );
-		expect( getWordCount( state ) ).toEqual( 420 );
+		expect( getTextLength( state ) ).toEqual( 420 );
 	} );
 } );

--- a/packages/yoastseo/spec/languageProcessing/AbstractResearcherSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/AbstractResearcherSpec.js
@@ -67,13 +67,16 @@ describe( "Adding to a Researcher", function() {
 	} );
 
 	it( "overloads a research in the default researches object with a custom one with the same name", function() {
-		var currentDefaultsLength = Object.keys( researcher.defaultResearches ).length;
-		var currentCustomLength = Object.keys( researcher.customResearches ).length;
-		var totalLength = currentDefaultsLength + currentCustomLength;
+		const currentDefaultsLength = Object.keys( researcher.defaultResearches ).length;
+		const currentCustomLength = Object.keys( researcher.customResearches ).length;
+		const totalLength = currentDefaultsLength + currentCustomLength;
 
 		expect( Object.keys( researcher.getAvailableResearches() ).length ).toEqual( totalLength );
 		researcher.addResearch( "wordCountInText", function() {
-			return 9000;
+			return {
+				count: 9000,
+				unit: "character",
+			};
 		} );
 		expect( Object.keys( researcher.getAvailableResearches() ).length ).toEqual( totalLength );
 		expect( researcher.getResearch( "wordCountInText" ).count ).toEqual( 9000 );

--- a/packages/yoastseo/spec/languageProcessing/AbstractResearcherSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/AbstractResearcherSpec.js
@@ -27,7 +27,7 @@ describe( "Calling a Researcher", function() {
 	} );
 
 	it( "returns a word count result when calling the wordCountInText researcher", function() {
-		expect( researcher.getResearch( "wordCountInText" ) ).toEqual( 4 );
+		expect( researcher.getResearch( "wordCountInText" ).count ).toEqual( 4 );
 	} );
 } );
 
@@ -76,7 +76,7 @@ describe( "Adding to a Researcher", function() {
 			return 9000;
 		} );
 		expect( Object.keys( researcher.getAvailableResearches() ).length ).toEqual( totalLength );
-		expect( researcher.getResearch( "wordCountInText" ) ).toEqual( 9000 );
+		expect( researcher.getResearch( "wordCountInText" ).count ).toEqual( 9000 );
 	} );
 } );
 

--- a/packages/yoastseo/spec/languageProcessing/languages/ja/customResearches/textLengthSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/languages/ja/customResearches/textLengthSpec.js
@@ -5,6 +5,6 @@ describe( "counts characters in a string", function() {
 	const paper = new Paper( "こんにちは。" );
 
 	it( "returns the number of characters for the text of a given paper", function() {
-		expect( textLength( paper ) ).toBe( 6 );
+		expect( textLength( paper ) ).toEqual( { count: 6, unit: "character" } );
 	} );
 } );

--- a/packages/yoastseo/spec/languageProcessing/researches/wordCountInTextSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/wordCountInTextSpec.js
@@ -4,6 +4,6 @@ import Paper from "../../../src/values/Paper";
 describe( "a test for counting the words in the text", function() {
 	it( "returns the count of words in the text", function() {
 		const paper = new Paper( "Tell me a story on how to love your cats", { keyword: "how to love your cats" } );
-		expect( wordCountInText( paper ) ).toBe( 10 );
+		expect( wordCountInText( paper ).count ).toBe( 10 );
 	} );
 } );

--- a/packages/yoastseo/spec/scoring/assessments/seo/TextLengthAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/TextLengthAssessmentSpec.js
@@ -9,7 +9,7 @@ const textLengthAssessment = new TextLengthAssessment();
 describe( "A text length assessment", function() {
 	it( "should assess an empty text", function() {
 		const mockPaper = new Paper( "" );
-		const assessment = textLengthAssessment.getResult( mockPaper, Factory.buildMockResearcher( 0 ) );
+		const assessment = textLengthAssessment.getResult( mockPaper, Factory.buildMockResearcher( { count: 0, unit: "word" } ) );
 
 		expect( assessment.getScore() ).toEqual( -20 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34n' target='_blank'>Text length</a>: " +
@@ -19,7 +19,7 @@ describe( "A text length assessment", function() {
 
 	it( "should assess a single word", function() {
 		const mockPaper = new Paper( "sample" );
-		const assessment = textLengthAssessment.getResult( mockPaper, Factory.buildMockResearcher( 1 ) );
+		const assessment = textLengthAssessment.getResult( mockPaper, Factory.buildMockResearcher( { count: 1, unit: "word" } ) );
 
 		expect( assessment.getScore() ).toEqual( -20 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34n' target='_blank'>Text length</a>: " +
@@ -29,7 +29,7 @@ describe( "A text length assessment", function() {
 
 	it( "should assess a low word count", function() {
 		const mockPaper = new Paper( "These are just five words" );
-		const assessment = textLengthAssessment.getResult( mockPaper, Factory.buildMockResearcher( 5 ) );
+		const assessment = textLengthAssessment.getResult( mockPaper, Factory.buildMockResearcher( { count: 5, unit: "word" } ) );
 
 		expect( assessment.getScore() ).toEqual( -20 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34n' target='_blank'>Text length</a>: " +
@@ -39,7 +39,7 @@ describe( "A text length assessment", function() {
 
 	it( "should assess a medium word count", function() {
 		const mockPaper = new Paper( Factory.buildMockString( "Sample ", 150 ) );
-		const assessment = textLengthAssessment.getResult( mockPaper, Factory.buildMockResearcher( 150 ) );
+		const assessment = textLengthAssessment.getResult( mockPaper, Factory.buildMockResearcher( { count: 150, unit: "word" } ) );
 
 		expect( assessment.getScore() ).toEqual( -10 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34n' target='_blank'>Text length</a>: " +
@@ -49,7 +49,7 @@ describe( "A text length assessment", function() {
 
 	it( "should assess a slightly higher than medium word count", function() {
 		const mockPaper = new Paper( Factory.buildMockString( "Sample ", 225 ) );
-		const assessment = textLengthAssessment.getResult( mockPaper, Factory.buildMockResearcher( 225 ) );
+		const assessment = textLengthAssessment.getResult( mockPaper, Factory.buildMockResearcher( { count: 225, unit: "word" } ) );
 
 		expect( assessment.getScore() ).toEqual( 3 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34n' target='_blank'>Text length</a>: " +
@@ -59,7 +59,7 @@ describe( "A text length assessment", function() {
 
 	it( "should assess an almost at the recommended amount, word count", function() {
 		const mockPaper = new Paper( Factory.buildMockString( "Sample ", 275 ) );
-		const assessment = textLengthAssessment.getResult( mockPaper, Factory.buildMockResearcher( 275 ) );
+		const assessment = textLengthAssessment.getResult( mockPaper, Factory.buildMockResearcher( { count: 275, unit: "word" } ) );
 
 		expect( assessment.getScore() ).toEqual( 6 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34n' target='_blank'>Text length</a>: " +
@@ -70,7 +70,7 @@ describe( "A text length assessment", function() {
 
 	it( "should assess high word count", function() {
 		const mockPaper = new Paper( Factory.buildMockString( "Sample ", 325 ) );
-		const assessment = textLengthAssessment.getResult( mockPaper, Factory.buildMockResearcher( 325 ) );
+		const assessment = textLengthAssessment.getResult( mockPaper, Factory.buildMockResearcher( { count: 325, unit: "word" } ) );
 
 		expect( assessment.getScore() ).toEqual( 9 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34n' target='_blank'>Text length</a>: " +
@@ -94,7 +94,7 @@ describe( "A text length assessment", function() {
 		const mockPaper = new Paper( Factory.buildMockString( "Sample ", 25 ) );
 		const assessmentCornerstone = new TextLengthAssessment( cornerstoneConfig );
 
-		const results = assessmentCornerstone.getResult( mockPaper, Factory.buildMockResearcher( 25 ) );
+		const results = assessmentCornerstone.getResult( mockPaper, Factory.buildMockResearcher( { count: 25, unit: "word" } ) );
 
 		expect( results.getScore() ).toEqual( -20 );
 		expect( results.getText() ).toEqual( "<a href='https://yoa.st/34n' target='_blank'>Text length</a>: " +
@@ -106,7 +106,7 @@ describe( "A text length assessment", function() {
 		const mockPaper = new Paper( Factory.buildMockString( "Sample ", 125 ) );
 		const assessmentCornerstone = new TextLengthAssessment( cornerstoneConfig );
 
-		const results = assessmentCornerstone.getResult( mockPaper, Factory.buildMockResearcher( 125 ) );
+		const results = assessmentCornerstone.getResult( mockPaper, Factory.buildMockResearcher( { count: 125, unit: "word" } ) );
 
 		expect( results.getScore() ).toEqual( -20 );
 		expect( results.getText() ).toEqual( "<a href='https://yoa.st/34n' target='_blank'>Text length</a>: " +
@@ -118,7 +118,7 @@ describe( "A text length assessment", function() {
 		const mockPaper = new Paper( Factory.buildMockString( "Sample ", 325 ) );
 		const assessmentCornerstone = new TextLengthAssessment( cornerstoneConfig );
 
-		const results = assessmentCornerstone.getResult( mockPaper, Factory.buildMockResearcher( 325 ) );
+		const results = assessmentCornerstone.getResult( mockPaper, Factory.buildMockResearcher( { count: 325, unit: "word" } ) );
 
 		expect( results.getScore() ).toEqual( -20 );
 		expect( results.getText() ).toEqual( "<a href='https://yoa.st/34n' target='_blank'>Text length</a>: " +
@@ -130,7 +130,7 @@ describe( "A text length assessment", function() {
 		const mockPaper = new Paper( Factory.buildMockString( "Sample ", 425 ) );
 		const assessmentCornerstone = new TextLengthAssessment( cornerstoneConfig );
 
-		const results = assessmentCornerstone.getResult( mockPaper, Factory.buildMockResearcher( 425 ) );
+		const results = assessmentCornerstone.getResult( mockPaper, Factory.buildMockResearcher( { count: 425, unit: "word" } ) );
 
 		expect( results.getScore() ).toEqual( 6 );
 		expect( results.getText() ).toEqual( "<a href='https://yoa.st/34n' target='_blank'>Text length</a>: " +
@@ -142,7 +142,7 @@ describe( "A text length assessment", function() {
 		const mockPaper = new Paper( Factory.buildMockString( "Sample ", 925 ) );
 		const assessmentCornerstone = new TextLengthAssessment( cornerstoneConfig );
 
-		const results = assessmentCornerstone.getResult( mockPaper, Factory.buildMockResearcher( 925 ) );
+		const results = assessmentCornerstone.getResult( mockPaper, Factory.buildMockResearcher( { count: 925, unit: "word" } ) );
 
 		expect( results.getScore() ).toEqual( 9 );
 		expect( results.getText() ).toEqual( "<a href='https://yoa.st/34n' target='_blank'>Text length</a>: The text contains 925 words. Good job!" );
@@ -159,7 +159,7 @@ describe( "A text length assessment", function() {
 		const mockPaper = new Paper( Factory.buildMockString( "Sample ", 25 ) );
 		const productAssessment = new TextLengthAssessment( productPageConfig );
 
-		const result = productAssessment.getResult( mockPaper, Factory.buildMockResearcher( 25 ) );
+		const result = productAssessment.getResult( mockPaper, Factory.buildMockResearcher( { count: 25, unit: "word" } ) );
 
 		expect( result.getScore() ).toEqual( -20 );
 		expect( result.getText() ).toEqual( "<a href='https://yoa.st/34n' target='_blank'>Text length</a>: " +
@@ -171,7 +171,7 @@ describe( "A text length assessment", function() {
 		const mockPaper = new Paper( Factory.buildMockString( "Sample ", 55 ) );
 		const productAssessment = new TextLengthAssessment( productPageConfig );
 
-		const result = productAssessment.getResult( mockPaper, Factory.buildMockResearcher( 55 ) );
+		const result = productAssessment.getResult( mockPaper, Factory.buildMockResearcher( { count: 55, unit: "word" } ) );
 
 		expect( result.getScore() ).toEqual( -10 );
 		expect( result.getText() ).toEqual( "<a href='https://yoa.st/34n' target='_blank'>Text length</a>: " +
@@ -183,7 +183,7 @@ describe( "A text length assessment", function() {
 		const mockPaper = new Paper( Factory.buildMockString( "Sample ", 101 ) );
 		const productAssessment = new TextLengthAssessment( productPageConfig );
 
-		const result = productAssessment.getResult( mockPaper, Factory.buildMockResearcher( 101 ) );
+		const result = productAssessment.getResult( mockPaper, Factory.buildMockResearcher( { count: 101, unit: "word" } ) );
 
 		expect( result.getScore() ).toEqual( 3 );
 		expect( result.getText() ).toEqual( "<a href='https://yoa.st/34n' target='_blank'>Text length</a>: " +
@@ -195,7 +195,7 @@ describe( "A text length assessment", function() {
 		const mockPaper = new Paper( Factory.buildMockString( "Sample ", 155 ) );
 		const productAssessment = new TextLengthAssessment( productPageConfig );
 
-		const result = productAssessment.getResult( mockPaper, Factory.buildMockResearcher( 155 ) );
+		const result = productAssessment.getResult( mockPaper, Factory.buildMockResearcher( { count: 155, unit: "word" } ) );
 
 		expect( result.getScore() ).toEqual( 6 );
 		expect( result.getText() ).toEqual( "<a href='https://yoa.st/34n' target='_blank'>Text length</a>: " +
@@ -208,7 +208,7 @@ describe( "A text length assessment", function() {
 		const mockPaper = new Paper( Factory.buildMockString( "Sample ", 201 ) );
 		const productAssessment = new TextLengthAssessment( productPageConfig );
 
-		const result = productAssessment.getResult( mockPaper, Factory.buildMockResearcher( 201 ) );
+		const result = productAssessment.getResult( mockPaper, Factory.buildMockResearcher( { count: 201, unit: "word" } ) );
 
 		expect( result.getScore() ).toEqual( 9 );
 		expect( result.getText() ).toEqual( "<a href='https://yoa.st/34n' target='_blank'>Text length</a>: " +
@@ -232,7 +232,7 @@ describe( "A text length assessment", function() {
 		const mockPaper = new Paper( Factory.buildMockString( "Sample ", 25 ) );
 		const productAssessmentCornerstone = new TextLengthAssessment( cornerstoneProductPageConfig );
 
-		const results = productAssessmentCornerstone.getResult( mockPaper, Factory.buildMockResearcher( 25 ) );
+		const results = productAssessmentCornerstone.getResult( mockPaper, Factory.buildMockResearcher( { count: 25, unit: "word" } ) );
 
 		expect( results.getScore() ).toEqual( -20 );
 		expect( results.getText() ).toEqual( "<a href='https://yoa.st/34n' target='_blank'>Text length</a>: " +
@@ -244,7 +244,7 @@ describe( "A text length assessment", function() {
 		const mockPaper = new Paper( Factory.buildMockString( "Sample ", 190 ) );
 		const productAssessmentCornerstone = new TextLengthAssessment( cornerstoneProductPageConfig );
 
-		const results = productAssessmentCornerstone.getResult( mockPaper, Factory.buildMockResearcher( 75 ) );
+		const results = productAssessmentCornerstone.getResult( mockPaper, Factory.buildMockResearcher( { count: 75, unit: "word" } ) );
 
 		expect( results.getScore() ).toEqual( -20 );
 		expect( results.getText() ).toEqual( "<a href='https://yoa.st/34n' target='_blank'>Text length</a>: " +
@@ -256,7 +256,7 @@ describe( "A text length assessment", function() {
 		const mockPaper = new Paper( Factory.buildMockString( "Sample ", 225 ) );
 		const productAssessmentCornerstone = new TextLengthAssessment( cornerstoneProductPageConfig );
 
-		const results = productAssessmentCornerstone.getResult( mockPaper, Factory.buildMockResearcher( 225 ) );
+		const results = productAssessmentCornerstone.getResult( mockPaper, Factory.buildMockResearcher( { count: 225, unit: "word" } ) );
 
 		expect( results.getScore() ).toEqual( -20 );
 		expect( results.getText() ).toEqual( "<a href='https://yoa.st/34n' target='_blank'>Text length</a>: " +
@@ -268,7 +268,7 @@ describe( "A text length assessment", function() {
 		const mockPaper = new Paper( Factory.buildMockString( "Sample ", 380 ) );
 		const productAssessmentCornerstone = new TextLengthAssessment( cornerstoneProductPageConfig );
 
-		const results = productAssessmentCornerstone.getResult( mockPaper, Factory.buildMockResearcher( 380 ) );
+		const results = productAssessmentCornerstone.getResult( mockPaper, Factory.buildMockResearcher( { count: 380, unit: "word" } ) );
 
 		expect( results.getScore() ).toEqual( 6 );
 		expect( results.getText() ).toEqual( "<a href='https://yoa.st/34n' target='_blank'>Text length</a>: " +
@@ -280,7 +280,7 @@ describe( "A text length assessment", function() {
 		const mockPaper = new Paper( Factory.buildMockString( "Sample ", 425 ) );
 		const productAssessmentCornerstone = new TextLengthAssessment( cornerstoneProductPageConfig );
 
-		const results = productAssessmentCornerstone.getResult( mockPaper, Factory.buildMockResearcher( 425 ) );
+		const results = productAssessmentCornerstone.getResult( mockPaper, Factory.buildMockResearcher( { count: 425, unit: "word" } ) );
 
 		expect( results.getScore() ).toEqual( 9 );
 		expect( results.getText() ).toEqual( "<a href='https://yoa.st/34n' target='_blank'>Text length</a>: The text contains 425 words. Good job!" );

--- a/packages/yoastseo/spec/scoring/assessments/seo/taxonomyTextLengthSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/taxonomyTextLengthSpec.js
@@ -12,7 +12,7 @@ describe( "A taxonomy page text length assessment.", function() {
 
 	it( "assesses a single word", function() {
 		const mockPaper = new Paper( "sample" );
-		const result = assessment.getResult( mockPaper, Factory.buildMockResearcher( 1 ) );
+		const result = assessment.getResult( mockPaper, Factory.buildMockResearcher( { count: 1, unit: "word" } ) );
 
 		expect( result.getScore() ).toEqual( -20 );
 		expect( result.getText() ).toEqual( "<a href='https://yoa.st/34j' target='_blank'>Text length</a>: The text contains 1 word. " +
@@ -21,7 +21,7 @@ describe( "A taxonomy page text length assessment.", function() {
 
 	it( "assesses a couple of words", function() {
 		const mockPaper = new Paper( "sample" );
-		const result = assessment.getResult( mockPaper, Factory.buildMockResearcher( 5 ) );
+		const result = assessment.getResult( mockPaper, Factory.buildMockResearcher( { count: 5, unit: "word" } ) );
 
 		expect( result.getScore() ).toEqual( -20 );
 		expect( result.getText() ).toEqual( "<a href='https://yoa.st/34j' target='_blank'>Text length</a>: The text contains 5 words. " +
@@ -30,7 +30,7 @@ describe( "A taxonomy page text length assessment.", function() {
 
 	it( "assesses words far below the minimum.", function() {
 		const mockPaper = new Paper( "sample" );
-		const result = assessment.getResult( mockPaper, Factory.buildMockResearcher( 51 ) );
+		const result = assessment.getResult( mockPaper, Factory.buildMockResearcher( { count: 51, unit: "word" } ) );
 
 		expect( result.getScore() ).toEqual( -10 );
 		expect( result.getText() ).toEqual( "<a href='https://yoa.st/34j' target='_blank'>Text length</a>: The text contains 51 words. " +
@@ -39,7 +39,7 @@ describe( "A taxonomy page text length assessment.", function() {
 
 	it( "assesses words below the minimum.", function() {
 		const mockPaper = new Paper( "sample" );
-		const result = assessment.getResult( mockPaper, Factory.buildMockResearcher( 101 ) );
+		const result = assessment.getResult( mockPaper, Factory.buildMockResearcher( { count: 101, unit: "word" } ) );
 
 		expect( result.getScore() ).toEqual( 3 );
 		expect( result.getText() ).toEqual( "<a href='https://yoa.st/34j' target='_blank'>Text length</a>: The text contains 101 words. " +
@@ -48,7 +48,7 @@ describe( "A taxonomy page text length assessment.", function() {
 
 	it( "assesses words slightly below the minimum.", function() {
 		const mockPaper = new Paper( "sample" );
-		const result = assessment.getResult( mockPaper, Factory.buildMockResearcher( 201 ) );
+		const result = assessment.getResult( mockPaper, Factory.buildMockResearcher( { count: 201, unit: "word" } ) );
 
 		expect( result.getScore() ).toEqual( 6 );
 		expect( result.getText() ).toEqual( "<a href='https://yoa.st/34j' target='_blank'>Text length</a>: The text contains 201 words. " +
@@ -57,7 +57,7 @@ describe( "A taxonomy page text length assessment.", function() {
 
 	it( "assesses words above the minimum.", function() {
 		const mockPaper = new Paper( "sample" );
-		const result = assessment.getResult( mockPaper, Factory.buildMockResearcher( 251 ) );
+		const result = assessment.getResult( mockPaper, Factory.buildMockResearcher( { count: 251, unit: "word" } ) );
 
 		expect( result.getScore() ).toEqual( 9 );
 		expect( result.getText() ).toEqual( "<a href='https://yoa.st/34j' target='_blank'>Text length</a>: The text contains 251 words. Good job!" );

--- a/packages/yoastseo/src/languageProcessing/helpers/word/countWords.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/word/countWords.js
@@ -7,7 +7,7 @@ import getWords from "./getWords.js";
  *
  * @param {string} text The text to be counted.
  *
- * @returns {int} The word count of the given text.
+ * @returns {number} The word count of the given text.
  */
 export default function( text ) {
 	return getWords( text ).length;

--- a/packages/yoastseo/src/languageProcessing/languages/ja/customResearches/textLength.js
+++ b/packages/yoastseo/src/languageProcessing/languages/ja/customResearches/textLength.js
@@ -1,7 +1,7 @@
 import countCharacters from "../helpers/countCharacters";
 
 /**
- * A result of the text length calculation.
+ * A result of the character count calculation.
  *
  * @typedef CharacterCountResult
  * @param {number} count The number of characters found in the text.

--- a/packages/yoastseo/src/languageProcessing/languages/ja/customResearches/textLength.js
+++ b/packages/yoastseo/src/languageProcessing/languages/ja/customResearches/textLength.js
@@ -8,5 +8,8 @@ import countCharacters from "../helpers/countCharacters";
  * @returns {number} The length of the text in characters.
  */
 export default function( paper ) {
-	return countCharacters( paper.getText() );
+	return {
+		count: countCharacters( paper.getText() ),
+		wordOrCharacter: "character",
+	};
 }

--- a/packages/yoastseo/src/languageProcessing/languages/ja/customResearches/textLength.js
+++ b/packages/yoastseo/src/languageProcessing/languages/ja/customResearches/textLength.js
@@ -1,15 +1,23 @@
 import countCharacters from "../helpers/countCharacters";
 
 /**
+ * A result of the text length calculation.
+ *
+ * @typedef CharacterCountResult
+ * @param {number} count The number of characters found in the text.
+ * @param {string} unit The unit used in the text length calculations, always "character".
+ */
+
+/**
  * Count the characters in the text.
  *
  * @param {Paper} paper The Paper object.
  *
- * @returns {number} The length of the text in characters.
+ * @returns {CharacterCountResult} The number of characters found in the text, plus "character" as the unit used in calculating the text length.
  */
 export default function( paper ) {
 	return {
 		count: countCharacters( paper.getText() ),
-		wordOrCharacter: "character",
+		unit: "character",
 	};
 }

--- a/packages/yoastseo/src/languageProcessing/languages/ja/helpers/countCharacters.js
+++ b/packages/yoastseo/src/languageProcessing/languages/ja/helpers/countCharacters.js
@@ -6,7 +6,7 @@ const { sanitizeString } = languageProcessing;
  *
  * @param {string} text The text to be counted.
  *
- * @returns {number} The word count of the given text.
+ * @returns {number} The character count of the given text.
  */
 export default function( text ) {
 	// This regex is used to match URLs in the text, either embedded in tags or not, so that they are excluded from the characters count.

--- a/packages/yoastseo/src/languageProcessing/languages/ja/helpers/countCharacters.js
+++ b/packages/yoastseo/src/languageProcessing/languages/ja/helpers/countCharacters.js
@@ -6,7 +6,7 @@ const { sanitizeString } = languageProcessing;
  *
  * @param {string} text The text to be counted.
  *
- * @returns {int} The word count of the given text.
+ * @returns {number} The word count of the given text.
  */
 export default function( text ) {
 	// This regex is used to match URLs in the text, either embedded in tags or not, so that they are excluded from the characters count.

--- a/packages/yoastseo/src/languageProcessing/researches/readingTime.js
+++ b/packages/yoastseo/src/languageProcessing/researches/readingTime.js
@@ -51,7 +51,7 @@ export default function( paper, researcher ) {
 	const charactersPerMinuteScore = charactersPerMinute[ language ];
 
 	// The default approach of calculating the text length is by counting the words in the text.
-	let textLength = wordCountInText( paper );
+	let textLength = wordCountInText( paper ).count;
 	let minutesToReadText;
 
 	if ( charactersPerMinuteScore ) {

--- a/packages/yoastseo/src/languageProcessing/researches/wordCountInText.js
+++ b/packages/yoastseo/src/languageProcessing/researches/wordCountInText.js
@@ -1,15 +1,23 @@
 import wordCount from "../helpers/word/countWords.js";
 
 /**
+ * A result of the word count calculation.
+ *
+ * @typedef WordCountResult
+ * @param {number} count The number of words found in the text.
+ * @param {"word"} unit The unit used in the text length calculations, always "word".
+ */
+
+/**
  * Count the words in the text.
  *
  * @param {Paper} paper The Paper object.
  *
- * @returns {number} The amount of words found in the text.
+ * @returns {WordCountResult} The number of words found in the text, plus "word" as the unit used in calculating the text length.
  */
 export default function( paper ) {
 	return {
 		count: wordCount( paper.getText() ),
-		wordOrCharacter: "word",
+		unit: "word",
 	};
 }

--- a/packages/yoastseo/src/languageProcessing/researches/wordCountInText.js
+++ b/packages/yoastseo/src/languageProcessing/researches/wordCountInText.js
@@ -8,5 +8,8 @@ import wordCount from "../helpers/word/countWords.js";
  * @returns {number} The amount of words found in the text.
  */
 export default function( paper ) {
-	return wordCount( paper.getText() );
+	return {
+		count: wordCount( paper.getText() ),
+		wordOrCharacter: "word",
+	};
 }

--- a/packages/yoastseo/src/scoring/assessments/readability/SubheadingDistributionTooLongAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/readability/SubheadingDistributionTooLongAssessment.js
@@ -126,7 +126,7 @@ class SubheadingsDistributionTooLong extends Assessment {
 			}
 
 			const customCountLength = researcher.getHelper( "customCountLength" );
-			const textLength = customCountLength ? customCountLength( paper.getText() ) : researcher.getResearch( "wordCountInText" );
+			const textLength = customCountLength ? customCountLength( paper.getText() ) : researcher.getResearch( "wordCountInText" ).count;
 			// Do not use hasEnoughContentForAssessment as it is redundant with textLength > this._config.applicableIfTextLongerThan.
 			return  textLength > this._config.applicableIfTextLongerThan;
 		}

--- a/packages/yoastseo/src/scoring/assessments/readability/TransitionWordsAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/readability/TransitionWordsAssessment.js
@@ -191,7 +191,7 @@ export default class TransitionWordsAssessment extends Assessment {
 		if ( customApplicabilityConfig ) {
 			this._config.applicableIfTextLongerThan = customApplicabilityConfig;
 		}
-		const textLength = customCountLength ? customCountLength( paper.getText() ) : researcher.getResearch( "wordCountInText" );
+		const textLength = customCountLength ? customCountLength( paper.getText() ) : researcher.getResearch( "wordCountInText" ).count;
 		// Do not use hasEnoughContent in this assessment as it is mostly redundant with `textLength >= this._config.applicableIfTextLongerThan`
 		return textLength >= this._config.applicableIfTextLongerThan &&
 			researcher.hasResearch( "findTransitionWords" );

--- a/packages/yoastseo/src/scoring/assessments/seo/KeywordDensityAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/KeywordDensityAssessment.js
@@ -328,7 +328,7 @@ class KeywordDensityAssessment extends Assessment {
 		if ( customApplicabilityConfig ) {
 			this._config.applicableIfTextLongerThan = customApplicabilityConfig;
 		}
-		const textLength = customCountLength ? customCountLength( paper.getText() ) : researcher.getResearch( "wordCountInText" );
+		const textLength = customCountLength ? customCountLength( paper.getText() ) : researcher.getResearch( "wordCountInText" ).count;
 
 		return paper.hasText() && paper.hasKeyword() && textLength >= this._config.applicableIfTextLongerThan;
 	}

--- a/packages/yoastseo/src/scoring/assessments/seo/TextLengthAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/TextLengthAssessment.js
@@ -56,7 +56,7 @@ export default class TextLengthAssessment extends Assessment {
 	 * @returns {AssessmentResult} The result of the assessment, containing both a score and a descriptive text.
 	 */
 	getResult( paper, researcher ) {
-		const wordCount = researcher.getResearch( "wordCountInText" ).count;
+		const wordCount = researcher.getResearch( "wordCountInText" );
 
 		if	( researcher.getConfig( "textLength" ) ) {
 			this._config = this.getLanguageSpecificConfig( researcher );
@@ -68,7 +68,7 @@ export default class TextLengthAssessment extends Assessment {
 			this._config.countTextIn.plural = __( "characters", "wordpress-seo" );
 		}
 
-		const calculatedResult = this.calculateResult( wordCount );
+		const calculatedResult = this.calculateResult( wordCount.count );
 
 		const assessmentResult = new AssessmentResult();
 		assessmentResult.setScore( calculatedResult.score );

--- a/packages/yoastseo/src/scoring/assessments/seo/TextLengthAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/TextLengthAssessment.js
@@ -56,7 +56,7 @@ export default class TextLengthAssessment extends Assessment {
 	 * @returns {AssessmentResult} The result of the assessment, containing both a score and a descriptive text.
 	 */
 	getResult( paper, researcher ) {
-		const wordCount = researcher.getResearch( "wordCountInText" );
+		const wordCount = researcher.getResearch( "wordCountInText" ).count;
 
 		if	( researcher.getConfig( "textLength" ) ) {
 			this._config = this.getLanguageSpecificConfig( researcher );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* For certain languages, e.g. Japanese, we do not count the text length in words, but in characters. This PR fixes a bug where the insights mistakenly showed "words" instead of "characters" when talking about the text length for these languages.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Displays "character/characters" string instead of "word/words" string inside Insights tab for languages that use character as the unit measurement for text length calculation.

## Relevant technical choices:

* Changed mentions of "word count" to "text length" inside of the insights, since text length can also be counted in number of characters, instead of words.
* We decided not to rename `wordCountInText` research in this PR to avoid scope creep.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

**Note**: test this PR in every combination of editor (classic, block, Elementor, Gutenberg) and content type (post, page, custom post type, taxonomy, custom taxonomy).
* Set the site language to Japanese.
* Create a new post / page/ CPT / taxonomy.
* Add some content.
* Open the insights tab (inside of the metabox and/or sidebar).
* Check the text length shown inside of the insights, it should mention "characters" (in Japanese: "文字") instead of "words".
* Replace the content with a single character.
* Check the text length shown inside of the insights, it should mention "character" (in Japanese: "文字") instead of "word".
* Also run the test in multisite WordPress and make sure that it still works as expected

#### Regression test for English
* Set the site language to English.
* Create a new post / page/ CPT / taxonomy.
* Add some content with multiple words.
* Open the insights tab (inside of the metabox and/or sidebar).
* Check the text length shown inside of the insights, it should mention "words" instead of "characters".
* Replace the content with a single word.
* Check the text length shown inside of the insights, it should mention "word" (so singular) instead of "character".

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Please do a smoke test to test if the following features still work as expected:
  * The reading time insight.
  * Text length assessment.
  * Transition words assessment.
  * Subheading distribution assessment.
  * Keyphrase density assessment.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes https://yoast.atlassian.net/browse/PC-91
