### PR TITLE
Include words in square brackets to the Inclusive language analysis for Block editor

### DIFF
--- a/admin/class-gutenberg-compatibility.php
+++ b/admin/class-gutenberg-compatibility.php
@@ -15,14 +15,14 @@ class WPSEO_Gutenberg_Compatibility {
 	 *
 	 * @var string
 	 */
-	const CURRENT_RELEASE = '13.8.1';
+	const CURRENT_RELEASE = '13.8.2';
 
 	/**
 	 * The minimally supported version of Gutenberg by the plugin.
 	 *
 	 * @var string
 	 */
-	const MINIMUM_SUPPORTED = '13.8.1';
+	const MINIMUM_SUPPORTED = '13.8.2';
 
 	/**
 	 * Holds the current version.

--- a/admin/class-inclusive-language-notice.php
+++ b/admin/class-inclusive-language-notice.php
@@ -27,6 +27,11 @@ class WPSEO_Inclusive_Language_Notice {
 	const OPTION_NAME = 'wpseo';
 
 	/**
+	 * The Premium version in which the Inclusive language feature was added.
+	 */
+	const PREMIUM_VERSION_ADDED = '19.2-RC1';
+
+	/**
 	 * Holds the notification center.
 	 *
 	 * @var Yoast_Notification_Center
@@ -80,7 +85,8 @@ class WPSEO_Inclusive_Language_Notice {
 
 		return YoastSEO()->helpers->product->is_premium()
 			&& YoastSEO()->helpers->language->has_inclusive_language_support( \WPSEO_Language_Utils::get_language( \get_locale() ) )
-			&& ! $availability->is_globally_enabled();
+			&& ! $availability->is_globally_enabled()
+			&& \version_compare( YoastSEO()->helpers->product->get_premium_version(), self::PREMIUM_VERSION_ADDED, '>=' );
 	}
 
 	/**
@@ -91,7 +97,10 @@ class WPSEO_Inclusive_Language_Notice {
 	protected function get_notification() {
 		$message = sprintf(
 			/* translators: %1$s is a link to the Features tab on the Yoast SEO Dashboard page, %2$s is a link to the blog post about this feature, %3$s is the link closing tag. */
-			__( '<strong>New in Yoast SEO Premium 19.2:</strong> Did you know that you can now enable the %1$sinclusive language feature%3$s to get feedback on inclusive language use? %2$sLearn more about this feature%3$s.', 'wordpress-seo' ),
+			__(
+				'<strong>New in Yoast SEO Premium 19.2:</strong> Did you know that you can now %1$senable the beta version of our inclusive language feature%3$s to get feedback on the use of inclusive language? This feature is disabled by default. %2$sLearn more about this feature%3$s.',
+				'wordpress-seo'
+			),
 			'<a href="' . admin_url( 'admin.php?page=wpseo_dashboard#top#features' ) . '">',
 			'<a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/inclusive-language-notification' ) . '">',
 			'</a>'

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "typescript": "^4.2.4"
   },
   "yoast": {
-    "pluginVersion": "19.6-RC3"
+    "pluginVersion": "19.6-RC4"
   },
   "version": "0.0.0"
 }

--- a/packages/js/src/components/contentAnalysis/InclusiveLanguageAnalysis.js
+++ b/packages/js/src/components/contentAnalysis/InclusiveLanguageAnalysis.js
@@ -94,7 +94,7 @@ const InclusiveLanguageAnalysis = ( props ) => {
 		__( "%1$sInclusive language%2$s: We haven't detected any potentially non-inclusive phrases. Great work!",
 			"wordpress-seo"
 		),
-		`<a href="${ analysisInfoLink }">`,
+		`<a href="${ analysisInfoLink }" target="_blank">`,
 		"</a>"
 	);
 

--- a/packages/js/src/components/fills/SidebarFill.js
+++ b/packages/js/src/components/fills/SidebarFill.js
@@ -51,23 +51,23 @@ export default function SidebarFill( { settings } ) {
 						isSEMrushIntegrationActive={ settings.isSEMrushIntegrationActive }
 					/>
 				</SidebarItem> }
-				<SidebarItem key="google-preview" renderPriority={ 23 }>
+				<SidebarItem key="google-preview" renderPriority={ 25 }>
 					<GooglePreviewModal />
 				</SidebarItem>
-				{ settings.displayFacebook && <SidebarItem key="facebook-preview" renderPriority={ 24 }>
+				{ settings.displayFacebook && <SidebarItem key="facebook-preview" renderPriority={ 26 }>
 					<FacebookPreviewModal />
 				</SidebarItem> }
-				{ settings.displayTwitter && <SidebarItem key="twitter-preview" renderPriority={ 25 }>
+				{ settings.displayTwitter && <SidebarItem key="twitter-preview" renderPriority={ 27 }>
 					<TwitterPreviewModal />
 				</SidebarItem> }
-				{ settings.displaySchemaSettings && <SidebarItem key="schema" renderPriority={ 26 }>
+				{ settings.displaySchemaSettings && <SidebarItem key="schema" renderPriority={ 28 }>
 					<SidebarCollapsible
 						title={ __( "Schema", "wordpress-seo" ) }
 					>
 						<SchemaTabContainer />
 					</SidebarCollapsible>
 				</SidebarItem> }
-				{ settings.displayAdvancedTab && <SidebarItem key="advanced" renderPriority={ 27 }>
+				{ settings.displayAdvancedTab && <SidebarItem key="advanced" renderPriority={ 29 }>
 					<SidebarCollapsible
 						title={ __( "Advanced", "wordpress-seo" ) }
 					>
@@ -99,7 +99,7 @@ export default function SidebarFill( { settings } ) {
 				{ settings.isCornerstoneActive && <SidebarItem key="cornerstone" renderPriority={ 30 }>
 					<CollapsibleCornerstone />
 				</SidebarItem> }
-				{ settings.isKeywordAnalysisActive && settings.isWincherIntegrationActive && <SidebarItem renderPriority={ 31 }>
+				{ settings.isKeywordAnalysisActive && settings.isWincherIntegrationActive && <SidebarItem renderPriority={ 23 }>
 					<WincherSEOPerformanceModal
 						location="sidebar"
 					/>

--- a/packages/js/src/elementor/components/fills/ElementorFill.js
+++ b/packages/js/src/elementor/components/fills/ElementorFill.js
@@ -67,23 +67,23 @@ export default function ElementorFill( { isLoading, onLoad, settings } ) {
 						<SEMrushRelatedKeyphrases />
 					</Fill> }
 				</SidebarItem> }
-				<SidebarItem renderPriority={ 23 }>
+				<SidebarItem renderPriority={ 25 }>
 					<GooglePreviewModal />
 				</SidebarItem>
-				{ settings.displayFacebook && <SidebarItem renderPriority={ 24 }>
+				{ settings.displayFacebook && <SidebarItem renderPriority={ 26 }>
 					<FacebookPreviewModal />
 				</SidebarItem> }
-				{ settings.displayTwitter && <SidebarItem renderPriority={ 25 }>
+				{ settings.displayTwitter && <SidebarItem renderPriority={ 27 }>
 					<TwitterPreviewModal />
 				</SidebarItem> }
-				{ settings.displaySchemaSettings && <SidebarItem renderPriority={ 26 }>
+				{ settings.displaySchemaSettings && <SidebarItem renderPriority={ 28 }>
 					<SidebarCollapsible
 						title={ __( "Schema", "wordpress-seo" ) }
 					>
 						<SchemaTabContainer />
 					</SidebarCollapsible>
 				</SidebarItem> }
-				{ settings.displayAdvancedTab && <SidebarItem renderPriority={ 27 }>
+				{ settings.displayAdvancedTab && <SidebarItem renderPriority={ 29 }>
 					<SidebarCollapsible
 						title={ __( "Advanced", "wordpress-seo" ) }
 					>

--- a/packages/js/src/initializers/post-scraper.js
+++ b/packages/js/src/initializers/post-scraper.js
@@ -491,18 +491,20 @@ export default function initPostScraper( $, store, editorData ) {
 		// Analysis plugins
 		window.YoastSEO.wp = {};
 		window.YoastSEO.wp.replaceVarsPlugin = new YoastReplaceVarPlugin( app, store );
-		window.YoastSEO.wp.shortcodePlugin = new YoastShortcodePlugin( {
-			registerPlugin: app.registerPlugin,
-			registerModification: app.registerModification,
-			pluginReady: app.pluginReady,
-			pluginReloaded: app.pluginReloaded,
-		} );
 
 		if ( isBlockEditor() ) {
 			const reusableBlocksPlugin = new YoastReusableBlocksPlugin( app.registerPlugin, app.registerModification, window.YoastSEO.app.refresh );
 			reusableBlocksPlugin.register();
 		}
-
+		// Only process shortcodes (for analysis) in the post text for editors other than the block editor.
+		if ( ! isBlockEditor() ) {
+			window.YoastSEO.wp.shortcodePlugin = new YoastShortcodePlugin( {
+				registerPlugin: app.registerPlugin,
+				registerModification: app.registerModification,
+				pluginReady: app.pluginReady,
+				pluginReloaded: app.pluginReloaded,
+			} );
+		}
 		if ( wpseoScriptData.metabox.markdownEnabled ) {
 			const markdownPlugin = new YoastMarkdownPlugin( app.registerPlugin, app.registerModification );
 			markdownPlugin.register();

--- a/packages/replacement-variable-editor/src/ReplacementVariableEditorStandalone.js
+++ b/packages/replacement-variable-editor/src/ReplacementVariableEditorStandalone.js
@@ -40,9 +40,13 @@ import { selectReplacementVariables } from "./helpers/selection";
  * WordPress admin menu. The admin menu has a z-index of 9990. Therefor we add
  * an extra 9990 to our z-index value.
  */
-const ZIndexOverride = styled.div`
+const MentionSuggestionsStyleWrapper = styled.div`
 	div {
 		z-index: 10995;
+	}
+	> div {
+		max-height: 450px;
+		overflow-y: auto;
 	}
 `;
 
@@ -641,14 +645,14 @@ class ReplacementVariableEditorStandalone extends React.Component {
 					fieldId
 				) }
 
-				<ZIndexOverride>
+				<MentionSuggestionsStyleWrapper>
 					<MentionSuggestions
 						onSearchChange={ this.onSearchChange }
 						suggestions={ suggestions }
 						onOpenChange={ this.onSuggestionsOpenChange }
 						open={ isSuggestionsOpen }
 					/>
-				</ZIndexOverride>
+				</MentionSuggestionsStyleWrapper>
 			</React.Fragment>
 		);
 	}

--- a/packages/yoastseo/src/languageProcessing/researches/getProductIdentifierDataShopify.js
+++ b/packages/yoastseo/src/languageProcessing/researches/getProductIdentifierDataShopify.js
@@ -1,0 +1,15 @@
+/**
+ * Gets the product data from Shopify.
+ *
+ * @param {Paper} paper The paper that contains the data.
+ *
+ * @returns {{hasVariants: (boolean|*), hasGlobalIdentifier: (boolean|*)}}  The object that contains information whether
+ * the product has global identifier or variants.
+ */
+export default function( paper ) {
+	const productData = paper.getCustomData();
+	return {
+		hasGlobalIdentifier: productData.hasGlobalIdentifier,
+		hasVariants: productData.hasVariants,
+	};
+}

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -15,7 +15,7 @@ if ( ! function_exists( 'add_filter' ) ) {
  * {@internal Nobody should be able to overrule the real version number as this can cause
  *            serious issues with the options, so no if ( ! defined() ).}}
  */
-define( 'WPSEO_VERSION', '19.6-RC3' );
+define( 'WPSEO_VERSION', '19.6-RC4' );
 
 
 if ( ! defined( 'WPSEO_PATH' ) ) {

--- a/wp-seo.php
+++ b/wp-seo.php
@@ -8,7 +8,7 @@
  *
  * @wordpress-plugin
  * Plugin Name: Yoast SEO
- * Version:     19.6-RC3
+ * Version:     19.6-RC4
  * Plugin URI:  https://yoa.st/1uj
  * Description: The first true all-in-one SEO solution for WordPress, including on-page content analysis, XML sitemaps and much more.
  * Author:      Team Yoast


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Since words in square brackets get removed from the analysis as shortcodes, there were false negatives in the Inclusive language assessment. This issue adds an improvement that make sure non-inclusive words get targeted even if they are in square brackets.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Includes words in square brackets to the analysis for multiple assessments in the block editor.
* [wordpress-seo-premium] Includes words in square brackets to the Inclusive language analysis in block editor.

## Relevant technical choices:

* There will be a new issue created to cover words in less common brackets ( `<>` and `{}` ) accross assessments. This issue focuses on square brackets, since they are more common in English (and since words in `()` are already covered).
* We currently remove unregistered shortcodes (shortcodes outside of a shortcode block) from being processed in `shortcode-plugin.js` . However, adding shortocodes directly is only possible in Block editor and not in Classic editor or Elementor. This is why we made the step for processing (and removing) shortcodes applicable only for editors other than Block editor.

* Unit tests were not added for this chance because we do not yet have these for `src/initializers`

* This PR also affects a lot of other assessments. An overview can be found [here](https://docs.google.com/spreadsheets/d/1295zCjPZZE8njDEFO7PB2S8gWbDMBmNn-OPmcSmN6nI/edit?usp=sharing).

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Activate Premium and enable the Inclusive language feature
* Create a post (in block editor)
* Add the following text: 
_The sea otter is a marine captured mammal native to the coasts of the northern and eastern North Pacific Ocean. Adult sea otters typically weigh between 14 and 45 kg (30 and 100 lb), making them the heaviest members of the weasel family, but among the smallest marine mammals. Unlike most marine mammals, the sea otter's primary form of insulation is an exceptionally thick coat of fur, the densest in the animal kingdom. Although it can walk on land, the sea otter is capable of living exclusively in the ocean._ 
* Add _midget_ anywhere in the text
* Make sure the Inclusive language feedback turns red and says:`Avoid using midget as it is potentially harmful. Consider using an alternative, such as little person, has short stature, someone with dwarfism. Learn more.
* Remove the word _midget_  from the text
* Make sure the Inclusive language feedback turns green says: `We haven't detected any potentially non-inclusive phrases. Great work!`
* Add _[midget]_ to the text
* Make sure the Inclusive language feedback turns red and says: `Avoid using midget as it is potentially harmful. Consider using an alternative, such as little person, has short stature, someone with dwarfism. Learn more.`
* Add _[First World]_ to the text
* Make sure a new red bullet appears in the Inclusive languag tab, and the feedback says: `Avoid using First World as it is overgeneralizing. Consider using the specific name for the region or country instead. Learn more.`
`

##### Additional tests for the other assessments:
First on `trunk` or `release/19.1` (old), then on `release/19.2` (new). Do the following:
* Add the **passive sentence** `I was killed by a sea otter.`
  * make sure that the sentence gets highlighted as passive voice.
* Change the sentence to `I was killed [by] a sea otter.`
  * [`old`]: sentence is not highlighted 
  * [`new`]: sentence is highlighted
  * NOTE: if you put the verb `was` between `[]`, the assessment still breaks

* Make sure that the following sentence is highlighted by **sentence length** assessment: `Unlike most marine mammals, the sea otter's primary form of insulation is an exceptionally thick coat of fur, the densest in the animal kingdom.`  
* Change the sentence to: `Unlike most marine mammals, the sea otter's primary form of [insulation] is an exceptionally thick coat of fur, the densest in the animal kingdom.`
  * [`old`] The sentence is not highlighted
  * [`new`] The sentence is highlighted

* Add the following three **consecutive sentences**: `This is a sentence. This is a sentence. This is a sentence.`
* Make sure they are highlighted by the consecutive sentence assessment
* Change to: `This is a sentence. [This] is a sentence. This is a sentence.`
  * [`old`] Consecutive sentence assessment turns green.
  * [`new`] Consecutive sentences stays red and sample is highlighted.

* Add this following paragraph of length 151 words. _The sea otter is a marine captured mammal native to the coasts of the northern and eastern North Pacific Ocean. Adult sea otters typically weigh between 14 and 45 kg (30 and 100 lb), making them the heaviest members of the weasel family, but among the smallest marine mammals. Unlike most marine mammals, the sea otter's primary form of insulation is an exceptionally thick coat of fur, the densest in the animal kingdom. Although it can walk on land, the sea otter is capable of living exclusively in the ocean. The sea otter is a marine captured mammal native to the coasts of the northern and eastern North Pacific Ocean. Adult sea otters typically weigh between 14 and 45 kg (30 and 100 lb), making them the heaviest members of the weasel family, but among the smallest marine mammals. Unlike most marine mammals, the sea otter's primary form of insulation is._
* Make sure the paragraph is highlighted by the paragraph length assessment.
* Put any word in the paragraph between `[]`
  * [`old`] The paragraph is no longer recognized as too long.
  * [`new`] The paragraph is still highlighted as too long.

* Go to the **Text length assessment** in the SEO tab.
* Put any word or words between [] while keeping an eye on the wordcount.
  * [`old`] The word count changes if you put words between `[]`
  * [`new`] The word count does not change if you put words between `[]`


#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes #https://yoast.atlassian.net/jira/software/c/projects/PC/boards/138?modal=detail&selectedIssue=PC-400
