### PR TITLE
Only show FRE notice when FRE is available.

### DIFF
--- a/packages/js/src/components/contentAnalysis/ReadabilityAnalysis.js
+++ b/packages/js/src/components/contentAnalysis/ReadabilityAnalysis.js
@@ -237,7 +237,7 @@ class ReadabilityAnalysis extends Component {
 								id={ `yoast-readability-analysis-collapsible-${ location }` }
 							>
 								{ this.renderResults( upsellResults ) }
-								{ this.renderFleschReadingEaseNote( location ) }
+								{ this.props.isFleschReadingEaseAvailable && this.renderFleschReadingEaseNote( location ) }
 							</Collapsible>
 						);
 					}
@@ -251,7 +251,7 @@ class ReadabilityAnalysis extends Component {
 										scoreIndicator={ score.className }
 									/>
 									{ this.renderResults( upsellResults ) }
-									{ this.renderFleschReadingEaseNote( location ) }
+									{ this.props.isFleschReadingEaseAvailable && this.renderFleschReadingEaseNote( location ) }
 								</ReadabilityResultsTabContainer>
 							</ReadabilityResultsPortal>
 						);
@@ -270,6 +270,7 @@ ReadabilityAnalysis.propTypes = {
 	isYoastSEOWooActive: PropTypes.bool,
 	isInsightsEnabled: PropTypes.bool,
 	isElementorEditor: PropTypes.bool,
+	isFleschReadingEaseAvailable: PropTypes.bool,
 };
 
 ReadabilityAnalysis.defaultProps = {
@@ -278,6 +279,7 @@ ReadabilityAnalysis.defaultProps = {
 	isYoastSEOWooActive: false,
 	isInsightsEnabled: false,
 	isElementorEditor: false,
+	isFleschReadingEaseAvailable: false,
 };
 
 export default withSelect( select => {
@@ -286,6 +288,7 @@ export default withSelect( select => {
 		getMarkButtonStatus,
 		getPreference,
 		getIsElementorEditor,
+		isFleschReadingEaseAvailable,
 	} = select( "yoast-seo/editor" );
 
 	const isInsightsEnabled = getPreference( "isInsightsEnabled", false );
@@ -295,5 +298,6 @@ export default withSelect( select => {
 		marksButtonStatus: getMarkButtonStatus(),
 		isInsightsEnabled,
 		isElementorEditor: getIsElementorEditor(),
+		isFleschReadingEaseAvailable: isFleschReadingEaseAvailable(),
 	};
 } )( ReadabilityAnalysis );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where a notice was shown indicating that the Flesch reading ease score has moved from the readability analysis to the Insights for languages that do not have Flesch reading ease support.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Language with no FRE support
* Set your site's language to a language that does not have Flesch reading ease support.
   * For example Japanese or Indonesian. 
* Create a post.
* Look into the readability analysis results (in the sidebar and the metabox).
* There **should not** be a note at the end of the results telling the user that the Flesch reading ease score has moved to the Insights.

#### Language with FRE support
* Set your site's language to a language that has Flesch reading ease support.
   * For example English or Dutch.
* Create a post.
* Look into the readability analysis results (in the sidebar and the metabox).
* There **should** be a note at the end of the results telling the user that the Flesch reading ease score has moved to the Insights.

Also test in different editors (block editor, classic editor, Elementor).

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* 

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes #
