### PR TITLE
PHP 8.2 | Import_Cursor_Helper: explicitly declare all properties

### DIFF
--- a/src/helpers/import-cursor-helper.php
+++ b/src/helpers/import-cursor-helper.php
@@ -8,6 +8,13 @@ namespace Yoast\WP\SEO\Helpers;
 class Import_Cursor_Helper {
 
 	/**
+	 * The Options_Helper.
+	 *
+	 * @var Options_Helper
+	 */
+	public $options;
+
+	/**
 	 * Class constructor.
 	 *
 	 * @param Options_Helper $options The options helper.


### PR DESCRIPTION

## Context

* Improves compatibility with PHP 8.2

## Summary

This PR can be summarized in the following changelog entry:

* Improves compatibility with PHP 8.2


## Relevant technical choices:

Dynamic (non-explicitly declared) property usage is expected to be deprecated as of PHP 8.2 and will become a fatal error in PHP 9.0.

There are a number of ways to mitigate this:
* If it's an accidental typo for a declared property: fix the typo.
* For known properties: declare them on the class.
* For unknown properties: add the magic `__get()`, `__set()` et al methods to the class or let the class extend `stdClass` which has highly optimized versions of these magic methods build in.
* For unknown _use of_ dynamic properties, the `#[AllowDynamicProperties]` attribute can be added to the class. The attribute will automatically be inherited by child classes.

In this case, the `$options` property is referenced multiple times throughout this class, so falls in the "known property" category.

Refs:
* https://wiki.php.net/rfc/deprecate_dynamic_properties


## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_
    This is a code-only change and should have no effect on the functionality. If the build passes (linting, test runs), we're good.
