### PR TITLE
PC-426 - Only show notification when Premium 19.2-RC1 or above is installed.

### DIFF
--- a/admin/class-inclusive-language-notice.php
+++ b/admin/class-inclusive-language-notice.php
@@ -27,6 +27,11 @@ class WPSEO_Inclusive_Language_Notice {
 	const OPTION_NAME = 'wpseo';
 
 	/**
+	 * The Premium version in which the Inclusive language feature was added.
+	 */
+	const PREMIUM_VERSION_ADDED = '19.2-RC1';
+
+	/**
 	 * Holds the notification center.
 	 *
 	 * @var Yoast_Notification_Center
@@ -80,7 +85,8 @@ class WPSEO_Inclusive_Language_Notice {
 
 		return YoastSEO()->helpers->product->is_premium()
 			&& YoastSEO()->helpers->language->has_inclusive_language_support( \WPSEO_Language_Utils::get_language( \get_locale() ) )
-			&& ! $availability->is_globally_enabled();
+			&& ! $availability->is_globally_enabled()
+			&& \version_compare( YoastSEO()->helpers->product->get_premium_version(), self::PREMIUM_VERSION_ADDED, '>=' );
 	}
 
 	/**

--- a/admin/class-inclusive-language-notice.php
+++ b/admin/class-inclusive-language-notice.php
@@ -97,7 +97,10 @@ class WPSEO_Inclusive_Language_Notice {
 	protected function get_notification() {
 		$message = sprintf(
 			/* translators: %1$s is a link to the Features tab on the Yoast SEO Dashboard page, %2$s is a link to the blog post about this feature, %3$s is the link closing tag. */
-			__( '<strong>New in Yoast SEO Premium 19.2:</strong> Did you know that you can now enable the %1$sinclusive language feature%3$s to get feedback on inclusive language use? %2$sLearn more about this feature%3$s.', 'wordpress-seo' ),
+			__(
+				'<strong>New in Yoast SEO Premium 19.2:</strong> Did you know that you can now %1$senable the beta version of our inclusive language feature%3$s to get feedback on the use of inclusive language? This feature is disabled by default. %2$sLearn more about this feature%3$s.',
+				'wordpress-seo'
+			),
 			'<a href="' . admin_url( 'admin.php?page=wpseo_dashboard#top#features' ) . '">',
 			'<a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/inclusive-language-notification' ) . '">',
 			'</a>'


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Changes the Inclusive language notification such that it is only shown when Premium version 19.2-RC1 or above is installed.
* Changes the text of the Inclusive language notification to emphasize that this is a beta feature that is disabled by default.

Note: this notification [will be removed in the next release again](https://yoast.atlassian.net/browse/PC-424).

## Relevant technical choices:

* 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

##### Premium version before 19.2-RC1
* Install and activate a Premium version before 19.2-RC1 (e.g. 19.1 or earlier).
* Go to the Yoast SEO notification center.
* You should not see the Inclusive language notification.

##### Premium version 19.2-RC1 or after
* Install and activate a Premium version after 19.2-RC1.
* Go to the Yoast SEO notification center.
* You should see the Inclusive language notification.
  * It should look like this:
    > <img width="646" alt="Screenshot 2022-08-16 at 12 02 23" src="https://user-images.githubusercontent.com/10195175/184855186-b8ec1aab-6f9f-4b99-a03b-3787d8f19708.png">
   * It should have the same text and markup [as described in the issue](https://yoast.atlassian.net/browse/PC-422).
   * The first link should point to the page where the user can enable the Inclusive language feature.
   * The second link should point to this page on yoast.com: https://yoa.st/inclusive-language-notification.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [x] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Test the conditions in which the Inclusive language should be shown:
  * Should **NOT** be shown when either one of these is the case:
     * The language of the site does not support Inclusive language (e.g any lang other than English).
     * Premium is not installed and active.
     * The feature is not already enabled by the user.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes https://yoast.atlassian.net/browse/PC-422
Fixes https://yoast.atlassian.net/browse/PC-426
