### PR TITLE
Fix eye highlighter not working for text containing the &nbsp; character 2nd edition

### DIFF
--- a/packages/yoastseo/src/languageProcessing/helpers/sentence/getSentences.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/sentence/getSentences.js
@@ -4,6 +4,7 @@ import { filter, flatMap, isEmpty, negate, memoize } from "lodash-es";
 // Internal dependencies.
 import { getBlocks } from "../html/html.js";
 import excludeTableOfContentsTag from "../sanitize/excludeTableOfContentsTag";
+import { unifyNonBreakingSpace } from "../sanitize/unifyWhitespace";
 import SentenceTokenizer from "./SentenceTokenizer";
 
 // Character classes.
@@ -47,6 +48,8 @@ export default function( text, memoizedTokenizer ) {
 	// We don't remove the other HTML tags here since removing them might lead to incorrect results when running the sentence tokenizer.
 	// Remove Table of Contents.
 	text = excludeTableOfContentsTag( text );
+	// Unify only non-breaking spaces and not the other whitespaces since a whitespace could signify a sentence break or a new line.
+	text = unifyNonBreakingSpace( text );
 
 	let blocks = getBlocks( text );
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* This PR fixes a small change done by [this one](https://github.com/Yoast/wordpress-seo/pull/18689).

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [yoastseo] Restores the `unifyNonBreakingSpace` santization step in `getSentences.js`.

## Relevant technical choices:

* Removing `unifyNonBreakingSpace` from `getSentences.js` caused a unit test to fail. So it was deemed better to return it back. 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* The test instructions are the same as in the other PR for [fixing eye highlighter not highlighting text that includes the &nbsp; character](https://github.com/Yoast/wordpress-seo/pull/18689).


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes #
