### PR TITLE
PHP 8.2 | Classes_Surface: explicitly declare all properties

### DIFF
--- a/src/surfaces/classes-surface.php
+++ b/src/surfaces/classes-surface.php
@@ -12,6 +12,13 @@ use YoastSEO_Vendor\Symfony\Component\DependencyInjection\ContainerInterface;
 class Classes_Surface {
 
 	/**
+	 * The dependency injection container.
+	 *
+	 * @var ContainerInterface
+	 */
+	public $container;
+
+	/**
 	 * Loader constructor.
 	 *
 	 * @param ContainerInterface $container The dependency injection container.


### PR DESCRIPTION
## Context

* Improves compatibility with PHP 8.2

## Summary

This PR can be summarized in the following changelog entry:

* Improves compatibility with PHP 8.2


## Relevant technical choices:

Dynamic (non-explicitly declared) property usage is expected to be deprecated as of PHP 8.2 and will become a fatal error in PHP 9.0.

There are a number of ways to mitigate this:
* If it's an accidental typo for a declared property: fix the typo.
* For known properties: declare them on the class.
* For unknown properties: add the magic `__get()`, `__set()` et al methods to the class or let the class extend `stdClass` which has highly optimized versions of these magic methods build in.
* For unknown _use of_ dynamic properties, the `#[AllowDynamicProperties]` attribute can be added to the class. The attribute will automatically be inherited by child classes.

In this case, the `$container` property is referenced multiple times throughout this class, so falls in the "known property" category.

Refs:
* https://wiki.php.net/rfc/deprecate_dynamic_properties


## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_
    This is a code-only change and should have no effect on the functionality. If the build passes (linting, test runs), we're good.
