### PR TITLE
PC- 218 Integrations page UX improvements

### DIFF
--- a/packages/js/src/integrations-page.js
+++ b/packages/js/src/integrations-page.js
@@ -2,7 +2,7 @@ import { get } from "lodash";
 import domReady from "@wordpress/dom-ready";
 
 import { Root } from "@yoast/ui-library";
-import IntegrationsGrid from "./integrations-page/tailwind-components/integrations-grid";
+import IntegrationsGrid from "./integrations-page/integrations-grid";
 import { registerReactComponent, renderReactRoot } from "./helpers/reactRoot";
 
 window.YoastSEO = window.YoastSEO || {};

--- a/packages/js/src/integrations-page/integrations-grid.js
+++ b/packages/js/src/integrations-page/integrations-grid.js
@@ -1,20 +1,20 @@
 import apiFetch from "@wordpress/api-fetch";
 import { Slot } from "@wordpress/components";
 import { useState, useCallback } from "@wordpress/element";
-import { __ } from "@wordpress/i18n";
+import { __, sprintf } from "@wordpress/i18n";
 import { PropTypes } from "prop-types";
 
-import { Button, Badge, ToggleField } from "@yoast/ui-library";
-import { Card } from "./card";
-import AlgoliaLogo from "../../../images/algolia-logo.svg";
-import ElementorLogo from "../../../images/elementor-logo.svg";
-import JetpackLogo from "../../../images/jetpack-logo.svg";
-import RyteLogo from "../../../images/ryte-logo.svg";
-import SemrushLogo from "../../../images/semrush-logo.svg";
-import WincherLogo from "../../../images/wincher-logo.svg";
-import ZapierLogo from "../../../images/zapier-logo.svg";
-import WordproofLogo from "../../../images/wordproof-logo.svg";
-import WoocommerceLogo from "../../../images/woocommerce-logo.svg";
+import { Button, Badge, ToggleField, Title } from "@yoast/ui-library";
+import { Card } from "./tailwind-components/card";
+import AlgoliaLogo from "../../images/algolia-logo.svg";
+import ElementorLogo from "../../images/elementor-logo.svg";
+import JetpackLogo from "../../images/jetpack-logo.svg";
+import RyteLogo from "../../images/ryte-logo.svg";
+import SemrushLogo from "../../images/semrush-logo.svg";
+import WincherLogo from "../../images/wincher-logo.svg";
+import ZapierLogo from "../../images/zapier-logo.svg";
+import WordproofLogo from "../../images/wordproof-logo.svg";
+import WoocommerceLogo from "../../images/woocommerce-logo.svg";
 import { ArrowSmRightIcon, CheckIcon, XIcon } from "@heroicons/react/solid";
 import { LockOpenIcon } from "@heroicons/react/outline";
 
@@ -475,6 +475,27 @@ Section.propTypes = {
 export default function IntegrationsGrid() {
 	return (
 		<div className="yst-h-full yst-flex yst-flex-col yst-bg-white yst-rounded-lg yst-shadow">
+			<header className="yst-border-b yst-border-gray-200">
+				<div className="yst-max-w-screen-sm yst-p-8">
+					<Title
+						as="h1"
+						className="yst-flex yst-items-center"
+					>
+						{
+							__( "Integrations", "wordpress-seo" )
+						}
+					</Title>
+					<p className="yst-text-tiny yst-mt-3">
+						{
+							sprintf(
+								/* translators: 1: Yoast SEO */
+								__( "%s can integrate with third party products. You can enable or disable these integrations below.", "wordpress-seo" ),
+								"Yoast SEO",
+							)
+						}
+					</p>
+				</div>
+			</header>
 			<div className="yst-flex-grow yst-max-w-6xl yst-p-8">
 
 				<Section

--- a/packages/js/src/integrations-page/integrations-grid.js
+++ b/packages/js/src/integrations-page/integrations-grid.js
@@ -1,3 +1,5 @@
+import { ArrowSmRightIcon, CheckIcon, XIcon } from "@heroicons/react/solid";
+import { LockOpenIcon } from "@heroicons/react/outline";
 import apiFetch from "@wordpress/api-fetch";
 import { Slot } from "@wordpress/components";
 import { useState, useCallback } from "@wordpress/element";
@@ -16,8 +18,6 @@ import WincherLogo from "../../images/wincher-logo.svg";
 import ZapierLogo from "../../images/zapier-logo.svg";
 import WordproofLogo from "../../images/wordproof-logo.svg";
 import WoocommerceLogo from "../../images/woocommerce-logo.svg";
-import { ArrowSmRightIcon, CheckIcon, XIcon } from "@heroicons/react/solid";
-import { LockOpenIcon } from "@heroicons/react/outline";
 
 const isPremiumInstalled = Boolean( window.wpseoScriptData.isPremium );
 

--- a/packages/js/src/integrations-page/integrations-grid.js
+++ b/packages/js/src/integrations-page/integrations-grid.js
@@ -19,7 +19,6 @@ import { ArrowSmRightIcon, CheckIcon, XIcon } from "@heroicons/react/solid";
 import { LockOpenIcon } from "@heroicons/react/outline";
 
 const isPremiumInstalled = Boolean( window.wpseoScriptData.isPremium );
-const upsellLink         = "https://yoa.st/workout-orphaned-content-upsell";
 
 const SEOTools = [
 	{
@@ -70,6 +69,7 @@ const SEOTools = [
 		isNew: false,
 		isMultisiteAvailable: true,
 		logo: ZapierLogo,
+		upsellLink: "https://yoa.st/get-zapier-integration",
 	},
 	{
 		name: "Ryte",
@@ -116,6 +116,7 @@ const pluginIntegrations = [
 		isNew: false,
 		isMultisiteAvailable: true,
 		logo: AlgoliaLogo,
+		upsellLink: "https://yoa.st/get-algolia-integration",
 	},
 	{
 		name: "WooCommerce",
@@ -258,6 +259,7 @@ const updateIntegrationState = async( integration, setActive ) => {
  * @param {object}    integration             The integration.
  * @param {bool}      InitialActivationState  True if the integration has been activated by the user.
  * @param {bool}      isNetworkControlEnabled True if the integration is network-enabled.
+ * @param {bool}      isMultisiteAvailable    True if the integration is available on multisites.
  * @param {string}    toggleLabel             The toggle label.
  * @param {function}  beforeToggle            Check function to call before toggling the integration.
  *
@@ -319,7 +321,7 @@ const ToggleableIntegration = ( {
 					/> }
 			</Card.Content>
 			<Card.Footer>
-				{ ! getIsFreeIntegrationOrPremiumAvailable( integration ) && <Button id={ `${ integration.name }-upsell-button` } type="button" as="a" href={ upsellLink } variant="upsell" className="yst-w-full yst-text-gray-800">
+				{ ! getIsFreeIntegrationOrPremiumAvailable( integration ) && <Button id={ `${ integration.name }-upsell-button` } type="button" as="a" href={ integration.upsellLink } variant="upsell" className="yst-w-full yst-text-gray-800">
 					<LockOpenIcon
 						className="yst--ml-1 yst-mr-2 yst-h-5 yst-w-5 yst-text-yellow-900"
 					/>
@@ -332,7 +334,12 @@ const ToggleableIntegration = ( {
 						className="yst-h-5 yst-w-5 yst-text-red-500 yst-flex-shrink-0"
 					/>
 				</p>  }
-				{ getIsFreeIntegrationOrPremiumAvailable( integration ) && getIsMultisiteAvailable( integration ) && <ToggleField checked={ isActive } label={ toggleLabel } onChange={ toggleActive } disabled={ ! isNetworkControlEnabled || ! isMultisiteAvailable }  className={ `${ getIsCardActive( integration, isActive ) ? "" : "yst-opacity-50 yst-filter yst-grayscale" }` } /> }
+				{ getIsFreeIntegrationOrPremiumAvailable( integration ) && getIsMultisiteAvailable( integration ) && <ToggleField
+					checked={ isActive }
+					label={ toggleLabel }
+					onChange={ toggleActive }
+					disabled={ ! isNetworkControlEnabled || ! isMultisiteAvailable }
+				/> }
 			</Card.Footer>
 		</Card>
 	 );
@@ -345,12 +352,13 @@ ToggleableIntegration.propTypes = {
 		learnMoreLink: PropTypes.string,
 		type: PropTypes.string,
 		slug: PropTypes.string,
-		description: __( PropTypes.string, "wordpress-seo" ),
+		description: PropTypes.string,
 		usps: PropTypes.array,
 		logo: PropTypes.string,
 		isPremium: PropTypes.bool,
 		isNew: PropTypes.bool,
 		isMultisiteAvailable: PropTypes.bool,
+		upsellLink: PropTypes.string,
 	} ),
 	InitialActivationState: PropTypes.bool,
 	isNetworkControlEnabled: PropTypes.bool,
@@ -405,7 +413,7 @@ SimpleIntegration.propTypes = {
 		claim: PropTypes.string,
 		type: PropTypes.string,
 		slug: PropTypes.string,
-		description: __( PropTypes.string, "wordpress-seo" ),
+		description: PropTypes.string,
 		usps: PropTypes.array,
 		logo: PropTypes.string,
 		isNew: PropTypes.bool,
@@ -463,7 +471,7 @@ const Section = ( { title, description, elements } ) => {
 
 Section.propTypes = {
 	title: PropTypes.string,
-	description: __( PropTypes.string, "wordpress-seo" ),
+	description: PropTypes.string,
 	elements: PropTypes.array,
 };
 
@@ -490,7 +498,7 @@ export default function IntegrationsGrid() {
 							sprintf(
 								/* translators: 1: Yoast SEO */
 								__( "%s can integrate with third party products. You can enable or disable these integrations below.", "wordpress-seo" ),
-								"Yoast SEO",
+								"Yoast SEO"
 							)
 						}
 					</p>

--- a/packages/js/src/integrations-page/integrations-grid.js
+++ b/packages/js/src/integrations-page/integrations-grid.js
@@ -2,9 +2,10 @@ import apiFetch from "@wordpress/api-fetch";
 import { Slot } from "@wordpress/components";
 import { useState, useCallback } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
+import classNames from "classnames";
 import { PropTypes } from "prop-types";
 
-import { Button, Badge, ToggleField, Title } from "@yoast/ui-library";
+import { Button, Badge, ToggleField, Title, Link } from "@yoast/ui-library";
 import { Card } from "./tailwind-components/card";
 import AlgoliaLogo from "../../images/algolia-logo.svg";
 import ElementorLogo from "../../images/elementor-logo.svg";
@@ -309,10 +310,19 @@ const ToggleableIntegration = ( {
 						<span>{ integration.claim && integration.claim }</span>
 					</h4>
 					<p> { integration.description }
-						{ integration.learnMoreLink && <a href={ integration.learnMoreLink } className={ `yst-flex yst-items-center yst-mt-3 yst-no-underline yst-font-medium ${ ( getIsCardActive( integration, isActive ) ) ? "" : "yst-pointer-events-none" }` }>
+						{ integration.learnMoreLink && <Link
+							href={ integration.learnMoreLink }
+							className={ classNames( "yst-flex yst-items-center yst-mt-3 yst-no-underline yst-font-medium", ( getIsCardActive( integration, isActive ) ) ? "" : "yst-pointer-events-none" ) }
+							target="_blank"
+						>
 							Learn more
-							<ArrowSmRightIcon  className="yst-h-4 yst-w-4 yst-ml-1" />
-						</a> }
+							<span className="yst-sr-only">
+								{
+									__( "(Opens in a new browser tab)", "wordpress-seo" )
+								}
+							</span>
+							<ArrowSmRightIcon className="yst-h-4 yst-w-4 yst-ml-1" />
+						</Link> }
 					</p>
 				</div>
 				{ isActive &&
@@ -321,11 +331,24 @@ const ToggleableIntegration = ( {
 					/> }
 			</Card.Content>
 			<Card.Footer>
-				{ ! getIsFreeIntegrationOrPremiumAvailable( integration ) && <Button id={ `${ integration.name }-upsell-button` } type="button" as="a" href={ integration.upsellLink } variant="upsell" className="yst-w-full yst-text-gray-800">
+				{ ! getIsFreeIntegrationOrPremiumAvailable( integration ) && <Button
+					id={ `${ integration.name }-upsell-button` }
+					type="button"
+					as="a"
+					href={ integration.upsellLink }
+					variant="upsell"
+					className="yst-w-full yst-text-gray-800"
+					target="_blank"
+				>
 					<LockOpenIcon
 						className="yst--ml-1 yst-mr-2 yst-h-5 yst-w-5 yst-text-yellow-900"
 					/>
 					{ __( "Unlock with Premium", "wordpress-seo" ) }
+					<span className="yst-sr-only">
+						{
+							__( "(Opens in a new browser tab)", "wordpress-seo" )
+						}
+					</span>
 				</Button>
 				}
 				{ getIsFreeIntegrationOrPremiumAvailable( integration ) && ! getIsMultisiteAvailable( integration ) && <p className="yst-flex yst-items-start yst-justify-between">

--- a/packages/js/src/integrations-page/tailwind-components/card.js
+++ b/packages/js/src/integrations-page/tailwind-components/card.js
@@ -67,7 +67,7 @@ Footer.propTypes = {
  */
 export function Card( { children } ) {
 	return (
-		<div className="yst-relative yst-flex yst-flex-col yst-bg-white yst-rounded-lg yst-border yst-p-6 yst-space-y-6 yst-overflow-hidden yst-transition-transform yst-ease-in-out yst-duration-200">
+		<div className="yst-relative yst-flex yst-flex-col yst-bg-white yst-rounded-lg yst-border yst-p-6 yst-space-y-6 yst-overflow-hidden yst-transition-transform yst-ease-in-out yst-duration-200 yst-shadow-sm">
 			{ children }
 		</div>
 	);

--- a/packages/js/src/integrations-page/tailwind-components/integrations-grid.js
+++ b/packages/js/src/integrations-page/tailwind-components/integrations-grid.js
@@ -1,7 +1,7 @@
 import apiFetch from "@wordpress/api-fetch";
 import { Slot } from "@wordpress/components";
 import { useState, useCallback } from "@wordpress/element";
-import { __, sprintf } from "@wordpress/i18n";
+import { __ } from "@wordpress/i18n";
 import { PropTypes } from "prop-types";
 
 import { Button, Badge, ToggleField } from "@yoast/ui-library";
@@ -15,6 +15,8 @@ import WincherLogo from "../../../images/wincher-logo.svg";
 import ZapierLogo from "../../../images/zapier-logo.svg";
 import WordproofLogo from "../../../images/wordproof-logo.svg";
 import WoocommerceLogo from "../../../images/woocommerce-logo.svg";
+import { ArrowSmRightIcon, CheckIcon, XIcon } from "@heroicons/react/solid";
+import { LockOpenIcon } from "@heroicons/react/outline";
 
 const isPremiumInstalled = Boolean( window.wpseoScriptData.isPremium );
 const upsellLink         = "https://yoa.st/workout-orphaned-content-upsell";
@@ -45,18 +47,6 @@ const SEOTools = [
 		logo: WincherLogo,
 	},
 	{
-		name: "Ryte",
-		claim: __( "Ensure your site is findable", "wordpress-seo" ),
-		learnMoreLink: "#",
-		type: "toggleable",
-		slug: "ryte",
-		description: __( "Ryte in Yoast SEO monitors your site’s findability and lets you know if your site is hidden from search engines.", "wordpress-seo" ),
-		isPremium: false,
-		isNew: false,
-		isMultisiteAvailable: true,
-		logo: RyteLogo,
-	},
-	{
 		name: "WordProof",
 		claim: __( "Put a stamp of trust on your content", "wordpress-seo" ),
 		learnMoreLink: "#",
@@ -80,6 +70,18 @@ const SEOTools = [
 		isNew: false,
 		isMultisiteAvailable: true,
 		logo: ZapierLogo,
+	},
+	{
+		name: "Ryte",
+		claim: __( "Ensure your site is findable", "wordpress-seo" ),
+		learnMoreLink: "#",
+		type: "toggleable",
+		slug: "ryte",
+		description: __( "Ryte in Yoast SEO monitors your site’s findability and lets you know if your site is hidden from search engines.", "wordpress-seo" ),
+		isPremium: false,
+		isNew: false,
+		isMultisiteAvailable: true,
+		logo: RyteLogo,
 	},
 ];
 
@@ -301,15 +303,13 @@ const ToggleableIntegration = ( {
 			</Card.Header>
 			<Card.Content>
 				<div className={ `${ ( getIsCardActive( integration, isActive ) ) ? "" : "yst-opacity-50  yst-filter yst-grayscale" }` }>
-					<h4 className="yst-flex yst-items-center yst-text-base yst-mb-3 yst-font-medium yst-text-[#111827]">
+					<h4 className="yst-flex yst-items-center yst-text-base yst-mb-3 yst-font-medium yst-text-[#111827] yst-leading-tight">
 						<span>{ integration.claim && integration.claim }</span>
 					</h4>
 					<p> { integration.description }
 						{ integration.learnMoreLink && <a href={ integration.learnMoreLink } className={ `yst-flex yst-items-center yst-mt-3 yst-no-underline yst-font-medium ${ ( getIsCardActive( integration, isActive ) ) ? "" : "yst-pointer-events-none" }` }>
 							Learn more
-							<svg xmlns="http://www.w3.org/2000/svg" className="yst-h-4 yst-w-4 yst-ml-1" viewBox="0 0 20 20" fill="currentColor">
-								<path fillRule="evenodd" d="M10.293 5.293a1 1 0 011.414 0l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414-1.414L12.586 11H5a1 1 0 110-2h7.586l-2.293-2.293a1 1 0 010-1.414z" clipRule="evenodd" />
-							</svg>
+							<ArrowSmRightIcon  className="yst-h-4 yst-w-4 yst-ml-1" />
 						</a> }
 					</p>
 				</div>
@@ -320,17 +320,17 @@ const ToggleableIntegration = ( {
 			</Card.Content>
 			<Card.Footer>
 				{ ! getIsFreeIntegrationOrPremiumAvailable( integration ) && <Button id={ `${ integration.name }-upsell-button` } type="button" as="a" href={ upsellLink } variant="upsell" className="yst-w-full yst-text-gray-800">
-					<svg xmlns="http://www.w3.org/2000/svg" className="yst--ml-1 yst-mr-2 yst-h-5 yst-w-5 yst-text-yellow-900" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="2">
-						<path strokeLinecap="round" strokeLinejoin="round" d="M8 11V7a4 4 0 118 0m-4 8v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2z" />
-					</svg>
+					<LockOpenIcon
+						className="yst--ml-1 yst-mr-2 yst-h-5 yst-w-5 yst-text-yellow-900"
+					/>
 					{ __( "Unlock with Premium", "wordpress-seo" ) }
 				</Button>
 				}
 				{ getIsFreeIntegrationOrPremiumAvailable( integration ) && ! getIsMultisiteAvailable( integration ) && <p className="yst-flex yst-items-start yst-justify-between">
 					<span className="yst-text-gray-700 yst-font-medium">{ __( "Integration unavailable for multisites", "wordpress-seo" ) }</span>
-					<svg xmlns="http://www.w3.org/2000/svg" className="yst-h-5 yst-w-5 yst-text-red-500 yst-flex-shrink-0" viewBox="0 0 20 20" fill="currentColor">
-						<path fillRule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clipRule="evenodd" />
-					</svg>
+					<XIcon
+						className="yst-h-5 yst-w-5 yst-text-red-500 yst-flex-shrink-0"
+					/>
 				</p>  }
 				{ getIsFreeIntegrationOrPremiumAvailable( integration ) && getIsMultisiteAvailable( integration ) && <ToggleField checked={ isActive } label={ toggleLabel } onChange={ toggleActive } disabled={ ! isNetworkControlEnabled || ! isMultisiteAvailable }  className={ `${ getIsCardActive( integration, isActive ) ? "" : "yst-opacity-50 yst-filter yst-grayscale" }` } /> }
 			</Card.Footer>
@@ -376,7 +376,7 @@ const SimpleIntegration = ( {
 				{ ( integration.isNew ) && <Badge className="yst-absolute yst-top-2 yst-right-2">{ __( "New", "wordpress-seo" ) }</Badge> }
 			</Card.Header>
 			<Card.Content>
-				<h4 className="yst-flex yst-items-center yst-text-base yst-mb-3 yst-font-medium yst-text-[#111827]">
+				<h4 className="yst-flex yst-items-center yst-text-base yst-mb-3 yst-font-medium yst-text-[#111827] yst-leading-tight">
 					<span>{ integration.claim }</span>
 				</h4>
 				{ integration.description && <p> { integration.description } </p> }
@@ -384,9 +384,9 @@ const SimpleIntegration = ( {
 					{ integration.usps.map( ( usp, idx ) => {
 						return (
 							<li key={ idx } className="yst-flex yst-items-start">
-								<svg xmlns="http://www.w3.org/2000/svg" className="yst-h-5 yst-w-5 yst-mr-2 yst-text-green-400 yst-flex-shrink-0" viewBox="0 0 20 20" fill="currentColor">
-									<path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
-								</svg>
+								<CheckIcon
+									className="yst-h-5 yst-w-5 yst-mr-2 yst-text-green-400 yst-flex-shrink-0"
+								/>
 								<span> { usp } </span>
 							</li>
 						);
@@ -425,19 +425,12 @@ const Section = ( { title, description, elements } ) => {
 	return (
 		<section>
 			<div className="yst-mb-8">
-				<h2 className="yst-mb-2 yst-text-lg">{ title }</h2>
+				<h2 className="yst-mb-2 yst-text-lg yst-font-medium">{ title }</h2>
 				<p className="yst-text-tiny">{ description }</p>
 			</div>
 			<div className="yst-grid yst-grid-cols-1 yst-gap-6 sm:yst-grid-cols-2 md:yst-grid-cols-3 lg:yst-grid-cols-4">
 				{ elements.map( ( integration, index ) => {
-					const label = sprintf(
-						// translators: %1$s expands to the name of the integration
-						__(
-							"Enable %1$s",
-							"wordpress-seo"
-						),
-						integration.name
-					);
+					const label = __( "Enable integration", "wordpress-seo" );
 					switch ( integration.type ) {
 						case "toggleable":
 							return (
@@ -481,7 +474,7 @@ Section.propTypes = {
 */
 export default function IntegrationsGrid() {
 	return (
-		<div className="yst-h-full yst-flex yst-flex-col yst-bg-white">
+		<div className="yst-h-full yst-flex yst-flex-col yst-bg-white yst-rounded-lg yst-shadow">
 			<div className="yst-flex-grow yst-max-w-6xl yst-p-8">
 
 				<Section

--- a/src/actions/integrations-action.php
+++ b/src/actions/integrations-action.php
@@ -26,27 +26,6 @@ class Integrations_Action {
 	}
 
 	/**
-	 * Checks if the current user has the capability a specific user.
-	 *
-	 * @param int $user_id The id of the user to be edited.
-	 *
-	 * @return object The response object.
-	 */
-	public function check_capability( $user_id ) {
-		if ( $this->social_profiles_helper->can_edit_profile( $user_id ) ) {
-			return (object) [
-				'success' => true,
-				'status'  => 200,
-			];
-		}
-
-		return (object) [
-			'success' => false,
-			'status'  => 403,
-		];
-	}
-
-	/**
 	 * Sets an integration state.
 	 *
 	 * @param string $integration_name The name of the integration to activate/deactivate.

--- a/src/integrations/admin/integrations-page.php
+++ b/src/integrations/admin/integrations-page.php
@@ -120,7 +120,7 @@ class Integrations_Page implements Integration_Interface {
 	public function render_target() {
 		?>
 		<div class="wrap yoast wpseo-admin-page page-wpseo">
-			<h1><?php \esc_html_e( 'Integrations', 'wordpress-seo' ); ?></h1>
+			<div class="wp-header-end" style="height: 0; width: 0;"></div>
 			<div id="wpseo-integrations"></div>
 		</div>
 		<?php

--- a/src/routes/integrations-route.php
+++ b/src/routes/integrations-route.php
@@ -23,13 +23,6 @@ class Integrations_Route implements Route_Interface {
 	const INTEGRATIONS_ROUTE = '/integrations';
 
 	/**
-	 * Represents a route to check if current user has the correct capabilities.
-	 *
-	 * @var string
-	 */
-	const CHECK_CAPABILITY_ROUTE = '/check_capability';
-
-	/**
 	 * Represents a route to set the state of Semrush integration.
 	 *
 	 * @var string

--- a/src/routes/integrations-route.php
+++ b/src/routes/integrations-route.php
@@ -95,18 +95,6 @@ class Integrations_Route implements Route_Interface {
 	 * @return void
 	 */
 	public function register_routes() {
-		$check_capability_route = [
-			'methods'             => 'GET',
-			'callback'            => [ $this, 'check_capability' ],
-			'permission_callback' => [ $this, 'can_manage_options' ],
-			'args'                => [
-				'user_id' => [
-					'required' => true,
-				],
-			],
-		];
-		\register_rest_route( Main::API_V1_NAMESPACE, self::INTEGRATIONS_ROUTE . self::CHECK_CAPABILITY_ROUTE, $check_capability_route );
-
 		$set_semrush_active_route = [
 			'methods'             => 'POST',
 			'callback'            => [ $this, 'set_semrush_active' ],


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to improve the UX of the integrations page.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes some UX issues for the Integrations page.

## Relevant technical choices:

* Also removes an unused `check_capability` route
* Also uses Heroicons components instead of inline SVGs
* Also moves the IntegrationsGrid (and related components) outside the `tailwind-components` folder since they're not candidates to be included in the UI library anytime soon (while Card might be)
* An empty div with `wp-header-end` class has been added on top of the integrations page to let the notifications attach to it, instead of attaching to the `<h1>` title messing up the layout.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Check https://yoast.atlassian.net/browse/PC-218 and see all the remaks have been addressed.
  * Some of them will be addressed in the UI library so they're not fixed by this PR
* Enable Premium ([the matching PR](https://github.com/Yoast/wordpress-seo-premium/pull/3611)) to check the Zapier Modal design.

**Note:** the integrations page behaviour and flows should not be affected by the changes.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.

Fixes [PC-218]


[PC-218]: https://yoast.atlassian.net/browse/PC-218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ