### PR TITLE
Add the deprecated front end inspector conditional to the DI container

### DIFF
--- a/config/dependency-injection/deprecated-classes.php
+++ b/config/dependency-injection/deprecated-classes.php
@@ -21,12 +21,9 @@
  */
 
 use Yoast\WP\SEO\Conditionals\Front_End_Inspector_Conditional;
-use Yoast\WP\SEO\Integrations\Third_Party\Elementor_Exclude_Post_Types;
-use Yoast\WP\SEO\Integrations\Third_Party\Exclude_Elementor_Post_Types as Renamed_To_Exclude_Elementor_Post_Types;
 
-$renamed_classes = [
-	Elementor_Exclude_Post_Types::class    => [ Renamed_To_Exclude_Elementor_Post_Types::class, '16.7' ],
-	Front_End_Inspector_Conditional::class => [ Front_End_Inspector_Conditional::class, '19.5' ],
+$deprecated_classes = [
+	Front_End_Inspector_Conditional::class => '19.5',
 ];
 
 foreach ( $renamed_classes as $original_class => $replacement ) {
@@ -35,7 +32,7 @@ foreach ( $renamed_classes as $original_class => $replacement ) {
 		->setAutowired( true )
 		->setAutoconfigured( true )
 		->setPublic( true )
-		->setDeprecated( true, "%service_id% is deprecated since version $version! Use $renamed_class instead." );
+		->setDeprecated( true, "%service_id% is deprecated since version $version!" );
 }
 
 // If the DI container is built by Composer this WordPress function will not exist.

--- a/config/dependency-injection/deprecated-classes.php
+++ b/config/dependency-injection/deprecated-classes.php
@@ -26,8 +26,7 @@ $deprecated_classes = [
 	Front_End_Inspector_Conditional::class => '19.5',
 ];
 
-foreach ( $renamed_classes as $original_class => $replacement ) {
-	list( $renamed_class, $version ) = $replacement;
+foreach ( $deprecated_classes as $original_class => $version ) {
 	$container->register( $original_class, $original_class )
 		->setAutowired( true )
 		->setAutoconfigured( true )

--- a/config/dependency-injection/renamed-classes.php
+++ b/config/dependency-injection/renamed-classes.php
@@ -20,13 +20,11 @@
  * @var $container \Symfony\Component\DependencyInjection\ContainerBuilder
  */
 
-use Yoast\WP\SEO\Conditionals\Front_End_Inspector_Conditional;
 use Yoast\WP\SEO\Integrations\Third_Party\Elementor_Exclude_Post_Types;
 use Yoast\WP\SEO\Integrations\Third_Party\Exclude_Elementor_Post_Types as Renamed_To_Exclude_Elementor_Post_Types;
 
 $renamed_classes = [
-	Elementor_Exclude_Post_Types::class    => [ Renamed_To_Exclude_Elementor_Post_Types::class, '16.7' ],
-	Front_End_Inspector_Conditional::class => [ Front_End_Inspector_Conditional::class, '19.5' ],
+	Elementor_Exclude_Post_Types::class => [ Renamed_To_Exclude_Elementor_Post_Types::class, '16.7' ],
 ];
 
 foreach ( $renamed_classes as $original_class => $replacement ) {

--- a/config/dependency-injection/services.php
+++ b/config/dependency-injection/services.php
@@ -45,6 +45,7 @@ $container->register( Adapter::class, Adapter::class )->setAutowired( true )->se
 
 // Elegantly deprecate renamed classes.
 include __DIR__ . '/renamed-classes.php';
+include __DIR__ . '/deprecated-classes.php';
 
 $yoast_seo_excluded_files = [
 	'main.php',

--- a/src/deprecated/src/conditionals/front-end-inspector-conditional.php
+++ b/src/deprecated/src/conditionals/front-end-inspector-conditional.php
@@ -4,16 +4,20 @@ namespace Yoast\WP\SEO\Conditionals;
 
 /**
  * Feature flag conditional for the front-end inspector.
+ *
+ * @deprecated 19.5
  */
 class Front_End_Inspector_Conditional extends Feature_Flag_Conditional {
 
 	/**
 	 * Returns the name of the feature flag.
 	 *
+	 * @deprecated 19.5
+	 *
 	 * @return string The name of the feature flag.
 	 */
 	protected function get_feature_flag() {
-		\_deprecated_function( __METHOD__, 'WPSEO 19.1' );
+		\_deprecated_function( __METHOD__, 'WPSEO 19.5' );
 		return 'FRONT_END_INSPECTOR';
 	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Adds the deprecated front end conditional to the DI container so it can still be used by old versions of premium.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a fatal error when the Yoast SEO 19.5 was used with an older version of Yoast SEO Premium.

## Relevant technical choices:

* Adds the `deprecated-classes.php` to easily do the same for future deprecated classes.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install Yoast SEO 19.5.1 and Yoast SEO Premium 19.0. There should be no fatals.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Running Yoast SEO with an older version of Yoast SEO Premium.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
