### PR TITLE
PC-375 - When the google preview tab is closed a console error appears and the actionable buttons dont work

### DIFF
--- a/packages/js/src/components/contentAnalysis/Results.js
+++ b/packages/js/src/components/contentAnalysis/Results.js
@@ -118,27 +118,13 @@ class Results extends Component {
 			inputField = "slug";
 		}
 
-		// Open the Google Preview collapsible first (for when it is closed).
-		const googlePreviewCollapsible = document.getElementById( "yoast-snippet-editor-metabox" );
-		googlePreviewCollapsible.click();
-
-		/**
-		 * Focuses the Google Preview field (as defined in `inputLField` and `inputFieldLocation`).
-		 *
-		 * @returns {void}
-		 */
-		const focusGooglePreviewField = () => {
-			const element = document.getElementById( "yoast-google-preview-" + inputField + "-" + inputFieldLocation );
-			element.focus();
-			element.scrollIntoView( {
-				behavior: "auto",
-				block: "center",
-				inline: "center",
-			} );
-		};
-
-		// Wait a bit to be sure that the collapsible is opened and fully loaded.
-		setTimeout( focusGooglePreviewField, 100 );
+		const element = document.getElementById( "yoast-google-preview-" + inputField + "-" + inputFieldLocation );
+		element.focus();
+		element.scrollIntoView( {
+			behavior: "auto",
+			block: "center",
+			inline: "center",
+		} );
 	}
 
 	/**
@@ -168,7 +154,10 @@ class Results extends Component {
 			// Wait for the input field elements to become available, then focus on the relevant field.
 			setTimeout( () => this.focusOnGooglePreviewField( id, inputFieldLocation ), 500 );
 		} else {
-			this.focusOnGooglePreviewField( id, inputFieldLocation );
+			// Open the Google Preview collapsible first (for when it is closed).
+			const googlePreviewCollapsible = document.getElementById( "yoast-snippet-editor-metabox" );
+			googlePreviewCollapsible.click();
+			setTimeout( () => this.focusOnGooglePreviewField( id, inputFieldLocation ), 100 );
 		}
 	}
 

--- a/packages/js/src/components/contentAnalysis/Results.js
+++ b/packages/js/src/components/contentAnalysis/Results.js
@@ -118,13 +118,27 @@ class Results extends Component {
 			inputField = "slug";
 		}
 
-		const element = document.getElementById( "yoast-google-preview-" + inputField + "-" + inputFieldLocation );
-		element.focus();
-		element.scrollIntoView( {
-			behavior: "auto",
-			block: "center",
-			inline: "center",
-		} );
+		// Open the Google Preview collapsible first (for when it is closed).
+		const googlePreviewCollapsible = document.getElementById( "yoast-snippet-editor-metabox" );
+		googlePreviewCollapsible.click();
+
+		/**
+		 * Focuses the Google Preview field (as defined in `inputLField` and `inputFieldLocation`).
+		 *
+		 * @returns {void}
+		 */
+		const focusGooglePreviewField = () => {
+			const element = document.getElementById( "yoast-google-preview-" + inputField + "-" + inputFieldLocation );
+			element.focus();
+			element.scrollIntoView( {
+				behavior: "auto",
+				block: "center",
+				inline: "center",
+			} );
+		};
+
+		// Wait a bit to be sure that the collapsible is opened and fully loaded.
+		setTimeout( focusGooglePreviewField, 100 );
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes SEO title, meta description or slug field not being focused when the Google Preview collapsible in the metabox is closed and a user clicks on an respective edit button next to an assessment.


## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Create or open a post.
* Enter a focus keyphrase.
* Leave or make the SEO title and meta description empty, and make sure that the post's slug does not contain the focus keyphrase.
* Close the Google Preview collapsible inside of the metabox.
* In the SEO analysis results inside of the metabox, click on edit button next to the result of the _Keyphrase in SEO title_ assessment.
* This should open the previously closed Google Preview collapsible and focus the SEO title field.
* Follow the same steps for the following assessments:
   * _Meta description length_.
   * _Keyphrase in slug_.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
   * You should **not** see [the error described in the issue](https://yoast.atlassian.net/browse/PC-375).  
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [x] Changes should be tested on different editors (Block/Classic/Elementor/other)
   * Only in editors where we show the metabox (Block, Classic, Gutenberg).  
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes #
