### PR TITLE
[PC-214] Dynamically load custom fields instead of loading all at once

### DIFF
--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -1103,9 +1103,25 @@ class WPSEO_Metabox extends WPSEO_Meta {
 			return $custom_replace_vars;
 		}
 
+		// Simply concatenate all fields containing replace vars so we can handle them all with a single regex find.
+		$replace_vars_fields = implode(
+			' ',
+			[
+				YoastSEO()->meta->for_post( $post->ID )->presentation->title,
+				YoastSEO()->meta->for_post( $post->ID )->presentation->meta_description,
+			]
+		);
+
+		preg_match_all( '/%%cf_([A-Za-z0-9_]+)%%/', $replace_vars_fields, $matches );
+		$fields_to_include = $matches[1];
 		foreach ( $custom_fields as $custom_field_name => $custom_field ) {
 			// Skip private custom fields.
 			if ( substr( $custom_field_name, 0, 1 ) === '_' ) {
+				continue;
+			}
+
+			// Skip custom fields that are not used, new ones will be fetched dynamically.
+			if ( ! in_array( $custom_field_name, $fields_to_include, true ) ) {
 				continue;
 			}
 

--- a/inc/class-wpseo-custom-fields.php
+++ b/inc/class-wpseo-custom-fields.php
@@ -47,6 +47,14 @@ class WPSEO_Custom_Fields {
 			LIMIT %d";
 		$fields = $wpdb->get_col( $wpdb->prepare( $sql, $limit ) );
 
+		/**
+		 * Filters the custom fields that are auto-completed and replaced as replacement variables
+		 * in the meta box and sidebar.
+		 *
+		 * @param string[] $fields The custom field names.
+		 */
+		$fields = apply_filters( 'wpseo_replacement_variables_custom_fields', $fields );
+
 		if ( is_array( $fields ) ) {
 			self::$custom_fields = array_map( [ 'WPSEO_Custom_Fields', 'add_custom_field_prefix' ], $fields );
 		}

--- a/packages/js/src/containers/SnippetEditor.js
+++ b/packages/js/src/containers/SnippetEditor.js
@@ -3,6 +3,7 @@ import { withDispatch, withSelect } from "@wordpress/data";
 import { __ } from "@wordpress/i18n";
 import { SnippetEditor } from "@yoast/search-metadata-previews";
 import { LocationConsumer } from "@yoast/externals/contexts";
+import { debounce } from "lodash-es";
 import SnippetPreviewSection from "../components/SnippetPreviewSection";
 import { applyReplaceUsingPlugin } from "../helpers/replacementVariableHelpers";
 
@@ -134,6 +135,10 @@ export function mapDispatchToProps( dispatch, ownProps, { select } ) {
 		findCustomFields,
 	} = dispatch( "yoast-seo/editor" );
 	const coreEditorDispatch = dispatch( "core/editor" );
+	const onReplacementVariableSearchChange = debounce(
+		value => findCustomFields( value, select( "core/editor" ).getCurrentPostId() ),
+		500
+	);
 
 	return {
 		onChange: ( key, value ) => {
@@ -160,9 +165,7 @@ export function mapDispatchToProps( dispatch, ownProps, { select } ) {
 			}
 		},
 		onChangeAnalysisData: updateAnalysisData,
-		onReplacementVariableSearchChange: ( value ) => {
-			findCustomFields( value, select( "core/editor" ).getCurrentPostId() );
-		},
+		onReplacementVariableSearchChange,
 	};
 }
 

--- a/packages/js/src/containers/SnippetEditor.js
+++ b/packages/js/src/containers/SnippetEditor.js
@@ -121,14 +121,17 @@ export function mapSelectToProps( select ) {
  * Maps the dispatch function to props.
  *
  * @param {function} dispatch The dispatch function.
+ * @param {Object}   ownProps The component's own props.
+ * @param {function} select   The select function.
  *
  * @returns {Object} The props.
  */
-export function mapDispatchToProps( dispatch ) {
+export function mapDispatchToProps( dispatch, ownProps, { select } ) {
 	const {
 		updateData,
 		switchMode,
 		updateAnalysisData,
+		findCustomFields,
 	} = dispatch( "yoast-seo/editor" );
 	const coreEditorDispatch = dispatch( "core/editor" );
 
@@ -157,6 +160,9 @@ export function mapDispatchToProps( dispatch ) {
 			}
 		},
 		onChangeAnalysisData: updateAnalysisData,
+		onReplacementVariableSearchChange: ( value ) => {
+			findCustomFields( value, select( "core/editor" ).getCurrentPostId() );
+		},
 	};
 }
 

--- a/packages/js/src/redux/actions/snippetEditor.js
+++ b/packages/js/src/redux/actions/snippetEditor.js
@@ -2,6 +2,8 @@ import { decodeHTML } from "@yoast/helpers";
 
 export const SWITCH_MODE = "SNIPPET_EDITOR_SWITCH_MODE";
 export const UPDATE_DATA = "SNIPPET_EDITOR_UPDATE_DATA";
+export const FIND_CUSTOM_FIELDS = "SNIPPET_EDITOR_FIND_CUSTOM_FIELDS";
+export const CUSTOM_FIELD_RESULTS = "SNIPPET_EDITOR_CUSTOM_FIELD_RESULTS";
 export const UPDATE_REPLACEMENT_VARIABLE = "SNIPPET_EDITOR_UPDATE_REPLACEMENT_VARIABLE";
 export const HIDE_REPLACEMENT_VARIABLES = "SNIPPET_EDITOR_HIDE_REPLACEMENT_VARIABLES";
 export const REMOVE_REPLACEMENT_VARIABLE = "SNIPPET_EDITOR_REMOVE_REPLACEMENT_VARIABLE";
@@ -41,6 +43,27 @@ export function updateData( data ) {
 }
 
 /**
+ * Triggers a control to fetch new replacement variables from the API and then adds them.
+ *
+ * @param {string} query  The search query.
+ * @param {int}    postId The post ID.
+ *
+ * @returns {Object} An action for redux.
+ */
+export function* findCustomFields( query, postId ) {
+	const results = yield{
+		type: FIND_CUSTOM_FIELDS,
+		query,
+		postId,
+	};
+
+	return {
+		type: CUSTOM_FIELD_RESULTS,
+		results,
+	};
+}
+
+/**
  * Updates replacement variables in redux.
  *
  * @param {string} name   The name of the replacement variable.
@@ -66,7 +89,7 @@ export function updateReplacementVariable( name, value, label = "", hidden = fal
 /**
  * Updates the words to highlight in the snippet editor.
  *
- * @param {Array} wordsToHighlight  The snippet editor keyword forms.
+ * @param {Array} wordsToHighlight The snippet editor keyword forms.
  *
  * @returns {Object} An action for redux.
  */

--- a/packages/js/src/redux/controls/dismissedAlerts.js
+++ b/packages/js/src/redux/controls/dismissedAlerts.js
@@ -2,7 +2,7 @@
 /**
  * Posts the dismissal to the API.
  *
- * @param {String} alertKey The key of the Alert that needs to be dismissed.
+ * @param {string} alertKey The key of the Alert that needs to be dismissed.
  *
  * @returns {Object} The API Post followed by a resolve.
  */

--- a/packages/js/src/redux/controls/index.js
+++ b/packages/js/src/redux/controls/index.js
@@ -1,1 +1,2 @@
 export * from "./dismissedAlerts";
+export * from "./snippetEditor";

--- a/packages/js/src/redux/controls/snippetEditor.js
+++ b/packages/js/src/redux/controls/snippetEditor.js
@@ -1,0 +1,17 @@
+/* global wpseoApi */
+/**
+ * Fetches meta keys from the API.
+ *
+ * @param {string} query  The search value.
+ * @param {int}    postId The post ID.
+ *
+ * @returns {Object} The API Post followed by a resolve.
+ */
+export function SNIPPET_EDITOR_FIND_CUSTOM_FIELDS( { query, postId } ) {
+	return new Promise( ( resolve ) => {
+		// eslint-disable-next-line camelcase
+		wpseoApi.get( "meta/search", { query, post_id: postId }, response => {
+			resolve( response.meta );
+		} );
+	} );
+}

--- a/packages/js/src/redux/reducers/snippetEditor.js
+++ b/packages/js/src/redux/reducers/snippetEditor.js
@@ -5,11 +5,13 @@ import {
 	UPDATE_REPLACEMENT_VARIABLE,
 	HIDE_REPLACEMENT_VARIABLES,
 	REMOVE_REPLACEMENT_VARIABLE,
+	CUSTOM_FIELD_RESULTS,
 	REFRESH,
 	UPDATE_WORDS_TO_HIGHLIGHT,
 	LOAD_SNIPPET_EDITOR_DATA,
 } from "../actions/snippetEditor";
-import { pushNewReplaceVar } from "../../helpers/replacementVariableHelpers";
+import { pushNewReplaceVar, replaceSpaces } from "../../helpers/replacementVariableHelpers";
+import { firstToUpperCase } from "../../helpers/stringHelpers";
 
 /**
  * Returns the initial state for the snippetEditorReducer.
@@ -32,6 +34,74 @@ function getInitialState() {
 			description: "",
 		},
 		isLoading: true,
+	};
+}
+
+/**
+ * Updates a replacement variable, adding it if it doesn't exist.
+ *
+ * @param {Object} state The current state.
+ * @param {Object} action The action that was just dispatched.
+ *
+ * @returns {Object} The new state.
+ */
+function updateReplacementVariable( state, action ) {
+	let isNewReplaceVar = true;
+	let nextReplacementVariables = state.replacementVariables.map( ( replaceVar ) => {
+		if ( replaceVar.name === action.name ) {
+			isNewReplaceVar = false;
+			return {
+				name: action.name,
+				label: action.label || replaceVar.label,
+				value: action.value,
+				hidden: replaceVar.hidden,
+			};
+		}
+		return replaceVar;
+	} );
+
+	if ( isNewReplaceVar ) {
+		nextReplacementVariables = pushNewReplaceVar( nextReplacementVariables, action );
+	}
+
+	return {
+		...state,
+		replacementVariables: nextReplacementVariables,
+	};
+}
+
+/**
+ * Updates replacement variables based off search results.
+ *
+ * @param {Object} state The current state.
+ * @param {Object} action The action that was just dispatched.
+ *
+ * @returns {Object} The new state.
+ */
+function customFieldResults( state, action ) {
+	// Filter out any already existing custom fields as data from server is outdated by default.
+	const results = action.results.filter( meta => {
+		return ! state.replacementVariables.some( replaceVar => replaceVar.name === ( "cf_" + meta.key ) );
+	} );
+
+	if ( results.length === 0 ) {
+		return state;
+	}
+
+	const nextReplacementVariables = [
+		...results.map( meta => ( {
+			name: "cf_" + replaceSpaces( meta.key ),
+			label: firstToUpperCase( meta.key + " (custom field)" ),
+			value: meta.value,
+			hidden: false,
+		} ) ),
+		...state.replacementVariables,
+	];
+
+
+	return {
+		...state,
+		replacementVariables: nextReplacementVariables,
 	};
 }
 
@@ -60,30 +130,11 @@ function snippetEditorReducer( state = getInitialState(), action ) {
 				},
 			};
 
-		case UPDATE_REPLACEMENT_VARIABLE: {
-			let isNewReplaceVar = true;
-			let nextReplacementVariables = state.replacementVariables.map( ( replaceVar ) => {
-				if ( replaceVar.name === action.name ) {
-					isNewReplaceVar = false;
-					return {
-						name: action.name,
-						label: action.label || replaceVar.label,
-						value: action.value,
-						hidden: replaceVar.hidden,
-					};
-				}
-				return replaceVar;
-			} );
+		case UPDATE_REPLACEMENT_VARIABLE:
+			return updateReplacementVariable( state, action );
 
-			if ( isNewReplaceVar ) {
-				nextReplacementVariables = pushNewReplaceVar( nextReplacementVariables, action );
-			}
-
-			return {
-				...state,
-				replacementVariables: nextReplacementVariables,
-			};
-		}
+		case CUSTOM_FIELD_RESULTS:
+			return customFieldResults( state, action );
 
 		case HIDE_REPLACEMENT_VARIABLES: {
 			const nextReplacementVariables = state.replacementVariables.map( ( replaceVar ) => {

--- a/packages/js/tests/containers/SnippetEditor.test.js
+++ b/packages/js/tests/containers/SnippetEditor.test.js
@@ -101,7 +101,7 @@ describe( "SnippetEditor container", () => {
 			}
 		} );
 
-		const result = mapDispatchToProps( dispatch );
+		const result = mapDispatchToProps( dispatch, null, { select: jest.fn() } );
 
 		expect( typeof result.onChange ).toEqual( "function" );
 		expect( result.onChangeAnalysisData ).toBe( yoastEditorDispatch.updateAnalysisData );

--- a/packages/replacement-variable-editor/src/ReplacementVariableEditor.js
+++ b/packages/replacement-variable-editor/src/ReplacementVariableEditor.js
@@ -75,6 +75,7 @@ class ReplacementVariableEditor extends React.Component {
 			onBlur,
 			isActive,
 			isHovered,
+			onSearchChange,
 			replacementVariables,
 			recommendedReplacementVariables,
 			editorRef,
@@ -126,6 +127,7 @@ class ReplacementVariableEditor extends React.Component {
 						onChange={ onChange }
 						onFocus={ onFocus }
 						onBlur={ onBlur }
+						onSearchChange={ onSearchChange }
 						replacementVariables={ replacementVariables }
 						recommendedReplacementVariables={ recommendedReplacementVariables }
 						ref={ ref => {
@@ -146,6 +148,7 @@ ReplacementVariableEditor.propTypes = {
 	content: PropTypes.string.isRequired,
 	onChange: PropTypes.func.isRequired,
 	onBlur: PropTypes.func,
+	onSearchChange: PropTypes.func,
 	replacementVariables: replacementVariablesShape,
 	recommendedReplacementVariables: recommendedReplacementVariablesShape,
 	isActive: PropTypes.bool,
@@ -166,6 +169,7 @@ ReplacementVariableEditor.propTypes = {
 ReplacementVariableEditor.defaultProps = {
 	onFocus: () => {},
 	onBlur: () => {},
+	onSearchChange: null,
 	replacementVariables: [],
 	recommendedReplacementVariables: [],
 	fieldId: "",

--- a/packages/replacement-variable-editor/src/ReplacementVariableEditorStandalone.js
+++ b/packages/replacement-variable-editor/src/ReplacementVariableEditorStandalone.js
@@ -272,6 +272,10 @@ class ReplacementVariableEditorStandalone extends React.Component {
 	 * @returns {void}
 	 */
 	onSearchChange( { value } ) {
+		if ( this.props.onSearchChange ) {
+			this.props.onSearchChange( value );
+		}
+
 		const recommendedReplacementVariables = this.determineCurrentReplacementVariables(
 			this.props.replacementVariables,
 			this.props.recommendedReplacementVariables,
@@ -411,25 +415,35 @@ class ReplacementVariableEditorStandalone extends React.Component {
 	componentWillReceiveProps( nextProps ) {
 		const { content, replacementVariables, recommendedReplacementVariables } = this.props;
 		const { searchValue } = this.state;
+		const nextState = {};
 
-		if (
-			( nextProps.content !== this._serializedContent && nextProps.content !== content ) ||
-			nextProps.replacementVariables !== replacementVariables
-		) {
+		if ( nextProps.content !== this._serializedContent && nextProps.content !== content ) {
 			this._serializedContent = nextProps.content;
-			const editorState = unserializeEditor( nextProps.content, nextProps.replacementVariables );
+			nextState.editorState = unserializeEditor( nextProps.content, nextProps.replacementVariables );
+		} else if ( nextProps.replacementVariables !== replacementVariables ) {
+			const newReplacementVariableNames = nextProps.replacementVariables
+				.map( rv => rv.name )
+				.filter( rvName => ! replacementVariables.map( rv => rv.name ).includes( rvName ) );
+
+			if ( newReplacementVariableNames.some( rvName => content.includes( "%%" + rvName + "%%" ) ) ) {
+				this._serializedContent = nextProps.content;
+				nextState.editorState = unserializeEditor( nextProps.content, nextProps.replacementVariables );
+			}
+		}
+
+		if ( nextProps.replacementVariables !== replacementVariables ) {
 			const currentReplacementVariables = this.determineCurrentReplacementVariables(
 				nextProps.replacementVariables,
 				recommendedReplacementVariables,
 				searchValue
 			);
-			const suggestions = this.mapReplacementVariablesToSuggestions( currentReplacementVariables );
-
-			this.setState( {
-				editorState,
-				suggestions: this.suggestionsFilter( searchValue, suggestions ),
-			} );
+			nextState.suggestions = this.suggestionsFilter(
+				searchValue,
+				this.mapReplacementVariablesToSuggestions( currentReplacementVariables )
+			);
 		}
+
+		this.setState( nextState );
 	}
 
 	/**
@@ -536,6 +550,7 @@ ReplacementVariableEditorStandalone.propTypes = {
 	replacementVariables: replacementVariablesShape.isRequired,
 	recommendedReplacementVariables: recommendedReplacementVariablesShape,
 	ariaLabelledBy: PropTypes.string.isRequired,
+	onSearchChange: PropTypes.func,
 	onChange: PropTypes.func.isRequired,
 	onFocus: PropTypes.func,
 	onBlur: PropTypes.func,
@@ -546,6 +561,7 @@ ReplacementVariableEditorStandalone.propTypes = {
 };
 
 ReplacementVariableEditorStandalone.defaultProps = {
+	onSearchChange: null,
 	onFocus: () => {},
 	onBlur: () => {},
 	placeholder: "",

--- a/packages/replacement-variable-editor/tests/__snapshots__/ReplacementVariableEditorTest.js.snap
+++ b/packages/replacement-variable-editor/tests/__snapshots__/ReplacementVariableEditorTest.js.snap
@@ -8,6 +8,7 @@ exports[`ReplacementVariableEditor wraps a Draft.js editor instance 1`] = `
   onBlur={[Function]}
   onChange={[Function]}
   onFocus={[Function]}
+  onSearchChange={null}
   placeholder=""
   recommendedReplacementVariables={Array []}
   replacementVariables={Array []}

--- a/packages/search-metadata-previews/src/snippet-editor/SnippetEditor.js
+++ b/packages/search-metadata-previews/src/snippet-editor/SnippetEditor.js
@@ -248,6 +248,7 @@ class SnippetEditor extends React.Component {
 		const {
 			data,
 			descriptionEditorFieldPlaceholder,
+			onReplacementVariableSearchChange,
 			replacementVariables,
 			recommendedReplacementVariables,
 			hasPaperStyle,
@@ -270,6 +271,7 @@ class SnippetEditor extends React.Component {
 					onChange={ this.handleChange }
 					onFocus={ this.setFieldFocus }
 					onBlur={ this.unsetFieldFocus }
+					onReplacementVariableSearchChange={ onReplacementVariableSearchChange }
 					replacementVariables={ replacementVariables }
 					recommendedReplacementVariables={ recommendedReplacementVariables }
 					titleLengthProgress={ titleLengthProgress }
@@ -584,6 +586,7 @@ class SnippetEditor extends React.Component {
 }
 
 SnippetEditor.propTypes = {
+	onReplacementVariableSearchChange: PropTypes.func,
 	replacementVariables: replacementVariablesShape,
 	recommendedReplacementVariables: recommendedReplacementVariablesShape,
 	data: PropTypes.shape( {
@@ -617,6 +620,7 @@ SnippetEditor.defaultProps = {
 	mode: DEFAULT_MODE,
 	date: "",
 	wordsToHighlight: [],
+	onReplacementVariableSearchChange: null,
 	replacementVariables: [],
 	recommendedReplacementVariables: [],
 	titleLengthProgress: {

--- a/packages/search-metadata-previews/src/snippet-editor/SnippetEditorFields.js
+++ b/packages/search-metadata-previews/src/snippet-editor/SnippetEditorFields.js
@@ -264,6 +264,7 @@ class SnippetEditorFields extends React.Component {
 		const {
 			activeField,
 			hoveredField,
+			onReplacementVariableSearchChange,
 			replacementVariables,
 			recommendedReplacementVariables,
 			titleLengthProgress,
@@ -299,6 +300,7 @@ class SnippetEditorFields extends React.Component {
 					recommendedReplacementVariables={ recommendedReplacementVariables }
 					content={ title }
 					onChange={ this.onChangeTitle }
+					onSearchChange={ onReplacementVariableSearchChange }
 					fieldId={ titleInputId }
 					type="title"
 				/>
@@ -379,6 +381,7 @@ SnippetEditorFields.propTypes = {
 	onChange: PropTypes.func.isRequired,
 	onFocus: PropTypes.func,
 	onBlur: PropTypes.func,
+	onReplacementVariableSearchChange: PropTypes.func,
 	data: PropTypes.shape( {
 		title: PropTypes.string.isRequired,
 		slug: PropTypes.string.isRequired,
@@ -397,8 +400,12 @@ SnippetEditorFields.propTypes = {
 
 SnippetEditorFields.defaultProps = {
 	replacementVariables: [],
+	recommendedReplacementVariables: [],
 	onFocus: () => {},
 	onBlur: () => {},
+	onReplacementVariableSearchChange: null,
+	activeField: null,
+	hoveredField: null,
 	titleLengthProgress: {
 		max: 600,
 		actual: 0,
@@ -409,6 +416,7 @@ SnippetEditorFields.defaultProps = {
 		actual: 0,
 		score: 0,
 	},
+	descriptionEditorFieldPlaceholder: null,
 	containerPadding: "0 20px",
 	titleInputId: "yoast-google-preview-title",
 	slugInputId: "yoast-google-preview-slug",

--- a/src/integrations/third-party/elementor.php
+++ b/src/integrations/third-party/elementor.php
@@ -705,9 +705,25 @@ class Elementor implements Integration_Interface {
 
 		$custom_fields = \get_post_custom( $post->ID );
 
+		// Simply concatenate all fields containing replace vars so we can handle them all with a single regex find.
+		$replace_vars_fields = implode(
+			' ',
+			[
+				YoastSEO()->meta->for_post( $post->ID )->presentation->title,
+				YoastSEO()->meta->for_post( $post->ID )->presentation->meta_description,
+			]
+		);
+
+		preg_match_all( '/%%cf_([A-Za-z0-9_]+)%%/', $replace_vars_fields, $matches );
+		$fields_to_include = $matches[1];
 		foreach ( $custom_fields as $custom_field_name => $custom_field ) {
 			// Skip private custom fields.
 			if ( \substr( $custom_field_name, 0, 1 ) === '_' ) {
+				continue;
+			}
+
+			// Skip custom fields that are not used, new ones will be fetched dynamically.
+			if ( ! in_array( $custom_field_name, $fields_to_include, true ) ) {
 				continue;
 			}
 

--- a/src/routes/meta-search-route.php
+++ b/src/routes/meta-search-route.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Yoast\WP\SEO\Routes;
+
+use WP_REST_Request;
+use WP_REST_Response;
+use Yoast\WP\SEO\Conditionals\No_Conditionals;
+use Yoast\WP\SEO\Main;
+
+class Meta_Search_Route implements Route_Interface {
+
+	use No_Conditionals;
+
+	/**
+	 * Represents meta search route.
+	 *
+	 * @var string
+	 */
+	const META_SEARCH_ROUTE = '/meta/search';
+
+	/**
+	 * Registers routes with WordPress.
+	 *
+	 * @return void
+	 */
+	public function register_routes() {
+		$route = [
+			[
+				'methods'             => 'GET',
+				'callback'            => [ $this, 'search_meta' ],
+				'permission_callback' => [ $this, 'permission_check' ],
+			],
+		];
+
+		\register_rest_route( Main::API_V1_NAMESPACE, self::META_SEARCH_ROUTE, $route );
+	}
+
+	/**
+	 * Performs the permission check.
+	 *
+	 * @param WP_REST_Request $request The request.
+	 *
+	 * @return bool
+	 */
+	public function permission_check( $request ) {
+		if ( ! isset( $request['post_id'] ) ) {
+			return false;
+		}
+
+		$post_type        = \get_post_type( $request['post_id'] );
+		$post_type_object = \get_post_type_object( $post_type );
+
+		return \current_user_can( $post_type_object->cap->edit_posts );
+	}
+
+	/**
+	 * Searches meta fields of a given post.
+	 *
+	 * @param WP_REST_Request $request The REST request.
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function search_meta( $request ) {
+		$post_id = $request['post_id'];
+		$query   = $request['query'];
+		$meta    = \get_post_custom( $post_id );
+		$matches = [];
+
+		foreach ( $meta as $key => $values ) {
+			if ( \substr( $key, 0, \strlen( $query ) ) !== $query ) {
+				continue;
+			}
+
+			if ( empty( $query ) && \substr( $key, 0, 1 ) === '_' ) {
+				continue;
+			}
+
+			// Skip custom field values that are serialized.
+			if ( \is_serialized( $values[0] ) ) {
+				continue;
+			}
+
+			$matches[] = [
+				'key'   => $key,
+				'value' => $values[0],
+			];
+
+			if ( \count( $matches ) >= 3 ) {
+				break;
+			}
+		}
+
+		return \rest_ensure_response(
+			[
+				'meta' => $matches,
+			]
+		);
+	}
+}

--- a/src/routes/meta-search-route.php
+++ b/src/routes/meta-search-route.php
@@ -90,10 +90,6 @@ class Meta_Search_Route implements Route_Interface {
 			}
 		}
 
-		return \rest_ensure_response(
-			[
-				'meta' => $matches,
-			]
-		);
+		return \rest_ensure_response( [ 'meta' => $matches ] );
 	}
 }

--- a/src/routes/meta-search-route.php
+++ b/src/routes/meta-search-route.php
@@ -7,6 +7,9 @@ use WP_REST_Response;
 use Yoast\WP\SEO\Conditionals\No_Conditionals;
 use Yoast\WP\SEO\Main;
 
+/**
+ * Meta_Search_Route class
+ */
 class Meta_Search_Route implements Route_Interface {
 
 	use No_Conditionals;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Instead of loading all custom fields at once dynamically load them when searching for replacement variables.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a performance issue in the meta description editor that would occur when very large amounts of custom fields were used.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Create a very large amount of custom fields:
```
$post_id = YOUR_POST_ID;
for ( $i = 0; $i < 99999; $i++ ) {
   add_post_meta( $post_id, wp_generate_password(), wp_generate_password() );
} 
```
* Open that post in your editor.
* Editing the meta description field should not be laggy.
* You should find all sorts of different custom fields if you start typing after using `%` to create a replacement variable.
* Note that custom field replacement variables aren't supported in Elementor so there should be no changes in elementor.
* The same applies to the replacement variables used on taxonomy pages and the settings. All of these should work the same.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* All replacement variable editors.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes https://github.com/Yoast/wordpress-seo/issues/17178
