### PR TITLE
PC-385 - Do not show SKU or product identifier assessments when a simple product does not have a regular price

### DIFF
--- a/packages/yoastseo/spec/scoring/assessments/seo/ProductIdentifiersAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/ProductIdentifiersAssessmentSpec.js
@@ -112,3 +112,43 @@ describe( "a test for Product identifiers assessment for Shopify", () => {
 	} );
 } );
 
+describe( "a test for the applicability of the assessment", function() {
+	const assessment = new ProductIdentifiersAssessment( { assessVariants: true }, );
+
+	it( "is not applicable when there is no price and no variants", function() {
+		const customData = {
+			hasPrice: false,
+			hasGlobalIdentifier: true,
+			hasVariants: false,
+		};
+		const paperWithCustomData = new Paper( "", { customData } );
+		const isApplicable = assessment.isApplicable( paperWithCustomData );
+
+		expect( isApplicable ).toBe( false );
+	} );
+
+	it( "is applicable when there is a price and no variants", function() {
+		const customData = {
+			hasPrice: true,
+			hasGlobalIdentifier: true,
+			hasVariants: false,
+		};
+		const paperWithCustomData = new Paper( "", { customData } );
+		const isApplicable = assessment.isApplicable( paperWithCustomData );
+
+		expect( isApplicable ).toBe( true );
+	} );
+
+	it( "is applicable when there is no price but there are variants", function() {
+		const customData = {
+			hasPrice: false,
+			hasGlobalIdentifier: false,
+			hasVariants: true,
+		};
+		const paperWithCustomData = new Paper( "", { customData } );
+		const isApplicable = assessment.isApplicable( paperWithCustomData );
+
+		expect( isApplicable ).toBe( true );
+	} );
+} );
+

--- a/packages/yoastseo/spec/scoring/assessments/seo/ProductSKUAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/ProductSKUAssessmentSpec.js
@@ -111,3 +111,42 @@ describe( "a test for SKU assessment for Shopify", () => {
 	} );
 } );
 
+describe( "a test for the applicability of the assessment", function() {
+	const assessment = new ProductSKUAssessment( { assessVariants: true }, );
+
+	it( "is not applicable when there is no price and no variants", function() {
+		const customData = {
+			hasPrice: false,
+			hasGlobalIdentifier: true,
+			hasVariants: false,
+		};
+		const paperWithCustomData = new Paper( "", { customData } );
+		const isApplicable = assessment.isApplicable( paperWithCustomData );
+
+		expect( isApplicable ).toBe( false );
+	} );
+
+	it( "is applicable when there is a price and no variants", function() {
+		const customData = {
+			hasPrice: true,
+			hasGlobalIdentifier: true,
+			hasVariants: false,
+		};
+		const paperWithCustomData = new Paper( "", { customData } );
+		const isApplicable = assessment.isApplicable( paperWithCustomData );
+
+		expect( isApplicable ).toBe( true );
+	} );
+
+	it( "is applicable when there is no price but there are variants", function() {
+		const customData = {
+			hasPrice: false,
+			hasGlobalIdentifier: false,
+			hasVariants: true,
+		};
+		const paperWithCustomData = new Paper( "", { customData } );
+		const isApplicable = assessment.isApplicable( paperWithCustomData );
+
+		expect( isApplicable ).toBe( true );
+	} );
+} );

--- a/packages/yoastseo/spec/scoring/productPages/cornerstone/seoAssessorSpec.js
+++ b/packages/yoastseo/spec/scoring/productPages/cornerstone/seoAssessorSpec.js
@@ -60,8 +60,6 @@ describe( "running assessments in the product page SEO assessor", function() {
 			"metaDescriptionLength",
 			"textLength",
 			"titleWidth",
-			"productIdentifier",
-			"productSKU",
 		] );
 	} );
 
@@ -76,8 +74,6 @@ describe( "running assessments in the product page SEO assessor", function() {
 			"textLength",
 			"titleWidth",
 			"images",
-			"productIdentifier",
-			"productSKU",
 		] );
 	} );
 
@@ -93,8 +89,6 @@ describe( "running assessments in the product page SEO assessor", function() {
 			"titleWidth",
 			"singleH1",
 			"images",
-			"productIdentifier",
-			"productSKU",
 		] );
 	} );
 
@@ -110,8 +104,6 @@ describe( "running assessments in the product page SEO assessor", function() {
 			"textLength",
 			"titleWidth",
 			"images",
-			"productIdentifier",
-			"productSKU",
 		] );
 	} );
 
@@ -125,8 +117,6 @@ describe( "running assessments in the product page SEO assessor", function() {
 			"textLength",
 			"titleWidth",
 			"functionWordsInKeyphrase",
-			"productIdentifier",
-			"productSKU",
 		] );
 	} );
 
@@ -144,8 +134,6 @@ describe( "running assessments in the product page SEO assessor", function() {
 			"textLength",
 			"titleWidth",
 			"images",
-			"productIdentifier",
-			"productSKU",
 		] );
 	} );
 
@@ -161,8 +149,6 @@ describe( "running assessments in the product page SEO assessor", function() {
 			"textLength",
 			"titleWidth",
 			"images",
-			"productIdentifier",
-			"productSKU",
 		] );
 	} );
 
@@ -179,9 +165,20 @@ describe( "running assessments in the product page SEO assessor", function() {
 			"titleWidth",
 			"slugKeyword",
 			"images",
-			"productIdentifier",
-			"productSKU",
 		] );
+	} );
+
+	it( "additionally runs assessments that require a product with variants or a price", function() {
+		const customData = {
+			hasVariants: true,
+			hasPrice: false,
+		};
+		assessor.assess( new Paper( "", { customData } ) );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toContain( "productIdentifier" );
+		expect( assessments ).toContain( "productSKU" );
 	} );
 
 	// These specifications will additionally trigger the largest keyword distance assessment.
@@ -211,8 +208,6 @@ describe( "running assessments in the product page SEO assessor", function() {
 			"titleWidth",
 			"images",
 			"keyphraseDistribution",
-			"productIdentifier",
-			"productSKU",
 		] );
 	} );
 
@@ -242,8 +237,6 @@ describe( "running assessments in the product page SEO assessor", function() {
 			"titleWidth",
 			"images",
 			"keyphraseDistribution",
-			"productIdentifier",
-			"productSKU",
 		] );
 	} );
 

--- a/packages/yoastseo/spec/scoring/productPages/fullTextTests/runFullTextTests.js
+++ b/packages/yoastseo/spec/scoring/productPages/fullTextTests/runFullTextTests.js
@@ -346,7 +346,7 @@ testPapers.forEach( function( testPaper ) {
 		} );
 
 		it( "returns a score and the associated feedback text for the SKU assessment", function() {
-			const isApplicable = productSKUAssessment.isApplicable();
+			const isApplicable = productSKUAssessment.isApplicable( paper, researcher );
 			expect( isApplicable ).toBe( expectedResults.productSKU.isApplicable );
 
 			if ( isApplicable ) {

--- a/packages/yoastseo/spec/scoring/productPages/fullTextTests/testTexts/en/englishPaper1.js
+++ b/packages/yoastseo/spec/scoring/productPages/fullTextTests/testTexts/en/englishPaper1.js
@@ -14,6 +14,7 @@ const paper = new Paper( content, {
 	permalink: "https://en.wikipedia.org/wiki/Cat_play_and_toys",
 	slug: "Cat_play_and_toys",
 	customData: {
+		hasPrice: true,
 		hasGlobalSKU: true,
 		hasGlobalIdentifier: true,
 		hasVariants: false,

--- a/packages/yoastseo/spec/scoring/productPages/fullTextTests/testTexts/en/englishPaper2.js
+++ b/packages/yoastseo/spec/scoring/productPages/fullTextTests/testTexts/en/englishPaper2.js
@@ -15,6 +15,7 @@ const paper = new Paper( content, {
 	permalink: "https://en.wikipedia.org/wiki/Monstera_deliciosa",
 	slug: "Monstera_deliciosa",
 	customData: {
+		hasPrice: true,
 		hasGlobalSKU: false,
 		hasGlobalIdentifier: false,
 		hasVariants: false,

--- a/packages/yoastseo/spec/scoring/productPages/fullTextTests/testTexts/en/englishPaper3.js
+++ b/packages/yoastseo/spec/scoring/productPages/fullTextTests/testTexts/en/englishPaper3.js
@@ -15,6 +15,7 @@ const paper = new Paper( content, {
 	permalink: "https://en.wikipedia.org/wiki/Cat_tree",
 	slug: "Cat_tree",
 	customData: {
+		hasPrice: false,
 		hasGlobalSKU: true,
 		hasGlobalIdentifier: true,
 		hasVariants: true,

--- a/packages/yoastseo/spec/scoring/productPages/seoAssessorSpec.js
+++ b/packages/yoastseo/spec/scoring/productPages/seoAssessorSpec.js
@@ -60,8 +60,6 @@ describe( "running assessments in the product page SEO assessor", function() {
 			"metaDescriptionLength",
 			"textLength",
 			"titleWidth",
-			"productIdentifier",
-			"productSKU",
 		] );
 	} );
 
@@ -76,8 +74,6 @@ describe( "running assessments in the product page SEO assessor", function() {
 			"textLength",
 			"titleWidth",
 			"images",
-			"productIdentifier",
-			"productSKU",
 		] );
 	} );
 
@@ -93,8 +89,6 @@ describe( "running assessments in the product page SEO assessor", function() {
 			"titleWidth",
 			"singleH1",
 			"images",
-			"productIdentifier",
-			"productSKU",
 		] );
 	} );
 
@@ -110,8 +104,6 @@ describe( "running assessments in the product page SEO assessor", function() {
 			"textLength",
 			"titleWidth",
 			"images",
-			"productIdentifier",
-			"productSKU",
 		] );
 	} );
 
@@ -125,8 +117,6 @@ describe( "running assessments in the product page SEO assessor", function() {
 			"metaDescriptionLength",
 			"textLength",
 			"titleWidth",
-			"productIdentifier",
-			"productSKU",
 		] );
 	} );
 
@@ -142,8 +132,6 @@ describe( "running assessments in the product page SEO assessor", function() {
 			"textLength",
 			"titleWidth",
 			"images",
-			"productIdentifier",
-			"productSKU",
 		] );
 	} );
 
@@ -161,8 +149,6 @@ describe( "running assessments in the product page SEO assessor", function() {
 			"textLength",
 			"titleWidth",
 			"images",
-			"productIdentifier",
-			"productSKU",
 		] );
 	} );
 
@@ -178,8 +164,6 @@ describe( "running assessments in the product page SEO assessor", function() {
 			"textLength",
 			"titleWidth",
 			"images",
-			"productIdentifier",
-			"productSKU",
 		] );
 	} );
 
@@ -196,26 +180,24 @@ describe( "running assessments in the product page SEO assessor", function() {
 			"titleWidth",
 			"slugKeyword",
 			"images",
-			"productIdentifier",
-			"productSKU",
 		] );
 	} );
 
 	// These specifications will additionally trigger the largest keyword distance assessment.
 	it( "additionally runs assessments that require a long enough text and two keyword occurrences", function() {
 		assessor.assess( new Paper( "This is a keyword and a keyword. Lorem ipsum dolor sit amet, vim illum aeque" +
-			" constituam at. Id latine tritani alterum pro. Ei quod stet affert sed. Usu putent fabellas suavitate id." +
-			" Quo ut stet recusabo torquatos. Eum ridens possim expetenda te. Ex per putant comprehensam. At vel utinam" +
-			" cotidieque, at erat brute eum, velit percipit ius et. Has vidit accusata deterruisset ea, quod facete te" +
-			" vis. Vix ei duis dolor, id eum sonet fabulas. Id vix imperdiet efficiantur. Percipit probatus pertinax te" +
-			" sit. Putant intellegebat eu sit. Vix reque tation prompta id, ea quo labore viderer definiebas." +
-			" Oratio vocibus offendit an mei, est esse pericula liberavisse. Lorem ipsum dolor sit amet, vim illum aeque" +
-			" constituam at. Id latine tritani alterum pro. Ei quod stet affert sed. Usu putent fabellas suavitate id." +
-			" Quo ut stet recusabo torquatos. Eum ridens possim expetenda te. Ex per putant comprehensam. At vel utinam" +
-			" cotidieque, at erat brute eum, velit percipit ius et. Has vidit accusata deterruisset ea, quod facete te" +
-			" vis. Vix ei duis dolor, id eum sonet fabulas. Id vix imperdiet efficiantur. Percipit probatus pertinax te" +
-			" sit. Putant intellegebat eu sit. Vix reque tation prompta id, ea quo labore viderer definiebas." +
-			" Oratio vocibus offendit an mei, est esse pericula liberavisse.", { keyword: "keyword" } ) );
+									" constituam at. Id latine tritani alterum pro. Ei quod stet affert sed. Usu putent fabellas suavitate id." +
+									" Quo ut stet recusabo torquatos. Eum ridens possim expetenda te. Ex per putant comprehensam. At vel utinam" +
+									" cotidieque, at erat brute eum, velit percipit ius et. Has vidit accusata deterruisset ea, quod facete te" +
+									" vis. Vix ei duis dolor, id eum sonet fabulas. Id vix imperdiet efficiantur. Percipit probatus pertinax te" +
+									" sit. Putant intellegebat eu sit. Vix reque tation prompta id, ea quo labore viderer definiebas." +
+									" Oratio vocibus offendit an mei, est esse pericula liberavisse. Lorem ipsum dolor sit amet, vim illum aeque" +
+									" constituam at. Id latine tritani alterum pro. Ei quod stet affert sed. Usu putent fabellas suavitate id." +
+									" Quo ut stet recusabo torquatos. Eum ridens possim expetenda te. Ex per putant comprehensam. At vel utinam" +
+									" cotidieque, at erat brute eum, velit percipit ius et. Has vidit accusata deterruisset ea, quod facete te" +
+									" vis. Vix ei duis dolor, id eum sonet fabulas. Id vix imperdiet efficiantur. Percipit probatus pertinax te" +
+									" sit. Putant intellegebat eu sit. Vix reque tation prompta id, ea quo labore viderer definiebas." +
+									" Oratio vocibus offendit an mei, est esse pericula liberavisse.", { keyword: "keyword" } ) );
 		const AssessmentResults = assessor.getValidResults();
 		const assessments = getResults( AssessmentResults );
 
@@ -228,8 +210,6 @@ describe( "running assessments in the product page SEO assessor", function() {
 			"titleWidth",
 			"images",
 			"keyphraseDistribution",
-			"productIdentifier",
-			"productSKU",
 		] );
 	} );
 
@@ -259,9 +239,20 @@ describe( "running assessments in the product page SEO assessor", function() {
 			"titleWidth",
 			"images",
 			"keyphraseDistribution",
-			"productIdentifier",
-			"productSKU",
 		] );
+	} );
+
+	it( "additionally runs assessments that require a product with variants or a price", function() {
+		const customData = {
+			hasVariants: true,
+			hasPrice: false,
+		};
+		assessor.assess( new Paper( "", { customData } ) );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toContain( "productIdentifier" );
+		expect( assessments ).toContain( "productSKU" );
 	} );
 
 	describe( "has configuration overrides", () => {

--- a/packages/yoastseo/src/scoring/assessments/seo/ProductIdentifiersAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/ProductIdentifiersAssessment.js
@@ -58,8 +58,7 @@ export default class ProductIdentifiersAssessment extends Assessment {
 	}
 
 	/**
-	 * Checks whether the assessment is applicable. Currently it is applicable when variants should be assessed (i.e.
-	 * in WooCommerce, but not in Shopify)
+	 * Checks whether the assessment is applicable.
 	 *
 	 * @param {Paper} paper The paper to check.
 	 *
@@ -67,7 +66,8 @@ export default class ProductIdentifiersAssessment extends Assessment {
 	 */
 	isApplicable( paper ) {
 		const customData = paper.getCustomData();
-		return this._config.assessVariants && customData.hasPrice;
+		// Product should either be a simple product with a price, or a product with variants.
+		return this._config.assessVariants && ( customData.hasPrice || customData.hasVariants );
 	}
 
 	/**

--- a/packages/yoastseo/src/scoring/assessments/seo/ProductIdentifiersAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/ProductIdentifiersAssessment.js
@@ -61,10 +61,13 @@ export default class ProductIdentifiersAssessment extends Assessment {
 	 * Checks whether the assessment is applicable. Currently it is applicable when variants should be assessed (i.e.
 	 * in WooCommerce, but not in Shopify)
 	 *
+	 * @param {Paper} paper The paper to check.
+	 *
 	 * @returns {Boolean} Whether the assessment is applicable.
 	 */
-	isApplicable() {
-		return this._config.assessVariants;
+	isApplicable( paper ) {
+		const customData = paper.getCustomData();
+		return this._config.assessVariants && customData.hasPrice;
 	}
 
 	/**

--- a/packages/yoastseo/src/scoring/assessments/seo/ProductSKUAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/ProductSKUAssessment.js
@@ -56,8 +56,7 @@ export default class ProductSKUAssessment extends Assessment {
 	}
 
 	/**
-	 * Checks whether the assessment is applicable. Currently it is applicable when variants should be assessed (i.e.
-	 * in WooCommerce, but not in Shopify)
+	 * Checks whether the assessment is applicable.
 	 *
 	 * @param {Paper} paper The paper to check.
 	 *
@@ -65,7 +64,8 @@ export default class ProductSKUAssessment extends Assessment {
 	 */
 	isApplicable( paper ) {
 		const customData = paper.getCustomData();
-		return this._config.assessVariants && customData.hasPrice;
+		// Product should either be a simple product with a price, or a product with variants.
+		return this._config.assessVariants && ( customData.hasPrice || customData.hasVariants );
 	}
 
 	/**

--- a/packages/yoastseo/src/scoring/assessments/seo/ProductSKUAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/ProductSKUAssessment.js
@@ -59,10 +59,13 @@ export default class ProductSKUAssessment extends Assessment {
 	 * Checks whether the assessment is applicable. Currently it is applicable when variants should be assessed (i.e.
 	 * in WooCommerce, but not in Shopify)
 	 *
+	 * @param {Paper} paper The paper to check.
+	 *
 	 * @returns {Boolean} Whether the assessment is applicable.
 	 */
-	isApplicable() {
-		return this._config.assessVariants;
+	isApplicable( paper ) {
+		const customData = paper.getCustomData();
+		return this._config.assessVariants && customData.hasPrice;
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* The SKU and Product identifier assessments are now shown for simple products only when they have a price set.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

**Note for acceptance testers**: Test this PR together with https://github.com/Yoast/wpseo-woocommerce/pull/806 in WooCommerce SEO. Link the WooCommerce SEO branch with this branch by running this command in WooCommerce SEO and building the WooCommerce SEO plugin as normal:
```
composer require yoast/wordpress-seo dev-PC-385-do-not-show-sku-or-product-identifier-assessments-when-a-simple-product-does-not-have-a-regular-price@dev
```

* Create a product in WooCommerce
* Confirm that the SKU and Product identifier assessments do not show up in the SEO analysis results
* Add a price to the product
* Confirm that the SKU and Product identifier assessments show up in the SEO analysis results
   * Both should have an orange bullet with the following respective feedback:
     * > Product identifier: Your product is missing an identifier (like a GTIN code). Include this if you can, as it will help search engines to better understand your content. 
     * > SKU: Your product is missing a SKU. Include this if you can, as it will help search engines to better understand your content.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The Product identifier and SKU assessments. Smoke test whether they still work as expected (e.g. different variations with prices, without prices).

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes #
