### PR TITLE
PHP 8.2 | Various Tests: explicitly declare all properties

### DIFF
--- a/tests/unit/builders/indexable-home-page-builder-test.php
+++ b/tests/unit/builders/indexable-home-page-builder-test.php
@@ -95,6 +95,13 @@ class Indexable_Home_Page_Builder_Test extends TestCase {
 	protected $post_helper;
 
 	/**
+	 * The post helper
+	 *
+	 * @var Indexable_Builder_Versions|Mockery\MockInterface
+	 */
+	protected $versions;
+
+	/**
 	 * The wpdb instance
 	 *
 	 * @var wpdb|Mockery\MockInterface

--- a/tests/unit/conditionals/estimated-reading-time-conditional-test.php
+++ b/tests/unit/conditionals/estimated-reading-time-conditional-test.php
@@ -20,6 +20,20 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
 class Estimated_Reading_Time_Conditional_Test extends TestCase {
 
 	/**
+	 * Holds the Post_Conditional instance.
+	 *
+	 * @var Post_Conditional|Mockery\MockInterface
+	 */
+	protected $post_conditional;
+
+	/**
+	 * Holds the Input_Helper instance.
+	 *
+	 * @var Input_Helper|Mockery\MockInterface
+	 */
+	protected $input_helper;
+
+	/**
 	 * The estimated reading time conditional.
 	 *
 	 * @var Estimated_Reading_Time_Conditional

--- a/tests/unit/helpers/wpdb-helper-test.php
+++ b/tests/unit/helpers/wpdb-helper-test.php
@@ -3,6 +3,7 @@
 namespace Yoast\WP\SEO\Tests\Unit\Helpers;
 
 use Mockery;
+use wpdb;
 use Yoast\WP\SEO\Helpers\Wpdb_Helper;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
@@ -14,6 +15,13 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  * @coversDefaultClass \Yoast\WP\SEO\Helpers\Wpdb_Helper
  */
 class Wpdb_Helper_Test extends TestCase {
+
+	/**
+	 * Mocked version of the WP native wpdb object.
+	 *
+	 * @var wpdb|Mockery\MockInterface
+	 */
+	protected $wpdb;
 
 	/**
 	 * The instance under test.
@@ -28,7 +36,7 @@ class Wpdb_Helper_Test extends TestCase {
 	public function set_up() {
 		parent::set_up();
 
-		$this->wpdb     = Mockery::mock( 'wpdb' );
+		$this->wpdb     = Mockery::mock( wpdb::class );
 		$this->instance = new Wpdb_Helper( $this->wpdb );
 	}
 

--- a/tests/unit/presentations/indexable-author-archive-presentation/presentation-instance-builder-trait.php
+++ b/tests/unit/presentations/indexable-author-archive-presentation/presentation-instance-builder-trait.php
@@ -55,6 +55,13 @@ trait Presentation_Instance_Builder {
 	protected $post_type;
 
 	/**
+	 * Holds the Author_Archive_Helper instance.
+	 *
+	 * @var Author_Archive_Helper|Mockery\MockInterface
+	 */
+	protected $author_archive;
+
+	/**
 	 * Holds the Pagination_Helper instance.
 	 *
 	 * @var Pagination_Helper|Mockery\MockInterface

--- a/tests/unit/presenters/meta-author-presenter-test.php
+++ b/tests/unit/presenters/meta-author-presenter-test.php
@@ -25,6 +25,20 @@ class Meta_Author_Presenter_Test extends TestCase {
 	/**
 	 * Holds the instance of the class being tested.
 	 *
+	 * @var HTML_Helper|Mockery\MockInterface
+	 */
+	protected $html;
+
+	/**
+	 * Holds the instance of the class being tested.
+	 *
+	 * @var Meta_Tags_Context_Mock|Mockery\MockInterface
+	 */
+	protected $context;
+
+	/**
+	 * Holds the instance of the class being tested.
+	 *
 	 * @var Meta_Author_Presenter
 	 */
 	protected $instance;

--- a/tests/unit/services/importing/importable-detector-service-test.php
+++ b/tests/unit/services/importing/importable-detector-service-test.php
@@ -42,6 +42,13 @@ class Importable_Detector_Service_Test extends TestCase {
 	protected $instance;
 
 	/**
+	 * Represents a mock of the instance to test.
+	 *
+	 * @var Mockery\MockInterface|Importable_Detector_Service_Double
+	 */
+	protected $mock_instance;
+
+	/**
 	 * The mocked importing action.
 	 *
 	 * @var Aioseo_Posts_Importing_Action_Double


### PR DESCRIPTION
## Context

* Improves compatibility with PHP 8.2

## Summary

This PR can be summarized in the following changelog entry:

* Improves compatibility with PHP 8.2


## Relevant technical choices:

Dynamic (non-explicitly declared) property usage is expected to be deprecated as of PHP 8.2 and will become a fatal error in PHP 9.0.

There are a number of ways to mitigate this:
* If it's an accidental typo for a declared property: fix the typo.
* For known properties: declare them on the class.
* For unknown properties: add the magic `__get()`, `__set()` et al methods to the class or let the class extend `stdClass` which has highly optimized versions of these magic methods build in.
* For unknown _use of_ dynamic properties, the `#[AllowDynamicProperties]` attribute can be added to the class. The attribute will automatically be inherited by child classes.

Refs:
* https://wiki.php.net/rfc/deprecate_dynamic_properties

### PHP 8.2 | Indexable_Home_Page_Builder_Test: explicitly declare all properties

In this case, the `$versions` property is referenced multiple times throughout this class, so falls in the "known property" category.

### PHP 8.2 | Estimated_Reading_Time_Conditional_Test: explicitly declare all properties

In this case, the `$post_conditional` and the `$input_helper` property are referenced multiple times throughout this class, so fall in the "known property" category.

### PHP 8.2 | ID_Helper_Test: explicitly declare all properties

In this case, the `$wpdb` property is referenced in the `set_up()` method, so falls in the "known property" category.

### PHP 8.2 | Meta_Author_Presenter_Test: explicitly declare all properties

In this case, the `$html` and `$context` properties are assigned in the `set_up()` method, so fall in the "known property" category.

### PHP 8.2 | Presentation_Instance_Builder: explicitly declare all properties

In this case, the `$author_archive` property is set in the `set_instance()` method, so falls in the "known property" category.

### PHP 8.2 | Importable_Detector_Service_Test: explicitly declare all properties

In this case, the `$mock_instance` property is set in the `set_up()` method, so falls in the "known property" category.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_
    This is a (test-)code-only change and should have no effect on the functionality. If the build passes (linting, test runs), we're good.
