### PR TITLE
PC-335 Fix image requests in elementor

### DIFF
--- a/packages/js/src/helpers/firstImageUrlInContent.js
+++ b/packages/js/src/helpers/firstImageUrlInContent.js
@@ -9,22 +9,18 @@ import { languageProcessing } from "yoastseo";
  */
 export default function firstImageUrlInContent( content ) {
 	const images = languageProcessing.imageInText( content );
-	let image = "";
 
 	if ( images.length === 0 ) {
 		return "";
 	}
 
-	do {
-		let currentImage = images.shift();
-		currentImage = jQuery( currentImage );
+	const imageElements = $.parseHTML( images.join( "" ) );
 
-		const imageSource = currentImage.prop( "src" );
-
-		if ( imageSource ) {
-			image = imageSource;
+	for ( const imageElement of imageElements ) {
+		if ( imageElement.src ) {
+			return imageElement.src;
 		}
-	} while ( "" === image && images.length > 0 );
+	}
 
-	return image;
+	return "";
 }

--- a/packages/js/src/helpers/firstImageUrlInContent.js
+++ b/packages/js/src/helpers/firstImageUrlInContent.js
@@ -14,7 +14,7 @@ export default function firstImageUrlInContent( content ) {
 		return "";
 	}
 
-	const imageElements = $.parseHTML( images.join( "" ) );
+	const imageElements = jQuery.parseHTML( images.join( "" ) );
 
 	for ( const imageElement of imageElements ) {
 		if ( imageElement.src ) {


### PR DESCRIPTION
## Context

* This prepares our elementor integration for if ever tinymce changes the way the handle the content. If that happens we don't want to start loading every image.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Changes the way the elementor data collection handles images

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

*  Add an image to a post and check if the `Image Keyphrase` assessment shows up
* Add an alt tag to the image and check if the `Image Keyphrase` assessment shows Images on this page have alt attributes, but you have not set your keyphrase. or another version of the assessment where alt tags are available


#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [X] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes #
 