### PR TITLE
CS: various doc fixes

### DIFF
--- a/admin/class-database-proxy.php
+++ b/admin/class-database-proxy.php
@@ -73,8 +73,8 @@ class WPSEO_Database_Proxy {
 	/**
 	 * Inserts data into the database.
 	 *
-	 * @param array $data   Data to insert.
-	 * @param null  $format Formats for the data.
+	 * @param array             $data   Data to insert.
+	 * @param array|string|null $format Formats for the data.
 	 *
 	 * @return false|int Total amount of inserted rows or false on error.
 	 */
@@ -91,10 +91,10 @@ class WPSEO_Database_Proxy {
 	/**
 	 * Updates data in the database.
 	 *
-	 * @param array $data         Data to update on the table.
-	 * @param array $where        Where condition as key => value array.
-	 * @param null  $format       Optional. Data prepare format.
-	 * @param null  $where_format Optional. Where prepare format.
+	 * @param array             $data         Data to update on the table.
+	 * @param array             $where        Where condition as key => value array.
+	 * @param array|string|null $format       Optional. Data prepare format.
+	 * @param array|string|null $where_format Optional. Where prepare format.
 	 *
 	 * @return false|int False when the update request is invalid, int on number of rows changed.
 	 */
@@ -113,10 +113,10 @@ class WPSEO_Database_Proxy {
 	 *
 	 * Performs an insert into and if key is duplicate it will update the existing record.
 	 *
-	 * @param array      $data         Data to update on the table.
-	 * @param array|null $where        Unused. Where condition as key => value array.
-	 * @param null       $format       Optional. Data prepare format.
-	 * @param null       $where_format Deprecated. Where prepare format.
+	 * @param array             $data         Data to update on the table.
+	 * @param array|null        $where        Unused. Where condition as key => value array.
+	 * @param array|string|null $format       Optional. Data prepare format.
+	 * @param array|string|null $where_format Optional. Where prepare format.
 	 *
 	 * @return false|int False when the upsert request is invalid, int on number of rows changed.
 	 */
@@ -158,8 +158,8 @@ class WPSEO_Database_Proxy {
 	/**
 	 * Deletes a record from the database.
 	 *
-	 * @param array      $where  Where clauses for the query.
-	 * @param array|null $format Formats for the data.
+	 * @param array             $where  Where clauses for the query.
+	 * @param array|string|null $format Formats for the data.
 	 *
 	 * @return false|int
 	 */

--- a/admin/class-inclusive-language-notice.php
+++ b/admin/class-inclusive-language-notice.php
@@ -36,7 +36,7 @@ class WPSEO_Inclusive_Language_Notice {
 	/**
 	 * WPSEO_Inclusive_Language_Notice constructor.
 	 *
-	 * @param Yoast_Notification_Center $notification_center  The notification center to add notifications to.
+	 * @param Yoast_Notification_Center $notification_center The notification center to add notifications to.
 	 */
 	public function __construct( Yoast_Notification_Center $notification_center ) {
 		$this->notification_center = $notification_center;

--- a/inc/options/class-wpseo-option-wpseo.php
+++ b/inc/options/class-wpseo-option-wpseo.php
@@ -431,10 +431,8 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 
 
 				/*
-				* Boolean (checkbox) fields.
-				*/
-
-				/*
+				 * Boolean (checkbox) fields.
+				 *
 				 * Covers:
 				 *  'disableadvanced_meta'
 				 *  'enable_headless_rest_endpoints'

--- a/inc/sitemaps/class-sitemap-image-parser.php
+++ b/inc/sitemaps/class-sitemap-image-parser.php
@@ -288,8 +288,8 @@ class WPSEO_Sitemap_Image_Parser {
 	/**
 	 * Get image item array with filters applied.
 	 *
-	 * @param WP_Post $post  Post object for the context.
-	 * @param string  $src   Image URL.
+	 * @param WP_Post $post Post object for the context.
+	 * @param string  $src  Image URL.
 	 *
 	 * @return array
 	 */

--- a/src/actions/configuration/first-time-configuration-action.php
+++ b/src/actions/configuration/first-time-configuration-action.php
@@ -154,7 +154,7 @@ class First_Time_Configuration_Action {
 	/**
 	 * Gets the values for the social profiles.
 	 *
-	 * @param int $user_id the person id.
+	 * @param int $user_id The person ID.
 	 *
 	 * @return object The response object.
 	 */

--- a/src/actions/importing/aioseo/aioseo-cleanup-action.php
+++ b/src/actions/importing/aioseo/aioseo-cleanup-action.php
@@ -46,8 +46,8 @@ class Aioseo_Cleanup_Action extends Abstract_Aioseo_Importing_Action {
 	/**
 	 * Class constructor.
 	 *
-	 * @param wpdb           $wpdb        The WordPress database instance.
-	 * @param Options_Helper $options     The options helper.
+	 * @param wpdb           $wpdb    The WordPress database instance.
+	 * @param Options_Helper $options The options helper.
 	 */
 	public function __construct(
 		wpdb $wpdb,

--- a/src/actions/importing/aioseo/aioseo-validate-data-action.php
+++ b/src/actions/importing/aioseo/aioseo-validate-data-action.php
@@ -101,7 +101,7 @@ class Aioseo_Validate_Data_Action extends Abstract_Aioseo_Importing_Action {
 	/**
 	 * Validates AIOSEO data.
 	 *
-	 * @return array|false An array of validated data or false if aioseo data did not pass validation.
+	 * @return array An array of validated data or false if aioseo data did not pass validation.
 	 *
 	 * @throws Aioseo_Validation_Exception If the validation fails.
 	 */

--- a/src/config/oauth-client.php
+++ b/src/config/oauth-client.php
@@ -205,7 +205,7 @@ abstract class OAuth_Client {
 	/**
 	 * Clears the stored token from storage.
 	 *
-	 * @return boolean The stored token.
+	 * @return bool The stored token.
 	 *
 	 * @throws Failed_Storage_Exception Exception thrown if clearing of the token fails.
 	 */

--- a/src/config/wordproof-app-config.php
+++ b/src/config/wordproof-app-config.php
@@ -23,7 +23,7 @@ class Wordproof_App_Config extends DefaultAppConfig {
 	/**
 	 * Returns if the WordProof Uikit should be loaded from a cdn.
 	 *
-	 * @return boolean True or false.
+	 * @return bool True or false.
 	 */
 	public function getLoadUikitFromCdn() {
 		return false;

--- a/src/deprecated/admin/ryte/class-ryte-option.php
+++ b/src/deprecated/admin/ryte/class-ryte-option.php
@@ -92,7 +92,7 @@ class WPSEO_Ryte_Option {
 	 * @deprecated 19.6
 	 * @codeCoverageIgnore
 	 *
-	 * @return integer|string
+	 * @return int|string
 	 */
 	public function get_status() {
 		if ( array_key_exists( self::STATUS, $this->ryte_option ) ) {

--- a/src/deprecated/src/services/health-check/ryte-check.php
+++ b/src/deprecated/src/services/health-check/ryte-check.php
@@ -30,7 +30,7 @@ class Ryte_Check extends Health_Check {
 	 * @deprecated 19.6
 	 * @codeCoverageIgnore
 	 *
-	 * @param Ryte_Runner  $runner The object that implements the actual health check.
+	 * @param Ryte_Runner  $runner  The object that implements the actual health check.
 	 * @param Ryte_Reports $reports The object that generates WordPress-friendly results.
 	 * @return void
 	 */

--- a/src/deprecated/src/services/health-check/ryte-reports.php
+++ b/src/deprecated/src/services/health-check/ryte-reports.php
@@ -29,8 +29,10 @@ class Ryte_Reports {
 	 * @deprecated 19.6
 	 * @codeCoverageIgnore
 	 *
-	 * @param  Report_Builder_Factory $report_builder_factory The factory for result builder objects. This class uses the report builder to generate WordPress-friendly health check results.
-	 * @param  WPSEO_Shortlinker      $shortlinker The WPSEO_Shortlinker object used to generate short links.
+	 * @param  Report_Builder_Factory $report_builder_factory The factory for result builder objects.
+	 *                                                        This class uses the report builder to generate WordPress-friendly
+	 *                                                        health check results.
+	 * @param  WPSEO_Shortlinker      $shortlinker            The WPSEO_Shortlinker object used to generate short links.
 	 * @return void
 	 */
 	public function __construct(

--- a/src/deprecated/src/services/health-check/ryte-runner.php
+++ b/src/deprecated/src/services/health-check/ryte-runner.php
@@ -55,7 +55,7 @@ class Ryte_Runner implements Runner_Interface {
 	 * @deprecated 19.6
 	 * @codeCoverageIgnore
 	 *
-	 * @param Ryte_Integration $ryte The Ryte_Integration object that the health check uses to check indexability.
+	 * @param Ryte_Integration $ryte  The Ryte_Integration object that the health check uses to check indexability.
 	 * @param WPSEO_Utils      $utils The WPSEO_Utils object used to determine whether the site is in development mode.
 	 */
 	public function __construct(

--- a/src/generators/schema/third-party/coauthor.php
+++ b/src/generators/schema/third-party/coauthor.php
@@ -12,7 +12,7 @@ class CoAuthor extends Author {
 	/**
 	 * The user ID of the author we're generating data for.
 	 *
-	 * @var int $user_id
+	 * @var int
 	 */
 	private $user_id;
 

--- a/src/integrations/admin/crawl-settings-integration.php
+++ b/src/integrations/admin/crawl-settings-integration.php
@@ -180,7 +180,7 @@ class Crawl_Settings_Integration implements Integration_Interface {
 	 * Print the settings sections.
 	 *
 	 * @param Yoast_Form $yform      The Yoast form class.
-	 * @param boolean    $is_network Whether we're on the network site.
+	 * @param bool       $is_network Whether we're on the network site.
 	 *
 	 * @return void
 	 */
@@ -240,7 +240,7 @@ class Crawl_Settings_Integration implements Integration_Interface {
 	 *
 	 * @param array      $settings    The settings being displayed.
 	 * @param Yoast_Form $yform       The Yoast form class.
-	 * @param boolean    $is_network  Whether we're on the network site.
+	 * @param bool       $is_network  Whether we're on the network site.
 	 * @param string     $title       Optional title for the settings being displayed.
 	 * @param string     $description Optional description of the settings being displayed.
 	 * @param array      $toggles     Optional naming of the toggle buttons.

--- a/src/integrations/admin/crawl-settings-integration.php
+++ b/src/integrations/admin/crawl-settings-integration.php
@@ -179,8 +179,8 @@ class Crawl_Settings_Integration implements Integration_Interface {
 	/**
 	 * Print the settings sections.
 	 *
-	 * @param Yoast_Form $yform        The Yoast form class.
-	 * @param boolean    $is_network   Whether we're on the network site.
+	 * @param Yoast_Form $yform      The Yoast form class.
+	 * @param boolean    $is_network Whether we're on the network site.
 	 *
 	 * @return void
 	 */
@@ -238,12 +238,12 @@ class Crawl_Settings_Integration implements Integration_Interface {
 	/**
 	 * Prints a list of toggles for an array of settings with labels.
 	 *
-	 * @param array      $settings     The settings being displayed.
-	 * @param Yoast_Form $yform        The Yoast form class.
-	 * @param boolean    $is_network   Whether we're on the network site.
-	 * @param string     $title        Optional title for the settings being displayed.
-	 * @param string     $description  Optional description of the settings being displayed.
-	 * @param array      $toggles      Optional naming of the toggle buttons.
+	 * @param array      $settings    The settings being displayed.
+	 * @param Yoast_Form $yform       The Yoast form class.
+	 * @param boolean    $is_network  Whether we're on the network site.
+	 * @param string     $title       Optional title for the settings being displayed.
+	 * @param string     $description Optional description of the settings being displayed.
+	 * @param array      $toggles     Optional naming of the toggle buttons.
 	 *
 	 * @return void
 	 */

--- a/src/integrations/admin/deactivated-premium-integration.php
+++ b/src/integrations/admin/deactivated-premium-integration.php
@@ -140,7 +140,7 @@ class Deactivated_Premium_Integration implements Integration_Interface {
 	 *
 	 * @param string $premium_file The premium file.
 	 *
-	 * @return boolean Whether or not premium is installed and not activated.
+	 * @return bool Whether or not premium is installed and not activated.
 	 */
 	protected function premium_is_installed_not_activated( $premium_file ) {
 		return (

--- a/src/integrations/admin/first-time-configuration-integration.php
+++ b/src/integrations/admin/first-time-configuration-integration.php
@@ -312,7 +312,7 @@ class First_Time_Configuration_Integration implements Integration_Interface {
 	 *
 	 * @param string $company_name The given company name by the user, default empty string.
 	 *
-	 * @return string The company name.
+	 * @return string|false The company name.
 	 */
 	private function get_fallback_company_name( $company_name ) {
 		if ( $company_name ) {
@@ -345,7 +345,7 @@ class First_Time_Configuration_Integration implements Integration_Interface {
 	 *
 	 * @param string $company_logo The given company logo by the user, default empty.
 	 *
-	 * @return {boolean | string} The company logo URL.
+	 * @return string|false The company logo URL.
 	 */
 	private function get_company_fallback_logo( $company_logo ) {
 		if ( $company_logo ) {
@@ -393,7 +393,7 @@ class First_Time_Configuration_Integration implements Integration_Interface {
 	 *
 	 * @param string $person_logo The given person logo by the user, default empty.
 	 *
-	 * @return {boolean | string} The person logo URL.
+	 * @return string|false The person logo URL.
 	 */
 	private function get_person_fallback_logo( $person_logo ) {
 		if ( $person_logo ) {

--- a/src/integrations/admin/social-profiles-helper.php
+++ b/src/integrations/admin/social-profiles-helper.php
@@ -58,7 +58,7 @@ class Social_Profiles_Helper {
 	 * Gets the person social profiles stored in the database.
 	 *
 	 * @param int $person_id The id of the person.
-
+	 *
 	 * @return array The person's social profiles.
 	 */
 	public function get_person_social_profiles( $person_id ) {

--- a/src/integrations/front-end/redirects.php
+++ b/src/integrations/front-end/redirects.php
@@ -224,8 +224,8 @@ class Redirects implements Integration_Interface {
 	/**
 	 * Redirects away query variables that shouldn't work.
 	 *
-	 * @param array  $query_vars   The query variables in the current URL.
-	 * @param string $base_url     The base URL without query string.
+	 * @param array  $query_vars The query variables in the current URL.
+	 * @param string $base_url   The base URL without query string.
 	 *
 	 * @return void
 	 */

--- a/src/integrations/front-end/robots-txt-integration.php
+++ b/src/integrations/front-end/robots-txt-integration.php
@@ -54,7 +54,7 @@ class Robots_Txt_Integration implements Integration_Interface {
 	 * @param string $robots_txt The robots.txt output from WordPress.
 	 * @param string $public     Option that says whether the site is public or not.
 	 *
-	 * @return string $output Filtered robots.txt output.
+	 * @return string Filtered robots.txt output.
 	 */
 	public function filter_robots( $robots_txt, $public ) {
 		// If the site isn't public, bail.

--- a/src/integrations/settings-integration.php
+++ b/src/integrations/settings-integration.php
@@ -192,7 +192,7 @@ class Settings_Integration implements Integration_Interface {
 				'wpseo_dashboard',
 				'',
 				\sprintf(
-				// translators: %1$s expands to the opening span tag (styling). %2$s expands to the closing span tag.
+					/* translators: %1$s expands to the opening span tag (styling). %2$s expands to the closing span tag. */
 					\__( 'Settings %1$sBeta%2$s', 'wordpress-seo' ),
 					'<span class="yoast-badge yoast-beta-badge">',
 					'</span>'

--- a/src/integrations/third-party/wordproof-integration-toggle.php
+++ b/src/integrations/third-party/wordproof-integration-toggle.php
@@ -17,7 +17,7 @@ class Wordproof_Integration_Toggle implements Integration_Interface {
 	/**
 	 * The WordProof helper instance.
 	 *
-	 * @var Wordproof_Helper $wordproof The helper instance.
+	 * @var Wordproof_Helper
 	 */
 	protected $wordproof;
 

--- a/src/integrations/third-party/wordproof.php
+++ b/src/integrations/third-party/wordproof.php
@@ -46,7 +46,7 @@ class Wordproof implements Integration_Interface {
 	/**
 	 * The WordProof integration constructor.
 	 *
-	 * @param Wordproof_Helper          $wordproof The WordProof helper instance.
+	 * @param Wordproof_Helper          $wordproof     The WordProof helper instance.
 	 * @param WPSEO_Admin_Asset_Manager $asset_manager The WPSEO admin asset manager instance.
 	 */
 	public function __construct( Wordproof_Helper $wordproof, WPSEO_Admin_Asset_Manager $asset_manager = null ) {
@@ -237,9 +237,9 @@ class Wordproof implements Integration_Interface {
 	/**
 	 * Adds async to the wordproof-uikit script.
 	 *
-	 * @param string $tag The script tag for the enqueued script.
+	 * @param string $tag    The script tag for the enqueued script.
 	 * @param string $handle The script's registered handle.
-	 * @param string $src The script's source URL.
+	 * @param string $src    The script's source URL.
 	 *
 	 * @return string The script's tag.
 	 *

--- a/src/integrations/third-party/wordproof.php
+++ b/src/integrations/third-party/wordproof.php
@@ -32,7 +32,7 @@ class Wordproof implements Integration_Interface {
 	/**
 	 * The WordProof helper instance.
 	 *
-	 * @var Wordproof_Helper $wordproof The helper instance.
+	 * @var Wordproof_Helper
 	 */
 	protected $wordproof;
 

--- a/src/services/health-check/curl-check.php
+++ b/src/services/health-check/curl-check.php
@@ -24,7 +24,7 @@ class Curl_Check extends Health_Check {
 	/**
 	 * Constructor.
 	 *
-	 * @param Curl_Runner  $runner The object that implements the actual health check.
+	 * @param Curl_Runner  $runner  The object that implements the actual health check.
 	 * @param Curl_Reports $reports The object that generates WordPress-friendly results.
 	 * @return void
 	 */

--- a/src/services/health-check/curl-reports.php
+++ b/src/services/health-check/curl-reports.php
@@ -22,8 +22,10 @@ class Curl_Reports {
 	/**
 	 * Constructor
 	 *
-	 * @param  Report_Builder_Factory $report_builder_factory The factory for result builder objects. This class uses the report builder to generate WordPress-friendly health check results.
-	 * @param  WPSEO_Shortlinker      $shortlinker The WPSEO_Shortlinker object used to generate short links.
+	 * @param  Report_Builder_Factory $report_builder_factory The factory for result builder objects.
+	 *                                                        This class uses the report builder to generate WordPress-friendly
+	 *                                                        health check results.
+	 * @param  WPSEO_Shortlinker      $shortlinker            The WPSEO_Shortlinker object used to generate short links.
 	 * @return void
 	 */
 	public function __construct(

--- a/src/services/health-check/curl-runner.php
+++ b/src/services/health-check/curl-runner.php
@@ -73,9 +73,10 @@ class Curl_Runner implements Runner_Interface {
 	 * Constructor.
 	 *
 	 * @psalm-suppress InvalidClass MyYoast is a product name, so it's an exception to the class naming conventions.
-	 * @param WPSEO_Addon_Manager         $addon_manager The add-on manager.
+	 * @param WPSEO_Addon_Manager         $addon_manager                The add-on manager.
 	 * @param MyYoast_Api_Request_Factory $my_yoast_api_request_factory A MyYoast API request object.
-	 * @param Curl_Helper                 $curl_helper A cURL helper object for obtaining cURL installation information.
+	 * @param Curl_Helper                 $curl_helper                  A cURL helper object for obtaining
+	 *                                                                  cURL installation information.
 	 */
 	public function __construct(
 		WPSEO_Addon_Manager $addon_manager,

--- a/src/services/health-check/default-tagline-check.php
+++ b/src/services/health-check/default-tagline-check.php
@@ -24,7 +24,7 @@ class Default_Tagline_Check extends Health_Check {
 	/**
 	 * Constructor.
 	 *
-	 * @param  Default_Tagline_Runner  $runner The object that implements the actual health check.
+	 * @param  Default_Tagline_Runner  $runner  The object that implements the actual health check.
 	 * @param  Default_Tagline_Reports $reports The object that generates WordPress-friendly results.
 	 * @return void
 	 */

--- a/src/services/health-check/default-tagline-reports.php
+++ b/src/services/health-check/default-tagline-reports.php
@@ -12,7 +12,9 @@ class Default_Tagline_Reports {
 	/**
 	 * Constructor
 	 *
-	 * @param  Report_Builder_Factory $report_builder_factory The factory for result builder objects. This class uses the report builder to generate WordPress-friendly health check results.
+	 * @param  Report_Builder_Factory $report_builder_factory The factory for result builder objects.
+	 *                                                        This class uses the report builder to generate WordPress-friendly
+	 *                                                        health check results.
 	 * @return void
 	 */
 	public function __construct( Report_Builder_Factory $report_builder_factory ) {

--- a/src/services/health-check/links-table-check.php
+++ b/src/services/health-check/links-table-check.php
@@ -24,7 +24,7 @@ class Links_Table_Check extends Health_Check {
 	/**
 	 * Constructor.
 	 *
-	 * @param Links_Table_Runner  $runner The object that implements the actual health check.
+	 * @param Links_Table_Runner  $runner  The object that implements the actual health check.
 	 * @param Links_Table_Reports $reports The object that generates WordPress-friendly results.
 	 * @return void
 	 */

--- a/src/services/health-check/links-table-reports.php
+++ b/src/services/health-check/links-table-reports.php
@@ -22,8 +22,10 @@ class Links_Table_Reports {
 	/**
 	 * Constructor
 	 *
-	 * @param  Report_Builder_Factory $report_builder_factory The factory for result builder objects. This class uses the report builder to generate WordPress-friendly health check results.
-	 * @param  WPSEO_Shortlinker      $shortlinker Object used to add short links to the report description.
+	 * @param  Report_Builder_Factory $report_builder_factory The factory for result builder objects.
+	 *                                                        This class uses the report builder to generate WordPress-friendly
+	 *                                                        health check results.
+	 * @param  WPSEO_Shortlinker      $shortlinker            Object used to add short links to the report description.
 	 * @return void
 	 */
 	public function __construct(

--- a/src/services/health-check/links-table-runner.php
+++ b/src/services/health-check/links-table-runner.php
@@ -35,7 +35,7 @@ class Links_Table_Runner implements Runner_Interface {
 	 * Constructor.
 	 *
 	 * @param Migration_Status $migration_status Object used to determine whether the links table is accessible.
-	 * @param Options_Helper   $options_helper Object used to determine whether the health check should run.
+	 * @param Options_Helper   $options_helper   Object used to determine whether the health check should run.
 	 */
 	public function __construct(
 		Migration_Status $migration_status,

--- a/src/services/health-check/myyoast-api-request-factory.php
+++ b/src/services/health-check/myyoast-api-request-factory.php
@@ -12,7 +12,7 @@ class MyYoast_Api_Request_Factory {
 	/**
 	 * Creates a new WPSEO_MyYoast_API_Request.
 	 *
-	 * @param string $url The URL for the request.
+	 * @param string $url  The URL for the request.
 	 * @param array  $args Optional arguments for the request.
 	 * @return WPSEO_MyYoast_Api_Request
 	 */

--- a/src/services/health-check/page-comments-check.php
+++ b/src/services/health-check/page-comments-check.php
@@ -24,7 +24,7 @@ class Page_Comments_Check extends Health_Check {
 	/**
 	 * Constructor.
 	 *
-	 * @param  Page_Comments_Runner  $runner The object that implements the actual health check.
+	 * @param  Page_Comments_Runner  $runner  The object that implements the actual health check.
 	 * @param  Page_Comments_Reports $reports The object that generates WordPress-friendly results.
 	 * @return void
 	 */

--- a/src/services/health-check/page-comments-reports.php
+++ b/src/services/health-check/page-comments-reports.php
@@ -12,7 +12,9 @@ class Page_Comments_Reports {
 	/**
 	 * Constructor.
 	 *
-	 * @param  Report_Builder_Factory $report_builder_factory The factory for result builder objects. This class uses the report builder to generate WordPress-friendly health check results.
+	 * @param  Report_Builder_Factory $report_builder_factory The factory for result builder objects.
+	 *                                                        This class uses the report builder to generate WordPress-friendly
+	 *                                                        health check results.
 	 */
 	public function __construct( Report_Builder_Factory $report_builder_factory ) {
 		$this->report_builder_factory = $report_builder_factory;

--- a/src/services/health-check/postname-permalink-check.php
+++ b/src/services/health-check/postname-permalink-check.php
@@ -24,7 +24,7 @@ class Postname_Permalink_Check extends Health_Check {
 	/**
 	 * Constructor.
 	 *
-	 * @param  Postname_Permalink_Runner  $runner The object that implements the actual health check.
+	 * @param  Postname_Permalink_Runner  $runner  The object that implements the actual health check.
 	 * @param  Postname_Permalink_Reports $reports The object that generates WordPress-friendly results.
 	 * @return void
 	 */

--- a/src/services/health-check/postname-permalink-reports.php
+++ b/src/services/health-check/postname-permalink-reports.php
@@ -12,7 +12,9 @@ class Postname_Permalink_Reports {
 	/**
 	 * Constructor.
 	 *
-	 * @param  Report_Builder_Factory $report_builder_factory The factory for result builder objects. This class uses the report builder to generate WordPress-friendly health check results.
+	 * @param  Report_Builder_Factory $report_builder_factory The factory for result builder objects.
+	 *                                                        This class uses the report builder to generate WordPress-friendly
+	 *                                                        health check results.
 	 */
 	public function __construct( Report_Builder_Factory $report_builder_factory ) {
 		$this->report_builder_factory = $report_builder_factory;

--- a/tests/unit/actions/configuration/first-time-configuration-action-test.php
+++ b/tests/unit/actions/configuration/first-time-configuration-action-test.php
@@ -369,13 +369,13 @@ class First_Time_Configuration_Action_Test extends TestCase {
 	/**
 	 * Tests the check_capability method.
 	 *
-	 * @param int    $user_id  The id of the user.
-	 * @param bool   $can_edit The result of the current_user_can call.
-	 * @param object $expected The expected result object.
-	 *
 	 * @covers ::check_capability
 	 *
 	 * @dataProvider check_capability_provider
+	 *
+	 * @param int    $user_id  The id of the user.
+	 * @param bool   $can_edit The result of the current_user_can call.
+	 * @param object $expected The expected result object.
 	 */
 	public function test_check_capability( $user_id, $can_edit, $expected ) {
 		$this->social_profiles_helper

--- a/tests/unit/actions/importing/aioseo-custom-archive-settings-importing-action-test.php
+++ b/tests/unit/actions/importing/aioseo-custom-archive-settings-importing-action-test.php
@@ -275,11 +275,11 @@ class Aioseo_Custom_Archive_Settings_Importing_Action_Test extends TestCase {
 	/**
 	 * Tests checking if the settings tab subsetting is set in the AIOSEO option.
 	 *
-	 * @param array $aioseo_settings The AIOSEO settings.
-	 * @param bool  $expected_result The expected result.
-	 *
 	 * @dataProvider provider_isset_settings_tab
 	 * @covers ::isset_settings_tab
+	 *
+	 * @param array $aioseo_settings The AIOSEO settings.
+	 * @param bool  $expected_result The expected result.
 	 */
 	public function test_isset_settings_tab( $aioseo_settings, $expected_result ) {
 		$isset_settings_tab = $this->instance->isset_settings_tab( $aioseo_settings );

--- a/tests/unit/actions/importing/aioseo-default-archive-settings-importing-action-test.php
+++ b/tests/unit/actions/importing/aioseo-default-archive-settings-importing-action-test.php
@@ -268,11 +268,11 @@ class Aioseo_Default_Archive_Settings_Importing_Action_Test extends TestCase {
 	/**
 	 * Tests checking if the settings tab subsetting is set in the AIOSEO option.
 	 *
-	 * @param array $aioseo_settings The AIOSEO settings.
-	 * @param bool  $expected_result The expected result.
-	 *
 	 * @dataProvider provider_isset_settings_tab
 	 * @covers ::isset_settings_tab
+	 *
+	 * @param array $aioseo_settings The AIOSEO settings.
+	 * @param bool  $expected_result The expected result.
 	 */
 	public function test_isset_settings_tab( $aioseo_settings, $expected_result ) {
 		$isset_settings_tab = $this->instance->isset_settings_tab( $aioseo_settings );

--- a/tests/unit/actions/importing/aioseo-general-settings-importing-action-test.php
+++ b/tests/unit/actions/importing/aioseo-general-settings-importing-action-test.php
@@ -292,11 +292,11 @@ class Aioseo_General_Settings_Importing_Action_Test extends TestCase {
 	/**
 	 * Tests checking if the settings tab subsetting is set in the AIOSEO option.
 	 *
-	 * @param array $aioseo_settings The AIOSEO settings.
-	 * @param bool  $expected_result The expected result.
-	 *
 	 * @dataProvider provider_isset_settings_tab
 	 * @covers ::isset_settings_tab
+	 *
+	 * @param array $aioseo_settings The AIOSEO settings.
+	 * @param bool  $expected_result The expected result.
 	 */
 	public function test_isset_settings_tab( $aioseo_settings, $expected_result ) {
 		$isset_settings_tab = $this->instance->isset_settings_tab( $aioseo_settings );

--- a/tests/unit/actions/importing/aioseo-posttype-defaults-settings-importing-action-test.php
+++ b/tests/unit/actions/importing/aioseo-posttype-defaults-settings-importing-action-test.php
@@ -306,11 +306,11 @@ class Aioseo_Posttype_Defaults_Settings_Importing_Action_Test extends TestCase {
 	/**
 	 * Tests checking if the settings tab subsetting is set in the AIOSEO option.
 	 *
-	 * @param array $aioseo_settings The AIOSEO settings.
-	 * @param bool  $expected_result The expected result.
-	 *
 	 * @dataProvider provider_isset_settings_tab
 	 * @covers ::isset_settings_tab
+	 *
+	 * @param array $aioseo_settings The AIOSEO settings.
+	 * @param bool  $expected_result The expected result.
 	 */
 	public function test_isset_settings_tab( $aioseo_settings, $expected_result ) {
 		$isset_settings_tab = $this->instance->isset_settings_tab( $aioseo_settings );

--- a/tests/unit/actions/importing/aioseo-taxonomy-settings-importing-action-test.php
+++ b/tests/unit/actions/importing/aioseo-taxonomy-settings-importing-action-test.php
@@ -369,11 +369,11 @@ class Aioseo_Taxonomy_Settings_Importing_Action_Test extends TestCase {
 	/**
 	 * Tests checking if the settings tab subsetting is set in the AIOSEO option.
 	 *
-	 * @param array $aioseo_settings The AIOSEO settings.
-	 * @param bool  $expected_result The expected result.
-	 *
 	 * @dataProvider provider_isset_settings_tab
 	 * @covers ::isset_settings_tab
+	 *
+	 * @param array $aioseo_settings The AIOSEO settings.
+	 * @param bool  $expected_result The expected result.
 	 */
 	public function test_isset_settings_tab( $aioseo_settings, $expected_result ) {
 		$isset_settings_tab = $this->instance->isset_settings_tab( $aioseo_settings );

--- a/tests/unit/actions/importing/aioseo-validate-data-action-test.php
+++ b/tests/unit/actions/importing/aioseo-validate-data-action-test.php
@@ -327,7 +327,7 @@ class Aioseo_Validate_Data_Action_Test extends TestCase {
 	 * @param array $pluck_setting_times The times we pluck the robot setting map.
 	 * @param array $aioseo_settings     The AIOSEO settings.
 	 * @param int   $get_option_times    The times we retrieve the AIOSEO settings.
-	 * @param bool  $expected_result    The expected result of the validate_default_robot_settings().
+	 * @param bool  $expected_result     The expected result of the validate_default_robot_settings().
 	 *
 	 * @dataProvider provider_validate_default_robot_settings
 	 * @covers ::validate_default_robot_settings

--- a/tests/unit/actions/importing/aioseo-validate-data-action-test.php
+++ b/tests/unit/actions/importing/aioseo-validate-data-action-test.php
@@ -138,12 +138,12 @@ class Aioseo_Validate_Data_Action_Test extends TestCase {
 	/**
 	 * Tests the checking if the validation action has been completed in the past.
 	 *
+	 * @dataProvider provider_get_unindexed
+	 * @covers ::get_total_unindexed
+	 *
 	 * @param array $completed_option    The persistent completed option.
 	 * @param int   $get_completed_times The times we're gonna get the persistent completed option.
 	 * @param int   $expected_result     The expected result.
-	 *
-	 * @dataProvider provider_get_unindexed
-	 * @covers ::get_total_unindexed
 	 */
 	public function test_get_total_unindexed( $completed_option, $get_completed_times, $expected_result ) {
 		$this->options->expects( 'get' )
@@ -158,12 +158,12 @@ class Aioseo_Validate_Data_Action_Test extends TestCase {
 	/**
 	 * Tests the checking if the cleanup has been completed in the past.
 	 *
+	 * @dataProvider provider_get_unindexed
+	 * @covers ::get_limited_unindexed_count
+	 *
 	 * @param array $completed_option    The persistent completed option.
 	 * @param int   $get_completed_times The times we're gonna get the persistent completed option.
 	 * @param int   $expected_result     The expected result.
-	 *
-	 * @dataProvider provider_get_unindexed
-	 * @covers ::get_limited_unindexed_count
 	 */
 	public function test_get_limited_unindexed_count( $completed_option, $get_completed_times, $expected_result ) {
 		$this->options->expects( 'get' )
@@ -178,14 +178,14 @@ class Aioseo_Validate_Data_Action_Test extends TestCase {
 	/**
 	 * Tests the validation of the AIOSEO indexable table.
 	 *
+	 * @dataProvider provider_validate_aioseo_table
+	 * @covers ::validate_aioseo_table
+	 *
 	 * @param bool  $table_exists         Whether the AIOSEO indexable table exists.
 	 * @param array $needed_data          The columns that we need from the AIOSEO indexable table.
 	 * @param array $aioseo_columns       The columns in the AIOSEO indexable table.
 	 * @param int   $aioseo_columns_times The columns in the AIOSEO indexable table.
 	 * @param bool  $expected_result      The expected result.
-	 *
-	 * @dataProvider provider_validate_aioseo_table
-	 * @covers ::validate_aioseo_table
 	 */
 	public function test_validate_aioseo_table( $table_exists, $needed_data, $aioseo_columns, $aioseo_columns_times, $expected_result ) {
 		$this->aioseo_helper->expects( 'aioseo_exists' )
@@ -212,14 +212,14 @@ class Aioseo_Validate_Data_Action_Test extends TestCase {
 	/**
 	 * Tests the validation of the AIOSEO settings from the options table.
 	 *
+	 * @dataProvider provider_validate_aioseo_settings
+	 * @covers ::validate_aioseo_settings
+	 *
 	 * @param string $aioseo_settings    The AIOSEO settings.
 	 * @param int    $get_option_times   The times we'll retrieve the AIOSEO settings.
 	 * @param bool   $isset_settings_tab Whether the tab of each subsetting is set in the options.
 	 * @param int    $isset_times        The times we'll check if the subsetting tab is set in the options.
 	 * @param bool   $expected_result    The expected result of the validate_aioseo_settings().
-	 *
-	 * @dataProvider provider_validate_aioseo_settings
-	 * @covers ::validate_aioseo_settings
 	 */
 	public function test_validate_aioseo_settings( $aioseo_settings, $get_option_times, $isset_settings_tab, $isset_times, $expected_result ) {
 		$this->custom_archive_settings_importing_action->expects( 'get_source_option_name' )
@@ -279,12 +279,12 @@ class Aioseo_Validate_Data_Action_Test extends TestCase {
 	/**
 	 * Tests the validation of the post AIOSEO robots settings from the options table.
 	 *
+	 * @dataProvider provider_validate_post_robot_settings
+	 * @covers ::validate_post_robot_settings
+	 *
 	 * @param string $aioseo_global_settings The AIOSEO global settings.
 	 * @param int    $aioseo_posts_settings  The post AIOSEO settings.
 	 * @param bool   $expected_result        The expected result of the validate_post_robot_settings().
-	 *
-	 * @dataProvider provider_validate_post_robot_settings
-	 * @covers ::validate_post_robot_settings
 	 */
 	public function test_validate_post_robot_settings( $aioseo_global_settings, $aioseo_posts_settings, $expected_result ) {
 		$post_robot_mapping = [
@@ -323,14 +323,14 @@ class Aioseo_Validate_Data_Action_Test extends TestCase {
 	/**
 	 * Tests the validation of the default AIOSEO robots settings for search appearance settings from the options table.
 	 *
+	 * @dataProvider provider_validate_default_robot_settings
+	 * @covers ::validate_default_robot_settings
+	 *
 	 * @param array $robot_setting_map   The robot setting map for each action.
 	 * @param array $pluck_setting_times The times we pluck the robot setting map.
 	 * @param array $aioseo_settings     The AIOSEO settings.
 	 * @param int   $get_option_times    The times we retrieve the AIOSEO settings.
 	 * @param bool  $expected_result     The expected result of the validate_default_robot_settings().
-	 *
-	 * @dataProvider provider_validate_default_robot_settings
-	 * @covers ::validate_default_robot_settings
 	 */
 	public function test_validate_default_robot_settings( $robot_setting_map, $pluck_setting_times, $aioseo_settings, $get_option_times, $expected_result ) {
 		$this->custom_archive_settings_importing_action->expects( 'pluck_robot_setting_from_mapping' )

--- a/tests/unit/config/indexable-builder-versions-test.php
+++ b/tests/unit/config/indexable-builder-versions-test.php
@@ -57,6 +57,7 @@ class Indexable_Builder_Versions_Test extends TestCase {
 	 * @dataProvider data_get_latest_version_for_type
 	 *
 	 * @covers ::get_latest_version_for_type
+	 *
 	 * @param mixed $key      The key of the indexable builder to check.
 	 * @param mixed $expected The expected result.
 	 */

--- a/tests/unit/generators/schema/third-party/coauthor-test.php
+++ b/tests/unit/generators/schema/third-party/coauthor-test.php
@@ -61,6 +61,11 @@ class CoAuthor_Test extends TestCase {
 	/**
 	 * Tests generating the Person data given a user ID.
 	 *
+	 * @dataProvider provider_generate_from_user_id
+	 * @covers ::generate_from_user_id
+	 * @covers ::generate
+	 * @covers ::determine_user_id
+	 *
 	 * @param int    $user_id                The user ID.
 	 * @param array  $person_data            The person data.
 	 * @param bool   $disable_author         Whether the disable-author option is true.
@@ -68,11 +73,6 @@ class CoAuthor_Test extends TestCase {
 	 * @param string $author_posts_url       The archive url of the user.
 	 * @param int    $author_posts_url_times The times we'll retrieve the archive url of the user.
 	 * @param mixed  $expected_result        The expected result.
-	 *
-	 * @dataProvider provider_generate_from_user_id
-	 * @covers ::generate_from_user_id
-	 * @covers ::generate
-	 * @covers ::determine_user_id
 	 */
 	public function test_generate_from_user_id( $user_id, $person_data, $disable_author, $disable_author_times, $author_posts_url, $author_posts_url_times, $expected_result ) {
 		$this->instance->expects( 'build_person_data' )

--- a/tests/unit/helpers/aioseo-helper-test.php
+++ b/tests/unit/helpers/aioseo-helper-test.php
@@ -70,11 +70,11 @@ class Aioseo_Helper_Test extends TestCase {
 	/**
 	 * Tests checking if the AIOSEO database table exists.
 	 *
-	 * @param bool $table_exists    Whether the AIOSEO table exists.
-	 * @param bool $expected_result The expected result.
-	 *
 	 * @dataProvider provider_aioseo_exists
 	 * @covers ::aioseo_exists
+	 *
+	 * @param bool $table_exists    Whether the AIOSEO table exists.
+	 * @param bool $expected_result The expected result.
 	 */
 	public function test_aioseo_exists( $table_exists, $expected_result ) {
 		$this->wpdb_helper->expects( 'table_exists' )
@@ -90,11 +90,11 @@ class Aioseo_Helper_Test extends TestCase {
 	/**
 	 * Tests retrieving the option where the global settings exist.
 	 *
-	 * @param string $retrieved_option Whether the AIOSEO table exists.
-	 * @param array  $expected_result  The expected result.
-	 *
 	 * @dataProvider provider_get_global_option
 	 * @covers ::get_global_option
+	 *
+	 * @param string $retrieved_option Whether the AIOSEO table exists.
+	 * @param array  $expected_result  The expected result.
 	 */
 	public function test_get_global_option( $retrieved_option, $expected_result ) {
 		Monkey\Functions\expect( 'get_option' )

--- a/tests/unit/helpers/score-icon-helper-test.php
+++ b/tests/unit/helpers/score-icon-helper-test.php
@@ -213,7 +213,7 @@ class Score_Icon_Helper_Test extends TestCase {
 	 * @param string $keyphrase    The keyphrase.
 	 * @param int    $score        The score.
 	 *
-	 * @return \Mockery\LegacyMockInterface|\Mockery\MockInterface|\Yoast\WP\SEO\Tests\Unit\Doubles\Models\Indexable_Mock
+	 * @return Mockery\LegacyMockInterface|Mockery\MockInterface|Indexable_Mock
 	 */
 	protected function create_indexable_and_set_mocks_for_seo( $is_indexable, $keyphrase, $score ) {
 		$this->robots_helper->expects( 'is_indexable' )->andReturn( $is_indexable );

--- a/tests/unit/helpers/url-helper-test.php
+++ b/tests/unit/helpers/url-helper-test.php
@@ -516,8 +516,8 @@ class Url_Helper_Test extends TestCase {
 	 *
 	 * @dataProvider recreate_current_url_test_data
 	 *
-	 * @param array  $params    The input parameters.
-	 * @param string $expected  The expected output.
+	 * @param array  $params   The input parameters.
+	 * @param string $expected The expected output.
 	 */
 	public function test_recreate_current_url( $params, $expected ) {
 		if ( ! empty( $params['HTTPS'] ) ) {

--- a/tests/unit/integrations/watchers/search-engines-discouraged-watcher-test.php
+++ b/tests/unit/integrations/watchers/search-engines-discouraged-watcher-test.php
@@ -142,13 +142,13 @@ class Search_Engines_Discouraged_Watcher_Test extends TestCase {
 	/**
 	 * Tests maybe_show_search_engines_discouraged_notice.
 	 *
-	 * @param string $blog_public_option_value The option value for blog_public.
+	 * @param string $blog_public_option_value        The option value for blog_public.
 	 * @param bool   $current_user_can_manage_options Whether the current user has manage_options permissions.
-	 * @param bool   $ignore_notice Whether the user ignored the notice before.
-	 * @param bool   $is_on_yoast_seo_page Whether the user is on a Yoast SEO admin page.
-	 * @param string $current_page_file The php file loaded for the current page.
-	 * @param string $current_yoast_page The current Yoast admin page.
-	 * @param bool   $expect_called Whether the notice show function should have been called.
+	 * @param bool   $ignore_notice                   Whether the user ignored the notice before.
+	 * @param bool   $is_on_yoast_seo_page            Whether the user is on a Yoast SEO admin page.
+	 * @param string $current_page_file               The php file loaded for the current page.
+	 * @param string $current_yoast_page              The current Yoast admin page.
+	 * @param bool   $expect_called                   Whether the notice show function should have been called.
 	 *
 	 * @dataProvider maybe_show_search_engines_discouraged_notice_dataprovider
 	 *
@@ -287,10 +287,10 @@ class Search_Engines_Discouraged_Watcher_Test extends TestCase {
 	/**
 	 * Tests manage_search_engines_discouraged_notification.
 	 *
-	 * @param string $blog_public_option_value The option value for blog_public.
-	 * @param bool   $ignore_notice Whether the user ignored the notice before.
+	 * @param string $blog_public_option_value   The option value for blog_public.
+	 * @param bool   $ignore_notice              Whether the user ignored the notice before.
 	 * @param bool   $remove_notification_called Whether the remove notification function should be called.
-	 * @param bool   $add_notification_called Whether the add notification function should be called.
+	 * @param bool   $add_notification_called    Whether the add notification function should be called.
 	 *
 	 * @dataProvider manage_search_engines_discouraged_notification_dataprovider
 	 *

--- a/tests/unit/integrations/watchers/search-engines-discouraged-watcher-test.php
+++ b/tests/unit/integrations/watchers/search-engines-discouraged-watcher-test.php
@@ -142,6 +142,10 @@ class Search_Engines_Discouraged_Watcher_Test extends TestCase {
 	/**
 	 * Tests maybe_show_search_engines_discouraged_notice.
 	 *
+	 * @dataProvider maybe_show_search_engines_discouraged_notice_dataprovider
+	 *
+	 * @covers ::maybe_show_search_engines_discouraged_notice
+	 *
 	 * @param string $blog_public_option_value        The option value for blog_public.
 	 * @param bool   $current_user_can_manage_options Whether the current user has manage_options permissions.
 	 * @param bool   $ignore_notice                   Whether the user ignored the notice before.
@@ -149,10 +153,6 @@ class Search_Engines_Discouraged_Watcher_Test extends TestCase {
 	 * @param string $current_page_file               The php file loaded for the current page.
 	 * @param string $current_yoast_page              The current Yoast admin page.
 	 * @param bool   $expect_called                   Whether the notice show function should have been called.
-	 *
-	 * @dataProvider maybe_show_search_engines_discouraged_notice_dataprovider
-	 *
-	 * @covers ::maybe_show_search_engines_discouraged_notice
 	 */
 	public function test_maybe_show_search_engines_discouraged_notice(
 		$blog_public_option_value,
@@ -287,14 +287,14 @@ class Search_Engines_Discouraged_Watcher_Test extends TestCase {
 	/**
 	 * Tests manage_search_engines_discouraged_notification.
 	 *
+	 * @dataProvider manage_search_engines_discouraged_notification_dataprovider
+	 *
+	 * @covers ::manage_search_engines_discouraged_notification
+	 *
 	 * @param string $blog_public_option_value   The option value for blog_public.
 	 * @param bool   $ignore_notice              Whether the user ignored the notice before.
 	 * @param bool   $remove_notification_called Whether the remove notification function should be called.
 	 * @param bool   $add_notification_called    Whether the add notification function should be called.
-	 *
-	 * @dataProvider manage_search_engines_discouraged_notification_dataprovider
-	 *
-	 * @covers ::manage_search_engines_discouraged_notification
 	 */
 	public function test_manage_search_engines_discouraged_notification( $blog_public_option_value, $ignore_notice, $remove_notification_called, $add_notification_called ) {
 		Monkey\Functions\expect( 'get_option' )

--- a/tests/unit/routes/first-time-configuration-route-test.php
+++ b/tests/unit/routes/first-time-configuration-route-test.php
@@ -265,11 +265,12 @@ class First_Time_Configuration_Route_Test extends TestCase {
 	/**
 	 * Tests the can_edit_user method.
 	 *
-	 * @param bool   $can_edit The result of the check_capability call.
-	 * @param object $expected The expected result object.
 	 * @covers ::can_edit_user
 	 *
 	 * @dataProvider can_edit_user_provider
+	 *
+	 * @param bool   $can_edit The result of the check_capability call.
+	 * @param object $expected The expected result object.
 	 */
 	public function test_can_edit_user( $can_edit, $expected ) {
 		$request = Mockery::mock( 'WP_Rest_Request' );

--- a/tests/unit/services/health-check/curl-check-test.php
+++ b/tests/unit/services/health-check/curl-check-test.php
@@ -57,9 +57,10 @@ class Curl_Check_Test extends TestCase {
 	/**
 	 * Checks if the health check returns the correct label.
 	 *
-	 * @return void
 	 * @covers ::__construct
 	 * @covers ::get_test_label
+	 *
+	 * @return void
 	 */
 	public function test_returns_correct_label() {
 		$expected_label = 'cURL';
@@ -71,11 +72,12 @@ class Curl_Check_Test extends TestCase {
 	/**
 	 * Checks if the health check returns the correct report when the health check's runner was successful.
 	 *
-	 * @return void
 	 * @covers ::__construct
 	 * @covers ::run_and_get_result
 	 * @covers ::get_result
 	 * @covers ::set_runner
+	 *
+	 * @return void
 	 */
 	public function test_returns_success_report() {
 		$expected_result = [ 'correct' ];
@@ -104,11 +106,12 @@ class Curl_Check_Test extends TestCase {
 	/**
 	 * Checks if the health check returns an empty report when the health check's runner didn't find any premium plugins.
 	 *
-	 * @return void
 	 * @covers ::__construct
 	 * @covers ::run_and_get_result
 	 * @covers ::get_result
 	 * @covers ::set_runner
+	 *
+	 * @return void
 	 */
 	public function test_returns_no_result() {
 		$expected_result = [];
@@ -129,11 +132,12 @@ class Curl_Check_Test extends TestCase {
 	/**
 	 * Checks if the health check returns the correct report when the health check's runner didn't find a recent cURL verison.
 	 *
-	 * @return void
 	 * @covers ::__construct
 	 * @covers ::run_and_get_result
 	 * @covers ::get_result
 	 * @covers ::set_runner
+	 *
+	 * @return void
 	 */
 	public function test_returns_no_recent_curl_version_installed_result() {
 		$expected_result = [ 'correct' ];
@@ -166,11 +170,12 @@ class Curl_Check_Test extends TestCase {
 	/**
 	 * Checks if the health check returns the correct report when the health check's runner couldn't reach the MyYoast API.
 	 *
-	 * @return void
 	 * @covers ::__construct
 	 * @covers ::run_and_get_result
 	 * @covers ::get_result
 	 * @covers ::set_runner
+	 *
+	 * @return void
 	 */
 	public function test_returns_my_yoast_api_not_reachable_result() {
 
@@ -208,11 +213,12 @@ class Curl_Check_Test extends TestCase {
 	/**
 	 * Checks if the health check returns an empty report when there aren't any conditions left to check.
 	 *
-	 * @return void
 	 * @covers ::__construct
 	 * @covers ::run_and_get_result
 	 * @covers ::get_result
 	 * @covers ::set_runner
+	 *
+	 * @return void
 	 */
 	public function test_returns_nothing_after_all_cases() {
 		$expected_result = [];

--- a/tests/unit/services/health-check/curl-reports-test.php
+++ b/tests/unit/services/health-check/curl-reports-test.php
@@ -60,9 +60,10 @@ class Curl_Reports_Test extends TestCase {
 	/**
 	 * Checks if the instance builds the correct success report.
 	 *
-	 * @return void
 	 * @covers ::__construct
 	 * @covers ::get_success_result
+	 *
+	 * @return void
 	 */
 	public function test_get_success_result() {
 		$expected_result      = [ 'correct' ];
@@ -96,10 +97,11 @@ class Curl_Reports_Test extends TestCase {
 	/**
 	 * Checks if the instance builds the correct report for when the MyYoast API is not reachable.
 	 *
-	 * @return void
 	 * @covers ::__construct
 	 * @covers ::get_my_yoast_api_not_reachable_result
 	 * @covers ::get_my_yoast_api_not_reachable_description
+	 *
+	 * @return void
 	 */
 	public function test_get_my_yoast_api_not_reachable_result() {
 		$expected_result      = [ 'correct' ];
@@ -137,10 +139,11 @@ class Curl_Reports_Test extends TestCase {
 	/**
 	 * Checks if the instance builds the correct report for when there's no recent version of cURL installed.
 	 *
-	 * @return void
 	 * @covers ::__construct
 	 * @covers ::get_no_recent_curl_version_installed_result
 	 * @covers ::get_no_recent_curl_version_installed_description
+	 *
+	 * @return void
 	 */
 	public function test_get_no_recent_curl_version_installed_result() {
 		$expected_result      = [ 'correct' ];

--- a/tests/unit/services/health-check/myyoast-api-request-factory-test.php
+++ b/tests/unit/services/health-check/myyoast-api-request-factory-test.php
@@ -33,8 +33,9 @@ class MyYoast_Api_Request_Factory_Test extends TestCase {
 	/**
 	 * Checks if the factory returns a new instance.
 	 *
-	 * @return void
 	 * @covers ::create
+	 *
+	 * @return void
 	 */
 	public function test_factory_returns_instance() {
 		$url      = 'sites/current';


### PR DESCRIPTION
## Context

* Code documentation consistency 

## Summary

This PR can be summarized in the following changelog entry:

* Code documentation consistency 

## Relevant technical choices:

* Docs: fix various minor formatting and punctuation issues
* Docs: remove redundant var name in `@var` tags in property docblocks.
* Docs: remove redundant var name in `@return` tags
* Docs: fix tag ordering
* Docs: fix incorrect/incomplete type information


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a documentation-only change and should have no effect on the functionality. If the build passes (linting, test runs), we're good.
