### PR TITLE
Pc 110 only show flesch reading ease score when there is enough content

### DIFF
--- a/packages/components/src/insights-card/InsightsCard.js
+++ b/packages/components/src/insights-card/InsightsCard.js
@@ -47,7 +47,7 @@ export default InsightsCard;
 
 InsightsCard.propTypes = {
 	title: PropTypes.string,
-	amount: PropTypes.number.isRequired,
+	amount: PropTypes.oneOfType( [ PropTypes.number, PropTypes.oneOf( [ "?" ] ) ] ).isRequired,
 	description: PropTypes.element,
 	unit: PropTypes.string,
 	linkTo: PropTypes.string,

--- a/packages/js/src/insights/components/flesch-reading-ease.js
+++ b/packages/js/src/insights/components/flesch-reading-ease.js
@@ -18,6 +18,8 @@ const OutboundLink = makeOutboundLink();
  */
 function getDifficultyFeedback( difficulty ) {
 	switch ( difficulty ) {
+		case DIFFICULTY.NO_DATA:
+			return __( "no data", "wordpress-seo" );
 		case DIFFICULTY.VERY_EASY:
 			return __( "very easy", "wordpress-seo" );
 		case DIFFICULTY.EASY:
@@ -50,6 +52,8 @@ function getCallToAction( difficulty ) {
 		case DIFFICULTY.DIFFICULT:
 		case DIFFICULTY.VERY_DIFFICULT:
 			return __( "Try to make shorter sentences, using less difficult words to improve readability", "wordpress-seo" );
+		case DIFFICULTY.NO_DATA:
+			return __( "Continue writing to get insight into the readability of your text!", "wordpress-seo" ); // TODO: suitable text
 		default:
 			return __( "Good job!", "wordpress-seo" );
 	}
@@ -64,10 +68,21 @@ function getCallToAction( difficulty ) {
  * @returns {string} The description.
  */
 function getDescription( score, difficulty ) {
+	if ( score === "?" ) {
+		return sprintf(
+			/* Translators: %1$s expands to the numeric Flesch reading ease score,
+				%2$s expands to the easiness of reading (e.g. 'easy' or 'very difficult').
+			 */
+			__(
+				"Your text should be slightly longer to calculate your Flesch reading ease score.", // TODO: good text in here
+				"wordpress-seo"
+			)
+		);
+	}
 	return sprintf(
 		/* Translators: %1$s expands to the numeric Flesch reading ease score,
-			%2$s expands to the easiness of reading (e.g. 'easy' or 'very difficult').
-		 */
+				%2$s expands to the easiness of reading (e.g. 'easy' or 'very difficult').
+			 */
 		__(
 			"The copy scores %1$s in the test, which is considered %2$s to read.",
 			"wordpress-seo"

--- a/packages/js/src/insights/components/flesch-reading-ease.js
+++ b/packages/js/src/insights/components/flesch-reading-ease.js
@@ -53,7 +53,7 @@ function getCallToAction( difficulty ) {
 		case DIFFICULTY.VERY_DIFFICULT:
 			return __( "Try to make shorter sentences, using less difficult words to improve readability", "wordpress-seo" );
 		case DIFFICULTY.NO_DATA:
-			return __( "Continue writing to get insight into the readability of your text!", "wordpress-seo" ); // TODO: suitable text
+			return __( "Continue writing to get insight into the readability of your text!", "wordpress-seo" );
 		default:
 			return __( "Good job!", "wordpress-seo" );
 	}
@@ -74,7 +74,7 @@ function getDescription( score, difficulty ) {
 				%2$s expands to the easiness of reading (e.g. 'easy' or 'very difficult').
 			 */
 			__(
-				"Your text should be slightly longer to calculate your Flesch reading ease score.", // TODO: good text in here
+				"Your text should be slightly longer to calculate your Flesch reading ease score.",
 				"wordpress-seo"
 			)
 		);

--- a/packages/js/src/insights/components/flesch-reading-ease.js
+++ b/packages/js/src/insights/components/flesch-reading-ease.js
@@ -4,7 +4,7 @@ import { __, sprintf } from "@wordpress/i18n";
 import { InsightsCard } from "@yoast/components";
 import { makeOutboundLink } from "@yoast/helpers";
 import { DIFFICULTY } from "yoastseo";
-import { get, isNil } from "lodash";
+import { get } from "lodash";
 
 const OutboundLink = makeOutboundLink();
 

--- a/packages/js/src/insights/components/flesch-reading-ease.js
+++ b/packages/js/src/insights/components/flesch-reading-ease.js
@@ -4,7 +4,7 @@ import { __, sprintf } from "@wordpress/i18n";
 import { InsightsCard } from "@yoast/components";
 import { makeOutboundLink } from "@yoast/helpers";
 import { DIFFICULTY } from "yoastseo";
-import { get } from "lodash";
+import { get, isNil } from "lodash";
 
 const OutboundLink = makeOutboundLink();
 
@@ -68,11 +68,8 @@ function getCallToAction( difficulty ) {
  * @returns {string} The description.
  */
 function getDescription( score, difficulty ) {
-	if ( score === "?" ) {
+	if ( score === -1 ) {
 		return sprintf(
-			/* Translators: %1$s expands to the numeric Flesch reading ease score,
-				%2$s expands to the easiness of reading (e.g. 'easy' or 'very difficult').
-			 */
 			__(
 				"Your text should be slightly longer to calculate your Flesch reading ease score.",
 				"wordpress-seo"
@@ -118,13 +115,17 @@ function getDescriptionElement( score, difficulty, link ) {
  * @returns {JSX.Element} The element.
  */
 const FleschReadingEase = () => {
-	const score = useSelect( select => select( "yoast-seo/editor" ).getFleschReadingEaseScore(), [] );
+	let score = useSelect( select => select( "yoast-seo/editor" ).getFleschReadingEaseScore(), [] );
 	const link = useMemo( () => get( window, "wpseoAdminL10n.shortlinks-insights-flesch_reading_ease", "" ), [] );
 	const difficulty = useSelect( select => select( "yoast-seo/editor" ).getFleschReadingEaseDifficulty(), [ score ] );
 	const description = useMemo( () => {
 		const articleLink = get( window, "wpseoAdminL10n.shortlinks-insights-flesch_reading_ease_article", "" );
 		return getDescriptionElement( score, difficulty, articleLink );
 	}, [ score, difficulty ] );
+
+	if ( score === -1 ) {
+		score = "?";
+	}
 
 	return (
 		<InsightsCard

--- a/packages/js/src/insights/components/flesch-reading-ease.js
+++ b/packages/js/src/insights/components/flesch-reading-ease.js
@@ -68,6 +68,8 @@ function getCallToAction( difficulty ) {
  * @returns {string} The description.
  */
 function getDescription( score, difficulty ) {
+	// A score of -1 signals that no valid FRE was calculated.
+
 	if ( score === -1 ) {
 		return sprintf(
 			__(
@@ -123,6 +125,7 @@ const FleschReadingEase = () => {
 		return getDescriptionElement( score, difficulty, articleLink );
 	}, [ score, difficulty ] );
 
+	// A score of -1 signals that no valid FRE was calculated.
 	if ( score === -1 ) {
 		score = "?";
 	}

--- a/packages/yoastseo/spec/languageProcessing/researches/getFleschReadingScoreSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/getFleschReadingScoreSpec.js
@@ -15,7 +15,7 @@ describe( "a test to calculate the fleschReading score", function() {
 		expect( fleschFunction( mockPaper, researcher ) ).toEqual( { score: 63.9, difficulty: DIFFICULTY.OKAY } );
 
 		mockPaper = new Paper( "" );
-		expect( fleschFunction( mockPaper, researcher ) ).toEqual( { score: "?", difficulty: DIFFICULTY.NO_DATA } );
+		expect( fleschFunction( mockPaper, researcher ) ).toEqual( { score: -1, difficulty: DIFFICULTY.NO_DATA } );
 	} );
 	it( "Clamps the score between 0 and 100.", () => {
 		let mockPaper = new Paper( "You can go auditorily impaired by heedfully aurally perceiving extravagantly loud music. " +
@@ -41,11 +41,11 @@ describe( "A test to check the filter of digits", function() {
 describe( "A test that returns a question mark if there is not enough textual data.", function() {
 	it( "returns a question mark when there is no textual data", function() {
 		const mockPaper = new Paper( "()" );
-		expect( fleschFunction( mockPaper, new EnglishResearcher( mockPaper ) ) ).toEqual( { score: "?", difficulty: DIFFICULTY.NO_DATA } );
+		expect( fleschFunction( mockPaper, new EnglishResearcher( mockPaper ) ) ).toEqual( { score: -1, difficulty: DIFFICULTY.NO_DATA } );
 	} );
 	it( "returns a question mark when there is less than 11 words.", function() {
 		const mockPaper = new Paper( "There are not enough words in this sentence now." );
-		expect( fleschFunction( mockPaper, new EnglishResearcher( mockPaper ) ) ).toEqual( { score: "?", difficulty: DIFFICULTY.NO_DATA } );
+		expect( fleschFunction( mockPaper, new EnglishResearcher( mockPaper ) ) ).toEqual( { score: -1, difficulty: DIFFICULTY.NO_DATA } );
 	} );
 } );
 

--- a/packages/yoastseo/spec/languageProcessing/researches/getFleschReadingScoreSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/getFleschReadingScoreSpec.js
@@ -5,9 +5,9 @@ import EnglishResearcher from "../../../src/languageProcessing/languages/en/Rese
 
 describe( "a test to calculate the fleschReading score", function() {
 	it( "returns a score", function() {
-		let mockPaper = new Paper( "A piece of text to calculate scores." );
+		let mockPaper = new Paper( "A piece of text that contains more than ten words to calculate scores." );
 		const researcher = new EnglishResearcher( mockPaper );
-		expect( fleschFunction( mockPaper, researcher ) ).toEqual( { score: 91, difficulty: DIFFICULTY.VERY_EASY } );
+		expect( fleschFunction( mockPaper, researcher ) ).toEqual( { score: 89.5, difficulty: DIFFICULTY.EASY } );
 
 		mockPaper = new Paper( "One question we get quite often in our website reviews is whether we can help people recover " +
 			"from the drop they noticed in their rankings or traffic. A lot of the times, this is a legitimate drop " +
@@ -15,7 +15,7 @@ describe( "a test to calculate the fleschReading score", function() {
 		expect( fleschFunction( mockPaper, researcher ) ).toEqual( { score: 63.9, difficulty: DIFFICULTY.OKAY } );
 
 		mockPaper = new Paper( "" );
-		expect( fleschFunction( mockPaper, researcher ) ).toEqual( { score: 100, difficulty: DIFFICULTY.VERY_EASY } );
+		expect( fleschFunction( mockPaper, researcher ) ).toEqual( { score: "?", difficulty: DIFFICULTY.NO_DATA } );
 	} );
 	it( "Clamps the score between 0 and 100.", () => {
 		let mockPaper = new Paper( "You can go auditorily impaired by heedfully aurally perceiving extravagantly loud music. " +
@@ -38,10 +38,14 @@ describe( "A test to check the filter of digits", function() {
 	} );
 } );
 
-describe( "A test that returns 100 after sentence formatting", function() {
-	it( "returns a score of 100", function() {
+describe( "A test that returns a question mark if there is not enough textual data.", function() {
+	it( "returns a question mark when there is no textual data", function() {
 		const mockPaper = new Paper( "()" );
-		expect( fleschFunction( mockPaper, new EnglishResearcher( mockPaper ) ) ).toEqual( { score: 100, difficulty: DIFFICULTY.VERY_EASY } );
+		expect( fleschFunction( mockPaper, new EnglishResearcher( mockPaper ) ) ).toEqual( { score: "?", difficulty: DIFFICULTY.NO_DATA } );
+	} );
+	it( "returns a question mark when there is less than 11 words.", function() {
+		const mockPaper = new Paper( "There are not enough words in this sentence now." );
+		expect( fleschFunction( mockPaper, new EnglishResearcher( mockPaper ) ) ).toEqual( { score: "?", difficulty: DIFFICULTY.NO_DATA } );
 	} );
 } );
 

--- a/packages/yoastseo/src/languageProcessing/researches/getFleschReadingScore.js
+++ b/packages/yoastseo/src/languageProcessing/researches/getFleschReadingScore.js
@@ -108,7 +108,7 @@ export default function( paper, researcher ) {
 
 	let text = paper.getText();
 	if ( text === "" ) {
-		// A score of -1 signals to the code down the line that no valid FRE was caculated.
+		// A score of -1 signals to the code down the line that no valid FRE was calculated.
 		return {
 			score: -1,
 			difficulty: DIFFICULTY.NO_DATA,
@@ -121,7 +121,7 @@ export default function( paper, researcher ) {
 	const numberOfWords = countWords( text );
 
 	// Do not show the Flesch reading ease when there is not enough data for the FRE to make sense. Also used to prevent division by zero errors.
-	// A score of -1 signals to the code down the line that no valid FRE was caculated.
+	// A score of -1 signals to the code down the line that no valid FRE was calculated.
 	if ( numberOfSentences < 1 || numberOfWords <= 10 ) {
 		return {
 			score: -1,

--- a/packages/yoastseo/src/languageProcessing/researches/getFleschReadingScore.js
+++ b/packages/yoastseo/src/languageProcessing/researches/getFleschReadingScore.js
@@ -23,6 +23,7 @@ const getAverage = function( total, amount ) {
  * @enum {number}
  */
 export const DIFFICULTY = {
+	NO_DATA: -1,
 	VERY_EASY: 0,
 	EASY: 1,
 	FAIRLY_EASY: 2,
@@ -108,8 +109,8 @@ export default function( paper, researcher ) {
 	let text = paper.getText();
 	if ( text === "" ) {
 		return {
-			score: 100,
-			difficulty: DIFFICULTY.VERY_EASY,
+			score: "?", // TODO: sensible score value. hugo: I propose X.X or sth
+			difficulty: DIFFICULTY.NO_DATA,
 		};
 	}
 

--- a/packages/yoastseo/src/languageProcessing/researches/getFleschReadingScore.js
+++ b/packages/yoastseo/src/languageProcessing/researches/getFleschReadingScore.js
@@ -109,7 +109,7 @@ export default function( paper, researcher ) {
 	let text = paper.getText();
 	if ( text === "" ) {
 		return {
-			score: "?", // TODO: sensible score value. hugo: I propose X.X or sth
+			score: "?",
 			difficulty: DIFFICULTY.NO_DATA,
 		};
 	}
@@ -117,14 +117,13 @@ export default function( paper, researcher ) {
 	text = stripNumbers( text );
 
 	const numberOfSentences = countSentences( text, memoizedTokenizer );
-
 	const numberOfWords = countWords( text );
 
-	// Prevent division by zero errors.
-	if ( numberOfSentences === 0 || numberOfWords === 0 ) {
+	// Do not show the Flesch reading ease when it does not make sense. Also used to prevent division by zero errors.
+	if ( numberOfSentences < 1 || numberOfWords <= 10 ) {
 		return {
-			score: 100,
-			difficulty: DIFFICULTY.VERY_EASY,
+			score: "?",
+			difficulty: DIFFICULTY.NO_DATA,
 		};
 	}
 

--- a/packages/yoastseo/src/languageProcessing/researches/getFleschReadingScore.js
+++ b/packages/yoastseo/src/languageProcessing/researches/getFleschReadingScore.js
@@ -108,8 +108,9 @@ export default function( paper, researcher ) {
 
 	let text = paper.getText();
 	if ( text === "" ) {
+		// A score of -1 signals to the code down the line that no valid FRE was caculated.
 		return {
-			score: "?",
+			score: -1,
 			difficulty: DIFFICULTY.NO_DATA,
 		};
 	}
@@ -120,9 +121,10 @@ export default function( paper, researcher ) {
 	const numberOfWords = countWords( text );
 
 	// Do not show the Flesch reading ease when there is not enough data for the FRE to make sense. Also used to prevent division by zero errors.
+	// A score of -1 signals to the code down the line that no valid FRE was caculated.
 	if ( numberOfSentences < 1 || numberOfWords <= 10 ) {
 		return {
-			score: "?",
+			score: -1,
 			difficulty: DIFFICULTY.NO_DATA,
 		};
 	}

--- a/packages/yoastseo/src/languageProcessing/researches/getFleschReadingScore.js
+++ b/packages/yoastseo/src/languageProcessing/researches/getFleschReadingScore.js
@@ -119,7 +119,7 @@ export default function( paper, researcher ) {
 	const numberOfSentences = countSentences( text, memoizedTokenizer );
 	const numberOfWords = countWords( text );
 
-	// Do not show the Flesch reading ease when it does not make sense. Also used to prevent division by zero errors.
+	// Do not show the Flesch reading ease when there is not enough data for the FRE to make sense. Also used to prevent division by zero errors.
 	if ( numberOfSentences < 1 || numberOfWords <= 10 ) {
 		return {
 			score: "?",


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* If the Flesch reading ease does not make sense (e.g. in cases where there is very little text (10 words or less), previously we would display 100: very easy to read. This PR chages this to a ? and the encouragement to write more text before watching the FRE.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Changes the feedback of Flesch reading ease in the insights tab when there is not enough text.
* [yoastseo] Changes the feedback of Flesch reading ease in the insights tab when there is not enough text.
* [@yoast/components] Changes the allowed proptype of `amount` in the `InsightCard.js` to also allow the '?' as a value.

## Relevant technical choices:

* In `packages/components/src/insights-card/InsightsCard.js` we changed the allowed proptypes of "amount" in order for it to also allow a question mark.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

### Scenario 1: not enough text (10 words or less)
1. Create a post and, in a text paragraph, a sentence with less than 10 words. For example: `This is a sentence.`
2. Go to the Insights tab. Make sure the flesh reading ease score is '? out of 100' and the feedback string is `Your text should be slightly longer to calculate your Flesch reading ease score. Continue writing to get insight into the readability of your text!`
3. Add one more sentence such that both sentences together have 11 or more words (e.g. `This is a sentence. This is a second sentence to test the FRE.`). 
4. Make sure the feedback string is `The copy scores 96.1 in the test, which is considered very easy to read. Good job!`

### Scenario 2: Not enough text and an image without caption.
1. Create a post and, in a text paragraph, a sentence with less than 10 words. For example: `This is a sentence.`
2. Add an image. As a description add any text, for example: `This is a description`. Do not add a caption.
3. Make sure the Flesch reading ease score is '? out of 100' and the feedback string is `Your text should be slightly longer to calculate your Flesch reading ease score. Continue writing to get insight into the readability of your text!`
4. Add one more sentence such that both sentences together have 11 or more words (e.g. `This is a sentence. This is a second sentence to test the FRE.`). 
5. Make sure that feedback strings are displayed and a Flesch reading ease score (98.3) is calcucated.

### Scenario 3: Not enough text and an image with caption.
1. Create a post and, in a text paragraph, a sentence with less than 10 words. For example: `This is a sentence.`
2. Add an image. As a description add any text, for example: `This is a description`. Add a caption such that together with the sentence from 1, there are 10 words. For example: `This is a caption increasing the total number of words in this post.`
3. Make sure that the following feedback string is reported `The copy scores 86.6 in the test, which is considered easy to read. Good job!` NOTE: in classic editor, the FRE has a different value. This is related to a [known issue](https://yoast.atlassian.net/jira/software/c/projects/PC/boards/138?view=detail&modal=detail&selectedIssue=PC-43). The precise score also differs in Elementor.

### Scenario 4: Enough data in existing post.
1. Create a post. Add 2 sentences with together at least 11 words. For example `This is a sentence. This is a second sentence to test the FRE.`
2. Add an image (no caption, a description is optional).
3. Save the post and close. 
4. Open the post and go to insights.
5. Make sure that feedback strings are displayed and a Flesch reading ease score is calcucated.

### Test scenarios with:
- the block editor    
- with Gutenberg as a plugin 
- with the classic editor 
- with different browsers 
- with Elementor 
- with posts/page/taxonomies/CTP/custom taxonomies  
- with WP 5.9 and the current WordPress version.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes #
