### PR TITLE
PC-154 exclude plurals of non complex nouns from the word complexity assessment

### DIFF
--- a/packages/yoastseo/spec/fullTextTests/testTexts/en/englishPaper.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/en/englishPaper.js
@@ -145,7 +145,7 @@ const expectedResults = {
 	wordComplexity: {
 		isApplicable: true,
 		score: 6,
-		resultText: "<a href='https://yoa.st/4ls' target='_blank'>Word complexity</a>: 7.49% of the words in your text are considered complex. " +
+		resultText: "<a href='https://yoa.st/4ls' target='_blank'>Word complexity</a>: 6.8% of the words in your text are considered complex. " +
 			"<a href='https://yoa.st/4lt' target='_blank'>Try to use shorter and more familiar words to improve readability</a>.",
 	},
 };

--- a/packages/yoastseo/spec/languageProcessing/languages/en/ResearcherSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/languages/en/ResearcherSpec.js
@@ -7,7 +7,6 @@ import firstWordExceptions from "../../../../src/languageProcessing/languages/en
 import twoPartTransitionWords from "../../../../src/languageProcessing/languages/en/config/twoPartTransitionWords";
 import stopWords from "../../../../src/languageProcessing/languages/en/config/stopWords";
 import syllables from "../../../../src/languageProcessing/languages/en/config/syllables.json";
-import frequencyList from "../../../../src/languageProcessing/languages/en/config/frequencyList.json";
 const morphologyDataEN = getMorphologyData( "en" );
 
 describe( "a test for the English Researcher", function() {
@@ -53,12 +52,6 @@ describe( "a test for the English Researcher", function() {
 		expect( researcher.getConfig( "passiveConstructionType" ) ).toEqual( "periphrastic" );
 	} );
 
-	it( "returns the English word complexity configs", function() {
-		expect( researcher.getConfig( "wordComplexity" ).frequencyList ).toEqual( frequencyList.list );
-		expect( researcher.getConfig( "wordComplexity" ).wordLength ).toEqual( 7 );
-		expect( researcher.getConfig( "wordComplexity" ).doesUpperCaseDecreasesComplexity ).toEqual( true );
-	} );
-
 	it( "stems a word using the English stemmer", function() {
 		researcher.addResearchData( "morphology", morphologyDataEN );
 		expect( researcher.getHelper( "getStemmer" )( researcher )( "cats" ) ).toEqual( "cat" );
@@ -82,5 +75,10 @@ describe( "a test for the English Researcher", function() {
 			averageWordsPerSentence: 20,
 		};
 		expect( researcher.getHelper( "fleschReadingScore" )( statistics ) ).toBe( 17.3 );
+	} );
+
+	it( "checks is a word is complex in English", function() {
+		expect( researcher.getHelper( "checkIfWordIsComplex" )( "polygonal" ) ).toEqual( true );
+		expect( researcher.getHelper( "checkIfWordIsComplex" )( "investigations" ) ).toEqual( false );
 	} );
 } );

--- a/packages/yoastseo/spec/languageProcessing/languages/en/ResearcherSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/languages/en/ResearcherSpec.js
@@ -77,7 +77,7 @@ describe( "a test for the English Researcher", function() {
 		expect( researcher.getHelper( "fleschReadingScore" )( statistics ) ).toBe( 17.3 );
 	} );
 
-	it( "checks is a word is complex in English", function() {
+	it( "checks if a word is complex in English", function() {
 		expect( researcher.getHelper( "checkIfWordIsComplex" )( "polygonal" ) ).toEqual( true );
 		expect( researcher.getHelper( "checkIfWordIsComplex" )( "investigations" ) ).toEqual( false );
 	} );

--- a/packages/yoastseo/spec/languageProcessing/languages/en/helpers/checkIfWordIsComplexSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/languages/en/helpers/checkIfWordIsComplexSpec.js
@@ -1,27 +1,27 @@
 import checkIfWordIsComplex from "../../../../../src/languageProcessing/languages/en/helpers/checkIfWordIsComplex";
 
 describe( "a test checking if the word is complex in English",  function() {
-	it( "returns word as non-complex if its singular version is found in the list", function() {
-		expect( checkIfWordIsComplex( "examples" ) ).toEqual(
-			false
-		);
-	} );
-	it( "returns word as non-complex if it is found in the list", function() {
+	it( "returns singular word as non-complex if it is found in the list", function() {
 		expect( checkIfWordIsComplex( "example" ) ).toEqual(
 			false
 		);
 	} );
 	it( "returns word as non-complex if its singular version is found in the list", function() {
-		expect( checkIfWordIsComplex( "characters" ) ).toEqual(
+		expect( checkIfWordIsComplex( "examples" ) ).toEqual(
 			false
 		);
 	} );
-	it( "returns word as non-complex if it is found in the list", function() {
-		expect( checkIfWordIsComplex( "character" ) ).toEqual(
+	it( "returns singular word as non-complex if it is found in the list", function() {
+		expect( checkIfWordIsComplex( "release" ) ).toEqual(
 			false
 		);
 	} );
-	it( "returns word as complex if it ends on -s and is not in the list", function() {
+	it( "returns plural word as non-complex if its singular version is found in the list", function() {
+		expect( checkIfWordIsComplex( "releases" ) ).toEqual(
+			false
+		);
+	} );
+	it( "returns plural word as complex if it is not in the list", function() {
 		expect( checkIfWordIsComplex( "refrigerators" ) ).toEqual(
 			true
 		);

--- a/packages/yoastseo/spec/languageProcessing/languages/en/helpers/checkIfWordIsComplexSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/languages/en/helpers/checkIfWordIsComplexSpec.js
@@ -1,0 +1,29 @@
+import checkIfWordIsComplex from "../../../../../src/languageProcessing/languages/en/helpers/checkIfWordIsComplex";
+
+describe( "a test checking if the word is complex in English",  function() {
+	it( "returns word as non-complex if its singular version is found in the list", function() {
+		expect( checkIfWordIsComplex( "examples" ) ).toEqual(
+			false
+		);
+	} );
+	it( "returns word as non-complex if it is found in the list", function() {
+		expect( checkIfWordIsComplex( "example" ) ).toEqual(
+			false
+		);
+	} );
+	it( "returns word as non-complex if its singular version is found in the list", function() {
+		expect( checkIfWordIsComplex( "characters" ) ).toEqual(
+			false
+		);
+	} );
+	it( "returns word as non-complex if it is found in the list", function() {
+		expect( checkIfWordIsComplex( "character" ) ).toEqual(
+			false
+		);
+	} );
+	it( "returns word as complex if it ends on -s and is not in the list", function() {
+		expect( checkIfWordIsComplex( "refrigerators" ) ).toEqual(
+			true
+		);
+	} );
+} );

--- a/packages/yoastseo/spec/languageProcessing/languages/en/helpers/checkIfWordIsComplexSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/languages/en/helpers/checkIfWordIsComplexSpec.js
@@ -2,28 +2,32 @@ import checkIfWordIsComplex from "../../../../../src/languageProcessing/language
 
 describe( "a test checking if the word is complex in English",  function() {
 	it( "returns singular word as non-complex if it is found in the list", function() {
-		expect( checkIfWordIsComplex( "example" ) ).toEqual(
-			false
-		);
+		expect( checkIfWordIsComplex( "example" ) ).toEqual( false );
 	} );
+
 	it( "returns word as non-complex if its singular version is found in the list", function() {
-		expect( checkIfWordIsComplex( "examples" ) ).toEqual(
-			false
-		);
+		expect( checkIfWordIsComplex( "examples" ) ).toEqual( false );
 	} );
+
 	it( "returns singular word as non-complex if it is found in the list", function() {
-		expect( checkIfWordIsComplex( "release" ) ).toEqual(
-			false
-		);
+		expect( checkIfWordIsComplex( "release" ) ).toEqual( false );
 	} );
+
 	it( "returns plural word as non-complex if its singular version is found in the list", function() {
-		expect( checkIfWordIsComplex( "releases" ) ).toEqual(
-			false
-		);
+		expect( checkIfWordIsComplex( "releases" ) ).toEqual( false );
 	} );
+
 	it( "returns plural word as complex if it is not in the list", function() {
-		expect( checkIfWordIsComplex( "refrigerators" ) ).toEqual(
-			true
-		);
+		expect( checkIfWordIsComplex( "refrigerators" ) ).toEqual( true );
+	} );
+
+	it( "returns plural word as non complex if the word starts with capital letter", function() {
+		expect( checkIfWordIsComplex( "Tortoiseshell" ) ).toEqual( false );
+		expect( checkIfWordIsComplex( "Outsiders" ) ).toEqual( false );
+	} );
+
+	it( "returns plural word as non complex if the word is less than 7 characters", function() {
+		expect( checkIfWordIsComplex( "cat" ) ).toEqual( false );
+		expect( checkIfWordIsComplex( "rabbit" ) ).toEqual( false );
 	} );
 } );

--- a/packages/yoastseo/spec/scoring/collectionPages/fullTextTests/testTexts/en/englishPaper1.js
+++ b/packages/yoastseo/spec/scoring/collectionPages/fullTextTests/testTexts/en/englishPaper1.js
@@ -125,7 +125,7 @@ const expectedResults = {
 	wordComplexity: {
 		isApplicable: true,
 		score: 6,
-		resultText: "<a href='https://yoa.st/shopify77' target='_blank'>Word complexity</a>: 10.38% of the words in your text are considered complex." +
+		resultText: "<a href='https://yoa.st/shopify77' target='_blank'>Word complexity</a>: 9.62% of the words in your text are considered complex." +
 			" <a href='https://yoa.st/shopify78' target='_blank'>Try to use shorter and more familiar words to improve readability</a>.",
 	},
 };

--- a/packages/yoastseo/spec/scoring/collectionPages/fullTextTests/testTexts/en/englishPaper2.js
+++ b/packages/yoastseo/spec/scoring/collectionPages/fullTextTests/testTexts/en/englishPaper2.js
@@ -120,7 +120,7 @@ const expectedResults = {
 	wordComplexity: {
 		isApplicable: true,
 		score: 6,
-		resultText: "<a href='https://yoa.st/shopify77' target='_blank'>Word complexity</a>: 18.45% of the words in your text are considered complex. " +
+		resultText: "<a href='https://yoa.st/shopify77' target='_blank'>Word complexity</a>: 17.26% of the words in your text are considered complex. " +
 			"<a href='https://yoa.st/shopify78' target='_blank'>Try to use shorter and more familiar words to improve readability</a>.",
 	},
 };

--- a/packages/yoastseo/spec/scoring/collectionPages/fullTextTests/testTexts/en/englishPaper3.js
+++ b/packages/yoastseo/spec/scoring/collectionPages/fullTextTests/testTexts/en/englishPaper3.js
@@ -129,7 +129,7 @@ const expectedResults = {
 	wordComplexity: {
 		isApplicable: true,
 		score: 6,
-		resultText: "<a href='https://yoa.st/shopify77' target='_blank'>Word complexity</a>: 14.19% of the words in your text are considered complex. " +
+		resultText: "<a href='https://yoa.st/shopify77' target='_blank'>Word complexity</a>: 13.96% of the words in your text are considered complex. " +
 			"<a href='https://yoa.st/shopify78' target='_blank'>Try to use shorter and more familiar words to improve readability</a>.",
 	},
 };

--- a/packages/yoastseo/spec/scoring/productPages/fullTextTests/testTexts/en/englishPaper1.js
+++ b/packages/yoastseo/spec/scoring/productPages/fullTextTests/testTexts/en/englishPaper1.js
@@ -146,7 +146,7 @@ const expectedResults = {
 	wordComplexity: {
 		isApplicable: true,
 		score: 6,
-		resultText: "<a href='https://yoa.st/shopify77' target='_blank'>Word complexity</a>: 12.44% of the words in your text are considered complex. " +
+		resultText: "<a href='https://yoa.st/shopify77' target='_blank'>Word complexity</a>: 11.52% of the words in your text are considered complex. " +
 			"<a href='https://yoa.st/shopify78' target='_blank'>Try to use shorter and more familiar words to improve readability</a>.",
 	},
 };

--- a/packages/yoastseo/spec/scoring/productPages/fullTextTests/testTexts/en/englishPaper3.js
+++ b/packages/yoastseo/spec/scoring/productPages/fullTextTests/testTexts/en/englishPaper3.js
@@ -153,7 +153,7 @@ const expectedResults = {
 	wordComplexity: {
 		isApplicable: true,
 		score: 6,
-		resultText: "<a href='https://yoa.st/shopify77' target='_blank'>Word complexity</a>: 13.04% of the words in your text are considered complex. " +
+		resultText: "<a href='https://yoa.st/shopify77' target='_blank'>Word complexity</a>: 11.59% of the words in your text are considered complex. " +
 			"<a href='https://yoa.st/shopify78' target='_blank'>Try to use shorter and more familiar words to improve readability</a>.",
 	},
 };

--- a/packages/yoastseo/src/languageProcessing/languages/en/Researcher.js
+++ b/packages/yoastseo/src/languageProcessing/languages/en/Researcher.js
@@ -8,12 +8,12 @@ import stopWords from "./config/stopWords";
 import transitionWords from "./config/transitionWords";
 import twoPartTransitionWords from "./config/twoPartTransitionWords";
 import syllables from "./config/syllables.json";
-import frequencyList from "./config/frequencyList.json";
 
 // All helpers
 import getClauses from "./helpers/getClauses";
 import getStemmer from "./helpers/getStemmer";
 import fleschReadingScore from "./helpers/calculateFleschReadingScore";
+import checkIfWordIsComplex from "./helpers/checkIfWordIsComplex";
 
 /**
  * The researches contains all the researches
@@ -36,17 +36,13 @@ export default class Researcher extends AbstractResearcher {
 			transitionWords,
 			twoPartTransitionWords,
 			syllables,
-			wordComplexity: {
-				frequencyList: frequencyList.list,
-				wordLength: 7,
-				doesUpperCaseDecreasesComplexity: true,
-			},
 		} );
 
 		Object.assign( this.helpers, {
 			getClauses,
 			getStemmer,
 			fleschReadingScore,
+			checkIfWordIsComplex,
 		} );
 	}
 }

--- a/packages/yoastseo/src/languageProcessing/languages/en/config/internal/wordComplexity.js
+++ b/packages/yoastseo/src/languageProcessing/languages/en/config/internal/wordComplexity.js
@@ -1,0 +1,7 @@
+import frequencyList from "../frequencyList.json";
+
+export default {
+	frequencyList: frequencyList.list,
+	wordLength: 7,
+	doesUpperCaseDecreasesComplexity: true,
+};

--- a/packages/yoastseo/src/languageProcessing/languages/en/helpers/checkIfWordIsComplex.js
+++ b/packages/yoastseo/src/languageProcessing/languages/en/helpers/checkIfWordIsComplex.js
@@ -1,4 +1,5 @@
 import wordComplexity from "../config/internal/wordComplexity";
+
 /**
  * Checks if a word is complex.
  *
@@ -13,8 +14,6 @@ export default function checkIfWordIsComplex( word ) {
 	// Whether uppercased beginning of a word decreases its complexity.
 	const doesUpperCaseDecreaseComplexity = wordComplexityConfig.doesUpperCaseDecreasesComplexity;
 
-	let isWordComplex = false;
-
 	/*
 	 * Check for each word whether it is a complex word or not.
 	 * A word is complex if:
@@ -23,15 +22,21 @@ export default function checkIfWordIsComplex( word ) {
 	 * if the word does NOT start with a capital letter
 	 * (for languages that see long words to be less complex if they start with a capital letter)
 	 */
-	if ( word.length > lengthLimit && ! frequencyList.includes( word ) ) {
-		if ( doesUpperCaseDecreaseComplexity === true && word[ 0 ].toLowerCase() === word[ 0 ] ) {
-			isWordComplex = true;
-		}
+	if ( word.length <= lengthLimit ) {
+		return false;
+	}
+	if ( frequencyList.includes( word ) ) {
+		return false;
+	}
+
+	if ( doesUpperCaseDecreaseComplexity === true && word[ 0 ].toLowerCase() === word[ 0 ] ) {
 		// Check if the word ends on -s (possible plural noun), if it ends on -s remove -s and check for the word is in the list.
 		if ( word.endsWith( "s" ) ) {
 			word = word.substring( 0, word.length - 1 );
-			isWordComplex = ! frequencyList.includes( word );
+			return ! frequencyList.includes( word );
 		}
+		return true;
 	}
-	return isWordComplex;
+
+	return false;
 }

--- a/packages/yoastseo/src/languageProcessing/languages/en/helpers/checkIfWordIsComplex.js
+++ b/packages/yoastseo/src/languageProcessing/languages/en/helpers/checkIfWordIsComplex.js
@@ -25,7 +25,14 @@ export default function checkIfWordIsComplex( word ) {
 	 */
 	if ( word.length > lengthLimit && ! frequencyList.includes( word ) ) {
 		if ( doesUpperCaseDecreaseComplexity === true && word[ 0 ].toLowerCase() === word[ 0 ] ) {
+			console.log( word );
 			isWordComplex = true;
+		}
+		// Check if the word ends on -s (possible plural noun), if it ends on -s remove -s and check for the word in the list
+		if ( word.endsWith( "s" ) ) {
+			word = word.substring( 0, word.length - 1 );
+			console.log( word );
+			isWordComplex = ! frequencyList.includes( word );
 		}
 	}
 	return isWordComplex;

--- a/packages/yoastseo/src/languageProcessing/languages/en/helpers/checkIfWordIsComplex.js
+++ b/packages/yoastseo/src/languageProcessing/languages/en/helpers/checkIfWordIsComplex.js
@@ -1,0 +1,32 @@
+import wordComplexity from "../config/internal/wordComplexity";
+/**
+ * Checks if a word is complex.
+ *
+ * @param {string} word     The word to check.
+ *
+ * @returns {boolean}    Whether or not a word is complex.
+ */
+export default function checkIfWordIsComplex( word ) {
+	const wordComplexityConfig = wordComplexity;
+	const lengthLimit = wordComplexityConfig.wordLength;
+	const frequencyList = wordComplexityConfig.frequencyList;
+	// Whether uppercased beginning of a word decreases its complexity.
+	const doesUpperCaseDecreaseComplexity = wordComplexityConfig.doesUpperCaseDecreasesComplexity;
+
+	let isWordComplex = false;
+
+	/*
+	 * Check for each word whether it is a complex word or not.
+	 * A word is complex if:
+	 * its length is longer than the limit, AND
+	 * the word is not in the frequency list, AND
+	 * if the word does NOT start with a capital letter
+	 * (for languages that see long words to be less complex if they start with a capital letter)
+	 */
+	if ( word.length > lengthLimit && ! frequencyList.includes( word ) ) {
+		if ( doesUpperCaseDecreaseComplexity === true && word[ 0 ].toLowerCase() === word[ 0 ] ) {
+			isWordComplex = true;
+		}
+	}
+	return isWordComplex;
+}

--- a/packages/yoastseo/src/languageProcessing/languages/en/helpers/checkIfWordIsComplex.js
+++ b/packages/yoastseo/src/languageProcessing/languages/en/helpers/checkIfWordIsComplex.js
@@ -25,13 +25,11 @@ export default function checkIfWordIsComplex( word ) {
 	 */
 	if ( word.length > lengthLimit && ! frequencyList.includes( word ) ) {
 		if ( doesUpperCaseDecreaseComplexity === true && word[ 0 ].toLowerCase() === word[ 0 ] ) {
-			console.log( word );
 			isWordComplex = true;
 		}
-		// Check if the word ends on -s (possible plural noun), if it ends on -s remove -s and check for the word in the list
+		// Check if the word ends on -s (possible plural noun), if it ends on -s remove -s and check for the word is in the list.
 		if ( word.endsWith( "s" ) ) {
 			word = word.substring( 0, word.length - 1 );
-			console.log( word );
 			isWordComplex = ! frequencyList.includes( word );
 		}
 	}

--- a/packages/yoastseo/src/languageProcessing/languages/en/helpers/checkIfWordIsComplex.js
+++ b/packages/yoastseo/src/languageProcessing/languages/en/helpers/checkIfWordIsComplex.js
@@ -3,9 +3,9 @@ import wordComplexity from "../config/internal/wordComplexity";
 /**
  * Checks if a word is complex.
  *
- * @param {string} word     The word to check.
+ * @param {string} word The word to check.
  *
- * @returns {boolean}    Whether or not a word is complex.
+ * @returns {boolean} Whether or not a word is complex.
  */
 export default function checkIfWordIsComplex( word ) {
 	const wordComplexityConfig = wordComplexity;
@@ -14,23 +14,27 @@ export default function checkIfWordIsComplex( word ) {
 	// Whether uppercased beginning of a word decreases its complexity.
 	const doesUpperCaseDecreaseComplexity = wordComplexityConfig.doesUpperCaseDecreasesComplexity;
 
-	/*
-	 * Check for each word whether it is a complex word or not.
-	 * A word is complex if:
-	 * its length is longer than the limit, AND
-	 * the word is not in the frequency list, AND
-	 * if the word does NOT start with a capital letter
-	 * (for languages that see long words to be less complex if they start with a capital letter)
-	 */
+	// The word is not complex if it's less than the length limit, i.e. 7 characters for English.
 	if ( word.length <= lengthLimit ) {
 		return false;
 	}
+
+	// The word is not complex if it's in the frequency list.
 	if ( frequencyList.includes( word ) ) {
 		return false;
 	}
 
+	/*
+	 * In English where capital letter beginning decreases the complexity of a word,
+	 * word longer than 7 characters is not complex if it starts with capital letter.
+	 */
 	if ( doesUpperCaseDecreaseComplexity === true && word[ 0 ].toLowerCase() === word[ 0 ] ) {
-		// Check if the word ends on -s (possible plural noun), if it ends on -s remove -s and check for the word is in the list.
+		/*
+		 * If a word is longer than 7 characters and doesn't start with capital letter,
+		 * we check further whether it is a plural ending in -s. If it is, we remove the -s suffix
+		 * and check if the singular word can be found in the frequency list.
+		 * The word is not complex if the singular form is in the list.
+		 */
 		if ( word.endsWith( "s" ) ) {
 			word = word.substring( 0, word.length - 1 );
 			return ! frequencyList.includes( word );

--- a/packages/yoastseo/src/languageProcessing/researches/wordComplexity.js
+++ b/packages/yoastseo/src/languageProcessing/researches/wordComplexity.js
@@ -2,53 +2,21 @@ import getWords from "../helpers/word/getWords.js";
 import getSentences from "../helpers/sentence/getSentences.js";
 import { flatMap } from "lodash-es";
 
-/**
- * Checks if a word is complex.
- *
- * @param {string} word     The word to check.
- * @param {object} config   The config to use.
- *
- * @returns {boolean}    Whether or not a word is complex.
- */
-const checkIfWordIsComplex = function( word, config ) {
-	const lengthLimit = config.wordLength;
-	const frequencyList = config.frequencyList;
-	// Whether uppercased beginning of a word decreases its complexity.
-	const doesUpperCaseDecreaseComplexity = config.doesUpperCaseDecreasesComplexity;
-
-	let isWordComplex = false;
-
-	/*
-	 * Check for each word whether it is a complex word or not.
-	 * A word is complex if:
-	 * its length is longer than the limit, AND
-	 * the word is not in the frequency list, AND
-	 * if the word does NOT start with a capital letter
-	 * (for languages that see long words to be less complex if they start with a capital letter)
-	 */
-	if ( word.length > lengthLimit && ! frequencyList.includes( word ) ) {
-		if ( doesUpperCaseDecreaseComplexity === true && word[ 0 ].toLowerCase() === word[ 0 ] ) {
-			isWordComplex = true;
-		}
-	}
-	return isWordComplex;
-};
-
 
 /**
  * Gets the complex word, along with the index for the sentence.
  *
  * @param {string} sentence  The sentence to get wordComplexity from.
- * @param {Object} config    The config to pass
+ * @param {function} complexWordsHelper A helper to check if a word is complex.
  *
  * @returns {Array} An array of complex word objects containing the  word, the index and the complexity of the word.
  */
-const getComplexWords = function( sentence, config ) {
+const getComplexWords = function( sentence, complexWordsHelper ) {
 	const words = getWords( sentence );
 	const results = [];
 
 	words.forEach( word => {
-		if ( checkIfWordIsComplex( word, config ) ) {
+		if ( complexWordsHelper( word ) ) {
 			results.push( word );
 		}
 	} );
@@ -91,7 +59,7 @@ const calculateComplexWordsPercentage = function( complexWordsResults, words ) {
  */
 export default function wordComplexity( paper, researcher ) {
 	const memoizedTokenizer = researcher.getHelper( "memoizedTokenizer" );
-	const wordComplexityConfig = researcher.getConfig( "wordComplexity" );
+	const wordComplexityConfig = researcher.getHelper( "checkIfWordIsComplex" );
 
 	const text = paper.getText();
 	const sentences = getSentences( text, memoizedTokenizer );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [wordpress-seo-premium] Excludes the plural version of frequent words in English from being marked as complex.
* [wpseo-woocommerce] Excludes the plural version of frequent words in English from being marked as complex.
* [shopify-seo] Excludes the plural version of frequent words in English from being marked as complex.

## Relevant technical choices:

* In this PR, we also move the helper to check if a word is complex to the language folder. This is because the way we check for a complex word might differ between languages.
* In this PR, we only address the regular plural forms with -s suffix.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

Requirement:
* Set the site language to English (currently Word complexity assessment is only available for English)

#### Test with Yoast SEO Premium
* Install and activate the Premium plugin.
   * For developer: run `composer require yoast/wordpress-seo:dev-PC-154-exclude-plurals-of-non-complex-nouns-from-the-word-complexity-assessment@dev` in the premium branch before building the premium plugin.
* Create a post and add this text of 115 words below that contains 9 complex words


[Gothic architecture](https://simple.wikipedia.org/wiki/Gothic_architecture) is a style of [architecture](https://simple.wikipedia.org/wiki/Architecture) used for buildings in Western Europe during the [Middle Ages](https://simple.wikipedia.org/wiki/Middle_Ages). Gothic architecture started in the 12th century, and lasted until the 16th century. Important features of the style are pointed arches, ribbed vaults and flying buttresses.

Today, people associate the style mainly with [cathedrals](https://simple.wikipedia.org/wiki/Cathedral), [churches](https://simple.wikipedia.org/wiki/Church_(building)), and [abbeys](https://simple.wikipedia.org/wiki/Abbey), but it was also used for [castles](https://simple.wikipedia.org/wiki/Castle), [palaces](https://simple.wikipedia.org/wiki/Palace), [universities](https://simple.wikipedia.org/wiki/University), and some houses.

Today, many buildings still remain in that style. Smaller ones are thought to be very beautiful, bigger ones are often seen as priceless works of art.

In the 19th century, the Gothic style became popular again, particularly for building churches and universities. This style is called [Gothic Revival architecture](https://simple.wikipedia.org/wiki/Gothic_Revival_architecture).


* Confirm that Word complexity assessment returns with an ORANGE bullet
   * Note: if [this PR ](https://github.com/Yoast/wordpress-seo/pull/18663)is merged, the bullet is GREEN
* Add these plural forms of words in the [Frequency list](https://github.com/Yoast/wordpress-seo/blob/trunk/packages/yoastseo/src/languageProcessing/languages/en/config/frequencyList.json): `professionals`, `televisions`, `competitions`, `neighborhoods`
* Confirm that Word complexity assessment still returns with an ORANGE bullet 
   * Note: if [this PR ](https://github.com/Yoast/wordpress-seo/pull/18663)is merged, the bullet is GREEN
* Repeat the steps above in taxonomy

#### Test with Yoast SEO: WooCommerce
* Install and activate WooCommerce plugin
* **Note**:
   * For developer: run `composer require yoast/wordpress-seo:dev-PC-154-exclude-plurals-of-non-complex-nouns-from-the-word-complexity-assessment@dev --dev` in the `wpseo-woocommerce` branch before building the Yoast SEO: WooCommerce plugin.
* Set the site language to English
* Create a post and add this text of 115 words below that contains 9 complex words


[Gothic architecture](https://simple.wikipedia.org/wiki/Gothic_architecture) is a style of [architecture](https://simple.wikipedia.org/wiki/Architecture) used for buildings in Western Europe during the [Middle Ages](https://simple.wikipedia.org/wiki/Middle_Ages). Gothic architecture started in the 12th century, and lasted until the 16th century. Important features of the style are pointed arches, ribbed vaults and flying buttresses.

Today, people associate the style mainly with [cathedrals](https://simple.wikipedia.org/wiki/Cathedral), [churches](https://simple.wikipedia.org/wiki/Church_(building)), and [abbeys](https://simple.wikipedia.org/wiki/Abbey), but it was also used for [castles](https://simple.wikipedia.org/wiki/Castle), [palaces](https://simple.wikipedia.org/wiki/Palace), [universities](https://simple.wikipedia.org/wiki/University), and some houses.

Today, many buildings still remain in that style. Smaller ones are thought to be very beautiful, bigger ones are often seen as priceless works of art.

In the 19th century, the Gothic style became popular again, particularly for building churches and universities. This style is called [Gothic Revival architecture](https://simple.wikipedia.org/wiki/Gothic_Revival_architecture).


* Confirm that Word complexity assessment still returns with an ORANGE bullet 
   * Note: if [this PR ](https://github.com/Yoast/wordpress-seo/pull/18663)is merged, the bullet is GREEN
* Add these plural forms of words in the [Frequency list](https://github.com/Yoast/wordpress-seo/blob/trunk/packages/yoastseo/src/languageProcessing/languages/en/config/frequencyList.json): `professionals`, `televisions`, `competitions`, `neighborhoods`
* Confirm that Word complexity assessment still returns with an ORANGE bullet 
   * Note: if [this PR ](https://github.com/Yoast/wordpress-seo/pull/18663)is merged, the bullet is GREEN
* Repeat the steps above in product taxonomy
* **Note**: If the Premium plugin is not activated, the Word complexity assessment doesn't appear inside Readability analysis metabox for Product categories (taxonomies), while it appears in a Product page.


#### Test in Shopify
* **Note**: for developers: link the `wordpress-seo` branch to the `shopify-seo/app` branch before building the app

* Set the store language to English (see [this page](https://yoast.atlassian.net/wiki/spaces/LIN/pages/2178187312/How+to+change+language+in+Shopify#Changing-store-language) on how to change store language in Shopify)
* Create a post and add this text of 115 words below that contains 9 complex words


[Gothic architecture](https://simple.wikipedia.org/wiki/Gothic_architecture) is a style of [architecture](https://simple.wikipedia.org/wiki/Architecture) used for buildings in Western Europe during the [Middle Ages](https://simple.wikipedia.org/wiki/Middle_Ages). Gothic architecture started in the 12th century, and lasted until the 16th century. Important features of the style are pointed arches, ribbed vaults and flying buttresses.

Today, people associate the style mainly with [cathedrals](https://simple.wikipedia.org/wiki/Cathedral), [churches](https://simple.wikipedia.org/wiki/Church_(building)), and [abbeys](https://simple.wikipedia.org/wiki/Abbey), but it was also used for [castles](https://simple.wikipedia.org/wiki/Castle), [palaces](https://simple.wikipedia.org/wiki/Palace), [universities](https://simple.wikipedia.org/wiki/University), and some houses.

Today, many buildings still remain in that style. Smaller ones are thought to be very beautiful, bigger ones are often seen as priceless works of art.

In the 19th century, the Gothic style became popular again, particularly for building churches and universities. This style is called [Gothic Revival architecture](https://simple.wikipedia.org/wiki/Gothic_Revival_architecture).


* Confirm that Word complexity assessment still returns with an ORANGE bullet 
   * Note: if [this PR ](https://github.com/Yoast/wordpress-seo/pull/18663)is merged, the bullet is GREEN
* Add these plural forms of words in the[ Frequency list](https://github.com/Yoast/wordpress-seo/blob/trunk/packages/yoastseo/src/languageProcessing/languages/en/config/frequencyList.json): `professionals`, `televisions`, `competitions`, `neighborhoods`
* Confirm that Word complexity assessment still returns with an ORANGE bullet 
   * Note: if [this PR ](https://github.com/Yoast/wordpress-seo/pull/18663)is merged, the bullet is GREEN
* Repeat the steps above in Collections, Pages, and Blog posts


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [x] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes https://yoast.atlassian.net/browse/PC-154
