### PR TITLE
PC-273 - 19.4 Yoast SEO: styling issues

### DIFF
--- a/css/src/toggle-switch.css
+++ b/css/src/toggle-switch.css
@@ -458,8 +458,7 @@
 		margin: 0 0 0.8em 0;
 	}
 
-	.switch-container .clear {
-		clear: both;
+	.switch-container.premium-upsell .clear {
 		display: none;
 	}
 

--- a/css/src/yst_plugin_tools.css
+++ b/css/src/yst_plugin_tools.css
@@ -65,6 +65,7 @@ tr.yst_row.even {
   float: left;
   width: 200px;
   margin: 5px 0;
+  word-wrap: break-word;
 }
 
 .wpseo_content_wrapper label.textinput.error,


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*  Fixes alignment issues of elements on pages with a switch-container.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes alignment issues of elements on pages with a switch-container.

## Relevant technical choices:

* Hides the 'clear' div only when its an upsell 'switch-container'.
* Adds word-wrap to 'label.select' else the text would go underneath the select field if the label was too long.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* SEO - Search Appearance:
  * Verify the 'description' of 'Force rewrite titles' is on a new line.
* Breadcrumbs:
  * The select label is now word wrapping instead of going underneath the select field if the label is too long.
* Social - Facebook & Twitter
  * Verify the 'description' is on a new line.
* Local SEO:
  * Visit Local SEO and verify the alignment of the elements after the 'switch-container' don't look off anymore. 

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes PC-273