### PR TITLE
Add ignore for sitemaps of a custom post type that have no posts

### DIFF
--- a/inc/sitemaps/class-post-type-sitemap-provider.php
+++ b/inc/sitemaps/class-post-type-sitemap-provider.php
@@ -104,6 +104,10 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 
 			$total_count = $this->get_post_type_count( $post_type );
 
+			if ( $total_count === 0 ) {
+				continue;
+			}
+
 			$max_pages = 1;
 			if ( $total_count > $max_entries ) {
 				$max_pages = (int) ceil( $total_count / $max_entries );

--- a/tests/integration/sitemaps/test-class-wpseo-post-type-sitemap-provider.php
+++ b/tests/integration/sitemaps/test-class-wpseo-post-type-sitemap-provider.php
@@ -42,9 +42,7 @@ class WPSEO_Post_Type_Sitemap_Provider_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_get_index_links_no_entries() {
 		$index_links = self::$class_instance->get_index_links( 1 );
-		$this->assertNotEmpty( $index_links );
-		$this->assertContains( 'http://example.org/post-sitemap.xml', $index_links[0] );
-		$this->assertContains( 'http://example.org/page-sitemap.xml', $index_links[1] );
+		$this->assertEquals( [], $index_links );
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Empty sitemaps should be excluded from the sitemap index (`/sitemap_index.xml`).

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Exclude empty custom post type sitemaps from `sitemap_index.xml`.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install and activate Yoast SEO and Custom Post Type UI.
* Add a custom post type by going to the WordPress administrator dashboard -> CPT UI -> Add/Edit Post Types.
* Add a custom taxonomy for the custom post type by going to CPT UI -> Add/Edit Taxonomies (make sure to add the taxonomy to the custom post type).
* Add a couple of posts, pages, categories, tags (and connect these to posts and pages), instances of the custom post type. and instances of the custom taxonomy to your WordPress installation.
* Check `/sitemap_index.xml` to see if all the sitemaps show up.
* Now remove all posts, check whether the post sitemap disappears (and if you had only tags connected to posts, this sitemap should also disappear, the same holds for categories).
* Remove all pages, see if the same happens for pages.
* Remove all custom taxonomies, see if the same happens for the custom taxonomy.
* Remove all custom post type instances, see if the same happens for the custom post type instances.
* For all the post types above, check after removing all instances of that post type whether the sitemap of the post type is still available (e.g. its reference should only be removed from `sitemap_index.xml`, the sitemap itself should not be removed). You can do this by navigating to the respective sitemap before deleting all the post instances and refreshing the page after deleting the post instances.

Note that while testing, it might be that the `sitemap_index` returns a 404. This happens when there is nothing to show in the sitemap (e.g. you removed everything from the site) and is expected behaviour. 

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [x] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes [PC-42](https://yoast.atlassian.net/browse/PC-42)
