### PR TITLE
Added note to the readability analysis that tells users that the Flesch reading ease score has moved to the insights section.

### DIFF
--- a/packages/analysis-report/src/AnalysisResult.js
+++ b/packages/analysis-report/src/AnalysisResult.js
@@ -43,7 +43,7 @@ export const AnalysisResult = ( props ) => {
 	return (
 		<AnalysisResultBase>
 			<ScoreIcon
-				icon="circle"
+				icon={ props.icon }
 				color={ props.bulletColor }
 				size="13px"
 			/>
@@ -68,6 +68,7 @@ export const AnalysisResult = ( props ) => {
 };
 
 AnalysisResult.propTypes = {
+	icon: PropTypes.string,
 	text: PropTypes.string.isRequired,
 	suppressedText: PropTypes.bool,
 	bulletColor: PropTypes.string.isRequired,
@@ -82,6 +83,7 @@ AnalysisResult.propTypes = {
 };
 
 AnalysisResult.defaultProps = {
+	icon: "circle",
 	suppressedText: false,
 	marksButtonStatus: "enabled",
 	marksButtonClassName: "",

--- a/packages/components/src/insights-card/InsightsCard.js
+++ b/packages/components/src/insights-card/InsightsCard.js
@@ -13,7 +13,7 @@ class InsightsCard extends React.Component {
 	 */
 	getInsightsCardContent() {
 		return (
-			<div className="yoast-insights-card__content">
+			<div className="yoast-insights-card__content" id={ this.props.id }>
 				<p className="yoast-insights-card__score">
 					<span className="yoast-insights-card__amount">{ this.props.amount }</span>
 					{ this.props.unit }
@@ -46,6 +46,7 @@ class InsightsCard extends React.Component {
 export default InsightsCard;
 
 InsightsCard.propTypes = {
+	id: PropTypes.string.isRequired,
 	title: PropTypes.string,
 	amount: PropTypes.oneOfType( [ PropTypes.number, PropTypes.oneOf( [ "?" ] ) ] ).isRequired,
 	description: PropTypes.element,

--- a/packages/components/src/insights-card/InsightsCard.js
+++ b/packages/components/src/insights-card/InsightsCard.js
@@ -13,7 +13,7 @@ class InsightsCard extends React.Component {
 	 */
 	getInsightsCardContent() {
 		return (
-			<div className="yoast-insights-card__content" id={ this.props.id }>
+			<div className="yoast-insights-card__content">
 				<p className="yoast-insights-card__score">
 					<span className="yoast-insights-card__amount">{ this.props.amount }</span>
 					{ this.props.unit }
@@ -31,14 +31,16 @@ class InsightsCard extends React.Component {
 	 */
 	render() {
 		return (
-			<FieldGroup
-				label={ this.props.title }
-				linkTo={ this.props.linkTo }
-				linkText={ this.props.linkText }
-				wrapperClassName={ "yoast-insights-card" }
-			>
-				{ this.getInsightsCardContent() }
-			</FieldGroup>
+			<div id={ this.props.id }>
+				<FieldGroup
+					label={ this.props.title }
+					linkTo={ this.props.linkTo }
+					linkText={ this.props.linkText }
+					wrapperClassName={ "yoast-insights-card" }
+				>
+					{ this.getInsightsCardContent() }
+				</FieldGroup>
+			</div>
 		);
 	}
 }

--- a/packages/js/src/insights/components/estimated-reading-time.js
+++ b/packages/js/src/insights/components/estimated-reading-time.js
@@ -14,6 +14,7 @@ const EstimatedReadingTime = () => {
 
 	return (
 		<InsightsCard
+			id={ "yoastseo-estimated-reading-time-insights" }
 			amount={ estimatedReadingTime }
 			unit={ _n( "minute", "minutes", estimatedReadingTime, "wordpress-seo" ) }
 			title={ __( "Reading time", "wordpress-seo" ) }

--- a/packages/js/src/insights/components/flesch-reading-ease.js
+++ b/packages/js/src/insights/components/flesch-reading-ease.js
@@ -132,6 +132,7 @@ const FleschReadingEase = () => {
 
 	return (
 		<InsightsCard
+			id={ "yoastseo-flesch-reading-ease-insights" }
 			amount={ score }
 			unit={ __( "out of 100", "wordpress-seo" ) }
 			title={ __( "Flesch reading ease", "wordpress-seo" ) }

--- a/packages/js/src/insights/components/text-length.js
+++ b/packages/js/src/insights/components/text-length.js
@@ -23,6 +23,7 @@ const TextLength = () => {
 
 	return (
 		<InsightsCard
+			id={ "yoastseo-text-length-insights" }
 			amount={ textLength.count }
 			unit={ unitString }
 			title={ titleString }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds a note to the readability analysis that tells users that the Flesch reading ease score has moved to the insights section.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Block / Gutenberg editor.
* Create a new post.
* Open the readability analysis in the metabox.
* Confirm that below the assessments, a paragraph with the following text is shown: `Curious to see the [Flesch reading ease] score of your text? We’ve moved it to our [Insights] section.`
* Confirm that the first link leads to the page on Flesch reading ease on [yoast.com](http://yoast.com/), including the tracking parameters.
* Confirm that clicking on the second link scrolls to the Flesch reading ease score in the Insights section.
* Repeat the above steps for the readability analysis in the sidebar.

#### Classic editor
* Repeat the above steps, but given that there is no sidebar, you only have to test the metabox.

#### Elementor
* Create a new post.
* Edit the post using Elementor.
* Open the readability analysis in the Yoast SEO section.
* Confirm that below the assessments, a paragraph with the following text is shown: `Curious to see the [Flesch reading ease] score of your text? We’ve moved it to our [Insights] section.`
* Confirm that the first link leads to the page on Flesch reading ease on [yoast.com](http://yoast.com/), including the tracking parameters.
* Confirm that clicking on the second link opens the insights modal.

Please repeat the above steps with Premium active.

#### Upgrade from previous release
* Install a previous version of the plugin.
* Create a new post.
* Install the latest version of the plugin (that includes this change).
* Open the post inside of the block editor.
* Open the readability analysis in the metabox.
* Confirm that below the assessments, a paragraph with the following text is shown: `Curious to see the [Flesch reading ease] score of your text? We’ve moved it to our [Insights] section.`
* Confirm that the first link leads to the page on Flesch reading ease on [yoast.com](http://yoast.com/), including the tracking parameters.
* Confirm that clicking on the second link scrolls to the Flesch reading ease score in the Insights section.
* Repeat the above steps for the readability analysis in the sidebar.

**Do a quick check on post/page/taxonomies/CPT/custom taxonomy.
**Test with Premium activated/deactivated

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes #
