### PR TITLE
QA: no reserved keyword as function parameter names

### DIFF
--- a/src/builders/indexable-post-builder.php
+++ b/src/builders/indexable-post-builder.php
@@ -413,15 +413,15 @@ class Indexable_Post_Builder {
 	/**
 	 * Transforms an empty string into null. Leaves non-empty strings intact.
 	 *
-	 * @param string $string The string.
+	 * @param string $text The string.
 	 *
 	 * @return string|null The input string or null.
 	 */
-	protected function empty_string_to_null( $string ) {
-		if ( ! \is_string( $string ) || $string === '' ) {
+	protected function empty_string_to_null( $text ) {
+		if ( ! \is_string( $text ) || $text === '' ) {
 			return null;
 		}
 
-		return $string;
+		return $text;
 	}
 }

--- a/src/integrations/front-end/robots-txt-integration.php
+++ b/src/integrations/front-end/robots-txt-integration.php
@@ -52,13 +52,13 @@ class Robots_Txt_Integration implements Integration_Interface {
 	 * Filters the robots.txt output.
 	 *
 	 * @param string $robots_txt The robots.txt output from WordPress.
-	 * @param string $public     Option that says whether the site is public or not.
+	 * @param string $is_public  Option that says whether the site is public or not.
 	 *
 	 * @return string $output Filtered robots.txt output.
 	 */
-	public function filter_robots( $robots_txt, $public ) {
+	public function filter_robots( $robots_txt, $is_public ) {
 		// If the site isn't public, bail.
-		if ( $public === '0' ) {
+		if ( $is_public === '0' ) {
 			return $robots_txt;
 		}
 

--- a/src/integrations/third-party/wordproof.php
+++ b/src/integrations/third-party/wordproof.php
@@ -154,10 +154,10 @@ class Wordproof implements Integration_Interface {
 	/**
 	 * Return the Yoast post meta key for the SDK to determine if the post should be timestamped.
 	 *
-	 * @param array $array The array containing meta keys that should be used.
+	 * @param array $meta_keys The array containing meta keys that should be used.
 	 * @return array
 	 */
-	public function add_post_meta_key( $array ) {
+	public function add_post_meta_key( $meta_keys ) {
 		return [ $this->post_meta_key ];
 	}
 

--- a/src/integrations/third-party/wordproof.php
+++ b/src/integrations/third-party/wordproof.php
@@ -164,10 +164,10 @@ class Wordproof implements Integration_Interface {
 	/**
 	 * Return an empty array to disable automatically timestamping selected post types.
 	 *
-	 * @param array $array The array containing post types that should be automatically timestamped.
+	 * @param array $post_types The array containing post types that should be automatically timestamped.
 	 * @return array
 	 */
-	public function wordproof_timestamp_post_types( $array ) {
+	public function wordproof_timestamp_post_types( $post_types ) {
 		return [];
 	}
 

--- a/src/presenters/score-icon-presenter.php
+++ b/src/presenters/score-icon-presenter.php
@@ -15,21 +15,21 @@ class Score_Icon_Presenter extends Abstract_Presenter {
 	protected $title;
 
 	/**
-	 * Holds the class.
+	 * Holds the CSS class.
 	 *
 	 * @var string
 	 */
-	protected $class;
+	protected $css_class;
 
 	/**
 	 * Constructs a Score_Icon_Presenter.
 	 *
-	 * @param string $title The title and screen reader text.
-	 * @param string $class The class.
+	 * @param string $title     The title and screen reader text.
+	 * @param string $css_class The CSS class.
 	 */
-	public function __construct( $title, $class ) {
-		$this->title = $title;
-		$this->class = $class;
+	public function __construct( $title, $css_class ) {
+		$this->title     = $title;
+		$this->css_class = $css_class;
 	}
 
 	/**
@@ -42,7 +42,7 @@ class Score_Icon_Presenter extends Abstract_Presenter {
 			'<div aria-hidden="true" title="%1$s" class="wpseo-score-icon %3$s"><span class="wpseo-score-text screen-reader-text">%2$s</span></div>',
 			\esc_attr( $this->title ),
 			\esc_html( $this->title ),
-			\esc_attr( $this->class )
+			\esc_attr( $this->css_class )
 		);
 	}
 }

--- a/tests/unit/presenters/score-icon-presenter-test.php
+++ b/tests/unit/presenters/score-icon-presenter-test.php
@@ -31,7 +31,7 @@ class Score_Icon_Presenter_Test extends TestCase {
 		$instance = new Score_Icon_Presenter( 'foo', 'bar' );
 
 		$this->assertSame( 'foo', $this->getPropertyValue( $instance, 'title' ) );
-		$this->assertSame( 'bar', $this->getPropertyValue( $instance, 'class' ) );
+		$this->assertSame( 'bar', $this->getPropertyValue( $instance, 'css_class' ) );
 	}
 
 	/**
@@ -41,12 +41,12 @@ class Score_Icon_Presenter_Test extends TestCase {
 	 *
 	 * @covers ::present
 	 *
-	 * @param string $title    The title and screen reader text.
-	 * @param string $class    The class.
-	 * @param string $expected The expected present output.
+	 * @param string $title     The title and screen reader text.
+	 * @param string $css_class The CSS class.
+	 * @param string $expected  The expected present output.
 	 */
-	public function test_present( $title, $class, $expected ) {
-		$instance = new Score_Icon_Presenter( $title, $class );
+	public function test_present( $title, $css_class, $expected ) {
+		$instance = new Score_Icon_Presenter( $title, $css_class );
 
 		$this->assertEquals( $expected, $instance->present() );
 	}
@@ -59,19 +59,19 @@ class Score_Icon_Presenter_Test extends TestCase {
 	public function present_provider() {
 		return [
 			'title and class' => [
-				'title'    => 'title',
-				'class'    => 'class',
-				'expected' => '<div aria-hidden="true" title="title" class="wpseo-score-icon class"><span class="wpseo-score-text screen-reader-text">title</span></div>',
+				'title'     => 'title',
+				'css_class' => 'class',
+				'expected'  => '<div aria-hidden="true" title="title" class="wpseo-score-icon class"><span class="wpseo-score-text screen-reader-text">title</span></div>',
 			],
 			'empty title' => [
-				'title'    => '',
-				'class'    => 'class',
-				'expected' => '<div aria-hidden="true" title="" class="wpseo-score-icon class"><span class="wpseo-score-text screen-reader-text"></span></div>',
+				'title'     => '',
+				'css_class' => 'class',
+				'expected'  => '<div aria-hidden="true" title="" class="wpseo-score-icon class"><span class="wpseo-score-text screen-reader-text"></span></div>',
 			],
 			'empty class' => [
-				'title'    => 'title',
-				'class'    => '',
-				'expected' => '<div aria-hidden="true" title="title" class="wpseo-score-icon "><span class="wpseo-score-text screen-reader-text">title</span></div>',
+				'title'     => 'title',
+				'css_class' => '',
+				'expected'  => '<div aria-hidden="true" title="title" class="wpseo-score-icon "><span class="wpseo-score-text screen-reader-text">title</span></div>',
 			],
 		];
 	}


### PR DESCRIPTION
## Context

* Improves compatibility with PHP 8.0

## Summary

This PR can be summarized in the following changelog entry:

* Improves compatibility with PHP 8.0


## Relevant technical choices:

Follow up on the previously addressed list of reserved keywords being used as param names.

This fixes a number of newly introduced issues.


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality. If the build passes (linting, test runs), we're good.
