### PR TITLE
An error occurred in the word complexity assessment in product pages in Woo

### DIFF
--- a/packages/yoastseo/spec/languageProcessing/helpers/sanitize/removePunctuationSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/helpers/sanitize/removePunctuationSpec.js
@@ -38,6 +38,9 @@ describe( "Removing punctuation at the begin and end of a word", function() {
 		expect( removePunctuation( "'word&" ) ).toBe( "word" );
 		expect( removePunctuation( "“word”" ) ).toBe( "word" );
 		expect( removePunctuation( "„word‟" ) ).toBe( "word" );
+		expect( removePunctuation( "\\\\word\\" ) ).toBe( "word" );
+		expect( removePunctuation( "\\\\word\\\\" ) ).toBe( "word" );
+		expect( removePunctuation( "\\\\\"word\\" ) ).toBe( "word" );
 	} );
 } );
 

--- a/packages/yoastseo/spec/scoring/assessments/readability/WordComplexityAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/readability/WordComplexityAssessmentSpec.js
@@ -31,7 +31,7 @@ describe( "a test for an assessment that checks complex words in a text", functi
 		);
 	} );
 
-	const runningPaper = new Paper( "Also called torties for short, tortoiseshell cats combine two colors other than white, " +
+	let runningPaper = new Paper( "Also called torties for short, tortoiseshell cats combine two colors other than white, " +
 		"either closely mixed or in larger patches." +
 		" The colors are often described as red and black, but the \"red\" patches can instead be orange, yellow, or cream," +
 		" and the \"black\" can instead be chocolate, gray, tabby, or blue. Tortoiseshell cats with the tabby pattern as one of their colors " +
@@ -67,6 +67,24 @@ describe( "a test for an assessment that checks complex words in a text", functi
 
 		expect( result.getScore() ).toBe( 3 );
 		expect( result.getText() ).toBe( "<a href='https://yoa.st/4ls' target='_blank'>Word complexity</a>: 9.64% of the words in " +
+			"your text is considered complex. <a href='https://yoa.st/4lt' target='_blank'>Try to use shorter and more familiar words " +
+			"to improve readability</a>." );
+		expect( result.hasMarks() ).toBe( true );
+	} );
+
+	it( "should not break the assessment when the text contains backslashes ", function() {
+		runningPaper = new Paper( "It is a \\\"tortoiseshell\\\" cat. It is lovely and lovable." );
+		const researcher = new EnglishResearcher( runningPaper );
+
+		assessment = new WordComplexityAssessment( {
+			scores: {
+				acceptableAmount: 3,
+			},
+		} );
+		const result = assessment.getResult( runningPaper, researcher );
+
+		expect( result.getScore() ).toBe( 3 );
+		expect( result.getText() ).toBe( "<a href='https://yoa.st/4ls' target='_blank'>Word complexity</a>: 10% of the words in " +
 			"your text is considered complex. <a href='https://yoa.st/4lt' target='_blank'>Try to use shorter and more familiar words " +
 			"to improve readability</a>." );
 		expect( result.hasMarks() ).toBe( true );

--- a/packages/yoastseo/src/languageProcessing/helpers/sanitize/removePunctuation.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/sanitize/removePunctuation.js
@@ -32,12 +32,9 @@ export default function( text ) {
 	 * After the text is split into words, we also need to remove those backslashes from the word.
 	 * Otherwise, it will be problematic when word boundary regex is added to the word.
 	 */
-	const backslashRegexStart = new RegExp( "^(\\\\{1,3})" );
-	const backslashRegexEnd = new RegExp( "(\\\\){1,3}$" );
+	const backslashRegex = new RegExp( "(\\\\)", "g" );
 
-	text = text.replace( backslashRegexStart, "" );
-	text = text.replace( backslashRegexEnd, "" );
-
+	text = text.replace( backslashRegex, "" );
 	text = text.replace( punctuationRegexStart, "" );
 	text = text.replace( punctuationRegexEnd, "" );
 

--- a/packages/yoastseo/src/languageProcessing/helpers/sanitize/removePunctuation.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/sanitize/removePunctuation.js
@@ -25,7 +25,13 @@ export default function( text ) {
 
 	const punctuationRegexStart = new RegExp( "^[" + punctuationRegexString + "]+" );
 	const punctuationRegexEnd = new RegExp( "[" + punctuationRegexString +  "]+$" );
-	// Remove backslash from the beginning of a word/text.
+	/*
+	 * Remove backslash from the beginning and end of a word/text.
+	 * When a string such as `This is a \"calico\" cat` enters the Paper,
+	 * the Paper adds two extra backslash in front of the original backslash.
+	 * After the text is split into words, we also need to remove those backslashes from the word.
+	 * Otherwise, it will be problematic when word boundary regex is added to the word.
+	 */
 	const backslashRegexStart = new RegExp( "^(\\\\{1,3})" );
 	const backslashRegexEnd = new RegExp( "(\\\\){1,3}$" );
 

--- a/packages/yoastseo/src/languageProcessing/helpers/sanitize/removePunctuation.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/sanitize/removePunctuation.js
@@ -22,8 +22,15 @@ export default function( text ) {
 		"\uff5d\uff5c\uff5e\uff5f\uff60\uff62\uff63\uff64\uff3b\uff3d\uff65\uffe5\uff04\uff05\uff20\uff06\uff07\uff08\uff09\uff0a\uff0f\uff1a" +
 		"\uff1b\uff1c\uff1e\uff3c\\<>";
 
+
 	const punctuationRegexStart = new RegExp( "^[" + punctuationRegexString + "]+" );
 	const punctuationRegexEnd = new RegExp( "[" + punctuationRegexString +  "]+$" );
+	// Remove backslash from the beginning of a word/text.
+	const backslashRegexStart = new RegExp( "^(\\\\{1,3})" );
+	const backslashRegexEnd = new RegExp( "(\\\\){1,3}$" );
+
+	text = text.replace( backslashRegexStart, "" );
+	text = text.replace( backslashRegexEnd, "" );
 
 	text = text.replace( punctuationRegexStart, "" );
 	text = text.replace( punctuationRegexEnd, "" );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* When a text containing backslash before the quotation mark, for example `It is a \"calico\" cat` entering the Paper (an object that collects data for the analysis), the paper adds (two) extra backslash: `It is a \\\"calico\\\" cat`. The backslash is not removed when the text is split into words. When we add word boundary using regex to these words with backslash, the regex is invalid. This invalid regex is the cause of the error in Word complexity assessment:
<img width="1837" alt="Edit product “test product” ‹ Basic — WordPress 2022-06-29 11-52-21" src="https://user-images.githubusercontent.com/48715883/176611369-66f502cb-c22d-47dc-ad1b-c786541256d2.png">


## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [wpseo-woocommerce] Fixes a bug where words preceded by or followed by `\` were causing an error in the Word Complexity assessment.
* [worpress-seo-premium] Fixes a bug where words preceded by or followed by `\` were causing an error in the Word Complexity assessment.
* [shopify-seo] Fixes a bug where words preceded by or followed by `\` were causing an error in the Word Complexity assessment.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

**Test in WordPress and Woo**
* Install and activate WooCommerce plugin
* Install and activate Yoast SEO Free and WooCommerce SEO plugin
* Create a product using this text:

````
Bread is one of the oldest prepared foods. Evidence from 30,000 years ago in Europe and Australia revealed starch residue on rocks used for pounding plants.
<sup id=\"cite_ref-1\" class=\"reference\"><a href=\"https://en.wikipedia.org/wiki/Bread#cite_note-1\">[1]</a></sup><sup id=\"cite_ref-2\" class=\"reference\">
<a href=\"https://en.wikipedia.org/wiki/Bread#cite_note-2\">[2]</a></sup> It is possible that during this time, starch extract from the roots of plants, such as 
cattails and <a class=\"mw-redirect\" title=\"Ferns\" href=\"https://en.wikipedia.org/wiki/Ferns\">ferns</a>, was spread on a flat rock, placed over a fire and cooked 
into a primitive form of <a title=\"Flatbread\" href=\"https://en.wikipedia.org/wiki/Flatbread\">flatbread</a>. The world's oldest evidence of bread-making has been 
found in a 14,500-year-old <a title=\"Natufian culture\" href=\"https://en.wikipedia.org/wiki/Natufian_culture\">Natufian</a> site in Jordan's northeastern desert.
<sup id=\"cite_ref-3\" class=\"reference\"><a href=\"https://en.wikipedia.org/wiki/Bread#cite_note-3\">[3]</a></sup><sup id=\"cite_ref-4\" class=\"reference\">
<a href=\"https://en.wikipedia.org/wiki/Bread#cite_note-4\">[4]</a></sup> Around 10,000 BC, with the dawn of the <a title=\"Neolithic\" 
href=\"https://en.wikipedia.org/wiki/Neolithic\">Neolithic</a> age and the spread of agriculture, grains became the mainstay of making bread. Yeast spores are ubiquitous, 
including on the surface of <a title=\"Cereal\" href=\"https://en.wikipedia.org/wiki/Cereal\">cereal grains</a>, so any dough left to rest leavens naturally.<sup id=\"cite_ref-5\" 
class=\"reference\"><a href=\"https://en.wikipedia.org/wiki/Bread#cite_note-5\">[5]</a></sup>\n
An early <a class=\"mw-redirect\" title=\"Leavened bread\" href=\"https://en.wikipedia.org/wiki/Leavened_bread\">leavened bread</a> was baked as early as 6000 BC by 
the <a class=\"mw-redirect\" title=\"Sumerians\" href=\"https://en.wikipedia.org/wiki/Sumerians\">Sumerians</a>, who may have passed on their knowledge to the Egyptians around 3000 BC. 
The Egyptians refined the process and started adding <a title=\"Yeast\" href=\"https://en.wikipedia.org/wiki/Yeast\">yeast</a> to the <a title=\"Flour\" href=\"https://en.wikipedia.org/wiki/Flour\">flour</a>. 
The Sumerians were already using <a title=\"Ash\" href=\"https://en.wikipedia.org/wiki/Ash\">ash</a> to supplement the dough as it was baked.<sup id=\"cite_ref-arzani11_6-0\" 
class=\"reference\"><a href=\"https://en.wikipedia.org/wiki/Bread#cite_note-arzani11-6\">[6]</a></sup>\n
There were multiple sources of <a class=\"mw-redirect\" title=\"Leavening\" href=\"https://en.wikipedia.org/wiki/Leavening\">leavening</a> available for early bread. Airborne yeasts could be harnessed by 
leaving uncooked dough exposed to air for some time before cooking. <a title=\"Pliny the Elder\" href=\"https://en.wikipedia.org/wiki/Pliny_the_Elder\">Pliny the Elder</a> reported that the <a title=\"Gauls\" 
href=\"https://en.wikipedia.org/wiki/Gauls\">Gauls</a> and <a title=\"Iberians\" href=\"https://en.wikipedia.org/wiki/Iberians\">Iberians</a> used the foam skimmed from <a title=\"Beer\" href=\"https://en.wikipedia.org/wiki/Beer\">beer</a>, 
called <a title=\"Barm\" href=\"https://en.wikipedia.org/wiki/Barm\">barm</a>, to produce \"a lighter kind of bread than other peoples\" such as <a title=\"Barm cake\" href=\"https://en.wikipedia.org/wiki/Barm_cake\">barm cake</a>. 
Parts of the ancient world that drank wine instead of beer used a paste composed of <a title=\"Grape\" href=\"https://en.wikipedia.org/wiki/Grape\">grape</a> juice and flour that was allowed to begin fermenting, or wheat bran steeped 
in <a title=\"Wine\" href=\"https://en.wikipedia.org/wiki/Wine\">wine</a>, as a source for <a title=\"Yeast\" href=\"https://en.wikipedia.org/wiki/Yeast\">yeast</a>. The most common source of leavening was to retain a piece of dough from 
the previous day to use as a form of sourdough <a class=\"mw-redirect\" title=\"Bread starter\" href=\"https://en.wikipedia.org/wiki/Bread_starter\">starter</a>, as Pliny also reported.<sup id=\"cite_ref-7\" class=\"reference\">
<a href=\"https://en.wikipedia.org/wiki/Bread#cite_note-7\">[7]</a></sup><sup id=\"cite_ref-8\" class=\"reference\"><a href=\"https://en.wikipedia.org/wiki/Bread#cite_note-8\">[8]</a></sup>\n
The ancient Egyptians, Greeks, and Romans all considered the degree of refinement in the bakery arts as a sign of civilization.<sup id=\"cite_ref-arzani11_6-1\" class=\"reference\"><a href=\"https://en.wikipedia.org/wiki/Bread#cite_note-arzani11-6\">[6]</a></sup>\n
The <a title=\"Chorleywood bread process\" href=\"https://en.wikipedia.org/wiki/Chorleywood_bread_process\">Chorleywood bread process</a> was developed in 1961; it uses the intense mechanical working of dough to dramatically reduce the <a class=\"mw-redirect\" 
title=\"Fermentation (food)\" href=\"https://en.wikipedia.org/wiki/Fermentation_(food)\">fermentation</a> period and the time taken to produce a loaf. The process, whose high-energy mixing allows for the use of grain with a lower protein content, 
is now widely used around the world in large factories. As a result, bread can be produced very quickly and at low costs to the manufacturer and the consumer. However, there has been some criticism of the effect on nutritional value.<sup id=\"cite_ref-9\" class=\"reference\">
<a href=\"https://en.wikipedia.org/wiki/Bread#cite_note-9\">[9]</a></sup><sup id=\"cite_ref-10\" class=\"reference\"><a href=\"https://en.wikipedia.org/wiki/Bread#cite_note-10\">[10]</a></sup><sup id=\"cite_ref-11\" class=\"reference\"><a href=\"https://en.wikipedia.org/wiki/Bread#cite_note-11\">[11]</a></sup>\n" );
````
* Confirm that the Word complexity assessment does not return an error

**Test in WordPress and Premium**
* Install and activate Yoast SEO Free and Yoast SEO Premium plugin
* Create/open a post 
* Use the same text as above
* Confirm that the Word complexity assessment does not return an error



**Test in Shopify**
* Create a product/collection/blog post/page
* Add some content (more than 50 characters) that contains backslash:
   * For example: `It is a \"tortoiseshell\" cat. It is lovely and lovable.`
* Confirm that the Word complexity assessment does not return an error 


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* 

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [x] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes https://yoast.atlassian.net/browse/PC-120
