### PR TITLE
PC-160 - Fixes marking words in text for strings that contain regex control characters

### DIFF
--- a/packages/yoastseo/spec/markers/addMarkSpec.js
+++ b/packages/yoastseo/spec/markers/addMarkSpec.js
@@ -10,6 +10,7 @@ describe( "addMark", function() {
 	} );
 
 	it( "should mark a text that starts with word boundaries", function() {
-		expect( addMarkSingleWord( "> ()A piece of text" ) ).toBe( "> ()".concat( "<yoastmark class='yoast-text-mark'>A piece of text</yoastmark>" ) );
+		expect( addMarkSingleWord( "> ()A piece of text" ) )
+			.toBe( "> ()".concat( "<yoastmark class='yoast-text-mark'>A piece of text</yoastmark>" ) );
 	} );
 } );

--- a/packages/yoastseo/src/languageProcessing/helpers/word/markWordsInSentences.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/word/markWordsInSentences.js
@@ -2,6 +2,7 @@ import matchWords from "../match/matchTextWithArray";
 import arrayToRegex from "../regex/createRegexFromArray";
 import addMark from "../../../markers/addMarkSingleWord";
 import Mark from "../../../values/Mark";
+import { escapeRegExp } from "lodash-es";
 
 /**
  * Adds marks to a sentence and merges marks if those are only separated by a space
@@ -15,6 +16,7 @@ import Mark from "../../../values/Mark";
  * @returns {string} The sentence with marks.
  */
 export const collectMarkingsInSentence = function( sentence, topicFoundInSentence, matchWordCustomHelper ) {
+	topicFoundInSentence = topicFoundInSentence.map( word => escapeRegExp( word ) );
 	// If a language has a custom helper to match words, we disable the word boundary when creating the regex.
 	const topicRegex = matchWordCustomHelper ? arrayToRegex( topicFoundInSentence, true ) : arrayToRegex( topicFoundInSentence );
 	const markup = sentence.replace( topicRegex, function( x ) {

--- a/packages/yoastseo/src/markers/addMarkSingleWord.js
+++ b/packages/yoastseo/src/markers/addMarkSingleWord.js
@@ -1,4 +1,5 @@
 import { stripWordBoundariesStart, stripWordBoundariesEnd } from "../languageProcessing/helpers/sanitize/stripWordBoundaries";
+import { escapeRegExp } from "lodash-es";
 
 /**
  * Marks a text with HTML tags, deals with word boundaries that were matched by regexes, but which should not be marked.
@@ -15,7 +16,7 @@ export default function( text ) {
 
 	// Get the actual word boundaries from the start of the text.
 	if ( strippedTextStart !== text ) {
-		const wordBoundaryStartIndex = text.search( strippedTextStart );
+		const wordBoundaryStartIndex = text.search( escapeRegExp( strippedTextStart ) );
 		wordBoundaryStart = text.substr( 0, wordBoundaryStartIndex );
 	}
 
@@ -23,7 +24,7 @@ export default function( text ) {
 	const strippedTextEnd = stripWordBoundariesEnd( strippedTextStart );
 	// Get the actual word boundaries from the end of the text.
 	if ( strippedTextEnd !== strippedTextStart ) {
-		const wordBoundaryEndIndex = strippedTextStart.search( strippedTextEnd ) + strippedTextEnd.length;
+		const wordBoundaryEndIndex = strippedTextStart.search( escapeRegExp( strippedTextEnd ) ) + strippedTextEnd.length;
 		wordBoundaryEnd = strippedTextStart.substr( wordBoundaryEndIndex );
 	}
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the keyphrase density assessment errors, or fails to mark the found keyphrases in the text, when using keyphrases that include some regular expression control characters, for example brackets.
* [wordpress-seo-premium] Fixes a bug where the keyphrase distribution assessment errors, or fails to mark the found keyphrases in the text, when using keyphrases that include some regular expression control characters, for example brackets.
* [shopify-seo] Fixes a bug where the keyphrase density and keyphrase distribution assessments error, or fails to mark the found keyphrases in the text, when using keyphrases that include some regular expression control characters, for example brackets.


## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Word complexity
* Create a post.
* Add content to the post that contains the word `keyphrase(s)`.
  * Use content that contains different control characters used in regular expressions.
    * Characters like `[`, `*`, `+`, `^`, `$`.  
* Click on the eye marker next to the word complexity assessment inside of the readability analysis.
* The phrase `keyphrase(s` should be marked inside the post's content and no error should be shown inside of the word complexity assessment. 
   * Note that the closing bracket at the end (`)`) is not marked. This is caused by a pre-existing issue (see https://yoast.atlassian.net/browse/LR-58).
* Follow the same test steps for other keyphrases that contain control characters used in regular expressions.
* Follow the same test steps for the classic editor and Gutenberg. 

#### Keyphrase density & Keyphrase distribution
* Create a post.
* Add a focus keyphrase that contains brackets. For example `cat(s)`.
* Add content to the post that contains the focus keyphrase multiple times.
  * Use content that contains different control characters used in regular expressions.
    * Characters like `[`, `*`, `+`, `^`, `$`.  
* Click on the eye marker next to the keyphrase density assessment in the SEO analysis.
* The occurrences of the focus keyphrase should be marked inside the post's content and no error should be shown inside of the word complexity assessment.
   * Note that the closing bracket at the end (`)`) is not marked. This is caused by a pre-existing issue (see https://yoast.atlassian.net/browse/LR-58).
* Follow the same steps as above, but now for the keyphrase distribution assessment.
  * Note: The keyphrase distribution assessment is only available in Premium, so you need to install and activate Premium first.
* Follow the same test steps for other keyphrases that contain control characters used in regular expressions.
* Follow the same test steps for the classic editor and Gutenberg.  

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [x] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes #
