### PR TITLE
bugfix: Update breadcrumbs-presenter.php

### DIFF
--- a/src/presenters/breadcrumbs-presenter.php
+++ b/src/presenters/breadcrumbs-presenter.php
@@ -139,24 +139,20 @@ class Breadcrumbs_Presenter extends Abstract_Indexable_Presenter {
 			$link      .= '<' . $this->get_element() . '>';
 			$title_attr = isset( $breadcrumb['title'] ) ? ' title="' . \esc_attr( $breadcrumb['title'] ) . '"' : '';
 			$link      .= '<a href="' . \esc_url( $breadcrumb['url'] ) . '"' . $title_attr . '>' . $text . '</a>';
+			$link      .= '</' . $this->get_element() . '>';
 		}
 		elseif ( $index === ( $total - 1 ) ) {
 			// If it's the last element.
-			$inner_elm = 'span';
+			
 			if ( $this->helpers->options->get( 'breadcrumbs-boldlast' ) === true ) {
-				$inner_elm = 'strong';
+				$text = '<strong>' . $text . '</strong>';
 			}
 
-			$link .= '<' . $inner_elm . ' class="breadcrumb_last" aria-current="page">' . $text . '</' . $inner_elm . '>';
-			// This is the last element, now close all previous elements.
-			while ( $index > 0 ) {
-				$link .= '</' . $this->get_element() . '>';
-				--$index;
-			}
+			$link .= '<' . $this->get_element() . ' class="breadcrumb_last" aria-current="page">' . $text . '</' . $this->get_element() . '>';
 		}
 		else {
 			// It's not the last element and has no url.
-			$link .= '<span>' . $text . '</span>';
+			$link .= '<' . $this->get_element() . '>' . $text . '</' . $this->get_element() . '>';
 		}
 
 		/**


### PR DESCRIPTION
Fix breadcrumbs output errors and logic. 

## Context
Close link elements properly, and let filters control the wrapper elements of all links, not just some. Works with default elements and custom elements (like the semantically correct ol and li).

## Summary

Fixes a bug where breadcrumbs markup would not validate due to improper nesting and closing of span tags.

## Relevant technical choices:

* Close breadcrumb elements properly
* Reference `get_element` on all breadcrumbs so custom filters can be used properly
* Move `<strong>` tag in last element to the `$text` variable

## Test instructions

* Use breadcrumbs on the site. Check the HTML markup.
* Use the `wpseo_breadcrumb_output_wrapper` and `wpseo_breadcrumb_single_link_wrapper` filters to change `span` to `ol` and `li` respectively.
* Use the `wpseo_breadcrumb_separator` filter to wrap separators in `li` elements to create valid HTML on the front end.

### Test instructions for QA when the code is in the RC

* [ x ] QA should use the same steps as above.

## Impact check

* I haven't tested headless, but the Gutenberg output for the Breadcrumbs block is now correct with this PR.

## UI changes

* None

## Documentation

* This change makes the current documentation more accurate.

## Quality assurance

* [ x ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ x ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ x ] I have written this PR in accordance with my team's definition of done.

Fixes #17569 #6339 #6338
