### PR TITLE
PC-231-keyphrase-density-highlighter-does-not-always-highlight-all-ocurrences-of-the-keyphrase

### DIFF
--- a/packages/yoastseo/spec/languageProcessing/helpers/sanitize/evaluateNBSPspec.js
+++ b/packages/yoastseo/spec/languageProcessing/helpers/sanitize/evaluateNBSPspec.js
@@ -1,0 +1,11 @@
+import evaluateNBSP from "../../../../src/languageProcessing/helpers/sanitize/evaluateNBSP";
+
+describe( "A test for the evaluateNBSP helper", () => {
+	it( "should return a string with all &nbsp; replaced with the actual character `\u00A0`", () => {
+		expect( evaluateNBSP( "Honeycomb metal rainboot planter are&nbsp;perfect for indoors or outdoors." ) ).toEqual(
+			"Honeycomb metal rainboot planter are\u00A0perfect for indoors or outdoors." );
+		// eslint-disable-next-line max-len
+		expect( evaluateNBSP( "&nbsp;Honeycomb&nbsp;metal&nbsp;rainboot&nbsp;planter&nbsp;are&nbsp;perfect&nbsp;for&nbsp;indoors&nbsp;or&nbsp;outdoors.&nbsp;" ) ).toEqual(
+			"\u00A0Honeycomb\u00A0metal\u00A0rainboot\u00A0planter\u00A0are\u00A0perfect\u00A0for\u00A0indoors\u00A0or\u00A0outdoors.\u00A0" );
+	} );
+} );

--- a/packages/yoastseo/src/languageProcessing/helpers/sanitize/evaluateNBSP.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/sanitize/evaluateNBSP.js
@@ -1,0 +1,9 @@
+
+/**
+ *
+ * @param {string} text replaces the &nbsp; string with the actual no-break space (nbsp) character.
+ * @returns {string} The original string but with all occurrences of nbsp replaced with the nbsp character.
+ */
+export default function( text ) {
+	return text.split( "&nbsp;" ).join( "\u00A0" ) // Or use this: text.replace( "&nbsp;", "\u00A0" );
+}

--- a/packages/yoastseo/src/values/Mark.js
+++ b/packages/yoastseo/src/values/Mark.js
@@ -1,4 +1,5 @@
 import { defaults } from "lodash-es";
+import evaluateNBSP from "../languageProcessing/helpers/sanitize/evaluateNBSP";
 
 /**
  * Represents a marked piece of text
@@ -44,16 +45,15 @@ Mark.prototype.applyWithReplace = function( text ) {
 	// Cute method to replace everything in a string without using regex.
 	console.log("TEST 1a", text)
 	console.log("TEST 1b", this._properties.original)
-	const original = this._properties.original.replace("&nbsp;", "\u00A0" )
+	const original = evaluateNBSP(this._properties.original)
 	console.log("TEST 1bb", original)
 	console.log("TEST 1c", this._properties.marked)
-	const marked = this._properties.marked.replace("&nbsp;", "\u00A0" )
+	const marked = evaluateNBSP(this._properties.marked)
 	console.log("TEST 1cb", marked)
 	console.log("TEST 1d", text.split( this._properties.original ).join( this._properties.marked ))
 	console.log("TEST 1db", text.split( original ).join( marked ))
-	const marked_text = text.split( original ).join( marked )
 	// return text.split( this._properties.original ).join( this._properties.marked );
-	return marked_text
+	return text.split( original ).join( marked )
 };
 
 /**

--- a/packages/yoastseo/src/values/Mark.js
+++ b/packages/yoastseo/src/values/Mark.js
@@ -11,6 +11,8 @@ import { defaults } from "lodash-es";
 function Mark( properties ) {
 	defaults( properties, { original: "", marked: "" } );
 	this._properties = properties;
+	console.log("TEST 2 original", this._properties.original)
+	console.log("TEST 2 marked", this._properties.marked)
 }
 
 
@@ -40,7 +42,18 @@ Mark.prototype.getMarked = function() {
  */
 Mark.prototype.applyWithReplace = function( text ) {
 	// Cute method to replace everything in a string without using regex.
-	return text.split( this._properties.original ).join( this._properties.marked );
+	console.log("TEST 1a", text)
+	console.log("TEST 1b", this._properties.original)
+	const original = this._properties.original.replace("&nbsp;", "\u00A0" )
+	console.log("TEST 1bb", original)
+	console.log("TEST 1c", this._properties.marked)
+	const marked = this._properties.marked.replace("&nbsp;", "\u00A0" )
+	console.log("TEST 1cb", marked)
+	console.log("TEST 1d", text.split( this._properties.original ).join( this._properties.marked ))
+	console.log("TEST 1db", text.split( original ).join( marked ))
+	const marked_text = text.split( original ).join( marked )
+	// return text.split( this._properties.original ).join( this._properties.marked );
+	return marked_text
 };
 
 /**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* In Shopify, when there is a non breaking space in a sentence, the keyword density marking did not work. This PR solves that.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where keyword density marking did not work when there is a no-break space in the sentence.
* [shopify] Fixes a bug where keyword density marking did not work when there is a no-break space in the sentence.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

*

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes #
