### PR TITLE
Refactor tests to not use mocked class

### DIFF
--- a/src/integrations/watchers/search-engines-discouraged-watcher.php
+++ b/src/integrations/watchers/search-engines-discouraged-watcher.php
@@ -211,22 +211,8 @@ class Search_Engines_Discouraged_Watcher implements Integration_Interface {
 	protected function show_search_engines_discouraged_notice() {
 		\printf(
 			'<div id="robotsmessage" class="notice notice-error"> %1$s </div>',
-			\wp_kses(
-				$this->presenter->present(),
-				[
-					'strong' => [],
-					'button' => [
-						'type'       => [],
-						'id'         => [],
-						'class'      => [],
-						'data-nonce' => [],
-					],
-					'a'      => [
-						'href' => [],
-					],
-					'p'      => [],
-				]
-			)
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			$this->presenter->present()
 		);
 	}
 

--- a/src/integrations/watchers/search-engines-discouraged-watcher.php
+++ b/src/integrations/watchers/search-engines-discouraged-watcher.php
@@ -210,8 +210,8 @@ class Search_Engines_Discouraged_Watcher implements Integration_Interface {
 	 */
 	protected function show_search_engines_discouraged_notice() {
 		\printf(
-			'<div id="robotsmessage" class="notice notice-error"> %1$s </div>',
-			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			'<div id="robotsmessage" class="notice notice-error">%1$s</div>',
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Output from present() is considered safe.
 			$this->presenter->present()
 		);
 	}

--- a/tests/unit/integrations/watchers/search-engines-discouraged-watcher-test.php
+++ b/tests/unit/integrations/watchers/search-engines-discouraged-watcher-test.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Integrations\Watchers;
 
 use Brain\Monkey;
 use Mockery;
+use ParagonIE\Sodium\Core\Curve25519\Ge\P1p1;
 use Yoast\WP\SEO\Helpers\Capability_Helper;
 use Yoast\WP\SEO\Helpers\Current_Page_Helper;
 use Yoast\WP\SEO\Helpers\Notification_Helper;
@@ -65,13 +66,6 @@ class Search_Engines_Discouraged_Watcher_Test extends TestCase {
 	protected $instance;
 
 	/**
-	 * The mocked instance under test.
-	 *
-	 * @var Mockery\MockInterface|Search_Engines_Discouraged_Watcher
-	 */
-	protected $mocked_instance;
-
-	/**
 	 * Sets up the class under test and mock objects.
 	 */
 	public function set_up() {
@@ -90,13 +84,6 @@ class Search_Engines_Discouraged_Watcher_Test extends TestCase {
 			$this->options_helper,
 			$this->capability_helper
 		);
-
-		$this->mocked_instance = Mockery::mock(
-			Search_Engines_Discouraged_Watcher::class,
-			[ $this->notification_center, $this->notification_helper, $this->current_page_helper, $this->options_helper, $this->capability_helper ]
-		)
-			->makePartial()
-			->shouldAllowMockingProtectedMethods();
 	}
 
 	/**
@@ -137,6 +124,28 @@ class Search_Engines_Discouraged_Watcher_Test extends TestCase {
 		Monkey\Actions\expectAdded( 'admin_notices' );
 
 		$this->instance->register_hooks();
+	}
+
+	/**
+	 * Mocks functions associated with Search_Engines_Discouraged_Presenter.
+	 *
+	 * @return void
+	 */
+	public function mock_notification_message() {
+		Monkey\Functions\expect( 'esc_html__' )
+			->andReturn( 'This is a test message' );
+
+		Monkey\Functions\expect( 'esc_url' )
+			->andReturn( 'http://test.url/' );
+
+		Monkey\Functions\expect( 'admin_url' )
+			->andReturn( '' );
+
+		Monkey\Functions\expect( 'esc_js' )
+			->andReturn( 'This is a test message' );
+
+		Monkey\Functions\expect( 'wp_create_nonce' )
+			->andReturn( 'test_nonce' );
 	}
 
 	/**
@@ -190,18 +199,16 @@ class Search_Engines_Discouraged_Watcher_Test extends TestCase {
 			->allows( 'get_current_yoast_seo_page' )
 			->andReturn( $current_yoast_page );
 
+		$this->mock_notification_message();
+
 		if ( $expect_called ) {
-			$this->mocked_instance
-				->expects( 'show_search_engines_discouraged_notice' )
-				->once()
-				->andReturns();
+			$this->expectOutputContains( 'robotsmessage' );
 		}
 		else {
-			$this->mocked_instance
-				->shouldNotReceive( 'show_search_engines_discouraged_notice' );
+			$this->assertEquals( $this->getActualOutput(), '' );
 		}
 
-		$this->mocked_instance->maybe_show_search_engines_discouraged_notice();
+		$this->instance->maybe_show_search_engines_discouraged_notice();
 	}
 
 	/**
@@ -293,10 +300,12 @@ class Search_Engines_Discouraged_Watcher_Test extends TestCase {
 	 *
 	 * @param string $blog_public_option_value   The option value for blog_public.
 	 * @param bool   $ignore_notice              Whether the user ignored the notice before.
+	 * @param bool   $notification_exists        Whether the notification that should be added already is added to the notification helper.
 	 * @param bool   $remove_notification_called Whether the remove notification function should be called.
-	 * @param bool   $add_notification_called    Whether the add notification function should be called.
+	 * @param bool   $maybe_add_notification_called    Whether the add notification function should be called.
+	 * @param bool   $notification_should_be_added     Whether the notification should be added.
 	 */
-	public function test_manage_search_engines_discouraged_notification( $blog_public_option_value, $ignore_notice, $remove_notification_called, $add_notification_called ) {
+	public function test_manage_search_engines_discouraged_notification( $blog_public_option_value, $ignore_notice, $notification_exists, $remove_notification_called, $maybe_add_notification_called, $notification_should_be_added ) {
 		Monkey\Functions\expect( 'get_option' )
 			->with( 'blog_public' )
 			->once()
@@ -308,28 +317,40 @@ class Search_Engines_Discouraged_Watcher_Test extends TestCase {
 			->andReturn( $ignore_notice );
 
 		if ( $remove_notification_called ) {
-			$this->mocked_instance
-				->expects( 'remove_search_engines_discouraged_notification_if_exists' )
+			$this->notification_center
+				->expects( 'remove_notification_by_id' )
 				->once()
 				->andReturns();
 		}
 		else {
-			$this->mocked_instance
-				->shouldNotReceive( 'remove_search_engines_discouraged_notification_if_exists' );
+			$this->notification_center
+				->shouldNotReceive( 'remove_notification_by_id' );
 		}
 
-		if ( $add_notification_called ) {
-			$this->mocked_instance
-				->expects( 'maybe_add_search_engines_discouraged_notification' )
+		if ( $maybe_add_notification_called ) {
+			$this->notification_center
+				->expects( 'get_notification_by_id' )
+				->andReturn( $notification_exists );
+		}
+
+		if ( $notification_should_be_added ) {
+			$this->mock_notification_message();
+			$this->notification_helper
+				->expects( 'restore_notification' );
+			$this->notification_center
+				->expects( 'add_notification' );
+			Monkey\Functions\expect( 'wp_get_current_user' )
 				->once()
-				->andReturns();
+				->andReturn( null );
 		}
 		else {
-			$this->mocked_instance
-				->shouldNotReceive( 'maybe_add_search_engines_discouraged_notification' );
+			$this->notification_helper
+				->shouldNotReceive( 'restore_notification' );
+			$this->notification_center
+				->shouldNotReceive( 'add_notification' );
 		}
 
-		$this->mocked_instance->manage_search_engines_discouraged_notification();
+		$this->instance->manage_search_engines_discouraged_notification();
 	}
 
 	/**
@@ -338,28 +359,61 @@ class Search_Engines_Discouraged_Watcher_Test extends TestCase {
 	 * @return array data for manage_search_engines_discouraged_notification.
 	 */
 	public function manage_search_engines_discouraged_notification_dataprovider() {
-		$should_add_notification = [
-			'blog_public_option_value'   => '0',
-			'ignore_notice'              => false,
-			'remove_notification_called' => false,
-			'add_notification_called'    => true,
+		$should_add_notification        = [
+			'blog_public_option_value'      => '0',
+			'ignore_notice'                 => false,
+			'notification_exists'           => false,
+			'remove_notification_called'    => false,
+			'maybe_add_notification_called' => true,
+			'notification_should_be_added'  => true,
 		];
-		$blog_not_public         = [
-			'blog_public_option_value'   => '1',
-			'ignore_notice'              => false,
-			'remove_notification_called' => true,
-			'add_notification_called'    => false,
+		$blog_not_public                = [
+			'blog_public_option_value'      => '1',
+			'ignore_notice'                 => false,
+			'notification_exists'           => false,
+			'remove_notification_called'    => true,
+			'maybe_add_notification_called' => false,
+			'notification_should_be_added'  => false,
 		];
-		$notice_ignored          = [
-			'blog_public_option_value'   => '0',
-			'ignore_notice'              => true,
-			'remove_notification_called' => true,
-			'add_notification_called'    => false,
+		$notice_ignored                 = [
+			'blog_public_option_value'      => '0',
+			'ignore_notice'                 => true,
+			'notification_exists'           => false,
+			'remove_notification_called'    => true,
+			'maybe_add_notification_called' => false,
+			'notification_should_be_added'  => false,
+		];
+		$notification_exists            = [
+			'blog_public_option_value'      => '0',
+			'ignore_notice'                 => false,
+			'notification_exists'           => true,
+			'remove_notification_called'    => false,
+			'maybe_add_notification_called' => true,
+			'notification_should_be_added'  => false,
+		];
+		$notification_does_not_exist    = [
+			'blog_public_option_value'      => '0',
+			'ignore_notice'                 => false,
+			'notification_exists'           => false,
+			'remove_notification_called'    => false,
+			'maybe_add_notification_called' => true,
+			'notification_should_be_added'  => true,
+		];
+		$notification_should_be_removed = [
+			'blog_public_option_value'      => '1',
+			'ignore_notice'                 => false,
+			'notification_exists'           => true,
+			'remove_notification_called'    => true,
+			'maybe_add_notification_called' => false,
+			'notification_should_be_added'  => false,
 		];
 		return [
-			'Should add notification' => $should_add_notification,
-			'Blog not public'         => $blog_not_public,
-			'Notice ignored'          => $notice_ignored,
+			'Should add notification'        => $should_add_notification,
+			'Blog not public'                => $blog_not_public,
+			'Notice ignored'                 => $notice_ignored,
+			'Notification exists'            => $notification_exists,
+			'Notification does not exist'    => $notification_does_not_exist,
+			'Notification should be removed' => $notification_should_be_removed,
 		];
 	}
 }

--- a/tests/unit/integrations/watchers/search-engines-discouraged-watcher-test.php
+++ b/tests/unit/integrations/watchers/search-engines-discouraged-watcher-test.php
@@ -4,7 +4,6 @@ namespace Yoast\WP\SEO\Tests\Unit\Integrations\Watchers;
 
 use Brain\Monkey;
 use Mockery;
-use ParagonIE\Sodium\Core\Curve25519\Ge\P1p1;
 use Yoast\WP\SEO\Helpers\Capability_Helper;
 use Yoast\WP\SEO\Helpers\Current_Page_Helper;
 use Yoast\WP\SEO\Helpers\Notification_Helper;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Some tests created in [PC-46](https://github.com/Yoast/wordpress-seo/pull/18744) used a mocked version of the `Search_Engines_Discouraged_Watcher`.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Changes tests for `Search_Engines_Discouraged_Watcher` to not use a mocked version of the class.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* re-check the notification introduced by https://github.com/Yoast/wordpress-seo/pull/18744 to make sure its look is unchanged.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes [PC-347](https://yoast.atlassian.net/browse/PC-347)
 