### PR TITLE
Fixes and improvements for inclusive language feedback

### DIFF
--- a/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessmentSpec.js
@@ -16,10 +16,11 @@ describe( "Disability assessments", function() {
 		expect( isApplicable ).toBeTruthy();
 		expect( assessmentResult.getScore() ).toEqual( 6 );
 		expect( assessmentResult.getText() ).toEqual(
-			"Avoid using <i>sociopath</i>, unless talking about the specific medical condition (in which case," +
-			" use <i>person with antisocial personality disorder</i>). If you are not referencing the medical condition," +
-			" consider other alternatives to describe the trait or behavior, such as <i>toxic, manipulative, cruel</i>." +
-			" <a href='https://yoa.st/' target='_blank'>Learn more.</a>" );
+			"Be careful when using <i>sociopath</i> as it is potentially harmful. If you are referencing the" +
+			" medical condition, use <i>person with antisocial personality disorder</i> instead, unless referring to" +
+			" someone who explicitly wants to be referred to with this term. If you are not referencing the medical" +
+			" condition, consider other alternatives to describe the trait or behavior, such as <i>toxic, manipulative," +
+			" cruel</i>. <a href='https://yoa.st/' target='_blank'>Learn more.</a>" );
 		expect( assessmentResult.hasMarks() ).toBeTruthy();
 		expect( assessor.getMarks() ).toEqual( [ new Mark( {
 			original: "Look at that sociopath.",

--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/cultureAssessments.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/cultureAssessments.js
@@ -37,6 +37,10 @@ const cultureAssessments = [
 		nonInclusivePhrases: [ "tribe" ],
 		inclusiveAlternatives: "<i>group, cohort, crew, league, guild</i>",
 		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
+		/*
+		 * Replace 'the culture in which this term originated' with 'a culture that uses this term' in the 'unless you are
+		 * referring to...' part of the potentiallyHarmfulUnlessCulture string.
+		 */
 		feedbackFormat: potentiallyHarmfulUnlessCulture.slice( 0, -42 ) + "a culture that uses this term.",
 		learnMoreUrl: "https://yoa.st/",
 	},

--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/cultureAssessments.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/cultureAssessments.js
@@ -37,7 +37,7 @@ const cultureAssessments = [
 		nonInclusivePhrases: [ "tribe" ],
 		inclusiveAlternatives: "<i>group, cohort, crew, league, guild</i>",
 		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
-		feedbackFormat: potentiallyHarmfulUnlessCulture,
+		feedbackFormat: potentiallyHarmfulUnlessCulture.slice( 0, -42 ) + "a culture that uses this term.",
 		learnMoreUrl: "https://yoa.st/",
 	},
 	{

--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessments.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessments.js
@@ -204,7 +204,7 @@ const disabilityAssessments =  [
 	},
 	{
 		identifier: "handicapParking",
-		nonInclusivePhrases: [ "handicap parking", "disabled parking" ],
+		nonInclusivePhrases: [ "handicap parking" ],
 		inclusiveAlternatives: "<i>accessible parking</i>",
 		score: SCORES.NON_INCLUSIVE,
 		feedbackFormat: potentiallyHarmful,
@@ -243,8 +243,8 @@ const disabilityAssessments =  [
 		learnMoreUrl: "https://yoa.st/",
 	},
 	{
-		identifier: "disabledToilet",
-		nonInclusivePhrases: [ "disabled toilet", "disabled toilets", "handicap toilet", "handicap toilets" ],
+		identifier: "handicapToilet",
+		nonInclusivePhrases: [ "handicap toilet", "handicap toilets" ],
 		inclusiveAlternatives: "<i>accessible toilet(s)</i>",
 		score: SCORES.NON_INCLUSIVE,
 		feedbackFormat: potentiallyHarmful,

--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessments.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessments.js
@@ -112,7 +112,7 @@ const disabilityAssessments =  [
 		feedbackFormat: potentiallyHarmful,
 		learnMoreUrl: "https://yoa.st/",
 		rule: ( words, inclusivePhrase ) => includesConsecutiveWords( words, inclusivePhrase )
-			.filter( isFollowedByException( words, inclusivePhrase, [ "toilet", "toilets", "parking" ] ) ),
+			.filter( isFollowedByException( words, inclusivePhrase, [ "toilet", "toilets", "parking", "bathroom", "bathrooms" ] ) ),
 	},
 	{
 		identifier: "insane",
@@ -233,8 +233,8 @@ const disabilityAssessments =  [
 		learnMoreUrl: "https://yoa.st/",
 	},
 	{
-		identifier: "disabledBathroom",
-		nonInclusivePhrases: [ "disabled bathroom", "disabled bathrooms", "handicap bathroom", "handicap bathrooms" ],
+		identifier: "handicapBathroom",
+		nonInclusivePhrases: [ "handicap bathroom", "handicap bathrooms" ],
 		inclusiveAlternatives: "<i>accessible bathroom(s)</i>",
 		score: SCORES.NON_INCLUSIVE,
 		feedbackFormat: potentiallyHarmful,

--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessments.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessments.js
@@ -12,10 +12,6 @@ const derogatory = "Avoid using <i>%1$s</i> as it is derogatory. Consider using 
 
 const medicalCondition = "Avoid using <i>%1$s</i>, unless talking about the specific medical condition. " +
 	"If you are not referencing the medical condition, consider other alternatives to describe the trait or behavior, such as %2$s.";
-const medicalConditionTwoAlternatives = "Avoid using <i>%1$s</i>, unless talking about the specific medical condition " +
-	"(in which case, use %2$s). " +
-	"If you are not referencing the medical condition, consider other alternatives to describe the trait or behavior, such as %3$s.";
-
 const potentiallyHarmfulTwoAlternatives = "Avoid using <i>%1$s</i> as it is potentially harmful. " +
 	"Consider using an alternative, such as %2$s when referring to someone's needs, or %3$s when referring to a person.";
 
@@ -398,7 +394,9 @@ const disabilityAssessments =  [
 		inclusiveAlternatives: [ "<i>person with antisocial personality disorder</i>",
 			"<i>toxic, manipulative, cruel</i>" ],
 		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
-		feedbackFormat: medicalConditionTwoAlternatives,
+		feedbackFormat: "Be careful when using <i>%1$s</i> as it is potentially harmful. If you are referencing the " +
+			"medical condition, use %2$s instead, unless referring to someone who explicitly wants to be referred to with this term. " +
+			"If you are not referencing the medical condition, consider other alternatives to describe the trait or behavior, such as %3$s.",
 		learnMoreUrl: "https://yoa.st/",
 	},
 	{
@@ -407,7 +405,9 @@ const disabilityAssessments =  [
 		inclusiveAlternatives: [ "<i>person with narcissistic personality disorder</i>",
 			"<i>selfish, egotistical, self-centered, self-absorbed, vain, toxic, manipulative</i>" ],
 		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
-		feedbackFormat: medicalConditionTwoAlternatives,
+		feedbackFormat: "Be careful when using <i>%1$s</i> as it is potentially harmful. If you are referencing the " +
+			"medical condition, use %2$s instead. If you are not referencing the medical condition, consider other" +
+			" alternatives to describe the trait or behavior, such as %3$s.",
 		learnMoreUrl: "https://yoa.st/",
 	},
 ];

--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessments.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessments.js
@@ -112,7 +112,8 @@ const disabilityAssessments =  [
 		feedbackFormat: potentiallyHarmful,
 		learnMoreUrl: "https://yoa.st/",
 		rule: ( words, inclusivePhrase ) => includesConsecutiveWords( words, inclusivePhrase )
-			.filter( isFollowedByException( words, inclusivePhrase, [ "toilet", "toilets", "parking", "bathroom", "bathrooms" ] ) ),
+			.filter( isFollowedByException( words, inclusivePhrase, [ "toilet", "toilets", "parking", "bathroom",
+				"bathrooms", "stall", "stalls" ] ) ),
 	},
 	{
 		identifier: "insane",
@@ -249,8 +250,8 @@ const disabilityAssessments =  [
 		learnMoreUrl: "https://yoa.st/",
 	},
 	{
-		identifier: "disabledStall",
-		nonInclusivePhrases: [ "disabled stall", "disabled stalls", "handicap stall", "handicap stalls" ],
+		identifier: "handicapStall",
+		nonInclusivePhrases: [ "handicap stall", "handicap stalls" ],
 		inclusiveAlternatives: "<i>accessible stall(s)</i>",
 		score: SCORES.NON_INCLUSIVE,
 		feedbackFormat: potentiallyHarmful,

--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessments.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessments.js
@@ -115,6 +115,8 @@ const disabilityAssessments =  [
 		score: SCORES.NON_INCLUSIVE,
 		feedbackFormat: potentiallyHarmful,
 		learnMoreUrl: "https://yoa.st/",
+		rule: ( words, inclusivePhrase ) => includesConsecutiveWords( words, inclusivePhrase )
+			.filter( isFollowedByException( words, inclusivePhrase, [ "toilet", "toilets", "parking" ] ) ),
 	},
 	{
 		identifier: "insane",


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We previously returned a red bullet when the text contained 'disabled parking' and 'disabled toilet' and suggested 'accessible parking/toilet' as the alternative. While that is a slightly more inclusive alternative, it was found during using testing that 'disabled parking' and 'disabled toilet' are widely used within the disability community. For that reason, we decided to not target these phrases anymore.
* We target the word 'handicap', as well as the phrases 'handicap parking', 'handicap toilet', 'handicap bathroom', 'handicap stall'. The phrases previously also triggered the feedback for 'handicap'. This PR fixes it so that the string for 'handicap' doesn't appear for those phrases.
* Since 'sociopath' can be used informally in a medical sense, we add to the feedback string that it can be used if referring to someone who explicitly wants to be referred to with this term. 
* 'Tribe' can be used for any culture that uses this term; the string was adjusted to reflect that.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Implements fixes and improvements for inclusive language feedback: removes 'disabled parking' and 'disabled toilet(s)' from the non-inclusive phrases; adds a rule so that the feedback for 'handicap' is not triggered in case of 'handicap parking' and 'handicap toilet'; improves feedback string for 'sociopath' and 'narcissistic'.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Activate Yoast SEO Free and Premium
* Activate the Inclusive language feature
* Create a new post and add the following text: `They are at the disabled toilet. They are at the disabled toilets. They are at the disabled parking. They are at the disabled stall. They are at the disabled stalls. They are at the disabled bathroom. They are at the disabled bathrooms. They are at the handicap toilet. They are at the handicap parking. They are at the handicap bathroom. They are at the handicap stall. They have a handicap. You are a sociopath. You are so narcissistic. I'm gonna hang out with my tribe.`
* Confirm that you get 5 red bullets for inclusive language, with the following feedback:
`Avoid using handicap as it is potentially harmful. Consider using an alternative, such as disability. Learn more.`
`Avoid using handicap bathroom as it is potentially harmful. Consider using an alternative, such as accessible bathroom(s). Learn more.`
`Avoid using handicap parking as it is potentially harmful. Consider using an alternative, such as accessible parking. Learn more.`
`Avoid using handicap stall as it is potentially harmful. Consider using an alternative, such as accessible stall(s). Learn more.`
`Avoid using handicap toilet as it is potentially harmful. Consider using an alternative, such as accessible toilet(s). Learn more.`
* Confirm that when you click the highlight button for 'handicap' it only highlights the sentence `They have a handicap.`
* Confirm that you get 3 orange bullets with the following feedback:
`Be careful when using narcissistic as it is potentially harmful. If you are referencing the medical condition, use person with narcissistic personality disorder instead. If you are not referencing the medical condition, consider other alternatives to describe the trait or behavior, such as selfish, egotistical, self-centered, self-absorbed, vain, toxic, manipulative. Learn more.`
`Be careful when using sociopath as it is potentially harmful. If you are referencing the medical condition, use person with antisocial personality disorder instead, unless referring to someone who explicitly wants to be referred to with this term. If you are not referencing the medical condition, consider other alternatives to describe the trait or behavior, such as toxic, manipulative, cruel. Learn more.`
`Be careful when using tribe as it is potentially harmful. Consider using an alternative, such as group, cohort, crew, league, guild instead, unless you are referring to a culture that uses this term. Learn more.`


#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [x] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes #
