### PR TITLE
PHP 8.2 | Indexable_*_Presentation: explicitly declare all properties

### DIFF
--- a/src/presentations/archive-adjacent-trait.php
+++ b/src/presentations/archive-adjacent-trait.php
@@ -13,6 +13,8 @@ use Yoast\WP\SEO\Models\Indexable;
  * @property Indexable         $model      The indexable.
  * @property Pagination_Helper $pagination The pagination helper. Should be defined in the parent
  *                                         class because of trait issues in PHP 5.6.
+ *                                         For a detailed explanation of the issue, see
+ *                                         {@link https://github.com/Yoast/wordpress-seo/pull/18820}.
  */
 trait Archive_Adjacent {
 

--- a/src/presentations/indexable-author-archive-presentation.php
+++ b/src/presentations/indexable-author-archive-presentation.php
@@ -3,6 +3,7 @@
 namespace Yoast\WP\SEO\Presentations;
 
 use Yoast\WP\SEO\Helpers\Author_Archive_Helper;
+use Yoast\WP\SEO\Helpers\Pagination_Helper;
 use Yoast\WP\SEO\Helpers\Post_Type_Helper;
 
 /**
@@ -27,6 +28,13 @@ class Indexable_Author_Archive_Presentation extends Indexable_Presentation {
 	 * @var Author_Archive_Helper
 	 */
 	protected $author_archive;
+
+	/**
+	 * Holds the Pagination_Helper instance.
+	 *
+	 * @var Pagination_Helper
+	 */
+	protected $pagination;
 
 	/**
 	 * Indexable_Author_Archive_Presentation constructor.

--- a/src/presentations/indexable-home-page-presentation.php
+++ b/src/presentations/indexable-home-page-presentation.php
@@ -2,6 +2,8 @@
 
 namespace Yoast\WP\SEO\Presentations;
 
+use Yoast\WP\SEO\Helpers\Pagination_Helper;
+
 /**
  * Class Indexable_Home_Page_Presentation.
  *
@@ -10,6 +12,13 @@ namespace Yoast\WP\SEO\Presentations;
 class Indexable_Home_Page_Presentation extends Indexable_Presentation {
 
 	use Archive_Adjacent;
+
+	/**
+	 * Holds the Pagination_Helper instance.
+	 *
+	 * @var Pagination_Helper
+	 */
+	protected $pagination;
 
 	/**
 	 * Generates the canonical.

--- a/src/presentations/indexable-post-type-archive-presentation.php
+++ b/src/presentations/indexable-post-type-archive-presentation.php
@@ -2,6 +2,8 @@
 
 namespace Yoast\WP\SEO\Presentations;
 
+use Yoast\WP\SEO\Helpers\Pagination_Helper;
+
 /**
  * Class Indexable_Post_Type_Archive_Presentation.
  *
@@ -10,6 +12,13 @@ namespace Yoast\WP\SEO\Presentations;
 class Indexable_Post_Type_Archive_Presentation extends Indexable_Presentation {
 
 	use Archive_Adjacent;
+
+	/**
+	 * Holds the Pagination_Helper instance.
+	 *
+	 * @var Pagination_Helper
+	 */
+	protected $pagination;
 
 	/**
 	 * Generates the canonical.

--- a/src/presentations/indexable-term-archive-presentation.php
+++ b/src/presentations/indexable-term-archive-presentation.php
@@ -3,6 +3,7 @@
 namespace Yoast\WP\SEO\Presentations;
 
 use WP_Term;
+use Yoast\WP\SEO\Helpers\Pagination_Helper;
 use Yoast\WP\SEO\Helpers\Taxonomy_Helper;
 use Yoast\WP\SEO\Wrappers\WP_Query_Wrapper;
 
@@ -16,6 +17,13 @@ use Yoast\WP\SEO\Wrappers\WP_Query_Wrapper;
 class Indexable_Term_Archive_Presentation extends Indexable_Presentation {
 
 	use Archive_Adjacent;
+
+	/**
+	 * Holds the Pagination_Helper instance.
+	 *
+	 * @var Pagination_Helper
+	 */
+	protected $pagination;
 
 	/**
 	 * Holds the WP query wrapper instance.

--- a/tests/unit/presentations/archive-adjacent-test.php
+++ b/tests/unit/presentations/archive-adjacent-test.php
@@ -3,8 +3,6 @@
 namespace Yoast\WP\SEO\Tests\Unit\Presentations;
 
 use Brain\Monkey;
-use Mockery;
-use Yoast\WP\SEO\Helpers\Pagination_Helper;
 use Yoast\WP\SEO\Tests\Unit\Presentations\Indexable_Post_Type_Archive_Presentation\Presentation_Instance_Builder;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
@@ -21,22 +19,12 @@ class Archive_Adjacent_Test extends TestCase {
 	use Presentation_Instance_Builder;
 
 	/**
-	 * Holds the Pagination_Helper instance.
-	 *
-	 * @var Pagination_Helper
-	 */
-	protected $pagination;
-
-	/**
 	 * Does the setup for testing.
 	 */
 	protected function set_up() {
 		parent::set_up();
 
-		$this->pagination = Mockery::mock( Pagination_Helper::class );
-
 		$this->set_instance();
-		$this->instance->set_archive_adjacent_helpers( $this->pagination );
 	}
 
 	/**

--- a/tests/unit/presentations/indexable-author-archive-presentation/presentation-instance-builder-trait.php
+++ b/tests/unit/presentations/indexable-author-archive-presentation/presentation-instance-builder-trait.php
@@ -10,7 +10,6 @@ use Yoast\WP\SEO\Presentations\Indexable_Author_Archive_Presentation;
 use Yoast\WP\SEO\Tests\Unit\Doubles\Context\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\Unit\Doubles\Models\Indexable_Mock;
 use Yoast\WP\SEO\Tests\Unit\Presentations\Presentation_Instance_Dependencies;
-use Yoast\WP\SEO\Wrappers\WP_Query_Wrapper;
 
 /**
  * Trait Presentation_Instance_Builder
@@ -39,13 +38,6 @@ trait Presentation_Instance_Builder {
 	 * @var Meta_Tags_Context_Mock|Mockery\MockInterface
 	 */
 	protected $context;
-
-	/**
-	 * Holds the WP_Query_Wrapper instance.
-	 *
-	 * @var WP_Query_Wrapper|Mockery\MockInterface
-	 */
-	protected $wp_query_wrapper;
 
 	/**
 	 * Holds the Post_Type_Helper instance.

--- a/tests/unit/presentations/indexable-date-archive-presentation/presentation-instance-builder-trait.php
+++ b/tests/unit/presentations/indexable-date-archive-presentation/presentation-instance-builder-trait.php
@@ -23,6 +23,13 @@ trait Presentation_Instance_Builder {
 	protected $indexable;
 
 	/**
+	 * Holds the Pagination_Helper instance.
+	 *
+	 * @var Pagination_Helper|Mockery\MockInterface
+	 */
+	protected $pagination;
+
+	/**
 	 * Represents the instance to test.
 	 *
 	 * @var Indexable_Date_Archive_Presentation

--- a/tests/unit/presentations/indexable-home-page-presentation/presentation-instance-builder-trait.php
+++ b/tests/unit/presentations/indexable-home-page-presentation/presentation-instance-builder-trait.php
@@ -23,6 +23,13 @@ trait Presentation_Instance_Builder {
 	protected $indexable;
 
 	/**
+	 * Holds the Pagination_Helper instance.
+	 *
+	 * @var Pagination_Helper|Mockery\MockInterface
+	 */
+	protected $pagination;
+
+	/**
 	 * Represents the instance to test.
 	 *
 	 * @var Indexable_Home_Page_Presentation

--- a/tests/unit/presentations/indexable-static-posts-page-presentation/presentation-instance-builder-trait.php
+++ b/tests/unit/presentations/indexable-static-posts-page-presentation/presentation-instance-builder-trait.php
@@ -9,7 +9,6 @@ use Yoast\WP\SEO\Helpers\Post_Helper;
 use Yoast\WP\SEO\Helpers\Post_Type_Helper;
 use Yoast\WP\SEO\Presentations\Indexable_Post_Type_Presentation;
 use Yoast\WP\SEO\Presentations\Indexable_Static_Posts_Page_Presentation;
-use Yoast\WP\SEO\Tests\Unit\Doubles\Context\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\Unit\Doubles\Models\Indexable_Mock;
 use Yoast\WP\SEO\Tests\Unit\Presentations\Presentation_Instance_Dependencies;
 
@@ -40,13 +39,6 @@ trait Presentation_Instance_Builder {
 	 * @var Post_Type_Helper|Mockery\MockInterface
 	 */
 	protected $post_type;
-
-	/**
-	 * Represents the meta tags context.
-	 *
-	 * @var Meta_Tags_Context_Mock|Mockery\MockInterface
-	 */
-	protected $context;
 
 	/**
 	 * Represents the date helper.

--- a/tests/unit/presentations/presentation-instance-dependencies-trait.php
+++ b/tests/unit/presentations/presentation-instance-dependencies-trait.php
@@ -14,7 +14,6 @@ use Yoast\WP\SEO\Helpers\Indexable_Helper;
 use Yoast\WP\SEO\Helpers\Open_Graph\Image_Helper as Open_Graph_Image_Helper;
 use Yoast\WP\SEO\Helpers\Open_Graph\Values_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
-use Yoast\WP\SEO\Helpers\Pagination_Helper;
 use Yoast\WP\SEO\Helpers\Permalink_Helper;
 use Yoast\WP\SEO\Helpers\Twitter\Image_Helper as Twitter_Image_Helper;
 use Yoast\WP\SEO\Helpers\Url_Helper;
@@ -92,13 +91,6 @@ trait Presentation_Instance_Dependencies {
 	 * @var Twitter_Image_Helper|Mockery\MockInterface
 	 */
 	protected $twitter;
-
-	/**
-	 * Holds the Pagination_Helper instance.
-	 *
-	 * @var Pagination_Helper|Mockery\MockInterface
-	 */
-	protected $pagination;
 
 	/**
 	 * Holds the open open graph image generator.


### PR DESCRIPTION
## Context

* Improves compatibility with PHP 8.2

## Summary

This PR can be summarized in the following changelog entry:

* Improves compatibility with PHP 8.2


## Relevant technical choices:

Dynamic (non-explicitly declared) property usage is expected to be deprecated as of PHP 8.2 and will become a fatal error in PHP 9.0.

There are a number of ways to mitigate this:
* If it's an accidental typo for a declared property: fix the typo.
* For known properties: declare them on the class.
* For unknown properties: add the magic `__get()`, `__set()` et al methods to the class or let the class extend `stdClass` which has highly optimized versions of these magic methods build in.
* For unknown _use of_ dynamic properties, the `#[AllowDynamicProperties]` attribute can be added to the class. The attribute will automatically be inherited by child classes.

In each of these classes, the `$pagination` property is referenced multiple times throughout this class (and set via the `Archive_Adjacent` trait), so falls in the "known property" category.

Note: I'd be tempted to declare the property in the trait, but the trait contains a note not to do so, though I have to admit I find it hard to phantom what the problem in PHP 5.6 would be, as I use properties in traits elsewhere in other repos running on PHP 5.6 and lower, without any problems.

https://github.com/Yoast/wordpress-seo/blob/77485c4775c1421a24dd462811f022d28f7fb097/src/presentations/archive-adjacent-trait.php#L14-L15

Refs:
* https://wiki.php.net/rfc/deprecate_dynamic_properties

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_
    This is a code-only change and should have no effect on the functionality. If the build passes (linting, test runs), we're good.
