### PR TITLE
PC-27 - don't show date in meta description in certain shopify content types and woo product pages

### DIFF
--- a/admin/formatter/class-post-metabox-formatter.php
+++ b/admin/formatter/class-post-metabox-formatter.php
@@ -84,6 +84,13 @@ class WPSEO_Post_Metabox_Formatter implements WPSEO_Metabox_Formatter_Interface 
 				'isInsightsEnabled'           => $this->is_insights_enabled(),
 			];
 
+			/*
+			 * We don't show the date in the Google preview for WooCommerce products.
+			 */
+			if ( $this->post->post_type === 'product' ) {
+				$values_to_set['metaDescriptionDate'] = '';
+			}
+
 			$values = ( $values_to_set + $values );
 		}
 

--- a/admin/formatter/class-post-metabox-formatter.php
+++ b/admin/formatter/class-post-metabox-formatter.php
@@ -84,17 +84,17 @@ class WPSEO_Post_Metabox_Formatter implements WPSEO_Metabox_Formatter_Interface 
 				'isInsightsEnabled'           => $this->is_insights_enabled(),
 			];
 
-			/*
-			 * We don't show the date in the Google preview for WooCommerce products.
-			 */
-			if ( $this->post->post_type === 'product' ) {
-				$values_to_set['metaDescriptionDate'] = '';
-			}
-
 			$values = ( $values_to_set + $values );
 		}
 
-		return $values;
+		/**
+		 * Filter: 'wpseo_post_edit_values' - Allows changing the values Yoast SEO uses inside the post editor.
+		 *
+		 * @api array $values The key-value map Yoast SEO uses inside the post editor.
+		 *
+		 * @param WP_Post $post The post opened in the editor.
+		 */
+		return \apply_filters( 'wpseo_post_edit_values', $values, $this->post );
 	}
 
 	/**

--- a/packages/yoastseo/src/scoring/assessments/SCORING SEO.md
+++ b/packages/yoastseo/src/scoring/assessments/SCORING SEO.md
@@ -306,7 +306,7 @@ With the example keyphrase `cat and dog` the following criteria would apply to c
 | Green	| 9	| Title width between 1 px and 600 px		| **SEO title width**: Good job! |
 
 ### 5) Meta description length
-**What it does**: Checks if the metadescription has a good length. The date (and the separator ' - ') length are also included in the calculation.
+**What it does**: Checks if the meta description has a good length. The date (and the separator ' - ') length are also included in the calculation, if the date is shown in the Google preview.
 
 **When applies**: Always.
 

--- a/src/integrations/third-party/woocommerce-post-edit.php
+++ b/src/integrations/third-party/woocommerce-post-edit.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Yoast\WP\SEO\Integrations\Third_Party;
+
+use Yoast\WP\SEO\Conditionals\Admin\Post_Conditional;
+use Yoast\WP\SEO\Conditionals\WooCommerce_Conditional;
+use Yoast\WP\SEO\Integrations\Integration_Interface;
+
+/**
+ * A WooCommerce integration that runs in the post editor.
+ */
+class WooCommerce_Post_Edit implements Integration_Interface {
+
+	/**
+	 * Register the hooks for this integration to work.
+	 *
+	 * @return void
+	 */
+	public function register_hooks() {
+		\add_filter( 'wpseo_post_edit_values', [ $this, 'remove_meta_description_date' ], 10, 2 );
+	}
+
+	/**
+	 * Only run this integration when WooCommerce is active and the user is in the post editor.
+	 *
+	 * @return string[] The conditionals that should be met before this integration is loaded.
+	 */
+	public static function get_conditionals() {
+		return [ WooCommerce_Conditional::class, Post_Conditional::class ];
+	}
+
+	/**
+	 * Don't show the date in the Google preview for WooCommerce products,
+	 * since Google does not show dates for product pages in the search results.
+	 *
+	 * @param array    $values Key-value map of variables we enqueue in the JavaScript of the post editor.
+	 * @param \WP_Post $post   The post currently opened in the editor.
+	 *
+	 * @return array The values, where the `metaDescriptionDate` is set to the empty string.
+	 */
+	public function remove_meta_description_date( $values, $post ) {
+		if ( $post->post_type === 'product' ) {
+			$values['metaDescriptionDate'] = '';
+		}
+
+		return $values;
+	}
+}

--- a/tests/unit/integrations/third-party/woocommerce-post-edit-test.php
+++ b/tests/unit/integrations/third-party/woocommerce-post-edit-test.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Integrations\Third_Party;
+
+use Brain\Monkey;
+
+use Mockery;
+use Yoast\WP\SEO\Conditionals\Admin\Post_Conditional;
+use Yoast\WP\SEO\Conditionals\WooCommerce_Conditional;
+use Yoast\WP\SEO\Integrations\Third_Party\WooCommerce_Post_Edit;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Unit tests for the `WooCommerce_Post_Edit` integration
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Integrations\Third_Party\WooCommerce_Post_Edit
+ */
+class WooCommerce_Post_Edit_Test extends TestCase {
+
+	/**
+	 * The WooCommerce post edit integration under test.
+	 *
+	 * @var WooCommerce_Post_Edit
+	 */
+	private $instance;
+
+	/**
+	 * Sets up the tests.
+	 *
+	 * @return void
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->instance = new WooCommerce_Post_Edit();
+	}
+
+	/**
+	 * Checks that the integration is only loaded when WooCommerce is active
+	 * and the user is in the post editor.
+	 *
+	 * @covers ::get_conditionals
+	 */
+	public function test_conditionals() {
+		$this->assertEquals(
+			[ WooCommerce_Conditional::class, Post_Conditional::class ],
+			WooCommerce_Post_Edit::get_conditionals()
+		);
+	}
+
+	/**
+	 * Tests the registration of the hooks.
+	 *
+	 * @covers ::register_hooks
+	 */
+	public function test_register_hooks() {
+		$this->instance->register_hooks();
+
+		$this->assertNotFalse(
+			Monkey\Filters\has(
+				'wpseo_post_edit_values',
+				[
+					$this->instance,
+					'remove_meta_description_date',
+				]
+			)
+		);
+	}
+
+	/**
+	 * Tests that the meta description date is removed on products.
+	 *
+	 * @covers ::remove_meta_description_date
+	 */
+	public function test_remove_meta_description_date_when_product() {
+		$original_values = [
+			'metaDescriptionDate' => 'June 5, 2022',
+			'author_name'         => 'Yoasie',
+		];
+
+		$expected_values = [
+			'metaDescriptionDate' => '',
+			'author_name'         => 'Yoasie',
+		];
+
+		$post            = Mockery::mock( '\WP_Post' )->makePartial();
+		$post->post_type = 'product';
+
+		$new_values = $this->instance->remove_meta_description_date( $original_values, $post );
+
+		$this->assertEquals( $expected_values, $new_values );
+	}
+
+	/**
+	 * Tests that the meta description date is not removed for non-products.
+	 *
+	 * @covers ::remove_meta_description_date
+	 */
+	public function test_do_not_remove_meta_description_date_when_not_a_product() {
+		$original_values = [
+			'metaDescriptionDate' => 'June 5, 2022',
+			'author_name'         => 'Yoasie',
+		];
+
+		$post            = Mockery::mock( '\WP_Post' )->makePartial();
+		$post->post_type = 'post';
+
+		$new_values = $this->instance->remove_meta_description_date( $original_values, $post );
+
+		$this->assertEquals( $original_values, $new_values );
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Google does not show dates in the search results for products, so we should do the same in the Google preview for WooCommerce products.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Removes the date from the meta description for WooCommerce products.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Posts/pages/CPT in block/classic/Elementor/Gutenberg
* Create a new post.
* In the Google Preview section, confirm that the date is shown.
* Confirm that the meta description length assessment and the color bar base their feedback on the meta description text with the date.
* Repeat these steps for pages and custom post types.
* Repeat the above steps for the Elementor, Gutenberg, and the Classic Editor plug-ins.

#### Products and categories/tags/custom taxonomies
* Activate the WooCommerce plug-in
* Create a new product.
* In the Google Preview section, confirm that the date is not shown.
* Confirm that the meta description length assessment and the color bar base their feedback on the meta description text without the date.
* Confirm that for categories, tags, and custom taxonomies, similarly, the date is not shown in the Google Preview.
* Because both WooCommerce products and taxonomies can only be edited with the Classic Editor, there is no need to repeat the above steps for every editor.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [x] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes #
