### PR TITLE
Rename SEO Analysis to Premium SEO Analysis when Premium is active

### DIFF
--- a/packages/js/src/components/contentAnalysis/SeoAnalysis.js
+++ b/packages/js/src/components/contentAnalysis/SeoAnalysis.js
@@ -6,6 +6,7 @@ import { YoastSeoIcon } from "@yoast/components";
 import PropTypes from "prop-types";
 import styled from "styled-components";
 import getIndicatorForScore from "../../analysis/getIndicatorForScore";
+import getL10nObject from "../../analysis/getL10nObject";
 import Results from "../../containers/Results";
 import AnalysisUpsell from "../AnalysisUpsell";
 import { LocationConsumer } from "@yoast/externals/contexts";
@@ -223,6 +224,7 @@ class SeoAnalysis extends Component {
 	 */
 	render() {
 		const score = getIndicatorForScore( this.props.overallScore );
+		const isPremium = getL10nObject().isPremium;
 
 		if ( score.className !== "loading" && this.props.keyword === "" ) {
 			score.className = "na";
@@ -242,7 +244,7 @@ class SeoAnalysis extends Component {
 					return (
 						<Fragment>
 							<Collapsible
-								title={ __( "SEO analysis", "wordpress-seo" ) }
+								title={ isPremium ? __( "Premium SEO analysis", "wordpress-seo" ) : __( "SEO analysis", "wordpress-seo" ) }
 								titleScreenReaderText={ score.screenReaderReadabilityText }
 								prefixIcon={ getIconForScore( score.className ) }
 								prefixIconCollapsed={ getIconForScore( score.className ) }

--- a/packages/js/src/helpers/addCheckToChecklist.js
+++ b/packages/js/src/helpers/addCheckToChecklist.js
@@ -1,5 +1,6 @@
 import { __ } from "@wordpress/i18n";
 import getIndicatorForScore from "../analysis/getIndicatorForScore";
+import getL10nObject from "../analysis/getL10nObject";
 
 /**
  * Adds a "No focus keyword was entered" result when no focus keyphrase
@@ -56,9 +57,10 @@ export function maybeAddSEOCheck( checklist, store ) {
 
 	if ( isContentAnalysisActive ) {
 		const seoScoreIndicator = getIndicatorForScore( store.getResultsForFocusKeyword().overallScore );
+		const isPremium = getL10nObject().isPremium;
 
 		checklist.push( {
-			label: __( "SEO analysis:", "wordpress-seo" ),
+			label: isPremium ? __( "Premium SEO analysis:", "wordpress-seo" ) : __( "SEO analysis:", "wordpress-seo" ),
 			score: seoScoreIndicator.className,
 			scoreValue: seoScoreIndicator.screenReaderReadabilityText,
 		} );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to change the label `SEO Analysis` to `Premium SEO Analysis` both in the post sidebar and in the metabox when Yoast SEO Premium is activated.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Changes `SEO Analysis` label to `Premium SEO Analysis` when Yoast SEO Premium is activated.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Be sure to have Yoast SEO Premium installed but *not* activated
* Edit a post, and check that:
  * in the block editor sidebar, `SEO Analysis` label is present
<img width="317" alt="Screenshot 2022-07-07 at 10 45 08" src="https://user-images.githubusercontent.com/68744851/177731834-931af522-5189-4bf0-a1f3-8dc7a3c6646a.png">

  * in the Yoast metabox and Yoast sidebar, both `SEO Analysis` and `Premium SEO Analysis` sections are present (the second one being an upsell):

<img width="644" alt="Screenshot 2022-07-07 at 10 45 18" src="https://user-images.githubusercontent.com/68744851/177731877-9b0ffc51-5f3b-42da-9e73-d793ef37b21d.png">

* Now Activate Yoast SEO Premium
* Edit a post, and check that:
  * in the block editor sidebar,  `Premium SEO Analysis` label is present
<img width="294" alt="Screenshot 2022-07-07 at 10 48 18" src="https://user-images.githubusercontent.com/68744851/177732482-f7c4f2e1-1b66-42d8-8667-817a61fcbcfb.png">

  * in the Yoast metabox and Yoast sidebar, only the `Premium SEO Analysis` section is present, and it has the SEO analysis results:
<img width="633" alt="Screenshot 2022-07-07 at 10 48 26" src="https://user-images.githubusercontent.com/68744851/177732525-22a4e5e2-b590-4981-b88f-257be7965758.png">

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->


## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [X] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes [PC-151](https://yoast.atlassian.net/browse/PC-151)
