### PR TITLE
Fix order of the metabox in Firefox

### DIFF
--- a/packages/js/src/components/fills/MetaboxFill.js
+++ b/packages/js/src/components/fills/MetaboxFill.js
@@ -77,17 +77,15 @@ export default function MetaboxFill( { settings, wincherKeyphrases, setWincherNo
 						shouldUpsell={ settings.shouldUpsell }
 					/>
 				</SidebarItem> }
-				{ settings.isKeywordAnalysisActive && <Fragment>
-					<SidebarItem key="seo-analysis" renderPriority={ 20 }>
+				{ settings.isKeywordAnalysisActive && <SidebarItem key="seo-analysis" renderPriority={ 20 }>
+					<Fragment>
 						<SeoAnalysis
 							shouldUpsell={ settings.shouldUpsell }
 							shouldUpsellWordFormRecognition={ settings.isWordFormRecognitionActive }
 						/>
-					</SidebarItem>
-					{ settings.shouldUpsell && <SidebarItem key="premium-seo-analysis-upsell" renderPriority={ 20 }>
-						<PremiumSEOAnalysisModal location="metabox" />
-					</SidebarItem> }
-				</Fragment> }
+						{ settings.shouldUpsell && <PremiumSEOAnalysisModal location="metabox" /> }
+					</Fragment>
+				</SidebarItem> }
 				{ settings.isKeywordAnalysisActive && <SidebarItem key="additional-keywords-upsell" renderPriority={ 22 }>
 					{ settings.shouldUpsell && <KeywordUpsell /> }
 				</SidebarItem> }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where the order of the SEO analysis and Premium SEO analysis in the Yoast metabox would be wrong in Firefox

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* In Firefox, go to create a new post (while Premium is not active)
* In both the Block Editor and the classic editor, SEO analysis and Premium SEO analysis should be at the top of the metabox (but below the Google preview). (with the previous RC the SEO analysis and Premium SEO analysis were at the bottom of the metabox)
* Which means that the order of the sidebar items in that metabox should be `1. SEO analysis 2. Premium SEO analysis 3. Add related Keyphrases, etc.`
* Confirm that clicking on the `Premium SEO Analysis` opens the modal:
![image](https://user-images.githubusercontent.com/12400734/175016248-778c4652-1446-4db6-a4b6-809732df1a04.png)
* Confirm that clicking on the button, it goes to `https://yoa.st/premium-seo-analysis-metabox`.

Also confirm that with Premium active, we don't show the Premium SEO analysis upsell item

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Smoke test the sidebar (mainly the SEO analysis and Premium SEO analysis sidebar items) in the Block Editor and Elementor 

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes #
