### PR TITLE
Change order of schema pieces to ensure parsing as one graph

### DIFF
--- a/src/generators/schema-generator.php
+++ b/src/generators/schema-generator.php
@@ -239,22 +239,22 @@ class Schema_Generator implements Generator_Interface {
 	protected function get_graph_pieces( $context ) {
 		if ( $context->indexable->object_type === 'post' && \post_password_required( $context->post ) ) {
 			$schema_pieces = [
-				new Schema\Organization(),
-				new Schema\Website(),
 				new Schema\WebPage(),
+				new Schema\Website(),
+				new Schema\Organization(),
 			];
 
 			\add_filter( 'wpseo_schema_webpage', [ $this, 'protected_webpage_schema' ], 1 );
 		}
 		else {
 			$schema_pieces = [
-				new Schema\Organization(),
-				new Schema\Person(),
-				new Schema\Website(),
+				new Schema\Article(),
 				new Schema\Main_Image(),
 				new Schema\WebPage(),
 				new Schema\Breadcrumb(),
-				new Schema\Article(),
+				new Schema\Website(),
+				new Schema\Organization(),
+				new Schema\Person(),
 				new Schema\Author(),
 				new Schema\FAQ(),
 				new Schema\HowTo(),

--- a/src/generators/schema-generator.php
+++ b/src/generators/schema-generator.php
@@ -249,8 +249,8 @@ class Schema_Generator implements Generator_Interface {
 		else {
 			$schema_pieces = [
 				new Schema\Article(),
-				new Schema\Main_Image(),
 				new Schema\WebPage(),
+				new Schema\Main_Image(),
 				new Schema\Breadcrumb(),
 				new Schema\Website(),
 				new Schema\Organization(),

--- a/tests/unit/generators/schema-generator-test.php
+++ b/tests/unit/generators/schema-generator-test.php
@@ -244,24 +244,6 @@ class Schema_Generator_Test extends TestCase {
 				'@context' => 'https://schema.org',
 				'@graph'   => [
 					[
-						'@type'           => 'WebSite',
-						'@id'             => '#website',
-						'url'             => null,
-						'name'            => '',
-						'description'     => 'description',
-						'potentialAction' => [
-							[
-								'@type'       => 'SearchAction',
-								'target'      => [
-									'@type'       => 'EntryPoint',
-									'urlTemplate' => '?s={search_term_string}',
-								],
-								'query-input' => 'required name=search_term_string',
-							],
-						],
-						'inLanguage'      => 'English',
-					],
-					[
 						'@type'           => null,
 						'@id'             => 'https://example.com/the-post/',
 						'url'             => null,
@@ -279,6 +261,24 @@ class Schema_Generator_Test extends TestCase {
 								],
 							],
 						],
+					],
+					[
+						'@type'           => 'WebSite',
+						'@id'             => '#website',
+						'url'             => null,
+						'name'            => '',
+						'description'     => 'description',
+						'potentialAction' => [
+							[
+								'@type'       => 'SearchAction',
+								'target'      => [
+									'@type'       => 'EntryPoint',
+									'urlTemplate' => '?s={search_term_string}',
+								],
+								'query-input' => 'required name=search_term_string',
+							],
+						],
+						'inLanguage'      => 'English',
 					],
 				],
 			],
@@ -617,7 +617,7 @@ class Schema_Generator_Test extends TestCase {
 				],
 				'inLanguage'      => 'English',
 			],
-			$this->instance->generate( $this->context )['@graph'][0]
+			$this->instance->generate( $this->context )['@graph'][1]
 		);
 	}
 
@@ -711,7 +711,7 @@ class Schema_Generator_Test extends TestCase {
 				],
 				'inLanguage'      => 'English',
 			],
-			$this->instance->generate( $this->context )['@graph'][0]
+			$this->instance->generate( $this->context )['@graph'][1]
 		);
 	}
 
@@ -771,6 +771,7 @@ class Schema_Generator_Test extends TestCase {
 			[
 				'@context' => 'https://schema.org',
 				'@graph'   => [
+					$filtered_webpage_schema,
 					[
 						'@type'           => 'WebSite',
 						'@id'             => '#website',
@@ -789,7 +790,6 @@ class Schema_Generator_Test extends TestCase {
 						],
 						'inLanguage'      => 'English',
 					],
-					$filtered_webpage_schema,
 				],
 			],
 			$this->instance->generate( $this->context )
@@ -865,6 +865,20 @@ class Schema_Generator_Test extends TestCase {
 				'@context' => 'https://schema.org',
 				'@graph'   => [
 					[
+						'@type'           => [
+							'CollectionPage',
+							'SearchResultsPage',
+						],
+						'@id'             => 'https://fake.url/?s=searchterm',
+						'url'             => 'https://fake.url/?s=searchterm',
+						'name'            => '',
+						'isPartOf'        => [
+							'@id' => 'https://fake.url/#website',
+						],
+						'inLanguage'      => 'English',
+						'breadcrumb'      => [ '@id' => '#breadcrumb' ],
+					],
+					[
 						'@type'           => 'WebSite',
 						'@id'             => 'https://fake.url/#website',
 						'url'             => 'https://fake.url/',
@@ -882,20 +896,6 @@ class Schema_Generator_Test extends TestCase {
 						],
 						'inLanguage'      => 'English',
 					],
-					[
-						'@type'           => [
-							'CollectionPage',
-							'SearchResultsPage',
-						],
-						'@id'             => 'https://fake.url/?s=searchterm',
-						'url'             => 'https://fake.url/?s=searchterm',
-						'name'            => '',
-						'isPartOf'        => [
-							'@id' => 'https://fake.url/#website',
-						],
-						'inLanguage'      => 'English',
-						'breadcrumb'      => [ '@id' => '#breadcrumb' ],
-					],
 				],
 			],
 			$this->instance->generate( $this->context )
@@ -911,24 +911,6 @@ class Schema_Generator_Test extends TestCase {
 		return [
 			'@context' => 'https://schema.org',
 			'@graph'   => [
-				[
-					'@type'           => 'WebSite',
-					'@id'             => '#website',
-					'url'             => null,
-					'name'            => '',
-					'description'     => 'description',
-					'potentialAction' => [
-						[
-							'@type'       => 'SearchAction',
-							'target'      => [
-								'@type'       => 'EntryPoint',
-								'urlTemplate' => '?s={search_term_string}',
-							],
-							'query-input' => 'required name=search_term_string',
-						],
-					],
-					'inLanguage'      => 'English',
-				],
 				[
 					'@type'           => [ null, 'FAQPage' ],
 					'@id'             => 'https://example.com/the-post/',
@@ -954,6 +936,24 @@ class Schema_Generator_Test extends TestCase {
 					],
 					'datePublished'   => 'date',
 					'dateModified'    => 'date',
+				],
+				[
+					'@type'           => 'WebSite',
+					'@id'             => '#website',
+					'url'             => null,
+					'name'            => '',
+					'description'     => 'description',
+					'potentialAction' => [
+						[
+							'@type'       => 'SearchAction',
+							'target'      => [
+								'@type'       => 'EntryPoint',
+								'urlTemplate' => '?s={search_term_string}',
+							],
+							'query-input' => 'required name=search_term_string',
+						],
+					],
+					'inLanguage'      => 'English',
 				],
 				[
 					'@type'          => 'Question',


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Currently, running [this article](https://yoast.com/trusted-web-timestamping-content/) through the Schema validator shows several different pieces, when it should be parsing as one piece. Outputting the most important thing first (`Article`, if applicable, otherwise `WebPage`) fixes that.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Change the order in which Schema nodes are output from `Organization / Person > WebSite > WebPage > Article` to `Article > WebPage > WebSite > Organization / Person`. This fixes validation issues for the Schema validator and puts the most important Schema content first.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* See that the output order of Schema pieces changes, and nothing else.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have _not_ written documentation for this change. Please ping @jonoalderson to update the developer docs.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
