### PR TITLE
PC-46 Add the search engines discouraged notice to the notification dashboard

### DIFF
--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -42,13 +42,6 @@ class WPSEO_Admin_Init {
 		add_action( 'admin_notices', [ $this, 'permalink_settings_notice' ] );
 		add_action( 'post_submitbox_misc_actions', [ $this, 'add_publish_box_section' ] );
 
-		/*
-		 * The `admin_notices` hook fires on single site admin pages vs.
-		 * `network_admin_notices` which fires on multisite admin pages and
-		 * `user_admin_notices` which fires on multisite user admin pagss.
-		 */
-		add_action( 'admin_notices', [ $this, 'search_engines_discouraged_notice' ] );
-
 		$this->load_meta_boxes();
 		$this->load_taxonomy_class();
 		$this->load_admin_page_class();
@@ -246,15 +239,6 @@ class WPSEO_Admin_Init {
 	}
 
 	/**
-	 * Checks whether search engines are discouraged from indexing the site.
-	 *
-	 * @return bool Whether search engines are discouraged from indexing the site.
-	 */
-	private function are_search_engines_discouraged() {
-		return (string) get_option( 'blog_public' ) === '0';
-	}
-
-	/**
 	 * Shows deprecation warnings to the user if a plugin has registered a filter we have deprecated.
 	 */
 	public function show_hook_deprecation_warnings() {
@@ -349,53 +333,6 @@ class WPSEO_Admin_Init {
 				esc_html__( 'Learn about why permalinks are important for SEO.', 'wordpress-seo' )
 			);
 		}
-	}
-
-	/**
-	 * Determines whether and where the "search engines discouraged" admin notice should be displayed.
-	 *
-	 * @return bool Whether the "search engines discouraged" admin notice should be displayed.
-	 */
-	private function should_display_search_engines_discouraged_notice() {
-		$discouraged_pages = [
-			'index.php',
-			'plugins.php',
-			'update-core.php',
-		];
-
-		return (
-			$this->are_search_engines_discouraged()
-			&& WPSEO_Capability_Utils::current_user_can( 'manage_options' )
-			&& WPSEO_Options::get( 'ignore_search_engines_discouraged_notice', false ) === false
-			&& (
-				$this->on_wpseo_admin_page()
-				|| in_array( $this->pagenow, $discouraged_pages, true )
-			)
-		);
-	}
-
-	/**
-	 * Displays an admin notice when WordPress is set to discourage search engines from indexing the site.
-	 *
-	 * @return void
-	 */
-	public function search_engines_discouraged_notice() {
-		if ( ! $this->should_display_search_engines_discouraged_notice() ) {
-			return;
-		}
-
-		printf(
-			'<div id="robotsmessage" class="notice notice-error"><p><strong>%1$s</strong> %2$s <button type="button" id="robotsmessage-dismiss-button" class="button-link hide-if-no-js" data-nonce="%3$s">%4$s</button></p></div>',
-			esc_html__( 'Huge SEO Issue: You\'re blocking access to robots.', 'wordpress-seo' ),
-			sprintf(
-				/* translators: 1: Link start tag to the WordPress Reading Settings page, 2: Link closing tag. */
-				esc_html__( 'If you want search engines to show this site in their results, you must %1$sgo to your Reading Settings%2$s and uncheck the box for Search Engine Visibility.', 'wordpress-seo' ),
-				'<a href="' . esc_url( admin_url( 'options-reading.php' ) ) . '">',
-				'</a>'
-			),
-			esc_js( wp_create_nonce( 'wpseo-ignore' ) ),
-			esc_html__( 'I don\'t want this site to show in the search results.', 'wordpress-seo' )
-		);
 	}
 
 	/**

--- a/packages/js/src/admin-global.js
+++ b/packages/js/src/admin-global.js
@@ -16,13 +16,13 @@ import jQuery from "jquery";
 	 */
 	function wpseoSetIgnore( option, hide, nonce ) {
 		const formData = new FormData();
-		let postData = {
+		const postData = {
 			action: "wpseo_set_ignore",
 			option: option,
 			_wpnonce: nonce,
-		}
-		for (const [key, value] of Object.entries(postData)) {
-			formData.append(key, value);
+		};
+		for ( const [ key, value ] of Object.entries( postData ) ) {
+			formData.append( key, value );
 		}
 		return fetch(
 			ajaxurl,
@@ -30,13 +30,13 @@ import jQuery from "jquery";
 				method: "POST",
 				body: formData,
 			}
-		).then(response => {
+		).then( response => {
 			if ( response ) {
 				jQuery( "#" + hide ).hide();
 				jQuery( "#hidden_ignore_" + option ).val( "ignore" );
 			}
 			return response;
-		});
+		} );
 	}
 
 	/**
@@ -99,12 +99,12 @@ import jQuery from "jquery";
 
 		// Dismiss the "search engines discouraged" admin notice.
 		jQuery( "button#robotsmessage-dismiss-button" ).on( "click", function() {
-			wpseoSetIgnore( "search_engines_discouraged_notice", "robotsmessage", jQuery( this ).data( "nonce" ) ).then(_ => {
+			wpseoSetIgnore( "search_engines_discouraged_notice", "robotsmessage", jQuery( this ).data( "nonce" ) ).then( _ => {
 				// If we are on the dashboard, reload because we need to reload notifications as well.
-				if (window.location.href.includes('page=wpseo_dashboard')) {
+				if ( window.location.href.includes( "page=wpseo_dashboard" ) ) {
 					window.location.reload();
 				}
-			});
+			} );
 		} );
 	} );
 

--- a/packages/js/src/admin-global.js
+++ b/packages/js/src/admin-global.js
@@ -6,13 +6,13 @@ import jQuery from "jquery";
 
 ( function( $ ) {
 	/**
-	 * Used to remove the admin notices for several purposes, dies on exit.
+	 * Used to remove the admin notices for several purposes.
 	 *
 	 * @param {string} option The option to ignore.
 	 * @param {string} hide   The target element to hide.
 	 * @param {string} nonce  Nonce for verification.
 	 *
-	 * @returns {Promise<Response>}
+	 * @returns {Promise<Response>} The promise resulting from the fetch() call.
 	 */
 	function wpseoSetIgnore( option, hide, nonce ) {
 		const formData = new FormData();
@@ -99,7 +99,7 @@ import jQuery from "jquery";
 
 		// Dismiss the "search engines discouraged" admin notice.
 		jQuery( "button#robotsmessage-dismiss-button" ).on( "click", function() {
-			wpseoSetIgnore( "search_engines_discouraged_notice", "robotsmessage", jQuery( this ).data( "nonce" ) ).then( _ => {
+			wpseoSetIgnore( "search_engines_discouraged_notice", "robotsmessage", jQuery( this ).data( "nonce" ) ).then( () => {
 				// If we are on the dashboard, reload because we need to reload notifications as well.
 				if ( window.location.href.includes( "page=wpseo_dashboard" ) ) {
 					window.location.reload();

--- a/src/integrations/watchers/search-engines-discouraged-watcher.php
+++ b/src/integrations/watchers/search-engines-discouraged-watcher.php
@@ -2,8 +2,6 @@
 
 namespace Yoast\WP\SEO\Integrations\Watchers;
 
-use WPSEO_Capability_Utils;
-use WPSEO_Options;
 use Yoast\WP\SEO\Conditionals\No_Conditionals;
 use Yoast\WP\SEO\Helpers\Capability_Helper;
 use Yoast\WP\SEO\Helpers\Current_Page_Helper;
@@ -15,7 +13,9 @@ use Yoast_Notification;
 use Yoast_Notification_Center;
 
 /**
- * Shows a notification for users who have WordPress auto updates enabled but not Yoast SEO auto updates.
+ * Shows a notification for users who have access for robots disabled.
+ *
+ * @class Search_Engines_Discouraged_Watcher
  */
 class Search_Engines_Discouraged_Watcher implements Integration_Interface {
 

--- a/src/integrations/watchers/search-engines-discouraged-watcher.php
+++ b/src/integrations/watchers/search-engines-discouraged-watcher.php
@@ -1,0 +1,205 @@
+<?php
+
+namespace Yoast\WP\SEO\Integrations\Watchers;
+
+use WPSEO_Capability_Utils;
+use WPSEO_Options;
+use Yoast\WP\SEO\Conditionals\No_Conditionals;
+use Yoast\WP\SEO\Helpers\Notification_Helper;
+use Yoast\WP\SEO\Integrations\Integration_Interface;
+use Yoast\WP\SEO\Presenters\Admin\Search_Engines_Discouraged_Presenter;
+use Yoast_Notification;
+use Yoast_Notification_Center;
+
+/**
+ * Shows a notification for users who have WordPress auto updates enabled but not Yoast SEO auto updates.
+ */
+class Search_Engines_Discouraged_Watcher implements Integration_Interface {
+
+	use No_Conditionals;
+
+	/**
+	 * The notification ID.
+	 */
+	const NOTIFICATION_ID = 'wpseo-search-engines-discouraged';
+
+	/**
+	 * The Yoast notification center.
+	 *
+	 * @var Yoast_Notification_Center
+	 */
+	protected $notification_center;
+
+	/**
+	 * The notification helper.
+	 *
+	 * @var Notification_Helper
+	 */
+	protected $notification_helper;
+
+	/**
+	 * Auto_Update constructor.
+	 *
+	 * @param Yoast_Notification_Center $notification_center The notification center.
+	 * @param Notification_Helper       $notification_helper The notification helper.
+	 */
+	public function __construct(
+		Yoast_Notification_Center $notification_center,
+		Notification_Helper $notification_helper
+	) {
+		$this->notification_center = $notification_center;
+		$this->notification_helper = $notification_helper;
+	}
+
+	/**
+	 * Initializes the integration.
+	 *
+	 * On admin_init, it is checked whether the notification about search engines being discouraged should be shown.
+	 * On admin_notices, the notice about the search engines being discouraged will be shown when necessary.
+	 *
+	 * @return void
+	 */
+	public function register_hooks() {
+		\add_action( 'admin_init', [ $this, 'manage_search_engines_discouraged_notification' ] );
+
+		/*
+		 * The `admin_notices` hook fires on single site admin pages vs.
+		 * `network_admin_notices` which fires on multisite admin pages and
+		 * `user_admin_notices` which fires on multisite user admin pagss.
+		 */
+		\add_action( 'admin_notices', [ $this, 'maybe_show_search_engines_discouraged_notice' ] );
+	}
+
+	/**
+	 * Checks whether search engines are discouraged from indexing the site.
+	 *
+	 * @return bool Whether search engines are discouraged from indexing the site.
+	 */
+	private function search_engines_are_discouraged() {
+		return (string) get_option( 'blog_public' ) === '0';
+	}
+
+	/**
+	 * Helper to verify if the user is currently visiting one of our admin pages.
+	 *
+	 * @return bool
+	 */
+	private function on_wpseo_admin_page() {
+		return $GLOBALS['pagenow'] === 'admin.php' && strpos( filter_input( INPUT_GET, 'page' ), 'wpseo' ) === 0;
+	}
+
+	/**
+	 * Whether the search engines discouraged notification should be shown.
+	 *
+	 * @return bool
+	 */
+	protected function should_show_search_engines_discouraged_notification() {
+		return $this->search_engines_are_discouraged() && WPSEO_Options::get( 'ignore_search_engines_discouraged_notice', false ) === false;
+	}
+
+	/**
+	 * Whether the search engines notice should be shown.
+	 *
+	 * @return bool
+	 */
+	protected function should_show_search_engines_discouraged_notice() {
+		$discouraged_pages = [
+			'index.php',
+			'plugins.php',
+			'update-core.php',
+		];
+
+		return (
+			$this->search_engines_are_discouraged()
+			&& WPSEO_Capability_Utils::current_user_can( 'manage_options' )
+			&& WPSEO_Options::get( 'ignore_search_engines_discouraged_notice', false ) === false
+			&& (
+				$this->on_wpseo_admin_page()
+				|| in_array( $GLOBALS['pagenow'], $discouraged_pages, true )
+			)
+		);
+	}
+
+	/**
+	 * Show the search engines discouraged notice.
+	 *
+	 * @return void
+	 */
+	public function show_search_engines_discouraged_notice() {
+		$presenter = new Search_Engines_Discouraged_Presenter();
+
+		printf(
+			'<div id="robotsmessage" class="notice notice-error"> %1$s </div>',
+			esc_html( $presenter->present() )
+		);
+	}
+
+	/**
+	 * Show the search engine discouraged notice when needed.
+	 *
+	 * @return void
+	 */
+	public function maybe_show_search_engines_discouraged_notice() {
+		if ( ! $this->should_show_search_engines_discouraged_notice() ) {
+			return;
+		}
+		$this->show_search_engines_discouraged_notice();
+	}
+
+	/**
+	 * Remove the search engines discouraged notification if it exists.
+	 *
+	 * @return void
+	 */
+	protected function remove_search_engines_discouraged_notification_if_exists() {
+		$this->notification_center->remove_notification_by_id( self::NOTIFICATION_ID );
+	}
+
+	/**
+	 * Add the search engines discouraged notification if it does not exist yet.
+	 *
+	 * @return void
+	 */
+	protected function maybe_add_search_engines_discouraged_notification() {
+		if ( ! $this->notification_center->get_notification_by_id( self::NOTIFICATION_ID ) ) {
+			$notification = $this->notification();
+			$this->notification_helper->restore_notification( $notification );
+			$this->notification_center->add_notification( $notification );
+		}
+	}
+
+	/**
+	 * Manage the search engines discouraged notification.
+	 *
+	 * Shows the notification if needed and deletes it if needed.
+	 *
+	 * @return void
+	 */
+	public function manage_search_engines_discouraged_notification() {
+		if ( ! $this->should_show_search_engines_discouraged_notification() ) {
+			$this->remove_search_engines_discouraged_notification_if_exists();
+		}
+		else {
+			$this->maybe_add_search_engines_discouraged_notification();
+		}
+	}
+
+	/**
+	 * Returns an instance of the notification.
+	 *
+	 * @return Yoast_Notification The notification to show.
+	 */
+	protected function notification() {
+		$presenter = new Search_Engines_Discouraged_Presenter();
+
+		return new Yoast_Notification(
+			$presenter->present(),
+			[
+				'type'         => Yoast_Notification::ERROR,
+				'id'           => self::NOTIFICATION_ID,
+				'capabilities' => 'wpseo_manage_options',
+				'priority'     => 1,
+			]
+		);
+	}
+}

--- a/src/integrations/watchers/search-engines-discouraged-watcher.php
+++ b/src/integrations/watchers/search-engines-discouraged-watcher.php
@@ -71,27 +71,25 @@ class Search_Engines_Discouraged_Watcher implements Integration_Interface {
 	/**
 	 * Auto_Update constructor.
 	 *
-	 * @param Yoast_Notification_Center            $notification_center The notification center.
-	 * @param Notification_Helper                  $notification_helper The notification helper.
-	 * @param Search_Engines_Discouraged_Presenter $presenter The presenter for the search engines discouraged notification.
-	 * @param Current_Page_Helper                  $current_page_helper The current page helper.
-	 * @param Options_Helper                       $options_helper The options helper.
-	 * @param Capability_Helper                    $capability_helper The capability helper.
+	 * @param Yoast_Notification_Center $notification_center The notification center.
+	 * @param Notification_Helper       $notification_helper The notification helper.
+	 * @param Current_Page_Helper       $current_page_helper The current page helper.
+	 * @param Options_Helper            $options_helper      The options helper.
+	 * @param Capability_Helper         $capability_helper   The capability helper.
 	 */
 	public function __construct(
 		Yoast_Notification_Center $notification_center,
 		Notification_Helper $notification_helper,
-		Search_Engines_Discouraged_Presenter $presenter,
 		Current_Page_Helper $current_page_helper,
 		Options_Helper $options_helper,
 		Capability_Helper $capability_helper
 	) {
 		$this->notification_center = $notification_center;
 		$this->notification_helper = $notification_helper;
-		$this->presenter           = $presenter;
 		$this->current_page_helper = $current_page_helper;
 		$this->options_helper      = $options_helper;
 		$this->capability_helper   = $capability_helper;
+		$this->presenter           = new Search_Engines_Discouraged_Presenter();
 	}
 
 	/**

--- a/src/integrations/watchers/search-engines-discouraged-watcher.php
+++ b/src/integrations/watchers/search-engines-discouraged-watcher.php
@@ -130,18 +130,21 @@ class Search_Engines_Discouraged_Watcher implements Integration_Interface {
 
 		printf(
 			'<div id="robotsmessage" class="notice notice-error"> %1$s </div>',
-			wp_kses( $presenter->present(), [
-				'strong' => [],
-				'button' => [
-					'type' => array(),
-					'id' => array(),
-					'class' => array(),
-					'data-nonce' => array(),
-				],
-				'a' => [
-					'href' => array(),
+			wp_kses(
+				$presenter->present(),
+				[
+					'strong' => [],
+					'button' => [
+						'type'       => [],
+						'id'         => [],
+						'class'      => [],
+						'data-nonce' => [],
+					],
+					'a'      => [
+						'href' => [],
+					],
 				]
-			] )
+			)
 		);
 	}
 

--- a/src/integrations/watchers/search-engines-discouraged-watcher.php
+++ b/src/integrations/watchers/search-engines-discouraged-watcher.php
@@ -69,7 +69,7 @@ class Search_Engines_Discouraged_Watcher implements Integration_Interface {
 	protected $capability_helper;
 
 	/**
-	 * Auto_Update constructor.
+	 * Search_Engines_Discouraged_Watcher constructor.
 	 *
 	 * @param Yoast_Notification_Center $notification_center The notification center.
 	 * @param Notification_Helper       $notification_helper The notification helper.
@@ -106,18 +106,37 @@ class Search_Engines_Discouraged_Watcher implements Integration_Interface {
 		/*
 		 * The `admin_notices` hook fires on single site admin pages vs.
 		 * `network_admin_notices` which fires on multisite admin pages and
-		 * `user_admin_notices` which fires on multisite user admin pagss.
+		 * `user_admin_notices` which fires on multisite user admin pages.
 		 */
 		\add_action( 'admin_notices', [ $this, 'maybe_show_search_engines_discouraged_notice' ] );
 	}
 
 	/**
-	 * Checks whether search engines are discouraged from indexing the site.
+	 * Manage the search engines discouraged notification.
 	 *
-	 * @return bool Whether search engines are discouraged from indexing the site.
+	 * Shows the notification if needed and deletes it if needed.
+	 *
+	 * @return void
 	 */
-	protected function search_engines_are_discouraged() {
-		return (string) \get_option( 'blog_public' ) === '0';
+	public function manage_search_engines_discouraged_notification() {
+		if ( ! $this->should_show_search_engines_discouraged_notification() ) {
+			$this->remove_search_engines_discouraged_notification_if_exists();
+		}
+		else {
+			$this->maybe_add_search_engines_discouraged_notification();
+		}
+	}
+
+	/**
+	 * Show the search engine discouraged notice when needed.
+	 *
+	 * @return void
+	 */
+	public function maybe_show_search_engines_discouraged_notice() {
+		if ( ! $this->should_show_search_engines_discouraged_notice() ) {
+			return;
+		}
+		$this->show_search_engines_discouraged_notice();
 	}
 
 	/**
@@ -127,6 +146,37 @@ class Search_Engines_Discouraged_Watcher implements Integration_Interface {
 	 */
 	protected function should_show_search_engines_discouraged_notification() {
 		return $this->search_engines_are_discouraged() && $this->options_helper->get( 'ignore_search_engines_discouraged_notice', false ) === false;
+	}
+
+	/**
+	 * Remove the search engines discouraged notification if it exists.
+	 *
+	 * @return void
+	 */
+	protected function remove_search_engines_discouraged_notification_if_exists() {
+		$this->notification_center->remove_notification_by_id( self::NOTIFICATION_ID );
+	}
+
+	/**
+	 * Add the search engines discouraged notification if it does not exist yet.
+	 *
+	 * @return void
+	 */
+	protected function maybe_add_search_engines_discouraged_notification() {
+		if ( ! $this->notification_center->get_notification_by_id( self::NOTIFICATION_ID ) ) {
+			$notification = $this->notification();
+			$this->notification_helper->restore_notification( $notification );
+			$this->notification_center->add_notification( $notification );
+		}
+	}
+
+	/**
+	 * Checks whether search engines are discouraged from indexing the site.
+	 *
+	 * @return bool Whether search engines are discouraged from indexing the site.
+	 */
+	protected function search_engines_are_discouraged() {
+		return (string) \get_option( 'blog_public' ) === '0';
 	}
 
 	/**
@@ -158,7 +208,7 @@ class Search_Engines_Discouraged_Watcher implements Integration_Interface {
 	 *
 	 * @return void
 	 */
-	public function show_search_engines_discouraged_notice() {
+	protected function show_search_engines_discouraged_notice() {
 		\printf(
 			'<div id="robotsmessage" class="notice notice-error"> %1$s </div>',
 			\wp_kses(
@@ -178,56 +228,6 @@ class Search_Engines_Discouraged_Watcher implements Integration_Interface {
 				]
 			)
 		);
-	}
-
-	/**
-	 * Show the search engine discouraged notice when needed.
-	 *
-	 * @return void
-	 */
-	public function maybe_show_search_engines_discouraged_notice() {
-		if ( ! $this->should_show_search_engines_discouraged_notice() ) {
-			return;
-		}
-		$this->show_search_engines_discouraged_notice();
-	}
-
-	/**
-	 * Remove the search engines discouraged notification if it exists.
-	 *
-	 * @return void
-	 */
-	protected function remove_search_engines_discouraged_notification_if_exists() {
-		$this->notification_center->remove_notification_by_id( self::NOTIFICATION_ID );
-	}
-
-	/**
-	 * Add the search engines discouraged notification if it does not exist yet.
-	 *
-	 * @return void
-	 */
-	protected function maybe_add_search_engines_discouraged_notification() {
-		if ( ! $this->notification_center->get_notification_by_id( self::NOTIFICATION_ID ) ) {
-			$notification = $this->notification();
-			$this->notification_helper->restore_notification( $notification );
-			$this->notification_center->add_notification( $notification );
-		}
-	}
-
-	/**
-	 * Manage the search engines discouraged notification.
-	 *
-	 * Shows the notification if needed and deletes it if needed.
-	 *
-	 * @return void
-	 */
-	public function manage_search_engines_discouraged_notification() {
-		if ( ! $this->should_show_search_engines_discouraged_notification() ) {
-			$this->remove_search_engines_discouraged_notification_if_exists();
-		}
-		else {
-			$this->maybe_add_search_engines_discouraged_notification();
-		}
 	}
 
 	/**

--- a/src/integrations/watchers/search-engines-discouraged-watcher.php
+++ b/src/integrations/watchers/search-engines-discouraged-watcher.php
@@ -130,7 +130,18 @@ class Search_Engines_Discouraged_Watcher implements Integration_Interface {
 
 		printf(
 			'<div id="robotsmessage" class="notice notice-error"> %1$s </div>',
-			esc_html( $presenter->present() )
+			wp_kses( $presenter->present(), [
+				'strong' => [],
+				'button' => [
+					'type' => array(),
+					'id' => array(),
+					'class' => array(),
+					'data-nonce' => array(),
+				],
+				'a' => [
+					'href' => array(),
+				]
+			] )
 		);
 	}
 

--- a/src/presenters/admin/search-engines-discouraged-presenter.php
+++ b/src/presenters/admin/search-engines-discouraged-presenter.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Yoast\WP\SEO\Presenters\Admin;
+
+use Yoast\WP\SEO\Presenters\Abstract_Presenter;
+
+/**
+ * Class Search_Engines_Discouraged_Presenter.
+ */
+class Search_Engines_Discouraged_Presenter extends Abstract_Presenter {
+
+	/**
+	 * Returns the notification as an HTML string.
+	 *
+	 * @return string The notification in an HTML string representation.
+	 */
+	public function present() {
+		$notification_text  = '<p>';
+		$notification_text .= $this->get_message();
+		$notification_text .= '</p>';
+
+		return $notification_text;
+	}
+
+	/**
+	 * Returns the message to show.
+	 *
+	 * @return string The message.
+	 */
+	protected function get_message() {
+		return sprintf(
+			'<strong>%1$s</strong> %2$s <button type="button" id="robotsmessage-dismiss-button" class="button-link hide-if-no-js" data-nonce="%3$s">%4$s</button>',
+			esc_html__( 'Huge SEO Issue: You\'re blocking access to robots.', 'wordpress-seo' ),
+			sprintf(
+			/* translators: 1: Link start tag to the WordPress Reading Settings page, 2: Link closing tag. */
+				esc_html__( 'If you want search engines to show this site in their results, you must %1$sgo to your Reading Settings%2$s and uncheck the box for Search Engine Visibility.', 'wordpress-seo' ),
+				'<a href="' . esc_url( admin_url( 'options-reading.php' ) ) . '">',
+				'</a>'
+			),
+			esc_js( wp_create_nonce( 'wpseo-ignore' ) ),
+			esc_html__( 'I don\'t want this site to show in the search results.', 'wordpress-seo' )
+		);
+	}
+}

--- a/src/presenters/admin/search-engines-discouraged-presenter.php
+++ b/src/presenters/admin/search-engines-discouraged-presenter.php
@@ -28,17 +28,17 @@ class Search_Engines_Discouraged_Presenter extends Abstract_Presenter {
 	 * @return string The message.
 	 */
 	protected function get_message() {
-		return sprintf(
+		return \sprintf(
 			'<strong>%1$s</strong> %2$s <button type="button" id="robotsmessage-dismiss-button" class="button-link hide-if-no-js" data-nonce="%3$s">%4$s</button>',
-			esc_html__( 'Huge SEO Issue: You\'re blocking access to robots.', 'wordpress-seo' ),
-			sprintf(
+			\esc_html__( 'Huge SEO Issue: You\'re blocking access to robots.', 'wordpress-seo' ),
+			\sprintf(
 			/* translators: 1: Link start tag to the WordPress Reading Settings page, 2: Link closing tag. */
-				esc_html__( 'If you want search engines to show this site in their results, you must %1$sgo to your Reading Settings%2$s and uncheck the box for Search Engine Visibility.', 'wordpress-seo' ),
-				'<a href="' . esc_url( admin_url( 'options-reading.php' ) ) . '">',
+				\esc_html__( 'If you want search engines to show this site in their results, you must %1$sgo to your Reading Settings%2$s and uncheck the box for Search Engine Visibility.', 'wordpress-seo' ),
+				'<a href="' . \esc_url( \admin_url( 'options-reading.php' ) ) . '">',
 				'</a>'
 			),
-			esc_js( wp_create_nonce( 'wpseo-ignore' ) ),
-			esc_html__( 'I don\'t want this site to show in the search results.', 'wordpress-seo' )
+			\esc_js( wp_create_nonce( 'wpseo-ignore' ) ),
+			\esc_html__( 'I don\'t want this site to show in the search results.', 'wordpress-seo' )
 		);
 	}
 }

--- a/tests/unit/integrations/watchers/search-engines-discouraged-watcher-test.php
+++ b/tests/unit/integrations/watchers/search-engines-discouraged-watcher-test.php
@@ -140,46 +140,6 @@ class Search_Engines_Discouraged_Watcher_Test extends TestCase {
 	}
 
 	/**
-	 * Tests show_search_engines_discouraged_notice().
-	 *
-	 * @covers ::show_search_engines_discouraged_notice
-	 */
-	public function test_show_search_engines_discouraged_notice() {
-		$this->presenter
-			->expects( 'present' )
-			->once()
-			->andReturn( 'Test Notification' );
-
-		Monkey\Functions\expect( 'wp_kses' )
-			->with(
-				'Test Notification',
-				[
-					'strong' => [],
-					'button' => [
-						'type'       => [],
-						'id'         => [],
-						'class'      => [],
-						'data-nonce' => [],
-					],
-					'a'      => [
-						'href' => [],
-					],
-					'p'      => [],
-				]
-			)
-			->once()
-			->andReturn( 'Test Notification' );
-
-		ob_start();
-		$this->instance->show_search_engines_discouraged_notice();
-		$output = ob_get_clean();
-		self::assertEquals(
-			'<div id="robotsmessage" class="notice notice-error"> Test Notification </div>',
-			$output
-		);
-	}
-
-	/**
 	 * Tests maybe_show_search_engines_discouraged_notice.
 	 *
 	 * @param string $blog_public_option_value The option value for blog_public.

--- a/tests/unit/integrations/watchers/search-engines-discouraged-watcher-test.php
+++ b/tests/unit/integrations/watchers/search-engines-discouraged-watcher-test.php
@@ -9,7 +9,6 @@ use Yoast\WP\SEO\Helpers\Current_Page_Helper;
 use Yoast\WP\SEO\Helpers\Notification_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Integrations\Watchers\Search_Engines_Discouraged_Watcher;
-use Yoast\WP\SEO\Presenters\Admin\Search_Engines_Discouraged_Presenter;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 use Yoast_Notification_Center;
 
@@ -36,13 +35,6 @@ class Search_Engines_Discouraged_Watcher_Test extends TestCase {
 	 * @var Mockery\MockInterface|Notification_Helper
 	 */
 	protected $notification_helper;
-
-	/**
-	 * Search_Engines_Discouraged_Presenter mock.
-	 *
-	 * @var Mockery\MockInterface|Search_Engines_Discouraged_Presenter
-	 */
-	protected $presenter;
 
 	/**
 	 * Current_Page_Helper mock.
@@ -87,7 +79,6 @@ class Search_Engines_Discouraged_Watcher_Test extends TestCase {
 
 		$this->notification_center = Mockery::mock( Yoast_Notification_Center::class );
 		$this->notification_helper = Mockery::mock( Notification_Helper::class );
-		$this->presenter           = Mockery::mock( Search_Engines_Discouraged_Presenter::class );
 		$this->current_page_helper = Mockery::mock( Current_Page_Helper::class );
 		$this->options_helper      = Mockery::mock( Options_Helper::class );
 		$this->capability_helper   = Mockery::mock( Capability_Helper::class );
@@ -95,7 +86,6 @@ class Search_Engines_Discouraged_Watcher_Test extends TestCase {
 		$this->instance = new Search_Engines_Discouraged_Watcher(
 			$this->notification_center,
 			$this->notification_helper,
-			$this->presenter,
 			$this->current_page_helper,
 			$this->options_helper,
 			$this->capability_helper
@@ -103,7 +93,7 @@ class Search_Engines_Discouraged_Watcher_Test extends TestCase {
 
 		$this->mocked_instance = Mockery::mock(
 			Search_Engines_Discouraged_Watcher::class,
-			[ $this->notification_center, $this->notification_helper, $this->presenter, $this->current_page_helper, $this->options_helper, $this->capability_helper ]
+			[ $this->notification_center, $this->notification_helper, $this->current_page_helper, $this->options_helper, $this->capability_helper ]
 		)
 			->makePartial()
 			->shouldAllowMockingProtectedMethods();
@@ -122,10 +112,6 @@ class Search_Engines_Discouraged_Watcher_Test extends TestCase {
 		self::assertInstanceOf(
 			Notification_Helper::class,
 			self::getPropertyValue( $this->instance, 'notification_helper' )
-		);
-		self::assertInstanceOf(
-			Search_Engines_Discouraged_Presenter::class,
-			self::getPropertyValue( $this->instance, 'presenter' )
 		);
 		self::assertInstanceOf(
 			Current_Page_Helper::class,

--- a/tests/unit/integrations/watchers/search-engines-discouraged-watcher-test.php
+++ b/tests/unit/integrations/watchers/search-engines-discouraged-watcher-test.php
@@ -1,0 +1,419 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Integrations\Watchers;
+
+use Brain\Monkey;
+use Mockery;
+use Yoast\WP\SEO\Helpers\Capability_Helper;
+use Yoast\WP\SEO\Helpers\Current_Page_Helper;
+use Yoast\WP\SEO\Helpers\Notification_Helper;
+use Yoast\WP\SEO\Helpers\Options_Helper;
+use Yoast\WP\SEO\Integrations\Watchers\Search_Engines_Discouraged_Watcher;
+use Yoast\WP\SEO\Presenters\Admin\Search_Engines_Discouraged_Presenter;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+use Yoast_Notification_Center;
+
+/**
+ * Class Search_Engines_Discouraged_Watcher_Test.
+ *
+ * @group integrations
+ * @group watchers
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Integrations\Watchers\Search_Engines_Discouraged_Watcher
+ */
+class Search_Engines_Discouraged_Watcher_Test extends TestCase {
+
+	/**
+	 * Yoast_Notification_Center mock.
+	 *
+	 * @var Mockery\MockInterface|Yoast_Notification_Center
+	 */
+	protected $notification_center;
+
+	/**
+	 * Notification_Helper mock.
+	 *
+	 * @var Mockery\MockInterface|Notification_Helper
+	 */
+	protected $notification_helper;
+
+	/**
+	 * Search_Engines_Discouraged_Presenter mock.
+	 *
+	 * @var Mockery\MockInterface|Search_Engines_Discouraged_Presenter
+	 */
+	protected $presenter;
+
+	/**
+	 * Current_Page_Helper mock.
+	 *
+	 * @var Mockery\MockInterface|Current_Page_Helper
+	 */
+	protected $current_page_helper;
+
+	/**
+	 * Options_Helper mock.
+	 *
+	 * @var Mockery\MockInterface|Options_Helper
+	 */
+	protected $options_helper;
+
+	/**
+	 * Capability_Helper mock.
+	 *
+	 * @var Mockery\MockInterface|Capability_Helper
+	 */
+	protected $capability_helper;
+
+	/**
+	 * The instance under test.
+	 *
+	 * @var Search_Engines_Discouraged_Watcher
+	 */
+	protected $instance;
+
+	/**
+	 * The mocked instance under test.
+	 *
+	 * @var Mockery\MockInterface|Search_Engines_Discouraged_Watcher
+	 */
+	protected $mocked_instance;
+
+	/**
+	 * Sets up the class under test and mock objects.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->notification_center = Mockery::mock( Yoast_Notification_Center::class );
+		$this->notification_helper = Mockery::mock( Notification_Helper::class );
+		$this->presenter           = Mockery::mock( Search_Engines_Discouraged_Presenter::class );
+		$this->current_page_helper = Mockery::mock( Current_Page_Helper::class );
+		$this->options_helper      = Mockery::mock( Options_Helper::class );
+		$this->capability_helper   = Mockery::mock( Capability_Helper::class );
+
+		$this->instance = new Search_Engines_Discouraged_Watcher(
+			$this->notification_center,
+			$this->notification_helper,
+			$this->presenter,
+			$this->current_page_helper,
+			$this->options_helper,
+			$this->capability_helper
+		);
+
+		$this->mocked_instance = Mockery::mock(
+			Search_Engines_Discouraged_Watcher::class,
+			[ $this->notification_center, $this->notification_helper, $this->presenter, $this->current_page_helper, $this->options_helper, $this->capability_helper ]
+		)
+			->makePartial()
+			->shouldAllowMockingProtectedMethods();
+	}
+
+	/**
+	 * Tests the constructor.
+	 *
+	 * @covers ::__construct
+	 */
+	public function test_constructor() {
+		self::assertInstanceOf(
+			Yoast_Notification_Center::class,
+			self::getPropertyValue( $this->instance, 'notification_center' )
+		);
+		self::assertInstanceOf(
+			Notification_Helper::class,
+			self::getPropertyValue( $this->instance, 'notification_helper' )
+		);
+		self::assertInstanceOf(
+			Search_Engines_Discouraged_Presenter::class,
+			self::getPropertyValue( $this->instance, 'presenter' )
+		);
+		self::assertInstanceOf(
+			Current_Page_Helper::class,
+			self::getPropertyValue( $this->instance, 'current_page_helper' )
+		);
+		self::assertInstanceOf(
+			Options_Helper::class,
+			self::getPropertyValue( $this->instance, 'options_helper' )
+		);
+		self::assertInstanceOf(
+			Capability_Helper::class,
+			self::getPropertyValue( $this->instance, 'capability_helper' )
+		);
+	}
+
+	/**
+	 * Tests registering the hooks.
+	 *
+	 * @covers ::register_hooks
+	 */
+	public function test_register_hooks() {
+		Monkey\Actions\expectAdded( 'admin_init' );
+		Monkey\Actions\expectAdded( 'admin_notices' );
+
+		$this->instance->register_hooks();
+	}
+
+	/**
+	 * Tests show_search_engines_discouraged_notice().
+	 *
+	 * @covers ::show_search_engines_discouraged_notice
+	 */
+	public function test_show_search_engines_discouraged_notice() {
+		$this->presenter
+			->expects( 'present' )
+			->once()
+			->andReturn( 'Test Notification' );
+
+		Monkey\Functions\expect( 'wp_kses' )
+			->with(
+				'Test Notification',
+				[
+					'strong' => [],
+					'button' => [
+						'type'       => [],
+						'id'         => [],
+						'class'      => [],
+						'data-nonce' => [],
+					],
+					'a'      => [
+						'href' => [],
+					],
+					'p'      => [],
+				]
+			)
+			->once()
+			->andReturn( 'Test Notification' );
+
+		ob_start();
+		$this->instance->show_search_engines_discouraged_notice();
+		$output = ob_get_clean();
+		self::assertEquals(
+			'<div id="robotsmessage" class="notice notice-error"> Test Notification </div>',
+			$output
+		);
+	}
+
+	/**
+	 * Tests maybe_show_search_engines_discouraged_notice.
+	 *
+	 * @param string $blog_public_option_value The option value for blog_public.
+	 * @param bool   $current_user_can_manage_options Whether the current user has manage_options permissions.
+	 * @param bool   $ignore_notice Whether the user ignored the notice before.
+	 * @param bool   $is_on_yoast_seo_page Whether the user is on a Yoast SEO admin page.
+	 * @param string $current_page_file The php file loaded for the current page.
+	 * @param string $current_yoast_page The current Yoast admin page.
+	 * @param bool   $expect_called Whether the notice show function should have been called.
+	 *
+	 * @dataProvider maybe_show_search_engines_discouraged_notice_dataprovider
+	 *
+	 * @covers ::maybe_show_search_engines_discouraged_notice
+	 */
+	public function test_maybe_show_search_engines_discouraged_notice(
+		$blog_public_option_value,
+		$current_user_can_manage_options,
+		$ignore_notice,
+		$is_on_yoast_seo_page,
+		$current_page_file,
+		$current_yoast_page,
+		$expect_called
+	) {
+		Monkey\Functions\expect( 'get_option' )
+			->with( 'blog_public' )
+			->once()
+			->andReturn( $blog_public_option_value );
+
+		$this->capability_helper
+			->allows( 'current_user_can' )
+			->with( 'manage_options' )
+			->andReturn( $current_user_can_manage_options );
+
+		$this->options_helper
+			->allows( 'get' )
+			->with( 'ignore_search_engines_discouraged_notice', false )
+			->andReturn( $ignore_notice );
+
+		$this->current_page_helper
+			->allows( 'is_yoast_seo_page' )
+			->andReturn( $is_on_yoast_seo_page );
+
+		$this->current_page_helper
+			->allows( 'get_current_admin_page' )
+			->andReturn( $current_page_file );
+
+		$this->current_page_helper
+			->allows( 'get_current_yoast_seo_page' )
+			->andReturn( $current_yoast_page );
+
+		if ( $expect_called ) {
+			$this->mocked_instance
+				->expects( 'show_search_engines_discouraged_notice' )
+				->once()
+				->andReturns();
+		}
+		else {
+			$this->mocked_instance
+				->shouldNotReceive( 'show_search_engines_discouraged_notice' );
+		}
+
+		$this->mocked_instance->maybe_show_search_engines_discouraged_notice();
+	}
+
+	/**
+	 * Data provider for test_maybe_show_search_engines_discouraged_notice.
+	 *
+	 * @return array Data for test_maybe_show_search_engines_discouraged_notice.
+	 */
+	public function maybe_show_search_engines_discouraged_notice_dataprovider() {
+		$should_show_notice             = [
+			'blog_public_option_value'        => '0',
+			'current_user_can_manage_options' => true,
+			'ignore_notice'                   => false,
+			'is_on_yoast_seo_page'            => true,
+			'current_page_file'               => 'admin.php',
+			'current_yoast_page'              => '',
+			'expect_called'                   => true,
+		];
+		$blog_is_public                 = [
+			'blog_public_option_value'        => '1',
+			'current_user_can_manage_options' => true,
+			'ignore_notice'                   => false,
+			'is_on_yoast_seo_page'            => true,
+			'current_page_file'               => 'admin.php',
+			'current_yoast_page'              => '',
+			'expect_called'                   => false,
+		];
+		$user_has_no_permissions        = [
+			'blog_public_option_value'        => '0',
+			'current_user_can_manage_options' => false,
+			'ignore_notice'                   => false,
+			'is_on_yoast_seo_page'            => true,
+			'current_page_file'               => 'admin.php',
+			'current_yoast_page'              => '',
+			'expect_called'                   => false,
+		];
+		$user_ignored_notice            = [
+			'blog_public_option_value'        => '0',
+			'current_user_can_manage_options' => true,
+			'ignore_notice'                   => true,
+			'is_on_yoast_seo_page'            => true,
+			'current_page_file'               => 'admin.php',
+			'current_yoast_page'              => '',
+			'expect_called'                   => false,
+		];
+		$user_not_on_yoast_seo_page     = [
+			'blog_public_option_value'        => '0',
+			'current_user_can_manage_options' => true,
+			'ignore_notice'                   => false,
+			'is_on_yoast_seo_page'            => false,
+			'current_page_file'               => 'admin.php',
+			'current_yoast_page'              => '',
+			'expect_called'                   => false,
+		];
+		$user_is_on_whitelisted_page    = [
+			'blog_public_option_value'        => '0',
+			'current_user_can_manage_options' => true,
+			'ignore_notice'                   => false,
+			'is_on_yoast_seo_page'            => false,
+			'current_page_file'               => 'index.php',
+			'current_yoast_page'              => '',
+			'expect_called'                   => true,
+		];
+		$user_is_on_yoast_seo_dashboard = [
+			'blog_public_option_value'        => '0',
+			'current_user_can_manage_options' => true,
+			'ignore_notice'                   => false,
+			'is_on_yoast_seo_page'            => true,
+			'current_page_file'               => 'admin.php',
+			'current_yoast_page'              => 'wpseo_dashboard',
+			'expect_called'                   => false,
+		];
+		return [
+			'Should show notice'                  => $should_show_notice,
+			'Blog is public'                      => $blog_is_public,
+			'User has not permissions'            => $user_has_no_permissions,
+			'User ignored the notice'             => $user_ignored_notice,
+			'User is not on Yoast SEO page'       => $user_not_on_yoast_seo_page,
+			'User is on whitelisted page'         => $user_is_on_whitelisted_page,
+			'User is on Yoast SEO dashboard page' => $user_is_on_yoast_seo_dashboard,
+		];
+	}
+
+	/**
+	 * Tests manage_search_engines_discouraged_notification.
+	 *
+	 * @param string $blog_public_option_value The option value for blog_public.
+	 * @param bool   $ignore_notice Whether the user ignored the notice before.
+	 * @param bool   $remove_notification_called Whether the remove notification function should be called.
+	 * @param bool   $add_notification_called Whether the add notification function should be called.
+	 *
+	 * @dataProvider manage_search_engines_discouraged_notification_dataprovider
+	 *
+	 * @covers ::manage_search_engines_discouraged_notification
+	 */
+	public function test_manage_search_engines_discouraged_notification( $blog_public_option_value, $ignore_notice, $remove_notification_called, $add_notification_called ) {
+		Monkey\Functions\expect( 'get_option' )
+			->with( 'blog_public' )
+			->once()
+			->andReturn( $blog_public_option_value );
+
+		$this->options_helper
+			->allows( 'get' )
+			->with( 'ignore_search_engines_discouraged_notice', false )
+			->andReturn( $ignore_notice );
+
+		if ( $remove_notification_called ) {
+			$this->mocked_instance
+				->expects( 'remove_search_engines_discouraged_notification_if_exists' )
+				->once()
+				->andReturns();
+		}
+		else {
+			$this->mocked_instance
+				->shouldNotReceive( 'remove_search_engines_discouraged_notification_if_exists' );
+		}
+
+		if ( $add_notification_called ) {
+			$this->mocked_instance
+				->expects( 'maybe_add_search_engines_discouraged_notification' )
+				->once()
+				->andReturns();
+		}
+		else {
+			$this->mocked_instance
+				->shouldNotReceive( 'maybe_add_search_engines_discouraged_notification' );
+		}
+
+		$this->mocked_instance->manage_search_engines_discouraged_notification();
+	}
+
+	/**
+	 * Data provider for manage_search_engines_discouraged_notification.
+	 *
+	 * @return array data for manage_search_engines_discouraged_notification.
+	 */
+	public function manage_search_engines_discouraged_notification_dataprovider() {
+		$should_add_notification = [
+			'blog_public_option_value'   => '0',
+			'ignore_notice'              => false,
+			'remove_notification_called' => false,
+			'add_notification_called'    => true,
+		];
+		$blog_not_public         = [
+			'blog_public_option_value'   => '1',
+			'ignore_notice'              => false,
+			'remove_notification_called' => true,
+			'add_notification_called'    => false,
+		];
+		$notice_ignored          = [
+			'blog_public_option_value'   => '0',
+			'ignore_notice'              => true,
+			'remove_notification_called' => true,
+			'add_notification_called'    => false,
+		];
+		return [
+			'Should add notification' => $should_add_notification,
+			'Blog not public'         => $blog_not_public,
+			'Notice ignored'          => $notice_ignored,
+		];
+	}
+}

--- a/tests/unit/presenters/admin/search-engines-discouraged-presenter-test.php
+++ b/tests/unit/presenters/admin/search-engines-discouraged-presenter-test.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Presenters\Admin;
+
+use Brain\Monkey;
+use Yoast\WP\SEO\Presenters\Admin\Auto_Update_Notification_Presenter;
+use Yoast\WP\SEO\Presenters\Admin\Search_Engines_Discouraged_Presenter;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Class Search_Engines_Discouraged_Presenter_Test.
+ *
+ * @covers \Yoast\WP\SEO\Presenters\Admin\Search_Engines_Discouraged_Presenter
+ * @coversDefaultClass \Yoast\WP\SEO\Presenters\Admin\Search_Engines_Discouraged_Presenter
+ *
+ * @group presenters
+ */
+class Search_Engines_Discouraged_Presenter_Test extends TestCase {
+
+	/**
+	 * The instance to test.
+	 *
+	 * @var Search_Engines_Discouraged_Presenter
+	 */
+	protected $instance;
+
+	/**
+	 * Sets up the test.
+	 *
+	 * @return void
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->stubTranslationFunctions();
+		$this->instance = new Search_Engines_Discouraged_Presenter();
+	}
+
+	/**
+	 * Tests returning the notification as an HTML string.
+	 *
+	 * @covers ::present
+	 * @covers ::get_message
+	 */
+	public function test_present() {
+		Monkey\Functions\expect( 'admin_url' )
+			->with( 'options-reading.php' )
+			->andReturn( 'http://basic.wordpress.test/wp-admin/options-reading.php' );
+
+		Monkey\Functions\expect( 'esc_url' )
+			->with( 'http://basic.wordpress.test/wp-admin/options-reading.php' )
+			->andReturn( 'http://basic.wordpress.test/wp-admin/options-reading.php' );
+
+		Monkey\Functions\expect( 'wp_create_nonce' )
+			->with( 'wpseo-ignore' )
+			->once()
+			->andReturn( 'this-is-a-random-nonce' );
+
+		Monkey\Functions\expect( 'esc_js' )
+			->with( 'this-is-a-random-nonce' )
+			->once()
+			->andReturn( 'this-is-a-random-nonce' );
+
+		$expected = '<p><strong>Huge SEO Issue: You\'re blocking access to robots.</strong> If you want search engines to show this site in their results, you must <a href="http://basic.wordpress.test/wp-admin/options-reading.php">go to your Reading Settings</a> and uncheck the box for Search Engine Visibility. <button type="button" id="robotsmessage-dismiss-button" class="button-link hide-if-no-js" data-nonce="this-is-a-random-nonce">I don\'t want this site to show in the search results.</button></p>';
+
+		$this->assertSame( $expected, $this->instance->present() );
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The search engines notice that is shown when indexability is disabled in the WordPress settings is not yet shown in the Problems section of the Yoast SEO dashboard.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds a "Search engines discouraged" notification in the Yoast SEO dashboard when indexability is turned off in WordPress settings.

## Relevant technical choices:

* Rewritten `wpseoSetIgnore` to not use a jQuery.post but instead use a fetch in order to be able to return the `Promise` and add an action after this `Promise` has been resolved.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install and activate Yoast SEO and the Yoast SEO Test Helper.
* Go to the administration dashboard.
* Go to `Settings` -> `Reading`.
* Enable `Discourage search engines from indexing this site`.

In order to reset the notification and notice during the following tests, follow these steps [1]:

* Go to the administration dashboard.
* Go to `Tools` -> `Yoast Test`.
* Click `Reset Options` under `Yoast SEO`.

Check if the normal notice still works:
* Go to `Dashboard` -> `Home` and check that the Huge SEO Issue notice is shown.
* Click on `I don't want this site to show in the search results` in the notice.
* Check that the page **does not** reload and the notice is gone.

Now reset the notification by following the steps at [1].

Check if the notification in the Yoast SEO dashboard works:
* Go to `Yoast SEO` -> `General` and check that the Huge SEO Issue notice is **not** shown (note that this is the old notice that should be gone).
* Check that the Huge SEO Issue is now displayed under `Problems`.
* Click on `I don't want this site to show in the search results` in the notification.
* Check that the page **does** reload and both the notice and the notification are gone.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes [PC-46](https://yoast.atlassian.net/browse/PC-46)