### PR TITLE
PC-62 Applies marks to Classic editor blocks inside the Block/Gutenberg editor

### DIFF
--- a/admin/class-admin-asset-manager.php
+++ b/admin/class-admin-asset-manager.php
@@ -238,16 +238,16 @@ class WPSEO_Admin_Asset_Manager {
 			'help-scout-beacon',
 		];
 		$additional_dependencies = [
-			'analysis-worker'    => [ self::PREFIX . 'analysis-package' ],
-			'api-client'         => [ 'wp-api' ],
-			'dashboard-widget'   => [ self::PREFIX . 'api-client' ],
-			'elementor'          => [
+			'analysis-worker'          => [ self::PREFIX . 'analysis-package' ],
+			'api-client'               => [ 'wp-api' ],
+			'dashboard-widget'         => [ self::PREFIX . 'api-client' ],
+			'elementor'                => [
 				self::PREFIX . 'api-client',
 				self::PREFIX . 'externals-components',
 				self::PREFIX . 'externals-contexts',
 				self::PREFIX . 'externals-redux',
 			],
-			'indexation'         => [
+			'indexation'               => [
 				'jquery-ui-core',
 				'jquery-ui-progressbar',
 			],
@@ -257,7 +257,7 @@ class WPSEO_Admin_Asset_Manager {
 				self::PREFIX . 'externals-contexts',
 				self::PREFIX . 'externals-redux',
 			],
-			'post-edit'          => [
+			'post-edit'                => [
 				self::PREFIX . 'api-client',
 				self::PREFIX . 'block-editor',
 				self::PREFIX . 'externals-components',
@@ -265,11 +265,11 @@ class WPSEO_Admin_Asset_Manager {
 				self::PREFIX . 'externals-redux',
 				self::PREFIX . 'select2',
 			],
-			'reindex-links'      => [
+			'reindex-links'            => [
 				'jquery-ui-core',
 				'jquery-ui-progressbar',
 			],
-			'settings'           => [
+			'settings'                 => [
 				'jquery-ui-core',
 				'jquery-ui-progressbar',
 				self::PREFIX . 'api-client',
@@ -278,7 +278,7 @@ class WPSEO_Admin_Asset_Manager {
 				self::PREFIX . 'externals-redux',
 				self::PREFIX . 'select2',
 			],
-			'term-edit'          => [
+			'term-edit'                => [
 				self::PREFIX . 'api-client',
 				self::PREFIX . 'classic-editor',
 				self::PREFIX . 'externals-components',
@@ -681,6 +681,10 @@ class WPSEO_Admin_Asset_Manager {
 				'deps' => [
 					self::PREFIX . 'monorepo',
 				],
+			],
+			[
+				'name' => 'inside-editor',
+				'src'  => 'inside-editor-' . $flat_version,
 			],
 		];
 	}

--- a/admin/metabox/class-metabox-editor.php
+++ b/admin/metabox/class-metabox-editor.php
@@ -16,7 +16,12 @@ class WPSEO_Metabox_Editor {
 	 * @codeCoverageIgnore
 	 */
 	public function register_hooks() {
+		// For the Classic editor.
 		add_filter( 'mce_css', [ $this, 'add_css_inside_editor' ] );
+		// For the Block/Gutenberg editor.
+		// See https://github.com/danielbachhuber/gutenberg-migration-guide/blob/master/filter-mce-css.md.
+		add_action( 'enqueue_block_editor_assets', [ $this, 'add_editor_styles' ] );
+
 		add_filter( 'tiny_mce_before_init', [ $this, 'add_custom_element' ] );
 	}
 
@@ -42,6 +47,14 @@ class WPSEO_Metabox_Editor {
 		}
 
 		return $css_files;
+	}
+
+	/**
+	 * Enqueues the CSS to use in the TinyMCE editor.
+	 */
+	public function add_editor_styles() {
+		$asset_manager = new WPSEO_Admin_Asset_Manager();
+		$asset_manager->enqueue_style( 'inside-editor' );
 	}
 
 	/**

--- a/packages/js/src/analysis/getApplyMarks.js
+++ b/packages/js/src/analysis/getApplyMarks.js
@@ -1,30 +1,52 @@
 /* global tinyMCE */
-import { noop } from "lodash-es";
+import { isUndefined, noop } from "lodash-es";
 import { select } from "@wordpress/data";
 import * as tinyMCEHelper from "../lib/tinymce";
 import { tinyMCEDecorator } from "../decorator/tinyMCE";
 import { isAnnotationAvailable, applyAsAnnotations } from "../decorator/gutenberg";
 
-let decorator = null;
+/**
+ * Create decorators for each editor and applies marks to each editor
+ *
+ * @param {Paper} paper The paper for which the marks have been generated.
+ * @param {Array.<Mark>} marks The marks to show in the editor.
+ *
+ * @returns {void}
+ */
+function applyMarksTinyMCE( paper, marks ) {
+	// Get all registered TinyMCE editors on the page.
+	const editors = tinyMCE.editors;
+	// Create decorators for all editors.
+	const decorators = editors.map( editor => tinyMCEDecorator( editor ) );
+	// Use decorators to apply marks for to each editor.
+	decorators.forEach( decorator => decorator( paper, marks ) );
+}
 
 /**
  * Applies the given marks to the content.
  *
- * @param {Paper}    paper The paper.
- * @param {Object[]} marks The marks.
+ * @param {Paper} paper The paper.
+ * @param {Array.<Mark>} marks The marks.
  *
  * @returns {void}
  */
 function applyMarks( paper, marks ) {
+	let decorator;
+
+	// Classic editor
 	if ( tinyMCEHelper.isTinyMCEAvailable( tinyMCEHelper.tmceId ) ) {
-		if ( null === decorator ) {
+		if ( isUndefined( decorator ) ) {
 			decorator = tinyMCEDecorator( tinyMCE.get( tinyMCEHelper.tmceId ) );
 		}
 
 		decorator( paper, marks );
 	}
 
+	// Block/Gutenberg editor
 	if ( isAnnotationAvailable() ) {
+		// Apply marks to Classic editor blocks
+		applyMarksTinyMCE( paper, marks );
+		// Apply marks to other blocks
 		applyAsAnnotations( paper, marks );
 	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* In the Gutenberg editor, our eye markers were unable to highlight content in so-called classic blocks (blocks that use the TinyMCE editor). This PR fixes this issue. 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Allows marking inside of Classic editor blocks in the Block/Gutenberg editor.

## Relevant technical choices:

* We have chosen to register the `inside-editor` script globally. 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### New functionality (in the **Block** editor)
* Create a post.
* Enter a focus keyphrase.
* Add content, including multiple classic editor blocks. Make sure that you use the focus keyphrase multiple times in multiple blocks.
* Within the SEO analysis, click on the marker next to the _Keyphrase density_ assessment.
* All of the occurrences of the focus keyphrase should be highlighted in the post. Including the occurrences inside of the classic editor blocks.
* Also test the above steps on pages and custom post types. 
* Repeat the above steps for the **Gutenberg** plug-in.

Should also be checked in different browsers.

#### Regression
* Activate the **Classic editor** plug-in.
* Create a post. 
* Enter a focus keyphrase.
* Add content. Make sure that you use the focus keyphrase multiple times.
* Within the SEO analysis, click on the marker next to the _Keyphrase density_ assessment.
* All of the occurrences of the focus keyphrase should be highlighted in the post. 
* Also test the above steps on pages, categories, custom post types, and custom taxonomies.

Note: the eye markers are not available for the **Elementor** plug-in. 

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Classic editor blocks inside Block/Gutenberg editors.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes https://yoast.atlassian.net/browse/PC-62
