### PR TITLE
Pc 43 fix discrepancies between elementor classic editor v2

### DIFF
--- a/packages/yoastseo/spec/fullTextTests/testTexts/en/englishPaperForPerformanceTest.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/en/englishPaperForPerformanceTest.js
@@ -112,12 +112,12 @@ const expectedResults = {
 	textSentenceLength: {
 		isApplicable: true,
 		score: 3,
-		resultText: "<a href='https://yoa.st/34v' target='_blank'>Sentence length</a>: 54% of the sentences contain more than 20 words, which is more than the recommended maximum of 25%. <a href='https://yoa.st/34w' target='_blank'>Try to shorten the sentences</a>.",
+		resultText: "<a href='https://yoa.st/34v' target='_blank'>Sentence length</a>: 53.8% of the sentences contain more than 20 words, which is more than the recommended maximum of 25%. <a href='https://yoa.st/34w' target='_blank'>Try to shorten the sentences</a>.",
 	},
 	textTransitionWords: {
 		isApplicable: true,
 		score: 3,
-		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 5.8% of the sentences contain transition words, which is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more of them</a>.",
+		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 5.6% of the sentences contain transition words, which is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more of them</a>.",
 	},
 	passiveVoice: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/fullTextTests/testTexts/es/spanishPaper.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/es/spanishPaper.js
@@ -106,8 +106,8 @@ const expectedResults = {
 	},
 	textSentenceLength: {
 		isApplicable: true,
-		score: 3,
-		resultText: "<a href='https://yoa.st/34v' target='_blank'>Sentence length</a>: 30.2% of the sentences contain more than 25 words, which is more than the recommended maximum of 25%. <a href='https://yoa.st/34w' target='_blank'>Try to shorten the sentences</a>.",
+		score: 6,
+		resultText: "<a href='https://yoa.st/34v' target='_blank'>Sentence length</a>: 29.6% of the sentences contain more than 25 words, which is more than the recommended maximum of 25%. <a href='https://yoa.st/34w' target='_blank'>Try to shorten the sentences</a>.",
 	},
 	textTransitionWords: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/fullTextTests/testTexts/es/spanishPaperForPerformanceTest.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/es/spanishPaperForPerformanceTest.js
@@ -113,7 +113,7 @@ const expectedResults = {
 	textSentenceLength: {
 		isApplicable: true,
 		score: 6,
-		resultText: "<a href='https://yoa.st/34v' target='_blank'>Sentence length</a>: 25.4% of the sentences contain more than 25 words, which is more than the recommended maximum of 25%. <a href='https://yoa.st/34w' target='_blank'>Try to shorten the sentences</a>.",
+		resultText: "<a href='https://yoa.st/34v' target='_blank'>Sentence length</a>: 26.2% of the sentences contain more than 25 words, which is more than the recommended maximum of 25%. <a href='https://yoa.st/34w' target='_blank'>Try to shorten the sentences</a>.",
 	},
 	textTransitionWords: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/fullTextTests/testTexts/fr/frenchPaper.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/fr/frenchPaper.js
@@ -107,17 +107,17 @@ const expectedResults = {
 	textSentenceLength: {
 		isApplicable: true,
 		score: 3,
-		resultText: "<a href='https://yoa.st/34v' target='_blank'>Sentence length</a>: 41.7% of the sentences contain more than 20 words, which is more than the recommended maximum of 25%. <a href='https://yoa.st/34w' target='_blank'>Try to shorten the sentences</a>.",
+		resultText: "<a href='https://yoa.st/34v' target='_blank'>Sentence length</a>: 40.8% of the sentences contain more than 20 words, which is more than the recommended maximum of 25%. <a href='https://yoa.st/34w' target='_blank'>Try to shorten the sentences</a>.",
 	},
 	textTransitionWords: {
 		isApplicable: true,
 		score: 6,
-		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 26.5% of the sentences contain transition words, which is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more of them</a>.",
+		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 26% of the sentences contain transition words, which is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more of them</a>.",
 	},
 	passiveVoice: {
 		isApplicable: true,
 		score: 3,
-		resultText: "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: 22.4% of the sentences contain passive voice, which is more than the recommended maximum of 10%. <a href='https://yoa.st/34u' target='_blank'>Try to use their active counterparts</a>.",
+		resultText: "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: 24% of the sentences contain passive voice, which is more than the recommended maximum of 10%. <a href='https://yoa.st/34u' target='_blank'>Try to use their active counterparts</a>.",
 	},
 	textPresence: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/fullTextTests/testTexts/it/italianPaper.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/it/italianPaper.js
@@ -54,7 +54,7 @@ const expectedResults = {
 	textLength: {
 		isApplicable: true,
 		score: 9,
-		resultText: "<a href='https://yoa.st/34n' target='_blank'>Text length</a>: The text contains 1141 words. Good job!",
+		resultText: "<a href='https://yoa.st/34n' target='_blank'>Text length</a>: The text contains 1140 words. Good job!",
 	},
 	externalLinks: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/fullTextTests/testTexts/pl/polishPaperForPerformanceTest.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/pl/polishPaperForPerformanceTest.js
@@ -112,7 +112,7 @@ const expectedResults = {
 	textSentenceLength: {
 		isApplicable: true,
 		score: 3,
-		resultText: "<a href='https://yoa.st/34v' target='_blank'>Sentence length</a>: 54% of the sentences contain more than 20 words, which is more than the recommended maximum of 15%. <a href='https://yoa.st/34w' target='_blank'>Try to shorten the sentences</a>.",
+		resultText: "<a href='https://yoa.st/34v' target='_blank'>Sentence length</a>: 53.8% of the sentences contain more than 20 words, which is more than the recommended maximum of 15%. <a href='https://yoa.st/34w' target='_blank'>Try to shorten the sentences</a>.",
 	},
 	textTransitionWords: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/languageProcessing/helpers/sanitize/quotesSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/helpers/sanitize/quotesSpec.js
@@ -12,6 +12,8 @@ describe( "a quote helper", function() {
 			expect( normalizeSingleQuotes( "’" ) ).toBe( "'" );
 			expect( normalizeSingleQuotes( "‛" ) ).toBe( "'" );
 			expect( normalizeSingleQuotes( "`" ) ).toBe( "'" );
+			expect( normalizeSingleQuotes( "‹" ) ).toBe( "'" );
+			expect( normalizeSingleQuotes( "›" ) ).toBe( "'" );
 		} );
 	} );
 
@@ -24,6 +26,10 @@ describe( "a quote helper", function() {
 			expect( normalizeDoubleQuotes( "〟" ) ).toBe( "\"" );
 			expect( normalizeDoubleQuotes( "‟" ) ).toBe( "\"" );
 			expect( normalizeDoubleQuotes( "„" ) ).toBe( "\"" );
+			expect( normalizeDoubleQuotes( "«" ) ).toBe( "\"" );
+			expect( normalizeDoubleQuotes( "»" ) ).toBe( "\"" );
+			expect( normalizeDoubleQuotes( "『" ) ).toBe( "\"" );
+			expect( normalizeDoubleQuotes( "』" ) ).toBe( "\"" );
 		} );
 	} );
 
@@ -41,6 +47,12 @@ describe( "a quote helper", function() {
 			expect( normalize( "〟" ) ).toBe( "\"" );
 			expect( normalize( "‟" ) ).toBe( "\"" );
 			expect( normalize( "„" ) ).toBe( "\"" );
+			expect( normalize( "‹" ) ).toBe( "'" );
+			expect( normalize( "›" ) ).toBe( "'" );
+			expect( normalize( "『" ) ).toBe( "\"" );
+			expect( normalize( "』" ) ).toBe( "\"" );
+			expect( normalize( "«" ) ).toBe( "\"" );
+			expect( normalize( "»" ) ).toBe( "\"" );
 		} );
 	} );
 } );

--- a/packages/yoastseo/spec/languageProcessing/helpers/sanitize/removePunctuationSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/helpers/sanitize/removePunctuationSpec.js
@@ -20,6 +20,10 @@ describe( "a test for removing punctuation from a string", function() {
 	it( "returns string without () around the word", function() {
 		expect( removePunctuation( "test)" ) ).toBe( "test" );
 	} );
+
+	it( "returns an empty string if &amp is encountered", function() {
+		expect( removePunctuation( "&amp" ) ).toBe( "" );
+	} );
 } );
 
 describe( "Removing punctuation at the begin and end of a word", function() {

--- a/packages/yoastseo/spec/languageProcessing/helpers/sentence/SentenceTokenizerSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/helpers/sentence/SentenceTokenizerSpec.js
@@ -2,7 +2,7 @@ import SentenceTokenizer from "../../../../src/languageProcessing/helpers/senten
 
 const mockTokenizer = new SentenceTokenizer();
 
-const doubleQuoteTypes = [ { start: "\"", end: "\"" },
+const doubleQuotePairs = [ { start: "\"", end: "\"" },
 	{ start: "〝", end: "〞" },
 	{ start: "“", end: "”" },
 	{ start: "‟", end: "„" },
@@ -21,7 +21,7 @@ describe( "A test for tokenizing a (html) text into sentences", function() {
 
 	it( "returns an array of sentences for a given array of tokens started and ended with block with the " +
 		" start and end of the quote pair", function() {
-		doubleQuoteTypes.forEach( ( quotePair ) => {
+		doubleQuotePairs.forEach( ( quotePair ) => {
 			const tokens = [
 				{ type: "block-start", src: "<form>" },
 				{ type: "html-start", src: "<p>" },
@@ -370,7 +370,7 @@ describe( "A test for tokenizing a (html) text into sentences", function() {
 	} );
 
 	it( "recognizes initials in the edge case where there are quotes around the initials", function() {
-		doubleQuoteTypes.forEach( ( quotePair ) => {
+		doubleQuotePairs.forEach( ( quotePair ) => {
 			const tokens = [
 				{ type: "sentence", src: "The reprint was favourably reviewed by" },
 				{ type: "sentence-delimiter", src: quotePair.start },
@@ -395,7 +395,7 @@ describe( "A test for tokenizing a (html) text into sentences", function() {
 	} );
 
 	it( "correctly constructs the sentence in the edge case where there are quotes around the initials", function() {
-		doubleQuoteTypes.forEach( ( quotePair ) => {
+		doubleQuotePairs.forEach( ( quotePair ) => {
 			const tokens = [
 				{ type: "sentence", src: "The reprint was favourably reviewed by" },
 				{ type: "sentence-delimiter", src: " " + quotePair.start },

--- a/packages/yoastseo/spec/languageProcessing/helpers/sentence/SentenceTokenizerSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/helpers/sentence/SentenceTokenizerSpec.js
@@ -2,9 +2,10 @@ import SentenceTokenizer from "../../../../src/languageProcessing/helpers/senten
 
 const mockTokenizer = new SentenceTokenizer();
 
-const doubleQuoteTypes = [ { start: "〝", end: "\"" },
-	{ start: "\"", end: "〞" },
-	{ start: "〟", end: "‟" },
+const doubleQuoteTypes = [ { start: "\"", end: "\"" },
+	{ start: "〝", end: "〞" },
+	{ start: "“", end: "”" },
+	{ start: "‟", end: "„" },
 	{ start: "『", end: "』" },
 	{ start: "«", end: "»" } ];
 
@@ -18,9 +19,9 @@ describe( "A test for tokenizing a (html) text into sentences", function() {
 		expect( mockTokenizer.isValidSentenceBeginning( "أ" ) ).toBe( true );
 	} );
 
-	doubleQuoteTypes.forEach( ( quotePair ) =>{
-		it( "returns an array of sentences for a given array of tokens started and ended with block with the " +
-			quotePair.start + quotePair.end + "quote pair", function() {
+	it( "returns an array of sentences for a given array of tokens started and ended with block with the " +
+		" start and end of the quote pair", function() {
+		doubleQuoteTypes.forEach( ( quotePair ) => {
 			const tokens = [
 				{ type: "block-start", src: "<form>" },
 				{ type: "html-start", src: "<p>" },

--- a/packages/yoastseo/spec/languageProcessing/helpers/sentence/SentenceTokenizerSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/helpers/sentence/SentenceTokenizerSpec.js
@@ -404,12 +404,15 @@ describe( "A test for tokenizing a (html) text into sentences", function() {
 				{ type: "sentence", src: " B" },
 				{ type: "full-stop", src: "." },
 				{ type: "sentence-delimiter", src: quotePair.end },
-				{ type: "full-stop", src: " in The Musical Times in 1935, who commented" + quotePair.start + "Praise is due to Mr Mercer." },
+				{ type: "sentence", src: " in The Musical Times in 1935, who commented" },
+				{ type: "sentence-delimiter", src: quotePair.start },
+				{ type: "sentence", src: "Praise is due to Mr Mercer." },
+				{ type: "sentence-delimiter", src: quotePair.end },
 			];
 
 			expect( mockTokenizer.getSentencesFromTokens( tokens ) ).toEqual( [
 				"The reprint was favourably reviewed by " + quotePair.start + "A. B." + quotePair.end +
-				" in The Musical Times in 1935, who commented" + quotePair.start +  "Praise is due to Mr Mercer." ] );
+				" in The Musical Times in 1935, who commented" + quotePair.start +  "Praise is due to Mr Mercer." + quotePair.end ] );
 		} );
 	} );
 } );

--- a/packages/yoastseo/spec/languageProcessing/helpers/sentence/SentenceTokenizerSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/helpers/sentence/SentenceTokenizerSpec.js
@@ -2,6 +2,12 @@ import SentenceTokenizer from "../../../../src/languageProcessing/helpers/senten
 
 const mockTokenizer = new SentenceTokenizer();
 
+const doubleQuoteTypes = [ { start: "〝", end: "\"" },
+	{ start: "\"", end: "〞" },
+	{ start: "〟", end: "‟" },
+	{ start: "『", end: "』" },
+	{ start: "«", end: "»" } ];
+
 describe( "A test for tokenizing a (html) text into sentences", function() {
 	it( "returns whether the sentenceBeginning beginning is a valid beginning.", function() {
 		expect( mockTokenizer.isValidSentenceBeginning( "Text with duplicate spaces." ) ).toBe( true );
@@ -12,29 +18,32 @@ describe( "A test for tokenizing a (html) text into sentences", function() {
 		expect( mockTokenizer.isValidSentenceBeginning( "أ" ) ).toBe( true );
 	} );
 
-	it( "returns an array of sentences for a given array of tokens started and ended with block.", function() {
-		const tokens = [
-			{ type: "block-start", src: "<form>" },
-			{ type: "html-start", src: "<p>" },
-			{ type: "sentence", src: "First sentence" },
-			{ type: "sentence-delimiter", src: ":" },
-			{ type: "sentence", src: " second sentence" },
-			{ type: "full-stop", src: "." },
-			{ type: "sentence", src: "  Third sentence" },
-			{ type: "full-stop", src: "." },
-			{ type: "sentence-delimiter", src: "\"" },
-			{ type: "sentence", src: "  Fourth sentence" },
-			{ type: "sentence-delimiter", src: "\"" },
-			{ type: "html-end", src: "<br> element.</p>" },
-			{ type: "block-end", src: "</form>" },
-		];
-		expect( mockTokenizer.getSentencesFromTokens( tokens ) ).toEqual(   [
-			"<form><p>First sentence:",
-			"second sentence.",
-			"Third sentence.\"",
-			"Fourth sentence\"",
-			"</form>",
-		] );
+	doubleQuoteTypes.forEach( ( quotePair ) =>{
+		it( "returns an array of sentences for a given array of tokens started and ended with block with the " +
+			quotePair.start + quotePair.end + "quote pair", function() {
+			const tokens = [
+				{ type: "block-start", src: "<form>" },
+				{ type: "html-start", src: "<p>" },
+				{ type: "sentence", src: "First sentence" },
+				{ type: "sentence-delimiter", src: ":" },
+				{ type: "sentence", src: " second sentence" },
+				{ type: "full-stop", src: "." },
+				{ type: "sentence", src: "  Third sentence" },
+				{ type: "full-stop", src: "." },
+				{ type: "sentence-delimiter", src: quotePair.start },
+				{ type: "sentence", src: "  Fourth sentence" },
+				{ type: "sentence-delimiter", src: quotePair.end },
+				{ type: "html-end", src: "<br> element.</p>" },
+				{ type: "block-end", src: "</form>" },
+			];
+			expect( mockTokenizer.getSentencesFromTokens( tokens ) ).toEqual(   [
+				"<form><p>First sentence:",
+				"second sentence.",
+				"Third sentence." + quotePair.start,
+				"Fourth sentence" + quotePair.end,
+				"</form>",
+			] );
+		}  );
 	} );
 
 	it( "returns an array of sentences for a given array of tokens that include quotation marks", function() {
@@ -359,40 +368,45 @@ describe( "A test for tokenizing a (html) text into sentences", function() {
 		expect( mockTokenizer.endsWithOrdinalDot( "Anything you want to put here, it shouldn't matter." ) ).toBe( false );
 	} );
 
-	it( "recognizes initials in the edge case where there are quotes arouond the initials", function() {
-		const tokens = [
-			{ type: "sentence", src: "The reprint was favourably reviewed by" },
-			{ type: "sentence-delimiter", src: "\"" },
-			{ type: "sentence", src: "A" },
-			{ type: "full-stop", src: "." },
-			{ type: "sentence", src: " B" },
-			{ type: "full-stop", src: "." },
-			{ type: "sentence-delimiter", src: "\"" },
-			{ type: "full-stop", src: " in The Musical Times in 1935, who commented \"Praise is due to Mr Mercer." },
-		];
+	it( "recognizes initials in the edge case where there are quotes around the initials", function() {
+		doubleQuoteTypes.forEach( ( quotePair ) => {
+			const tokens = [
+				{ type: "sentence", src: "The reprint was favourably reviewed by" },
+				{ type: "sentence-delimiter", src: quotePair.start },
+				{ type: "sentence", src: "A" },
+				{ type: "full-stop", src: "." },
+				{ type: "sentence", src: " B" },
+				{ type: "full-stop", src: "." },
+				{ type: "sentence-delimiter", src: quotePair.end },
+				{ type: "full-stop", src: " in The Musical Times in 1935, who commented" + quotePair.start + "Praise is due to Mr Mercer." },
+			];
 
-		const token = tokens[ 3 ];
-		const previousToken = tokens[ 2 ];
-		const nextToken = tokens[ 4 ];
-		const secondToNextToken = tokens[ 5 ];
+			const token = tokens[ 3 ];
+			const previousToken = tokens[ 2 ];
+			const nextToken = tokens[ 4 ];
+			const secondToNextToken = tokens[ 5 ];
 
-		expect( mockTokenizer.isPartOfPersonInitial( token, previousToken, nextToken, secondToNextToken ) ).toBe( true );
+			expect( mockTokenizer.isPartOfPersonInitial( token, previousToken, nextToken, secondToNextToken ) ).toBe( true );
+		} );
 	} );
 
 	it( "correctly constructs the sentence in the edge case where there are quotes around the initials", function() {
-		const tokens = [
-			{ type: "sentence", src: "The reprint was favourably reviewed by" },
-			{ type: "sentence-delimiter", src: " \"" },
-			{ type: "sentence", src: "A" },
-			{ type: "full-stop", src: "." },
-			{ type: "sentence", src: " B" },
-			{ type: "full-stop", src: "." },
-			{ type: "sentence-delimiter", src: "\"" },
-			{ type: "full-stop", src: " in The Musical Times in 1935, who commented \"Praise is due to Mr Mercer." },
-		];
+		doubleQuoteTypes.forEach( ( quotePair ) => {
+			const tokens = [
+				{ type: "sentence", src: "The reprint was favourably reviewed by" },
+				{ type: "sentence-delimiter", src: " " + quotePair.start },
+				{ type: "sentence", src: "A" },
+				{ type: "full-stop", src: "." },
+				{ type: "sentence", src: " B" },
+				{ type: "full-stop", src: "." },
+				{ type: "sentence-delimiter", src: quotePair.end },
+				{ type: "full-stop", src: " in The Musical Times in 1935, who commented" + quotePair.start + "Praise is due to Mr Mercer." },
+			];
 
-		expect( mockTokenizer.getSentencesFromTokens( tokens ) ).toEqual( [
-			"The reprint was favourably reviewed by \"A. B.\" in The Musical Times in 1935, who commented \"Praise is due to Mr Mercer." ] );
+			expect( mockTokenizer.getSentencesFromTokens( tokens ) ).toEqual( [
+				"The reprint was favourably reviewed by " + quotePair.start + "A. B." + quotePair.end +
+				" in The Musical Times in 1935, who commented" + quotePair.start +  "Praise is due to Mr Mercer." ] );
+		} );
 	} );
 } );
 

--- a/packages/yoastseo/spec/languageProcessing/helpers/sentence/SentenceTokenizerSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/helpers/sentence/SentenceTokenizerSpec.js
@@ -381,7 +381,8 @@ describe( "A test for tokenizing a (html) text into sentences", function() {
 				{ type: "sentence-delimiter", src: quotePair.end },
 				{ type: "sentence", src: " in The Musical Times in 1935, who commented" },
 				{ type: "sentence-delimiter", src: quotePair.start },
-				{ type: "sentence", src: "Praise is due to Mr Mercer." },
+				{ type: "sentence", src: "Praise is due to Mr Mercer" },
+				{ type: "full-stop", src: "." },
 				{ type: "sentence-delimiter", src: quotePair.end },
 			];
 
@@ -406,7 +407,8 @@ describe( "A test for tokenizing a (html) text into sentences", function() {
 				{ type: "sentence-delimiter", src: quotePair.end },
 				{ type: "sentence", src: " in The Musical Times in 1935, who commented" },
 				{ type: "sentence-delimiter", src: quotePair.start },
-				{ type: "sentence", src: "Praise is due to Mr Mercer." },
+				{ type: "sentence", src: "Praise is due to Mr Mercer" },
+				{ type: "full-stop", src: "." },
 				{ type: "sentence-delimiter", src: quotePair.end },
 			];
 

--- a/packages/yoastseo/spec/languageProcessing/helpers/sentence/SentenceTokenizerSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/helpers/sentence/SentenceTokenizerSpec.js
@@ -379,7 +379,10 @@ describe( "A test for tokenizing a (html) text into sentences", function() {
 				{ type: "sentence", src: " B" },
 				{ type: "full-stop", src: "." },
 				{ type: "sentence-delimiter", src: quotePair.end },
-				{ type: "full-stop", src: " in The Musical Times in 1935, who commented" + quotePair.start + "Praise is due to Mr Mercer." },
+				{ type: "sentence", src: " in The Musical Times in 1935, who commented" },
+				{ type: "sentence-delimiter", src: quotePair.start },
+				{ type: "sentence", src: "Praise is due to Mr Mercer." },
+				{ type: "sentence-delimiter", src: quotePair.end },
 			];
 
 			const token = tokens[ 3 ];

--- a/packages/yoastseo/spec/scoring/collectionPages/fullTextTests/testTexts/en/englishPaper3.js
+++ b/packages/yoastseo/spec/scoring/collectionPages/fullTextTests/testTexts/en/englishPaper3.js
@@ -48,7 +48,7 @@ const expectedResults = {
 	textLength: {
 		isApplicable: true,
 		score: 9,
-		resultText: "<a href='https://yoa.st/shopify58' target='_blank'>Text length</a>: The text contains 437 words. Good job!",
+		resultText: "<a href='https://yoa.st/shopify58' target='_blank'>Text length</a>: The text contains 436 words. Good job!",
 	},
 	keyphraseInSEOTitle: {
 		isApplicable: true,
@@ -129,7 +129,7 @@ const expectedResults = {
 	wordComplexity: {
 		isApplicable: true,
 		score: 6,
-		resultText: "<a href='https://yoa.st/shopify77' target='_blank'>Word complexity</a>: 14.19% of the words in your text are considered complex. " +
+		resultText: "<a href='https://yoa.st/shopify77' target='_blank'>Word complexity</a>: 14.22% of the words in your text are considered complex. " +
 			"<a href='https://yoa.st/shopify78' target='_blank'>Try to use shorter and more familiar words to improve readability</a>.",
 	},
 };

--- a/packages/yoastseo/src/languageProcessing/helpers/sanitize/quotes.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/sanitize/quotes.js
@@ -5,7 +5,7 @@
  * @returns {string} The normalized text.
  */
 function normalizeSingleQuotes( text ) {
-	return text.replace( /[‘’‛`]/g, "'" );
+	return text.replace( /[‘’‛`‹›]/g, "'" );
 }
 
 /**
@@ -15,7 +15,7 @@ function normalizeSingleQuotes( text ) {
  * @returns {string} The normalized text.
  */
 function normalizeDoubleQuotes( text ) {
-	return text.replace( /[“”〝〞〟‟„『』]/g, "\"" );
+	return text.replace( /[“”〝〞〟‟„『』«»]/g, "\"" );
 }
 
 /**

--- a/packages/yoastseo/src/languageProcessing/helpers/sanitize/removePunctuation.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/sanitize/removePunctuation.js
@@ -26,8 +26,8 @@ export default function( text ) {
 	// If it would not be removed it is returned as amp and counted as a word in assessments downstream.
 	text = text.replace( "\u0026amp", "" );
 
-	const punctuationRegexStart = new RegExp( "^(\u0026amp$|[" + punctuationRegexString + "])+" );
-	const punctuationRegexEnd = new RegExp( "(^\u0026amp|[" + punctuationRegexString +  "])+$" );
+	const punctuationRegexStart = new RegExp( "^[" + punctuationRegexString + "]+" );
+	const punctuationRegexEnd = new RegExp( "[" + punctuationRegexString +  "]+$" );
 
 	/*
 	 * Remove backslash from the beginning and end of a word/text.

--- a/packages/yoastseo/src/languageProcessing/helpers/sanitize/removePunctuation.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/sanitize/removePunctuation.js
@@ -22,9 +22,13 @@ export default function( text ) {
 		"\uff5d\uff5c\uff5e\uff5f\uff60\uff62\uff63\uff64\uff3b\uff3d\uff65\uffe5\uff04\uff05\uff20\uff06\uff07\uff08\uff09\uff0a\uff0f\uff1a" +
 		"\uff1b\uff1c\uff1e\uff3c\\<>";
 
+	// Remove &amp from the string. In some editors (a.o. Block and Elementor) the ampersand (&) is transformed into &amp.
+	// If it would not be removed it is returned as amp and counted as a word in assessments downstream.
+	text = text.replace( "\u0026amp", "" );
 
-	const punctuationRegexStart = new RegExp( "^[" + punctuationRegexString + "]+" );
-	const punctuationRegexEnd = new RegExp( "[" + punctuationRegexString +  "]+$" );
+	const punctuationRegexStart = new RegExp( "^(\u0026amp$|[" + punctuationRegexString + "])+" );
+	const punctuationRegexEnd = new RegExp( "(^\u0026amp|[" + punctuationRegexString +  "])+$" );
+
 	/*
 	 * Remove backslash from the beginning and end of a word/text.
 	 * When a string such as `This is a \"calico\" cat` enters the Paper,

--- a/packages/yoastseo/src/languageProcessing/helpers/sentence/SentenceTokenizer.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/sentence/SentenceTokenizer.js
@@ -42,7 +42,7 @@ export default class SentenceTokenizer {
          * \u06D4 - Urdu full stop.
          * \u061f - Arabic question mark.
         */
-		this.sentenceDelimiters = "”〞〟„』\"?!\u2026\u06d4\u061f";
+		this.sentenceDelimiters = "”〞〟„』›»’‛`\"?!\u2026\u06d4\u061f";
 	}
 
 	/**
@@ -467,7 +467,7 @@ export default class SentenceTokenizer {
 					     * a) There is a next sentence, and the next character is a valid sentence beginning preceded by a white space, OR
 					     * b) The next token is a sentence start
 					    */
-						if ( token.src === "…" || token.src === "\"" ) {
+						if ( this.isQuotation( token.src ) || token.src === "…" ) {
 							currentSentence = this.getValidSentence( hasNextSentence,
 								nextSentenceStart,
 								nextCharacters,


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->
 
* There were different results for some readability assessments (such as passive voice) between editors. The reason was that not all different quotation marks were supported by the SentenceTokenizer, and that the ampersand (&) was processed differently between different editors. This issue resolves this by adding support for more quotation marks and removing all versions of the ampersand from the text.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves the text analysis by adding curly (“”) and angular quotation marks («»).
* Improves the text analysis by filtering out all versions of the ampersand (&).
* [yoastseo] Improves the SentenceTokenizer performance by adding curly (“”) and angular quotation marks («»).
* [yoastseo] Adds the html code (&amp) for the ampersand character (&) to the removePunctuation helper.
* [shopify-seo] Improves the text analysis by adding curly (“”) and angular quotation marks («»).
* [shopify-seo] Improves the text analysis by filtering out all versions of the ampersand (&).


## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

### Wordpress
* Downgrade to yoast 19.2. Use [this text](https://github.com/Yoast/wordpress-seo/files/9047064/LR_7_test_text.txt)
* Test in these editors: classic, block (with the Gutenberg plugin activated and not), Elementor, Woo
* Test in these content types: posts, pages, CPTs, product (Woo) 
* Check the following assessments.
  * In classic editor, block editor, Woo :
    * Passive voice (42.9% of sentences)
    * Sentence length (28.6% of the sentences)
    * Transition words (23.8% of the sentences)
    * Flesch Reading Ease (in Readability tab) (79.7) (Note: it doesn't appear in Woo)
    * Text length (263 words)
  * Elementor:
    * Passive voice (37.5% of sentences)
    * Sentence length (Great!)
    * Transition words (25% of the sentences)
    * Flesch Reading Ease (in Readability tab) (81.3)
    * Text length: (263 words, same as in classic)

* Upgrade to a version with with this PR (e.g. cherrypick/19.4)
* Make sure that the results for the following assessments are the same across editors
  * Passive voice (39.1% of sentences)
  * Sentence length (26.1% of the sentences)
  * Transition words (21.7% of the sentences)
  * Flesch Reading Ease (in insights tab) (80.8) (Note: it doesn't appear in Woo)
  * Text length: (263 words)
* Test in different browsers.

### Shopify
* Downgrade to wordpress-seo 19.2.
* Create a product
* Add [this text](https://github.com/Yoast/wordpress-seo/files/9047064/LR_7_test_text.txt) as the product description. 
* Make sure that the following assessments show the following result:
  * passive voice (42.9% of sentences)
  * sentence length (28.6% of the sentences)
  * Transition words (23.8% of the sentences)
  * Text length: (263 words)
* Upgrade to a wordpress-seo version with with this PR (e.g. cherrypick/19.4)
* Make sure that the following assessments show the following results:
  * passive voice (39.1% of sentences)
  * sentence length (26.1% of the sentences)
  * Transition words (21.7% of the sentences)
  * Text length: (263 words)

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [x] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [x] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes #
