### PR TITLE
Fix notice in block-editor-integration.js

### DIFF
--- a/packages/js/src/initializers/block-editor-integration.js
+++ b/packages/js/src/initializers/block-editor-integration.js
@@ -70,7 +70,7 @@ function registerFormats() {
  * @returns {void}
  */
 function initiallyOpenDocumentSettings() {
-	const firstLoad = ! select( "core/edit-post" ).getPreferences().panels[ "yoast-seo/document-panel" ];
+	const firstLoad = ! select( 'core/preferences' ).get.panels[ "yoast-seo/document-panel" ];
 	if ( firstLoad ) {
 		dispatch( "core/edit-post" ).toggleEditorPanelOpened( "yoast-seo/document-panel" );
 	}


### PR DESCRIPTION
Changing to what WordPress core tells me.

## Context
A user is reporting seeing a notice in the browser console when editing pages (in Chrome). I was able to replicate and with this PR, I'm trying to fix the relevant notice.