### PR TITLE
Get slug only when `rewrite` is `true`

### DIFF
--- a/admin/formatter/class-term-metabox-formatter.php
+++ b/admin/formatter/class-term-metabox-formatter.php
@@ -133,7 +133,9 @@ class WPSEO_Term_Metabox_Formatter implements WPSEO_Metabox_Formatter_Interface 
 
 		$base_url = home_url( '/', null );
 		if ( ! WPSEO_Options::get( 'stripcategorybase', false ) ) {
-			$base_url = trailingslashit( $base_url . $this->taxonomy->rewrite['slug'] );
+			if ( $this->taxonomy->rewrite ) {
+				$base_url = trailingslashit( $base_url . $this->taxonomy->rewrite['slug'] );
+			}
 		}
 
 		return $base_url;


### PR DESCRIPTION
## Context
* When the rewrite rule is set to false for a custom post type or taxonomy, a PHP notice `Trying to access array offset on value of type bool` occurs. The relevant PHP notice is expected since there are no values for `rewrite` key that we use without checking. This PR adds a condition before using the `rewrite` key to prevent the relevant PHP notice.

## Summary
This PR can be summarized in the following changelog entry:
* Prevent a PHP notice when editing a custom post type or taxonomy where `rewrite` is set to `false`.

## Relevant technical choices:
* When `rewrite` is set to `false`, there's no slug that we need to show in the snippet preview. Otherwise, we could have either used the following two possible solutions to get the slug from the labels:

**Possible solution 1**
```php
$base_url = trailingslashit( $base_url . strtolower($this->taxonomy->labels->{'singular_name'}) );
```
**Possible solution 2**
```php
if ( $this->taxonomy->rewrite ) {
	$base_url = trailingslashit( $base_url . $this->taxonomy->rewrite['slug'] );
} else {
	$base_url = trailingslashit( $base_url . strtolower( $this->taxonomy->labels->{'singular_name'} ) );
}
```

## Test instructions
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:
* Create a custom taxonomy by adding the following code snippet to the theme `functions.php` file that disables the `rewrite` rules for it:
```php
function wporg_register_taxonomy_course() {
    $labels = array(
        'name'              => _x( 'Courses', 'taxonomy general name' ),
        'singular_name'     => _x( 'Course', 'taxonomy singular name' ),
        'search_items'      => __( 'Search Courses' ),
        'all_items'         => __( 'All Courses' ),
        'parent_item'       => __( 'Parent Course' ),
        'parent_item_colon' => __( 'Parent Course:' ),
        'edit_item'         => __( 'Edit Course' ),
        'update_item'       => __( 'Update Course' ),
        'add_new_item'      => __( 'Add New Course' ),
        'new_item_name'     => __( 'New Course Name' ),
        'menu_name'         => __( 'Course' ),
    );
    $args   = array(
        'hierarchical'      => true,
        'labels'            => $labels,
        'show_ui'           => true,
        'show_admin_column' => true,
        'query_var'         => true,
        'rewrite'           => false,
    );
    register_taxonomy( 'course', [ 'post' ], $args );
}
add_action( 'init', 'wporg_register_taxonomy_course' );
```
* It will create a new Course taxonomy under the default Posts content type.
* Create a new item on the Course taxonomy.
* Go to edit the relevant item.
* Check the Query Monitor for the `Trying to access array offset on value of type bool` PHP notice.
* Now, use the current PR.
* Check the relevant PHP notice in the Query Monitor.
* Make sure to check the Snippet Preview in the meta box to see the URL structure.
<img width="595" alt="Screenshot 2022-07-23 at 12 51 08 AM" src="https://user-images.githubusercontent.com/8946603/180578118-4c88fe5c-72eb-4323-aa0b-e9e7b21e7f8d.png">

* When the `rewrite` rule is set to `[ 'slug' => 'course' ]` or not set to `false`, Snippet Preview shall show the URL like this: `example.com > course > title of the taxonomy`.
* When the `rewrite` rule is set to `false`, Snippet Preview shall show the URL like this: `example.com > title of the taxonomy`.

### Test instructions for QA when the code is in the RC
* [x] QA should use the same steps as above.

## Impact check
This PR affects the following parts of the plugin, which may require extra testing:
* It affects the URL structure in the Snippet Preview. So, make sure that you check the URL structure in Snippet Preview for Custom Post Types, Posts, and Pages as well.

## Quality assurance

* [x] I have tested this code to the best of my abilities

Fixes #18675