### PR TITLE
PC-148 Make word complexity and keyphrase distribution premium upsell is available for products

### DIFF
--- a/packages/js/src/components/contentAnalysis/ReadabilityAnalysis.js
+++ b/packages/js/src/components/contentAnalysis/ReadabilityAnalysis.js
@@ -80,9 +80,12 @@ class ReadabilityAnalysis extends Component {
 			link = wpseoAdminL10n[ "shortlinks.upsell.sidebar.word_complexity" ];
 		}
 
-		// We don't show the upsell in WooCommerce product pages.
+		/*
+		 * We don't show the upsell in WooCommerce product pages when Yoast SEO WooCommerce plugin is activated.
+		 * This is because the premium assessments of the upsell are already loaded even when the Premium plugin is not activated.
+		*/
 		const contentType = wpseoAdminL10n.postType;
-		if ( contentType === "product" ) {
+		if ( this.props.isYoastSEOWooActive && contentType === "product" ) {
 			return [];
 		}
 
@@ -168,11 +171,13 @@ ReadabilityAnalysis.propTypes = {
 	marksButtonStatus: PropTypes.string.isRequired,
 	overallScore: PropTypes.number,
 	shouldUpsell: PropTypes.bool,
+	isYoastSEOWooActive: PropTypes.bool,
 };
 
 ReadabilityAnalysis.defaultProps = {
 	overallScore: null,
 	shouldUpsell: false,
+	isYoastSEOWooActive: false,
 };
 
 export default withSelect( select => {

--- a/packages/js/src/components/contentAnalysis/SeoAnalysis.js
+++ b/packages/js/src/components/contentAnalysis/SeoAnalysis.js
@@ -181,9 +181,12 @@ class SeoAnalysis extends Component {
 			link = wpseoAdminL10n[ "shortlinks.upsell.sidebar.keyphrase_distribution" ];
 		}
 
-		// We don't show the upsell in WooCommerce product pages.
+		/*
+		 * We don't show the upsell in WooCommerce product pages when Yoast SEO WooCommerce plugin is activated.
+		 * This is because the premium assessments of the upsell are already loaded even when the Premium plugin is not activated.
+		 */
 		const contentType = wpseoAdminL10n.postType;
-		if ( contentType === "product" ) {
+		if ( this.props.isYoastSEOWooActive && contentType === "product" ) {
 			return [];
 		}
 
@@ -278,6 +281,7 @@ SeoAnalysis.propTypes = {
 	shouldUpsell: PropTypes.bool,
 	shouldUpsellWordFormRecognition: PropTypes.bool,
 	overallScore: PropTypes.number,
+	isYoastSEOWooActive: PropTypes.bool,
 };
 
 SeoAnalysis.defaultProps = {
@@ -287,6 +291,7 @@ SeoAnalysis.defaultProps = {
 	shouldUpsell: false,
 	shouldUpsellWordFormRecognition: false,
 	overallScore: null,
+	isYoastSEOWooActive: false,
 };
 
 export default withSelect( ( select, ownProps ) => {

--- a/packages/js/src/components/fills/MetaboxFill.js
+++ b/packages/js/src/components/fills/MetaboxFill.js
@@ -75,6 +75,7 @@ export default function MetaboxFill( { settings, wincherKeyphrases, setWincherNo
 				{ settings.isContentAnalysisActive && <SidebarItem key="readability-analysis" renderPriority={ 10 }>
 					<ReadabilityAnalysis
 						shouldUpsell={ settings.shouldUpsell }
+						isYoastSEOWooActive={ settings.isYoastSEOWooEnabled }
 					/>
 				</SidebarItem> }
 				{ settings.isKeywordAnalysisActive && <SidebarItem key="seo-analysis" renderPriority={ 20 }>
@@ -82,6 +83,7 @@ export default function MetaboxFill( { settings, wincherKeyphrases, setWincherNo
 						<SeoAnalysis
 							shouldUpsell={ settings.shouldUpsell }
 							shouldUpsellWordFormRecognition={ settings.isWordFormRecognitionActive }
+							isYoastSEOWooActive={ settings.isYoastSEOWooEnabled }
 						/>
 						{ settings.shouldUpsell && <PremiumSEOAnalysisModal location="metabox" /> }
 					</Fragment>

--- a/packages/js/src/components/fills/SidebarFill.js
+++ b/packages/js/src/components/fills/SidebarFill.js
@@ -79,6 +79,7 @@ export default function SidebarFill( { settings } ) {
 						<SeoAnalysis
 							shouldUpsell={ settings.shouldUpsell }
 							shouldUpsellWordFormRecognition={ settings.isWordFormRecognitionActive }
+							isYoastSEOWooActive={ settings.isYoastSEOWooEnabled }
 						/>
 						{ settings.shouldUpsell && <PremiumSEOAnalysisModal location="sidebar" /> }
 					</Fragment>
@@ -86,6 +87,7 @@ export default function SidebarFill( { settings } ) {
 				{ settings.isContentAnalysisActive && <SidebarItem key="readability" renderPriority={ 20 }>
 					<ReadabilityAnalysis
 						shouldUpsell={ settings.shouldUpsell }
+						isYoastSEOWooActive={ settings.isYoastSEOWooEnabled }
 					/>
 				</SidebarItem> }
 				{ settings.isKeywordAnalysisActive && <SidebarItem key="additional-keywords-upsell" renderPriority={ 21 }>

--- a/packages/js/src/elementor/components/fills/ElementorFill.js
+++ b/packages/js/src/elementor/components/fills/ElementorFill.js
@@ -95,6 +95,7 @@ export default function ElementorFill( { isLoading, onLoad, settings } ) {
 						<SeoAnalysis
 							shouldUpsell={ settings.shouldUpsell }
 							shouldUpsellWordFormRecognition={ settings.isWordFormRecognitionActive }
+							isYoastSEOWooActive={ settings.isYoastSEOWooEnabled }
 						/>
 						{ settings.shouldUpsell && <PremiumSEOAnalysisModal /> }
 					</Fragment>
@@ -102,6 +103,7 @@ export default function ElementorFill( { isLoading, onLoad, settings } ) {
 				{ settings.isContentAnalysisActive && <SidebarItem renderPriority={ 20 }>
 					<ReadabilityAnalysis
 						shouldUpsell={ settings.shouldUpsell }
+						isYoastSEOWooActive={ settings.isYoastSEOWooEnabled }
 					/>
 				</SidebarItem> }
 				{ settings.isKeywordAnalysisActive && <SidebarItem key="additional-keywords-upsell" renderPriority={ 21 }>

--- a/packages/js/src/redux/reducers/preferences.js
+++ b/packages/js/src/redux/reducers/preferences.js
@@ -37,7 +37,7 @@ function getDefaultState() {
 		isWordProofIntegrationActive: isWordProofIntegrationActive(),
 		isInsightsEnabled: get( window, "wpseoScriptData.metabox.isInsightsEnabled", false ),
 		isNewsEnabled: ! ! window.wpseoAdminL10n.news_seo_is_active,
-		isYoastSEOWooEnabled: window.wpseoWooL10n,
+		isYoastSEOWooEnabled: ! isUndefined( window.wpseoWooL10n ),
 	};
 }
 

--- a/packages/js/src/redux/reducers/preferences.js
+++ b/packages/js/src/redux/reducers/preferences.js
@@ -37,6 +37,7 @@ function getDefaultState() {
 		isWordProofIntegrationActive: isWordProofIntegrationActive(),
 		isInsightsEnabled: get( window, "wpseoScriptData.metabox.isInsightsEnabled", false ),
 		isNewsEnabled: ! ! window.wpseoAdminL10n.news_seo_is_active,
+		isYoastSEOWooEnabled: window.wpseoWooL10n,
 	};
 }
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* When a user activated Yoast SEO and WooCommerce plugins, the premium upsell of Word complexity and Keyphrase distribution assessments are not loaded in the metabox of a product page. This PR makes sure that the upsell is loaded in the aforementioned case.
* The keyphrase distribution assessment only appears when there are at least 15 sentences and a keyphrase is added to the metabox.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [wpseo-woocommerce] Loads word complexity and keyphrase distribution premium upsell for products when Yoast SEO WooCommerce plugin is not activated.

## Relevant technical choices:

* We don't show the upsell in WooCommerce product pages when Yoast SEO WooCommerce plugin is activated. This is because the premium assessments of the upsell are already loaded even when the Premium plugin is not activated.
* The logic of checking the condition above (i.e. whether Yoast SEO WooCommerce plugin and whether the content type is "product") is not added as part of `shouldUpsell` property. And instead, it is added inside `getUpsellResults()` of `ReadabilityAnalysis` and `SEOAnalysis` components.
* The approach above is taken since `shouldUpsell` is also used for other features that checking whether Premium plugin is not activated is the only condition for loading the upsell.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

Requirement:
* Set the site language to English

#### Test without Yoast SEO: WooCommerce activated
* Install and activate Yoast SEO
* Install and activate WooCommerce
* Create/open a product
* Add a text of at least 300 words
* Confirm that the upsell for Word complexity assessment appears when opening the Readability analysis tab, as shown in the screnshot below
<img width="585" alt="Screenshot 2022-07-05 at 13 31 32" src="https://user-images.githubusercontent.com/48715883/177318178-b564a66e-49e8-4f05-8c4b-050ec793e0dc.png">

* Confirm that the Word complexity assessment feedback does NOT appear 
* Confirm that the upsell for Keyphrase distribution assessment appears when opening the SEO analysis tab
<img width="596" alt="Screenshot 2022-07-05 at 13 31 22" src="https://user-images.githubusercontent.com/48715883/177318158-c3c30fcb-d917-4f6b-9ac2-b2aaa9df3d3f.png">

* Confirm that the Keyphrase distribution assessment does NOT appear
* Repeat the steps above for product category/tag and confirm that the behaviour is the same as described above

#### Test with Yoast SEO: WooCommerce activated
* Install and activate Yoast SEO
* Install and activate WooCommerce
* Install and activate Yoast SEO: WooCommerce

##### Test in product pages
* Create/open a product
* Add at least 300 words
* Confirm that the upsell for Word complexity assessment does NOT appear when opening the Readability analysis tab
* Confirm that the Word complexity assessment feedback appears
* Confirm that the upsell for Keyphrase distribution assessment does NOT appear when opening the SEO analysis tab
* Add a keyphrase
* Confirm that the Keyphrase distribution assessment feedback appears

##### Test in product category/tag
* Create/open a product category/tag
* Add at least 300 words
* Confirm that the upsell for Word complexity assessment still appears when opening the Readability analysis tab
* Confirm that the Word complexity assessment feedback does NOT appear
* Confirm that the upsell for Keyphrase distribution assessment still appears when opening the SEO analysis tab
* Confirm that the Keyphrase distribution assessment feedback does NOT appear

#### Test with Yoast SEO: WooCommerce and Yoast SEO Premium activated
* Install and activate Yoast SEO
* Install and activate WooCommerce
* Install and activate Yoast SEO: WooCommerce
* Install and activate Yoast SEO Premium
* Create/open a product
* Add at least 300 words
* Confirm that the upsell for Word complexity assessment does NOT appear when opening the Readability analysis tab
* Confirm that the Word complexity assessment feedback appears
* Confirm that the upsell for Keyphrase distribution assessment does NOT appear when opening the SEO analysis tab
* Add a keyphrase
* Confirm that the Keyphrase distribution assessment feedback appears
* Repeat the steps above for product category/tag and confirm that the behaviour is the same as described above


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes https://yoast.atlassian.net/browse/PC-148
