### PR TITLE
Pc 339 replacement fields suggestions not showing in metabox description field

### DIFF
--- a/packages/search-metadata-previews/src/snippet-editor/SnippetEditorFields.js
+++ b/packages/search-metadata-previews/src/snippet-editor/SnippetEditorFields.js
@@ -344,6 +344,7 @@ class SnippetEditorFields extends React.Component {
 					recommendedReplacementVariables={ recommendedReplacementVariables }
 					content={ description }
 					onChange={ this.onChangeDescription }
+					onSearchChange={ onReplacementVariableSearchChange }
 					fieldId={ descriptionInputId }
 				/>
 				<ProgressBar

--- a/src/routes/meta-search-route.php
+++ b/src/routes/meta-search-route.php
@@ -88,7 +88,7 @@ class Meta_Search_Route implements Route_Interface {
 				'value' => $values[0],
 			];
 
-			if ( \count( $matches ) >= 3 ) {
+			if ( \count( $matches ) >= 25 ) {
 				break;
 			}
 		}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Custom replacement variables suggestions not showing in the Yoast metabox description.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where custom replacement variables suggestions are not shown in the Yoast metabox description field.

## Relevant technical choices:

* The number of suggestions displayed has been raised to 25.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Add some custom replacement variables to a post:
```$post_id = YOUR_POST_ID;
for ( $i = 0; $i < 30; $i++ ) {
   add_post_meta( $post_id, "my_custom_" . $i, "my_custom_" . $i );
} 
```
This snippet of code creates 30 meta fields named `my_custom_0` - `my_custom_29`
(use the [Code Snippets](https://wordpress.org/plugins/code-snippets/) plugin to conveniently execute the code snippet once)
* Open that post for editing and verify:
  * Both in the metabox `SEO title` and `meta description` fields, when you write `%my_cu` for the first time you get 25 suggestions from `my_custom_0` to `my_custom_24`
  * If you then proceed and complete the field name by writing `%my_custom_2` you get also the remaining fields `my_custom_25` to `my_custom_29`
 * Please note that custom field replacement variables aren't supported in Elementor so there should be no changes in elementor, and the same goes for replacement variables used on taxonomy pages and the settings: all of these should work the same (see also [this PR](https://github.com/Yoast/wordpress-seo/pull/18687))
#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [X] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [X] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

* I set `Changes should be tested with the browser console open` because doing so, if you switch to the browser console's `Network` tab you can see the request firing each time you type a character in the `SEO title` and `meta description` fields

<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes [PC-339](https://yoast.atlassian.net/browse/PC-339)
