### PR TITLE
QA: fix incorrect output escaping

### DIFF
--- a/inc/class-addon-manager.php
+++ b/inc/class-addon-manager.php
@@ -367,7 +367,7 @@ class WPSEO_Addon_Manager {
 		if ( $subscription && $this->has_subscription_expired( $subscription ) ) {
 			echo '<br><br>';
 			/* translators: %1$s is the plugin name, %2$s and %3$s are a link. */
-			echo '<strong><span class="wp-ui-text-notification alert dashicons dashicons-warning"></span> ' . sprintf( esc_html__( 'A new version of %1$s is available. %2$sRenew your subscription%3$s if you want to update to the latest version.', 'wordpress-seo' ), esc_html( $plugin_data['name'] ), '<a href="' . esc_attr( WPSEO_Shortlinker::get( 'https://yoa.st/4ey' ) ) . '">', '</a>' ) . '</strong>';
+			echo '<strong><span class="wp-ui-text-notification alert dashicons dashicons-warning"></span> ' . sprintf( esc_html__( 'A new version of %1$s is available. %2$sRenew your subscription%3$s if you want to update to the latest version.', 'wordpress-seo' ), esc_html( $plugin_data['name'] ), '<a href="' . esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/4ey' ) ) . '">', '</a>' ) . '</strong>';
 		}
 	}
 

--- a/src/schema-templates/cooking-time.block.php
+++ b/src/schema-templates/cooking-time.block.php
@@ -9,7 +9,7 @@ use Yoast\WP\SEO\Schema_Templates\Assets\Icons;
 
 // phpcs:disable WordPress.Security.EscapeOutput -- Reason: The Icons contains safe svg.
 ?>
-{{block name="yoast/cooking-time" title="<?php esc_attr_e( 'Recipe cooking time', 'wordpress-seo' ); ?>" category="yoast-structured-data-blocks" parent=[ "yoast/recipe" ] description="<?php esc_html_e( 'The time it takes to actually cook the dish.', 'wordpress-seo' ); ?>" icon="<?php echo Icons::heroicons_clock(); ?>" supports={"multiple": false} }}
+{{block name="yoast/cooking-time" title="<?php esc_attr_e( 'Recipe cooking time', 'wordpress-seo' ); ?>" category="yoast-structured-data-blocks" parent=[ "yoast/recipe" ] description="<?php esc_attr_e( 'The time it takes to actually cook the dish.', 'wordpress-seo' ); ?>" icon="<?php echo Icons::heroicons_clock(); ?>" supports={"multiple": false} }}
 <div class={{class-name}}>
 	{{heading name="title" default-heading-level=3 tags=[ "h2", "h3", "h4", "h5", "h6", "strong" ] default="<?php esc_attr_e( 'Cooking time', 'wordpress-seo' ); ?>" }}
 	{{duration name="cooking-time" }}

--- a/src/schema-templates/preparation-time.block.php
+++ b/src/schema-templates/preparation-time.block.php
@@ -9,7 +9,7 @@ use Yoast\WP\SEO\Schema_Templates\Assets\Icons;
 
 // phpcs:disable WordPress.Security.EscapeOutput -- Reason: The Icons contains safe svg.
 ?>
-{{block name="yoast/preparation-time" title="<?php esc_attr_e( 'Recipe prep time', 'wordpress-seo' ); ?>" category="yoast-structured-data-blocks" parent=[ "yoast/recipe" ] description="<?php esc_html_e( 'The time it takes to prepare the items to be used in the instructions.', 'wordpress-seo' ); ?>" icon="<?php echo Icons::heroicons_clock(); ?>" supports={"multiple": false} }}
+{{block name="yoast/preparation-time" title="<?php esc_attr_e( 'Recipe prep time', 'wordpress-seo' ); ?>" category="yoast-structured-data-blocks" parent=[ "yoast/recipe" ] description="<?php esc_attr_e( 'The time it takes to prepare the items to be used in the instructions.', 'wordpress-seo' ); ?>" icon="<?php echo Icons::heroicons_clock(); ?>" supports={"multiple": false} }}
 <div class={{class-name}}>
 	{{heading name="title" default-heading-level=3 tags=[ "h2", "h3", "h4", "h5", "h6", "strong" ] default="<?php esc_attr_e( 'Prep time', 'wordpress-seo' ); ?>" }}
 	{{duration name="preparation-time" }}


### PR DESCRIPTION
## Context

* Minor security improvement

## Summary

This PR can be summarized in the following changelog entry:

* Minor security improvement

## Relevant technical choices:

### QA: use the correct escaping function [1]

HTML attributes should be escaped using `esc_attr*()` functions, not `esc_html*()`.

### QA: use the correct escaping function [2]

URLs in HTML attributes should be escaped using `esc_url()` functions, not `esc_attr()`.


## Test instructions

This PR can be tested by following these steps:
* _N/A_ Functionally, there should be no noticeable difference
