### PR TITLE
Don't complain about curl version if API response is fine

### DIFF
--- a/src/services/health-check/curl-runner.php
+++ b/src/services/health-check/curl-runner.php
@@ -158,7 +158,7 @@ class Curl_Runner implements Runner_Interface {
 	 * @return bool True if all the routines for this health check were successful.
 	 */
 	public function is_successful() {
-		return $this->has_installed_addons && $this->curl_is_recent && $this->got_my_yoast_api_response;
+		return $this->has_installed_addons && $this->got_my_yoast_api_response;
 	}
 
 	/**


### PR DESCRIPTION
The curl health-check should not complain the installed version of curl if the API response is working fine

## Context
Customers get confused when warned about curl version, even though the curl version is not causing any issues.

The suggested minimum version of curl is too high, as older versions work fine if they are patched.
