### PR TITLE
Fix inactive setting toggles get a false value upon saving the settings form

### DIFF
--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -848,6 +848,11 @@ class Yoast_Form {
 		];
 		$attr     = wp_parse_args( $attr, $defaults );
 
+		if ( isset( $attr['disabled'] ) && $attr['disabled'] ) {
+			// $this->handle_disabled_settings( $variable ); This is what we probably have to do, to create a hidden field.
+			// And also edit the variable name (maybe appending a _disabled suffix in its name, so that its value doesnt become false in the db after saving)
+		}
+
 		$val = $this->get_field_value( $variable, false );
 		if ( $val === true ) {
 			$val = 'on';

--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -849,8 +849,8 @@ class Yoast_Form {
 		$attr     = wp_parse_args( $attr, $defaults );
 
 		if ( isset( $attr['disabled'] ) && $attr['disabled'] ) {
-			// $this->handle_disabled_settings( $variable ); This is what we probably have to do, to create a hidden field.
-			// And also edit the variable name (maybe appending a _disabled suffix in its name, so that its value doesnt become false in the db after saving)
+			$this->hidden( $variable );
+			$variable .= '_disabled';
 		}
 
 		$val = $this->get_field_value( $variable, false );

--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -848,7 +848,7 @@ class Yoast_Form {
 		];
 		$attr     = wp_parse_args( $attr, $defaults );
 
-		if ( isset( $attr['disabled'] ) && $attr['disabled'] ) {
+		if ( isset( $attr['preserve_disabled_value'] ) && $attr['preserve_disabled_value'] ) {
 			$this->hidden( $variable );
 			$variable .= '_disabled';
 		}

--- a/admin/views/tabs/dashboard/features.php
+++ b/admin/views/tabs/dashboard/features.php
@@ -62,6 +62,11 @@ $feature_toggles = Yoast_Feature_Toggles::instance()->get_all();
 			$disabled = true;
 		}
 
+		$preserve_disabled_value = false;
+		if ( $disabled ) {
+			$preserve_disabled_value = true;
+		}
+
 		$yform->toggle_switch(
 			$feature->setting,
 			[
@@ -70,7 +75,10 @@ $feature_toggles = Yoast_Feature_Toggles::instance()->get_all();
 			],
 			$name,
 			$feature_help->get_button_html() . $feature_help->get_panel_html(),
-			[ 'disabled' => $disabled ]
+			[
+				'disabled'                => $disabled,
+				'preserve_disabled_value' => $preserve_disabled_value,
+			]
 		);
 
 		if ( ! empty( $feature->after ) ) {

--- a/admin/views/tabs/dashboard/integrations.php
+++ b/admin/views/tabs/dashboard/integrations.php
@@ -81,6 +81,13 @@ $integration_toggles = Yoast_Integration_Toggles::instance()->get_all();
 				];
 			}
 
+			$preserve_disabled_value = false;
+			if ( isset( $attributes['disabled'] ) && $attributes['disabled'] ) {
+				$preserve_disabled_value = true;
+			}
+
+			$attributes['preserve_disabled_value'] = $preserve_disabled_value;
+
 			$yform->toggle_switch(
 				$integration->setting,
 				[

--- a/css/src/admin-global.css
+++ b/css/src/admin-global.css
@@ -663,14 +663,14 @@ body.folded .wpseo-admin-submit-fixed {
 
 /* Disabled toggles in the Crawl settings tab */
 
-.yoast #crawl-settings fieldset[id$="_free"] ,
+.yoast #crawl-settings fieldset[id$="_disabled"] ,
 .yoast label[for="search_character_limit_free"],
 .yoast label[for="clean_permalinks_extra_variables_free"],
 .yoast p.yoast-extra-variables-label-free {
 	opacity: 0.5;
 }
 
-.yoast #crawl-settings fieldset[id$="_free"] .switch-toggle.switch-yoast-seo input:disabled ~ a {
+.yoast #crawl-settings fieldset[id$="_disabled"] .switch-toggle.switch-yoast-seo input:disabled ~ a {
 	border: 1px solid #b5b5b5;
 	background: #a4286a;
 }

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -80,6 +80,7 @@ class WPSEO_Upgrade {
 			'18.6-RC0'   => 'upgrade_186',
 			'18.9-RC0'   => 'upgrade_189',
 			'19.1-RC0'   => 'upgrade_191',
+			'19.3-RC0'   => 'upgrade_193',
 		];
 
 		array_walk( $routines, [ $this, 'run_upgrade_routine' ], $version );
@@ -924,6 +925,16 @@ class WPSEO_Upgrade {
 	private function upgrade_191() {
 		if ( is_multisite() ) {
 			WPSEO_Options::set( 'allow_remove_feed_post_comments', true );
+		}
+	}
+
+	/**
+	 * Performs the 19.3 upgrade routine.
+	 */
+	private function upgrade_193() {
+		if ( empty( get_option( 'wpseo_premium', [] ) ) ) {
+			WPSEO_Options::set( 'enable_index_now', true );
+			WPSEO_Options::set( 'enable_link_suggestions', true );
 		}
 	}
 

--- a/src/integrations/admin/crawl-settings-integration.php
+++ b/src/integrations/admin/crawl-settings-integration.php
@@ -281,7 +281,8 @@ class Crawl_Settings_Integration implements Integration_Interface {
 				$label,
 				'',
 				[
-					'disabled' => true,
+					'disabled'                => true,
+					'preserve_disabled_value' => true,
 				]
 			);
 			if ( $setting === 'remove_feed_global_comments' && ! $is_network ) {

--- a/src/integrations/admin/crawl-settings-integration.php
+++ b/src/integrations/admin/crawl-settings-integration.php
@@ -276,7 +276,7 @@ class Crawl_Settings_Integration implements Integration_Interface {
 		}
 		foreach ( $settings as $setting => $label ) {
 			$yform->toggle_switch(
-				$setting_prefix . $setting . '_free',
+				$setting_prefix . $setting,
 				$toggles,
 				$label,
 				'',
@@ -289,9 +289,6 @@ class Crawl_Settings_Integration implements Integration_Interface {
 				echo \esc_html__( 'By removing Global comments feed, Post comments feeds will be removed too.', 'wordpress-seo' );
 				echo '</p>';
 			}
-
-			$setting_name = $setting_prefix . $setting;
-			$yform->hidden( $setting_name, $setting_name );
 		}
 	}
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to fix a bug where disabled setting toggles would set to `false` when the form in the General page would get saved, instead of persisting their current value.
* That bug would affect users with no Premium, where when they eventually install Premium, they would have their otherwise-enabled-by-default settings set to disabled
* We also want to remedy this bug for current users that might have already performed a form save in the General page. For those, we check upon Free upgrade whether they have never installed Premium before, and if they hadn't, we set enabled-by-default Premium settings to `On`.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where disabled settings in the General page would be set to `Off` upon saving the settings form

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

**For the bug**
* Have Premium not active, in a clean setup.
* Go to the Yoast SEO->General page in the `Features` tab. 
* Confirm that the Premium/disabled features are set to `Off` and are greyed out (with the previous RC, they were just greyed out, but set to `On` ).
* Click Save changes.
* Now activate Premium
* Confirm that the **Link Suggestions** and **IndexNow** features are set to `On`. With the previous RC (and also the live 19.2 version), the **Link Suggestions** and **IndexNow** features would be set to `Off` which is a bug



**For the remedy of the bug to older users:**
* In a setup where Premium was never activated before, install RC1 (or the 19.2 version).
* Go to the Yoast SEO->General page in the `Features` tab. Click Save changes.
* Perform upgrade routine to the current RC.
* Activate Premium.
* Now confirm that the **Link Suggestions** and **IndexNow** features are set to `On`
* Confirm that the Zapier and Algolia integrations are set to `Off` (although they should be `Off` with the 19.2 version as well)

**For confirming that the remedy doesnt affect users that had Premium before:**
* In a clean setup activate Premium and Free v19.2
* Set **Link Suggestions** and **IndexNow** to `Off`
* Perform upgrade routine to the current RC
* Confirm that the **Link Suggestions** and **IndexNow** features are still set to `Off`


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

**Crawl Settings regression testing**
* Have Premium inactive and Save changes in the General page.
* The Crawl settings should still look like this: 
![image](https://user-images.githubusercontent.com/12400734/176446898-5196f22e-ac34-46ff-bb55-e69e9f26d549.png)
* Confirm that the Crawl settings are set to `Keep` when you then activate Premium.
* In multisite, have Premium disabled and Save changes in the network General page
* If you enable Premium now, you should get all Crawl settings as `Allow control` 

**Algolia and Zapier regression testing**
* Have Premium inactive and Save changes in the General page.
* Confirm that the Algolia and Zapier integration settings are set to `Off` when you then activate Premium.

**Wordproof regression testing**
* Have Wordproof active and Save changes in the General page.
* Confirm that the Algolia and Zapier integration settings are set to `Off` when you then deactivate Wordproof.

**Multisite regression testing**
* In a multisite, in the network site, set every feature and integration as `Disabled` instead of `Allow control`
* In a subsite then, hit Save changes, while on the General page
* If you revert in the network site every feature and integration as `Allow control` instead of `Disabled` 
* In the subsite, refresh the General page. Confirm that every feature and integration has the default setting still.
## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes #
