### PR TITLE
PC-395-wpseo-variable-products-show-wrong-feedback-when-variants-are-deleted-in-woo

### DIFF
--- a/packages/yoastseo/spec/languageProcessing/researches/getProductIdentifierDataSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/getProductIdentifierDataSpec.js
@@ -1,6 +1,5 @@
 import productIdentifierData from "../../../src/languageProcessing/researches/getProductIdentifierData.js";
 import Paper from "../../../src/values/Paper.js";
-import productSKUData from "../../../src/languageProcessing/researches/getProductSKUData";
 
 describe( "A test to check if at least one global product barcode is filled in", () => {
 	it( "returns true if at least one barcode is filled in", function() {

--- a/packages/yoastseo/spec/languageProcessing/researches/getProductIdentifierDataSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/getProductIdentifierDataSpec.js
@@ -1,5 +1,6 @@
 import productIdentifierData from "../../../src/languageProcessing/researches/getProductIdentifierData.js";
 import Paper from "../../../src/values/Paper.js";
+import productSKUData from "../../../src/languageProcessing/researches/getProductSKUData";
 
 describe( "A test to check if at least one global product barcode is filled in", () => {
 	it( "returns true if at least one barcode is filled in", function() {
@@ -108,5 +109,20 @@ describe( "A test to check if all variants of a product have an identifier", () 
 		} );
 
 		expect( productIdentifierData( paper ).doAllVariantsHaveIdentifier ).toEqual( true );
+	} );
+} );
+
+
+describe( "correctly adds productType to data", () => {
+	it( "correctly adds productType to data", () => {
+		[ "simple", "variable", "grouped", "external" ].forEach( productType => {
+			const paper = new Paper( "Text.", {
+				customData: {
+					doAllVariantsHaveSKU: true,
+					productType: productType,
+				},
+			} );
+			expect( productIdentifierData( paper ).productType ).toEqual( productType );
+		} );
 	} );
 } );

--- a/packages/yoastseo/spec/languageProcessing/researches/getProductSKUDataSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/getProductSKUDataSpec.js
@@ -110,3 +110,17 @@ describe( "A test to check if all variants of a product have a SKU", () => {
 		expect( productSKUData( paper ).doAllVariantsHaveSKU ).toEqual( true );
 	} );
 } );
+
+describe( "correctly adds productType to data", () => {
+	it( "correctly adds productType to data", () => {
+		[ "simple", "variable", "grouped", "external" ].forEach( productType => {
+			const paper = new Paper( "Text.", {
+				customData: {
+					doAllVariantsHaveSKU: true,
+					productType: productType,
+				},
+			} );
+			expect( productSKUData( paper ).productType ).toEqual( productType );
+		} );
+	} );
+} );

--- a/packages/yoastseo/spec/scoring/assessments/seo/ProductIdentifiersAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/ProductIdentifiersAssessmentSpec.js
@@ -3,7 +3,11 @@ import ProductIdentifiersAssessment from "../../../../src/scoring/assessments/se
 import Paper from "../../../../src/values/Paper";
 import Factory from "../../../specHelpers/factory";
 
-const paper = new Paper( "" );
+const paper = new Paper( "", {
+	customData: {
+		productType: "simple",
+	},
+} );
 
 
 describe( "a test for Product identifiers assessment for WooCommerce", function() {
@@ -14,6 +18,7 @@ describe( "a test for Product identifiers assessment for WooCommerce", function(
 			hasGlobalIdentifier: true,
 			hasVariants: false,
 			doAllVariantsHaveIdentifier: false,
+			productType: "simple",
 		} ) );
 
 		expect( assessmentResult.getScore() ).toEqual( 9 );
@@ -26,6 +31,7 @@ describe( "a test for Product identifiers assessment for WooCommerce", function(
 			hasGlobalIdentifier: false,
 			hasVariants: true,
 			doAllVariantsHaveIdentifier: true,
+			productType: "variable",
 		} ) );
 
 		expect( assessmentResult.getScore() ).toEqual( 9 );
@@ -38,6 +44,7 @@ describe( "a test for Product identifiers assessment for WooCommerce", function(
 			hasGlobalIdentifier: false,
 			hasVariants: false,
 			doAllVariantsHaveIdentifier: false,
+			productType: "simple",
 		} ) );
 
 		expect( assessmentResult.getScore() ).toEqual( 6 );
@@ -51,6 +58,7 @@ describe( "a test for Product identifiers assessment for WooCommerce", function(
 			hasGlobalIdentifier: true,
 			hasVariants: true,
 			doAllVariantsHaveIdentifier: false,
+			productType: "variable",
 		} ) );
 
 		expect( assessmentResult.getScore() ).toEqual( 6 );
@@ -64,6 +72,7 @@ describe( "a test for Product identifiers assessment for WooCommerce", function(
 			hasGlobalIdentifier: false,
 			hasVariants: true,
 			doAllVariantsHaveIdentifier: false,
+			productType: "variable",
 		} ) );
 
 		expect( assessmentResult.getScore() ).toEqual( 6 );
@@ -73,13 +82,14 @@ describe( "a test for Product identifiers assessment for WooCommerce", function(
 	} );
 } );
 
+// Ignore the shopify specs as long as it is not yet implemented for shopify.
 describe( "a test for Product identifiers assessment for Shopify", () => {
 	const assessment = new ProductIdentifiersAssessment( { urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify81" ),
 		urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify82" ),
 		assessVariants: false,
 		productIdentifierOrBarcode: "Barcode" } );
 
-	it( "returns with score 9 when the product has global identifier and no variants", () => {
+	xit( "returns with score 9 when the product has global identifier and no variants", () => {
 		const assessmentResult = assessment.getResult( paper, Factory.buildMockResearcher( {
 			hasGlobalIdentifier: true,
 			hasVariants: false,
@@ -90,7 +100,7 @@ describe( "a test for Product identifiers assessment for Shopify", () => {
 			"Your product has a barcode. Good job!" );
 	} );
 
-	it( "returns with score 6 when the product doesn't have a global identifier nor variants", () => {
+	xit( "returns with score 6 when the product doesn't have a global identifier nor variants", () => {
 		const assessmentResult = assessment.getResult( paper, Factory.buildMockResearcher( {
 			hasGlobalIdentifier: false,
 			hasVariants: false,
@@ -102,7 +112,7 @@ describe( "a test for Product identifiers assessment for Shopify", () => {
 			" this if you can, as it will help search engines to better understand your content.</a>" );
 	} );
 
-	it( "should not return a score if the product has variants", () => {
+	xit( "should not return a score if the product has variants", () => {
 		const assessmentResult = assessment.getResult( paper, Factory.buildMockResearcher( {
 			hasGlobalIdentifier: false,
 			hasVariants: true,
@@ -112,8 +122,8 @@ describe( "a test for Product identifiers assessment for Shopify", () => {
 	} );
 } );
 
-describe( "a test for the applicability of the assessment", function() {
-	const assessment = new ProductIdentifiersAssessment( { assessVariants: true }, );
+xdescribe( "a test for the applicability of the assessment", function() {
+	const assessment = new ProductIdentifiersAssessment( { assessVariants: true } );
 
 	it( "is not applicable when there is no price and no variants", function() {
 		const customData = {
@@ -152,3 +162,59 @@ describe( "a test for the applicability of the assessment", function() {
 	} );
 } );
 
+describe( "test the applicabilityHelper", () => {
+	it( "returns false when assessVariants is false", () => {
+		const assessment = new ProductIdentifiersAssessment( { assessVariants: false } );
+		const customData = {
+			hasPrice: true,
+			hasGlobalIdentifier: true,
+			hasVariants: false,
+		};
+		const paperWithCustomData = new Paper( "", { customData } );
+		const isApplicable = assessment.isApplicable( paperWithCustomData );
+
+		expect( isApplicable ).toBe( false );
+	} );
+
+	it( "returns false variable product has no variants.", () => {
+		const assessment = new ProductIdentifiersAssessment( { assessVariants: true } );
+		const customData = {
+			hasPrice: true,
+			hasGlobalIdentifier: true,
+			hasVariants: false,
+			productType: "variable",
+		};
+		const paperWithCustomData = new Paper( "", { customData } );
+		const isApplicable = assessment.isApplicable( paperWithCustomData );
+
+		expect( isApplicable ).toBe( false );
+	} );
+
+	it( "returns true variable product has variants.", () => {
+		const assessment = new ProductIdentifiersAssessment( { assessVariants: true } );
+		const customData = {
+			hasPrice: true,
+			hasGlobalIdentifier: true,
+			hasVariants: true,
+			productType: "variable",
+		};
+		const paperWithCustomData = new Paper( "", { customData } );
+		const isApplicable = assessment.isApplicable( paperWithCustomData );
+
+		expect( isApplicable ).toBe( true );
+	} );
+
+	it( "returns false variable product has no price and no variants.", () => {
+		const assessment = new ProductIdentifiersAssessment( { assessVariants: true } );
+		const customData = {
+			hasPrice: false,
+			hasGlobalIdentifier: true,
+			hasVariants: false,
+			productType: "variable",
+		};
+		const paperWithCustomData = new Paper( "", { customData } );
+		const isApplicable = assessment.isApplicable( paperWithCustomData );
+
+		expect( isApplicable ).toBe( false );
+	} );
+} );

--- a/packages/yoastseo/spec/scoring/assessments/seo/ProductIdentifiersAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/ProductIdentifiersAssessmentSpec.js
@@ -3,11 +3,7 @@ import ProductIdentifiersAssessment from "../../../../src/scoring/assessments/se
 import Paper from "../../../../src/values/Paper";
 import Factory from "../../../specHelpers/factory";
 
-const paper = new Paper( "", {
-	customData: {
-		productType: "simple",
-	},
-} );
+const paper = new Paper( "" );
 
 
 describe( "a test for Product identifiers assessment for WooCommerce", function() {
@@ -83,13 +79,13 @@ describe( "a test for Product identifiers assessment for WooCommerce", function(
 } );
 
 // Ignore the shopify specs as long as it is not yet implemented for shopify.
-describe( "a test for Product identifiers assessment for Shopify", () => {
+xdescribe( "a test for Product identifiers assessment for Shopify", () => {
 	const assessment = new ProductIdentifiersAssessment( { urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify81" ),
 		urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify82" ),
 		assessVariants: false,
 		productIdentifierOrBarcode: "Barcode" } );
 
-	xit( "returns with score 9 when the product has global identifier and no variants", () => {
+	it( "returns with score 9 when the product has global identifier and no variants", () => {
 		const assessmentResult = assessment.getResult( paper, Factory.buildMockResearcher( {
 			hasGlobalIdentifier: true,
 			hasVariants: false,
@@ -100,7 +96,7 @@ describe( "a test for Product identifiers assessment for Shopify", () => {
 			"Your product has a barcode. Good job!" );
 	} );
 
-	xit( "returns with score 6 when the product doesn't have a global identifier nor variants", () => {
+	it( "returns with score 6 when the product doesn't have a global identifier nor variants", () => {
 		const assessmentResult = assessment.getResult( paper, Factory.buildMockResearcher( {
 			hasGlobalIdentifier: false,
 			hasVariants: false,
@@ -112,7 +108,7 @@ describe( "a test for Product identifiers assessment for Shopify", () => {
 			" this if you can, as it will help search engines to better understand your content.</a>" );
 	} );
 
-	xit( "should not return a score if the product has variants", () => {
+	it( "should not return a score if the product has variants", () => {
 		const assessmentResult = assessment.getResult( paper, Factory.buildMockResearcher( {
 			hasGlobalIdentifier: false,
 			hasVariants: true,
@@ -122,7 +118,7 @@ describe( "a test for Product identifiers assessment for Shopify", () => {
 	} );
 } );
 
-xdescribe( "a test for the applicability of the assessment", function() {
+describe( "a test for the applicability of the assessment", function() {
 	const assessment = new ProductIdentifiersAssessment( { assessVariants: true } );
 
 	it( "is not applicable when there is no price and no variants", function() {

--- a/packages/yoastseo/spec/scoring/assessments/seo/ProductIdentifiersAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/ProductIdentifiersAssessmentSpec.js
@@ -156,9 +156,7 @@ describe( "a test for the applicability of the assessment", function() {
 
 		expect( isApplicable ).toBe( true );
 	} );
-} );
 
-describe( "test the applicabilityHelper", () => {
 	it( "returns false when assessVariants is false", () => {
 		const assessment = new ProductIdentifiersAssessment( { assessVariants: false } );
 		const customData = {
@@ -214,3 +212,4 @@ describe( "test the applicabilityHelper", () => {
 		expect( isApplicable ).toBe( false );
 	} );
 } );
+

--- a/packages/yoastseo/spec/scoring/assessments/seo/ProductIdentifiersAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/ProductIdentifiersAssessmentSpec.js
@@ -119,9 +119,8 @@ xdescribe( "a test for Product identifiers assessment for Shopify", () => {
 } );
 
 describe( "a test for the applicability of the assessment", function() {
-	const assessment = new ProductIdentifiersAssessment( { assessVariants: true } );
-
 	it( "is not applicable when there is no price and no variants", function() {
+		const assessment = new ProductIdentifiersAssessment( { assessVariants: true } );
 		const customData = {
 			hasPrice: false,
 			hasGlobalIdentifier: true,
@@ -134,6 +133,7 @@ describe( "a test for the applicability of the assessment", function() {
 	} );
 
 	it( "is applicable when there is a price and no variants", function() {
+		const assessment = new ProductIdentifiersAssessment( { assessVariants: true } );
 		const customData = {
 			hasPrice: true,
 			hasGlobalIdentifier: true,
@@ -146,6 +146,7 @@ describe( "a test for the applicability of the assessment", function() {
 	} );
 
 	it( "is applicable when there is no price but there are variants", function() {
+		const assessment = new ProductIdentifiersAssessment( { assessVariants: true } );
 		const customData = {
 			hasPrice: false,
 			hasGlobalIdentifier: false,

--- a/packages/yoastseo/spec/scoring/assessments/seo/ProductSKUAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/ProductSKUAssessmentSpec.js
@@ -2,7 +2,6 @@ import { createAnchorOpeningTag } from "../../../../src/helpers/shortlinker";
 import ProductSKUAssessment from "../../../../src/scoring/assessments/seo/ProductSKUAssessment";
 import Paper from "../../../../src/values/Paper";
 import Factory from "../../../specHelpers/factory";
-import ProductIdentifiersAssessment from "../../../../src/scoring/assessments/seo/ProductIdentifiersAssessment";
 
 const paper = new Paper( "" );
 
@@ -156,10 +155,7 @@ describe( "a test for the applicability of the assessment", function() {
 
 		expect( isApplicable ).toBe( true );
 	} );
-} );
 
-
-describe( "test the applicabilityHelper", () => {
 	it( "returns false when assessVariants is false", () => {
 		const assessment = new ProductSKUAssessment( { assessVariants: false } );
 		const customData = {

--- a/packages/yoastseo/spec/scoring/assessments/seo/ProductSKUAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/ProductSKUAssessmentSpec.js
@@ -14,7 +14,7 @@ describe( "a test for SKU assessment for WooCommerce", function() {
 			hasGlobalSKU: true,
 			hasVariants: false,
 			doAllVariantsHaveSKU: false,
-			productType: "simple"
+			productType: "simple",
 		} ) );
 
 		expect( assessmentResult.getScore() ).toEqual( 9 );
@@ -118,9 +118,8 @@ xdescribe( "a test for SKU assessment for Shopify", () => {
 } );
 
 describe( "a test for the applicability of the assessment", function() {
-	const assessment = new ProductSKUAssessment( { assessVariants: true }, );
-
 	it( "is not applicable when there is no price and no variants", function() {
+		const assessment = new ProductSKUAssessment( { assessVariants: true } );
 		const customData = {
 			hasPrice: false,
 			hasGlobalIdentifier: true,
@@ -133,6 +132,7 @@ describe( "a test for the applicability of the assessment", function() {
 	} );
 
 	it( "is applicable when there is a price and no variants", function() {
+		const assessment = new ProductSKUAssessment( { assessVariants: true } );
 		const customData = {
 			hasPrice: true,
 			hasGlobalIdentifier: true,
@@ -145,6 +145,7 @@ describe( "a test for the applicability of the assessment", function() {
 	} );
 
 	it( "is applicable when there is no price but there are variants", function() {
+		const assessment = new ProductSKUAssessment( { assessVariants: true } );
 		const customData = {
 			hasPrice: false,
 			hasGlobalIdentifier: false,

--- a/packages/yoastseo/spec/scoring/assessments/seo/ProductSKUAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/ProductSKUAssessmentSpec.js
@@ -2,6 +2,7 @@ import { createAnchorOpeningTag } from "../../../../src/helpers/shortlinker";
 import ProductSKUAssessment from "../../../../src/scoring/assessments/seo/ProductSKUAssessment";
 import Paper from "../../../../src/values/Paper";
 import Factory from "../../../specHelpers/factory";
+import ProductIdentifiersAssessment from "../../../../src/scoring/assessments/seo/ProductIdentifiersAssessment";
 
 const paper = new Paper( "" );
 
@@ -14,6 +15,7 @@ describe( "a test for SKU assessment for WooCommerce", function() {
 			hasGlobalSKU: true,
 			hasVariants: false,
 			doAllVariantsHaveSKU: false,
+			productType: "simple"
 		} ) );
 
 		expect( assessmentResult.getScore() ).toEqual( 9 );
@@ -25,6 +27,7 @@ describe( "a test for SKU assessment for WooCommerce", function() {
 			hasGlobalSKU: false,
 			hasVariants: true,
 			doAllVariantsHaveSKU: true,
+			productType: "variable",
 		} ) );
 
 		expect( assessmentResult.getScore() ).toEqual( 9 );
@@ -37,6 +40,7 @@ describe( "a test for SKU assessment for WooCommerce", function() {
 			hasGlobalSKU: false,
 			hasVariants: false,
 			doAllVariantsHaveSKU: false,
+			productType: "simple",
 		} ) );
 
 		expect( assessmentResult.getScore() ).toEqual( 6 );
@@ -50,6 +54,7 @@ describe( "a test for SKU assessment for WooCommerce", function() {
 			hasGlobalSKU: true,
 			hasVariants: true,
 			doAllVariantsHaveSKU: false,
+			productType: "variable",
 		} ) );
 
 		expect( assessmentResult.getScore() ).toEqual( 6 );
@@ -63,6 +68,7 @@ describe( "a test for SKU assessment for WooCommerce", function() {
 			hasGlobalSKU: false,
 			hasVariants: true,
 			doAllVariantsHaveSKU: false,
+			productType: "variable",
 		} ) );
 
 		expect( assessmentResult.getScore() ).toEqual( 6 );
@@ -72,7 +78,8 @@ describe( "a test for SKU assessment for WooCommerce", function() {
 	} );
 } );
 
-describe( "a test for SKU assessment for Shopify", () => {
+// Ignore the shopify specs as long as it is not yet implemented for shopify.
+xdescribe( "a test for SKU assessment for Shopify", () => {
 	const assessment = new ProductSKUAssessment( { urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify79" ),
 		urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify80" ),
 		assessVariants: false,
@@ -148,5 +155,63 @@ describe( "a test for the applicability of the assessment", function() {
 		const isApplicable = assessment.isApplicable( paperWithCustomData );
 
 		expect( isApplicable ).toBe( true );
+	} );
+} );
+
+
+describe( "test the applicabilityHelper", () => {
+	it( "returns false when assessVariants is false", () => {
+		const assessment = new ProductSKUAssessment( { assessVariants: false } );
+		const customData = {
+			hasPrice: true,
+			hasGlobalIdentifier: true,
+			hasVariants: false,
+		};
+		const paperWithCustomData = new Paper( "", { customData } );
+		const isApplicable = assessment.isApplicable( paperWithCustomData );
+
+		expect( isApplicable ).toBe( false );
+	} );
+
+	it( "returns false variable product has no variants.", () => {
+		const assessment = new ProductSKUAssessment( { assessVariants: true } );
+		const customData = {
+			hasPrice: true,
+			hasGlobalIdentifier: true,
+			hasVariants: false,
+			productType: "variable",
+		};
+		const paperWithCustomData = new Paper( "", { customData } );
+		const isApplicable = assessment.isApplicable( paperWithCustomData );
+
+		expect( isApplicable ).toBe( false );
+	} );
+
+	it( "returns true variable product has variants.", () => {
+		const assessment = new ProductSKUAssessment( { assessVariants: true } );
+		const customData = {
+			hasPrice: true,
+			hasGlobalIdentifier: true,
+			hasVariants: true,
+			productType: "variable",
+		};
+		const paperWithCustomData = new Paper( "", { customData } );
+		const isApplicable = assessment.isApplicable( paperWithCustomData );
+
+		expect( isApplicable ).toBe( true );
+	} );
+
+	it( "returns false variable product has no price and no variants.", () => {
+		const assessment = new ProductSKUAssessment( { assessVariants: true } );
+		const customData = {
+			hasPrice: false,
+			hasGlobalIdentifier: true,
+			hasVariants: false,
+			productType: "variable",
+		};
+		const paperWithCustomData = new Paper( "", { customData } );
+		const isApplicable = assessment.isApplicable( paperWithCustomData );
+
+		expect( isApplicable ).toBe( false );
 	} );
 } );

--- a/packages/yoastseo/spec/scoring/productPages/cornerstone/seoAssessorSpec.js
+++ b/packages/yoastseo/spec/scoring/productPages/cornerstone/seoAssessorSpec.js
@@ -172,6 +172,7 @@ describe( "running assessments in the product page SEO assessor", function() {
 		const customData = {
 			hasVariants: true,
 			hasPrice: false,
+			productType: "simple",
 		};
 		assessor.assess( new Paper( "", { customData } ) );
 		const AssessmentResults = assessor.getValidResults();

--- a/packages/yoastseo/spec/scoring/productPages/fullTextTests/runFullTextTests.js
+++ b/packages/yoastseo/spec/scoring/productPages/fullTextTests/runFullTextTests.js
@@ -126,6 +126,7 @@ testPapers.forEach( function( testPaper ) {
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/4lw" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/4lx" ),
 			assessVariants: true,
+			productType: "simple",
 		} );
 		const imageKeyphraseAssessment = new ImageKeyphraseAssessment( {
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify22" ),

--- a/packages/yoastseo/spec/scoring/productPages/fullTextTests/testTexts/en/englishPaper1.js
+++ b/packages/yoastseo/spec/scoring/productPages/fullTextTests/testTexts/en/englishPaper1.js
@@ -18,6 +18,7 @@ const paper = new Paper( content, {
 		hasGlobalSKU: true,
 		hasGlobalIdentifier: true,
 		hasVariants: false,
+		productType: "simple",
 	},
 } );
 

--- a/packages/yoastseo/spec/scoring/productPages/fullTextTests/testTexts/en/englishPaper2.js
+++ b/packages/yoastseo/spec/scoring/productPages/fullTextTests/testTexts/en/englishPaper2.js
@@ -19,6 +19,7 @@ const paper = new Paper( content, {
 		hasGlobalSKU: false,
 		hasGlobalIdentifier: false,
 		hasVariants: false,
+		productType: "simple",
 	},
 
 } );

--- a/packages/yoastseo/spec/scoring/productPages/fullTextTests/testTexts/en/englishPaper3.js
+++ b/packages/yoastseo/spec/scoring/productPages/fullTextTests/testTexts/en/englishPaper3.js
@@ -21,6 +21,7 @@ const paper = new Paper( content, {
 		hasVariants: true,
 		doAllVariantsHaveSKU: false,
 		doAllVariantsHaveIdentifier: false,
+		productType: "variable",
 	},
 } );
 

--- a/packages/yoastseo/spec/scoring/productPages/seoAssessorSpec.js
+++ b/packages/yoastseo/spec/scoring/productPages/seoAssessorSpec.js
@@ -246,6 +246,7 @@ describe( "running assessments in the product page SEO assessor", function() {
 		const customData = {
 			hasVariants: true,
 			hasPrice: false,
+			productType: "simple",
 		};
 		assessor.assess( new Paper( "", { customData } ) );
 		const AssessmentResults = assessor.getValidResults();

--- a/packages/yoastseo/src/languageProcessing/researches/getProductIdentifierData.js
+++ b/packages/yoastseo/src/languageProcessing/researches/getProductIdentifierData.js
@@ -15,5 +15,8 @@ export default function( paper ) {
 	if ( customData.hasOwnProperty( "doAllVariantsHaveIdentifier" ) ) {
 		productData.doAllVariantsHaveIdentifier = customData.doAllVariantsHaveIdentifier;
 	}
+	if ( customData.hasOwnProperty( "productType" ) ) {
+		productData.productType = customData.productType;
+	}
 	return productData;
 }

--- a/packages/yoastseo/src/languageProcessing/researches/getProductSKUData.js
+++ b/packages/yoastseo/src/languageProcessing/researches/getProductSKUData.js
@@ -15,5 +15,8 @@ export default function( paper ) {
 	if ( customData.hasOwnProperty( "doAllVariantsHaveSKU" ) ) {
 		productData.doAllVariantsHaveSKU = customData.doAllVariantsHaveSKU;
 	}
+	if ( customData.hasOwnProperty( "productType" ) ) {
+		productData.productType = customData.productType;
+	}
 	return productData;
 }

--- a/packages/yoastseo/src/scoring/assessments/seo/ProductIdentifiersAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/ProductIdentifiersAssessment.js
@@ -61,7 +61,6 @@ export default class ProductIdentifiersAssessment extends Assessment {
 	 * Contains extra logic for the isApplicable method.
 	 *
 	 * @param {object} customData The custom data part of the Paper object.
-	 * @private
 	 *
 	 * @returns {bool} Whether the productIdentifierAssessment is applicable.
 	 */
@@ -90,7 +89,6 @@ export default class ProductIdentifiersAssessment extends Assessment {
 	 */
 	isApplicable( paper ) {
 		const customData = paper.getCustomData();
-		// Product should either be a simple product with a price, or a product with variants.
 		return this.applicabilityHelper( customData );
 	}
 
@@ -122,7 +120,6 @@ export default class ProductIdentifiersAssessment extends Assessment {
 			};
 		}
 
-		// If a product has no variants, return orange bullet if it has no global identifier, and green bullet if it has one.
 		if ( [ "simple", "external" ].includes( productIdentifierData.productType ) ) {
 			if ( ! productIdentifierData.hasGlobalIdentifier ) {
 				return {

--- a/packages/yoastseo/src/scoring/assessments/seo/ProductIdentifiersAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/ProductIdentifiersAssessment.js
@@ -58,28 +58,26 @@ export default class ProductIdentifiersAssessment extends Assessment {
 	}
 
 	/**
+	 * Contains extra logic for the isApplicable method.
 	 *
-	 * @param customData
+	 * @param {object} customData The custom data part of the Paper object.
 	 * @private
+	 *
+	 * @returns {bool} Whether the productIdentifierAssessment is applicable.
 	 */
 	applicabilityHelper( customData ) {
-		console.log( "TEST (not) hasvariants identifier: ", ! customData.hasVariants );
 		// Checks if we are in Woo or Shopify. assessVariants is always true in Woo
 		// Don't return a score if the product has variants but we don't want to assess variants for this product.
 		// This is currently the case for Shopify products because we don't have access data about product variant identifiers in Shopify.
-		// TODO: check how this influences shopify: not totally accurate. (Possibly find other solution). Minimal solution: document
 		if ( ! this._config.assessVariants ) {
-			console.log( "condition 1" );
 			return false;
 		}
 
 		// If we have a variable product with no (active) variants. (active variant = variant with a price)
 		if (  customData.productType === "variable" && ! customData.hasVariants  ) {
-			console.log( "condition 2" );
 			return false;
 		}
 
-		console.log( "condition 3" );
 		return ( customData.hasPrice || customData.hasVariants );
 	}
 
@@ -126,7 +124,6 @@ export default class ProductIdentifiersAssessment extends Assessment {
 
 		// If a product has no variants, return orange bullet if it has no global identifier, and green bullet if it has one.
 		if ( [ "simple", "external" ].includes( productIdentifierData.productType ) ) {
-			console.log("TEST simple")
 			if ( ! productIdentifierData.hasGlobalIdentifier ) {
 				return {
 					score: config.scores.ok,
@@ -166,7 +163,6 @@ export default class ProductIdentifiersAssessment extends Assessment {
 				),
 			};
 		} else if ( productIdentifierData.productType === "variable" ) {
-			console.log("test variable")
 			if ( ! productIdentifierData.doAllVariantsHaveIdentifier ) {
 				// If we want to assess variants, and if product has variants but not all variants have an identifier, return orange bullet.
 				// If all variants have an identifier, return green bullet.

--- a/packages/yoastseo/src/scoring/assessments/seo/ProductIdentifiersAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/ProductIdentifiersAssessment.js
@@ -58,6 +58,30 @@ export default class ProductIdentifiersAssessment extends Assessment {
 	}
 
 	/**
+	 *
+	 * @param customData
+	 * @private
+	 */
+	applicabilityHelper( customData ) {
+		console.log( "TEST (not) hasvariants: ", ! customData.hasVariants );
+		// Checks if we are in Woo or Shopify. assessVariants is always true in Woo
+		// TODO: check how this influences shopify: not totally accurate. (Possibly find other solution). Minimal solution: document
+		if ( ! this._config.assessVariants ) {
+			console.log( "condition 1" );
+			return false;
+		}
+
+		// If we have a variable product with no (active) variants. (active variant = variant with a price)
+		if (  customData.productType === "variable" && ! customData.hasVariants  ) {
+			console.log( "condition 2" );
+			return false;
+		}
+
+		console.log( "condition 3" );
+		return ( customData.hasPrice || customData.hasVariants );
+	}
+
+	/**
 	 * Checks whether the assessment is applicable.
 	 *
 	 * @param {Paper} paper The paper to check.
@@ -67,7 +91,7 @@ export default class ProductIdentifiersAssessment extends Assessment {
 	isApplicable( paper ) {
 		const customData = paper.getCustomData();
 		// Product should either be a simple product with a price, or a product with variants.
-		return this._config.assessVariants && ( customData.hasPrice || customData.hasVariants );
+		return this.applicabilityHelper( customData );
 	}
 
 	/**

--- a/packages/yoastseo/src/scoring/assessments/seo/ProductSKUAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/ProductSKUAssessment.js
@@ -3,6 +3,7 @@ import AssessmentResult from "../../../values/AssessmentResult";
 import { merge } from "lodash-es";
 import { createAnchorOpeningTag } from "../../../helpers/shortlinker";
 import { __, sprintf } from "@wordpress/i18n";
+
 /**
  * Represents the assessment for the product SKU.
  */
@@ -58,7 +59,6 @@ export default class ProductSKUAssessment extends Assessment {
 	 * Contains extra logic for the isApplicable method.
 	 *
 	 * @param {object} customData The custom data part of the Paper object.
-	 * @private
 	 *
 	 * @returns {bool} Whether the productSKUAssessment is applicable.
 	 */
@@ -84,7 +84,6 @@ export default class ProductSKUAssessment extends Assessment {
 	 */
 	isApplicable( paper ) {
 		const customData = paper.getCustomData();
-		// Product should either be a simple product with a price, or a product with variants.
 		return this.applicabilityHelper( customData );
 	}
 
@@ -98,7 +97,6 @@ export default class ProductSKUAssessment extends Assessment {
 	 * 													or empty object if no score should be returned.
 	 */
 	scoreProductSKU( productSKUData, config ) {
-		// If a product has no variants, return orange bullet if it has no global SKU, and green bullet if it has one.
 		// NOTE: product types might not be available in shopify or they might differ.
 		// So take this into account when implementing SKUAssessment for shopify.
 		if (  [ "simple", "external" ].includes( productSKUData.productType ) ) {

--- a/packages/yoastseo/src/scoring/assessments/seo/ProductSKUAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/ProductSKUAssessment.js
@@ -3,7 +3,6 @@ import AssessmentResult from "../../../values/AssessmentResult";
 import { merge } from "lodash-es";
 import { createAnchorOpeningTag } from "../../../helpers/shortlinker";
 import { __, sprintf } from "@wordpress/i18n";
-console.log( "ProductSKU is loaded" );
 /**
  * Represents the assessment for the product SKU.
  */
@@ -41,7 +40,6 @@ export default class ProductSKUAssessment extends Assessment {
 	 * @returns {AssessmentResult} An assessment result with the score and formatted text.
 	 */
 	getResult( paper, researcher ) {
-		console.log( "TEST8", this._config );
 		const productSKUData = researcher.getResearch( "getProductSKUData" );
 
 		const result = this.scoreProductSKU( productSKUData, this._config );
@@ -57,30 +55,23 @@ export default class ProductSKUAssessment extends Assessment {
 	}
 
 	/**
+	 * Contains extra logic for the isApplicable method.
 	 *
-	 * @param customData
+	 * @param {object} customData The custom data part of the Paper object.
 	 * @private
+	 *
+	 * @returns {bool} Whether the productSKUAssessment is applicable.
 	 */
 	applicabilityHelper( customData ) {
-		console.log( "TEST (not) hasvariants: ", ! customData.hasVariants );
 		// Checks if we are in Woo or Shopify. assessVariants is always true in Woo
-		// TODO: check how this influences shopify: not totally accurate. (Possibly find other solution). Minimal solution: document
 		if ( ! this._config.assessVariants ) {
-			console.log("condition 1")
 			return false;
 		}
 
 		// If we have a variable product with no (active) variants. (active variant = variant with a price)
-		if (  customData.productType === "variable" && ! customData.hasVariants  ) {
-			console.log("condition 2")
+		if (  customData.productType === "variable" && ! customData.hasVariants ) {
 			return false;
 		}
-		// } else if ( customData.productType === "simple" ) {
-		//
-		// } else {
-		// 	Console.log( "undefined case" );
-		// }
-		console.log("condition 3")
 		return ( customData.hasPrice || customData.hasVariants );
 	}
 
@@ -108,10 +99,6 @@ export default class ProductSKUAssessment extends Assessment {
 	 */
 	scoreProductSKU( productSKUData, config ) {
 		// If a product has no variants, return orange bullet if it has no global SKU, and green bullet if it has one.
-		console.log( "TEST6", productSKUData );
-		console.log( "TEST7", config );
-
-		// TODO: in shopify there are different product types.
 		// NOTE: product types might not be available in shopify or they might differ.
 		// So take this into account when implementing SKUAssessment for shopify.
 		if (  [ "simple", "external" ].includes( productSKUData.productType ) ) {
@@ -175,7 +162,6 @@ export default class ProductSKUAssessment extends Assessment {
 				),
 			};
 		}
-		//TODO: document that for grouped product we never show assessment.
 		return {};
 	}
 }

--- a/packages/yoastseo/src/scoring/assessments/seo/ProductSKUAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/ProductSKUAssessment.js
@@ -112,14 +112,16 @@ export default class ProductSKUAssessment extends Assessment {
 		console.log( "TEST7", config );
 
 		// TODO: in shopify there are different product types.
-		if (  [ "simple", "external" ].contains( productSKUData.productType ) ) {
+		// NOTE: product types might not be available in shopify or they might differ.
+		// So take this into account when implementing SKUAssessment for shopify.
+		if (  [ "simple", "external" ].includes( productSKUData.productType ) ) {
 			if ( ! productSKUData.hasGlobalSKU ) {
 				return {
 					score: config.scores.ok,
 					text: sprintf(
 						// Translators: %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag.
 						__(
-							"%1$sSKU%3$s: Your product is missing a dadaSKU. %2$sInclude this if you can, as it" +
+							"%1$sSKU%3$s: Your product is missing a SKU. %2$sInclude this if you can, as it" +
 							" will help search engines to better understand your content.%3$s",
 							"wordpress-seo"
 						),
@@ -150,7 +152,7 @@ export default class ProductSKUAssessment extends Assessment {
 					text: sprintf(
 						// Translators: %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag.
 						__(
-							"%1$sSKU%3$s: Not all your product variants have a SKUUUU. %2$sInclude this if you can, as it" +
+							"%1$sSKU%3$s: Not all your product variants have a SKU. %2$sInclude this if you can, as it" +
 							" will help search engines to better understand your content.%3$s",
 							"wordpress-seo"
 						),

--- a/packages/yoastseo/src/scoring/assessments/seo/ProductSKUAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/ProductSKUAssessment.js
@@ -3,7 +3,7 @@ import AssessmentResult from "../../../values/AssessmentResult";
 import { merge } from "lodash-es";
 import { createAnchorOpeningTag } from "../../../helpers/shortlinker";
 import { __, sprintf } from "@wordpress/i18n";
-console.log("ProductSKU is loaded")
+console.log( "ProductSKU is loaded" );
 /**
  * Represents the assessment for the product SKU.
  */
@@ -41,7 +41,7 @@ export default class ProductSKUAssessment extends Assessment {
 	 * @returns {AssessmentResult} An assessment result with the score and formatted text.
 	 */
 	getResult( paper, researcher ) {
-		console.log("HELLO WORLD", this._config)
+		console.log( "TEST8", this._config );
 		const productSKUData = researcher.getResearch( "getProductSKUData" );
 
 		const result = this.scoreProductSKU( productSKUData, this._config );
@@ -57,6 +57,31 @@ export default class ProductSKUAssessment extends Assessment {
 	}
 
 	/**
+	 *
+	 * @param customData
+	 * @private
+	 */
+	applicabilityHelper( customData ) {
+		console.log( "TEST (not) hasvariants: ", ! customData.hasVariants );
+		// Checks if we are in Woo or Shopify. assessVariants is always true in Woo
+		if ( ! this._config.assessVariants ) {
+			return false;
+		}
+		// If we have a variable product with no (active) variants. (active variant = variant with a price)
+		if (  customData.productType === "variable" && ! customData.hasVariants  ) {
+			console.log( "NOT APPLICABLE" );
+			return false;
+		}
+		// } else if ( customData.productType === "simple" ) {
+		//
+		// } else {
+		// 	Console.log( "undefined case" );
+		// }
+
+		return ( customData.hasPrice || customData.hasVariants );
+	}
+
+	/**
 	 * Checks whether the assessment is applicable.
 	 *
 	 * @param {Paper} paper The paper to check.
@@ -64,10 +89,11 @@ export default class ProductSKUAssessment extends Assessment {
 	 * @returns {Boolean} Whether the assessment is applicable.
 	 */
 	isApplicable( paper ) {
-		console.log("HELLO isApplicable")
+
 		const customData = paper.getCustomData();
+		console.log( "HELLO isApplicable" );
 		// Product should either be a simple product with a price, or a product with variants.
-		return this._config.assessVariants && ( customData.hasPrice || customData.hasVariants );
+		return this.applicabilityHelper( customData );
 	}
 
 	/**
@@ -81,8 +107,8 @@ export default class ProductSKUAssessment extends Assessment {
 	 */
 	scoreProductSKU( productSKUData, config ) {
 		// If a product has no variants, return orange bullet if it has no global SKU, and green bullet if it has one.
-		console.log("TEST6", productSKUData)
-		console.log("TEST7", config)
+		console.log( "TEST6", productSKUData );
+		console.log( "TEST7", config );
 		if ( ! productSKUData.hasVariants ) {
 			if ( ! productSKUData.hasGlobalSKU ) {
 				return {

--- a/packages/yoastseo/src/scoring/assessments/seo/ProductSKUAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/ProductSKUAssessment.js
@@ -3,7 +3,7 @@ import AssessmentResult from "../../../values/AssessmentResult";
 import { merge } from "lodash-es";
 import { createAnchorOpeningTag } from "../../../helpers/shortlinker";
 import { __, sprintf } from "@wordpress/i18n";
-
+console.log("ProductSKU is loaded")
 /**
  * Represents the assessment for the product SKU.
  */
@@ -41,6 +41,7 @@ export default class ProductSKUAssessment extends Assessment {
 	 * @returns {AssessmentResult} An assessment result with the score and formatted text.
 	 */
 	getResult( paper, researcher ) {
+		console.log("HELLO WORLD", this._config)
 		const productSKUData = researcher.getResearch( "getProductSKUData" );
 
 		const result = this.scoreProductSKU( productSKUData, this._config );
@@ -63,6 +64,7 @@ export default class ProductSKUAssessment extends Assessment {
 	 * @returns {Boolean} Whether the assessment is applicable.
 	 */
 	isApplicable( paper ) {
+		console.log("HELLO isApplicable")
 		const customData = paper.getCustomData();
 		// Product should either be a simple product with a price, or a product with variants.
 		return this._config.assessVariants && ( customData.hasPrice || customData.hasVariants );
@@ -79,6 +81,8 @@ export default class ProductSKUAssessment extends Assessment {
 	 */
 	scoreProductSKU( productSKUData, config ) {
 		// If a product has no variants, return orange bullet if it has no global SKU, and green bullet if it has one.
+		console.log("TEST6", productSKUData)
+		console.log("TEST7", config)
 		if ( ! productSKUData.hasVariants ) {
 			if ( ! productSKUData.hasGlobalSKU ) {
 				return {
@@ -86,7 +90,7 @@ export default class ProductSKUAssessment extends Assessment {
 					text: sprintf(
 						// Translators: %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag.
 						__(
-							"%1$sSKU%3$s: Your product is missing a SKU. %2$sInclude this if you can, as it" +
+							"%1$sSKU%3$s: Your product is missing a dadaSKU. %2$sInclude this if you can, as it" +
 							" will help search engines to better understand your content.%3$s",
 							"wordpress-seo"
 						),
@@ -124,7 +128,7 @@ export default class ProductSKUAssessment extends Assessment {
 				text: sprintf(
 					// Translators: %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag.
 					__(
-						"%1$sSKU%3$s: Not all your product variants have a SKU. %2$sInclude this if you can, as it" +
+						"%1$sSKU%3$s: Not all your product variants have a SKUUUU. %2$sInclude this if you can, as it" +
 						" will help search engines to better understand your content.%3$s",
 						"wordpress-seo"
 					),

--- a/packages/yoastseo/src/scoring/productPages/cornerstone/seoAssessor.js
+++ b/packages/yoastseo/src/scoring/productPages/cornerstone/seoAssessor.js
@@ -150,7 +150,7 @@ const ProductCornerstoneSEOAssessor = function( researcher, options ) {
 		new ProductSKUAssessment( {
 			urlTitle: createAnchorOpeningTag( options.productSKUUrlTitle ),
 			urlCallToAction: createAnchorOpeningTag( options.productSKUCTAUrl ),
-			assessVariants: options.console.log("HELLO WORLD", this._config),
+			assessVariants: options.assessVariants,
 		} ),
 	];
 };

--- a/packages/yoastseo/src/scoring/productPages/cornerstone/seoAssessor.js
+++ b/packages/yoastseo/src/scoring/productPages/cornerstone/seoAssessor.js
@@ -150,7 +150,7 @@ const ProductCornerstoneSEOAssessor = function( researcher, options ) {
 		new ProductSKUAssessment( {
 			urlTitle: createAnchorOpeningTag( options.productSKUUrlTitle ),
 			urlCallToAction: createAnchorOpeningTag( options.productSKUCTAUrl ),
-			assessVariants: options.assessVariants,
+			assessVariants: options.console.log("HELLO WORLD", this._config),
 		} ),
 	];
 };


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* When a variable product had no variants, the analysis treated the product as a simple product. 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where variable products were treated as simple products if they had no variants.
* [wpseo-woocommerce] Fixes a bug where variable products were treated as simple products if they had no variants.

## Relevant technical choices:

* We added checks for `product type` and decide if (and which) feedback to show based on it. Note that Shopify might have different/no product types. 
* This PR also required changes in woocommerce. These changes are in [this pr](https://github.com/Yoast/wpseo-woocommerce/pull/811)

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### TESTING

**NOTE:** make sure to pull and build both yoastse-woocommerce and yoastseo-free.

* Should be tested together with: [this PR](https://github.com/Yoast/wpseo-woocommerce/pull/811)

Branch names:
- **WOO**: `PC-395-woo-variable-products-show-wrong-feedback-when-variants-are-deleted`
- **wpseo**: `PC-395-wpseo-variable-products-show-wrong-feedback-when-variants-are-deleted-in-woo`

##### Scenario 1: simple product
1. Activate Yoast SEO, Woocommerce, yoastseo-woocommerce
2. Create a simple product (dont give it a price)
3. Make sure the SKU assessment and product identifier assessment don't show up in SEO analysis result.
4. Check the schema. There should be no product schema.
5. Add a price. 
6. Make sure that SKU assessment and product identifier assessment show up with an orange bullet and the following feedback strings:
   6.1. `Product identifier: Your product is missing an identifier (like a GTIN code).`
   6.2. `SKU: Your product is missing a SKU. Include this if you can, as it will help search engines to better understand your content.`
7. Make sure that product schema is created.
8. Add a SKU & product identifier.
9. Make sure SKU and product identifier assessment now both have a green bullet. With the following feedback strings:
   9.1. `Product identifier: Your product has an identifier. Good job!`
   9.2. `SKU: Your product has a SKU. Good job!`
  
10. Make sure that product schema is created.
11. Repeat Scenario 1 for external/affiliate product.

##### Scenario 2: variable
1. Create a variable product.
2. Make sure the SKU assessment and product identifier assessment don't show up in SEO analysis result.
3. Check the schema. There should be no product schema.
4. Add variants (add attributes first.)
5. Make sure the SKU assessment and product identifier assessment don't show up in SEO analysis result.
6. Check the schema. There should be no product schema.
7. Add a price to 1 or products.
8. Make sure SKU and product identifier assessment now both have an orange bullet and the following feedback strings.

   8.1. `Product identifier: Not all your product variants have an identifier. Include this if you can, as it will help search engines to better understand your content.`
   8.2. `SKU: Not all your product variants have a SKU. Include this if you can, as it will help search engines to better understand your content.`

9. Make sure that product schema is created. 
10. Add a SKU and product identifier to all products with a price.
11. Make sure SKU and product identifier assessment now both have a green bullet and the following feedback strings.
   11.1. `Product identifier: All your product variants have an identifier. Good job!`
   11.2. `SKU: All your product variants have a SKU. Good job!`
   
13. Make sure that product schema is created.
14. In bulk actions: delete all products 
15. Make sure the SKU assessment and product identifier assessment don't show up in SEO analysis result.
16. Check the schema. There should be no product schema.

##### Scenario 3: grouped
1. Create a `grouped` product
2. Make sure both SKU and product identifier assessments don't show up
3. Check the schema and confirm that no product schema is output
4. Add a SKU and a product identifier
5. Confirm that both SKU and product identifier assessments still don't show up
3. Check the schema and confirm that product schema is still not output

##### Scenario 4: switching between product types
**Note**: This scenario is to make sure that switching between product types should update the assessment accordingly without the need to save the changes first.
1. Create a simple product and don't add a price
2. Confirm that both SKU and product identifier assessment don't show up
3. Switch the product type to external/affiliate and don't add a price
4. Confirm that both SKU and product identifier assessment still don't show up
5. Add a price to your external/affiliate product
6. Confirm that both SKU and product identifier assessment give an orange bullet with the following feedback:
   6.1. `Product identifier: Your product is missing an identifier (like a GTIN code). Include this if you can, as it will help search engines to better understand your content.`
   6.2. `SKU: Your product is missing a SKU. Include this if you can, as it will help search engines to better understand your content.`
7. Switch back to simple product
8. Confirm that both SKU and product identifier assessment don't show up
9. Add a price to your simple product
10. Add a SKU and a product identifier
11. Confirm that both SKU and product identifier assessment give a green bullet with the following feedback:
   11.1. `Product identifier: Your product has an identifier. Good job!`
   11.2. `SKU: Your product has a SKU. Good job!`
12. Switch the product type to variable
   12.1. Confirm that both SKU and product identifier assessment don't show up until variants are created and at least one of the variants have a price
13. Create variants and add a price to at least one of the variants
14. Confirm that both SKU and product identifier assessment give an orange bullet with the following feedback:
   14.1. `Product identifier: Not all your product variants have an identifier. Include this if you can, as it will help search engines to better understand your content.`
   14.2. `SKU: Not all your product variants have a SKU. Include this if you can, as it will help search engines to better understand your content.`
15. Switch back to simple product
17. Confirm that both SKU and product identifier assessment give a green bullet with the following feedback
   16.1. `Product identifier: Your product has an identifier. Good job!`
   16.2. `SKU: Your product has a SKU. Good job!`


#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes #
