### PR TITLE
Lib\Model::__debugInfo(): work-around for Mockery

### DIFF
--- a/lib/model.php
+++ b/lib/model.php
@@ -571,7 +571,11 @@ class Model implements JsonSerializable {
 	 * @return array
 	 */
 	public function __debugInfo() {
-		return $this->orm->as_array();
+		if ( $this->orm ) {
+			return $this->orm->as_array();
+		}
+
+		return [];
 	}
 
 	/**


### PR DESCRIPTION
## Context

* Stabilize code for use in tests

## Summary

This PR can be summarized in the following changelog entry:

* Stabilize code for use in tests

## Relevant technical choices:

When the `Model` class is mocked, the `__debugInfo()` magic method is not mocked. This can (and will) lead to fatal errors along the lines of:
```
Warning: Uncaught Error: Call to a member function as_array() on null in path/to/wpseo-premium/vendor/yoast/wordpress-seo/lib/model.php:574

Fatal error: __debuginfo() must return an array in path/to/wpseo-premium/vendor/yoast/wordpress-seo/vendor/mockery/mockery/library/Mockery/Loader/EvalLoader.php(34) : eval()'d code on line 933
```

While maybe not needed during "normal" run-time, this small tweak prevents these errors and allows the tests to run properly on higher PHP/higher PHPUnit combinations.


## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* This is an issue which will only occur in test situations and is covered by the automated tests.