### PR TITLE
Fixed insights link in Elementor editor.

### DIFF
--- a/packages/js/src/components/contentAnalysis/ReadabilityAnalysis.js
+++ b/packages/js/src/components/contentAnalysis/ReadabilityAnalysis.js
@@ -150,20 +150,20 @@ class ReadabilityAnalysis extends Component {
 			
 			if ( isElementor ) {
 				document.getElementById( "yoast-insights-modal-elementor-open-button" ).click();
-			}
-			
-			const metaTab = document.getElementById( "wpseo-meta-tab-content" );
-			if ( metaTab && location === "metabox" ) {
-				metaTab.click();
-				setTimeout( () => {
-					const collapsible = document.getElementById( "yoast-insights-collapsible-metabox" );
-					if( collapsible.getAttribute( "aria-expanded" ) === "false" ) {
-						collapsible.click();
-					}
-					document.getElementById( "yoastseo-flesch-reading-ease-insights" ).scrollIntoView();
-				}, 300 );
-			} else if ( location === "sidebar" ) {
-				document.getElementById( "yoast-insights-modal-sidebar-open-button" ).click();
+			} else {
+				const metaTab = document.getElementById( "wpseo-meta-tab-content" );
+				if ( metaTab && location === "metabox" ) {
+					metaTab.click();
+					setTimeout( () => {
+						const collapsible = document.getElementById( "yoast-insights-collapsible-metabox" );
+						if( collapsible.getAttribute( "aria-expanded" ) === "false" ) {
+							collapsible.click();
+						}
+						document.getElementById( "yoastseo-flesch-reading-ease-insights" ).scrollIntoView();
+					}, 300 );
+				} else if ( location === "sidebar" ) {
+					document.getElementById( "yoast-insights-modal-sidebar-open-button" ).click();
+				}
 			}
 			`.replaceAll( /(\n|\s)+/g, " " );
 

--- a/packages/js/src/components/contentAnalysis/ReadabilityAnalysis.js
+++ b/packages/js/src/components/contentAnalysis/ReadabilityAnalysis.js
@@ -146,6 +146,12 @@ class ReadabilityAnalysis extends Component {
 		if ( this.props.isInsightsEnabled ) {
 			const onClick = `
 			const location = "${ location }";
+			const isElementor = ${ this.props.isElementorEditor };
+			
+			if ( isElementor ) {
+				document.getElementById( "yoast-insights-modal-elementor-open-button" ).click();
+			}
+			
 			const metaTab = document.getElementById( "wpseo-meta-tab-content" );
 			if ( metaTab && location === "metabox" ) {
 				metaTab.click();
@@ -158,8 +164,6 @@ class ReadabilityAnalysis extends Component {
 				}, 300 );
 			} else if ( location === "sidebar" ) {
 				document.getElementById( "yoast-insights-modal-sidebar-open-button" ).click();
-			} else {
-				document.getElementById( "yoast-insights-modal-elementor-open-button" ).click();
 			}
 			`.replaceAll( /(\n|\s)+/g, " " );
 
@@ -263,6 +267,7 @@ ReadabilityAnalysis.propTypes = {
 	shouldUpsell: PropTypes.bool,
 	isYoastSEOWooActive: PropTypes.bool,
 	isInsightsEnabled: PropTypes.bool,
+	isElementorEditor: PropTypes.bool,
 };
 
 ReadabilityAnalysis.defaultProps = {
@@ -270,6 +275,7 @@ ReadabilityAnalysis.defaultProps = {
 	shouldUpsell: false,
 	isYoastSEOWooActive: false,
 	isInsightsEnabled: false,
+	isElementorEditor: false,
 };
 
 export default withSelect( select => {
@@ -277,6 +283,7 @@ export default withSelect( select => {
 		getReadabilityResults,
 		getMarkButtonStatus,
 		getPreference,
+		getIsElementorEditor,
 	} = select( "yoast-seo/editor" );
 
 	const isInsightsEnabled = getPreference( "isInsightsEnabled", false );
@@ -285,5 +292,6 @@ export default withSelect( select => {
 		...getReadabilityResults(),
 		marksButtonStatus: getMarkButtonStatus(),
 		isInsightsEnabled,
+		isElementorEditor: getIsElementorEditor(),
 	};
 } )( ReadabilityAnalysis );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the insights link does not work in the Elementor editor.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Create or open a post in the Elementor editor.
* Navigate to the readability analysis results.
* in the "Flesch reading ease has moved" notification, click in the link labeled "Insights".
* The Insights modal should open.
* Also test the link in the classic editor, block editor, Gutenberg. 
* Test the link found in the sidebar as well as the metabox where applicable.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes https://yoast.atlassian.net/browse/PC-203
