### PR TITLE
Pc 133 incorrect singular in feedback string for word complexity assessment v2

### DIFF
--- a/packages/yoastseo/spec/fullTextTests/testTexts/en/englishPaper.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/en/englishPaper.js
@@ -145,7 +145,7 @@ const expectedResults = {
 	wordComplexity: {
 		isApplicable: true,
 		score: 6,
-		resultText: "<a href='https://yoa.st/4ls' target='_blank'>Word complexity</a>: 7.49% of the words in your text is considered complex. " +
+		resultText: "<a href='https://yoa.st/4ls' target='_blank'>Word complexity</a>: 7.49% of the words in your text are considered complex. " +
 			"<a href='https://yoa.st/4lt' target='_blank'>Try to use shorter and more familiar words to improve readability</a>.",
 	},
 };

--- a/packages/yoastseo/spec/fullTextTests/testTexts/en/englishPaperForPerformanceTest.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/en/englishPaperForPerformanceTest.js
@@ -148,7 +148,7 @@ const expectedResults = {
 	wordComplexity: {
 		isApplicable: true,
 		score: 6,
-		resultText: "<a href='https://yoa.st/4ls' target='_blank'>Word complexity</a>: 27.84% of the words in your text is considered complex. " +
+		resultText: "<a href='https://yoa.st/4ls' target='_blank'>Word complexity</a>: 27.84% of the words in your text are considered complex. " +
 			"<a href='https://yoa.st/4lt' target='_blank'>Try to use shorter and more familiar words to improve readability</a>.",
 	},
 };

--- a/packages/yoastseo/spec/scoring/assessments/readability/WordComplexityAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/readability/WordComplexityAssessmentSpec.js
@@ -50,7 +50,7 @@ describe( "a test for an assessment that checks complex words in a text", functi
 
 		expect( result.getScore() ).toBe( 6 );
 		expect( result.getText() ).toBe( "<a href='https://yoa.st/4ls' target='_blank'>Word complexity</a>: 9.64% of the words in " +
-			"your text is considered complex. <a href='https://yoa.st/4lt' target='_blank'>Try to use shorter and more familiar words " +
+			"your text are considered complex. <a href='https://yoa.st/4lt' target='_blank'>Try to use shorter and more familiar words " +
 			"to improve readability</a>." );
 		expect( result.hasMarks() ).toBe( true );
 	} );
@@ -67,7 +67,7 @@ describe( "a test for an assessment that checks complex words in a text", functi
 
 		expect( result.getScore() ).toBe( 3 );
 		expect( result.getText() ).toBe( "<a href='https://yoa.st/4ls' target='_blank'>Word complexity</a>: 9.64% of the words in " +
-			"your text is considered complex. <a href='https://yoa.st/4lt' target='_blank'>Try to use shorter and more familiar words " +
+			"your text are considered complex. <a href='https://yoa.st/4lt' target='_blank'>Try to use shorter and more familiar words " +
 			"to improve readability</a>." );
 		expect( result.hasMarks() ).toBe( true );
 	} );
@@ -85,7 +85,7 @@ describe( "a test for an assessment that checks complex words in a text", functi
 
 		expect( result.getScore() ).toBe( 3 );
 		expect( result.getText() ).toBe( "<a href='https://yoa.st/4ls' target='_blank'>Word complexity</a>: 10% of the words in " +
-			"your text is considered complex. <a href='https://yoa.st/4lt' target='_blank'>Try to use shorter and more familiar words " +
+			"your text are considered complex. <a href='https://yoa.st/4lt' target='_blank'>Try to use shorter and more familiar words " +
 			"to improve readability</a>." );
 		expect( result.hasMarks() ).toBe( true );
 	} );

--- a/packages/yoastseo/spec/scoring/collectionPages/fullTextTests/testTexts/en/englishPaper1.js
+++ b/packages/yoastseo/spec/scoring/collectionPages/fullTextTests/testTexts/en/englishPaper1.js
@@ -125,7 +125,7 @@ const expectedResults = {
 	wordComplexity: {
 		isApplicable: true,
 		score: 6,
-		resultText: "<a href='https://yoa.st/shopify77' target='_blank'>Word complexity</a>: 10.38% of the words in your text is considered complex." +
+		resultText: "<a href='https://yoa.st/shopify77' target='_blank'>Word complexity</a>: 10.38% of the words in your text are considered complex." +
 			" <a href='https://yoa.st/shopify78' target='_blank'>Try to use shorter and more familiar words to improve readability</a>.",
 	},
 };

--- a/packages/yoastseo/spec/scoring/collectionPages/fullTextTests/testTexts/en/englishPaper2.js
+++ b/packages/yoastseo/spec/scoring/collectionPages/fullTextTests/testTexts/en/englishPaper2.js
@@ -120,7 +120,7 @@ const expectedResults = {
 	wordComplexity: {
 		isApplicable: true,
 		score: 6,
-		resultText: "<a href='https://yoa.st/shopify77' target='_blank'>Word complexity</a>: 18.45% of the words in your text is considered complex. " +
+		resultText: "<a href='https://yoa.st/shopify77' target='_blank'>Word complexity</a>: 18.45% of the words in your text are considered complex. " +
 			"<a href='https://yoa.st/shopify78' target='_blank'>Try to use shorter and more familiar words to improve readability</a>.",
 	},
 };

--- a/packages/yoastseo/spec/scoring/collectionPages/fullTextTests/testTexts/en/englishPaper3.js
+++ b/packages/yoastseo/spec/scoring/collectionPages/fullTextTests/testTexts/en/englishPaper3.js
@@ -129,7 +129,7 @@ const expectedResults = {
 	wordComplexity: {
 		isApplicable: true,
 		score: 6,
-		resultText: "<a href='https://yoa.st/shopify77' target='_blank'>Word complexity</a>: 14.19% of the words in your text is considered complex. " +
+		resultText: "<a href='https://yoa.st/shopify77' target='_blank'>Word complexity</a>: 14.19% of the words in your text are considered complex. " +
 			"<a href='https://yoa.st/shopify78' target='_blank'>Try to use shorter and more familiar words to improve readability</a>.",
 	},
 };

--- a/packages/yoastseo/spec/scoring/productPages/fullTextTests/testTexts/en/englishPaper1.js
+++ b/packages/yoastseo/spec/scoring/productPages/fullTextTests/testTexts/en/englishPaper1.js
@@ -146,7 +146,7 @@ const expectedResults = {
 	wordComplexity: {
 		isApplicable: true,
 		score: 6,
-		resultText: "<a href='https://yoa.st/shopify77' target='_blank'>Word complexity</a>: 12.44% of the words in your text is considered complex. " +
+		resultText: "<a href='https://yoa.st/shopify77' target='_blank'>Word complexity</a>: 12.44% of the words in your text are considered complex. " +
 			"<a href='https://yoa.st/shopify78' target='_blank'>Try to use shorter and more familiar words to improve readability</a>.",
 	},
 };

--- a/packages/yoastseo/spec/scoring/productPages/fullTextTests/testTexts/en/englishPaper2.js
+++ b/packages/yoastseo/spec/scoring/productPages/fullTextTests/testTexts/en/englishPaper2.js
@@ -156,7 +156,7 @@ const expectedResults = {
 	wordComplexity: {
 		isApplicable: true,
 		score: 6,
-		resultText: "<a href='https://yoa.st/shopify77' target='_blank'>Word complexity</a>: 15.02% of the words in your text is considered complex." +
+		resultText: "<a href='https://yoa.st/shopify77' target='_blank'>Word complexity</a>: 15.02% of the words in your text are considered complex." +
 			" <a href='https://yoa.st/shopify78' target='_blank'>Try to use shorter and more familiar words to improve readability</a>.",
 	},
 };

--- a/packages/yoastseo/spec/scoring/productPages/fullTextTests/testTexts/en/englishPaper3.js
+++ b/packages/yoastseo/spec/scoring/productPages/fullTextTests/testTexts/en/englishPaper3.js
@@ -153,7 +153,7 @@ const expectedResults = {
 	wordComplexity: {
 		isApplicable: true,
 		score: 6,
-		resultText: "<a href='https://yoa.st/shopify77' target='_blank'>Word complexity</a>: 13.04% of the words in your text is considered complex. " +
+		resultText: "<a href='https://yoa.st/shopify77' target='_blank'>Word complexity</a>: 13.04% of the words in your text are considered complex. " +
 			"<a href='https://yoa.st/shopify78' target='_blank'>Try to use shorter and more familiar words to improve readability</a>.",
 	},
 };

--- a/packages/yoastseo/src/scoring/assessments/SCORING READABILITY.md
+++ b/packages/yoastseo/src/scoring/assessments/SCORING READABILITY.md
@@ -143,7 +143,7 @@
 
 **Call to action URL**: https://yoa.st/4lt (link placement is in bold in the feedback strings)
 
-|Bullet	|Score|	Criterion|	Feedback|
-|-------|------	|----- |------- |
-|Orange	(cornerstone: red) |6 (cornerstone: 3) |	If the complex words are more than X% in the text (English: 5%) |**Word complexity**: X% of the words in your text is considered complex. **Try to use shorter and more familiar words to improve readability**.|
-|Green	|9 |	If the complex words are less than X% in the text (English: 5%)              |**Word complexity**: You are not using too many complex words, which makes your text easy to read. Good job! |
+|Bullet	|Score|	Criterion| 	Feedback                                                                                                                                        |
+|-------|------	|----- |--------------------------------------------------------------------------------------------------------------------------------------------------|
+|Orange	(cornerstone: red) |6 (cornerstone: 3) |	If the complex words are more than X% in the text (English: 5%) | **Word complexity**: X% of the words in your text are considered complex. **Try to use shorter and more familiar words to improve readability**. |
+|Green	|9 |	If the complex words are less than X% in the text (English: 5%)              | **Word complexity**: You are not using too many complex words, which makes your text easy to read. Good job!                                     |

--- a/packages/yoastseo/src/scoring/assessments/readability/WordComplexityAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/readability/WordComplexityAssessment.js
@@ -94,7 +94,7 @@ export default class WordComplexityAssessment extends Assessment {
 					 %3$s expand to a link on yoast.com, %4$s expands to the anchor end tag. */
 				__(
 					// eslint-disable-next-line max-len
-					"%1$s: %2$s of the words in your text is considered complex. %3$sTry to use shorter and more familiar words to improve readability%4$s.",
+					"%1$s: %2$s of the words in your text are considered complex. %3$sTry to use shorter and more familiar words to improve readability%4$s.",
 					"wordpress-seo"
 				),
 				assessmentLink,


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* This PR fixes a small grammatical error in the word complexity feedback string. (X% of the words in your text **is** considered complex --> X% of the words in your text **are** considered complex)

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [yoastseo] Fixes a small grammatical error in the feedback string.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Create a post/page/CPT with block/elementor/gutenberg/classic editor and add enough text to get the word complexity feedback. Also make sure to include at least 5% complex words to get an orange (or red with cornerstone) bullet. For example use this text: `pandemic simple simple simple simple simple simple simple simple simple simple simple simple simple `
* Make sure that the feedback string for word complexity says `Word complexity: 7.14% of the words in your text are considered complex. Try to use shorter and more familiar words to improve readability.` and NOT `Word complexity: 7.14% of the words in your text are considered complex. Try to use shorter and more familiar words to improve readability.`

* The basic functionality/availability of word complexity has been tested as part of [this pr](https://github.com/Yoast/wordpress-seo/pull/18592).

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes # https://yoast.atlassian.net/browse/PC-133?atlOrigin=eyJpIjoiYWIxYzNlNDMxMzFjNDA2NmI0YjlmZmJlYThjN2NkODQiLCJwIjoiaiJ9
