### PR TITLE
PC-88 PC-142 Improve meta author presenter

### DIFF
--- a/src/presenters/meta-author-presenter.php
+++ b/src/presenters/meta-author-presenter.php
@@ -2,6 +2,8 @@
 
 namespace Yoast\WP\SEO\Presenters;
 
+use Yoast\WP\SEO\Presentations\Indexable_Presentation;
+
 /**
  * Presenter class for the meta author tag.
  */
@@ -35,12 +37,22 @@ class Meta_Author_Presenter extends Abstract_Indexable_Tag_Presenter {
 	 * @return string The author's display name.
 	 */
 	public function get() {
+		if ( $this->presentation->model->object_sub_type !== 'post' ) {
+			return '';
+		}
+
 		$user_data = \get_userdata( $this->presentation->context->post->post_author );
 
 		if ( ! $user_data instanceof \WP_User ) {
 			return '';
 		}
 
-		return \trim( $this->helpers->schema->html->smart_strip_tags( $user_data->display_name ) );
+		/**
+		 * Filter: 'wpseo_meta_author' - Allow developers to filter the article's author meta tag.
+		 *
+		 * @param string                 $author_name  The article author's display name. Return empty to disable the tag.
+		 * @param Indexable_Presentation $presentation The presentation of an indexable.
+		 */
+		return \trim( $this->helpers->schema->html->smart_strip_tags( \apply_filters( 'wpseo_meta_author', $user_data->display_name, $this->presentation ) ) );
 	}
 }

--- a/tests/unit/presenters/meta-author-presenter-test.php
+++ b/tests/unit/presenters/meta-author-presenter-test.php
@@ -8,6 +8,7 @@ use Yoast\WP\SEO\Helpers\Schema\HTML_Helper;
 use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 use Yoast\WP\SEO\Presenters\Meta_Author_Presenter;
 use Yoast\WP\SEO\Tests\Unit\Doubles\Context\Meta_Tags_Context_Mock;
+use Yoast\WP\SEO\Tests\Unit\Doubles\Models\Indexable_Mock;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
@@ -70,7 +71,8 @@ class Meta_Author_Presenter_Test extends TestCase {
 	 * @covers ::get
 	 */
 	public function test_present_and_filter_happy_path() {
-		$this->indexable_presentation->meta_description = 'the_meta_description';
+		$this->indexable_presentation->model                  = new Indexable_Mock();
+		$this->indexable_presentation->model->object_sub_type = 'post';
 
 		$user_mock               = Mockery::mock( \WP_User::class );
 		$user_mock->display_name = 'John Doe';
@@ -88,6 +90,7 @@ class Meta_Author_Presenter_Test extends TestCase {
 
 		$output = '<meta name="author" content="John Doe" />';
 
+		Monkey\Filters\expectApplied( 'wpseo_meta_author' );
 		$this->assertSame( $output, $this->instance->present() );
 	}
 
@@ -98,12 +101,35 @@ class Meta_Author_Presenter_Test extends TestCase {
 	 * @covers ::get
 	 */
 	public function test_present_and_filter_unhappy_path() {
-		$this->indexable_presentation->meta_description = 'the_meta_description';
+		$this->indexable_presentation->model                  = new Indexable_Mock();
+		$this->indexable_presentation->model->object_sub_type = 'post';
 
 		Monkey\Functions\expect( 'get_userdata' )
 			->once()
 			->with( 123 )
 			->andReturnFalse();
+
+		$this->html
+			->expects( 'smart_strip_tags' )
+			->never();
+
+		$output = '';
+
+		$this->assertSame( $output, $this->instance->present() );
+	}
+
+	/**
+	 * Tests the presenter of the meta description when we are not on a post.
+	 *
+	 * @covers ::present
+	 * @covers ::get
+	 */
+	public function test_present_and_filter_not_a_post() {
+		$this->indexable_presentation->model                  = new Indexable_Mock();
+		$this->indexable_presentation->model->object_sub_type = 'page';
+
+		Monkey\Functions\expect( 'get_userdata' )
+			->never();
 
 		$this->html
 			->expects( 'smart_strip_tags' )


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Improves the meta author presenter

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves the author meta tag to be displayed only on posts.
* Adds a `wpseo_meta_author` hook to filter the content of the author meta tag.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Visit a _page_ in the front-end, check that you *can't* see a tag such as `<meta name="author" content="Kathlyn Rodriguez" />`
* Visit a _custom post type item_ in the front-end, check that you *can't* see a tag such as `<meta name="author" content="Kathlyn Rodriguez" />`
* Visit a _WooCommerce product page_ in the front-end, check that you *can't* see a tag such as `<meta name="author" content="Kathlyn Rodriguez" />`
* Visit a _post_ in the front-end, check that you *can* see a tag such as `<meta name="author" content="Kathlyn Rodriguez" />`
* edit your theme's `functions.php` and add:
```
add_filter( 'wpseo_meta_author', 'my_test_meta_author', 10, 2);
function my_test_meta_author( $author_name, $presentation ) {
   return 'Foo Bar';
}
```
* Visit the same post above in the front-end, check that the tag is now `<meta name="author" content="Foo Bar" />`
* Visit a page or a custom post type item, check that you still can't see a tag such as `<meta name="author" content="Foo Bar" />`

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes [PC-88][PC-142]


[PC-88]: https://yoast.atlassian.net/browse/PC-88?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ