### PR TITLE
Don't load Yoast SEO on the login screen

### DIFF
--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -443,7 +443,7 @@ if ( ! $filter_exists ) {
 	add_action( 'admin_init', 'yoast_wpseo_missing_filter', 1 );
 }
 
-if ( ! wp_installing() && ( $spl_autoload_exists && $filter_exists ) ) {
+if ( ! wp_installing() && stripos( wp_login_url(), $_SERVER['SCRIPT_NAME'] ) === false && ( $spl_autoload_exists && $filter_exists ) ) {
 	add_action( 'plugins_loaded', 'wpseo_init', 14 );
 	add_action( 'rest_api_init', 'wpseo_init_rest_api' );
 

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -443,7 +443,15 @@ if ( ! $filter_exists ) {
 	add_action( 'admin_init', 'yoast_wpseo_missing_filter', 1 );
 }
 
-if ( ! wp_installing() && stripos( wp_login_url(), $_SERVER['SCRIPT_NAME'] ) === false && ( $spl_autoload_exists && $filter_exists ) ) {
+$is_login_page = false;
+if ( isset( $_SERVER['SCRIPT_NAME'] ) ) {
+	$script_name = sanitize_text_field( wp_unslash( $_SERVER['SCRIPT_NAME'] ) );
+	if ( stripos( wp_login_url(), $script_name ) !== false ) {
+		$is_login_page = true;
+	}
+}
+
+if ( ! wp_installing() && ! $is_login_page && ( $spl_autoload_exists && $filter_exists ) ) {
 	add_action( 'plugins_loaded', 'wpseo_init', 14 );
 	add_action( 'rest_api_init', 'wpseo_init_rest_api' );
 

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -446,7 +446,7 @@ if ( ! $filter_exists ) {
 $is_login_page = false;
 if ( isset( $_SERVER['SCRIPT_NAME'] ) ) {
 	$script_name = sanitize_text_field( wp_unslash( $_SERVER['SCRIPT_NAME'] ) );
-	if ( stripos( wp_login_url(), $script_name ) !== false ) {
+	if ( strlen( $script_name ) > 0 && stripos( wp_login_url(), $script_name ) !== false ) {
 		$is_login_page = true;
 	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Don't load Yoast SEO on login.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves handling of fatal errors in the front-end by preventing Yoast SEO to run in the login page, allowing users to access their dashboard.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Introduction
* The purpose of the tests is to check that an error affecting the front-end of a website doesn't affect the login screen anymore, so users can access their backend and e.g. disable/downgrade Yoast SEO (or the addons). So we need to mimic this case by creating front-end errors; we could easily trigger any fatal error but that might affect the backend as well.
* We need to check Premium to test that preventing Free to run in the login page shields the site from errors caused by the Premium as well.
* **Local** tries to load Free in all the pages (both front-end and back-end). So we can only check that the login page can be accessed, but the backend will still be broken. Testing this case is useful anyway because it proves that Yoast SEO doesn't actually run in the login page.
* **WooCommerce SEO**, *News* and **Video**. instead, load all the classes on its own instead of relying on Free, so there is no way that a failure can affect the front-end + the login page but not the backend.

#### Free
* Make sure Free (with this change) is activated in the website
* logout from the website
* introduce a frontend error: e.g. add a `wp_die();` as the first line of `register_hooks()` of `src/integrations/front-end-integration.php`
* visit the frontend of the website, see that the output is broken
* visit the login page, see that the page is working
* log in
* see that the backend can be accessed and navigated

#### Premium
* Make sure Premium is activated in the website
* logout from the website
* introduce a frontend error: e.g. add a `wp_die();` as the first line of `register_hooks()` of `src/integrations/frontend-inspector.php`
* visit the frontend of the website, see that the output is broken
* visit the login page, see that the page is working
* log in
* see that the backend can be accessed and navigated

#### Local
* Make sure Local is activated in the website
* logout from the website
* introduce a frontend error: e.g. add a `wp_die();` as line 26 of `src/functions.php`
* visit the frontend of the website, see that the output is broken
* visit the login page, see that the page is working
* log in
* the backend will still be broken anyway, see explanation above.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [x] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

Since we are relying on the login page and a multisite intstallation has several of them, the above checks should be performed also in a multisite environment for at least one subsite.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes [PC-419]


[PC-419]: https://yoast.atlassian.net/browse/PC-419?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ