### PR TITLE
PC-59 Adds support for organization / person fallback image.

### DIFF
--- a/admin/views/tabs/metas/paper-content/general/knowledge-graph.php
+++ b/admin/views/tabs/metas/paper-content/general/knowledge-graph.php
@@ -15,6 +15,20 @@ echo sprintf(
 );
 
 /**
+ * Retrieve the site logo ID from WordPress settings.
+ *
+ * @return false|int
+ */
+function fallback_to_site_logo() {
+	$logo_id = \get_option( 'site_logo' );
+	if ( ! $logo_id ) {
+		$logo_id = \get_theme_mod( 'custom_logo' );
+	}
+
+	return $logo_id;
+}
+
+/**
  * Filter: 'wpseo_knowledge_graph_setting_msg' - Allows adding a message above these settings.
  *
  * @api string unsigned Message.
@@ -43,13 +57,27 @@ $yform->select( 'company_or_person', __( 'Organization or person', 'wordpress-se
 	 */
 	$yoast_seo_company_name = WPSEO_Options::get( 'company_name', '' );
 	$yoast_seo_company_logo = WPSEO_Options::get( 'company_logo', '' );
+	$yoast_seo_person_logo = WPSEO_Options::get( 'person_logo', '' );
+
+	$yoast_seo_site_name = ( WPSEO_Options::get( 'company_name', '' ) === '' ) ? get_bloginfo( 'name' ) : '';
+
+	$fallback_logo = fallback_to_site_logo();
+
+	if ( empty( $yoast_seo_company_logo ) && $fallback_logo ) {
+		$yform->hidden( 'company_logo_fallback_id', 'company_logo_fallback_id', $fallback_logo );
+	}
+
 	if ( empty( $yoast_seo_company_name ) || empty( $yoast_seo_company_logo ) ) :
 		?>
 		<div id="knowledge-graph-company-warning"></div>
-		<?php
+	<?php
 	endif;
 
-	$yform->textinput( 'company_name', __( 'Organization name', 'wordpress-seo' ), [ 'autocomplete' => 'organization' ] );
+
+	$yform->textinput( 'company_name', __( 'Organization name', 'wordpress-seo' ), [
+		'autocomplete' => 'organization',
+		'placeholder'  => $yoast_seo_site_name,
+	] );
 	$yform->hidden( 'company_logo', 'company_logo' );
 	$yform->hidden( 'company_logo_id', 'company_logo_id' );
 	?>
@@ -60,9 +88,23 @@ $yform->select( 'company_or_person', __( 'Organization or person', 'wordpress-se
 	<h3><?php esc_html_e( 'Personal info', 'wordpress-seo' ); ?></h3>
 
 	<div id="wpseo-person-selector"></div>
-	<div id="yoast-person-image-select"></div>
 	<?php
+
+	if ( empty ( $yoast_seo_person_logo ) ) :
+	?>
+	<div id="knowledge-graph-person-image-info"></div>
+	<?php
+	endif;
+	?>
+
+	<div id="yoast-person-image-select"></div>
+
+	<?php
+
 	$yform->hidden( 'person_logo', 'person_logo' );
+	if ( empty ( $yoast_seo_person_logo ) && $fallback_logo ) {
+		$yform->hidden( 'person_logo_fallback_id', 'person_logo_fallback_id', $fallback_logo );
+	}
 	$yform->hidden( 'person_logo_id', 'person_logo_id' );
 	$yform->hidden( 'company_or_person_user_id', 'person_id' );
 	?>

--- a/admin/views/tabs/metas/paper-content/general/knowledge-graph.php
+++ b/admin/views/tabs/metas/paper-content/general/knowledge-graph.php
@@ -73,7 +73,6 @@ $yform->select( 'company_or_person', __( 'Organization or person', 'wordpress-se
 		<?php
 	endif;
 
-
 	$yform->textinput(
 		'company_name',
 		__( 'Organization name', 'wordpress-seo' ),

--- a/admin/views/tabs/metas/paper-content/general/knowledge-graph.php
+++ b/admin/views/tabs/metas/paper-content/general/knowledge-graph.php
@@ -57,7 +57,7 @@ $yform->select( 'company_or_person', __( 'Organization or person', 'wordpress-se
 	 */
 	$yoast_seo_company_name = WPSEO_Options::get( 'company_name', '' );
 	$yoast_seo_company_logo = WPSEO_Options::get( 'company_logo', '' );
-	$yoast_seo_person_logo = WPSEO_Options::get( 'person_logo', '' );
+	$yoast_seo_person_logo  = WPSEO_Options::get( 'person_logo', '' );
 
 	$yoast_seo_site_name = ( WPSEO_Options::get( 'company_name', '' ) === '' ) ? get_bloginfo( 'name' ) : '';
 
@@ -70,14 +70,18 @@ $yform->select( 'company_or_person', __( 'Organization or person', 'wordpress-se
 	if ( empty( $yoast_seo_company_name ) || empty( $yoast_seo_company_logo ) ) :
 		?>
 		<div id="knowledge-graph-company-warning"></div>
-	<?php
+		<?php
 	endif;
 
 
-	$yform->textinput( 'company_name', __( 'Organization name', 'wordpress-seo' ), [
-		'autocomplete' => 'organization',
-		'placeholder'  => $yoast_seo_site_name,
-	] );
+	$yform->textinput(
+		'company_name',
+		__( 'Organization name', 'wordpress-seo' ),
+		[
+			'autocomplete' => 'organization',
+			'placeholder'  => $yoast_seo_site_name,
+		]
+	);
 	$yform->hidden( 'company_logo', 'company_logo' );
 	$yform->hidden( 'company_logo_id', 'company_logo_id' );
 	?>
@@ -90,10 +94,10 @@ $yform->select( 'company_or_person', __( 'Organization or person', 'wordpress-se
 	<div id="wpseo-person-selector"></div>
 	<?php
 
-	if ( empty ( $yoast_seo_person_logo ) ) :
-	?>
+	if ( empty( $yoast_seo_person_logo ) ) :
+		?>
 	<div id="knowledge-graph-person-image-info"></div>
-	<?php
+		<?php
 	endif;
 	?>
 
@@ -102,7 +106,7 @@ $yform->select( 'company_or_person', __( 'Organization or person', 'wordpress-se
 	<?php
 
 	$yform->hidden( 'person_logo', 'person_logo' );
-	if ( empty ( $yoast_seo_person_logo ) && $fallback_logo ) {
+	if ( empty( $yoast_seo_person_logo ) && $fallback_logo ) {
 		$yform->hidden( 'person_logo_fallback_id', 'person_logo_fallback_id', $fallback_logo );
 	}
 	$yform->hidden( 'person_logo_id', 'person_logo_id' );

--- a/composer.json
+++ b/composer.json
@@ -85,8 +85,8 @@
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_coding_standards"
 		],
 		"check-cs-thresholds": [
-			"@putenv YOASTCS_THRESHOLD_ERRORS=173",
-			"@putenv YOASTCS_THRESHOLD_WARNINGS=217",
+			"@putenv YOASTCS_THRESHOLD_ERRORS=152",
+			"@putenv YOASTCS_THRESHOLD_WARNINGS=209",
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_cs_thresholds"
 		],
 		"check-cs": [

--- a/inc/language-utils.php
+++ b/inc/language-utils.php
@@ -79,7 +79,7 @@ class WPSEO_Language_Utils {
 			'URL'     => esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/3r3' ) ),
 			/* translators: 1: expands to a link opening tag; 2: expands to a link closing tag */
 			'message' => esc_html__(
-				'A company name and logo need to be set for structured data to work properly. %1$sLearn more about the importance of structured data.%2$s',
+				'A company name and logo need to be set for structured data to work properly. Since you haven’t set these yet, we are using the site name and logo as default values. %1$sLearn more about the importance of structured data.%2$s',
 				'wordpress-seo'
 			),
 		];

--- a/packages/components/src/image-select/ImageSelect.js
+++ b/packages/components/src/image-select/ImageSelect.js
@@ -13,7 +13,7 @@ import Alert from "../Alert";
  * @returns {React.Component} The ImageSelect.
  */
 function ImageSelect( props ) {
-	const imageSelected = props.imageUrl !== "";
+	const imageSelected = props.usingFallback === false && props.imageUrl !== "";
 	const previewImageUrl = props.imageUrl || props.defaultImageUrl || "";
 	const showWarnings = props.warnings.length > 0 && imageSelected;
 
@@ -104,6 +104,7 @@ ImageSelect.propTypes = {
 	warnings: PropTypes.arrayOf( PropTypes.string ),
 	hasNewBadge: PropTypes.bool,
 	isDisabled: PropTypes.bool,
+	usingFallback: PropTypes.bool,
 	hasPremiumBadge: PropTypes.bool,
 };
 
@@ -121,5 +122,6 @@ ImageSelect.defaultProps = {
 	warnings: [],
 	hasNewBadge: false,
 	isDisabled: false,
+	usingFallback: false,
 	hasPremiumBadge: false,
 };

--- a/packages/js/src/components/CompanyInfoMissing.js
+++ b/packages/js/src/components/CompanyInfoMissing.js
@@ -36,7 +36,7 @@ CompanyInfoMissing.propTypes = {
 };
 
 CompanyInfoMissing.defaultProps = {
-	type: "warning",
+	type: "info",
 };
 
 export default CompanyInfoMissing;

--- a/packages/js/src/components/ImageSelectComponent.js
+++ b/packages/js/src/components/ImageSelectComponent.js
@@ -12,8 +12,7 @@ import { fetchAttachment, openMedia } from "../helpers/selectMedia";
  * @returns {JSX.Element} The ImageSelectComponent.
  */
 const ImageSelectComponent = ( { hiddenField, hiddenFieldImageId, hiddenFieldFallbackImageId, hasImageValidation, ...imageSelectProps } ) => {
-
-	const [ usingFallback, setUsingFallback ] = useState( ( document.getElementById( hiddenFieldFallbackImageId  ) !== null ) );
+	const [ usingFallback, setUsingFallback ] = useState( ( document.getElementById( hiddenFieldFallbackImageId ) !== null ) );
 	const hiddenFieldElement = useMemo( () => document.getElementById( hiddenField ) );
 	const hiddenFieldSelectImageElement = useMemo( () => document.getElementById( hiddenFieldImageId ) );
 

--- a/packages/js/src/components/PersonImageFallbackInfoMissing.js
+++ b/packages/js/src/components/PersonImageFallbackInfoMissing.js
@@ -1,0 +1,31 @@
+/* External dependencies */
+import PropTypes from "prop-types";
+
+/* Yoast dependencies */
+import { Alert } from "@yoast/components";
+
+/**
+ * Shows an alert with a message and a link.
+ *
+ * @constructor
+ *
+ * @param {Object} props The properties to use.
+ *
+ * @returns {wp.Element} The Alert component.
+ */
+const PersonImageFallbackInfoMissing = ( props ) => {
+	return <Alert type={ props.type }>
+		{ props.message }
+	</Alert>;
+};
+
+PersonImageFallbackInfoMissing.propTypes = {
+	type: PropTypes.oneOf( [ "error", "info", "success", "warning" ] ),
+	message: PropTypes.string.isRequired,
+};
+
+PersonImageFallbackInfoMissing.defaultProps = {
+	type: "info",
+};
+
+export default PersonImageFallbackInfoMissing;

--- a/packages/js/src/components/portals/ImageSelectPortal.js
+++ b/packages/js/src/components/portals/ImageSelectPortal.js
@@ -5,18 +5,19 @@ import Portal from "./Portal";
 
 /**
  *
- * @param {string} target               A target element ID in which to render the portal.
- * @param {string} label                The label for the Image Select component.
- * @param {bool}   hasPreview           A boolean to determine if a preview should be rendered.
- * @param {string} hiddenField          A hidden field to save the image.
- * @param {string} hiddenFieldImageId   The ID for the hidden field.
- * @param {string} selectImageButtonId  The ID for the image select button.
- * @param {string} replaceImageButtonId The ID for the image replace button.
- * @param {string} removeImageButtonId  The ID for the image remove button.
- * @param {bool}   hasNewBadge          Optional. Whether the ImageSelectComponent has a 'New' badge.
- * @param {bool}   isDisabled           Optional. Whether the ImageSelectComponent is disabled.
- * @param {bool}   hasPremiumBadge      Optional. Whether the ImageSelectComponent has a 'Premium' badge.
- * @param {bool}   hasImageValidation   Optional. Whether the uploaded image uses validation.
+ * @param {string} target                       A target element ID in which to render the portal.
+ * @param {string} label                        The label for the Image Select component.
+ * @param {bool}   hasPreview                   A boolean to determine if a preview should be rendered.
+ * @param {string} hiddenField                  A hidden field to save the image.
+ * @param {string} hiddenFieldImageId           The ID for the hidden field.
+ * @param {string} hiddenFieldFallbackImageId   The ID for the hidden fallback image field.
+ * @param {string} selectImageButtonId          The ID for the image select button.
+ * @param {string} replaceImageButtonId         The ID for the image replace button.
+ * @param {string} removeImageButtonId          The ID for the image remove button.
+ * @param {bool}   hasNewBadge                  Optional. Whether the ImageSelectComponent has a 'New' badge.
+ * @param {bool}   isDisabled                   Optional. Whether the ImageSelectComponent is disabled.
+ * @param {bool}   hasPremiumBadge              Optional. Whether the ImageSelectComponent has a 'Premium' badge.
+ * @param {bool}   hasImageValidation           Optional. Whether the uploaded image uses validation.
  *
  * @returns {null|wp.Element} The element.
  * @constructor
@@ -27,6 +28,7 @@ export default function ImageSelectPortal(
 		hasPreview,
 		hiddenField,
 		hiddenFieldImageId,
+		hiddenFieldFallbackImageId,
 		selectImageButtonId,
 		replaceImageButtonId,
 		removeImageButtonId,
@@ -42,6 +44,7 @@ export default function ImageSelectPortal(
 				hasPreview={ hasPreview }
 				hiddenField={ hiddenField }
 				hiddenFieldImageId={ hiddenFieldImageId }
+				hiddenFieldFallbackImageId={ hiddenFieldFallbackImageId }
 				selectImageButtonId={ selectImageButtonId }
 				replaceImageButtonId={ replaceImageButtonId }
 				removeImageButtonId={ removeImageButtonId }
@@ -60,6 +63,7 @@ ImageSelectPortal.propTypes = {
 	hasPreview: PropTypes.bool.isRequired,
 	hiddenField: PropTypes.string.isRequired,
 	hiddenFieldImageId: PropTypes.string,
+	hiddenFieldFallbackImageId: PropTypes.string,
 	selectImageButtonId: PropTypes.string,
 	replaceImageButtonId: PropTypes.string,
 	removeImageButtonId: PropTypes.string,
@@ -71,6 +75,7 @@ ImageSelectPortal.propTypes = {
 
 ImageSelectPortal.defaultProps = {
 	hiddenFieldImageId: "",
+	hiddenFieldFallbackImageId: "",
 	selectImageButtonId: "",
 	replaceImageButtonId: "",
 	removeImageButtonId: "",

--- a/packages/js/src/components/portals/PersonImageFallbackInfoPortal.js
+++ b/packages/js/src/components/portals/PersonImageFallbackInfoPortal.js
@@ -1,0 +1,25 @@
+import PropTypes from "prop-types";
+
+import PersonImageFallbackInfoMissing from "../PersonImageFallbackInfoMissing";
+import Portal from "./Portal";
+
+/**
+ * Renders a portal for a person image missing notice in the search appearance settings.
+ *
+ * @param {string} target A target element ID in which to render the portal.
+ * @param {string} message The message to show in the notice.
+ *
+ * @returns {null|wp.Element} The element.
+ */
+export default function PersonImageFallbackInfoPortal( { target, message } ) {
+	return (
+		<Portal target={ target }>
+			<PersonImageFallbackInfoMissing message={ message } />
+		</Portal>
+	);
+}
+
+PersonImageFallbackInfoPortal.propTypes = {
+	target: PropTypes.string.isRequired,
+	message: PropTypes.string.isRequired,
+};

--- a/packages/js/src/first-time-configuration/first-time-configuration-steps.js
+++ b/packages/js/src/first-time-configuration/first-time-configuration-steps.js
@@ -163,7 +163,7 @@ async function saveFinishedSteps( finishedSteps ) {
  * @returns {Object} The initial state.
  */
 function calculateInitialState( windowObject, isStepFinished ) {
-	let { companyOrPerson, companyName,	companyLogo, companyOrPersonOptions, shouldForceCompany } = windowObject; // eslint-disable-line prefer-const
+	let { companyOrPerson, companyName, companyLogo, companyOrPersonOptions, shouldForceCompany } = windowObject; // eslint-disable-line prefer-const
 
 	if ( shouldForceCompany ) {
 		companyOrPerson = "company";
@@ -238,7 +238,7 @@ export default function FirstTimeConfigurationSteps() {
 						// The classList replace will return false if the class was not present (and thus an adminbar counter).
 						const isAdminBarCounter = ! counterNode.classList.replace( "count-" + oldCount, "count-" + newCount );
 						// If the count reaches zero because of this, remove the red dot alltogether.
-						if ( isAdminBarCounter  && newCount === "0" ) {
+						if ( isAdminBarCounter && newCount === "0" ) {
 							counterNode.style.display = "none";
 						} else {
 							counterNode.firstChild.textContent = counterNode.firstChild.textContent.replace( oldCount, newCount );
@@ -264,8 +264,8 @@ export default function FirstTimeConfigurationSteps() {
 		dispatch( { type: "SET_ERROR_FIELDS", payload: value } );
 	} );
 
-	const isCompanyAndEmpty = state.companyOrPerson === "company" && ( ! state.companyName || ! state.companyLogo );
-	const isPersonAndEmpty = state.companyOrPerson === "person" && ( ! state.personId || ! state.personLogo );
+	const isCompanyAndEmpty = state.companyOrPerson === "company" && ( ! state.companyName || ( ! state.companyLogo && ! state.companyLogoFallback ) );
+	const isPersonAndEmpty = state.companyOrPerson === "person" && ( ! state.personId || ( ! state.personLogo && ! state.personLogoFallback ) );
 
 	/**
 	 * Runs checks of finishing the site representation step.

--- a/packages/js/src/first-time-configuration/tailwind-components/base/image-select.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/base/image-select.js
@@ -16,6 +16,7 @@ import Spinner from "./spinner";
  * @param {string}   props.id                 Id attribute.
  * @param {string}   props.imageAltText       Alternative text for image.
  * @param {string}   props.url                Url for image.
+ * @param {string}   props.fallbackUrl        Fallback url for image.
  * @param {string}   props.label              Label.
  * @param {function} props.onSelectImageClick Select image handler.
  * @param {function} props.onRemoveImageClick Remove image handler.
@@ -28,6 +29,7 @@ export default function ImageSelect( {
 	id,
 	imageAltText,
 	url,
+	fallbackUrl,
 	label,
 	onSelectImageClick,
 	onRemoveImageClick,
@@ -53,7 +55,10 @@ export default function ImageSelect( {
 			);
 		} else if ( url ) {
 			return <img src={ url } alt={ imageAltText } className="yst-w-full yst-h-full yst-object-contain" />;
+		} else if ( fallbackUrl ) {
+			return <img src={ fallbackUrl } alt={ imageAltText } className="yst-w-full yst-h-full yst-object-contain" />;
 		}
+
 		return <PhotographIcon id={ `${ id }-no-image-svg` } className="yst-w-14 yst-h-14 yst-text-gray-500" />;
 	}, [ status, id, url, imageAltText ] );
 
@@ -98,6 +103,7 @@ ImageSelect.propTypes = {
 	label: PropTypes.string,
 	id: PropTypes.string.isRequired,
 	url: PropTypes.string,
+	fallbackUrl: PropTypes.string,
 	imageAltText: PropTypes.string,
 	onRemoveImageClick: PropTypes.func,
 	onSelectImageClick: PropTypes.func,
@@ -112,6 +118,7 @@ ImageSelect.propTypes = {
 ImageSelect.defaultProps = {
 	label: "",
 	url: "",
+	fallbackUrl: "",
 	imageAltText: "",
 	onRemoveImageClick: noop,
 	onSelectImageClick: noop,

--- a/packages/js/src/first-time-configuration/tailwind-components/steps/site-representation/organization-section.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/steps/site-representation/organization-section.js
@@ -9,13 +9,15 @@ import { openMedia } from "../../../../helpers/selectMedia";
 /**
  * The Organization section.
  *
- * @param {function} dispatch     The function to update the container's state.
- * @param {string}   imageUrl         The image URL.
- * @param {string}   organizationName The name of the organization.
- * @param {bool}     isDisabled       A flag to disable the field.
+ * @param {function} dispatch                   The function to update the container's state.
+ * @param {string}   imageUrl                   The image URL.
+ * @param {string}   fallbackImageUrl           The fallback image URL for when there is no image.
+ * @param {string}   organizationName           The name of the organization.
+ * @param {string}   fallbackOrganizationName   The fallback name of the organization.
+ * @param {bool}     isDisabled                 A flag to disable the field.
  * @returns {WPElement} The organization section.
  */
-export function OrganizationSection( { dispatch, imageUrl, organizationName, errorFields } ) {
+export function OrganizationSection( { dispatch, imageUrl, fallbackImageUrl, organizationName, fallbackOrganizationName, errorFields } ) {
 	const openImageSelect = useCallback( () => {
 		openMedia( ( selectedImage ) => {
 			dispatch( { type: "SET_COMPANY_LOGO", payload: { ...selectedImage } } );
@@ -37,7 +39,7 @@ export function OrganizationSection( { dispatch, imageUrl, organizationName, err
 				id="organization-name-input"
 				name="organization-name"
 				label={ __( "Organization name", "wordpress-seo" ) }
-				value={ organizationName }
+				value={ ( organizationName === "" ) ? fallbackOrganizationName : organizationName }
 				onChange={ handleChange }
 				feedback={ {
 					isVisible: errorFields.includes( "company_name" ),
@@ -49,6 +51,7 @@ export function OrganizationSection( { dispatch, imageUrl, organizationName, err
 				className="yst-mt-6"
 				id="organization-logo-input"
 				url={ imageUrl }
+				fallbackUrl={ fallbackImageUrl }
 				onSelectImageClick={ openImageSelect }
 				onRemoveImageClick={ removeImage }
 				imageAltText=""
@@ -62,12 +65,16 @@ export function OrganizationSection( { dispatch, imageUrl, organizationName, err
 OrganizationSection.propTypes = {
 	dispatch: PropTypes.func.isRequired,
 	imageUrl: PropTypes.string,
+	fallbackImageUrl: PropTypes.string,
 	organizationName: PropTypes.string,
+	fallbackOrganizationName: PropTypes.string,
 	errorFields: PropTypes.array,
 };
 
 OrganizationSection.defaultProps = {
 	imageUrl: "",
+	fallbackImageUrl: "",
 	organizationName: "",
+	fallbackOrganizationName: "",
 	errorFields: [],
 };

--- a/packages/js/src/first-time-configuration/tailwind-components/steps/site-representation/person-section.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/steps/site-representation/person-section.js
@@ -11,15 +11,16 @@ import ImageSelect from "../../base/image-select";
 /**
  * The Person section.
  *
- * @param {Object}   props             The props object.
- * @param {function} props.dispatch    The function to update the container's state.
- * @param {string}   props.imageUrl    The image URL.
- * @param {integer}  props.personId    The ID of the user.
- * @param {Boolean}  props.canEditUser Whether the current user can edit the selected person's profile.
+ * @param {Object}   props                      The props object.
+ * @param {function} props.dispatch             The function to update the container's state.
+ * @param {string}   props.imageUrl             The image URL.
+ * @param {string}   props.fallbackImageUrl     The fallback image URL for when there is no image.
+ * @param {integer}  props.personId             The ID of the user.
+ * @param {Boolean}  props.canEditUser          Whether the current user can edit the selected person's profile.
 
  * @returns {WPElement} The person section.
  */
-export function PersonSection( { dispatch, imageUrl, person, canEditUser } ) {
+export function PersonSection( { dispatch, imageUrl, fallbackImageUrl, person, canEditUser } ) {
 	const openImageSelect = useCallback( () => {
 		openMedia( ( selectedImage ) => {
 			dispatch( { type: "SET_PERSON_LOGO", payload: { ...selectedImage } } );
@@ -93,6 +94,7 @@ export function PersonSection( { dispatch, imageUrl, person, canEditUser } ) {
 				className="yst-mt-6"
 				id="person-logo-input"
 				url={ imageUrl }
+				fallbackUrl={ fallbackImageUrl }
 				onSelectImageClick={ openImageSelect }
 				onRemoveImageClick={ removeImage }
 				imageAltText=""
@@ -106,6 +108,7 @@ export function PersonSection( { dispatch, imageUrl, person, canEditUser } ) {
 PersonSection.propTypes = {
 	dispatch: PropTypes.func.isRequired,
 	imageUrl: PropTypes.string,
+	fallbackImageUrl: PropTypes.string,
 	person: PropTypes.shape( {
 		id: PropTypes.number,
 		name: PropTypes.string,
@@ -115,6 +118,7 @@ PersonSection.propTypes = {
 
 PersonSection.defaultProps = {
 	imageUrl: "",
+	fallbackImageUrl: "",
 	person: {
 		id: 0,
 		name: "",

--- a/packages/js/src/first-time-configuration/tailwind-components/steps/site-representation/site-representation-step.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/steps/site-representation/site-representation-step.js
@@ -39,9 +39,29 @@ export default function SiteRepresentationStep( { onOrganizationOrPersonChange, 
 		"yoast-configuration-rich-text-link"
 	);
 
+	/**
+	 * Determines if the default values notice should be displayed.
+	 *
+	 * @returns {boolean} if the notices should be displayed.
+	 */
+	function shouldDisplayDefaultValuesNotice() {
+		if ( state.companyOrPerson === "company" && state.companyName && state.companyLogo ) {
+			return false;
+		}
+
+		if ( state.companyOrPerson === "company" && ! state.companyLogoFallback ) {
+			return false;
+		}
+		if ( state.companyOrPerson === "person" && state.personLogo ) {
+			return false;
+		}
+
+		return ! ( state.companyOrPerson === "person" && ! state.personLogoFallback );
+	}
+
 	return <Fragment>
-		{  window.wpseoFirstTimeConfigurationData.knowledgeGraphMessage &&  <Alert type="info">
-			{  window.wpseoFirstTimeConfigurationData.knowledgeGraphMessage }
+		{ window.wpseoFirstTimeConfigurationData.knowledgeGraphMessage && <Alert type="info">
+			{ window.wpseoFirstTimeConfigurationData.knowledgeGraphMessage }
 		</Alert> }
 		<p className={ classNames( "yst-text-sm yst-whitespace-pre-line yst-mb-6", state.shouldForceCompany ? "yst-mt-4" : "yst-mt-0" ) }>
 			{
@@ -63,6 +83,11 @@ export default function SiteRepresentationStep( { onOrganizationOrPersonChange, 
 			choices={ state.companyOrPersonOptions }
 			disabled={ !! state.shouldForceCompany }
 		/>
+
+		{ shouldDisplayDefaultValuesNotice() && <Alert type="info" className="yst-mt-6">
+			{ __( "We took the liberty of using your site title and logo for the organization name and logo. Feel free to change them below.", "wordpress-seo" ) }
+		</Alert> }
+
 		<ReactAnimateHeight
 			height={ [ "company", "person" ].includes( state.companyOrPerson ) ? "auto" : 0 }
 			duration={ 400 }
@@ -73,12 +98,15 @@ export default function SiteRepresentationStep( { onOrganizationOrPersonChange, 
 				{ state.companyOrPerson === "company" && <OrganizationSection
 					dispatch={ dispatch }
 					imageUrl={ state.companyLogo }
+					fallbackImageUrl={ state.companyLogoFallback }
 					organizationName={ state.companyName }
+					fallbackOrganizationName={ state.fallbackCompanyName }
 					errorFields={ state.errorFields }
 				/> }
 				{ state.companyOrPerson === "person" && <PersonSection
 					dispatch={ dispatch }
 					imageUrl={ state.personLogo }
+					fallbackImageUrl={ state.personLogoFallback }
 					person={ {
 						id: state.personId,
 						name: state.personName,

--- a/packages/js/src/first-time-configuration/tailwind-components/steps/site-representation/site-representation-step.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/steps/site-representation/site-representation-step.js
@@ -52,11 +52,16 @@ export default function SiteRepresentationStep( { onOrganizationOrPersonChange, 
 		if ( state.companyOrPerson === "company" && ! state.companyLogoFallback ) {
 			return false;
 		}
+
 		if ( state.companyOrPerson === "person" && state.personLogo ) {
 			return false;
 		}
 
-		return ! ( state.companyOrPerson === "person" && ! state.personLogoFallback );
+		if ( state.companyOrPerson === "person" && ! state.personLogoFallback ) {
+			return false;
+		}
+
+		return true;
 	}
 
 	return <Fragment>

--- a/packages/js/src/initializers/search-appearance.js
+++ b/packages/js/src/initializers/search-appearance.js
@@ -5,6 +5,7 @@ import { ThemeProvider } from "styled-components";
 import CompanyInfoMissingPortal from "../components/portals/CompanyInfoMissingPortal";
 import ImageSelectPortal from "../components/portals/ImageSelectPortal";
 import LocalSEOUpsellPortal from "../components/portals/LocalSEOUpsellPortal";
+import PersonImageFallbackInfoPortal from "../components/portals/PersonImageFallbackInfoPortal";
 import UserSelectPortal from "../components/portals/UserSelectPortal";
 import SettingsReplacementVariableEditors from "../components/SettingsReplacementVariableEditors";
 import SchemaSettings from "../containers/SchemaSettings";
@@ -55,9 +56,14 @@ export default function initSearchAppearance() {
 						target="yoast-organization-image-select"
 						hiddenField="company_logo"
 						hiddenFieldImageId="company_logo_id"
+						hiddenFieldFallbackImageId="company_logo_fallback_id"
 						selectImageButtonId="yoast-organization-image-select-button"
 						replaceImageButtonId="yoast-organization-image-replace-button"
 						removeImageButtonId="yoast-organization-image-remove-button"
+					/>
+					<PersonImageFallbackInfoPortal
+						target="knowledge-graph-person-image-info"
+						message={ __( "A person logo / avatar need to be set for structured data to work properly. Since you haven’t set these yet, we are using the site logo as default values.", "wordpress-seo" ) }
 					/>
 					<ImageSelectPortal
 						label={ __( "Person logo / avatar", "wordpress-seo" ) }
@@ -65,6 +71,7 @@ export default function initSearchAppearance() {
 						target="yoast-person-image-select"
 						hiddenField="person_logo"
 						hiddenFieldImageId="person_logo_id"
+						hiddenFieldFallbackImageId="person_logo_fallback_id"
 						selectImageButtonId="yoast-person-image-select-button"
 						replaceImageButtonId="yoast-person-image-replace-button"
 						removeImageButtonId="yoast-person-image-remove-button"

--- a/src/context/meta-tags-context.php
+++ b/src/context/meta-tags-context.php
@@ -653,7 +653,7 @@ class Meta_Tags_Context extends Abstract_Presentation {
 	 *
 	 * @return false|int
 	 */
-	private function fallback_to_site_logo() {
+	public function fallback_to_site_logo() {
 		$logo_id = \get_option( 'site_logo' );
 		if ( ! $logo_id ) {
 			$logo_id = \get_theme_mod( 'custom_logo', false );

--- a/src/integrations/admin/first-time-configuration-integration.php
+++ b/src/integrations/admin/first-time-configuration-integration.php
@@ -340,14 +340,14 @@ class First_Time_Configuration_Integration implements Integration_Interface {
 	}
 
 	/**
-	 * Gets the company logo id from the option in the database.
+	 * Gets the company logo url from the option in the database.
 	 *
-	 * @param int|string $company_logo_id The given company logo id by the user, default empty.
+	 * @param string $company_logo The given company logo by the user, default empty.
 	 *
-	 * @return string The company logo id.
+	 * @return {boolean | string} The company logo URL.
 	 */
-	private function get_company_fallback_logo( $company_logo_id ) {
-		if ( $company_logo_id ) {
+	private function get_company_fallback_logo( $company_logo ) {
+		if ( $company_logo ) {
 			return false;
 		}
 		$logo_id = $this->meta_tags_context->fallback_to_site_logo();
@@ -388,14 +388,14 @@ class First_Time_Configuration_Integration implements Integration_Interface {
 	}
 
 	/**
-	 * Gets the company logo id from the option in the database.
+	 * Gets the person logo url from the option in the database.
 	 *
-	 * @param int|string $person_logo_id The given person logo id by the user, default empty.
+	 * @param string $person_logo The given person logo by the user, default empty.
 	 *
-	 * @return string The company logo id.
+	 * @return {boolean | string} The person logo URL.
 	 */
-	private function get_person_fallback_logo( $person_logo_id ) {
-		if ( $person_logo_id ) {
+	private function get_person_fallback_logo( $person_logo ) {
+		if ( $person_logo ) {
 			return false;
 		}
 		$logo_id = $this->meta_tags_context->fallback_to_site_logo();

--- a/src/integrations/admin/first-time-configuration-integration.php
+++ b/src/integrations/admin/first-time-configuration-integration.php
@@ -7,12 +7,10 @@ use WPSEO_Admin_Asset_Manager;
 use WPSEO_Shortlinker;
 use WPSEO_Utils;
 use WPSEO_Option_Tab;
-
 use Yoast\WP\SEO\Conditionals\Admin_Conditional;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Product_Helper;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
-use Yoast\WP\SEO\Integrations\Admin\Social_Profiles_Helper;
 use Yoast\WP\SEO\Routes\Indexing_Route;
 use Yoast\WP\SEO\Context\Meta_Tags_Context;
 
@@ -86,6 +84,7 @@ class First_Time_Configuration_Integration implements Integration_Interface {
 	 * @param Options_Helper            $options_helper         The options helper.
 	 * @param Social_Profiles_Helper    $social_profiles_helper The social profile helper.
 	 * @param Product_Helper            $product_helper         The product helper.
+	 * @param Meta_Tags_Context         $meta_tags_context      The meta tags context helper.
 	 */
 	public function __construct(
 		WPSEO_Admin_Asset_Manager $admin_asset_manager,
@@ -102,7 +101,7 @@ class First_Time_Configuration_Integration implements Integration_Interface {
 		$this->options_helper         = $options_helper;
 		$this->social_profiles_helper = $social_profiles_helper;
 		$this->product_helper         = $product_helper;
-		$this->meta_tags_context 	  = $meta_tags_context;
+		$this->meta_tags_context      = $meta_tags_context;
 	}
 
 	/**
@@ -310,8 +309,9 @@ class First_Time_Configuration_Integration implements Integration_Interface {
 	/**
 	 * Gets the fallback company name from the option in the database if there is no company name.
 	 *
+	 * @param string $company_name The given company name by the user, default empty string.
+	 *
 	 * @return string The company name.
-	 * @var string $company_name
 	 */
 	private function get_fallback_company_name( $company_name ) {
 		if ( $company_name ) {
@@ -320,7 +320,6 @@ class First_Time_Configuration_Integration implements Integration_Interface {
 
 		return \get_bloginfo( 'name' );
 	}
-
 
 	/**
 	 * Gets the company logo from the option in the database.
@@ -343,8 +342,9 @@ class First_Time_Configuration_Integration implements Integration_Interface {
 	/**
 	 * Gets the company logo id from the option in the database.
 	 *
+	 * @param int|string $company_logo_id The given company logo id by the user, default empty.
+	 *
 	 * @return string The company logo id.
-	 * @var int|string $company_logo_id
 	 */
 	private function get_company_fallback_logo( $company_logo_id ) {
 		if ( $company_logo_id ) {
@@ -390,8 +390,9 @@ class First_Time_Configuration_Integration implements Integration_Interface {
 	/**
 	 * Gets the company logo id from the option in the database.
 	 *
+	 * @param int|string $person_logo_id The given person logo id by the user, default empty.
+	 *
 	 * @return string The company logo id.
-	 * @var int|string $person_logo_id
 	 */
 	private function get_person_fallback_logo( $person_logo_id ) {
 		if ( $person_logo_id ) {

--- a/src/integrations/admin/first-time-configuration-integration.php
+++ b/src/integrations/admin/first-time-configuration-integration.php
@@ -14,6 +14,7 @@ use Yoast\WP\SEO\Helpers\Product_Helper;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
 use Yoast\WP\SEO\Integrations\Admin\Social_Profiles_Helper;
 use Yoast\WP\SEO\Routes\Indexing_Route;
+use Yoast\WP\SEO\Context\Meta_Tags_Context;
 
 /**
  * First_Time_Configuration_Integration class
@@ -63,6 +64,13 @@ class First_Time_Configuration_Integration implements Integration_Interface {
 	private $product_helper;
 
 	/**
+	 * The meta tags context helper.
+	 *
+	 * @var \Yoast\WP\SEO\Context\Meta_Tags_Context
+	 */
+	private $meta_tags_context;
+
+	/**
 	 * {@inheritDoc}
 	 */
 	public static function get_conditionals() {
@@ -85,7 +93,8 @@ class First_Time_Configuration_Integration implements Integration_Interface {
 		WPSEO_Shortlinker $shortlinker,
 		Options_Helper $options_helper,
 		Social_Profiles_Helper $social_profiles_helper,
-		Product_Helper $product_helper
+		Product_Helper $product_helper,
+		Meta_Tags_Context $meta_tags_context
 	) {
 		$this->admin_asset_manager    = $admin_asset_manager;
 		$this->addon_manager          = $addon_manager;
@@ -93,6 +102,7 @@ class First_Time_Configuration_Integration implements Integration_Interface {
 		$this->options_helper         = $options_helper;
 		$this->social_profiles_helper = $social_profiles_helper;
 		$this->product_helper         = $product_helper;
+		$this->meta_tags_context 	  = $meta_tags_context;
 	}
 
 	/**
@@ -182,12 +192,15 @@ class First_Time_Configuration_Integration implements Integration_Interface {
 					"companyOrPerson": "%s",
 					"companyOrPersonLabel": "%s",
 					"companyName": "%s",
+					"fallbackCompanyName": "%s",
 					"companyLogo": "%s",
+					"companyLogoFallback": "%s",
 					"companyLogoId": %d,
 					"finishedSteps": %s,
 					"personId": %d,
 					"personName": "%s",
 					"personLogo": "%s",
+					"personLogoFallback": "%s",
 					"personLogoId": %d,
 					"siteTagline": "%s",
 					"socialProfiles": {
@@ -212,12 +225,15 @@ class First_Time_Configuration_Integration implements Integration_Interface {
 				$this->is_company_or_person(),
 				$selected_option_label,
 				$this->get_company_name(),
+				$this->get_fallback_company_name( $this->get_company_name() ),
 				$this->get_company_logo(),
+				$this->get_company_fallback_logo( $this->get_company_logo() ),
 				$this->get_company_logo_id(),
 				WPSEO_Utils::format_json_encode( $finished_steps ),
 				$person_id,
 				$this->get_person_name(),
 				$this->get_person_logo(),
+				$this->get_person_fallback_logo( $this->get_person_logo() ),
 				$this->get_person_logo_id(),
 				$this->get_site_tagline(),
 				$social_profiles['facebook_url'],
@@ -292,6 +308,21 @@ class First_Time_Configuration_Integration implements Integration_Interface {
 	}
 
 	/**
+	 * Gets the fallback company name from the option in the database if there is no company name.
+	 *
+	 * @return string The company name.
+	 * @var string $company_name
+	 */
+	private function get_fallback_company_name( $company_name ) {
+		if ( $company_name ) {
+			return false;
+		}
+
+		return \get_bloginfo( 'name' );
+	}
+
+
+	/**
 	 * Gets the company logo from the option in the database.
 	 *
 	 * @return string The company logo.
@@ -307,6 +338,21 @@ class First_Time_Configuration_Integration implements Integration_Interface {
 	 */
 	private function get_company_logo_id() {
 		return $this->options_helper->get( 'company_logo_id', '' );
+	}
+
+	/**
+	 * Gets the company logo id from the option in the database.
+	 *
+	 * @return string The company logo id.
+	 * @var int|string $company_logo_id
+	 */
+	private function get_company_fallback_logo( $company_logo_id ) {
+		if ( $company_logo_id ) {
+			return false;
+		}
+		$logo_id = $this->meta_tags_context->fallback_to_site_logo();
+
+		return esc_url( wp_get_attachment_url( $logo_id ) );
 	}
 
 	/**
@@ -328,6 +374,7 @@ class First_Time_Configuration_Integration implements Integration_Interface {
 		if ( $user instanceof \WP_User ) {
 			return $user->get( 'display_name' );
 		}
+
 		return '';
 	}
 
@@ -338,6 +385,21 @@ class First_Time_Configuration_Integration implements Integration_Interface {
 	 */
 	private function get_person_logo() {
 		return $this->options_helper->get( 'person_logo', '' );
+	}
+
+	/**
+	 * Gets the company logo id from the option in the database.
+	 *
+	 * @return string The company logo id.
+	 * @var int|string $person_logo_id
+	 */
+	private function get_person_fallback_logo( $person_logo_id ) {
+		if ( $person_logo_id ) {
+			return false;
+		}
+		$logo_id = $this->meta_tags_context->fallback_to_site_logo();
+
+		return esc_url( wp_get_attachment_url( $logo_id ) );
 	}
 
 	/**

--- a/tests/unit/inc/language-utils-test.php
+++ b/tests/unit/inc/language-utils-test.php
@@ -79,7 +79,7 @@ class Language_Utils_Test extends TestCase {
 		$this->assertEquals(
 			[
 				'URL'     => 'https://yoast.com',
-				'message' => 'A company name and logo need to be set for structured data to work properly. %1$sLearn more about the importance of structured data.%2$s',
+				'message' => 'A company name and logo need to be set for structured data to work properly. Since you haven’t set these yet, we are using the site name and logo as default values. %1$sLearn more about the importance of structured data.%2$s',
 			],
 			WPSEO_Language_Utils::get_knowledge_graph_company_info_missing_l10n()
 		);


### PR DESCRIPTION
## Context
This adds functionality to display the site logo and name in the search appearance and first time configuration.
These values are already represented in the schema.

*

## Summary

This PR can be summarized in the following changelog entry:

* Adds the site logo and name as default values in the first time configuration and search appearance.

## Relevant technical choices:

* Added 'fallback images' to the image components to make sure you cannot remove these.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

*  In search appearance with organization selected, `without` a logo set in the customizer:
	*  	You should see no placeholder image. and in the front-end there should not be any schema for `"@type": "Organization",`
	* 	You should see a placeholder text in the organization name
	*   Select a logo and save. The logo should now be visible. and the `"@type": "Organization",` schema is now visible in the front-end

* In search appearance with organization selected, `with` a logo set in the customizer:
	* 	You should see your site logo as the placeholder image. 
	* 	You should see a placeholder text in the organization name
	*   Select a logo and save. The logo should now be visible. and the `"@type": "Organization",` schema now represents the new logo.

* In search appearance with person selected, `without` a logo set in the customizer:
	*  	You should see no placeholder image. and in the front-end there should not be any schema for `"@type": "Person",`
	*   Select a logo and save. The logo should now be visible. and the `"@type": "Person",` schema is now visible in the front-end.

* In search appearance with person selected, `with` a logo set in the customizer:
	* 	You should see your site logo as the placeholder image. 
	*   Select a logo and save. The logo should now be visible. and the `"@type": "Person",` schema now represents the new logo.


* In the first time configuration repeat the same steps as above for the site representation part.
* When there is no site logo and you hit `save changes` the should be a notice message that appears that reads `Please be aware that you need to fill out all settings in this step to get the most value out of structured data.`
When there is a site logo this message should not appear and the settings should just be saved.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The search appearance page
* The first time configuration.

## UI changes

* [X] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.

Fixes #
PC-59