### PR TITLE
Fix access to possible non-existent array element

### DIFF
--- a/src/context/meta-tags-context.php
+++ b/src/context/meta-tags-context.php
@@ -621,7 +621,9 @@ class Meta_Tags_Context extends Abstract_Presentation {
 			case is_search():
 			case is_date():
 			case is_post_type_archive():
-				return $this->get_singular_post_image( $GLOBALS['wp_query']->posts[0]->ID );
+				if ( ! empty ( $GLOBALS['wp_query']->posts ) ) {
+					return $this->get_singular_post_image( $GLOBALS['wp_query']->posts[0]->ID );
+				}
 			default:
 				return null;
 		}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Trying to generate the schema main image element for empty collection pages (e.g. archives, search results, categories, etc. ) leads to PHP notices being displayed

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where a non-existing array element is accessed if an attempt is made to generate a main image schema element for empty collection pages.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Perform a search which you know would lead to an empty results set, e.g. `http://basic.wordpress.test/?s=whdfyavtr`
  * without this PR, check that two PHP notices are generated: `Undefined offset: 0` and `Trying to get property 'ID' of non-object` referencing line 624 of `meta-tags-context.php` file
  * with this PR, the above notices are not present
* Create a new post category 
* Visit the category in the frontend (e.g. by doing `http://basic.wordpress.test/category/empty-category/`) and verify the above behavior holds

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->


## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes [PC-272](https://yoast.atlassian.net/browse/PC-272)
