### PR TITLE
Fix custom field replacement variables in social inputs

### DIFF
--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -924,6 +924,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 			'userLanguageCode'           => WPSEO_Language_Utils::get_language( \get_user_locale() ),
 			'isPost'                     => true,
 			'isBlockEditor'              => $is_block_editor,
+			'postId'                     => $post_id,
 			'postStatus'                 => get_post_status( $post_id ),
 			'analysis'                   => [
 				'plugins' => $plugins_script_data,

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -1119,9 +1119,25 @@ class WPSEO_Metabox extends WPSEO_Meta {
 			return $custom_replace_vars;
 		}
 
+		// Simply concatenate all fields containing replace vars so we can handle them all with a single regex find.
+		$replace_vars_fields = implode(
+			' ',
+			[
+				YoastSEO()->meta->for_post( $post->ID )->presentation->title,
+				YoastSEO()->meta->for_post( $post->ID )->presentation->meta_description,
+			]
+		);
+
+		preg_match_all( '/%%cf_([A-Za-z0-9_]+)%%/', $replace_vars_fields, $matches );
+		$fields_to_include = $matches[1];
 		foreach ( $custom_fields as $custom_field_name => $custom_field ) {
 			// Skip private custom fields.
 			if ( substr( $custom_field_name, 0, 1 ) === '_' ) {
+				continue;
+			}
+
+			// Skip custom fields that are not used, new ones will be fetched dynamically.
+			if ( ! in_array( $custom_field_name, $fields_to_include, true ) ) {
 				continue;
 			}
 

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -1119,12 +1119,18 @@ class WPSEO_Metabox extends WPSEO_Meta {
 			return $custom_replace_vars;
 		}
 
+		$meta = YoastSEO()->meta->for_post( $post->ID );
+
+		if ( ! $meta ) {
+			return $custom_replace_vars;
+		}
+
 		// Simply concatenate all fields containing replace vars so we can handle them all with a single regex find.
 		$replace_vars_fields = implode(
 			' ',
 			[
-				YoastSEO()->meta->for_post( $post->ID )->presentation->title,
-				YoastSEO()->meta->for_post( $post->ID )->presentation->meta_description,
+				$meta->presentation->title,
+				$meta->presentation->meta_description,
 			]
 		);
 

--- a/admin/taxonomy/class-taxonomy.php
+++ b/admin/taxonomy/class-taxonomy.php
@@ -176,6 +176,7 @@ class WPSEO_Taxonomy {
 				'metabox'          => $this->localize_term_scraper_script(),
 				'userLanguageCode' => WPSEO_Language_Utils::get_language( \get_user_locale() ),
 				'isTerm'           => true,
+				'postId'           => $tag_id,
 			];
 			$asset_manager->localize_script( 'term-edit', 'wpseoScriptData', $script_data );
 			$asset_manager->enqueue_user_language_script();

--- a/inc/class-wpseo-custom-fields.php
+++ b/inc/class-wpseo-custom-fields.php
@@ -47,6 +47,14 @@ class WPSEO_Custom_Fields {
 			LIMIT %d";
 		$fields = $wpdb->get_col( $wpdb->prepare( $sql, $limit ) );
 
+		/**
+		 * Filters the custom fields that are auto-completed and replaced as replacement variables
+		 * in the meta box and sidebar.
+		 *
+		 * @param string[] $fields The custom field names.
+		 */
+		$fields = apply_filters( 'wpseo_replacement_variables_custom_fields', $fields );
+
 		if ( is_array( $fields ) ) {
 			self::$custom_fields = array_map( [ 'WPSEO_Custom_Fields', 'add_custom_field_prefix' ], $fields );
 		}

--- a/packages/js/src/components/social/SocialForm.js
+++ b/packages/js/src/components/social/SocialForm.js
@@ -123,6 +123,7 @@ class SocialPreviewEditor extends Component {
 			titleInputPlaceholder,
 			replacementVariables,
 			recommendedReplacementVariables,
+			onReplacementVariableSearchChange,
 			isPremium,
 			location,
 		} = this.props;
@@ -146,6 +147,7 @@ class SocialPreviewEditor extends Component {
 					imageWarnings={ imageWarnings }
 					replacementVariables={ replacementVariables }
 					recommendedReplacementVariables={ recommendedReplacementVariables }
+					onReplacementVariableSearchChange={ onReplacementVariableSearchChange }
 					onMouseHover={ this.setHoveredField }
 					hoveredField={ this.state.hoveredField }
 					onSelect={ this.setActiveField }
@@ -174,6 +176,7 @@ SocialPreviewEditor.propTypes = {
 	titleInputPlaceholder: PropTypes.string,
 	replacementVariables: replacementVariablesShape,
 	recommendedReplacementVariables: recommendedReplacementVariablesShape,
+	onReplacementVariableSearchChange: PropTypes.func,
 	location: PropTypes.string,
 	alt: PropTypes.string,
 };
@@ -185,6 +188,7 @@ SocialPreviewEditor.defaultProps = {
 	isPremium: false,
 	descriptionInputPlaceholder: "",
 	titleInputPlaceholder: "",
+	onReplacementVariableSearchChange: null,
 	location: "",
 	alt: "",
 };

--- a/packages/js/src/containers/FacebookEditor.js
+++ b/packages/js/src/containers/FacebookEditor.js
@@ -7,6 +7,7 @@ import FacebookWrapper from "../components/social/FacebookWrapper";
 import getL10nObject from "../analysis/getL10nObject";
 import withLocation from "../helpers/withLocation";
 import { openMedia, prepareFacebookPreviewImage } from "../helpers/selectMedia";
+import getMemoizedFindCustomFields from "../helpers/getMemoizedFindCustomFields";
 
 const socialMediumName = "Facebook";
 
@@ -73,19 +74,24 @@ export default compose( [
 		};
 	} ),
 
-	withDispatch( dispatch => {
+	withDispatch( ( dispatch, ownProps, { select } ) => {
 		const {
 			setFacebookPreviewTitle,
 			setFacebookPreviewDescription,
 			clearFacebookPreviewImage,
 			loadFacebookPreviewData,
+			findCustomFields,
 		} = dispatch( "yoast-seo/editor" );
+
+		const postId = select( "yoast-seo/editor" ).getPostId();
+
 		return {
 			onSelectImageClick: selectMedia,
 			onRemoveImageClick: clearFacebookPreviewImage,
 			onDescriptionChange: setFacebookPreviewDescription,
 			onTitleChange: setFacebookPreviewTitle,
 			onLoad: loadFacebookPreviewData,
+			onReplacementVariableSearchChange: getMemoizedFindCustomFields( postId, findCustomFields ),
 		};
 	} ),
 

--- a/packages/js/src/containers/SnippetEditor.js
+++ b/packages/js/src/containers/SnippetEditor.js
@@ -3,6 +3,7 @@ import { withDispatch, withSelect } from "@wordpress/data";
 import { __ } from "@wordpress/i18n";
 import { SnippetEditor } from "@yoast/search-metadata-previews";
 import { LocationConsumer } from "@yoast/externals/contexts";
+import { debounce } from "lodash-es";
 import SnippetPreviewSection from "../components/SnippetPreviewSection";
 import { applyReplaceUsingPlugin } from "../helpers/replacementVariableHelpers";
 
@@ -134,6 +135,10 @@ export function mapDispatchToProps( dispatch, ownProps, { select } ) {
 		findCustomFields,
 	} = dispatch( "yoast-seo/editor" );
 	const coreEditorDispatch = dispatch( "core/editor" );
+	const onReplacementVariableSearchChange = debounce(
+		value => findCustomFields( value, select( "core/editor" ).getCurrentPostId() ),
+		500
+	);
 
 	return {
 		onChange: ( key, value ) => {
@@ -160,9 +165,7 @@ export function mapDispatchToProps( dispatch, ownProps, { select } ) {
 			}
 		},
 		onChangeAnalysisData: updateAnalysisData,
-		onReplacementVariableSearchChange: ( value ) => {
-			findCustomFields( value, select( "core/editor" ).getCurrentPostId() );
-		},
+		onReplacementVariableSearchChange,
 	};
 }
 

--- a/packages/js/src/containers/SnippetEditor.js
+++ b/packages/js/src/containers/SnippetEditor.js
@@ -5,6 +5,7 @@ import { SnippetEditor } from "@yoast/search-metadata-previews";
 import { LocationConsumer } from "@yoast/externals/contexts";
 import SnippetPreviewSection from "../components/SnippetPreviewSection";
 import { applyReplaceUsingPlugin } from "../helpers/replacementVariableHelpers";
+import getMemoizedFindCustomFields from "../helpers/getMemoizedFindCustomFields";
 
 /**
  * Process the snippet editor form data before it's being displayed in the snippet preview.

--- a/packages/js/src/containers/SnippetEditor.js
+++ b/packages/js/src/containers/SnippetEditor.js
@@ -121,14 +121,17 @@ export function mapSelectToProps( select ) {
  * Maps the dispatch function to props.
  *
  * @param {function} dispatch The dispatch function.
+ * @param {Object}   ownProps The component's own props.
+ * @param {function} select   The select function.
  *
  * @returns {Object} The props.
  */
-export function mapDispatchToProps( dispatch ) {
+export function mapDispatchToProps( dispatch, ownProps, { select } ) {
 	const {
 		updateData,
 		switchMode,
 		updateAnalysisData,
+		findCustomFields,
 	} = dispatch( "yoast-seo/editor" );
 	const coreEditorDispatch = dispatch( "core/editor" );
 
@@ -157,6 +160,9 @@ export function mapDispatchToProps( dispatch ) {
 			}
 		},
 		onChangeAnalysisData: updateAnalysisData,
+		onReplacementVariableSearchChange: ( value ) => {
+			findCustomFields( value, select( "core/editor" ).getCurrentPostId() );
+		},
 	};
 }
 

--- a/packages/js/src/containers/SnippetEditor.js
+++ b/packages/js/src/containers/SnippetEditor.js
@@ -136,7 +136,7 @@ export function mapDispatchToProps( dispatch, ownProps, { select } ) {
 	} = dispatch( "yoast-seo/editor" );
 	const coreEditorDispatch = dispatch( "core/editor" );
 	const onReplacementVariableSearchChange = debounce(
-		value => findCustomFields( value, select( "core/editor" ).getCurrentPostId() ),
+		value => findCustomFields( value, select( "yoast-seo/editor" ).getPostId() ),
 		500
 	);
 

--- a/packages/js/src/containers/SnippetEditor.js
+++ b/packages/js/src/containers/SnippetEditor.js
@@ -3,7 +3,6 @@ import { withDispatch, withSelect } from "@wordpress/data";
 import { __ } from "@wordpress/i18n";
 import { SnippetEditor } from "@yoast/search-metadata-previews";
 import { LocationConsumer } from "@yoast/externals/contexts";
-import { debounce, memoize } from "lodash-es";
 import SnippetPreviewSection from "../components/SnippetPreviewSection";
 import { applyReplaceUsingPlugin } from "../helpers/replacementVariableHelpers";
 
@@ -117,16 +116,6 @@ export function mapSelectToProps( select ) {
 		locale: getContentLocale(),
 	};
 }
-
-// Memoize this so that prop changes of the container don't lead to a new debounce working on a different timer than the previous one.
-const getMemoizedFindCustomFields = memoize(
-	( postId, findCustomFields ) => {
-		return debounce(
-			value => findCustomFields( value, postId ),
-			500
-		);
-	}
-);
 
 /**
  * Maps the dispatch function to props.

--- a/packages/js/src/containers/TwitterEditor.js
+++ b/packages/js/src/containers/TwitterEditor.js
@@ -7,6 +7,7 @@ import TwitterWrapper from "../components/social/TwitterWrapper";
 import getL10nObject from "../analysis/getL10nObject";
 import withLocation from "../helpers/withLocation";
 import { openMedia, prepareTwitterPreviewImage } from "../helpers/selectMedia";
+import getMemoizedFindCustomFields from "../helpers/getMemoizedFindCustomFields";
 
 const socialMediumName = "Twitter";
 
@@ -80,13 +81,16 @@ export default compose( [
 		};
 	} ),
 
-	withDispatch( dispatch => {
+	withDispatch( ( dispatch, ownProps, { select } ) => {
 		const {
 			setTwitterPreviewTitle,
 			setTwitterPreviewDescription,
 			clearTwitterPreviewImage,
 			loadTwitterPreviewData,
+			findCustomFields,
 		} = dispatch( "yoast-seo/editor" );
+
+		const postId = select( "yoast-seo/editor" ).getPostId();
 
 		return {
 			onSelectImageClick: selectMedia,
@@ -94,6 +98,7 @@ export default compose( [
 			onDescriptionChange: setTwitterPreviewDescription,
 			onTitleChange: setTwitterPreviewTitle,
 			onLoad: loadTwitterPreviewData,
+			onReplacementVariableSearchChange: getMemoizedFindCustomFields( postId, findCustomFields ),
 		};
 	} ),
 

--- a/packages/js/src/elementor/initializers/editor-store.js
+++ b/packages/js/src/elementor/initializers/editor-store.js
@@ -54,6 +54,7 @@ const populateStore = store => {
 
 	store.dispatch( actions.setDismissedAlerts( get( window, "wpseoScriptData.dismissedAlerts", {} ) ) );
 	store.dispatch( actions.setIsPremium( Boolean( get( window, "wpseoScriptData.metabox.isPremium", false ) ) ) );
+	store.dispatch( actions.setPostId( Number( get( window, "wpseoScriptData.postId", null ) ) ) );
 };
 
 /**

--- a/packages/js/src/elementor/initializers/editor-store.js
+++ b/packages/js/src/elementor/initializers/editor-store.js
@@ -54,7 +54,6 @@ const populateStore = store => {
 
 	store.dispatch( actions.setDismissedAlerts( get( window, "wpseoScriptData.dismissedAlerts", {} ) ) );
 	store.dispatch( actions.setIsPremium( Boolean( get( window, "wpseoScriptData.metabox.isPremium", false ) ) ) );
-	store.dispatch( actions.setPostId( Number( get( window, "wpseoScriptData.postId", null ) ) ) );
 };
 
 /**

--- a/packages/js/src/helpers/getMemoizedFindCustomFields.js
+++ b/packages/js/src/helpers/getMemoizedFindCustomFields.js
@@ -1,0 +1,18 @@
+import { debounce, memoize, noop } from "lodash-es";
+
+// Memoize this so that prop changes of the container don't lead to a new debounce working on a different timer than the previous one.
+const getMemoizedFindCustomFields = memoize(
+	( postId, findCustomFields ) => {
+		// If the post ID is 0 there can be no custom fields as it's a newly created post so noop.
+		if ( postId === 0 ) {
+			return noop;
+		}
+
+		return debounce(
+			value => findCustomFields( value, postId ),
+			500
+		);
+	}
+);
+
+export default getMemoizedFindCustomFields;

--- a/packages/js/src/initializers/editor-store.js
+++ b/packages/js/src/initializers/editor-store.js
@@ -36,6 +36,7 @@ const populateStore = store => {
 
 	store.dispatch( actions.setDismissedAlerts( get( window, "wpseoScriptData.dismissedAlerts", {} ) ) );
 	store.dispatch( actions.setIsPremium( Boolean( get( window, "wpseoScriptData.metabox.isPremium", false ) ) ) );
+	store.dispatch( actions.setPostId( Number( get( window, "wpseoScriptData.postId", null ) ) ) );
 };
 
 /**

--- a/packages/js/src/redux/actions/index.js
+++ b/packages/js/src/redux/actions/index.js
@@ -30,6 +30,7 @@ export * from "./WincherModal";
 export * from "./WincherRequest";
 export * from "./WincherSEOPerformance";
 export * from "./isPremium";
+export * from "./postId";
 
 /**
  * A wrapper function so that we can wrap the field helper to the monorepo action.

--- a/packages/js/src/redux/actions/postId.js
+++ b/packages/js/src/redux/actions/postId.js
@@ -1,0 +1,10 @@
+export const SET_POST_ID = "SET_POST_ID";
+
+/**
+ * @param {number} postId The post ID.
+ * @returns {Object} Action object.
+ */
+export const setPostId = ( postId ) => ( {
+	type: SET_POST_ID,
+	payload: postId,
+} );

--- a/packages/js/src/redux/actions/snippetEditor.js
+++ b/packages/js/src/redux/actions/snippetEditor.js
@@ -2,6 +2,8 @@ import { decodeHTML } from "@yoast/helpers";
 
 export const SWITCH_MODE = "SNIPPET_EDITOR_SWITCH_MODE";
 export const UPDATE_DATA = "SNIPPET_EDITOR_UPDATE_DATA";
+export const FIND_CUSTOM_FIELDS = "SNIPPET_EDITOR_FIND_CUSTOM_FIELDS";
+export const CUSTOM_FIELD_RESULTS = "SNIPPET_EDITOR_CUSTOM_FIELD_RESULTS";
 export const UPDATE_REPLACEMENT_VARIABLE = "SNIPPET_EDITOR_UPDATE_REPLACEMENT_VARIABLE";
 export const HIDE_REPLACEMENT_VARIABLES = "SNIPPET_EDITOR_HIDE_REPLACEMENT_VARIABLES";
 export const REMOVE_REPLACEMENT_VARIABLE = "SNIPPET_EDITOR_REMOVE_REPLACEMENT_VARIABLE";
@@ -41,6 +43,27 @@ export function updateData( data ) {
 }
 
 /**
+ * Triggers a control to fetch new replacement variables from the API and then adds them.
+ *
+ * @param {string} query  The search query.
+ * @param {int}    postId The post ID.
+ *
+ * @returns {Object} An action for redux.
+ */
+export function* findCustomFields( query, postId ) {
+	const results = yield{
+		type: FIND_CUSTOM_FIELDS,
+		query,
+		postId,
+	};
+
+	return {
+		type: CUSTOM_FIELD_RESULTS,
+		results,
+	};
+}
+
+/**
  * Updates replacement variables in redux.
  *
  * @param {string} name   The name of the replacement variable.
@@ -66,7 +89,7 @@ export function updateReplacementVariable( name, value, label = "", hidden = fal
 /**
  * Updates the words to highlight in the snippet editor.
  *
- * @param {Array} wordsToHighlight  The snippet editor keyword forms.
+ * @param {Array} wordsToHighlight The snippet editor keyword forms.
  *
  * @returns {Object} An action for redux.
  */

--- a/packages/js/src/redux/controls/dismissedAlerts.js
+++ b/packages/js/src/redux/controls/dismissedAlerts.js
@@ -2,7 +2,7 @@
 /**
  * Posts the dismissal to the API.
  *
- * @param {String} alertKey The key of the Alert that needs to be dismissed.
+ * @param {string} alertKey The key of the Alert that needs to be dismissed.
  *
  * @returns {Object} The API Post followed by a resolve.
  */

--- a/packages/js/src/redux/controls/index.js
+++ b/packages/js/src/redux/controls/index.js
@@ -1,1 +1,2 @@
 export * from "./dismissedAlerts";
+export * from "./snippetEditor";

--- a/packages/js/src/redux/controls/snippetEditor.js
+++ b/packages/js/src/redux/controls/snippetEditor.js
@@ -1,0 +1,17 @@
+/* global wpseoApi */
+/**
+ * Fetches meta keys from the API.
+ *
+ * @param {string} query  The search value.
+ * @param {int}    postId The post ID.
+ *
+ * @returns {Object} The API Post followed by a resolve.
+ */
+export function SNIPPET_EDITOR_FIND_CUSTOM_FIELDS( { query, postId } ) {
+	return new Promise( ( resolve ) => {
+		// eslint-disable-next-line camelcase
+		wpseoApi.get( "meta/search", { query, post_id: postId }, response => {
+			resolve( response.meta );
+		} );
+	} );
+}

--- a/packages/js/src/redux/reducers/index.js
+++ b/packages/js/src/redux/reducers/index.js
@@ -11,6 +11,7 @@ import editorModals from "./editorModals";
 import facebookEditor from "./facebookEditor";
 import focusKeyword from "./focusKeyword";
 import isPremium from "./isPremium";
+import postId from "./postId";
 import marksButtonStatus from "./markerButtons";
 import isMarkerPaused from "./markerPauseStatus";
 import preferences from "./preferences";
@@ -42,6 +43,7 @@ export default {
 	isCornerstone,
 	isMarkerPaused,
 	isPremium,
+	postId,
 	marksButtonStatus,
 	preferences,
 	primaryTaxonomies,

--- a/packages/js/src/redux/reducers/postId.js
+++ b/packages/js/src/redux/reducers/postId.js
@@ -1,0 +1,19 @@
+import { SET_POST_ID } from "../actions/postId";
+
+/**
+ * A reducer for the post ID.
+ *
+ * @param {boolean} state The current state of the object.
+ * @param {Object} action The current action received.
+ *
+ * @returns {boolean} The state.
+ */
+const postId = ( state = false, action ) => {
+	switch ( action.type ) {
+		case SET_POST_ID:
+			return action.payload;
+		default: return state;
+	}
+};
+
+export default postId;

--- a/packages/js/src/redux/reducers/snippetEditor.js
+++ b/packages/js/src/redux/reducers/snippetEditor.js
@@ -5,11 +5,13 @@ import {
 	UPDATE_REPLACEMENT_VARIABLE,
 	HIDE_REPLACEMENT_VARIABLES,
 	REMOVE_REPLACEMENT_VARIABLE,
+	CUSTOM_FIELD_RESULTS,
 	REFRESH,
 	UPDATE_WORDS_TO_HIGHLIGHT,
 	LOAD_SNIPPET_EDITOR_DATA,
 } from "../actions/snippetEditor";
-import { pushNewReplaceVar } from "../../helpers/replacementVariableHelpers";
+import { pushNewReplaceVar, replaceSpaces } from "../../helpers/replacementVariableHelpers";
+import { firstToUpperCase } from "../../helpers/stringHelpers";
 
 /**
  * Returns the initial state for the snippetEditorReducer.
@@ -32,6 +34,74 @@ function getInitialState() {
 			description: "",
 		},
 		isLoading: true,
+	};
+}
+
+/**
+ * Updates a replacement variable, adding it if it doesn't exist.
+ *
+ * @param {Object} state The current state.
+ * @param {Object} action The action that was just dispatched.
+ *
+ * @returns {Object} The new state.
+ */
+function updateReplacementVariable( state, action ) {
+	let isNewReplaceVar = true;
+	let nextReplacementVariables = state.replacementVariables.map( ( replaceVar ) => {
+		if ( replaceVar.name === action.name ) {
+			isNewReplaceVar = false;
+			return {
+				name: action.name,
+				label: action.label || replaceVar.label,
+				value: action.value,
+				hidden: replaceVar.hidden,
+			};
+		}
+		return replaceVar;
+	} );
+
+	if ( isNewReplaceVar ) {
+		nextReplacementVariables = pushNewReplaceVar( nextReplacementVariables, action );
+	}
+
+	return {
+		...state,
+		replacementVariables: nextReplacementVariables,
+	};
+}
+
+/**
+ * Updates replacement variables based off search results.
+ *
+ * @param {Object} state The current state.
+ * @param {Object} action The action that was just dispatched.
+ *
+ * @returns {Object} The new state.
+ */
+function customFieldResults( state, action ) {
+	// Filter out any already existing custom fields as data from server is outdated by default.
+	const results = action.results.filter( meta => {
+		return ! state.replacementVariables.some( replaceVar => replaceVar.name === ( "cf_" + meta.key ) );
+	} );
+
+	if ( results.length === 0 ) {
+		return state;
+	}
+
+	const nextReplacementVariables = [
+		...results.map( meta => ( {
+			name: "cf_" + replaceSpaces( meta.key ),
+			label: firstToUpperCase( meta.key + " (custom field)" ),
+			value: meta.value,
+			hidden: false,
+		} ) ),
+		...state.replacementVariables,
+	];
+
+
+	return {
+		...state,
+		replacementVariables: nextReplacementVariables,
 	};
 }
 
@@ -60,30 +130,11 @@ function snippetEditorReducer( state = getInitialState(), action ) {
 				},
 			};
 
-		case UPDATE_REPLACEMENT_VARIABLE: {
-			let isNewReplaceVar = true;
-			let nextReplacementVariables = state.replacementVariables.map( ( replaceVar ) => {
-				if ( replaceVar.name === action.name ) {
-					isNewReplaceVar = false;
-					return {
-						name: action.name,
-						label: action.label || replaceVar.label,
-						value: action.value,
-						hidden: replaceVar.hidden,
-					};
-				}
-				return replaceVar;
-			} );
+		case UPDATE_REPLACEMENT_VARIABLE:
+			return updateReplacementVariable( state, action );
 
-			if ( isNewReplaceVar ) {
-				nextReplacementVariables = pushNewReplaceVar( nextReplacementVariables, action );
-			}
-
-			return {
-				...state,
-				replacementVariables: nextReplacementVariables,
-			};
-		}
+		case CUSTOM_FIELD_RESULTS:
+			return customFieldResults( state, action );
 
 		case HIDE_REPLACEMENT_VARIABLES: {
 			const nextReplacementVariables = state.replacementVariables.map( ( replaceVar ) => {

--- a/packages/js/src/redux/selectors/index.js
+++ b/packages/js/src/redux/selectors/index.js
@@ -25,3 +25,4 @@ export * from "./WincherModal";
 export * from "./WincherRequest";
 export * from "./WincherSEOPerformance";
 export * from "./isPremium";
+export * from "./postId";

--- a/packages/js/src/redux/selectors/postId.js
+++ b/packages/js/src/redux/selectors/postId.js
@@ -1,0 +1,7 @@
+import { get } from "lodash";
+
+/**
+ * @param {Ojbect} state The current Redux state.
+ * @returns {number} The post ID.
+ */
+export const getPostId = ( state ) => get( state, "postId", null );

--- a/packages/js/tests/containers/SnippetEditor.test.js
+++ b/packages/js/tests/containers/SnippetEditor.test.js
@@ -101,7 +101,7 @@ describe( "SnippetEditor container", () => {
 			}
 		} );
 
-		const result = mapDispatchToProps( dispatch );
+		const result = mapDispatchToProps( dispatch, null, { select: jest.fn() } );
 
 		expect( typeof result.onChange ).toEqual( "function" );
 		expect( result.onChangeAnalysisData ).toBe( yoastEditorDispatch.updateAnalysisData );

--- a/packages/js/tests/containers/SnippetEditor.test.js
+++ b/packages/js/tests/containers/SnippetEditor.test.js
@@ -101,7 +101,9 @@ describe( "SnippetEditor container", () => {
 			}
 		} );
 
-		const result = mapDispatchToProps( dispatch, null, { select: jest.fn() } );
+		const result = mapDispatchToProps( dispatch, null, { select: jest.fn(
+			() => ( { getPostId: jest.fn() } )
+		) } );
 
 		expect( typeof result.onChange ).toEqual( "function" );
 		expect( result.onChangeAnalysisData ).toBe( yoastEditorDispatch.updateAnalysisData );

--- a/packages/replacement-variable-editor/src/ReplacementVariableEditor.js
+++ b/packages/replacement-variable-editor/src/ReplacementVariableEditor.js
@@ -76,6 +76,7 @@ class ReplacementVariableEditor extends React.Component {
 			onBlur,
 			isActive,
 			isHovered,
+			onSearchChange,
 			replacementVariables,
 			recommendedReplacementVariables,
 			editorRef,
@@ -128,6 +129,7 @@ class ReplacementVariableEditor extends React.Component {
 						onChange={ onChange }
 						onFocus={ onFocus }
 						onBlur={ onBlur }
+						onSearchChange={ onSearchChange }
 						replacementVariables={ replacementVariables }
 						recommendedReplacementVariables={ recommendedReplacementVariables }
 						ref={ ref => {
@@ -148,6 +150,7 @@ ReplacementVariableEditor.propTypes = {
 	content: PropTypes.string.isRequired,
 	onChange: PropTypes.func.isRequired,
 	onBlur: PropTypes.func,
+	onSearchChange: PropTypes.func,
 	replacementVariables: replacementVariablesShape,
 	recommendedReplacementVariables: recommendedReplacementVariablesShape,
 	isActive: PropTypes.bool,
@@ -168,6 +171,7 @@ ReplacementVariableEditor.propTypes = {
 ReplacementVariableEditor.defaultProps = {
 	onFocus: () => {},
 	onBlur: () => {},
+	onSearchChange: null,
 	replacementVariables: [],
 	recommendedReplacementVariables: [],
 	fieldId: "",

--- a/packages/replacement-variable-editor/src/ReplacementVariableEditorStandalone.js
+++ b/packages/replacement-variable-editor/src/ReplacementVariableEditorStandalone.js
@@ -371,6 +371,10 @@ class ReplacementVariableEditorStandalone extends React.Component {
 	 * @returns {void}
 	 */
 	onSearchChange( { value } ) {
+		if ( this.props.onSearchChange ) {
+			this.props.onSearchChange( value );
+		}
+
 		const recommendedReplacementVariables = this.determineCurrentReplacementVariables(
 			this.props.replacementVariables,
 			this.props.recommendedReplacementVariables,
@@ -510,25 +514,35 @@ class ReplacementVariableEditorStandalone extends React.Component {
 	componentWillReceiveProps( nextProps ) {
 		const { content, replacementVariables, recommendedReplacementVariables } = this.props;
 		const { searchValue } = this.state;
+		const nextState = {};
 
-		if (
-			( nextProps.content !== this._serializedContent && nextProps.content !== content ) ||
-			nextProps.replacementVariables !== replacementVariables
-		) {
+		if ( nextProps.content !== this._serializedContent && nextProps.content !== content ) {
 			this._serializedContent = nextProps.content;
-			const editorState = unserializeEditor( nextProps.content, nextProps.replacementVariables );
+			nextState.editorState = unserializeEditor( nextProps.content, nextProps.replacementVariables );
+		} else if ( nextProps.replacementVariables !== replacementVariables ) {
+			const newReplacementVariableNames = nextProps.replacementVariables
+				.map( rv => rv.name )
+				.filter( rvName => ! replacementVariables.map( rv => rv.name ).includes( rvName ) );
+
+			if ( newReplacementVariableNames.some( rvName => content.includes( "%%" + rvName + "%%" ) ) ) {
+				this._serializedContent = nextProps.content;
+				nextState.editorState = unserializeEditor( nextProps.content, nextProps.replacementVariables );
+			}
+		}
+
+		if ( nextProps.replacementVariables !== replacementVariables ) {
 			const currentReplacementVariables = this.determineCurrentReplacementVariables(
 				nextProps.replacementVariables,
 				recommendedReplacementVariables,
 				searchValue
 			);
-			const suggestions = this.mapReplacementVariablesToSuggestions( currentReplacementVariables );
-
-			this.setState( {
-				editorState,
-				suggestions: this.suggestionsFilter( searchValue, suggestions ),
-			} );
+			nextState.suggestions = this.suggestionsFilter(
+				searchValue,
+				this.mapReplacementVariablesToSuggestions( currentReplacementVariables )
+			);
 		}
+
+		this.setState( nextState );
 	}
 
 	/**
@@ -645,6 +659,7 @@ ReplacementVariableEditorStandalone.propTypes = {
 	replacementVariables: replacementVariablesShape.isRequired,
 	recommendedReplacementVariables: recommendedReplacementVariablesShape,
 	ariaLabelledBy: PropTypes.string.isRequired,
+	onSearchChange: PropTypes.func,
 	onChange: PropTypes.func.isRequired,
 	onFocus: PropTypes.func,
 	onBlur: PropTypes.func,
@@ -655,6 +670,7 @@ ReplacementVariableEditorStandalone.propTypes = {
 };
 
 ReplacementVariableEditorStandalone.defaultProps = {
+	onSearchChange: null,
 	onFocus: () => {},
 	onBlur: () => {},
 	placeholder: "",

--- a/packages/replacement-variable-editor/tests/__snapshots__/ReplacementVariableEditorTest.js.snap
+++ b/packages/replacement-variable-editor/tests/__snapshots__/ReplacementVariableEditorTest.js.snap
@@ -8,6 +8,7 @@ exports[`ReplacementVariableEditor wraps a Draft.js editor instance 1`] = `
   onBlur={[Function]}
   onChange={[Function]}
   onFocus={[Function]}
+  onSearchChange={null}
   placeholder=""
   recommendedReplacementVariables={Array []}
   replacementVariables={Array []}

--- a/packages/search-metadata-previews/src/snippet-editor/SnippetEditor.js
+++ b/packages/search-metadata-previews/src/snippet-editor/SnippetEditor.js
@@ -3,7 +3,7 @@ import styled from "styled-components";
 import React from "react";
 import PropTypes from "prop-types";
 import { __ } from "@wordpress/i18n";
-import { noop } from "lodash";
+import { escapeRegExp, noop } from "lodash";
 
 /* Yoast dependencies */
 import { assessments, languageProcessing, helpers } from "yoastseo";
@@ -407,7 +407,7 @@ class SnippetEditor extends React.Component {
 		}
 
 		for ( const { name, value } of replacementVariables ) {
-			content = content.replace( new RegExp( "%%" + name + "%%", "g" ), value );
+			content = content.replace( new RegExp( "%%" + escapeRegExp( name ) + "%%", "g" ), value );
 		}
 
 		return content;

--- a/packages/search-metadata-previews/src/snippet-editor/SnippetEditor.js
+++ b/packages/search-metadata-previews/src/snippet-editor/SnippetEditor.js
@@ -249,6 +249,7 @@ class SnippetEditor extends React.Component {
 		const {
 			data,
 			descriptionEditorFieldPlaceholder,
+			onReplacementVariableSearchChange,
 			replacementVariables,
 			recommendedReplacementVariables,
 			hasPaperStyle,
@@ -271,6 +272,7 @@ class SnippetEditor extends React.Component {
 					onChange={ this.handleChange }
 					onFocus={ this.setFieldFocus }
 					onBlur={ this.unsetFieldFocus }
+					onReplacementVariableSearchChange={ onReplacementVariableSearchChange }
 					replacementVariables={ replacementVariables }
 					recommendedReplacementVariables={ recommendedReplacementVariables }
 					titleLengthProgress={ titleLengthProgress }
@@ -589,6 +591,7 @@ class SnippetEditor extends React.Component {
 }
 
 SnippetEditor.propTypes = {
+	onReplacementVariableSearchChange: PropTypes.func,
 	replacementVariables: replacementVariablesShape,
 	recommendedReplacementVariables: recommendedReplacementVariablesShape,
 	data: PropTypes.shape( {
@@ -623,6 +626,7 @@ SnippetEditor.defaultProps = {
 	mode: DEFAULT_MODE,
 	date: "",
 	wordsToHighlight: [],
+	onReplacementVariableSearchChange: null,
 	replacementVariables: [],
 	recommendedReplacementVariables: [],
 	titleLengthProgress: {

--- a/packages/search-metadata-previews/src/snippet-editor/SnippetEditorFields.js
+++ b/packages/search-metadata-previews/src/snippet-editor/SnippetEditorFields.js
@@ -264,6 +264,7 @@ class SnippetEditorFields extends React.Component {
 		const {
 			activeField,
 			hoveredField,
+			onReplacementVariableSearchChange,
 			replacementVariables,
 			recommendedReplacementVariables,
 			titleLengthProgress,
@@ -299,6 +300,7 @@ class SnippetEditorFields extends React.Component {
 					recommendedReplacementVariables={ recommendedReplacementVariables }
 					content={ title }
 					onChange={ this.onChangeTitle }
+					onSearchChange={ onReplacementVariableSearchChange }
 					fieldId={ titleInputId }
 					type="title"
 				/>
@@ -379,6 +381,7 @@ SnippetEditorFields.propTypes = {
 	onChange: PropTypes.func.isRequired,
 	onFocus: PropTypes.func,
 	onBlur: PropTypes.func,
+	onReplacementVariableSearchChange: PropTypes.func,
 	data: PropTypes.shape( {
 		title: PropTypes.string.isRequired,
 		slug: PropTypes.string.isRequired,
@@ -397,8 +400,12 @@ SnippetEditorFields.propTypes = {
 
 SnippetEditorFields.defaultProps = {
 	replacementVariables: [],
+	recommendedReplacementVariables: [],
 	onFocus: () => {},
 	onBlur: () => {},
+	onReplacementVariableSearchChange: null,
+	activeField: null,
+	hoveredField: null,
 	titleLengthProgress: {
 		max: 600,
 		actual: 0,
@@ -409,6 +416,7 @@ SnippetEditorFields.defaultProps = {
 		actual: 0,
 		score: 0,
 	},
+	descriptionEditorFieldPlaceholder: null,
 	containerPadding: "0 20px",
 	titleInputId: "yoast-google-preview-title",
 	slugInputId: "yoast-google-preview-slug",

--- a/packages/search-metadata-previews/src/snippet-editor/SnippetEditorFields.js
+++ b/packages/search-metadata-previews/src/snippet-editor/SnippetEditorFields.js
@@ -344,6 +344,7 @@ class SnippetEditorFields extends React.Component {
 					recommendedReplacementVariables={ recommendedReplacementVariables }
 					content={ description }
 					onChange={ this.onChangeDescription }
+					onSearchChange={ onReplacementVariableSearchChange }
 					fieldId={ descriptionInputId }
 				/>
 				<ProgressBar

--- a/packages/social-metadata-forms/src/SocialMetadataPreviewForm.js
+++ b/packages/social-metadata-forms/src/SocialMetadataPreviewForm.js
@@ -160,6 +160,7 @@ class SocialMetadataPreviewForm extends Component {
 			descriptionInputPlaceholder,
 			onTitleChange,
 			onDescriptionChange,
+			onReplacementVariableSearchChange,
 			hoveredField,
 			activeField,
 			isPremium,
@@ -213,6 +214,7 @@ class SocialMetadataPreviewForm extends Component {
 					label={ titleEditorTitle }
 					onMouseEnter={ this.onTitleEnter }
 					onMouseLeave={ this.onLeave }
+					onSearchChange={ onReplacementVariableSearchChange }
 					isActive={ activeField === "title" }
 					isHovered={ hoveredField === "title" }
 					withCaret={ true }
@@ -231,6 +233,7 @@ class SocialMetadataPreviewForm extends Component {
 					label={ descEditorTitle }
 					onMouseEnter={ this.onDescriptionEnter }
 					onMouseLeave={ this.onLeave }
+					onSearchChange={ onReplacementVariableSearchChange }
 					isActive={ activeField === "description" }
 					isHovered={ hoveredField === "description" }
 					withCaret={ true }
@@ -251,6 +254,7 @@ SocialMetadataPreviewForm.propTypes = {
 	description: PropTypes.string.isRequired,
 	onTitleChange: PropTypes.func.isRequired,
 	onDescriptionChange: PropTypes.func.isRequired,
+	onReplacementVariableSearchChange: PropTypes.func,
 	isPremium: PropTypes.bool,
 	hoveredField: PropTypes.string,
 	activeField: PropTypes.string,
@@ -274,6 +278,7 @@ SocialMetadataPreviewForm.defaultProps = {
 	hoveredField: "",
 	activeField: "",
 	onSelect: () => {},
+	onReplacementVariableSearchChange: null,
 	imageUrl: "",
 	imageAltText: "",
 	titleInputPlaceholder: "",

--- a/packages/social-metadata-previews/src/editor/SocialPreviewEditor.js
+++ b/packages/social-metadata-previews/src/editor/SocialPreviewEditor.js
@@ -134,6 +134,7 @@ class SocialPreviewEditor extends Component {
 			replacementVariables,
 			recommendedReplacementVariables,
 			applyReplacementVariables,
+			onReplacementVariableSearchChange,
 			isPremium,
 			isLarge,
 			socialPreviewLabel,
@@ -180,6 +181,7 @@ class SocialPreviewEditor extends Component {
 					imageWarnings={ imageWarnings }
 					replacementVariables={ replacementVariables }
 					recommendedReplacementVariables={ recommendedReplacementVariables }
+					onReplacementVariableSearchChange={ onReplacementVariableSearchChange }
 					onMouseHover={ this.setHoveredField }
 					hoveredField={ this.state.hoveredField }
 					onSelect={ this.setActiveField }
@@ -215,6 +217,7 @@ SocialPreviewEditor.propTypes = {
 	replacementVariables: replacementVariablesShape,
 	recommendedReplacementVariables: recommendedReplacementVariablesShape,
 	applyReplacementVariables: PropTypes.func,
+	onReplacementVariableSearchChange: PropTypes.func,
 	socialPreviewLabel: PropTypes.string,
 	idSuffix: PropTypes.string,
 	activeMetaTabId: PropTypes.string,
@@ -233,6 +236,7 @@ SocialPreviewEditor.defaultProps = {
 	titlePreviewFallback: "",
 	alt: "",
 	applyReplacementVariables: data => data,
+	onReplacementVariableSearchChange: null,
 	socialPreviewLabel: "",
 	idSuffix: "",
 	activeMetaTabId: "",

--- a/src/integrations/third-party/elementor.php
+++ b/src/integrations/third-party/elementor.php
@@ -718,9 +718,25 @@ class Elementor implements Integration_Interface {
 
 		$custom_fields = \get_post_custom( $post->ID );
 
+		// Simply concatenate all fields containing replace vars so we can handle them all with a single regex find.
+		$replace_vars_fields = implode(
+			' ',
+			[
+				YoastSEO()->meta->for_post( $post->ID )->presentation->title,
+				YoastSEO()->meta->for_post( $post->ID )->presentation->meta_description,
+			]
+		);
+
+		preg_match_all( '/%%cf_([A-Za-z0-9_]+)%%/', $replace_vars_fields, $matches );
+		$fields_to_include = $matches[1];
 		foreach ( $custom_fields as $custom_field_name => $custom_field ) {
 			// Skip private custom fields.
 			if ( \substr( $custom_field_name, 0, 1 ) === '_' ) {
+				continue;
+			}
+
+			// Skip custom fields that are not used, new ones will be fetched dynamically.
+			if ( ! in_array( $custom_field_name, $fields_to_include, true ) ) {
 				continue;
 			}
 

--- a/src/routes/meta-search-route.php
+++ b/src/routes/meta-search-route.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Yoast\WP\SEO\Routes;
+
+use WP_REST_Request;
+use WP_REST_Response;
+use Yoast\WP\SEO\Conditionals\No_Conditionals;
+use Yoast\WP\SEO\Main;
+
+class Meta_Search_Route implements Route_Interface {
+
+	use No_Conditionals;
+
+	/**
+	 * Represents meta search route.
+	 *
+	 * @var string
+	 */
+	const META_SEARCH_ROUTE = '/meta/search';
+
+	/**
+	 * Registers routes with WordPress.
+	 *
+	 * @return void
+	 */
+	public function register_routes() {
+		$route = [
+			[
+				'methods'             => 'GET',
+				'callback'            => [ $this, 'search_meta' ],
+				'permission_callback' => [ $this, 'permission_check' ],
+			],
+		];
+
+		\register_rest_route( Main::API_V1_NAMESPACE, self::META_SEARCH_ROUTE, $route );
+	}
+
+	/**
+	 * Performs the permission check.
+	 *
+	 * @param WP_REST_Request $request The request.
+	 *
+	 * @return bool
+	 */
+	public function permission_check( $request ) {
+		if ( ! isset( $request['post_id'] ) ) {
+			return false;
+		}
+
+		$post_type        = \get_post_type( $request['post_id'] );
+		$post_type_object = \get_post_type_object( $post_type );
+
+		return \current_user_can( $post_type_object->cap->edit_posts );
+	}
+
+	/**
+	 * Searches meta fields of a given post.
+	 *
+	 * @param WP_REST_Request $request The REST request.
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function search_meta( $request ) {
+		$post_id = $request['post_id'];
+		$query   = $request['query'];
+		$meta    = \get_post_custom( $post_id );
+		$matches = [];
+
+		foreach ( $meta as $key => $values ) {
+			if ( \substr( $key, 0, \strlen( $query ) ) !== $query ) {
+				continue;
+			}
+
+			if ( empty( $query ) && \substr( $key, 0, 1 ) === '_' ) {
+				continue;
+			}
+
+			// Skip custom field values that are serialized.
+			if ( \is_serialized( $values[0] ) ) {
+				continue;
+			}
+
+			$matches[] = [
+				'key'   => $key,
+				'value' => $values[0],
+			];
+
+			if ( \count( $matches ) >= 3 ) {
+				break;
+			}
+		}
+
+		return \rest_ensure_response(
+			[
+				'meta' => $matches,
+			]
+		);
+	}
+}

--- a/src/routes/meta-search-route.php
+++ b/src/routes/meta-search-route.php
@@ -88,7 +88,7 @@ class Meta_Search_Route implements Route_Interface {
 				'value' => $values[0],
 			];
 
-			if ( \count( $matches ) >= 3 ) {
+			if ( \count( $matches ) >= 25 ) {
 				break;
 			}
 		}

--- a/src/routes/meta-search-route.php
+++ b/src/routes/meta-search-route.php
@@ -90,10 +90,6 @@ class Meta_Search_Route implements Route_Interface {
 			}
 		}
 
-		return \rest_ensure_response(
-			[
-				'meta' => $matches,
-			]
-		);
+		return \rest_ensure_response( [ 'meta' => $matches ] );
 	}
 }

--- a/src/routes/meta-search-route.php
+++ b/src/routes/meta-search-route.php
@@ -7,6 +7,9 @@ use WP_REST_Response;
 use Yoast\WP\SEO\Conditionals\No_Conditionals;
 use Yoast\WP\SEO\Main;
 
+/**
+ * Meta_Search_Route class
+ */
 class Meta_Search_Route implements Route_Interface {
 
 	use No_Conditionals;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Fixes the social input fields.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->

This PR can be summarized in the following changelog entry:

* Fixes a performance issue in the meta description, SEO title and social meta field editors that would occur when very large amounts of custom fields were used.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

Test if this PR dynamically loads the custom fields:
* For this PR make sure premium is not active ( for test instructions for premium see https://github.com/Yoast/wordpress-seo-premium/pull/3641 )
* Create a very large amount of custom fields:
```
$post_id = YOUR_POST_ID;
for ( $i = 0; $i < 99999; $i++ ) {
   add_post_meta( $post_id, wp_generate_password(), wp_generate_password() );
} 
```
* Open that post in your editor.
* Editing the meta description field should not be laggy.
* You should find all sorts of different custom fields if you start typing after using `%<field_name>` to create a replacement variable.
* Note that this should only happen after you stop typing, e.g. there should NOT be a request per character typed. This can be checked in the network tab, there should only be a single request half a second after you stop typing.
* Note that custom field replacement variables aren't supported in Elementor so there should be no changes in elementor.
* The same applies to the replacement variables used on taxonomy pages and the settings. All of these should work the same.
* This should also be tested for the social input fields ( such as the Twitter title ), on post pages you should be able to find custom fields and should follow the same logic as the meta description.

New post

* Create a new post
* Start typing a % in the meta description editor, there should be no custom fields popping up.
* Also check whether no search request is being sent to the server for a custom meta variable (we can't search for custom meta variables if there is not post ID yet). This can be checked in the network tab of the browser console.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [x] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Custom field replacement variables in the social input fields on posts in both classic and Gutenberg.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
