### PR TITLE
PC-122 Prevent warning if no user data is available

### DIFF
--- a/src/presenters/meta-author-presenter.php
+++ b/src/presenters/meta-author-presenter.php
@@ -37,6 +37,10 @@ class Meta_Author_Presenter extends Abstract_Indexable_Tag_Presenter {
 	public function get() {
 		$user_data = \get_userdata( $this->presentation->context->post->post_author );
 
+		if ( ! $user_data instanceof \WP_User ) {
+			return '';
+		}
+
 		return \trim( $this->helpers->schema->html->smart_strip_tags( $user_data->display_name ) );
 	}
 }

--- a/tests/unit/presenters/meta-author-presenter-test.php
+++ b/tests/unit/presenters/meta-author-presenter-test.php
@@ -72,19 +72,45 @@ class Meta_Author_Presenter_Test extends TestCase {
 	public function test_present_and_filter_happy_path() {
 		$this->indexable_presentation->meta_description = 'the_meta_description';
 
+		$user_mock               = Mockery::mock( \WP_User::class );
+		$user_mock->display_name = 'John Doe';
+
+		Monkey\Functions\expect( 'get_userdata' )
+			->once()
+			->with( 123 )
+			->andReturn( $user_mock );
+
 		$this->html
 			->expects( 'smart_strip_tags' )
 			->once()
 			->with( 'John Doe' )
 			->andReturn( 'John Doe' );
 
+		$output = '<meta name="author" content="John Doe" />';
+
+		$this->assertSame( $output, $this->instance->present() );
+	}
+
+	/**
+	 * Tests the presenter of the meta description when there's a failure.
+	 *
+	 * @covers ::present
+	 * @covers ::get
+	 */
+	public function test_present_and_filter_unhappy_path() {
+		$this->indexable_presentation->meta_description = 'the_meta_description';
+
 		Monkey\Functions\expect( 'get_userdata' )
 			->once()
 			->with( 123 )
-			->andReturn( (object) [ 'display_name' => 'John Doe' ] );
+			->andReturnFalse();
 
-		$output = '<meta name="author" content="John Doe" />';
+		$this->html
+			->expects( 'smart_strip_tags' )
+			->never();
 
-		$this->assertEquals( $output, $this->instance->present() );
+		$output = '';
+
+		$this->assertSame( $output, $this->instance->present() );
 	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to prevent warning if no user data is available

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where a warning would be triggered when author data wasn't available for a post.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* install and activate BBPress
* in the BBPress settings, enable `Allow guest users without accounts to create topics and replies`
* switch to the Twenty Twenty-One theme
* create a new Forum
* visit the forum in the frontend in an incognito window, so you appear unlogged 
* use the form at the bottom to create a new topic. **Note**: you may get an error because of some problem not related to our plugin. If so, just visit the forum once more
* visit the topic you just created:
  * without this patch, you'll get a Warning/Notice: `Notice: Trying to get property 'display_name' of non-object in /var/www/html/wp-content/plugins/wordpress-seo/src/presenters/meta-author-presenter.php on line 44`
  * with this patch, you should not get any warning, and you shouldn't see any `<meta name="author" ... />` tag in the source.



### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes [PC-122]


[PC-122]: https://yoast.atlassian.net/browse/PC-122?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ