### PR TITLE
Fix insights link in sidebar

### DIFF
--- a/admin/class-expose-shortlinks.php
+++ b/admin/class-expose-shortlinks.php
@@ -62,6 +62,8 @@ class WPSEO_Expose_Shortlinks implements WPSEO_WordPress_Integration {
 		'shortlinks.wincher.seo_performance'                        => 'https://yoa.st/wincher-integration',
 		'shortlinks-insights-estimated_reading_time'                => 'https://yoa.st/4fd',
 		'shortlinks-insights-flesch_reading_ease'                   => 'https://yoa.st/34r',
+		'shortlinks-insights-flesch_reading_ease_sidebar'           => 'https://yoa.st/4mf',
+		'shortlinks-insights-flesch_reading_ease_metabox'           => 'https://yoa.st/4mg',
 		'shortlinks-insights-flesch_reading_ease_article'           => 'https://yoa.st/34s',
 		'shortlinks-insights-keyword_research_link'                 => 'https://yoa.st/keyword-research-metabox',
 		'shortlinks-insights-upsell-sidebar-prominent_words'        => 'https://yoa.st/prominent-words-upsell-sidebar',

--- a/packages/js/src/components/contentAnalysis/ReadabilityAnalysis.js
+++ b/packages/js/src/components/contentAnalysis/ReadabilityAnalysis.js
@@ -120,12 +120,15 @@ class ReadabilityAnalysis extends Component {
 	 * Returns a note letting the user know that the Flesch reading ease score has moved to
 	 * the insights section.
 	 *
+	 * @param {string} location The location of the readability analysis (e.g. "metabox" or "sidebar" ).
+	 *
 	 * @returns {JSX.Element} The Flesch reading ease note.
 	 */
-	renderFleschReadingEaseNote() {
+	renderFleschReadingEaseNote( location ) {
 		const onClick = `
+			const location = "${ location }";
 			const metaTab = document.getElementById( "wpseo-meta-tab-content" );
-			if ( metaTab ) {
+			if ( metaTab && location === "metabox" ) {
 				metaTab.click();
 				setTimeout( () => {
 					const collapsible = document.getElementById( "yoast-insights-collapsible-metabox" );
@@ -134,6 +137,8 @@ class ReadabilityAnalysis extends Component {
 					}
 					document.getElementById( "yoastseo-flesch-reading-ease-insights" ).scrollIntoView();
 				}, 300 );
+			} else if ( location === "sidebar" ) {
+				document.getElementById( "yoast-insights-modal-sidebar-open-button" ).click();
 			} else {
 				document.getElementById( "yoast-insights-modal-elementor-open-button" ).click();
 			}
@@ -208,7 +213,7 @@ class ReadabilityAnalysis extends Component {
 								id={ `yoast-readability-analysis-collapsible-${ location }` }
 							>
 								{ this.renderResults( upsellResults ) }
-								{ this.renderFleschReadingEaseNote() }
+								{ this.renderFleschReadingEaseNote( location ) }
 							</Collapsible>
 						);
 					}
@@ -222,7 +227,7 @@ class ReadabilityAnalysis extends Component {
 										scoreIndicator={ score.className }
 									/>
 									{ this.renderResults( upsellResults ) }
-									{ this.renderFleschReadingEaseNote() }
+									{ this.renderFleschReadingEaseNote( location ) }
 								</ReadabilityResultsTabContainer>
 							</ReadabilityResultsPortal>
 						);

--- a/packages/js/src/components/contentAnalysis/ReadabilityAnalysis.js
+++ b/packages/js/src/components/contentAnalysis/ReadabilityAnalysis.js
@@ -182,7 +182,7 @@ class ReadabilityAnalysis extends Component {
 					%2$s is an anchor closing tag; */
 				__( "Curious to see the %1$sFlesch reading ease%2$s score of your text? " +
 					"We've moved the score to our Insights section. " +
-					"Enable the Insights feature in General > Settings, or ask your admin to enable it for you.", "wordpress-seo" ),
+					"Enable the Insights feature in General > Features, or ask your admin to enable it for you.", "wordpress-seo" ),
 				`<a href='${ linkToYoastCom }' target='_blank'>`,
 				"</a>"
 			);

--- a/packages/js/src/components/contentAnalysis/ReadabilityAnalysis.js
+++ b/packages/js/src/components/contentAnalysis/ReadabilityAnalysis.js
@@ -157,6 +157,10 @@ class ReadabilityAnalysis extends Component {
 				<path d="${ icons[ "pencil-square" ].path }"></path>
 		</svg>`;
 
+		const linkToYoastCom = location === "sidebar"
+			? wpseoAdminL10n[ "shortlinks-insights-flesch_reading_ease_sidebar" ]
+			: wpseoAdminL10n[ "shortlinks-insights-flesch_reading_ease_metabox" ];
+
 		const text = sprintf(
 			/* Translators:
 				%1$s is an anchor opening tag with a link leading to an article on yoast.com;
@@ -164,7 +168,7 @@ class ReadabilityAnalysis extends Component {
 				%3$s is an anchor opening tag with a link to our insights section;
 				%4$s is an icon. */
 			__( "Curious to see the %1$sFlesch reading ease%2$s score of your text? We've moved the score to our %3$sInsights%4$s%2$s section.", "wordpress-seo" ),
-			`<a href='${ wpseoAdminL10n[ "shortlinks-insights-flesch_reading_ease" ] }' target='_blank'>`,
+			`<a href='${ linkToYoastCom }' target='_blank'>`,
 			"</a>",
 			`<a href='#' onclick='${ onClick }'>`,
 			icon

--- a/packages/js/src/components/contentAnalysis/ReadabilityAnalysis.js
+++ b/packages/js/src/components/contentAnalysis/ReadabilityAnalysis.js
@@ -125,25 +125,6 @@ class ReadabilityAnalysis extends Component {
 	 * @returns {JSX.Element} The Flesch reading ease note.
 	 */
 	renderFleschReadingEaseNote( location ) {
-		const onClick = `
-			const location = "${ location }";
-			const metaTab = document.getElementById( "wpseo-meta-tab-content" );
-			if ( metaTab && location === "metabox" ) {
-				metaTab.click();
-				setTimeout( () => {
-					const collapsible = document.getElementById( "yoast-insights-collapsible-metabox" );
-					if( collapsible.getAttribute( "aria-expanded" ) === "false" ) {
-						collapsible.click();
-					}
-					document.getElementById( "yoastseo-flesch-reading-ease-insights" ).scrollIntoView();
-				}, 300 );
-			} else if ( location === "sidebar" ) {
-				document.getElementById( "yoast-insights-modal-sidebar-open-button" ).click();
-			} else {
-				document.getElementById( "yoast-insights-modal-elementor-open-button" ).click();
-			}
-		`.replaceAll( /(\n|\s)+/g, " " );
-
 		const icon = `<svg
 			style="vertical-align: middle; margin-left: 2px"
 			width="14px"
@@ -161,18 +142,51 @@ class ReadabilityAnalysis extends Component {
 			? wpseoAdminL10n[ "shortlinks-insights-flesch_reading_ease_sidebar" ]
 			: wpseoAdminL10n[ "shortlinks-insights-flesch_reading_ease_metabox" ];
 
-		const text = sprintf(
-			/* Translators:
-				%1$s is an anchor opening tag with a link leading to an article on yoast.com;
-				%2$s is an anchor closing tag;
-				%3$s is an anchor opening tag with a link to our insights section;
-				%4$s is an icon. */
-			__( "Curious to see the %1$sFlesch reading ease%2$s score of your text? We've moved the score to our %3$sInsights%4$s%2$s section.", "wordpress-seo" ),
-			`<a href='${ linkToYoastCom }' target='_blank'>`,
-			"</a>",
-			`<a href='#' onclick='${ onClick }'>`,
-			icon
-		);
+		let text = "";
+		if ( this.props.isInsightsEnabled ) {
+			const onClick = `
+			const location = "${ location }";
+			const metaTab = document.getElementById( "wpseo-meta-tab-content" );
+			if ( metaTab && location === "metabox" ) {
+				metaTab.click();
+				setTimeout( () => {
+					const collapsible = document.getElementById( "yoast-insights-collapsible-metabox" );
+					if( collapsible.getAttribute( "aria-expanded" ) === "false" ) {
+						collapsible.click();
+					}
+					document.getElementById( "yoastseo-flesch-reading-ease-insights" ).scrollIntoView();
+				}, 300 );
+			} else if ( location === "sidebar" ) {
+				document.getElementById( "yoast-insights-modal-sidebar-open-button" ).click();
+			} else {
+				document.getElementById( "yoast-insights-modal-elementor-open-button" ).click();
+			}
+			`.replaceAll( /(\n|\s)+/g, " " );
+
+			text = sprintf(
+				/* Translators:
+					%1$s is an anchor opening tag with a link leading to an article on yoast.com;
+					%2$s is an anchor closing tag;
+					%3$s is an anchor opening tag with a link to our insights section;
+					%4$s is an icon. */
+				__( "Curious to see the %1$sFlesch reading ease%2$s score of your text? We've moved the score to our %3$sInsights%4$s%2$s section.", "wordpress-seo" ),
+				`<a href='${ linkToYoastCom }' target='_blank'>`,
+				"</a>",
+				`<a href='#' onclick='${ onClick }'>`,
+				icon
+			);
+		} else {
+			text = sprintf(
+				/* Translators:
+					%1$s is an anchor opening tag with a link leading to an article on yoast.com;
+					%2$s is an anchor closing tag; */
+				__( "Curious to see the %1$sFlesch reading ease%2$s score of your text? " +
+					"We've moved the score to our Insights section. " +
+					"Enable the Insights feature in General > Settings, or ask your admin to enable it for you.", "wordpress-seo" ),
+				`<a href='${ linkToYoastCom }' target='_blank'>`,
+				"</a>"
+			);
+		}
 
 		return <ul>
 			<AnalysisResult
@@ -248,22 +262,28 @@ ReadabilityAnalysis.propTypes = {
 	overallScore: PropTypes.number,
 	shouldUpsell: PropTypes.bool,
 	isYoastSEOWooActive: PropTypes.bool,
+	isInsightsEnabled: PropTypes.bool,
 };
 
 ReadabilityAnalysis.defaultProps = {
 	overallScore: null,
 	shouldUpsell: false,
 	isYoastSEOWooActive: false,
+	isInsightsEnabled: false,
 };
 
 export default withSelect( select => {
 	const {
 		getReadabilityResults,
 		getMarkButtonStatus,
+		getPreference,
 	} = select( "yoast-seo/editor" );
+
+	const isInsightsEnabled = getPreference( "isInsightsEnabled", false );
 
 	return {
 		...getReadabilityResults(),
 		marksButtonStatus: getMarkButtonStatus(),
+		isInsightsEnabled,
 	};
 } )( ReadabilityAnalysis );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the link to the insights section inside of the "Flesch reading ease has moved" notification inside of the sidebar would not link to the insights modal in the sidebar, but to the insights section in the metabox instead.
* Splits up the shortlinks used in the "Flesch reading ease has moved" notification to one used in the metabox and one used in the sidebar.
* Changes the copy of the "Flesch reading ease has moved" notification when insights are disabled.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Insights link in sidebar
* Create a post (in the default block editor).
* Open the readability analysis results in the Yoast sidebar.
* Click on the "Insights" link inside of the "Flesch reading ease has moved" notification.
* The Insights modal should be opened, instead of the insights section in the metabox.
* Activate the Gutenberg editor.
* Repeat the steps above.

#### Different shortlinks in sidebar and metabox
* Create a post.
* Open the readability analysis results in the Yoast **sidebar**.
* Hover over the "Flesch reading ease" link inside of the "Flesch reading ease has moved" notification.
    * The link should lead to https://yoa.st/4mf.
* Open the readability analysis results in the Yoast **metabox**.
* Hover over the "Flesch reading ease" link inside of the "Flesch reading ease has moved" notification.
    * The link should lead to https://yoa.st/4mg
* Also test in classic editor and/or categories/tags. In these cases, only the metabox is shown and the link there should lead to https://yoa.st/4mg.

#### Different text when insights are disabled
* Disable the insights feature in the Yoast SEO settings (_Yoast SEO_ > _General_ > _Features_)
* Create a post.
* Open the readability analysis results.
* Navigate to the "Flesch reading ease has moved" notification.
   * It should have the text: `Curious to see the Flesch reading ease score of your text? We've moved the score to our Insights section. Enable the Insights feature in General > Features, or ask your admin to enable it for you.`.
* Enable the insights feature in the Yoast SEO settings.
* Open a post (or create a new one).
* Open the readability analysis results.
* Navigate to the "Flesch reading ease has moved" notification.
   * It should have the text: `Curious to see the Flesch reading ease score of your text? We've moved the score to our Insights section.`.
   
** Do a quick check on post/page/taxonomies/CPT/custom taxonomy.
** Test with Premium activated/deactivated
** Test on multisite

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes #https://yoast.atlassian.net/browse/PC-197
