### PR TITLE
PC-221 fix SERVER_NAME warning

### DIFF
--- a/src/helpers/url-helper.php
+++ b/src/helpers/url-helper.php
@@ -234,15 +234,29 @@ class Url_Helper {
 		$current_url .= '://';
 
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput -- We know this is scary.
-		$suffix = ( $with_request_uri ) ? $_SERVER['REQUEST_URI'] : '';
+		$suffix = ( $with_request_uri && isset( $_SERVER['REQUEST_URI'] ) ) ? $_SERVER['REQUEST_URI'] : '';
 
+		if ( isset( $_SERVER['SERVER_NAME'] ) && ! empty( $_SERVER['SERVER_NAME'] ) ) {
+			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput -- We know this is scary.
+			$server_name = $_SERVER['SERVER_NAME'];
+		}
+		else {
+			// Early return with just the path.
+			return $suffix;
+		}
+
+		$server_port = '';
 		if ( isset( $_SERVER['SERVER_PORT'] ) && $_SERVER['SERVER_PORT'] !== '80' && $_SERVER['SERVER_PORT'] !== '443' ) {
 			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput -- We know this is scary.
-			$current_url .= $_SERVER['SERVER_NAME'] . ':' . $_SERVER['SERVER_PORT'] . $suffix;
+			$server_port = $_SERVER['SERVER_PORT'];
+		}
+
+		if ( ! empty( $server_port ) ) {
+			$current_url .= $server_name . ':' . $server_port . $suffix;
 		}
 		else {
 			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput -- We know this is scary.
-			$current_url .= $_SERVER['SERVER_NAME'] . $suffix;
+			$current_url .= $server_name . $suffix;
 		}
 
 		return $current_url;

--- a/src/integrations/front-end/redirects.php
+++ b/src/integrations/front-end/redirects.php
@@ -104,7 +104,7 @@ class Redirects implements Integration_Interface {
 		\add_action( 'wp', [ $this, 'archive_redirect' ] );
 		\add_action( 'wp', [ $this, 'page_redirect' ], 99 );
 		\add_action( 'template_redirect', [ $this, 'attachment_redirect' ], 1 );
-		\add_action( 'pre_get_posts', [ $this, 'disable_date_queries' ] );
+		\add_action( 'template_redirect', [ $this, 'disable_date_queries' ] );
 	}
 
 	/**

--- a/tests/unit/helpers/url-helper-test.php
+++ b/tests/unit/helpers/url-helper-test.php
@@ -508,4 +508,126 @@ class Url_Helper_Test extends TestCase {
 			],
 		];
 	}
+
+	/**
+	 * Tests the recreate_current_url function.
+	 *
+	 * @covers ::recreate_current_url
+	 *
+	 * @dataProvider recreate_current_url_test_data
+	 *
+	 * @param array  $params    The input parameters.
+	 * @param string $expected  The expected output.
+	 */
+	public function test_recreate_current_url( $params, $expected ) {
+		if ( ! empty( $params['HTTPS'] ) ) {
+			$_SERVER['HTTPS'] = $params['HTTPS'];
+		}
+
+		if ( ! empty( $params['REQUEST_URI'] ) ) {
+			$_SERVER['REQUEST_URI'] = $params['REQUEST_URI'];
+		}
+
+		if ( ! empty( $params['SERVER_NAME'] ) ) {
+			$_SERVER['SERVER_NAME'] = $params['SERVER_NAME'];
+		}
+
+		if ( ! empty( $params['SERVER_PORT'] ) ) {
+			$_SERVER['SERVER_PORT'] = $params['SERVER_PORT'];
+		}
+
+		$this->assertSame(
+			$expected,
+			$this->instance->recreate_current_url( $params['with_request_uri'] )
+		);
+
+		unset( $_SERVER );
+	}
+
+	/**
+	 * Data for the test_recreate_current_url.
+	 *
+	 * @return array The test data.
+	 */
+	public function recreate_current_url_test_data() {
+		return [
+			'HTTP with request uri' => [
+				'params'   => [
+					'with_request_uri' => true,
+					'REQUEST_URI'      => '/path',
+					'SERVER_NAME'      => 'foobar.tld',
+				],
+				'expected' => 'http://foobar.tld/path',
+			],
+			'HTTP without request uri' => [
+				'params'   => [
+					'with_request_uri' => false,
+					'REQUEST_URI'      => '/path',
+					'SERVER_NAME'      => 'foobar.tld',
+				],
+				'expected' => 'http://foobar.tld',
+			],
+			'HTTPS with request uri' => [
+				'params'   => [
+					'with_request_uri' => true,
+					'HTTPS'            => 'on',
+					'REQUEST_URI'      => '/path',
+					'SERVER_NAME'      => 'foobar.tld',
+				],
+				'expected' => 'https://foobar.tld/path',
+			],
+			'HTTPS without request uri' => [
+				'params'   => [
+					'with_request_uri' => false,
+					'HTTPS'            => 'on',
+					'REQUEST_URI'      => '/path',
+					'SERVER_NAME'      => 'foobar.tld',
+				],
+				'expected' => 'https://foobar.tld',
+			],
+			'HTTP with port and request uri' => [
+				'params'   => [
+					'with_request_uri' => true,
+					'REQUEST_URI'      => '/path',
+					'SERVER_NAME'      => 'foobar.tld',
+					'SERVER_PORT'      => '8080',
+				],
+				'expected' => 'http://foobar.tld:8080/path',
+			],
+			'HTTP with port and without request uri' => [
+				'params'   => [
+					'with_request_uri' => false,
+					'REQUEST_URI'      => '/path',
+					'SERVER_NAME'      => 'foobar.tld',
+					'SERVER_PORT'      => '8080',
+				],
+				'expected' => 'http://foobar.tld:8080',
+			],
+			'No server name with request uri' => [
+				'params'   => [
+					'with_request_uri' => true,
+					'REQUEST_URI'      => '/path',
+					'SERVER_PORT'      => '8080',
+				],
+				'expected' => '/path',
+			],
+			'Empty server name with request uri' => [
+				'params'   => [
+					'with_request_uri' => true,
+					'REQUEST_URI'      => '/path',
+					'SERVER_NAME'      => '',
+					'SERVER_PORT'      => '8080',
+				],
+				'expected' => '/path',
+			],
+			'No server name with no request uri' => [
+				'params'   => [
+					'with_request_uri' => false,
+					'REQUEST_URI'      => '/path',
+					'SERVER_PORT'      => '8080',
+				],
+				'expected' => '',
+			],
+		];
+	}
 }

--- a/tests/unit/helpers/url-helper-test.php
+++ b/tests/unit/helpers/url-helper-test.php
@@ -541,7 +541,21 @@ class Url_Helper_Test extends TestCase {
 			$this->instance->recreate_current_url( $params['with_request_uri'] )
 		);
 
-		unset( $_SERVER );
+		if ( ! empty( $params['HTTPS'] ) ) {
+			unset( $_SERVER['HTTPS'] );
+		}
+
+		if ( ! empty( $params['REQUEST_URI'] ) ) {
+			unset( $_SERVER['REQUEST_URI'] );
+		}
+
+		if ( ! empty( $params['SERVER_NAME'] ) ) {
+			unset( $_SERVER['SERVER_NAME'] );
+		}
+
+		if ( ! empty( $params['SERVER_PORT'] ) ) {
+			unset( $_SERVER['SERVER_PORT'] );
+		}
 	}
 
 	/**

--- a/tests/unit/integrations/front-end/redirects-test.php
+++ b/tests/unit/integrations/front-end/redirects-test.php
@@ -104,6 +104,7 @@ class Redirects_Test extends TestCase {
 		$this->assertNotFalse( Monkey\Actions\has( 'wp', [ $this->instance, 'archive_redirect' ] ) );
 		$this->assertNotFalse( Monkey\Actions\has( 'wp', [ $this->instance, 'page_redirect' ] ) );
 		$this->assertNotFalse( Monkey\Actions\has( 'template_redirect', [ $this->instance, 'attachment_redirect' ] ) );
+		$this->assertNotFalse( Monkey\Actions\has( 'template_redirect', [ $this->instance, 'disable_date_queries' ] ) );
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to prevent the `Url_Helper::recreate_current_url` method to trigger warnings.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where an `Undefined index: SERVER_NAME` warning would be triggered in cronjobs or WP CLI commands.

## Relevant technical choices:

* Moved the date redirect method to the `template_redirect` instead of `pre_get_posts` to avoid affecting all the queries.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* in Search Appearance, disable the Date Archives.
* execute `wp post get 1` in a command line
  * if you're using Rancher/Docker environment:
    * in the terminal, go to the plugins development environment base dir (`plugin-development-docker`)
    * run `docker ps` and copy the name of the container running WordPress ( e.g. `basic-wordpress` ) from the `NAMES` column of the output
    *  run `./wp.sh CONTAINER_NAME post get 1` where `CONTAINER_NAME` is the name you've copied before
* without this patch: you'll get a warning `PHP Notice:  Undefined index: SERVER_NAME in /var/www/html/wp-content/plugins/wordpress-seo/src/helpers/url-helper.php on line 245`
* without this patch: you should not get such warning
* check that https://github.com/Yoast/wordpress-seo/pull/18564 still works: visit e.g. https://example.com/hello-world/?year=2022 and see that the `year` variable is stripped out
* install and activate Premium, and check that the `Campaign tracking URL parameters` and `Unregistered URL parameters` features in the Crawl cleanup settings still work.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes [PC-221] #18688


[PC-221]: https://yoast.atlassian.net/browse/PC-221?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ