### PR TITLE
Enable the product identifiers assessment in WooCommerce

### DIFF
--- a/packages/yoastseo/spec/languageProcessing/researches/getProductIdentifierDataSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/getProductIdentifierDataSpec.js
@@ -115,7 +115,7 @@ describe( "A test to check if the variant identifier data is valid", () => {
 	it( "returns false if the variant identifier data is not valid", function() {
 		const paper = new Paper( "Text.", {
 			customData: {
-				doAllVariantsHaveIdentifier: false,
+				variantIdentifierDataIsValid: false,
 			},
 		} );
 
@@ -125,7 +125,7 @@ describe( "A test to check if the variant identifier data is valid", () => {
 	it( "returns true if the variant identifier data is valid", function() {
 		const paper = new Paper( "Text.", {
 			customData: {
-				doAllVariantsHaveIdentifier: true,
+				variantIdentifierDataIsValid: true,
 			},
 		} );
 

--- a/packages/yoastseo/spec/languageProcessing/researches/getProductIdentifierDataSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/getProductIdentifierDataSpec.js
@@ -110,3 +110,25 @@ describe( "A test to check if all variants of a product have an identifier", () 
 		expect( productIdentifierData( paper ).doAllVariantsHaveIdentifier ).toEqual( true );
 	} );
 } );
+
+describe( "A test to check if the variant identifier data is valid", () => {
+	it( "returns false if the variant identifier data is not valid", function() {
+		const paper = new Paper( "Text.", {
+			customData: {
+				doAllVariantsHaveIdentifier: false,
+			},
+		} );
+
+		expect( productIdentifierData( paper ).isVariantIdentifierDataValid ).toEqual( false );
+	} );
+
+	it( "returns true if the variant identifier data is valid", function() {
+		const paper = new Paper( "Text.", {
+			customData: {
+				doAllVariantsHaveIdentifier: true,
+			},
+		} );
+
+		expect( productIdentifierData( paper ).isVariantIdentifierDataValid ).toEqual( true );
+	} );
+} );

--- a/packages/yoastseo/spec/scoring/assessments/seo/ProductIdentifiersAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/ProductIdentifiersAssessmentSpec.js
@@ -7,7 +7,7 @@ const paper = new Paper( "" );
 
 
 describe( "a test for Product identifiers assessment for WooCommerce", function() {
-	const assessment = new ProductIdentifiersAssessment();
+	const assessment = new ProductIdentifiersAssessment( { assessVariants: true } );
 
 	it( "returns the score 9 when a product has a global identifier and no variants", function() {
 		const assessmentResult = assessment.getResult( paper, Factory.buildMockResearcher( {
@@ -62,12 +62,26 @@ describe( "a test for Product identifiers assessment for WooCommerce", function(
 			hasGlobalIdentifier: false,
 			hasVariants: true,
 			doAllVariantsHaveIdentifier: false,
+			isVariantIdentifierDataValid: true
 		} ) );
 
 		expect( assessmentResult.getScore() ).toEqual( 6 );
 		expect( assessmentResult.getText() ).toEqual( "<a href='https://yoa.st/4ly' target='_blank'>Product identifier</a>:" +
 			" Not all your product variants have a product identifier. <a href='https://yoa.st/4lz' target='_blank'>Include" +
 			" this if you can, as it will help search engines to better understand your content.</a>" );
+	} );
+
+	it( "returns the score 0 when the product variant data is not valid", function() {
+		const assessmentResult = assessment.getResult( paper, Factory.buildMockResearcher( {
+			hasGlobalIdentifier: false,
+			hasVariants: true,
+			doAllVariantsHaveIdentifier: false,
+			isVariantIdentifierDataValid: false
+		} ) );
+
+		expect( assessmentResult.getScore() ).toEqual( 0 );
+		expect( assessmentResult.getText() ).toEqual( "<a href='https://yoa.st/4ly' target='_blank'>Product identifier</a>:" +
+			" Please save and refresh the page to view the result for this assessment." );
 	} );
 } );
 

--- a/packages/yoastseo/spec/scoring/assessments/seo/ProductIdentifiersAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/ProductIdentifiersAssessmentSpec.js
@@ -62,7 +62,7 @@ describe( "a test for Product identifiers assessment for WooCommerce", function(
 			hasGlobalIdentifier: false,
 			hasVariants: true,
 			doAllVariantsHaveIdentifier: false,
-			isVariantIdentifierDataValid: true
+			isVariantIdentifierDataValid: true,
 		} ) );
 
 		expect( assessmentResult.getScore() ).toEqual( 6 );
@@ -76,7 +76,7 @@ describe( "a test for Product identifiers assessment for WooCommerce", function(
 			hasGlobalIdentifier: false,
 			hasVariants: true,
 			doAllVariantsHaveIdentifier: false,
-			isVariantIdentifierDataValid: false
+			isVariantIdentifierDataValid: false,
 		} ) );
 
 		expect( assessmentResult.getScore() ).toEqual( 0 );

--- a/packages/yoastseo/src/languageProcessing/researches/getProductIdentifierData.js
+++ b/packages/yoastseo/src/languageProcessing/researches/getProductIdentifierData.js
@@ -8,6 +8,7 @@
  */
 export default function( paper ) {
 	const customData = paper.getCustomData();
+	console.log( customData, "customData" );
 	const productData = {
 		hasGlobalIdentifier: customData.hasGlobalIdentifier,
 		hasVariants: customData.hasVariants,

--- a/packages/yoastseo/src/languageProcessing/researches/getProductIdentifierData.js
+++ b/packages/yoastseo/src/languageProcessing/researches/getProductIdentifierData.js
@@ -15,5 +15,8 @@ export default function( paper ) {
 	if ( customData.hasOwnProperty( "doAllVariantsHaveIdentifier" ) ) {
 		productData.doAllVariantsHaveIdentifier = customData.doAllVariantsHaveIdentifier;
 	}
+	if ( customData.hasOwnProperty( "isVariantIdentifierDataValid" ) ) {
+		productData.isVariantIdentifierDataValid = customData.isVariantIdentifierDataValid;
+	}
 	return productData;
 }

--- a/packages/yoastseo/src/languageProcessing/researches/getProductIdentifierData.js
+++ b/packages/yoastseo/src/languageProcessing/researches/getProductIdentifierData.js
@@ -16,7 +16,7 @@ export default function( paper ) {
 	if ( customData.hasOwnProperty( "doAllVariantsHaveIdentifier" ) ) {
 		productData.doAllVariantsHaveIdentifier = customData.doAllVariantsHaveIdentifier;
 	}
-	if ( customData.hasOwnProperty( "isVariantIdentifierDataValid" ) ) {
+	if ( customData.hasOwnProperty( "variantIdentifierDataIsValid" ) ) {
 		productData.isVariantIdentifierDataValid = customData.isVariantIdentifierDataValid;
 	}
 	return productData;

--- a/packages/yoastseo/src/languageProcessing/researches/getProductIdentifierData.js
+++ b/packages/yoastseo/src/languageProcessing/researches/getProductIdentifierData.js
@@ -17,7 +17,7 @@ export default function( paper ) {
 		productData.doAllVariantsHaveIdentifier = customData.doAllVariantsHaveIdentifier;
 	}
 	if ( customData.hasOwnProperty( "variantIdentifierDataIsValid" ) ) {
-		productData.isVariantIdentifierDataValid = customData.isVariantIdentifierDataValid;
+		productData.isVariantIdentifierDataValid = customData.variantIdentifierDataIsValid;
 	}
 	return productData;
 }

--- a/packages/yoastseo/src/languageProcessing/researches/getProductIdentifierData.js
+++ b/packages/yoastseo/src/languageProcessing/researches/getProductIdentifierData.js
@@ -3,12 +3,12 @@
  *
  * @param {Paper} paper The paper that contains the data.
  *
- * @returns {{hasVariants: (boolean|*), hasGlobalIdentifier: (boolean|*), doAllVariantsHaveIdentifier: (boolean|*) }}
- * The object that contains information whether the product has global identifier or variants.
+ * @returns {{hasVariants: (boolean|*), hasGlobalIdentifier: (boolean|*), doAllVariantsHaveIdentifier: (boolean|*),
+ * 			isVariantIdentifierDataValid: (boolean|*) }}
+ *			The object that contains information whether the product has global identifier or variants.
  */
 export default function( paper ) {
 	const customData = paper.getCustomData();
-	console.log( customData, "customData" );
 	const productData = {
 		hasGlobalIdentifier: customData.hasGlobalIdentifier,
 		hasVariants: customData.hasVariants,

--- a/packages/yoastseo/src/scoring/assessments/seo/ProductIdentifiersAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/ProductIdentifiersAssessment.js
@@ -84,7 +84,25 @@ export default class ProductIdentifiersAssessment extends Assessment {
 	 * 													or empty object if no score should be returned.
 	 */
 	scoreProductIdentifier( productIdentifierData, config ) {
-		console.log( productIdentifierData, "productIdentifierData in assessment scoring" );
+		// Return a grey bullet if the variant identifier data is not valid.
+		// This can currently occur in WooCommerce because we cannot know what kind of bulk action the user performed without them reloading the page.
+		if( ! isUndefined( productIdentifierData.isVariantIdentifierDataValid ) && productIdentifierData.isVariantIdentifierDataValid === false  ) {
+			return {
+				score: config.scores.invalidVariantData,
+				text: sprintf(
+					/* Translators: %1$s expands to a link on yoast.com, %3$s expands to the anchor end tag,
+					* %3$s expands to the string "Barcode" or "Product identifier". */
+					__(
+						"%1$s%2$s%3$s: Please save and refresh the page to view the result for this assessment.",
+						"wordpress-seo"
+					),
+					this._config.urlTitle,
+					this._config.productIdentifierOrBarcode.uppercase,
+					"</a>"
+				),
+			};
+		}
+
 		// If a product has no variants, return orange bullet if it has no global identifier, and green bullet if it has one.
 		if ( ! productIdentifierData.hasVariants ) {
 			if ( ! productIdentifierData.hasGlobalIdentifier ) {
@@ -127,24 +145,6 @@ export default class ProductIdentifiersAssessment extends Assessment {
 		// This is currently the case for Shopify products because we don't have access data about product variant identifiers in Shopify.
 		if ( ! config.assessVariants ) {
 			return {};
-		}
-
-		if( ! isUndefined( productIdentifierData.isVariantIdentifierDataValid ) && ! productIdentifierData.isVariantIdentifierDataValid  ) {
-			console.log( "hello" );
-			return {
-				score: config.scores.invalidVariantData,
-				text: sprintf(
-					/* Translators: %1$s expands to a link on yoast.com, %3$s expands to the anchor end tag,
-					* %3$s expands to the string "Barcode" or "Product identifier". */
-					__(
-						"%1$s%2$s%3$s: Sorry, we were unable to give a result for this assessment. Please refresh the page to view the result",
-						"wordpress-seo"
-					),
-					this._config.urlTitle,
-					this._config.productIdentifierOrBarcode.uppercase,
-					"</a>"
-				),
-			};
 		}
 
 		// If we want to assess variants, and if product has variants but not all variants have an identifier, return orange bullet.

--- a/packages/yoastseo/src/scoring/assessments/seo/ProductIdentifiersAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/ProductIdentifiersAssessment.js
@@ -3,6 +3,7 @@ import AssessmentResult from "../../../values/AssessmentResult";
 import { merge } from "lodash-es";
 import { createAnchorOpeningTag } from "../../../helpers/shortlinker";
 import { __, sprintf } from "@wordpress/i18n";
+import { isUndefined } from "lodash-es";
 
 /**
  * Represents the assessment for the product identifiers.
@@ -127,7 +128,7 @@ export default class ProductIdentifiersAssessment extends Assessment {
 			return {};
 		}
 
-		if( ! productIdentifierData.isVariantIdentifierDataValid ) {
+		if( ! isUndefined( productIdentifierData.isVariantIdentifierDataValid ) && ! productIdentifierData.isVariantIdentifierDataValid  ) {
 			console.log( "hello" );
 			return {
 				score: config.scores.invalidVariantData,
@@ -140,7 +141,6 @@ export default class ProductIdentifiersAssessment extends Assessment {
 					),
 					this._config.urlTitle,
 					this._config.productIdentifierOrBarcode.uppercase,
-					this._config.productIdentifierOrBarcode.lowercase,
 					"</a>"
 				),
 			};

--- a/packages/yoastseo/src/scoring/assessments/seo/ProductIdentifiersAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/ProductIdentifiersAssessment.js
@@ -84,6 +84,7 @@ export default class ProductIdentifiersAssessment extends Assessment {
 	 * 													or empty object if no score should be returned.
 	 */
 	scoreProductIdentifier( productIdentifierData, config ) {
+		console.log( productIdentifierData, "productIdentifierData in assessment scoring" );
 		// If a product has no variants, return orange bullet if it has no global identifier, and green bullet if it has one.
 		if ( ! productIdentifierData.hasVariants ) {
 			if ( ! productIdentifierData.hasGlobalIdentifier ) {

--- a/packages/yoastseo/src/scoring/assessments/seo/ProductIdentifiersAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/ProductIdentifiersAssessment.js
@@ -86,7 +86,7 @@ export default class ProductIdentifiersAssessment extends Assessment {
 	scoreProductIdentifier( productIdentifierData, config ) {
 		// Return a grey bullet if the variant identifier data is not valid.
 		// This can currently occur in WooCommerce because we cannot know what kind of bulk action the user performed without them reloading the page.
-		if( ! isUndefined( productIdentifierData.isVariantIdentifierDataValid ) && productIdentifierData.isVariantIdentifierDataValid === false  ) {
+		if ( ! isUndefined( productIdentifierData.isVariantIdentifierDataValid ) && productIdentifierData.isVariantIdentifierDataValid === false  ) {
 			return {
 				score: config.scores.invalidVariantData,
 				text: sprintf(

--- a/packages/yoastseo/src/scoring/assessments/seo/ProductIdentifiersAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/ProductIdentifiersAssessment.js
@@ -86,12 +86,12 @@ export default class ProductIdentifiersAssessment extends Assessment {
 	scoreProductIdentifier( productIdentifierData, config ) {
 		// Return a grey bullet if the variant identifier data is not valid.
 		// This can currently occur in WooCommerce because we cannot know what kind of bulk action the user performed without them reloading the page.
-		if ( ! isUndefined( productIdentifierData.isVariantIdentifierDataValid ) && productIdentifierData.isVariantIdentifierDataValid === false  ) {
+		if ( productIdentifierData.isVariantIdentifierDataValid === false  ) {
 			return {
 				score: config.scores.invalidVariantData,
 				text: sprintf(
 					/* Translators: %1$s expands to a link on yoast.com, %3$s expands to the anchor end tag,
-					* %3$s expands to the string "Barcode" or "Product identifier". */
+					* %2$s expands to the string "Barcode" or "Product identifier". */
 					__(
 						"%1$s%2$s%3$s: Please save and refresh the page to view the result for this assessment.",
 						"wordpress-seo"

--- a/packages/yoastseo/src/scoring/assessments/seo/ProductIdentifiersAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/ProductIdentifiersAssessment.js
@@ -22,6 +22,7 @@ export default class ProductIdentifiersAssessment extends Assessment {
 			scores: {
 				good: 9,
 				ok: 6,
+				invalidVariantData: 0,
 			},
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/4ly" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/4lz" ),
@@ -126,7 +127,26 @@ export default class ProductIdentifiersAssessment extends Assessment {
 			return {};
 		}
 
-		// If we want to assess variants, if product has variants and not all variants have an identifier, return orange bullet.
+		if( ! productIdentifierData.isVariantIdentifierDataValid ) {
+			console.log( "hello" );
+			return {
+				score: config.scores.invalidVariantData,
+				text: sprintf(
+					/* Translators: %1$s expands to a link on yoast.com, %3$s expands to the anchor end tag,
+					* %3$s expands to the string "Barcode" or "Product identifier". */
+					__(
+						"%1$s%2$s%3$s: Sorry, we were unable to give a result for this assessment. Please refresh the page to view the result",
+						"wordpress-seo"
+					),
+					this._config.urlTitle,
+					this._config.productIdentifierOrBarcode.uppercase,
+					this._config.productIdentifierOrBarcode.lowercase,
+					"</a>"
+				),
+			};
+		}
+
+		// If we want to assess variants, and if product has variants but not all variants have an identifier, return orange bullet.
 		// If all variants have an identifier, return green bullet.
 		if ( ! productIdentifierData.doAllVariantsHaveIdentifier ) {
 			return {

--- a/packages/yoastseo/src/scoring/assessments/seo/ProductIdentifiersAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/ProductIdentifiersAssessment.js
@@ -25,7 +25,7 @@ export default class ProductIdentifiersAssessment extends Assessment {
 			},
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/4ly" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/4lz" ),
-			assessVariants: true,
+			assessVariants: false,
 			productIdentifierOrBarcode: {
 				lowercase: "product identifier",
 				uppercase: "",
@@ -63,12 +63,13 @@ export default class ProductIdentifiersAssessment extends Assessment {
 	}
 
 	/**
-	 * Makes the assessment temporarily not applicable, until we have access to the needed data from WooCommerce and Shopify.
+	 * Checks whether the assessment is applicable. Currently it is applicable when variants should be assessed (i.e.
+	 * in WooCommerce, but not in Shopify)
 	 *
-	 * @returns {Boolean} Always returns false.
+	 * @returns {Boolean} Whether the assessment is applicable.
 	 */
 	isApplicable() {
-		return false;
+		return this._config.assessVariants;
 	}
 
 	/**

--- a/packages/yoastseo/src/scoring/assessments/seo/ProductIdentifiersAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/ProductIdentifiersAssessment.js
@@ -3,7 +3,6 @@ import AssessmentResult from "../../../values/AssessmentResult";
 import { merge } from "lodash-es";
 import { createAnchorOpeningTag } from "../../../helpers/shortlinker";
 import { __, sprintf } from "@wordpress/i18n";
-import { isUndefined } from "lodash-es";
 
 /**
  * Represents the assessment for the product identifiers.


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The assessment was partially implemented in this [PR](https://github.com/Yoast/wordpress-seo/pull/18609). In this PR, we enable the assessment for WooCommerce as well as add a grey bullet condition to the assessment. In the accompanying [WooCommerce PR](https://github.com/Yoast/wpseo-woocommerce/pull/789), the data used for scoring on this assessment is retrieved and passed to the Paper.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [wpseo-woocommerce] Adds a new assessment which checks whether products (or product variants) have an identifier.
* [yoastseo] Enables the Product identifiers assessment in WooCommerce.
* [yoastseo] Adds a condition to the assessment that returns a grey bullet when the product variant data is not valid.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Follow the test instructions for WooCommerce from this task: https://yoast.atlassian.net/browse/PC-144 


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [x] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes #
