### PR TITLE
PHP 8.2 | Yoast_Notification_Center: bugfix for partially supported callback

### DIFF
--- a/admin/class-yoast-notification-center.php
+++ b/admin/class-yoast-notification-center.php
@@ -298,7 +298,7 @@ class Yoast_Notification_Center {
 	 */
 	public function add_notification( Yoast_Notification $notification ) {
 
-		$callback = [ $this, __METHOD__ ];
+		$callback = [ $this, __FUNCTION__ ];
 		$args     = func_get_args();
 		if ( $this->queue_transaction( $callback, $args ) ) {
 			return;
@@ -405,7 +405,7 @@ class Yoast_Notification_Center {
 	 */
 	public function remove_notification( Yoast_Notification $notification, $resolve = true ) {
 
-		$callback = [ $this, __METHOD__ ];
+		$callback = [ $this, __FUNCTION__ ];
 		$args     = func_get_args();
 		if ( $this->queue_transaction( $callback, $args ) ) {
 			return;


### PR DESCRIPTION

## Context

* Improves compatibility with PHP 8.2

## Summary

This PR can be summarized in the following changelog entry:

* Improves compatibility with PHP 8.2


## Relevant technical choices:

As things were, the callback which was being created would have the following form:
```
["Yoast_Notification_Center", "Yoast_Notification_Center::add_notification"]
```

Take note of the class name also being prepended to the method name.

This is due to the use of the `__METHOD__` magic constant, which includes the class name already. By changing this to `__FUNCTION__`, the method name _without_ the class name is returned.

As this type of callback is only partially supported by PHP, will be deprecated in PHP 8.2, with support being completely removed in PHP 9.0, fixing this seems prudent.

The integration test suite runs into this issue in the test bootstrap.

Refs:
* https://wiki.php.net/rfc/deprecate_partially_supported_callables


## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_
    This is a code-only change and should have no effect on the functionality. If the build passes (linting, test runs), we're good.
