### PR TITLE
Frontend inspector: change to beta badge

### DIFF
--- a/css/src/adminbar.css
+++ b/css/src/adminbar.css
@@ -9,10 +9,11 @@
 	border-radius: 8px;
 	font-weight: 600;
 	line-height: 1.6;
+	margin-left: 4px;
 }
 
-#wpadminbar .yoast-new-badge {
-	background-color: #cce5ff;
+#wpadminbar .yoast-beta-badge {
+	background-color: #CCE5FF;
 	color: #004973;
 }
 

--- a/inc/class-wpseo-admin-bar-menu.php
+++ b/inc/class-wpseo-admin-bar-menu.php
@@ -291,9 +291,9 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 			'parent' => self::MENU_IDENTIFIER,
 			'id'     => self::FRONTEND_INSPECTOR_SUBMENU_IDENTIFIER,
 			'title'  => sprintf(
-				'%1$s <span class="yoast-badge yoast-new-badge">%2$s</span>',
+				'%1$s <span class="yoast-badge yoast-beta-badge">%2$s</span>',
 				__( 'Inspect', 'wordpress-seo' ),
-				__( 'New', 'wordpress-seo' )
+				__( 'Beta', 'wordpress-seo' )
 			),
 			'href'   => '#wpseo-frontend-inspector',
 			'meta'   => [


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Changes the frontend inspector' badge to `Beta` instead of `New`.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Checkout the frontend admin bar menu
* Verify the badge is now the `Beta` badge, with the color the same as for the crawl settings
* Also note that there is now a margin of 4px in front of the badge (just like the crawl settings)


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes https://yoast.atlassian.net/browse/PC-137
