### PR TITLE
Replace action with a filter to add additional draft-js-plugins

### DIFF
--- a/packages/replacement-variable-editor/src/ReplacementVariableEditorStandalone.js
+++ b/packages/replacement-variable-editor/src/ReplacementVariableEditorStandalone.js
@@ -10,7 +10,7 @@ import includes from "lodash/includes";
 import get from "lodash/get";
 import PropTypes from "prop-types";
 import { speak as a11ySpeak } from "@wordpress/a11y";
-import { applyFilters, addAction } from "@wordpress/hooks";
+import { applyFilters } from "@wordpress/hooks";
 import { __, _n, sprintf } from "@wordpress/i18n";
 import styled from "styled-components";
 import { withTheme } from "styled-components";
@@ -154,11 +154,10 @@ class ReplacementVariableEditorStandalone extends React.Component {
 			} ),
 		};
 
-		addAction( "yoast.draftjs.additionalPluginLoaded", "yoast/yoast-seo/initializeDraftJsPlugins", ( fieldId ) => {
-			if ( fieldId === this.props.fieldId ) {
-				this.setState( { editorKey: this.props.fieldId + "-loaded"  } );
-			}
-		} );
+		this.pluginList = applyFilters(
+			"yoast.replacementVariableEditor.pluginList",
+			this.pluginList
+		);
 	}
 
 	/**
@@ -533,8 +532,7 @@ class ReplacementVariableEditorStandalone extends React.Component {
 					"yoast.replacementVariableEditor.additionalPlugins",
 					<React.Fragment />,
 					this.pluginList,
-					fieldId,
-					this.editor
+					fieldId
 				) }
 
 				<ZIndexOverride>


### PR DESCRIPTION
## Context
Replace action with a filter to add additional draft-js-plugins to the plugin list.
*

## Summary

This PR can be summarized in the following changelog entry:

* Adds support for providing additional draft js plugins via a filter.

## Relevant technical choices:

* N/A

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* N/A


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.

Fixes #
