### PR TITLE
PC-198 only show word complexity upsell for languages that support word complexity

### DIFF
--- a/packages/js/src/components/contentAnalysis/ReadabilityAnalysis.js
+++ b/packages/js/src/components/contentAnalysis/ReadabilityAnalysis.js
@@ -89,7 +89,7 @@ class ReadabilityAnalysis extends Component {
 		 * Additionally, we also don't show the upsell for Word complexity assessment if it's not supported for the current locale.
 		*/
 		const contentType = wpseoAdminL10n.postType;
-		if ( this.props.isYoastSEOWooActive && contentType === "product" && ! isWordComplexitySupported() ) {
+		if ( ( this.props.isYoastSEOWooActive && contentType === "product" ) || ! isWordComplexitySupported() ) {
 			return [];
 		}
 

--- a/packages/js/src/components/contentAnalysis/ReadabilityAnalysis.js
+++ b/packages/js/src/components/contentAnalysis/ReadabilityAnalysis.js
@@ -18,6 +18,7 @@ import HelpLink from "../HelpLink";
 import ReadabilityResultsPortal from "../portals/ReadabilityResultsPortal";
 import { AnalysisResult } from "@yoast/analysis-report";
 import { icons } from "@yoast/components";
+import { isWordComplexitySupported } from "../../helpers/assessmentUpsellHelpers";
 
 const AnalysisHeader = styled.span`
 	font-size: 1em;
@@ -85,9 +86,10 @@ class ReadabilityAnalysis extends Component {
 		/*
 		 * We don't show the upsell in WooCommerce product pages when Yoast SEO WooCommerce plugin is activated.
 		 * This is because the premium assessments of the upsell are already loaded even when the Premium plugin is not activated.
+		 * Additionally, we also don't show the upsell for Word complexity assessment if it's not supported for the current locale.
 		*/
 		const contentType = wpseoAdminL10n.postType;
-		if ( this.props.isYoastSEOWooActive && contentType === "product" ) {
+		if ( this.props.isYoastSEOWooActive && contentType === "product" && ! isWordComplexitySupported() ) {
 			return [];
 		}
 

--- a/packages/js/src/helpers/assessmentUpsellHelpers.js
+++ b/packages/js/src/helpers/assessmentUpsellHelpers.js
@@ -10,7 +10,5 @@ export function isWordComplexitySupported() {
 	const locale = window.wpseoScriptData.metabox.contentLocale;
 	const language = languageProcessing.getLanguage( locale );
 
-	console.log(  languagesWithSupport.includes( language ), "word complexity" );
-
 	return languagesWithSupport.includes( language );
 }

--- a/packages/js/src/helpers/assessmentUpsellHelpers.js
+++ b/packages/js/src/helpers/assessmentUpsellHelpers.js
@@ -1,0 +1,16 @@
+import { languageProcessing, helpers } from "yoastseo";
+
+/**
+ * Checks if the content language has Word complexity assessment support.
+ *
+ * @returns {boolean} Returns true if Word complexity assessment is supported for the current locale.
+ */
+export function isWordComplexitySupported() {
+	const languagesWithSupport = helpers.getLanguagesWithWordComplexity();
+	const locale = window.wpseoScriptData.metabox.contentLocale;
+	const language = languageProcessing.getLanguage( locale );
+
+	console.log(  languagesWithSupport.includes( language ), "word complexity" );
+
+	return languagesWithSupport.includes( language );
+}

--- a/packages/yoastseo/spec/helpers/getLanguagesWithWordComplexitySpec.js
+++ b/packages/yoastseo/spec/helpers/getLanguagesWithWordComplexitySpec.js
@@ -1,0 +1,8 @@
+import { getLanguagesWithWordComplexity } from "../../src/helpers";
+const supportedLanguages = [ "en" ];
+
+describe( "a test to check whether we have word complexity support for a language", function() {
+	it( "compares the array of languages for which we support word complexity to a test array", function() {
+		expect( getLanguagesWithWordComplexity() ).toEqual( supportedLanguages );
+	} );
+} );

--- a/packages/yoastseo/spec/helpers/getLanguagesWithWordFormSupportSpec.js
+++ b/packages/yoastseo/spec/helpers/getLanguagesWithWordFormSupportSpec.js
@@ -1,5 +1,6 @@
 import { getLanguagesWithWordFormSupport } from "../../src/helpers";
-const supportedLanguagesSpec = [ "en", "de", "es", "fr", "it", "nl", "ru", "id", "pt", "pl", "ar", "sv", "he", "hu", "nb", "tr", "cs", "sk", "el", "ja" ];
+const supportedLanguagesSpec = [ "en", "de", "es", "fr", "it", "nl", "ru", "id", "pt", "pl", "ar", "sv", "he", "hu",
+	"nb", "tr", "cs", "sk", "el", "ja" ];
 
 describe( "a test to check whether we have morphology support for a language", function() {
 	it( "compares the array of languages for which we support morphology to a test array", function() {

--- a/packages/yoastseo/src/helpers/getLanguagesWithWordComplexity.js
+++ b/packages/yoastseo/src/helpers/getLanguagesWithWordComplexity.js
@@ -1,0 +1,8 @@
+/**
+ * Checks which languages have Word complexity support.
+ *
+ * @returns {string[]} A list of languages that have Word complexity support.
+ */
+export function getLanguagesWithWordComplexity() {
+	return [ "en", "de", "fr", "es" ];
+}

--- a/packages/yoastseo/src/helpers/getLanguagesWithWordComplexity.js
+++ b/packages/yoastseo/src/helpers/getLanguagesWithWordComplexity.js
@@ -4,5 +4,5 @@
  * @returns {string[]} A list of languages that have Word complexity support.
  */
 export function getLanguagesWithWordComplexity() {
-	return [ "en", "de", "fr", "es" ];
+	return [ "en" ];
 }

--- a/packages/yoastseo/src/helpers/getLanguagesWithWordComplexity.js
+++ b/packages/yoastseo/src/helpers/getLanguagesWithWordComplexity.js
@@ -1,5 +1,5 @@
 /**
- * Checks which languages have Word complexity support.
+ * Returns an array of languages with Word complexity support.
  *
  * @returns {string[]} A list of languages that have Word complexity support.
  */

--- a/packages/yoastseo/src/helpers/index.js
+++ b/packages/yoastseo/src/helpers/index.js
@@ -1,9 +1,11 @@
 import { measureTextWidth } from "./createMeasurementElement";
 import { getLanguagesWithWordFormSupport } from "./getLanguagesWithWordFormSupport";
 import formatNumber from "./formatNumber";
+import { getLanguagesWithWordComplexity } from "./getLanguagesWithWordComplexity";
 
 export {
 	measureTextWidth,
 	getLanguagesWithWordFormSupport,
 	formatNumber,
+	getLanguagesWithWordComplexity,
 };

--- a/packages/yoastseo/src/languageProcessing/index.js
+++ b/packages/yoastseo/src/languageProcessing/index.js
@@ -26,6 +26,7 @@ import { stripFullTags as stripHTMLTags } from "./helpers/sanitize/stripHTMLTags
 import sanitizeString from "./helpers/sanitize/sanitizeString";
 import removePunctuation from "./helpers/sanitize/removePunctuation";
 import countMetaDescriptionLength from "./helpers/word/countMetaDescriptionLength";
+import getLanguage from "./helpers/language/getLanguage";
 
 export {
 	AbstractResearcher,
@@ -57,4 +58,5 @@ export {
 	countMetaDescriptionLength,
 	sanitizeString,
 	removePunctuation,
+	getLanguage,
 };


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [yoastseo] Adds a helper to return the supported languages for Word complexity assessment.
* [wpseo-woocommerce] Makes the Word complexity assessment upsell not show in product pages and taxonomies for unsupported languages.
* [wordpress-seo-premium] Makes the Word complexity assessment upsell not show in all content types for unsupported languages.
* Makes the Word complexity assessment upsell not show in all content types for unsupported languages.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Test with Yoast SEO Free in all editors
* Install and activate Yoast SEO
* Set the site language to any language other than English
* Create a post with at least 50 characters
* Go to Readability analysis and confirm that the greyed out upsell for Word complexity assessment doesn't appear
* Change the site language to English
* Go back to the previous post
* Go to Readability analysis and confirm that the greyed out upsell for Word complexity assessment appears
* Repeat the steps above for other post types (pages/ custom post type/ custom taxonomy)
* Repeat the steps above in all editors (Classic, default/Gutenberg, Elementor)

##### Test Yoast SEO Free and WooCommerce plugin
* Install and activate Yoast SEO
* Install and activate WooCommerce plugin
* Set the site language to any language other than English
* Create a product with at least 50 characters
* Go to Readability analysis and confirm that the greyed out upsell for Word complexity assessment doesn't appear
* Change the site language to English
* Go back to the previous product
* Go to Readability analysis and confirm that the greyed out upsell for Word complexity assessment appears
* Repeat the steps above for other product taxonomies

#### Test with Yoast SEO Premium in all editors
* Install and activate Yoast SEO
* Install and activate Yoast SEO Premium
   * For developers: run `composer require yoast/wordpress-seo:dev-PC-198-only-show-word-complexity-upsell-for-languages-that-support-word-complexity@dev` before building the Premium plugin. Build the premium plugin from `release/18.9` branch. 
* Set the site language to any language other than English
* Create a post with at least 50 characters
* Go to Readability analysis and confirm that the greyed out upsell for Word complexity assessment doesn't appear
* Change the site language to English
* Go back to the previous post
* Go to Readability analysis and confirm:
   * that the greyed out upsell for Word complexity assessment doesn't appear
   * that the Word complexity assessment appears with one of the feedback in [this documentation](https://github.com/Yoast/wordpress-seo/blob/trunk/packages/yoastseo/src/scoring/assessments/SCORING%20READABILITY.md#8-word-complexity-only-in-premium)
* Repeat the steps above for other post types (pages/ custom post type/ custom taxonomy)
* Repeat the steps above in all editors (Classic, default/Gutenberg, Elementor)

#### Test with Yoast SEO for WooCommerce
* Install and activate WooCommerce plugin
* Install and activate Yoast SEO
* Install and activate Yoast SEO for WooCommerce
   * For developers: run `composer require yoast/wordpress-seo:dev-PC-198-only-show-word-complexity-upsell-for-languages-that-support-word-complexity@dev --dev` before building the `wpseo-woocommerce` plugin. Build the `wpseo-woocommerce` plugin from `release/15.0` branch. 

##### Test in Product
* Set the site language to any language other than English
* Create a product with at least 50 characters
* Go to Readability analysis and confirm that the greyed out upsell for Word complexity assessment doesn't appear
* Change the site language to English
* Go back to the previous product
* Go to Readability analysis and confirm:
   * that the greyed out upsell for Word complexity assessment doesn't appear
   * that the Word complexity assessment appears with one of the feedback in [this documentation](https://github.com/Yoast/wordpress-seo/blob/trunk/packages/yoastseo/src/scoring/assessments/SCORING%20READABILITY.md#8-word-complexity-only-in-premium)
##### test in product taxonomies
* Set the site language to any language other than English
* Create a product taxonomy with at least 50 characters
* Go to Readability analysis and confirm that the greyed out upsell for Word complexity assessment doesn't appear
* Change the site language to English
* Go to Readability analysis and confirm that the greyed out upsell for Word complexity assessment appears
* Note: If the Premium plugin is not activated, the Word complexity assessment doesn't appear inside Readability analysis metabox for Product categories (taxonomies), while it appears in a Product page. The expected behaviour for this case still needs to be discussed in [a separate issue](https://yoast.atlassian.net/browse/LINGO-1529). For now, this behaviour is inline with the behaviour of Keyphrase distribution assessment (premium feature).

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes #
