### PR TITLE
PHP 8.2 | Elementor_Exclude_Post_Types: fix for partially supported callback

### DIFF
--- a/src/deprecated/src/integrations/third-party/elementor.php
+++ b/src/deprecated/src/integrations/third-party/elementor.php
@@ -36,7 +36,7 @@ class Elementor_Exclude_Post_Types extends Exclude_Elementor_Post_Types {
 		\_deprecated_function( __METHOD__, 'Yoast SEO 16.7', '\Yoast\WP\SEO\Integrations\Third_Party\Exclude_Elementor_Post_Types' );
 
 		// Only call a constructor if the parent has one; we already are a subclass of the parent.
-		if ( \is_callable( 'parent::__construct' ) ) {
+		if ( \is_callable( [ parent::class, '__construct' ] ) ) {
 			parent::__construct();
 		}
 	}


### PR DESCRIPTION

## Context

* Improves compatibility with PHP 8.2

## Summary

This PR can be summarized in the following changelog entry:

* Improves compatibility with PHP 8.2

## Relevant technical choices:

`parent::method_name`-like callbacks are only partially supported by PHP. With this mind, they will be deprecated in PHP 8.2, with support being completely removed in PHP 9.0.

Fixed by changing it to a fully supported syntax.

Note: while this issue is not covered by tests, as this is a deprecated class, I'm not going to bother with adding tests.

Refs:
* https://wiki.php.net/rfc/deprecate_partially_supported_callables


## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_
    This is a code-only change and should have no effect on the functionality. If the build passes (linting, test runs), we're good.
