### PR TITLE
PC 162 Exclude estimated reading time from the analysis

### DIFF
--- a/packages/yoastseo/spec/languageProcessing/helpers/sanitize/excludeEstimatedReadingTimeSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/helpers/sanitize/excludeEstimatedReadingTimeSpec.js
@@ -1,0 +1,14 @@
+const estimatedReadingTimeRegex = new RegExp( "(<p class=\"yoast-reading-time__wrapper\"><span class=\"yoast-reading-time__icon\">).*?(</div>)",
+	"igs" );
+
+/**
+ * Excludes table of contents from text.
+ *
+ * @param {String} text The text to check.
+ *
+ * @returns {String} The text without table of contents.
+ */
+export default function excludeEstimatedReadingTime( text ) {
+	text = text.replace( estimatedReadingTimeRegex, "" );
+	return text;
+}

--- a/packages/yoastseo/spec/languageProcessing/helpers/sanitize/excludeEstimatedReadingTimeSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/helpers/sanitize/excludeEstimatedReadingTimeSpec.js
@@ -2,14 +2,19 @@ import excludeEstimatedReadingTime from "../../../../src/languageProcessing/help
 
 describe( "Strips the estimated reading time from the analysis text.", function() {
 	it( "returns a text without the estimated reading time", function() {
-		const text = "<p class='yoast-reading-time__wrapper'><span class='yoast-reading-time__icon'><svg aria-hidden='true' focusable='false' data-icon='clock' width='20' height='20' fill='none' stroke='currentColor' style='display:inline-block;vertical-align:-0.1em' role='img' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z'></path></svg></span><span class='yoast-reading-time__spacer' style='display:inline-block;width:1em'></span><span class='yoast-reading-time__descriptive-text'>Estimated reading time:  </span><span class='yoast-reading-time__reading-time'>2</span><span class='yoast-reading-time__time-unit'> minutes</span></p>\n" +
-			"<p>For the first time in 70 years, India’s forests will be home to cheetahs.</strong></p>\n" +
-			"<p>Eight of them are set to arrive in August from Namibia, home to one of the world’s largest populations of the wild cat.</p>\n" +
-			"<p>Their return comes decades after India’s indigenous population was declared officially extinct in 1952.</p>\n" +
-			"<p>The world’s fastest land animal, the cheetah can reach speeds of 70 miles (113km) an hour.</p>\n";
-		expect( excludeEstimatedReadingTime( text ) ).toEqual( "<p>For the first time in 70 years, India’s forests will be home to cheetahs.</strong></p>\n" +
-			"<p>Eight of them are set to arrive in August from Namibia, home to one of the world’s largest populations of the wild cat.</p>\n" +
-			"<p>Their return comes decades after India’s indigenous population was declared officially extinct in 1952.</p>\n" +
+		const text = "<p class='yoast-reading-time__wrapper'>" +
+			"<span class='yoast-reading-time__icon'><svg><path></path></svg></span>" +
+			"<span class='yoast-reading-time__spacer' style='display:inline-block;width:1em'></span>" +
+			"<span class='yoast-reading-time__descriptive-text'>Estimated reading time:  </span>" +
+			"<span class='yoast-reading-time__reading-time'>2</span><span class='yoast-reading-time__time-unit'> minutes</span></p>" +
+			"<p>For the first time in 70 years, India’s forests will be home to cheetahs.</p>" +
+			"<p>Eight of them are set to arrive in August from Namibia, home to one of the world’s largest populations of the wild cat.</p>" +
+			"<p>Their return comes decades after India’s indigenous population was declared officially extinct in 1952.</p>" +
+			"<p>The world’s fastest land animal, the cheetah can reach speeds of 70 miles (113km) an hour.</p>";
+		expect( excludeEstimatedReadingTime( text ) ).toEqual(
+			"<p>For the first time in 70 years, India’s forests will be home to cheetahs.</p>" +
+			"<p>Eight of them are set to arrive in August from Namibia, home to one of the world’s largest populations of the wild cat.</p>" +
+			"<p>Their return comes decades after India’s indigenous population was declared officially extinct in 1952.</p>" +
 			"<p>The world’s fastest land animal, the cheetah can reach speeds of 70 miles (113km) an hour.</p>" );
 	} );
 } );

--- a/packages/yoastseo/spec/languageProcessing/helpers/sanitize/excludeEstimatedReadingTimeSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/helpers/sanitize/excludeEstimatedReadingTimeSpec.js
@@ -3,13 +3,13 @@ import excludeEstimatedReadingTime from "../../../../src/languageProcessing/help
 describe( "Strips the estimated reading time from the analysis text.", function() {
 	it( "returns a text without the estimated reading time", function() {
 		const text = "<p class='yoast-reading-time__wrapper'><span class='yoast-reading-time__icon'><svg aria-hidden='true' focusable='false' data-icon='clock' width='20' height='20' fill='none' stroke='currentColor' style='display:inline-block;vertical-align:-0.1em' role='img' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z'></path></svg></span><span class='yoast-reading-time__spacer' style='display:inline-block;width:1em'></span><span class='yoast-reading-time__descriptive-text'>Estimated reading time:  </span><span class='yoast-reading-time__reading-time'>2</span><span class='yoast-reading-time__time-unit'> minutes</span></p>\n" +
-			"<p><strong>For the first time in 70 years, India’s forests will be home to cheetahs.</strong></p>\n" +
+			"<p>For the first time in 70 years, India’s forests will be home to cheetahs.</strong></p>\n" +
 			"<p>Eight of them are set to arrive in August from Namibia, home to one of the world’s largest populations of the wild cat.</p>\n" +
 			"<p>Their return comes decades after India’s indigenous population was declared officially extinct in 1952.</p>\n" +
 			"<p>The world’s fastest land animal, the cheetah can reach speeds of 70 miles (113km) an hour.</p>\n";
-		expect( excludeEstimatedReadingTime( text ) ).toBe( "<p><strong>For the first time in 70 years, India’s forests will be home to cheetahs.</strong></p>\n" +
+		expect( excludeEstimatedReadingTime( text ) ).toEqual( "<p>For the first time in 70 years, India’s forests will be home to cheetahs.</strong></p>\n" +
 			"<p>Eight of them are set to arrive in August from Namibia, home to one of the world’s largest populations of the wild cat.</p>\n" +
 			"<p>Their return comes decades after India’s indigenous population was declared officially extinct in 1952.</p>\n" +
-			"<p>The world’s fastest land animal, the cheetah can reach speeds of 70 miles (113km) an hour.</p>\n" );
+			"<p>The world’s fastest land animal, the cheetah can reach speeds of 70 miles (113km) an hour.</p>" );
 	} );
 } );

--- a/packages/yoastseo/spec/languageProcessing/helpers/sanitize/excludeEstimatedReadingTimeSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/helpers/sanitize/excludeEstimatedReadingTimeSpec.js
@@ -1,14 +1,15 @@
-const estimatedReadingTimeRegex = new RegExp( "(<p class=\"yoast-reading-time__wrapper\"><span class=\"yoast-reading-time__icon\">).*?(</div>)",
-	"igs" );
+import excludeEstimatedReadingTime from "../../../../src/languageProcessing/helpers/sanitize/excludeEstimatedReadingTime.js";
 
-/**
- * Excludes table of contents from text.
- *
- * @param {String} text The text to check.
- *
- * @returns {String} The text without table of contents.
- */
-export default function excludeEstimatedReadingTime( text ) {
-	text = text.replace( estimatedReadingTimeRegex, "" );
-	return text;
-}
+describe( "Strips the estimated reading time from the analysis text.", function() {
+	it( "returns a text without the estimated reading time", function() {
+		const text = "<p class='yoast-reading-time__wrapper'><span class='yoast-reading-time__icon'><svg aria-hidden='true' focusable='false' data-icon='clock' width='20' height='20' fill='none' stroke='currentColor' style='display:inline-block;vertical-align:-0.1em' role='img' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z'></path></svg></span><span class='yoast-reading-time__spacer' style='display:inline-block;width:1em'></span><span class='yoast-reading-time__descriptive-text'>Estimated reading time:  </span><span class='yoast-reading-time__reading-time'>2</span><span class='yoast-reading-time__time-unit'> minutes</span></p>\n" +
+			"<p><strong>For the first time in 70 years, India’s forests will be home to cheetahs.</strong></p>\n" +
+			"<p>Eight of them are set to arrive in August from Namibia, home to one of the world’s largest populations of the wild cat.</p>\n" +
+			"<p>Their return comes decades after India’s indigenous population was declared officially extinct in 1952.</p>\n" +
+			"<p>The world’s fastest land animal, the cheetah can reach speeds of 70 miles (113km) an hour.</p>\n";
+		expect( excludeEstimatedReadingTime( text ) ).toBe( "<p><strong>For the first time in 70 years, India’s forests will be home to cheetahs.</strong></p>\n" +
+			"<p>Eight of them are set to arrive in August from Namibia, home to one of the world’s largest populations of the wild cat.</p>\n" +
+			"<p>Their return comes decades after India’s indigenous population was declared officially extinct in 1952.</p>\n" +
+			"<p>The world’s fastest land animal, the cheetah can reach speeds of 70 miles (113km) an hour.</p>\n" );
+	} );
+} );

--- a/packages/yoastseo/spec/languageProcessing/helpers/sanitize/excludeEstimatedReadingTimeSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/helpers/sanitize/excludeEstimatedReadingTimeSpec.js
@@ -17,4 +17,15 @@ describe( "Strips the estimated reading time from the analysis text.", function(
 			"<p>Their return comes decades after India’s indigenous population was declared officially extinct in 1952.</p>" +
 			"<p>The world’s fastest land animal, the cheetah can reach speeds of 70 miles (113km) an hour.</p>" );
 	} );
+
+	it( "returns a text without the estimated reading time, even if additional classes are added to the p element", function() {
+		const text = "<p class='yoast-reading-time__wrapper some-additional-class some-other-additional-class'>" +
+			"<span class='yoast-reading-time__icon'><svg><path></path></svg></span>" +
+			"<span class='yoast-reading-time__spacer' style='display:inline-block;width:1em'></span>" +
+			"<span class='yoast-reading-time__descriptive-text'>Estimated reading time:  </span>" +
+			"<span class='yoast-reading-time__reading-time'>2</span><span class='yoast-reading-time__time-unit'> minutes</span></p>" +
+			"<p>This test has some more class(es).</p>";
+		expect( excludeEstimatedReadingTime( text ) ).toEqual(
+			"<p>This test has some more class(es).</p>" );
+	} );
 } );

--- a/packages/yoastseo/spec/languageProcessing/researches/findKeywordInFirstParagraphSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/findKeywordInFirstParagraphSpec.js
@@ -455,6 +455,27 @@ describe( "tests for edge cases", function() {
 		} );
 	} );
 
+	it( "skips the first paragraph if there is an estimated reading time element", function() {
+		const paper = new Paper(
+			"<p class='yoast-reading-time__wrapper'>" +
+			"<span class='yoast-reading-time__icon'><svg><path></path></svg></span>" +
+			"<span class='yoast-reading-time__spacer' style='display:inline-block;width:1em'></span>" +
+			"<span class='yoast-reading-time__descriptive-text'>Estimated reading time:  </span>" +
+			"<span class='yoast-reading-time__reading-time'>2</span><span class='yoast-reading-time__time-unit'> minutes</span></p>" +
+			"<div>A sentence with a keyword</div>", {
+				keyword: "keyword",
+				synonyms: "",
+			}
+		);
+		const researcher = new EnglishResearcher( paper );
+		researcher.addResearchData( "morphology", morphologyData );
+		expect( firstParagraph( paper, researcher ) ).toEqual( {
+			foundInOneSentence: true,
+			foundInParagraph: true,
+			keyphraseOrSynonym: "keyphrase",
+		} );
+	} );
+
 	it( "does not find keyword in the link in the first paragraph", function() {
 		const paper = new Paper(
 			"<a href=\"https://test.keyword.com/test\"> keyword <img src=\"https://www.keyword.com/test.jpg\" alt=\"a keyword tag\"> keyword </a>", {

--- a/packages/yoastseo/src/languageProcessing/helpers/sanitize/excludeEstimatedReadingTime.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/sanitize/excludeEstimatedReadingTime.js
@@ -1,0 +1,14 @@
+const estimatedReadingTimeRegex = new RegExp( "(<p class=\"yoast-reading-time__wrapper\"><span class=\"yoast-reading-time__icon\">).*?(</div>)",
+	"igs" );
+
+/**
+ * Excludes table of contents from text.
+ *
+ * @param {String} text The text to check.
+ *
+ * @returns {String} The text without table of contents.
+ */
+export default function excludeEstimatedReadingTime( text ) {
+	text = text.replace( estimatedReadingTimeRegex, "" );
+	return text;
+}

--- a/packages/yoastseo/src/languageProcessing/helpers/sanitize/excludeEstimatedReadingTime.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/sanitize/excludeEstimatedReadingTime.js
@@ -1,5 +1,5 @@
-const estimatedReadingTimeRegex = new RegExp( "(<p class=\"yoast-reading-time__wrapper\">).*?(</p>)",
-	"igs" );
+const estimatedReadingTimeRegex = new RegExp( "(<p class='yoast-reading-time__wrapper'>).*?(<\\/p>)",
+	"gmi" );
 
 /**
  * Excludes table of contents from text.
@@ -9,6 +9,8 @@ const estimatedReadingTimeRegex = new RegExp( "(<p class=\"yoast-reading-time__w
  * @returns {String} The text without table of contents.
  */
 export default function excludeEstimatedReadingTime( text ) {
+	console.log( text );
 	text = text.replace( estimatedReadingTimeRegex, "" );
-	return text;
+	console.log( text );
+	return text.trim();
 }

--- a/packages/yoastseo/src/languageProcessing/helpers/sanitize/excludeEstimatedReadingTime.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/sanitize/excludeEstimatedReadingTime.js
@@ -1,4 +1,4 @@
-const estimatedReadingTimeRegex = new RegExp( "<p class='yoast-reading-time__wrapper'>.*?</p>", "igs" );
+const estimatedReadingTimeRegex = new RegExp( "<p class='yoast-reading-time__wrapper.*?</p>", "igs" );
 
 /**
  * Excludes table of contents from text.

--- a/packages/yoastseo/src/languageProcessing/helpers/sanitize/excludeEstimatedReadingTime.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/sanitize/excludeEstimatedReadingTime.js
@@ -1,4 +1,4 @@
-const estimatedReadingTimeRegex = new RegExp( "(<p class=\"yoast-reading-time__wrapper\"><span class=\"yoast-reading-time__icon\">).*?(</div>)",
+const estimatedReadingTimeRegex = new RegExp( "(<p className=\"yoast-reading-time__wrapper\">).*?(</p>)",
 	"igs" );
 
 /**

--- a/packages/yoastseo/src/languageProcessing/helpers/sanitize/excludeEstimatedReadingTime.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/sanitize/excludeEstimatedReadingTime.js
@@ -9,8 +9,6 @@ const estimatedReadingTimeRegex = new RegExp( "(<p class='yoast-reading-time__wr
  * @returns {String} The text without table of contents.
  */
 export default function excludeEstimatedReadingTime( text ) {
-	console.log( text );
 	text = text.replace( estimatedReadingTimeRegex, "" );
-	console.log( text );
 	return text.trim();
 }

--- a/packages/yoastseo/src/languageProcessing/helpers/sanitize/excludeEstimatedReadingTime.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/sanitize/excludeEstimatedReadingTime.js
@@ -1,5 +1,4 @@
-const estimatedReadingTimeRegex = new RegExp( "(<p class='yoast-reading-time__wrapper'>).*?(<\\/p>)",
-	"gmi" );
+const estimatedReadingTimeRegex = new RegExp( "<p class='yoast-reading-time__wrapper'>.*?</p>", "igs" );
 
 /**
  * Excludes table of contents from text.
@@ -10,5 +9,5 @@ const estimatedReadingTimeRegex = new RegExp( "(<p class='yoast-reading-time__wr
  */
 export default function excludeEstimatedReadingTime( text ) {
 	text = text.replace( estimatedReadingTimeRegex, "" );
-	return text.trim();
+	return text;
 }

--- a/packages/yoastseo/src/languageProcessing/helpers/sanitize/excludeEstimatedReadingTime.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/sanitize/excludeEstimatedReadingTime.js
@@ -1,4 +1,4 @@
-const estimatedReadingTimeRegex = new RegExp( "(<p className=\"yoast-reading-time__wrapper\">).*?(</p>)",
+const estimatedReadingTimeRegex = new RegExp( "(<p class=\"yoast-reading-time__wrapper\">).*?(</p>)",
 	"igs" );
 
 /**

--- a/packages/yoastseo/src/languageProcessing/helpers/sanitize/sanitizeString.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/sanitize/sanitizeString.js
@@ -1,4 +1,5 @@
 import excludeTableOfContentsTag from "./excludeTableOfContentsTag";
+import excludeEstimatedReadingTime from "../sanitize/excludeEstimatedReadingTime";
 import { stripFullTags as stripTags } from "./stripHTMLTags.js";
 import { unifyAllSpaces } from "./unifyWhitespace";
 
@@ -14,6 +15,8 @@ export default function( text ) {
 	text = unifyAllSpaces( text );
 	// Remove Table of Contents.
 	text = excludeTableOfContentsTag( text );
+	// Remove Estimated reading time
+	text = excludeEstimatedReadingTime( text );
 	// Strip the tags and multiple spaces.
 	text = stripTags( text );
 

--- a/packages/yoastseo/src/languageProcessing/helpers/sentence/getSentences.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/sentence/getSentences.js
@@ -49,7 +49,7 @@ export default function( text, memoizedTokenizer ) {
 	// We don't remove the other HTML tags here since removing them might lead to incorrect results when running the sentence tokenizer.
 	// Remove Table of Contents.
 	text = excludeTableOfContentsTag( text );
-	// Remove Estimated reading time
+	// Remove Estimated reading time.
 	text = excludeEstimatedReadingTime( text );
 	// Unify only non-breaking spaces and not the other whitespaces since a whitespace could signify a sentence break or a new line.
 	text = unifyNonBreakingSpace( text );

--- a/packages/yoastseo/src/languageProcessing/helpers/sentence/getSentences.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/sentence/getSentences.js
@@ -4,6 +4,7 @@ import { filter, flatMap, isEmpty, negate, memoize } from "lodash-es";
 // Internal dependencies.
 import { getBlocks } from "../html/html.js";
 import excludeTableOfContentsTag from "../sanitize/excludeTableOfContentsTag";
+import excludeEstimatedReadingTime from "../sanitize/excludeEstimatedReadingTime";
 import { unifyNonBreakingSpace } from "../sanitize/unifyWhitespace";
 import SentenceTokenizer from "./SentenceTokenizer";
 
@@ -48,6 +49,8 @@ export default function( text, memoizedTokenizer ) {
 	// We don't remove the other HTML tags here since removing them might lead to incorrect results when running the sentence tokenizer.
 	// Remove Table of Contents.
 	text = excludeTableOfContentsTag( text );
+	// Remove Estimated reading time
+	text = excludeEstimatedReadingTime( text );
 	// Unify only non-breaking spaces and not the other whitespaces since a whitespace could signify a sentence break or a new line.
 	text = unifyNonBreakingSpace( text );
 

--- a/packages/yoastseo/src/languageProcessing/researches/findKeywordInFirstParagraph.js
+++ b/packages/yoastseo/src/languageProcessing/researches/findKeywordInFirstParagraph.js
@@ -7,6 +7,7 @@ import imageInText from "../helpers/image/imageInText";
 import findEmptyDivisions from "../helpers/html/findEmptyDivisions";
 import getAnchorsFromText from "../helpers/link/getAnchorsFromText";
 import matchStringWithRegex from "../helpers/regex/matchStringWithRegex";
+import excludeEstimatedReadingTime from "../helpers/sanitize/excludeEstimatedReadingTime";
 
 import { reject } from "lodash-es";
 import { isEmpty } from "lodash-es";
@@ -112,7 +113,7 @@ export default function( paper, researcher ) {
 	const memoizedTokenizer = researcher.getHelper( "memoizedTokenizer" );
 	const locale = paper.getLocale();
 
-	let paragraphs = matchParagraphs( paper.getText() );
+	let paragraphs = matchParagraphs( excludeEstimatedReadingTime( paper.getText() ) );
 	paragraphs = reject( paragraphs, isEmpty );
 	paragraphs = reject( paragraphs, paragraphHasNoText )[ 0 ] || "";
 

--- a/packages/yoastseo/src/languageProcessing/researches/getParagraphLength.js
+++ b/packages/yoastseo/src/languageProcessing/researches/getParagraphLength.js
@@ -1,4 +1,5 @@
 import excludeTableOfContentsTag from "../helpers/sanitize/excludeTableOfContentsTag";
+import excludeEstimatedReadingTime from "../helpers/sanitize/excludeEstimatedReadingTime";
 import sanitizeLineBreakTag from "../helpers/sanitize/sanitizeLineBreakTag";
 import countWords from "../helpers/word/countWords.js";
 import matchParagraphs from "../helpers/html/matchParagraphs.js";
@@ -14,7 +15,8 @@ import { filter } from "lodash-es";
  */
 export default function( paper, researcher ) {
 	let text = excludeTableOfContentsTag( paper.getText() );
-
+	// Excludes the Estimated Reading time text from the research
+	text = excludeEstimatedReadingTime( text );
 	// Replaces line break tags containing attribute(s) with paragraph tag.
 	text = sanitizeLineBreakTag( text );
 	const paragraphs = matchParagraphs( text );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The text from the estimated reading time block was taken into account during the analysis, which led to a bug (for example, in Keyphrase in Introduction). This PR fixes that bug by excluding the estimated reading time block from the analysis.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [yoastseo] Excludes Table of Contents from the analysis.
* [wordpress-seo-premium] Excludes the Table of Contents block from the SEO and readability analysis.


## Relevant technical choices:

* A helper to exclude the Estimated Reading time is created.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:
    1. Run yarn test and make sure that all tests pass
    2. Build the Free and Premium plugin (run `composer require yoast/wordpress-seo:dev-PC-162-exlude-estimated-reading-time-new@dev` in Premium before building)

Perform the steps below in **default (block) editor**, as well as the **Gutenberg editor**.

1. Create a post
2. Add this text:
_For the first time in 70 years, India's forests will be home to cheetahs.
Eight of them are set to arrive in August from Namibia, home to one of the world's largest populations of the wild cat.
Their return comes decades after India's indigenous population was declared officially extinct in 1952.
The world's fastest land animal, the cheetah can reach speeds of 70 miles (113km) an hour.
Classified as a vulnerable species under the International Union for Conservation of Nature Red List of Threatened Species, only around 7,000 are left in the wild worldwide._
3. Add _forest_ as a keyphrase
4. Make sure the keyphrase in introduction assessment gives a green bullet.
5. Check the text length assessment and make sure the text length is 94 words.
6. Add an estimated reading time block **before** the text.
7. Confirm that the keyphrase in introduction assessment still returns a green bullet.
8. Check the text length assessment and confirm the text length is still 94 words.
9. Add an additional CSS class to the estimated reading time block. E.g., add the class `bright` as shown in the screenshot and confirm that you have this line in the source code of your article: `class="yoast-reading-time__wrapper bright">`
<img width="906" alt="Screenshot 2022-07-25 at 14 08 40" src="https://user-images.githubusercontent.com/56546633/180774567-1154ea61-7773-46d2-8a59-29b0b79bcc15.png">

10. Confirm that the keyphrase in introduction assessment still returns a green bullet.
11. Check the text length assessment and confirm the text length is still 94 words.

**Other editors:**
As we do not have the estimated reading time block available in Classic and Elementor, we can skip steps 6-11 for these editors.

**Other content types:**
As always, check whether the above steps work for posts, pages, and custom post types. As taxonomies can only be edited with the Classic editor, again, steps 6-11 can be skipped.

**Other browsers:**
Be sure to test this PR in different browsers (Chrome, Safari, Edge, Firefox).

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes https://yoast.atlassian.net/browse/PC-162
