### PR TITLE
PHP 8.2 | Tests: bug fix - typo in property name x 2

### DIFF
--- a/tests/unit/presentations/indexable-static-posts-page-presentation/presentation-instance-builder-trait.php
+++ b/tests/unit/presentations/indexable-static-posts-page-presentation/presentation-instance-builder-trait.php
@@ -53,7 +53,7 @@ trait Presentation_Instance_Builder {
 	 *
 	 * @var Date_Helper
 	 */
-	protected $date_helper;
+	protected $date;
 
 	/**
 	 * Holds the Pagination_Helper instance.

--- a/tests/unit/services/importing/aioseo-robots-transformer-service-test.php
+++ b/tests/unit/services/importing/aioseo-robots-transformer-service-test.php
@@ -23,7 +23,7 @@ class Aioseo_Robots_Transformer_Service_Test extends TestCase {
 	 *
 	 * @var Mockery\MockInterface|Aioseo_Robots_Provider_Service
 	 */
-	protected $aioseo_robots_provider_service;
+	protected $robots_provider;
 
 	/**
 	 * The class under test.


### PR DESCRIPTION
## Context

* Improves compatibility with PHP 8.2

## Summary

This PR can be summarized in the following changelog entry:

* Improves compatibility with PHP 8.2


## Relevant technical choices:

Dynamic (non-explicitly declared) property usage is expected to be deprecated as of PHP 8.2 and will become a fatal error in PHP 9.0.

There are a number of ways to mitigate this:
* If it's an accidental typo for a declared property: fix the typo.
* For known properties: declare them on the class.
* For unknown properties: add the magic `__get()`, `__set()` et al methods to the class or let the class extend `stdClass` which has highly optimized versions of these magic methods build in.
* For unknown _use of_ dynamic properties, the `#[AllowDynamicProperties]` attribute can be added to the class. The attribute will automatically be inherited by child classes.

Refs:
* https://wiki.php.net/rfc/deprecate_dynamic_properties

### PHP 8.2 | Aioseo_Robots_Transformer_Service_Test: bug fix - typo in property name

In this case, the (non-existent) `$robots_provider` property is being assigned to and used in the tests, but the actual property was called `$aioseo_robots_provider_service`, so falls in the "typo" category.

### PHP 8.2 | Presentation_Instance_Builder: bug fix - typo in property name

In this case, the (non-existent) `$date` property is being assigned to and used in the tests, but the actual property was called `$date_helper`, so falls in the "typo" category.


## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_
    This is a (test-)code-only change and should have no effect on the functionality. If the build passes (linting, test runs), we're good.
