### PR TITLE
Normalize single quotes before removing contractions in the French word complexity assessment.

### DIFF
--- a/packages/yoastseo/spec/languageProcessing/languages/de/helpers/checkIfWordIsComplexSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/languages/de/helpers/checkIfWordIsComplexSpec.js
@@ -27,4 +27,8 @@ describe( "a test checking if the word is complex in German",  function() {
 	it( "returns plural word as non complex if the word is less than 10 characters", function() {
 		expect( checkIfWordIsComplex( "boxen" ) ).toEqual( false );
 	} );
+
+	it( "recognized contractions when the contraction uses ’ (right single quotation mark) instead of ' (apostrophe)", function() {
+		expect( checkIfWordIsComplex( "l’histoire" ) ).toEqual( false );
+	} );
 } );

--- a/packages/yoastseo/src/languageProcessing/languages/fr/helpers/checkIfWordIsComplex.js
+++ b/packages/yoastseo/src/languageProcessing/languages/fr/helpers/checkIfWordIsComplex.js
@@ -1,5 +1,6 @@
 import wordComplexity from "../config/internal/wordComplexity";
 import functionWords from "../config/functionWords";
+import { normalizeSingle } from "../../../helpers/sanitize/quotes";
 
 const contractionPrefixes = "^(c'|d'|l'|s')";
 const contractionRegex = new RegExp( contractionPrefixes );
@@ -15,6 +16,9 @@ export default function checkIfWordIsComplex( word ) {
 	const wordComplexityConfig = wordComplexity;
 	const lengthLimit = wordComplexityConfig.wordLength;
 	const frequencyList = wordComplexityConfig.frequencyList;
+
+	// Normalize single quotes before checking for contractions.
+	word = normalizeSingle( word );
 
 	/*
 	 * We want to remove the definite article l', preposition d' from a word,


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the word complexity assessment for French gave inconsistent results when the text contains words of length 8 with contractions, like _l'histoire_.

## Relevant technical choices:

* Single quotes are normalized before trying to remove contractions.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Set your site's language to French.
* Create a post in either the block editor or the classic editor.
* Add a text to the post that contains one or multiple words of 8 characters with a contraction (for example _l'histoire_ -> where _histoire_ = 8 characters).
* Check and note down the result of the word complexity assessment.
* Save the post.
* Install and activate the Elementor plugin.
* Open the post you just created in the Elementor editor.
* Check and note down the result of the word complexity assessment. It should be the same as the one in the block or classic editor.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes https://yoast.atlassian.net/browse/PC-248
