### PR TITLE
Revert revert of front end inspector

### DIFF
--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -863,8 +863,8 @@ class Yoast_Form {
 
 		$help_class = ! empty( $help ) ? ' switch-container__has-help' : '';
 
-		$has_premium_upsell = ( isset( $attr['show_premium_upsell'] ) && $attr['show_premium_upsell'] ) && ( isset( $attr['premium_upsell_url'] ) && ! empty( $attr['premium_upsell_url'] ) );
-		$upsell_class       = $has_premium_upsell ? ' premium-upsell' : '';
+		$has_premium_upsell = ( isset( $attr[ 'show_premium_upsell' ] ) && $attr[ 'show_premium_upsell'] ) && ( isset( $attr[ 'premium_upsell_url' ] ) && ! empty( $attr[ 'premium_upsell_url' ] ) );
+		$upsell_class = $has_premium_upsell ? ' premium-upsell' : '';
 
 		$var_esc = esc_attr( $variable );
 
@@ -899,9 +899,9 @@ class Yoast_Form {
 			'<label for="', $for, '">', esc_html( $value ), $screen_reader_text_html, '</label>';
 		}
 
-		$upsell_button = '';
+		$upsell_button = "";
 		if ( $has_premium_upsell ) {
-			$upsell_button = '<a class="yoast-button yoast-button--buy yoast-button--small" href=' . esc_url( $attr['premium_upsell_url'] ) . ' target="_blank">' . esc_html__( 'Unlock with Premium!', 'wordpress-seo' ) . '<span class="screen-reader-text">' . esc_html__( '(Opens in a new browser tab)', 'wordpress-seo' ) . '</span>' .
+			$upsell_button = '<a class="yoast-button yoast-button--buy yoast-button--small" href=' . esc_url( $attr[ 'premium_upsell_url' ] ) . ' target="_blank">' . esc_html__( 'Unlock with Premium!', 'wordpress-seo' ) . '<span class="screen-reader-text">' . esc_html__( '(Opens in a new browser tab)', 'wordpress-seo' ) . '</span>' .
 			'<span aria-hidden="true" class="yoast-button--buy__caret"></span></a>';
 		}
 

--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -863,8 +863,8 @@ class Yoast_Form {
 
 		$help_class = ! empty( $help ) ? ' switch-container__has-help' : '';
 
-		$has_premium_upsell = ( isset( $attr[ 'show_premium_upsell' ] ) && $attr[ 'show_premium_upsell'] ) && ( isset( $attr[ 'premium_upsell_url' ] ) && ! empty( $attr[ 'premium_upsell_url' ] ) );
-		$upsell_class = $has_premium_upsell ? ' premium-upsell' : '';
+		$has_premium_upsell = ( isset( $attr['show_premium_upsell'] ) && $attr['show_premium_upsell'] ) && ( isset( $attr['premium_upsell_url'] ) && ! empty( $attr['premium_upsell_url'] ) );
+		$upsell_class       = $has_premium_upsell ? ' premium-upsell' : '';
 
 		$var_esc = esc_attr( $variable );
 
@@ -899,9 +899,9 @@ class Yoast_Form {
 			'<label for="', $for, '">', esc_html( $value ), $screen_reader_text_html, '</label>';
 		}
 
-		$upsell_button = "";
+		$upsell_button = '';
 		if ( $has_premium_upsell ) {
-			$upsell_button = '<a class="yoast-button yoast-button--buy yoast-button--small" href=' . esc_url( $attr[ 'premium_upsell_url' ] ) . ' target="_blank">' . esc_html__( 'Unlock with Premium!', 'wordpress-seo' ) . '<span class="screen-reader-text">' . esc_html__( '(Opens in a new browser tab)', 'wordpress-seo' ) . '</span>' .
+			$upsell_button = '<a class="yoast-button yoast-button--buy yoast-button--small" href=' . esc_url( $attr['premium_upsell_url'] ) . ' target="_blank">' . esc_html__( 'Unlock with Premium!', 'wordpress-seo' ) . '<span class="screen-reader-text">' . esc_html__( '(Opens in a new browser tab)', 'wordpress-seo' ) . '</span>' .
 			'<span aria-hidden="true" class="yoast-button--buy__caret"></span></a>';
 		}
 

--- a/inc/class-wpseo-admin-bar-menu.php
+++ b/inc/class-wpseo-admin-bar-menu.php
@@ -98,7 +98,7 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 		}
 
 		$this->add_root_menu( $wp_admin_bar );
-
+		
 		$front_end_inspector_conditional = new Front_End_Inspector_Conditional();
 		if ( ! is_admin() && YoastSEO()->helpers->product->is_premium() && $front_end_inspector_conditional->is_met() ) {
 			$this->add_frontend_inspector_submenu( $wp_admin_bar );

--- a/inc/class-wpseo-admin-bar-menu.php
+++ b/inc/class-wpseo-admin-bar-menu.php
@@ -98,7 +98,7 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 		}
 
 		$this->add_root_menu( $wp_admin_bar );
-		
+
 		if ( ! is_admin() && YoastSEO()->helpers->product->is_premium() ) {
 			$this->add_frontend_inspector_submenu( $wp_admin_bar );
 		}

--- a/inc/class-wpseo-admin-bar-menu.php
+++ b/inc/class-wpseo-admin-bar-menu.php
@@ -99,8 +99,7 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 
 		$this->add_root_menu( $wp_admin_bar );
 		
-		$front_end_inspector_conditional = new Front_End_Inspector_Conditional();
-		if ( ! is_admin() && YoastSEO()->helpers->product->is_premium() && $front_end_inspector_conditional->is_met() ) {
+		if ( ! is_admin() && YoastSEO()->helpers->product->is_premium() ) {
 			$this->add_frontend_inspector_submenu( $wp_admin_bar );
 		}
 		$this->add_keyword_research_submenu( $wp_admin_bar );

--- a/src/deprecated/src/conditionals/front-end-inspector-conditional.php
+++ b/src/deprecated/src/conditionals/front-end-inspector-conditional.php
@@ -13,6 +13,7 @@ class Front_End_Inspector_Conditional extends Feature_Flag_Conditional {
 	 * @return string The name of the feature flag.
 	 */
 	protected function get_feature_flag() {
+		\_deprecated_function( __METHOD__, 'WPSEO 19.1' );
 		return 'FRONT_END_INSPECTOR';
 	}
 }

--- a/src/presenters/abstract-indexable-tag-presenter.php
+++ b/src/presenters/abstract-indexable-tag-presenter.php
@@ -9,9 +9,9 @@ namespace Yoast\WP\SEO\Presenters;
  */
 abstract class Abstract_Indexable_Tag_Presenter extends Abstract_Indexable_Presenter {
 
-	const META_PROPERTY_CONTENT = '<meta property="%2$s" content="%1$s" />';
-	const META_NAME_CONTENT     = '<meta name="%2$s" content="%1$s" />';
-	const LINK_REL_HREF         = '<link rel="%2$s" href="%1$s" />';
+	const META_PROPERTY_CONTENT = '<meta property="%2$s" content="%1$s"%3$s />';
+	const META_NAME_CONTENT     = '<meta name="%2$s" content="%1$s"%3$s />';
+	const LINK_REL_HREF         = '<link rel="%2$s" href="%1$s"%3$s />';
 	const DEFAULT_TAG_FORMAT    = self::META_NAME_CONTENT;
 
 	/**
@@ -47,7 +47,8 @@ abstract class Abstract_Indexable_Tag_Presenter extends Abstract_Indexable_Prese
 		return \sprintf(
 			$this->tag_format,
 			$this->escape_value( $value ),
-			$this->key
+			$this->key,
+			\is_admin_bar_showing() ? ' class="yoast-seo-meta-tag"' : ''
 		);
 	}
 

--- a/src/presenters/open-graph/image-presenter.php
+++ b/src/presenters/open-graph/image-presenter.php
@@ -43,15 +43,16 @@ class Image_Presenter extends Abstract_Indexable_Presenter {
 		$return = '';
 		foreach ( $images as $image_index => $image_meta ) {
 			$image_url = $image_meta['url'];
+			$class     = \is_admin_bar_showing() ? ' class="yoast-seo-meta-tag"' : '';
 
-			$return .= '<meta property="og:image" content="' . \esc_url( $image_url, null, 'attribute' ) . '" />';
+			$return .= '<meta property="og:image" content="' . \esc_url( $image_url, null, 'attribute' ) . '"' . $class . ' />';
 
 			foreach ( static::$image_tags as $key => $value ) {
 				if ( empty( $image_meta[ $key ] ) ) {
 					continue;
 				}
 
-				$return .= \PHP_EOL . "\t" . '<meta property="og:image:' . \esc_attr( $key ) . '" content="' . \esc_attr( $image_meta[ $key ] ) . '" />';
+				$return .= \PHP_EOL . "\t" . '<meta property="og:image:' . \esc_attr( $key ) . '" content="' . \esc_attr( $image_meta[ $key ] ) . '"' . $class . ' />';
 			}
 		}
 

--- a/src/presenters/slack/enhanced-data-presenter.php
+++ b/src/presenters/slack/enhanced-data-presenter.php
@@ -26,9 +26,10 @@ class Enhanced_Data_Presenter extends Abstract_Indexable_Presenter {
 		$enhanced_data = $this->get();
 		$twitter_tags  = '';
 		$i             = 1;
+		$class         = \is_admin_bar_showing() ? ' class="yoast-seo-meta-tag"' : '';
 		foreach ( $enhanced_data as $label => $value ) {
-			$twitter_tags .= \sprintf( "\t" . '<meta name="twitter:label%1$d" content="%2$s" />' . "\n", $i, $label );
-			$twitter_tags .= \sprintf( "\t" . '<meta name="twitter:data%1$d" content="%2$s" />' . "\n", $i, $value );
+			$twitter_tags .= \sprintf( "\t" . '<meta name="twitter:label%1$d" content="%2$s"' . $class . ' />' . "\n", $i, $label );
+			$twitter_tags .= \sprintf( "\t" . '<meta name="twitter:data%1$d" content="%2$s"' . $class . ' />' . "\n", $i, $value );
 			++$i;
 		}
 

--- a/tests/unit/presenters/canonical-presenter-test.php
+++ b/tests/unit/presenters/canonical-presenter-test.php
@@ -42,6 +42,7 @@ class Canonical_Presenter_Test extends TestCase {
 		$presentation->canonical = 'https://permalink';
 		$presentation->robots    = [];
 
+		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
 
 		$presented_canonical = $instance->present();
 
@@ -86,6 +87,7 @@ class Canonical_Presenter_Test extends TestCase {
 			->once()
 			->with( 'https://permalink', $presentation )
 			->andReturn( 'https://filtered' );
+		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
 
 		$this->assertEquals(
 			'<link rel="canonical" href="https://filtered" />',
@@ -108,5 +110,29 @@ class Canonical_Presenter_Test extends TestCase {
 		$presentation->robots    = [ 'noindex' ];
 
 		$this->assertEmpty( $instance->present() );
+	}
+
+	/**
+	 * Tests the presenter of the canonical when the admin bar is showing a class is added.
+	 *
+	 * @covers ::present
+	 * @covers ::get
+	 */
+	public function test_present_with_class() {
+		$instance               = new Canonical_Presenter();
+		$instance->presentation = new Indexable_Presentation();
+		$presentation           = $instance->presentation;
+
+		$presentation->canonical = 'https://permalink';
+		$presentation->robots    = [];
+
+		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( true );
+
+		$presented_canonical = $instance->present();
+
+		$this->assertEquals(
+			'<link rel="canonical" href="https://permalink" class="yoast-seo-meta-tag" />',
+			$presented_canonical
+		);
 	}
 }

--- a/tests/unit/presenters/meta-author-presenter-test.php
+++ b/tests/unit/presenters/meta-author-presenter-test.php
@@ -87,6 +87,7 @@ class Meta_Author_Presenter_Test extends TestCase {
 			->once()
 			->with( 'John Doe' )
 			->andReturn( 'John Doe' );
+		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
 
 		$output = '<meta name="author" content="John Doe" />';
 
@@ -108,6 +109,7 @@ class Meta_Author_Presenter_Test extends TestCase {
 			->once()
 			->with( 123 )
 			->andReturnFalse();
+		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
 
 		$this->html
 			->expects( 'smart_strip_tags' )
@@ -136,6 +138,36 @@ class Meta_Author_Presenter_Test extends TestCase {
 			->never();
 
 		$output = '';
+
+		$this->assertSame( $output, $this->instance->present() );
+	}
+
+	/**
+	 * Tests the presenter of the meta description when the admin bar is showing a class is added.
+	 *
+	 * @covers ::present
+	 * @covers ::get
+	 */
+	public function test_present_and_filter_with_class() {
+		$this->indexable_presentation->model                  = new Indexable_Mock();
+		$this->indexable_presentation->model->object_sub_type = 'post';
+
+		$user_mock               = Mockery::mock( \WP_User::class );
+		$user_mock->display_name = 'John Doe';
+
+		Monkey\Functions\expect( 'get_userdata' )
+			->once()
+			->with( 123 )
+			->andReturn( $user_mock );
+
+		$this->html
+			->expects( 'smart_strip_tags' )
+			->once()
+			->with( 'John Doe' )
+			->andReturn( 'John Doe' );
+		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( true );
+
+		$output = '<meta name="author" content="John Doe" class="yoast-seo-meta-tag" />';
 
 		$this->assertSame( $output, $this->instance->present() );
 	}

--- a/tests/unit/presenters/meta-description-presenter-test.php
+++ b/tests/unit/presenters/meta-description-presenter-test.php
@@ -95,6 +95,7 @@ class Meta_Description_Presenter_Test extends TestCase {
 			->once()
 			->with( 'the_meta_description', $this->indexable_presentation )
 			->andReturn( 'the_meta_description' );
+		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
 
 		$this->string
 			->expects( 'strip_all_tags' )
@@ -170,5 +171,40 @@ class Meta_Description_Presenter_Test extends TestCase {
 		$notice = '<!-- Admin only notice: this page does not show a meta description because it does not have one, either write it for this page specifically or go into the [SEO - Search Appearance] menu and set up a template. -->';
 
 		$this->assertEquals( $notice, $this->instance->present() );
+	}
+
+	/**
+	 * Tests the presenter of the meta description when admin bar is showing a clas.
+	 *
+	 * @covers ::present
+	 * @covers ::get
+	 */
+	public function test_present_and_filter_with_class() {
+		$this->indexable_presentation->meta_description = 'the_meta_description';
+
+		$this->replace_vars
+			->expects( 'replace' )
+			->once()
+			->andReturnUsing(
+				static function( $replace_string ) {
+					return $replace_string;
+				}
+			);
+
+		Monkey\Filters\expectApplied( 'wpseo_metadesc' )
+			->once()
+			->with( 'the_meta_description', $this->indexable_presentation )
+			->andReturn( 'the_meta_description' );
+		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( true );
+
+		$this->string
+			->expects( 'strip_all_tags' )
+			->once()
+			->with( 'the_meta_description' )
+			->andReturn( 'the_meta_description' );
+
+		$output = '<meta name="description" content="the_meta_description" class="yoast-seo-meta-tag" />';
+
+		$this->assertEquals( $output, $this->instance->present() );
 	}
 }

--- a/tests/unit/presenters/open-graph/article-author-presenter-test.php
+++ b/tests/unit/presenters/open-graph/article-author-presenter-test.php
@@ -53,6 +53,8 @@ class Article_Author_Presenter_Test extends TestCase {
 	public function test_present() {
 		$this->presentation->open_graph_article_author = 'https://facebook.com/author';
 
+		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
+
 		$expected = '<meta property="article:author" content="https://facebook.com/author" />';
 		$actual   = $this->instance->present();
 
@@ -86,8 +88,25 @@ class Article_Author_Presenter_Test extends TestCase {
 			->once()
 			->with( 'https://facebook.com/author', $this->presentation )
 			->andReturn( 'https://facebook.com/newauthor' );
+		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
 
 		$expected = '<meta property="article:author" content="https://facebook.com/newauthor" />';
+		$actual   = $this->instance->present();
+
+		$this->assertEquals( $expected, $actual );
+	}
+
+	/**
+	 * Tests whether the presenter returns the correct title when the admin bar is showing a class is added.
+	 *
+	 * @covers ::present
+	 */
+	public function test_present_with_class() {
+		$this->presentation->open_graph_article_author = 'https://facebook.com/author';
+
+		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( true );
+
+		$expected = '<meta property="article:author" content="https://facebook.com/author" class="yoast-seo-meta-tag" />';
 		$actual   = $this->instance->present();
 
 		$this->assertEquals( $expected, $actual );

--- a/tests/unit/presenters/open-graph/article-modified-time-presenter-test.php
+++ b/tests/unit/presenters/open-graph/article-modified-time-presenter-test.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\WP\SEO\Tests\Unit\Presenters\Open_Graph;
 
+use Brain\Monkey;
 use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 use Yoast\WP\SEO\Presenters\Open_Graph\Article_Modified_Time_Presenter;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
@@ -52,6 +53,8 @@ class Article_Modified_Time_Presenter_Test extends TestCase {
 
 		$this->presentation->open_graph_article_modified_time = '2019-10-08T12:26:31+00:00';
 
+		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
+
 		$expected = '<meta property="article:modified_time" content="2019-10-08T12:26:31+00:00" />';
 		$actual   = $this->instance->present();
 
@@ -80,5 +83,23 @@ class Article_Modified_Time_Presenter_Test extends TestCase {
 		$this->presentation->open_graph_article_modified_time = '2019-10-08T12:26:31+00:00';
 
 		$this->assertSame( '2019-10-08T12:26:31+00:00', $this->instance->get() );
+	}
+
+	/**
+	 * Tests whether the presenter returns the correct modified time tag when the admin bar is showing a class is added.
+	 *
+	 * @covers ::present
+	 */
+	public function test_present_with_class() {
+		$this->stubEscapeFunctions();
+
+		$this->presentation->open_graph_article_modified_time = '2019-10-08T12:26:31+00:00';
+
+		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( true );
+
+		$expected = '<meta property="article:modified_time" content="2019-10-08T12:26:31+00:00" class="yoast-seo-meta-tag" />';
+		$actual   = $this->instance->present();
+
+		$this->assertEquals( $expected, $actual );
 	}
 }

--- a/tests/unit/presenters/open-graph/article-published-time-presenter-test.php
+++ b/tests/unit/presenters/open-graph/article-published-time-presenter-test.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\WP\SEO\Tests\Unit\Presenters\Open_Graph;
 
+use Brain\Monkey;
 use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 use Yoast\WP\SEO\Presenters\Open_Graph\Article_Published_Time_Presenter;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
@@ -52,6 +53,8 @@ class Article_Published_Time_Presenter_Test extends TestCase {
 
 		$this->presentation->open_graph_article_published_time = '2019-10-08T12:26:31+00:00';
 
+		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
+
 		$expected = '<meta property="article:published_time" content="2019-10-08T12:26:31+00:00" />';
 		$actual   = $this->instance->present();
 
@@ -80,5 +83,23 @@ class Article_Published_Time_Presenter_Test extends TestCase {
 		$this->presentation->open_graph_article_published_time = '2019-10-08T12:26:31+00:00';
 
 		$this->assertSame( '2019-10-08T12:26:31+00:00', $this->instance->get() );
+	}
+
+	/**
+	 * Tests whether the presenter returns the correct published time tag when the admin bar is showing a class is added.
+	 *
+	 * @covers ::present
+	 */
+	public function test_present_with_class() {
+		$this->stubEscapeFunctions();
+
+		$this->presentation->open_graph_article_published_time = '2019-10-08T12:26:31+00:00';
+
+		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( true );
+
+		$expected = '<meta property="article:published_time" content="2019-10-08T12:26:31+00:00" class="yoast-seo-meta-tag" />';
+		$actual   = $this->instance->present();
+
+		$this->assertEquals( $expected, $actual );
 	}
 }

--- a/tests/unit/presenters/open-graph/article-publisher-presenter-test.php
+++ b/tests/unit/presenters/open-graph/article-publisher-presenter-test.php
@@ -53,6 +53,8 @@ class Article_Publisher_Presenter_Test extends TestCase {
 	public function test_present() {
 		$this->presentation->open_graph_article_publisher = 'https://example.com';
 
+		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
+
 		$expected = '<meta property="article:publisher" content="https://example.com" />';
 		$actual   = $this->instance->present();
 
@@ -86,8 +88,25 @@ class Article_Publisher_Presenter_Test extends TestCase {
 			->once()
 			->with( 'https://example.com', $this->presentation )
 			->andReturn( 'https://otherpublisher.com' );
+		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
 
 		$expected = '<meta property="article:publisher" content="https://otherpublisher.com" />';
+		$actual   = $this->instance->present();
+
+		$this->assertEquals( $expected, $actual );
+	}
+
+	/**
+	 * Tests whether the presenter returns the correct title when the admin bar is showing a class is added.
+	 *
+	 * @covers ::present
+	 */
+	public function test_present_with_class() {
+		$this->presentation->open_graph_article_publisher = 'https://example.com';
+
+		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( true );
+
+		$expected = '<meta property="article:publisher" content="https://example.com" class="yoast-seo-meta-tag" />';
 		$actual   = $this->instance->present();
 
 		$this->assertEquals( $expected, $actual );

--- a/tests/unit/presenters/open-graph/description-presenter-test.php
+++ b/tests/unit/presenters/open-graph/description-presenter-test.php
@@ -90,6 +90,8 @@ class Description_Presenter_Test extends TestCase {
 	public function test_present() {
 		$this->presentation->open_graph_description = 'My description';
 
+		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
+
 		$expected = '<meta property="og:description" content="My description" />';
 		$actual   = $this->instance->present();
 
@@ -123,10 +125,28 @@ class Description_Presenter_Test extends TestCase {
 			->once()
 			->with( 'My description', $this->presentation )
 			->andReturn( 'My filtered description' );
+		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
 
 		$expected = '<meta property="og:description" content="My filtered description" />';
 		$actual   = $this->instance->present();
 
 		$this->assertEquals( $expected, $actual );
 	}
+
+	/**
+	 * Tests whether the presenter returns the correct description when the admin bar is showing a class is added.
+	 *
+	 * @covers ::present
+	 */
+	public function test_present_with_class() {
+		$this->presentation->open_graph_description = 'My description';
+
+		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( true );
+
+		$expected = '<meta property="og:description" content="My description" class="yoast-seo-meta-tag" />';
+		$actual   = $this->instance->present();
+
+		$this->assertEquals( $expected, $actual );
+	}
+
 }

--- a/tests/unit/presenters/open-graph/description-presenter-test.php
+++ b/tests/unit/presenters/open-graph/description-presenter-test.php
@@ -148,5 +148,4 @@ class Description_Presenter_Test extends TestCase {
 
 		$this->assertEquals( $expected, $actual );
 	}
-
 }

--- a/tests/unit/presenters/open-graph/image-presenter-test.php
+++ b/tests/unit/presenters/open-graph/image-presenter-test.php
@@ -72,6 +72,8 @@ class Image_Presenter_Test extends TestCase {
 
 		$this->presentation->open_graph_images = [ $image ];
 
+		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
+
 		$this->assertEquals(
 			'<meta property="og:image" content="https://example.com/image.jpg" />' . \PHP_EOL . "\t" . '<meta property="og:image:width" content="100" />' . \PHP_EOL . "\t" . '<meta property="og:image:height" content="100" />',
 			$this->instance->present()
@@ -136,5 +138,29 @@ class Image_Presenter_Test extends TestCase {
 		$this->presentation->open_graph_images = [ $raw_image ];
 
 		$this->assertSame( [ $expected_image ], $this->instance->get() );
+	}
+
+	/**
+	 * Tests the presentation with a set image when the admin bar is showing a class is added.
+	 *
+	 * @covers ::present
+	 */
+	public function test_present_with_a_set_image_with_class() {
+		$this->stubEscapeFunctions();
+
+		$image = [
+			'url'    => 'https://example.com/image.jpg',
+			'width'  => 100,
+			'height' => 100,
+		];
+
+		$this->presentation->open_graph_images = [ $image ];
+
+		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( true );
+
+		$this->assertEquals(
+			'<meta property="og:image" content="https://example.com/image.jpg" class="yoast-seo-meta-tag" />' . \PHP_EOL . "\t" . '<meta property="og:image:width" content="100" class="yoast-seo-meta-tag" />' . \PHP_EOL . "\t" . '<meta property="og:image:height" content="100" class="yoast-seo-meta-tag" />',
+			$this->instance->present()
+		);
 	}
 }

--- a/tests/unit/presenters/open-graph/locale-presenter-test.php
+++ b/tests/unit/presenters/open-graph/locale-presenter-test.php
@@ -53,6 +53,8 @@ class Locale_Presenter_Test extends TestCase {
 	public function test_present() {
 		$this->presentation->open_graph_locale = 'nl_BE';
 
+		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
+
 		$expected = '<meta property="og:locale" content="nl_BE" />';
 		$actual   = $this->instance->present();
 
@@ -72,8 +74,25 @@ class Locale_Presenter_Test extends TestCase {
 			->once()
 			->with( 'nl_BE', $this->presentation )
 			->andReturn( 'nl_BE' );
+		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
 
 		$expected = '<meta property="og:locale" content="nl_BE" />';
+		$actual   = $this->instance->present();
+
+		$this->assertEquals( $expected, $actual );
+	}
+
+	/**
+	 * Tests whether the presenter returns the correct locale when the admin bar is showing a class is added.
+	 *
+	 * @covers ::present
+	 */
+	public function test_present_with_class() {
+		$this->presentation->open_graph_locale = 'nl_BE';
+
+		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( true );
+
+		$expected = '<meta property="og:locale" content="nl_BE" class="yoast-seo-meta-tag" />';
 		$actual   = $this->instance->present();
 
 		$this->assertEquals( $expected, $actual );

--- a/tests/unit/presenters/open-graph/site-name-presenter-test.php
+++ b/tests/unit/presenters/open-graph/site-name-presenter-test.php
@@ -53,6 +53,8 @@ class Site_Name_Presenter_Test extends TestCase {
 	public function test_present() {
 		$this->presentation->open_graph_site_name = 'My Site';
 
+		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
+
 		$expected = '<meta property="og:site_name" content="My Site" />';
 		$actual   = $this->instance->present();
 
@@ -86,8 +88,25 @@ class Site_Name_Presenter_Test extends TestCase {
 			->once()
 			->with( 'My Site', $this->presentation )
 			->andReturn( 'My Site' );
+		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
 
 		$expected = '<meta property="og:site_name" content="My Site" />';
+		$actual   = $this->instance->present();
+
+		$this->assertEquals( $expected, $actual );
+	}
+
+	/**
+	 * Tests whether the presenter returns the correct title when the admin bar is showing a class is added.
+	 *
+	 * @covers ::present
+	 */
+	public function test_present_with_class() {
+		$this->presentation->open_graph_site_name = 'My Site';
+
+		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( true );
+
+		$expected = '<meta property="og:site_name" content="My Site" class="yoast-seo-meta-tag" />';
 		$actual   = $this->instance->present();
 
 		$this->assertEquals( $expected, $actual );

--- a/tests/unit/presenters/open-graph/title-presenter-test.php
+++ b/tests/unit/presenters/open-graph/title-presenter-test.php
@@ -94,6 +94,7 @@ class Title_Presenter_Test extends TestCase {
 					return $str;
 				}
 			);
+		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
 
 		$expected = '<meta property="og:title" content="example_title" />';
 		$actual   = $this->instance->present();
@@ -143,8 +144,32 @@ class Title_Presenter_Test extends TestCase {
 			->once()
 			->with( 'example_title', $this->presentation )
 			->andReturn( 'exampletitle' );
+		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
 
 		$expected = '<meta property="og:title" content="exampletitle" />';
+		$actual   = $this->instance->present();
+
+		$this->assertEquals( $expected, $actual );
+	}
+
+	/**
+	 * Tests whether the presenter returns the correct title when the admin bar is showing a class is added.
+	 *
+	 * @covers ::present
+	 */
+	public function test_present_with_class() {
+		$this->presentation->open_graph_title = 'example_title';
+
+		$this->replace_vars
+			->expects( 'replace' )
+			->andReturnUsing(
+				static function ( $str ) {
+					return $str;
+				}
+			);
+		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( true );
+
+		$expected = '<meta property="og:title" content="example_title" class="yoast-seo-meta-tag" />';
 		$actual   = $this->instance->present();
 
 		$this->assertEquals( $expected, $actual );

--- a/tests/unit/presenters/open-graph/type-presenter-test.php
+++ b/tests/unit/presenters/open-graph/type-presenter-test.php
@@ -54,6 +54,8 @@ class Type_Presenter_Test extends TestCase {
 	public function test_present() {
 		$this->presentation->open_graph_type = 'article';
 
+		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
+
 		$expected = '<meta property="og:type" content="article" />';
 		$actual   = $this->instance->present();
 
@@ -87,8 +89,25 @@ class Type_Presenter_Test extends TestCase {
 			->once()
 			->with( 'website', $this->presentation )
 			->andReturn( 'article' );
+		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
 
 		$expected = '<meta property="og:type" content="article" />';
+		$actual   = $this->instance->present();
+
+		$this->assertEquals( $expected, $actual );
+	}
+
+	/**
+	 * Tests whether the presenter returns the correct open graph type when the admin bar is showing a class is added.
+	 *
+	 * @covers ::present
+	 */
+	public function test_present_with_class() {
+		$this->presentation->open_graph_type = 'article';
+
+		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( true );
+
+		$expected = '<meta property="og:type" content="article" class="yoast-seo-meta-tag" />';
 		$actual   = $this->instance->present();
 
 		$this->assertEquals( $expected, $actual );

--- a/tests/unit/presenters/open-graph/url-presenter-test.php
+++ b/tests/unit/presenters/open-graph/url-presenter-test.php
@@ -53,6 +53,8 @@ class Url_Presenter_Test extends TestCase {
 	public function test_present() {
 		$this->presentation->open_graph_url = 'www.example.com';
 
+		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
+
 		$expected = '<meta property="og:url" content="www.example.com" />';
 		$actual   = $this->instance->present();
 
@@ -83,8 +85,25 @@ class Url_Presenter_Test extends TestCase {
 			->once()
 			->with( 'www.example.com', $this->presentation )
 			->andReturn( 'www.example.com' );
+		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
 
 		$expected = '<meta property="og:url" content="www.example.com" />';
+		$actual   = $this->instance->present();
+
+		$this->assertEquals( $expected, $actual );
+	}
+
+	/**
+	 * Tests whether the presenter returns the correct URL when the admin bar is showing a class is added.
+	 *
+	 * @covers ::present
+	 */
+	public function test_present_with_class() {
+		$this->presentation->open_graph_url = 'www.example.com';
+
+		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( true );
+
+		$expected = '<meta property="og:url" content="www.example.com" class="yoast-seo-meta-tag" />';
 		$actual   = $this->instance->present();
 
 		$this->assertEquals( $expected, $actual );

--- a/tests/unit/presenters/rel-next-presenter-test.php
+++ b/tests/unit/presenters/rel-next-presenter-test.php
@@ -37,25 +37,6 @@ class Rel_Next_Presenter_Test extends TestCase {
 	}
 
 	/**
-	 * Tests the presentation of the rel next meta tag.
-	 *
-	 * @covers ::present
-	 * @covers ::get
-	 */
-	public function test_present() {
-		$this->instance->presentation = new Indexable_Presentation();
-		$presentation                 = $this->instance->presentation;
-
-		$presentation->rel_next = 'https://permalink/post/2';
-		$presentation->robots   = [];
-
-		$this->assertEquals(
-			'<link rel="next" href="https://permalink/post/2" />',
-			$this->instance->present()
-		);
-	}
-
-	/**
 	 * Tests the presentation of the rel prev next tag when it's empty.
 	 *
 	 * @covers ::present
@@ -107,9 +88,31 @@ class Rel_Next_Presenter_Test extends TestCase {
 			->with( 'https://permalink/post/2', 'next' )
 			->once()
 			->andReturn( 'https://filtered' );
+		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
 
 		$this->assertEquals(
 			'<link rel="next" href="https://filtered" />',
+			$this->instance->present()
+		);
+	}
+
+	/**
+	 * Tests the presentation of the rel next meta tag when the admin bar is showing a class is added.
+	 *
+	 * @covers ::present
+	 * @covers ::get
+	 */
+	public function test_present_with_class() {
+		$this->instance->presentation = new Indexable_Presentation();
+		$presentation                 = $this->instance->presentation;
+
+		$presentation->rel_next = 'https://permalink/post/2';
+		$presentation->robots   = [];
+
+		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( true );
+
+		$this->assertEquals(
+			'<link rel="next" href="https://permalink/post/2" class="yoast-seo-meta-tag" />',
 			$this->instance->present()
 		);
 	}

--- a/tests/unit/presenters/rel-prev-presenter-test.php
+++ b/tests/unit/presenters/rel-prev-presenter-test.php
@@ -49,6 +49,8 @@ class Rel_Prev_Presenter_Test extends TestCase {
 		$presentation->rel_prev = 'https://permalink/post/2';
 		$presentation->robots   = [];
 
+		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
+
 		$this->assertEquals(
 			'<link rel="prev" href="https://permalink/post/2" />',
 			$this->instance->present()
@@ -107,9 +109,31 @@ class Rel_Prev_Presenter_Test extends TestCase {
 			->with( 'https://permalink/post/2', 'prev' )
 			->once()
 			->andReturn( 'https://filtered' );
+		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
 
 		$this->assertEquals(
 			'<link rel="prev" href="https://filtered" />',
+			$this->instance->present()
+		);
+	}
+
+	/**
+	 * Tests the presentation of the rel prev meta tag when the admin bar is showing a class is added.
+	 *
+	 * @covers ::present
+	 * @covers ::get
+	 */
+	public function test_present_with_class() {
+		$this->instance->presentation = new Indexable_Presentation();
+		$presentation                 = $this->instance->presentation;
+
+		$presentation->rel_prev = 'https://permalink/post/2';
+		$presentation->robots   = [];
+
+		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( true );
+
+		$this->assertEquals(
+			'<link rel="prev" href="https://permalink/post/2" class="yoast-seo-meta-tag" />',
 			$this->instance->present()
 		);
 	}

--- a/tests/unit/presenters/slack/enhanced-data-presenter-test.php
+++ b/tests/unit/presenters/slack/enhanced-data-presenter-test.php
@@ -72,6 +72,7 @@ class Enhanced_Data_Presenter_Test extends TestCase {
 				'is_singular'         => true,
 			]
 		);
+		Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
 
 		$this->assertEquals(
 			"<meta name=\"twitter:label1\" content=\"Written by\" />\n"
@@ -105,10 +106,45 @@ class Enhanced_Data_Presenter_Test extends TestCase {
 				'is_singular'         => true,
 			]
 		);
+		Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
 
 		$this->assertEquals(
 			"<meta name=\"twitter:label1\" content=\"Est. reading time\" />\n"
 			. "\t<meta name=\"twitter:data1\" content=\"40 minutes\" />",
+			$this->instance->present()
+		);
+	}
+
+	/**
+	 * Tests the presentation for a set of enhanced data when the admin bar is showing a class is added.
+	 *
+	 * @covers ::present
+	 * @covers ::get
+	 */
+	public function test_present_with_class() {
+		$post_content = '';
+		for ( $i = 0; $i < 10; $i++ ) {
+			$post_content .= 'yoast ';
+		}
+
+		$this->presentation->source->post_content           = $post_content;
+		$this->presentation->source->post_author            = '123';
+		$this->presentation->estimated_reading_time_minutes = 40;
+		$this->presentation->model->object_sub_type         = 'post';
+
+		Functions\stubs(
+			[
+				'get_the_author_meta' => 'Agatha Christie',
+				'is_singular'         => true,
+			]
+		);
+		Functions\expect( 'is_admin_bar_showing' )->andReturn( true );
+
+		$this->assertEquals(
+			"<meta name=\"twitter:label1\" content=\"Written by\" class=\"yoast-seo-meta-tag\" />\n"
+			. "\t<meta name=\"twitter:data1\" content=\"Agatha Christie\" class=\"yoast-seo-meta-tag\" />\n"
+			. "\t<meta name=\"twitter:label2\" content=\"Est. reading time\" class=\"yoast-seo-meta-tag\" />\n"
+			. "\t<meta name=\"twitter:data2\" content=\"40 minutes\" class=\"yoast-seo-meta-tag\" />",
 			$this->instance->present()
 		);
 	}

--- a/tests/unit/presenters/twitter/card-presenter-test.php
+++ b/tests/unit/presenters/twitter/card-presenter-test.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\WP\SEO\Tests\Unit\Presenters\Twitter;
 
+use Brain\Monkey;
 use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 use Yoast\WP\SEO\Presenters\Twitter\Card_Presenter;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
@@ -46,6 +47,8 @@ class Card_Presenter_Test extends TestCase {
 		$presentation                 = $this->instance->presentation;
 		$presentation->twitter_card   = 'summary';
 
+		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
+
 		$this->assertEquals(
 			'<meta name="twitter:card" content="summary" />',
 			$this->instance->present()
@@ -64,5 +67,24 @@ class Card_Presenter_Test extends TestCase {
 		$presentation->twitter_card   = '';
 
 		$this->assertEmpty( $this->instance->present() );
+	}
+
+	/**
+	 * Tests the presentation for a set twitter creator when the admin bar is showing a class is added.
+	 *
+	 * @covers ::present
+	 * @covers ::get
+	 */
+	public function test_present_with_class() {
+		$this->instance->presentation = new Indexable_Presentation();
+		$presentation                 = $this->instance->presentation;
+		$presentation->twitter_card   = 'summary';
+
+		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( true );
+
+		$this->assertEquals(
+			'<meta name="twitter:card" content="summary" class="yoast-seo-meta-tag" />',
+			$this->instance->present()
+		);
 	}
 }

--- a/tests/unit/presenters/twitter/creator-presenter-test.php
+++ b/tests/unit/presenters/twitter/creator-presenter-test.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\WP\SEO\Tests\Unit\Presenters\Twitter;
 
+use Brain\Monkey;
 use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 use Yoast\WP\SEO\Presenters\Twitter\Creator_Presenter;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
@@ -53,6 +54,8 @@ class Creator_Presenter_Test extends TestCase {
 
 		$this->presentation->twitter_creator = '@TwitterHandle';
 
+		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
+
 		$this->assertEquals(
 			'<meta name="twitter:creator" content="@TwitterHandle" />',
 			$this->instance->present()
@@ -79,5 +82,23 @@ class Creator_Presenter_Test extends TestCase {
 		$this->presentation->twitter_creator = '@TwitterHandle';
 
 		$this->assertSame( '@TwitterHandle', $this->instance->get() );
+	}
+
+	/**
+	 * Tests the presentation for a set twitter creator when the admin bar is showing a class is added.
+	 *
+	 * @covers ::present
+	 */
+	public function test_present_with_class() {
+		$this->stubEscapeFunctions();
+
+		$this->presentation->twitter_creator = '@TwitterHandle';
+
+		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( true );
+
+		$this->assertEquals(
+			'<meta name="twitter:creator" content="@TwitterHandle" class="yoast-seo-meta-tag" />',
+			$this->instance->present()
+		);
 	}
 }

--- a/tests/unit/presenters/twitter/description-presenter-test.php
+++ b/tests/unit/presenters/twitter/description-presenter-test.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\WP\SEO\Tests\Unit\Presenters\Twitter;
 
+use Brain\Monkey;
 use Mockery;
 use WPSEO_Replace_Vars;
 use Yoast\WP\SEO\Presentations\Indexable_Presentation;
@@ -62,6 +63,7 @@ class Description_Presenter_Test extends TestCase {
 		$this->replace_vars
 			->expects( 'replace' )
 			->andReturn( 'This is the twitter description' );
+		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
 
 		$this->assertEquals(
 			'<meta name="twitter:description" content="This is the twitter description" />',
@@ -86,5 +88,28 @@ class Description_Presenter_Test extends TestCase {
 			->andReturn( '' );
 
 		$this->assertEmpty( $this->instance->present() );
+	}
+
+	/**
+	 * Tests the presenter for a set twitter description when the admin bar is showing a class is added.
+	 *
+	 * @covers ::present
+	 * @covers ::get
+	 */
+	public function test_present_with_class() {
+		$this->instance->presentation      = new Indexable_Presentation();
+		$presentation                      = $this->instance->presentation;
+		$presentation->source              = [];
+		$presentation->twitter_description = 'This is the twitter description';
+
+		$this->replace_vars
+			->expects( 'replace' )
+			->andReturn( 'This is the twitter description' );
+		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( true );
+
+		$this->assertEquals(
+			'<meta name="twitter:description" content="This is the twitter description" class="yoast-seo-meta-tag" />',
+			$this->instance->present()
+		);
 	}
 }

--- a/tests/unit/presenters/twitter/image-presenter-test.php
+++ b/tests/unit/presenters/twitter/image-presenter-test.php
@@ -55,6 +55,8 @@ class Image_Presenter_Test extends TestCase {
 	public function test_present() {
 		$this->presentation->twitter_image = 'relative_image.jpg';
 
+		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
+
 		$expected = '<meta name="twitter:image" content="relative_image.jpg" />';
 		$actual   = $this->instance->present();
 
@@ -86,8 +88,25 @@ class Image_Presenter_Test extends TestCase {
 			->once()
 			->with( 'relative_image.jpg', $this->presentation )
 			->andReturn( 'relative_image.jpg' );
+		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
 
 		$expected = '<meta name="twitter:image" content="relative_image.jpg" />';
+		$actual   = $this->instance->present();
+
+		$this->assertEquals( $expected, $actual );
+	}
+
+	/**
+	 * Tests whether the presenter returns the correct image when the admin bar is showing a class is added.
+	 *
+	 * @covers ::present
+	 */
+	public function test_present_with_class() {
+		$this->presentation->twitter_image = 'relative_image.jpg';
+
+		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( true );
+
+		$expected = '<meta name="twitter:image" content="relative_image.jpg" class="yoast-seo-meta-tag" />';
 		$actual   = $this->instance->present();
 
 		$this->assertEquals( $expected, $actual );

--- a/tests/unit/presenters/twitter/site-presenter-test.php
+++ b/tests/unit/presenters/twitter/site-presenter-test.php
@@ -47,21 +47,6 @@ class Site_Presenter_Test extends TestCase {
 	}
 
 	/**
-	 * Tests the presentation for a set twitter creator.
-	 *
-	 * @covers ::present
-	 * @covers ::get
-	 */
-	public function test_present() {
-		$this->presentation->twitter_site = '@TwitterHandle';
-
-		$this->assertEquals(
-			'<meta name="twitter:site" content="@TwitterHandle" />',
-			$this->instance->present()
-		);
-	}
-
-	/**
 	 * Tests the presentation of an empty creator.
 	 *
 	 * @covers ::present
@@ -85,6 +70,7 @@ class Site_Presenter_Test extends TestCase {
 			->once()
 			->with( '@TwitterHandle', $this->presentation )
 			->andReturn( '@AlteredTwitterHandle' );
+		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
 
 		$this->assertEquals(
 			'<meta name="twitter:site" content="@AlteredTwitterHandle" />',
@@ -100,6 +86,8 @@ class Site_Presenter_Test extends TestCase {
 	 */
 	public function test_present_with_get_twitter_id_fixing_url_as_input() {
 		$this->presentation->twitter_site = 'http://twitter.com/TwitterHandle';
+
+		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
 
 		$this->assertEquals(
 			'<meta name="twitter:site" content="@TwitterHandle" />',
@@ -151,5 +139,22 @@ class Site_Presenter_Test extends TestCase {
 			->andReturn( '' );
 
 		$this->assertSame( '', $this->instance->get() );
+	}
+
+	/**
+	 * Tests the presentation for a set twitter creator when the admin bar is showing a class is added.
+	 *
+	 * @covers ::present
+	 * @covers ::get
+	 */
+	public function test_present_with_class() {
+		$this->presentation->twitter_site = '@TwitterHandle';
+
+		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( true );
+
+		$this->assertEquals(
+			'<meta name="twitter:site" content="@TwitterHandle" class="yoast-seo-meta-tag" />',
+			$this->instance->present()
+		);
 	}
 }

--- a/tests/unit/presenters/twitter/title-presenter-test.php
+++ b/tests/unit/presenters/twitter/title-presenter-test.php
@@ -72,6 +72,7 @@ class Title_Presenter_Test extends TestCase {
 					return $str;
 				}
 			);
+		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
 
 		$expected = '<meta name="twitter:title" content="twitter_example_title" />';
 		$actual   = $this->instance->present();
@@ -119,10 +120,33 @@ class Title_Presenter_Test extends TestCase {
 			->once()
 			->with( 'twitter_example_title', $this->indexable_presentation )
 			->andReturn( 'twitterexampletitle' );
+		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
 
 		$expected = '<meta name="twitter:title" content="twitterexampletitle" />';
 		$actual   = $this->instance->present();
 
+		$this->assertEquals( $expected, $actual );
+	}
+
+	/**
+	 * Tests whether the presenter returns the correct Twitter title when the admin bar is showing a class is added.
+	 *
+	 * @covers ::present
+	 */
+	public function test_present_with_class() {
+		$this->indexable_presentation->twitter_title = 'twitter_example_title';
+
+		$this->replace_vars
+			->expects( 'replace' )
+			->andReturnUsing(
+				static function( $str ) {
+					return $str;
+				}
+			);
+		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( true );
+
+		$expected = '<meta name="twitter:title" content="twitter_example_title" class="yoast-seo-meta-tag" />';
+		$actual   = $this->instance->present();
 		$this->assertEquals( $expected, $actual );
 	}
 }

--- a/tests/unit/presenters/webmaster/baidu-presenter-test.php
+++ b/tests/unit/presenters/webmaster/baidu-presenter-test.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\WP\SEO\Tests\Unit\Presenters\Webmaster;
 
+use Brain\Monkey;
 use Mockery;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Presenters\Webmaster\Baidu_Presenter;
@@ -64,6 +65,8 @@ class Baidu_Presenter_Test extends TestCase {
 	public function test_present() {
 		$this->options->expects( 'get' )->with( $this->option_name, '' )->andReturn( 'baidu' );
 
+		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
+
 		$this->assertSame(
 			'<meta name="baidu-site-verification" content="baidu" />',
 			$this->instance->present()
@@ -110,6 +113,23 @@ class Baidu_Presenter_Test extends TestCase {
 		$this->assertSame(
 			'',
 			$this->instance->get()
+		);
+	}
+
+	/**
+	 * Tests the presentation for a Baidu site verification string when the admin bar is showing a class is added.
+	 *
+	 * @covers ::present
+	 * @covers ::get
+	 */
+	public function test_present_with_class() {
+		$this->options->expects( 'get' )->with( $this->option_name, '' )->andReturn( 'baidu' );
+
+		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( true );
+
+		$this->assertSame(
+			'<meta name="baidu-site-verification" content="baidu" class="yoast-seo-meta-tag" />',
+			$this->instance->present()
 		);
 	}
 }

--- a/tests/unit/presenters/webmaster/bing-presenter-test.php
+++ b/tests/unit/presenters/webmaster/bing-presenter-test.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\WP\SEO\Tests\Unit\Presenters\Webmaster;
 
+use Brain\Monkey;
 use Mockery;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Presenters\Webmaster\Bing_Presenter;
@@ -64,6 +65,8 @@ class Bing_Presenter_Test extends TestCase {
 	public function test_present() {
 		$this->options->expects( 'get' )->with( $this->option_name, '' )->andReturn( 'bing-ver' );
 
+		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
+
 		$this->assertSame(
 			'<meta name="msvalidate.01" content="bing-ver" />',
 			$this->instance->present()
@@ -96,6 +99,23 @@ class Bing_Presenter_Test extends TestCase {
 		$this->assertSame(
 			'bing-ver',
 			$this->instance->get()
+		);
+	}
+
+	/**
+	 * Tests the presentation for a Bing site verification string when the admin bar is showing a class is added.
+	 *
+	 * @covers ::present
+	 * @covers ::get
+	 */
+	public function test_present_with_class() {
+		$this->options->expects( 'get' )->with( $this->option_name, '' )->andReturn( 'bing-ver' );
+
+		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( true );
+
+		$this->assertSame(
+			'<meta name="msvalidate.01" content="bing-ver" class="yoast-seo-meta-tag" />',
+			$this->instance->present()
 		);
 	}
 }

--- a/tests/unit/presenters/webmaster/google-presenter-test.php
+++ b/tests/unit/presenters/webmaster/google-presenter-test.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\WP\SEO\Tests\Unit\Presenters\Webmaster;
 
+use Brain\Monkey;
 use Mockery;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Presenters\Webmaster\Google_Presenter;
@@ -64,6 +65,8 @@ class Google_Presenter_Test extends TestCase {
 	public function test_present() {
 		$this->options->expects( 'get' )->with( $this->option_name, '' )->andReturn( 'google-ver' );
 
+		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
+
 		$this->assertSame(
 			'<meta name="google-site-verification" content="google-ver" />',
 			$this->instance->present()
@@ -96,6 +99,23 @@ class Google_Presenter_Test extends TestCase {
 		$this->assertSame(
 			'google-ver',
 			$this->instance->get()
+		);
+	}
+
+	/**
+	 * Tests the presentation for a Google site verification string when the admin bar is showing a class is added.
+	 *
+	 * @covers ::present
+	 * @covers ::get
+	 */
+	public function test_present_with_class() {
+		$this->options->expects( 'get' )->with( $this->option_name, '' )->andReturn( 'google-ver' );
+
+		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( true );
+
+		$this->assertSame(
+			'<meta name="google-site-verification" content="google-ver" class="yoast-seo-meta-tag" />',
+			$this->instance->present()
 		);
 	}
 }

--- a/tests/unit/presenters/webmaster/pinterest-presenter-test.php
+++ b/tests/unit/presenters/webmaster/pinterest-presenter-test.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\WP\SEO\Tests\Unit\Presenters\Webmaster;
 
+use Brain\Monkey;
 use Mockery;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Presenters\Webmaster\Pinterest_Presenter;
@@ -64,6 +65,8 @@ class Pinterest_Presenter_Test extends TestCase {
 	public function test_present() {
 		$this->options->expects( 'get' )->with( $this->option_name, '' )->andReturn( 'pinterest-ver' );
 
+		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
+
 		$this->assertSame(
 			'<meta name="p:domain_verify" content="pinterest-ver" />',
 			$this->instance->present()
@@ -96,6 +99,23 @@ class Pinterest_Presenter_Test extends TestCase {
 		$this->assertSame(
 			'pinterest-ver',
 			$this->instance->get()
+		);
+	}
+
+	/**
+	 * Tests the presentation for a Pinterest site verification string when the admin bar is showing a class is added.
+	 *
+	 * @covers ::present
+	 * @covers ::get
+	 */
+	public function test_present_with_class() {
+		$this->options->expects( 'get' )->with( $this->option_name, '' )->andReturn( 'pinterest-ver' );
+
+		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( true );
+
+		$this->assertSame(
+			'<meta name="p:domain_verify" content="pinterest-ver" class="yoast-seo-meta-tag" />',
+			$this->instance->present()
 		);
 	}
 }

--- a/tests/unit/presenters/webmaster/yandex-presenter-test.php
+++ b/tests/unit/presenters/webmaster/yandex-presenter-test.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\WP\SEO\Tests\Unit\Presenters\Webmaster;
 
+use Brain\Monkey;
 use Mockery;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Presenters\Webmaster\Yandex_Presenter;
@@ -64,6 +65,8 @@ class Yandex_Presenter_Test extends TestCase {
 	public function test_present() {
 		$this->options->expects( 'get' )->with( $this->option_name, '' )->andReturn( 'yandex-ver' );
 
+		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
+
 		$this->assertSame(
 			'<meta name="yandex-verification" content="yandex-ver" />',
 			$this->instance->present()
@@ -96,6 +99,23 @@ class Yandex_Presenter_Test extends TestCase {
 		$this->assertSame(
 			'yandex-ver',
 			$this->instance->get()
+		);
+	}
+
+	/**
+	 * Tests the presentation for a Yandex site verification string when the admin bar is showing a class is added.
+	 *
+	 * @covers ::present
+	 * @covers ::get
+	 */
+	public function test_present_with_class() {
+		$this->options->expects( 'get' )->with( $this->option_name, '' )->andReturn( 'yandex-ver' );
+
+		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( true );
+
+		$this->assertSame(
+			'<meta name="yandex-verification" content="yandex-ver" class="yoast-seo-meta-tag" />',
+			$this->instance->present()
 		);
 	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Reverts https://github.com/Yoast/wordpress-seo/pull/18710

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Reverts https://github.com/Yoast/wordpress-seo/pull/18710

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Test with https://github.com/Yoast/wordpress-seo-premium/pull/3622

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes https://yoast.atlassian.net/browse/PC-299