### PR TITLE
PC-362 fix tokenizing quotation

### DIFF
--- a/packages/yoastseo/spec/languageProcessing/helpers/sentence/getSentencesSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/helpers/sentence/getSentencesSpec.js
@@ -531,8 +531,9 @@ describe( "a test for when texts containing sentence delimiter", () => {
 	it( "should not break when the text starts with double quotation mark followed by space", ()=>{
 		let text = "\" This is a text with double quotation mark.";
 		expect( getSentences( text ) ).toEqual( [ "\"", "This is a text with double quotation mark." ] );
-		text = "\" \"This is a text with double quotation mark.";
-		expect( getSentences( text ) ).toEqual(  [ "\"", "\"This is a text with double quotation mark." ] );
+
+		text = "\" \"This is a text with two double quotation marks.";
+		expect( getSentences( text ) ).toEqual(  [ "\"", "\"This is a text with two double quotation marks." ] );
 
 		text = "” This is a text with double quotation mark.";
 		expect( getSentences( text ) ).toEqual( [ "”", "This is a text with double quotation mark." ] );
@@ -543,8 +544,8 @@ describe( "a test for when texts containing sentence delimiter", () => {
 		text = "» This is a text with double quotation mark.";
 		expect( getSentences( text ) ).toEqual( [ "»", "This is a text with double quotation mark." ] );
 
-		text = "« »This is a text with double quotation mark.";
-		expect( getSentences( text ) ).toEqual( [ "« »This is a text with double quotation mark." ] );
+		text = "« »This is a text with two double quotation marks.";
+		expect( getSentences( text ) ).toEqual( [ "« »This is a text with two double quotation marks." ] );
 	} );
 } );
 

--- a/packages/yoastseo/spec/languageProcessing/helpers/sentence/getSentencesSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/helpers/sentence/getSentencesSpec.js
@@ -523,8 +523,28 @@ describe( "a test for when texts containing sentence delimiter", () => {
 	} );
 
 	it( "can deal with the edge case of quotes around initials.", ()=>{
-		expect( getSentences( "The reprint was favourably reviewed by \"A. B.\" in The Musical Times in 1935, who commented \"Praise is due to Mr Mercer." ) ).toEqual(
+		const text = "The reprint was favourably reviewed by \"A. B.\" in The Musical Times in 1935, who commented \"Praise is due to Mr Mercer.";
+		expect( getSentences( text ) ).toEqual(
 			[ "The reprint was favourably reviewed by \"A. B.\" in The Musical Times in 1935, who commented \"Praise is due to Mr Mercer." ] );
+	} );
+
+	it( "should not break when the text starts with double quotation mark followed by space", ()=>{
+		let text = "\" This is a text with double quotation mark.";
+		expect( getSentences( text ) ).toEqual( [ "\"", "This is a text with double quotation mark." ] );
+		text = "\" \"This is a text with double quotation mark.";
+		expect( getSentences( text ) ).toEqual(  [ "\"", "\"This is a text with double quotation mark." ] );
+
+		text = "” This is a text with double quotation mark.";
+		expect( getSentences( text ) ).toEqual( [ "”", "This is a text with double quotation mark." ] );
+
+		text = "„ This is a text with double quotation mark.";
+		expect( getSentences( text ) ).toEqual( [ "„", "This is a text with double quotation mark." ] );
+
+		text = "» This is a text with double quotation mark.";
+		expect( getSentences( text ) ).toEqual( [ "»", "This is a text with double quotation mark." ] );
+
+		text = "« »This is a text with double quotation mark.";
+		expect( getSentences( text ) ).toEqual( [ "« »This is a text with double quotation mark." ] );
 	} );
 } );
 

--- a/packages/yoastseo/src/languageProcessing/helpers/sentence/SentenceTokenizer.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/sentence/SentenceTokenizer.js
@@ -459,7 +459,7 @@ export default class SentenceTokenizer {
 						"sentence-delimiter" !== nextToken.type &&
 						this.isCharacterASpace( nextToken.src[ 0 ] ) ) {
 						// Don't split on quotation marks unless they're preceded by a full stop.
-						if ( this.isQuotation( token.src ) && previousToken.src !== "." ) {
+						if ( this.isQuotation( token.src ) && previousToken && previousToken.src !== "." ) {
 							break;
 						}
 						/*


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Inside `SentenceTokenizer.js`, we have a check whether the previous token is a period when the current token is a quotation mark:

> `if ( this.isQuotation( token.src ) && previousToken.src !== "." ) {`

* However, it's possible that the quotation mark occurs at the beginning of a text/block, hence the `previousToken` would be undefined.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where a text starting with a double quotation mark followed by a space(s) broke the analysis.
* [shopify-seo] Fixes a bug where a text starting with a double quotation mark followed by a space(s) broke the analysis.

## Relevant technical choices:

* I added an extra check for previousToken in this line:
`if ( this.isQuotation( token.src ) && previousToken && previousToken.src !== "." ) {`
* The extra check is added since it's possible that previousToken returns undefined if there is no token preceding the current token.


## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Test with previous version of Yoast SEO
* Install and activate Yoast SEO
* Set the site language to English
* Create a post
* Add a text with 300 words to the post
* Add a double quotation mark followed by a space at the beginning of your text
* Confirm that an error appears in the console: i.e. `An error occurred after running the 'getFleschReadingScore' research. TypeError: Cannot read properties of undefined (reading 'src')`
* Install and activate previous version of Yoast SEO premium
* Go back to your previous post
* Confirm that an additional error appears in the console: i.e. `An error occurred while running the analysis. TypeError: Cannot read properties of undefined (reading 'src')`

#### Test with current version of Yoast SEO (that contains the fix)
##### Test in English
* Install and activate Yoast SEO
* Set the site language to English
* Create a post
* Add a text with 300 words to the post
* Add a double quotation mark followed by a space at the beginning of your text
* Confirm that no error appears in the console: i.e. `TypeError: Cannot read properties of undefined (reading 'src')`
* Confirm that the text length is 300 words: 
   * `Text length: The text contains 300 words. Good job!` 
   * In Japanese, the length unit is `character(s)`
* Repeat the step above for other types of double quotation mark `“”〝〞〟‟„『』«»`
* Make sure that still no error is found
* Install and activate Yoast SEO Premium
* Go back to your previous post and confirm that no error is still not found in the console
* Repeat the steps above on different content types: posts/pages/taxonomies/custom post types/custom taxonomies/WooCommerce products
   * If testing by building Yoast SEO WooCommerce SEO plugin, run `composer require yoast/wordpress-seo:dev-PC-362-fix-tokenizing-quotation@dev --dev`
* Repeat the steps above on different editors:  (Block/Classic/Elementor/Gutenberg)
   * In Block editor and in Gutenberg, also run the steps above inside:
      * WordPress blocks (e.g. list, image caption, quote, and others that allow entering the content)
      * Yoast blocks that allow entering the content
* Repeat the steps above in Shopify

##### Test in Japanese
* Do the testing with the site language set to Japanese
* Run the testing step in "Test in English" but with this quotation mark list &#x300C; &#x300E; &#x3008; &#x3014; &#x3010; &#xFF5B; &#xFF3B;

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [x] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [x] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes #
