### PR TITLE
Sanitize filters compatibility in PHP v8.1

### DIFF
--- a/src/conditionals/third-party/elementor-edit-conditional.php
+++ b/src/conditionals/third-party/elementor-edit-conditional.php
@@ -19,13 +19,13 @@ class Elementor_Edit_Conditional implements Conditional {
 		global $pagenow;
 
 		// Check if we are on an Elementor edit page.
-		$get_action = \filter_input( \INPUT_GET, 'action', \FILTER_SANITIZE_STRING );
+		$get_action = \filter_input( \INPUT_GET, 'action', \FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 		if ( $pagenow === 'post.php' && $get_action === 'elementor' ) {
 			return true;
 		}
 
 		// Check if we are in our Elementor ajax request.
-		$post_action = \filter_input( \INPUT_POST, 'action', \FILTER_SANITIZE_STRING );
+		$post_action = \filter_input( \INPUT_POST, 'action', \FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 		return \wp_doing_ajax() && $post_action === 'wpseo_elementor_save';
 	}
 }

--- a/src/integrations/admin/helpscout-beacon.php
+++ b/src/integrations/admin/helpscout-beacon.php
@@ -105,7 +105,7 @@ class HelpScout_Beacon implements Integration_Interface {
 		$this->options          = $options;
 		$this->asset_manager    = $asset_manager;
 		$this->ask_consent      = ! $this->options->get( 'tracking' );
-		$this->page             = \filter_input( \INPUT_GET, 'page', \FILTER_SANITIZE_STRING );
+		$this->page             = \filter_input( \INPUT_GET, 'page', \FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 		$this->migration_status = $migration_status;
 
 		foreach ( $this->base_pages as $page ) {

--- a/tests/unit/conditionals/estimated-reading-time-conditional-test.php
+++ b/tests/unit/conditionals/estimated-reading-time-conditional-test.php
@@ -48,7 +48,7 @@ class Estimated_Reading_Time_Conditional_Test extends TestCase {
 	 *
 	 * @covers ::is_met
 	 *
-	 * @requires PHP < 8.1
+	 * @requires PHP <= 8.1
 	 */
 	public function test_ajax_elementor_save() {
 		// We are in an Ajax request.
@@ -68,7 +68,7 @@ class Estimated_Reading_Time_Conditional_Test extends TestCase {
 	 *
 	 * @covers ::is_met
 	 *
-	 * @requires PHP < 8.1
+	 * @requires PHP <= 8.1
 	 */
 	public function test_not_post_not_elementor_save() {
 		// We are in an Ajax request.

--- a/tests/unit/conditionals/estimated-reading-time-conditional-test.php
+++ b/tests/unit/conditionals/estimated-reading-time-conditional-test.php
@@ -57,7 +57,7 @@ class Estimated_Reading_Time_Conditional_Test extends TestCase {
 		// We are saving in Elementor with Ajax.
 		$this->input_helper
 			->expects( 'filter' )
-			->with( \INPUT_POST, 'action', \FILTER_SANITIZE_STRING )
+			->with( \INPUT_POST, 'action', \FILTER_SANITIZE_FULL_SPECIAL_CHARS )
 			->andReturn( 'wpseo_elementor_save' );
 
 		$this->assertEquals( true, $this->instance->is_met() );
@@ -77,7 +77,7 @@ class Estimated_Reading_Time_Conditional_Test extends TestCase {
 		// The Ajax action is not for saving Elementor.
 		$this->input_helper
 			->expects( 'filter' )
-			->with( \INPUT_POST, 'action', \FILTER_SANITIZE_STRING )
+			->with( \INPUT_POST, 'action', \FILTER_SANITIZE_FULL_SPECIAL_CHARS )
 			->andReturn( 'some_other_value' );
 
 		// We are not on a post according to the post conditional.


### PR DESCRIPTION
## Context

* We have been using `FILTER_SANITIZE_STRING` sanitize filters in our code that have been deprecated from PHP v8.1. When activating Yoast SEO with PHP v8.1, three deprecation notices occur due to the deprecated sanitize filters. This PR replaces the deprecated `FILTER_SANITIZE_STRING` sanitize filter with the `FILTER_SANITIZE_FULL_SPECIAL_CHARS` to have a safe string output. Further information is available [here](https://www.php.net/manual/en/filter.filters.sanitize.php).

## Summary

This PR can be summarized in the following changelog entry:

* Sanitize filters compatibility in PHP v8.1

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Activate Yoast SEO on a WordPress site that is running in PHP v8.1
* Open Query Monitor PHP Errors (tab) to check the deprecation notices related to the sanitize filters.
* Use this PR and check the Query Monitor to see whether the relevant deprecation notices persist.


### Test instructions for QA when the code is in the RC

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Elementor integration to edit a post/page.
* Save post metadata through an Ajax request.

## Quality assurance

* [x] I have tested this code to the best of my abilities

Fixes #17991
