### PR TITLE
Frontend inspector: fix inconsistent color indicators

### DIFF
--- a/admin/class-meta-columns.php
+++ b/admin/class-meta-columns.php
@@ -6,6 +6,7 @@
  */
 
 use Yoast\WP\SEO\Context\Meta_Tags_Context;
+use Yoast\WP\SEO\Helpers\Score_Icon_Helper;
 use Yoast\WP\SEO\Integrations\Admin\Admin_Columns_Cache_Integration;
 use Yoast\WP\SEO\Surfaces\Values\Meta;
 
@@ -43,6 +44,13 @@ class WPSEO_Meta_Columns {
 	private $admin_columns_cache;
 
 	/**
+	 * Holds the Score_Icon_Helper.
+	 *
+	 * @var Score_Icon_Helper
+	 */
+	private $score_icon_helper;
+
+	/**
 	 * When page analysis is enabled, just initialize the hooks.
 	 */
 	public function __construct() {
@@ -53,6 +61,7 @@ class WPSEO_Meta_Columns {
 		$this->analysis_seo         = new WPSEO_Metabox_Analysis_SEO();
 		$this->analysis_readability = new WPSEO_Metabox_Analysis_Readability();
 		$this->admin_columns_cache  = YoastSEO()->classes->get( Admin_Columns_Cache_Integration::class );
+		$this->score_icon_helper    = YoastSEO()->helpers->score_icon;
 	}
 
 	/**
@@ -120,15 +129,18 @@ class WPSEO_Meta_Columns {
 			case 'wpseo-score':
 				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Correctly escaped in render_score_indicator() method.
 				echo $this->parse_column_score( $post_id );
+
 				return;
 
 			case 'wpseo-score-readability':
 				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Correctly escaped in render_score_indicator() method.
 				echo $this->parse_column_score_readability( $post_id );
+
 				return;
 
 			case 'wpseo-title':
 				echo esc_html( $this->get_meta( $post_id )->title );
+
 				return;
 
 			case 'wpseo-metadesc':
@@ -136,12 +148,14 @@ class WPSEO_Meta_Columns {
 
 				if ( $metadesc_val === '' ) {
 					echo '<span aria-hidden="true">&#8212;</span><span class="screen-reader-text">',
-						esc_html__( 'Meta description not set.', 'wordpress-seo' ),
-						'</span>';
+					esc_html__( 'Meta description not set.', 'wordpress-seo' ),
+					'</span>';
+
 					return;
 				}
 
 				echo esc_html( $metadesc_val );
+
 				return;
 
 			case 'wpseo-focuskw':
@@ -149,12 +163,14 @@ class WPSEO_Meta_Columns {
 
 				if ( $focuskw_val === '' ) {
 					echo '<span aria-hidden="true">&#8212;</span><span class="screen-reader-text">',
-						esc_html__( 'Focus keyphrase not set.', 'wordpress-seo' ),
-						'</span>';
+					esc_html__( 'Focus keyphrase not set.', 'wordpress-seo' ),
+					'</span>';
+
 					return;
 				}
 
 				echo esc_html( $focuskw_val );
+
 				return;
 		}
 	}
@@ -652,27 +668,9 @@ class WPSEO_Meta_Columns {
 	 * @return string The HTML for the SEO score indicator.
 	 */
 	private function parse_column_score( $post_id ) {
-		if ( ! $this->is_indexable( $post_id ) ) {
-			$rank  = new WPSEO_Rank( WPSEO_Rank::NO_INDEX );
-			$title = __( 'Post is set to noindex.', 'wordpress-seo' );
+		$meta = $this->get_meta( $post_id );
 
-			WPSEO_Meta::set_value( 'linkdex', 0, $post_id );
-
-			return $this->render_score_indicator( $rank, $title );
-		}
-
-		if ( WPSEO_Meta::get_value( 'focuskw', $post_id ) === '' ) {
-			$rank  = new WPSEO_Rank( WPSEO_Rank::BAD );
-			$title = __( 'Focus keyphrase not set.', 'wordpress-seo' );
-
-			return $this->render_score_indicator( $rank, $title );
-		}
-
-		$score = (int) WPSEO_Meta::get_value( 'linkdex', $post_id );
-		$rank  = WPSEO_Rank::from_numeric_score( $score );
-		$title = $rank->get_label();
-
-		return $this->render_score_indicator( $rank, $title );
+		return $this->score_icon_helper->for_seo( $meta->indexable, '', __( 'Post is set to noindex.', 'wordpress-seo' ) );
 	}
 
 	/**
@@ -683,10 +681,9 @@ class WPSEO_Meta_Columns {
 	 * @return string The HTML for the readability score indicator.
 	 */
 	private function parse_column_score_readability( $post_id ) {
-		$score = (int) WPSEO_Meta::get_value( 'content_score', $post_id );
-		$rank  = WPSEO_Rank::from_numeric_score( $score );
+		$meta = $this->get_meta( $post_id );
 
-		return $this->render_score_indicator( $rank );
+		return $this->score_icon_helper->for_readability( $meta->indexable->readability_score );
 	}
 
 	/**
@@ -730,22 +727,6 @@ class WPSEO_Meta_Columns {
 		}
 
 		return WPSEO_Utils::is_metabox_active( $post_type, 'post_type' );
-	}
-
-	/**
-	 * Renders the score indicator.
-	 *
-	 * @param WPSEO_Rank $rank  The rank this indicator should have.
-	 * @param string     $title Optional. The title for this rank, defaults to the title of the rank.
-	 *
-	 * @return string The HTML for a score indicator.
-	 */
-	private function render_score_indicator( $rank, $title = '' ) {
-		if ( empty( $title ) ) {
-			$title = $rank->get_label();
-		}
-
-		return '<div aria-hidden="true" title="' . esc_attr( $title ) . '" class="' . esc_attr( 'wpseo-score-icon ' . $rank->get_css_class() ) . '"></div><span class="screen-reader-text wpseo-score-text">' . esc_html( $title ) . '</span>';
 	}
 
 	/**

--- a/admin/taxonomy/class-taxonomy-columns.php
+++ b/admin/taxonomy/class-taxonomy-columns.php
@@ -5,6 +5,9 @@
  * @package WPSEO\Admin
  */
 
+use Yoast\WP\SEO\Helpers\Score_Icon_Helper;
+use Yoast\WP\SEO\Repositories\Indexable_Repository;
+
 /**
  * This class adds columns to the taxonomy table.
  */
@@ -32,6 +35,20 @@ class WPSEO_Taxonomy_Columns {
 	private $taxonomy;
 
 	/**
+	 * Holds the Indexable_Repository.
+	 *
+	 * @var Indexable_Repository
+	 */
+	protected $indexable_repository;
+
+	/**
+	 * Holds the Score_Icon_Helper.
+	 *
+	 * @var Score_Icon_Helper
+	 */
+	protected $score_icon_helper;
+
+	/**
 	 * WPSEO_Taxonomy_Columns constructor.
 	 */
 	public function __construct() {
@@ -45,6 +62,8 @@ class WPSEO_Taxonomy_Columns {
 
 		$this->analysis_seo         = new WPSEO_Metabox_Analysis_SEO();
 		$this->analysis_readability = new WPSEO_Metabox_Analysis_Readability();
+		$this->indexable_repository = YoastSEO()->classes->get( Indexable_Repository::class );
+		$this->score_icon_helper    = YoastSEO()->helpers->score_icon;
 	}
 
 	/**
@@ -128,22 +147,9 @@ class WPSEO_Taxonomy_Columns {
 	 * @return string
 	 */
 	private function get_score_value( $term_id ) {
-		$term = get_term( $term_id, $this->taxonomy );
+		$indexable = $this->indexable_repository->find_by_id_and_type( (int) $term_id, 'term' );
 
-		// When the term isn't indexable.
-		if ( ! $this->is_indexable( $term ) ) {
-			return $this->create_score_icon(
-				new WPSEO_Rank( WPSEO_Rank::NO_INDEX ),
-				__( 'Term is set to noindex.', 'wordpress-seo' )
-			);
-		}
-
-		// When there is a focus key word.
-		$focus_keyword = $this->get_focus_keyword( $term );
-		$score         = (int) WPSEO_Taxonomy_Meta::get_term_meta( $term_id, $this->taxonomy, 'linkdex' );
-		$rank          = WPSEO_Rank::from_numeric_score( $score );
-
-		return $this->create_score_icon( $rank, $rank->get_label() );
+		return $this->score_icon_helper->for_seo( $indexable, '', __( 'Term is set to noindex.', 'wordpress-seo' ) );
 	}
 
 	/**
@@ -155,25 +161,8 @@ class WPSEO_Taxonomy_Columns {
 	 */
 	private function get_score_readability_value( $term_id ) {
 		$score = (int) WPSEO_Taxonomy_Meta::get_term_meta( $term_id, $this->taxonomy, 'content_score' );
-		$rank  = WPSEO_Rank::from_numeric_score( $score );
 
-		return $this->create_score_icon( $rank );
-	}
-
-	/**
-	 * Creates an icon by the given values.
-	 *
-	 * @param WPSEO_Rank $rank  The ranking object.
-	 * @param string     $title Optional. The title to show. Defaults to the rank label.
-	 *
-	 * @return string The HTML for a score icon.
-	 */
-	private function create_score_icon( WPSEO_Rank $rank, $title = '' ) {
-		if ( empty( $title ) ) {
-			$title = $rank->get_label();
-		}
-
-		return '<div aria-hidden="true" title="' . esc_attr( $title ) . '" class="wpseo-score-icon ' . esc_attr( $rank->get_css_class() ) . '"></div><span class="screen-reader-text wpseo-score-text">' . $title . '</span>';
+		return $this->score_icon_helper->for_readability( $score );
 	}
 
 	/**
@@ -200,22 +189,6 @@ class WPSEO_Taxonomy_Columns {
 		}
 
 		return true;
-	}
-
-	/**
-	 * Returns the focus keyword if this is set, otherwise it will give the term name.
-	 *
-	 * @param stdClass|WP_Term $term The current term.
-	 *
-	 * @return string
-	 */
-	private function get_focus_keyword( $term ) {
-		$focus_keyword = WPSEO_Taxonomy_Meta::get_term_meta( 'focuskw', $term->term_id, $term->taxonomy );
-		if ( $focus_keyword !== false ) {
-			return $focus_keyword;
-		}
-
-		return $term->name;
 	}
 
 	/**

--- a/css/src/adminbar.css
+++ b/css/src/adminbar.css
@@ -1,5 +1,6 @@
 @import url(../src/score_icon.css);
-.adminbar-seo-score {
+
+#wp-admin-bar-wpseo-menu .wpseo-score-icon {
   margin: 10px 0 0 4px !important;
 }
 
@@ -56,7 +57,7 @@
 }
 
 @media screen and (max-width: 782px) {
-  .adminbar-seo-score {
+  #wp-admin-bar-wpseo-menu .wpseo-score-icon {
     margin: 16px 10px 0 2px !important;
   }
   #wpadminbar #wp-admin-bar-wpseo-menu {

--- a/inc/class-wpseo-admin-bar-menu.php
+++ b/inc/class-wpseo-admin-bar-menu.php
@@ -5,7 +5,6 @@
  * @package WPSEO
  */
 
-use Yoast\WP\SEO\Conditionals\Front_End_Inspector_Conditional;
 use Yoast\WP\SEO\Helpers\Score_Icon_Helper;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
 
@@ -282,19 +281,19 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 
 		$submenu_items = [
 			[
-				'id'     => 'wpseo-kwresearchtraining',
-				'title'  => __( 'Keyword research training', 'wordpress-seo' ),
-				'href'   => WPSEO_Shortlinker::get( 'https://yoa.st/wp-admin-bar' ),
+				'id'    => 'wpseo-kwresearchtraining',
+				'title' => __( 'Keyword research training', 'wordpress-seo' ),
+				'href'  => WPSEO_Shortlinker::get( 'https://yoa.st/wp-admin-bar' ),
 			],
 			[
-				'id'     => 'wpseo-adwordsexternal',
-				'title'  => __( 'Google Ads', 'wordpress-seo' ),
-				'href'   => $adwords_url,
+				'id'    => 'wpseo-adwordsexternal',
+				'title' => __( 'Google Ads', 'wordpress-seo' ),
+				'href'  => $adwords_url,
 			],
 			[
-				'id'     => 'wpseo-googleinsights',
-				'title'  => __( 'Google Trends', 'wordpress-seo' ),
-				'href'   => $trends_url,
+				'id'    => 'wpseo-googleinsights',
+				'title' => __( 'Google Trends', 'wordpress-seo' ),
+				'href'  => $trends_url,
 			],
 		];
 
@@ -371,55 +370,55 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 		$encoded_url   = rawurlencode( $url );
 		$submenu_items = [
 			[
-				'id'     => 'wpseo-inlinks',
-				'title'  => __( 'Check links to this URL', 'wordpress-seo' ),
-				'href'   => 'https://search.google.com/search-console/links/drilldown?resource_id=' . rawurlencode( get_option( 'siteurl' ) ) . '&type=EXTERNAL&target=' . $encoded_url . '&domain=',
+				'id'    => 'wpseo-inlinks',
+				'title' => __( 'Check links to this URL', 'wordpress-seo' ),
+				'href'  => 'https://search.google.com/search-console/links/drilldown?resource_id=' . rawurlencode( get_option( 'siteurl' ) ) . '&type=EXTERNAL&target=' . $encoded_url . '&domain=',
 			],
 			[
-				'id'     => 'wpseo-kwdensity',
-				'title'  => __( 'Check Keyphrase Density', 'wordpress-seo' ),
+				'id'    => 'wpseo-kwdensity',
+				'title' => __( 'Check Keyphrase Density', 'wordpress-seo' ),
 				// HTTPS not available.
-				'href'   => 'http://www.zippy.co.uk/keyworddensity/index.php?url=' . $encoded_url . '&keyword=' . rawurlencode( $focus_keyword ),
+				'href'  => 'http://www.zippy.co.uk/keyworddensity/index.php?url=' . $encoded_url . '&keyword=' . rawurlencode( $focus_keyword ),
 			],
 			[
-				'id'     => 'wpseo-cache',
-				'title'  => __( 'Check Google Cache', 'wordpress-seo' ),
-				'href'   => '//webcache.googleusercontent.com/search?strip=1&q=cache:' . $encoded_url,
+				'id'    => 'wpseo-cache',
+				'title' => __( 'Check Google Cache', 'wordpress-seo' ),
+				'href'  => '//webcache.googleusercontent.com/search?strip=1&q=cache:' . $encoded_url,
 			],
 			[
-				'id'     => 'wpseo-structureddata',
-				'title'  => __( 'Google Rich Results Test', 'wordpress-seo' ),
-				'href'   => 'https://search.google.com/test/rich-results?url=' . $encoded_url,
+				'id'    => 'wpseo-structureddata',
+				'title' => __( 'Google Rich Results Test', 'wordpress-seo' ),
+				'href'  => 'https://search.google.com/test/rich-results?url=' . $encoded_url,
 			],
 			[
-				'id'     => 'wpseo-facebookdebug',
-				'title'  => __( 'Facebook Debugger', 'wordpress-seo' ),
-				'href'   => '//developers.facebook.com/tools/debug/?q=' . $encoded_url,
+				'id'    => 'wpseo-facebookdebug',
+				'title' => __( 'Facebook Debugger', 'wordpress-seo' ),
+				'href'  => '//developers.facebook.com/tools/debug/?q=' . $encoded_url,
 			],
 			[
-				'id'     => 'wpseo-pinterestvalidator',
-				'title'  => __( 'Pinterest Rich Pins Validator', 'wordpress-seo' ),
-				'href'   => 'https://developers.pinterest.com/tools/url-debugger/?link=' . $encoded_url,
+				'id'    => 'wpseo-pinterestvalidator',
+				'title' => __( 'Pinterest Rich Pins Validator', 'wordpress-seo' ),
+				'href'  => 'https://developers.pinterest.com/tools/url-debugger/?link=' . $encoded_url,
 			],
 			[
-				'id'     => 'wpseo-htmlvalidation',
-				'title'  => __( 'HTML Validator', 'wordpress-seo' ),
-				'href'   => '//validator.w3.org/check?uri=' . $encoded_url,
+				'id'    => 'wpseo-htmlvalidation',
+				'title' => __( 'HTML Validator', 'wordpress-seo' ),
+				'href'  => '//validator.w3.org/check?uri=' . $encoded_url,
 			],
 			[
-				'id'     => 'wpseo-cssvalidation',
-				'title'  => __( 'CSS Validator', 'wordpress-seo' ),
-				'href'   => '//jigsaw.w3.org/css-validator/validator?uri=' . $encoded_url,
+				'id'    => 'wpseo-cssvalidation',
+				'title' => __( 'CSS Validator', 'wordpress-seo' ),
+				'href'  => '//jigsaw.w3.org/css-validator/validator?uri=' . $encoded_url,
 			],
 			[
-				'id'     => 'wpseo-pagespeed',
-				'title'  => __( 'Google Page Speed Test', 'wordpress-seo' ),
-				'href'   => '//developers.google.com/speed/pagespeed/insights/?url=' . $encoded_url,
+				'id'    => 'wpseo-pagespeed',
+				'title' => __( 'Google Page Speed Test', 'wordpress-seo' ),
+				'href'  => '//developers.google.com/speed/pagespeed/insights/?url=' . $encoded_url,
 			],
 			[
-				'id'     => 'wpseo-google-mobile-friendly',
-				'title'  => __( 'Mobile-Friendly Test', 'wordpress-seo' ),
-				'href'   => 'https://www.google.com/webmasters/tools/mobile-friendly/?url=' . $encoded_url,
+				'id'    => 'wpseo-google-mobile-friendly',
+				'title' => __( 'Mobile-Friendly Test', 'wordpress-seo' ),
+				'href'  => 'https://www.google.com/webmasters/tools/mobile-friendly/?url=' . $encoded_url,
 			],
 		];
 

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -117,26 +117,6 @@ class WPSEO_Utils {
 	}
 
 	/**
-	 * Translates a decimal analysis score into a textual one.
-	 *
-	 * @since 1.8.0
-	 *
-	 * @param int  $val       The decimal score to translate.
-	 * @param bool $css_value Whether to return the i18n translated score or the CSS class value.
-	 *
-	 * @return string
-	 */
-	public static function translate_score( $val, $css_value = true ) {
-		$seo_rank = WPSEO_Rank::from_numeric_score( $val );
-
-		if ( $css_value ) {
-			return $seo_rank->get_css_class();
-		}
-
-		return $seo_rank->get_label();
-	}
-
-	/**
 	 * Emulate the WP native sanitize_text_field function in a %%variable%% safe way.
 	 *
 	 * Sanitize a string from user input or from the db.
@@ -1417,5 +1397,29 @@ SVG;
 		}
 
 		return is_super_admin();
+	}
+
+	/**
+	 * Translates a decimal analysis score into a textual one.
+	 *
+	 * @since 1.8.0
+	 * @deprecated 19.5
+	 * @codeCoverageIgnore
+	 *
+	 * @param int  $val       The decimal score to translate.
+	 * @param bool $css_value Whether to return the i18n translated score or the CSS class value.
+	 *
+	 * @return string
+	 */
+	public static function translate_score( $val, $css_value = true ) {
+		_deprecated_function( __METHOD__, 'WPSEO 19.5', 'YoastSEO()->helpers->score_icon' );
+
+		$seo_rank = WPSEO_Rank::from_numeric_score( $val );
+
+		if ( $css_value ) {
+			return $seo_rank->get_css_class();
+		}
+
+		return $seo_rank->get_label();
 	}
 }

--- a/packages/js/src/components/contentAnalysis/mapResults.js
+++ b/packages/js/src/components/contentAnalysis/mapResults.js
@@ -1,5 +1,5 @@
-import { interpreters } from "yoastseo";
 import { colors } from "@yoast/style-guide";
+import { interpreters } from "yoastseo";
 
 /**
  * Mapped result definition.
@@ -93,28 +93,23 @@ function processResult( mappedResult, mappedResults ) {
  *
  * @returns {Object} The icon and color for the score.
  */
-export function getIconForScore( score ) {
-	let icon = { icon: "seo-score-none", color: colors.$color_red };
-
+export function getIconForScore( score ) { // eslint-disable-line complexity
 	switch ( score ) {
 		case "loading":
-			icon = { icon: "loading-spinner", color: colors.$color_green_medium_light };
-			break;
-		case "not-set":
-			icon = { icon: "seo-score-none", color: colors.$color_grey };
-			break;
+			return { icon: "loading-spinner", color: colors.$color_green_medium_light };
+		case "na":
+			return { icon: "seo-score-none", color: colors.$color_score_icon };
+		case "noindex":
+			return { icon: "seo-score-none", color: colors.$color_noindex };
 		case "good":
-			icon = { icon: "seo-score-good", color: colors.$color_green_medium };
-			break;
+			return { icon: "seo-score-good", color: colors.$color_green_medium };
 		case "ok":
-			icon = { icon: "seo-score-ok", color: colors.$color_ok };
-			break;
+			return { icon: "seo-score-ok", color: colors.$color_ok };
 		case "bad":
-			icon = { icon: "seo-score-bad", color: colors.$color_red };
-			break;
+			return { icon: "seo-score-bad", color: colors.$color_red };
+		default:
+			return { icon: "seo-score-none", color: colors.$color_red };
 	}
-
-	return icon;
 }
 
 /**

--- a/packages/js/src/ui/adminBar.js
+++ b/packages/js/src/ui/adminBar.js
@@ -7,6 +7,7 @@
  */
 export function update( indicator ) {
 	jQuery( "#wp-admin-bar-wpseo-menu .wpseo-score-icon" )
+		.attr( "title", indicator.screenReaderText )
 		.attr( "class", "wpseo-score-icon " + indicator.className )
 		.find( ".wpseo-score-text" ).text( indicator.screenReaderText );
 }

--- a/packages/js/src/ui/adminBar.js
+++ b/packages/js/src/ui/adminBar.js
@@ -6,7 +6,7 @@
  * @returns {void}
  */
 export function update( indicator ) {
-	jQuery( ".adminbar-seo-score" )
-		.attr( "class", "wpseo-score-icon adminbar-seo-score " + indicator.className )
-		.find( ".adminbar-seo-score-text" ).text( indicator.screenReaderText );
+	jQuery( "#wp-admin-bar-wpseo-menu .wpseo-score-icon" )
+		.attr( "class", "wpseo-score-icon " + indicator.className )
+		.find( ".wpseo-score-text" ).text( indicator.screenReaderText );
 }

--- a/src/helpers/robots-helper.php
+++ b/src/helpers/robots-helper.php
@@ -44,25 +44,18 @@ class Robots_Helper {
 	 *
 	 * @return bool Whether the Indexable is indexable.
 	 */
-	public function is_indexable( $indexable ) {
-		$is_indexable = $indexable->is_robots_noindex === false;
-
+	public function is_indexable( Indexable $indexable ) {
 		if ( $indexable->is_robots_noindex === null ) {
 			// No individual value set, check the global setting.
 			switch ( $indexable->object_type ) {
 				case 'post':
-					$is_indexable = $this->post_type_helper->is_indexable( $indexable->object_sub_type );
-					break;
+					return $this->post_type_helper->is_indexable( $indexable->object_sub_type );
 				case 'term':
-					$is_indexable = $this->taxonomy_helper->is_indexable( $indexable->object_sub_type );
-					break;
-				default:
-					$is_indexable = true;
-					break;
+					return $this->taxonomy_helper->is_indexable( $indexable->object_sub_type );
 			}
 		}
 
-		return $is_indexable;
+		return $indexable->is_robots_noindex === false;
 	}
 
 	/**

--- a/src/helpers/robots-helper.php
+++ b/src/helpers/robots-helper.php
@@ -2,10 +2,68 @@
 
 namespace Yoast\WP\SEO\Helpers;
 
+use Yoast\WP\SEO\Models\Indexable;
+
 /**
  * A helper object for the robots meta tag.
  */
 class Robots_Helper {
+
+	/**
+	 * Holds the Post_Type_Helper.
+	 *
+	 * @var Post_Type_Helper
+	 */
+	protected $post_type_helper;
+
+	/**
+	 * Holds the Taxonomy_Helper.
+	 *
+	 * @var Taxonomy_Helper
+	 */
+	protected $taxonomy_helper;
+
+	/**
+	 * Constructs a Score_Helper.
+	 *
+	 * @param Post_Type_Helper $post_type_helper The Post_Type_Helper.
+	 * @param Taxonomy_Helper  $taxonomy_helper  The Taxonomy_Helper.
+	 */
+	public function __construct(
+		Post_Type_Helper $post_type_helper,
+		Taxonomy_Helper $taxonomy_helper
+	) {
+		$this->post_type_helper = $post_type_helper;
+		$this->taxonomy_helper  = $taxonomy_helper;
+	}
+
+	/**
+	 * Retrieves whether the Indexable is indexable.
+	 *
+	 * @param Indexable $indexable The Indexable.
+	 *
+	 * @return bool Whether the Indexable is indexable.
+	 */
+	public function is_indexable( $indexable ) {
+		$is_indexable = $indexable->is_robots_noindex === false;
+
+		if ( $indexable->is_robots_noindex === null ) {
+			// No individual value set, check the global setting.
+			switch ( $indexable->object_type ) {
+				case 'post':
+					$is_indexable = $this->post_type_helper->is_indexable( $indexable->object_sub_type );
+					break;
+				case 'term':
+					$is_indexable = $this->taxonomy_helper->is_indexable( $indexable->object_sub_type );
+					break;
+				default:
+					$is_indexable = true;
+					break;
+			}
+		}
+
+		return $is_indexable;
+	}
 
 	/**
 	 * Sets the robots index to noindex.

--- a/src/helpers/score-icon-helper.php
+++ b/src/helpers/score-icon-helper.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Yoast\WP\SEO\Helpers;
+
+use WPSEO_Rank;
+use Yoast\WP\SEO\Models\Indexable;
+use Yoast\WP\SEO\Presenters\Score_Icon_Presenter;
+
+/**
+ * A helper object for score icons.
+ */
+class Score_Icon_Helper {
+
+	/**
+	 * Holds the Robots_Helper.
+	 *
+	 * @var Robots_Helper
+	 */
+	protected $robots_helper;
+
+	/**
+	 * Constructs a Score_Helper.
+	 *
+	 * @param Robots_Helper $robots_helper The Robots_Helper.
+	 */
+	public function __construct( Robots_Helper $robots_helper ) {
+		$this->robots_helper = $robots_helper;
+	}
+
+	/**
+	 * Creates a Score_Icon_Presenter for the readability analysis.
+	 *
+	 * @param int    $score       The readability analysis score.
+	 * @param string $extra_class Optional. Any extra class.
+	 *
+	 * @return Score_Icon_Presenter The Score_Icon_Presenter.
+	 */
+	public function for_readability( $score, $extra_class = '' ) {
+		$rank  = WPSEO_Rank::from_numeric_score( (int) $score );
+		$class = $rank->get_css_class();
+		if ( $extra_class ) {
+			$class .= " $extra_class";
+		}
+
+		return new Score_Icon_Presenter( $rank->get_label(), $class );
+	}
+
+	/**
+	 * Creates a Score_Icon_Presenter for the SEO analysis from an indexable.
+	 *
+	 * @param Indexable|false $indexable      The Indexable.
+	 * @param string          $extra_class    Optional. Any extra class.
+	 * @param string          $no_index_title Optional. Override the title when not indexable.
+	 *
+	 * @return Score_Icon_Presenter The Score_Icon_Presenter.
+	 */
+	public function for_seo( $indexable, $extra_class = '', $no_index_title = '' ) {
+		$is_indexable = $indexable && $this->robots_helper->is_indexable( $indexable );
+
+		if ( ! $is_indexable ) {
+			$rank  = new WPSEO_Rank( WPSEO_Rank::NO_INDEX );
+			$title = empty( $no_index_title ) ? $rank->get_label() : $no_index_title;
+		}
+		elseif ( empty( $indexable && $indexable->primary_focus_keyword ) ) {
+			$rank  = new WPSEO_Rank( WPSEO_Rank::BAD );
+			$title = __( 'Focus keyphrase not set', 'wordpress-seo' );
+		}
+		else {
+			$rank  = WPSEO_Rank::from_numeric_score( ( $indexable ) ? $indexable->primary_focus_keyword_score : 0 );
+			$title = $rank->get_label();
+		}
+
+		$class = $rank->get_css_class();
+		if ( $extra_class ) {
+			$class .= " $extra_class";
+		}
+
+		return new Score_Icon_Presenter( $title, $class );
+	}
+}

--- a/src/presenters/score-icon-presenter.php
+++ b/src/presenters/score-icon-presenter.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Yoast\WP\SEO\Presenters;
+
+/**
+ * Presenter class for a score icon.
+ */
+class Score_Icon_Presenter extends Abstract_Presenter {
+
+	/**
+	 * Holds the title.
+	 *
+	 * @var string
+	 */
+	protected $title;
+
+	/**
+	 * Holds the class.
+	 *
+	 * @var string
+	 */
+	protected $class;
+
+	/**
+	 * Constructs a Score_Icon_Presenter.
+	 *
+	 * @param string $title The title and screen reader text.
+	 * @param string $class The class.
+	 */
+	public function __construct( $title, $class ) {
+		$this->title = $title;
+		$this->class = $class;
+	}
+
+	/**
+	 * Presents the score icon.
+	 *
+	 * @return string The score icon.
+	 */
+	public function present() {
+		return \sprintf(
+			'<div aria-hidden="true" title="%1$s" class="wpseo-score-icon %3$s"><span class="wpseo-score-text screen-reader-text">%2$s</span></div>',
+			\esc_attr( $this->title ),
+			\esc_html( $this->title ),
+			\esc_attr( $this->class )
+		);
+	}
+}

--- a/tests/integration/test-class-wpseo-utils.php
+++ b/tests/integration/test-class-wpseo-utils.php
@@ -49,20 +49,6 @@ class WPSEO_Utils_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	 * Tests translate_score function.
-	 *
-	 * @dataProvider translate_score_provider
-	 * @covers       WPSEO_Utils::translate_score
-	 *
-	 * @param int    $score     The decimal score to translate.
-	 * @param bool   $css_value Whether to return the i18n translated score or the CSS class value.
-	 * @param string $expected  Expected function result.
-	 */
-	public function test_translate_score( $score, $css_value, $expected ) {
-		$this->assertEquals( $expected, WPSEO_Utils::translate_score( $score, $css_value ) );
-	}
-
-	/**
 	 * Provides test data for test_translate_score().
 	 *
 	 * @return array

--- a/tests/unit/helpers/robots-helper-test.php
+++ b/tests/unit/helpers/robots-helper-test.php
@@ -3,7 +3,10 @@
 namespace Yoast\WP\SEO\Tests\Unit\Helpers;
 
 use Brain\Monkey;
+use Mockery;
+use Yoast\WP\SEO\Helpers\Post_Type_Helper;
 use Yoast\WP\SEO\Helpers\Robots_Helper;
+use Yoast\WP\SEO\Helpers\Taxonomy_Helper;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
@@ -23,12 +26,29 @@ class Robots_Helper_Test extends TestCase {
 	private $instance;
 
 	/**
+	 * Represents the Post_Type_Helper.
+	 *
+	 * @var Mockery\MockInterface|Post_Type_Helper
+	 */
+	protected $post_type_helper;
+
+	/**
+	 * Represents the Taxonomy_Helper.
+	 *
+	 * @var Mockery\MockInterface|Taxonomy_Helper
+	 */
+	protected $taxonomy_helper;
+
+	/**
 	 * Sets up the test class.
 	 */
 	protected function set_up() {
 		parent::set_up();
 
-		$this->instance = new Robots_Helper();
+		$this->post_type_helper = Mockery::mock( Post_Type_Helper::class );
+		$this->taxonomy_helper  = Mockery::mock( Taxonomy_Helper::class );
+
+		$this->instance = new Robots_Helper( $this->post_type_helper, $this->taxonomy_helper );
 	}
 
 	/**

--- a/tests/unit/helpers/score-icon-helper-test.php
+++ b/tests/unit/helpers/score-icon-helper-test.php
@@ -1,0 +1,216 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Helpers;
+
+use Brain\Monkey;
+use Mockery;
+use Yoast\WP\SEO\Helpers\Robots_Helper;
+use Yoast\WP\SEO\Helpers\Score_Icon_Helper;
+use Yoast\WP\SEO\Presenters\Score_Icon_Presenter;
+use Yoast\WP\SEO\Tests\Unit\Doubles\Models\Indexable_Mock;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Class Score_Icon_Helper_Test
+ *
+ * @group helpers
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Helpers\Score_Icon_Helper
+ */
+class Score_Icon_Helper_Test extends TestCase {
+
+	/**
+	 * Represents the Score_Icon_Helper.
+	 *
+	 * @var Score_Icon_Helper
+	 */
+	private $instance;
+
+	/**
+	 * Represents the Robots_Helper.
+	 *
+	 * @var Mockery\MockInterface|Robots_Helper
+	 */
+	protected $robots_helper;
+
+	/**
+	 * Sets up the test class.
+	 */
+	protected function set_up() {
+		parent::set_up();
+		$this->stubEscapeFunctions();
+		$this->stubTranslationFunctions();
+
+		$this->robots_helper = Mockery::mock( Robots_Helper::class );
+
+		$this->instance = new Score_Icon_Helper( $this->robots_helper );
+	}
+
+	/**
+	 * Tests if the needed attributes are set correctly.
+	 *
+	 * @covers ::__construct
+	 */
+	public function test_constructor() {
+		$this->assertInstanceOf(
+			Robots_Helper::class,
+			$this->getPropertyValue( $this->instance, 'robots_helper' )
+		);
+	}
+
+	/**
+	 * Tests that the readability icon is as expected.
+	 *
+	 * @dataProvider readability_provider
+	 *
+	 * @covers ::for_readability
+	 *
+	 * @param int    $score       The score.
+	 * @param string $extra_class The extra class.
+	 * @param string $expected    The expected present output.
+	 */
+	public function test_for_readability( $score, $extra_class, $expected ) {
+		$actual = $this->instance->for_readability( $score, $extra_class );
+
+		$this->assertInstanceOf( Score_Icon_Presenter::class, $actual );
+		$this->assertSame( $expected, $actual->present() );
+	}
+
+	/**
+	 * Provides the readability test data.
+	 *
+	 * @return array The readability data.
+	 */
+	public function readability_provider() {
+		return [
+			'not available' => [
+				'score'       => 0,
+				'extra_class' => '',
+				'expected'    => '<div aria-hidden="true" title="Not available" class="wpseo-score-icon na"><span class="wpseo-score-text screen-reader-text">Not available</span></div>',
+			],
+			'bad'           => [
+				'score'       => 1,
+				'extra_class' => '',
+				'expected'    => '<div aria-hidden="true" title="Needs improvement" class="wpseo-score-icon bad"><span class="wpseo-score-text screen-reader-text">Needs improvement</span></div>',
+			],
+			'ok'            => [
+				'score'       => 41,
+				'extra_class' => '',
+				'expected'    => '<div aria-hidden="true" title="OK" class="wpseo-score-icon ok"><span class="wpseo-score-text screen-reader-text">OK</span></div>',
+			],
+			'good'          => [
+				'score'       => 71,
+				'extra_class' => '',
+				'expected'    => '<div aria-hidden="true" title="Good" class="wpseo-score-icon good"><span class="wpseo-score-text screen-reader-text">Good</span></div>',
+			],
+			'with_class'    => [
+				'score'       => 50,
+				'extra_class' => 'FOO',
+				'expected'    => '<div aria-hidden="true" title="OK" class="wpseo-score-icon ok FOO"><span class="wpseo-score-text screen-reader-text">OK</span></div>',
+			],
+		];
+	}
+
+	/**
+	 * Tests that the SEO icon is as expected.
+	 *
+	 * @dataProvider seo_provider
+	 *
+	 * @covers ::for_seo
+	 *
+	 * @param string $extra_class    The extra class.
+	 * @param string $no_index_title The title when noindex.
+	 * @param string $expected       The expected present output.
+	 */
+	public function test_for_seo( $is_indexable, $keyphrase, $score, $extra_class, $no_index_title, $expected ) {
+		$indexable = $this->create_indexable_and_set_mocks_for_seo( $is_indexable, $keyphrase, $score );
+		$actual    = $this->instance->for_seo( $indexable, $extra_class, $no_index_title );
+
+		$this->assertInstanceOf( Score_Icon_Presenter::class, $actual );
+		$this->assertSame( $expected, $actual->present() );
+	}
+
+	/**
+	 * Provides the SEO test data.
+	 *
+	 * @return array The SEO data.
+	 */
+	public function seo_provider() {
+		return [
+			'not available'      => [
+				'is_indexable'   => true,
+				'keyphrase'      => 'keyphrase',
+				'score'          => 0,
+				'extra_class'    => '',
+				'no_index_title' => '',
+				'expected'       => '<div aria-hidden="true" title="Not available" class="wpseo-score-icon na"><span class="wpseo-score-text screen-reader-text">Not available</span></div>',
+			],
+			'bad'                => [
+				'is_indexable'   => true,
+				'keyphrase'      => 'keyphrase',
+				'score'          => 1,
+				'extra_class'    => '',
+				'no_index_title' => '',
+				'expected'       => '<div aria-hidden="true" title="Needs improvement" class="wpseo-score-icon bad"><span class="wpseo-score-text screen-reader-text">Needs improvement</span></div>',
+			],
+			'ok'                 => [
+				'is_indexable'   => true,
+				'keyphrase'      => 'keyphrase',
+				'score'          => 41,
+				'extra_class'    => '',
+				'no_index_title' => '',
+				'expected'       => '<div aria-hidden="true" title="OK" class="wpseo-score-icon ok"><span class="wpseo-score-text screen-reader-text">OK</span></div>',
+			],
+			'good'               => [
+				'is_indexable'   => true,
+				'keyphrase'      => 'keyphrase',
+				'score'          => 71,
+				'extra_class'    => '',
+				'no_index_title' => '',
+				'expected'       => '<div aria-hidden="true" title="Good" class="wpseo-score-icon good"><span class="wpseo-score-text screen-reader-text">Good</span></div>',
+			],
+			'noindex'            => [
+				'is_indexable'   => false,
+				'keyphrase'      => 'keyphrase',
+				'score'          => 50,
+				'extra_class'    => '',
+				'no_index_title' => '',
+				'expected'       => '<div aria-hidden="true" title="No index" class="wpseo-score-icon noindex"><span class="wpseo-score-text screen-reader-text">No index</span></div>',
+			],
+			'noindex_with_title' => [
+				'is_indexable'   => false,
+				'keyphrase'      => 'keyphrase',
+				'score'          => 50,
+				'extra_class'    => '',
+				'no_index_title' => 'FOO',
+				'expected'       => '<div aria-hidden="true" title="FOO" class="wpseo-score-icon noindex"><span class="wpseo-score-text screen-reader-text">FOO</span></div>',
+			],
+			'without_keyphrase'  => [
+				'is_indexable'   => true,
+				'keyphrase'      => '',
+				'score'          => 50,
+				'extra_class'    => '',
+				'no_index_title' => '',
+				'expected'       => '<div aria-hidden="true" title="Focus keyphrase not set" class="wpseo-score-icon bad"><span class="wpseo-score-text screen-reader-text">Focus keyphrase not set</span></div>',
+			],
+			'with_class'         => [
+				'is_indexable'   => true,
+				'keyphrase'      => 'keyphrase',
+				'score'          => 50,
+				'extra_class'    => 'FOO',
+				'no_index_title' => '',
+				'expected'       => '<div aria-hidden="true" title="OK" class="wpseo-score-icon ok FOO"><span class="wpseo-score-text screen-reader-text">OK</span></div>',
+			],
+		];
+	}
+
+	protected function create_indexable_and_set_mocks_for_seo( $is_indexable, $keyphrase, $score ) {
+		$this->robots_helper->expects( 'is_indexable' )->andReturn( $is_indexable );
+
+		$indexable                              = Mockery::mock( Indexable_Mock::class );
+		$indexable->primary_focus_keyword       = $keyphrase;
+		$indexable->primary_focus_keyword_score = $score;
+
+		return $indexable;
+	}
+}

--- a/tests/unit/presenters/score-icon-presenter-test.php
+++ b/tests/unit/presenters/score-icon-presenter-test.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Presenters;
+
+use Brain\Monkey;
+use Mockery;
+use Yoast\WP\SEO\Presenters\Score_Icon_Presenter;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Class Score_Icon_Presenter_Test
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Presenters\Score_Icon_Presenter
+ *
+ * @group presenters
+ */
+class Score_Icon_Presenter_Test extends TestCase {
+
+	/**
+	 * Sets up the test class.
+	 */
+	protected function set_up() {
+		parent::set_up();
+		$this->stubEscapeFunctions();
+	}
+
+	/**
+	 * Tests if the needed attributes are set correctly.
+	 *
+	 * @covers ::__construct
+	 */
+	public function test_constructor() {
+		$instance = new Score_Icon_Presenter( 'foo', 'bar' );
+
+		$this->assertSame( 'foo', $this->getPropertyValue( $instance, 'title' ) );
+		$this->assertSame( 'bar', $this->getPropertyValue( $instance, 'class' ) );
+	}
+
+	/**
+	 * Tests whether the presenter returns the correct title.
+	 *
+	 * @dataProvider present_provider
+	 *
+	 * @covers ::present
+	 *
+	 * @param string $title    The title and screen reader text.
+	 * @param string $class    The class.
+	 * @param string $expected The expected present output.
+	 */
+	public function test_present( $title, $class, $expected ) {
+		$instance = new Score_Icon_Presenter( $title, $class );
+
+		$this->assertEquals( $expected, $instance->present() );
+	}
+
+	/**
+	 * Provides the test data.
+	 *
+	 * @return array The test data.
+	 */
+	public function present_provider() {
+		return [
+			'title and class' => [
+				'title'    => 'title',
+				'class'    => 'class',
+				'expected' => '<div aria-hidden="true" title="title" class="wpseo-score-icon class"><span class="wpseo-score-text screen-reader-text">title</span></div>',
+			],
+			'empty title' => [
+				'title'    => '',
+				'class'    => 'class',
+				'expected' => '<div aria-hidden="true" title="" class="wpseo-score-icon class"><span class="wpseo-score-text screen-reader-text"></span></div>',
+			],
+			'empty class' => [
+				'title'    => 'title',
+				'class'    => '',
+				'expected' => '<div aria-hidden="true" title="title" class="wpseo-score-icon "><span class="wpseo-score-text screen-reader-text">title</span></div>',
+			],
+		];
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Fixes an unreleased bug where the Frontend Inspector score indicators were not matching up with the admin bar' and the overview' score indicators. This highlighted some more inconsistencies which are now (mostly) addressed. Key thing to note is that within the editor, the indicators all show the outcome of the analysis that just ran. Meaning mostly: no `noindex` indication.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the score indicators of the overview pages and admin bar where inconsistent. The taxonomy overview and admin bar score indicators now uses red to indicate `Focus keyphrase not set`. The admin bar score indicator now shows blue when set to `noindex`.
* Fixes a bug where the score indicator in the classic editor would not update the hovering text when the score changed.

## Relevant technical choices:

* Created a presenter and helper for the score icon logic. Each place (in PHP) now uses the same logic.
* Created a score icon helper instead of adding that to the presenter (I thought of adding the now score icon methods as static "constructors" in the presenter, but decided against that).
* Added the `is_indexable` to the robots helper, seems most applicable there.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

Test with https://github.com/Yoast/wordpress-seo-premium/pull/3630 for ease of instructions with the Frontend Inspector

* Ensure you have multiple posts (or whatever content type)
  * One with a focus keyphrase
  * One without a focus keyphrase
  * One with noindex specifically set
  * One with index specifically set (so we can flip the type setting later)
  * One for each score: red, orange, green
* Go to the overview page
* Verify the score indicators are correct: color and title (when hovering)
  * Red indicator with `Focus keyphrase not set` title
    * This is for SEO scores only
    * This is a change for taxonomies, the admin bar and the frontend inspector
    * _Note_ the missing dot, as per solution of https://yoast.atlassian.net/browse/QA-3594 
  * Blue indicator with `Post is set to noindex.` title
    * This is for SEO scores only
    * This is a change for the admin bar and the frontend inspector
    * _Note_ for terms this is `Term is set to noindex.` but for pages etc this still says `Post ...`. If this needs to be changed, I would vote for the original `No index` and not override it specifically as is done now for those. I kept it like this because I did not want to increase the scope further.
  * The normal scores:
    * Red indicator with `Needs improvement`
    * Orange indicator with `OK`
      * or when SEO: `OK SEO score` in the Frontend inspector (Left this in due to it being JS and the same as in the editor, preventing scope increase again)
    * Green indicator with `Good`
      * or when SEO: `Good SEO score` in the Frontend inspector (same reason as above)
* Visit the frontend and open the frontend inspector
* Verify the score indicator is the same in the frontend inspector
* Verify the score indicator in the admin bar is the same as:
  * the SEO score when the SEO analysis feature is enabled
  * the Readability score when the SEO analysis feature is disabled
* Make sure to re-enable the SEO analysis feature.
* Go to settings and change the `noindex` for posts (or whatever content type) to not index
* Go back to the overview
* Verify that most SEO indicators have changed to blue, indicating `noindex`. Except for the specifically `yes` ones
* Verify the same for one or two in the frontend
* Repeat these steps for a taxonomy (and possibly a custom post type and custom taxonomy)

#### Classic editor
Due to the admin bar using the presenter, the class / content changed. So I had to adapt the script that is used for updating the score indicator in the editor (only used in the classic editor). Here I noticed a (pre-existing) bug (while writing these instructions) that the hover text did not change. So let's test:
* Edit a post/term or whatever in the classic editor
* Verify you have the SEO score indicator in the admin bar
  * Note that there is a difference with the other functionality in this PR. I can not tell you exactly right now, as I did not change it (but grey for no keyphrase & different text for sure). Focus on what happens when it the score changes and it should update
* Edit until you get a different score
* Verify the score indicator in the admin bar changed too, including the screen reader text and hover text (title)

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes https://yoast.atlassian.net/browse/PC-337
Fixes https://yoast.atlassian.net/browse/QA-3594