### PR TITLE
Include words in square brackets to the Inclusive language analysis for Block editor (release branch based)

### DIFF
--- a/packages/js/src/initializers/post-scraper.js
+++ b/packages/js/src/initializers/post-scraper.js
@@ -467,18 +467,20 @@ export default function initPostScraper( $, store, editorData ) {
 		// Analysis plugins
 		window.YoastSEO.wp = {};
 		window.YoastSEO.wp.replaceVarsPlugin = new YoastReplaceVarPlugin( app, store );
-		window.YoastSEO.wp.shortcodePlugin = new YoastShortcodePlugin( {
-			registerPlugin: app.registerPlugin,
-			registerModification: app.registerModification,
-			pluginReady: app.pluginReady,
-			pluginReloaded: app.pluginReloaded,
-		} );
 
 		if ( isBlockEditor() ) {
 			const reusableBlocksPlugin = new YoastReusableBlocksPlugin( app.registerPlugin, app.registerModification, window.YoastSEO.app.refresh );
 			reusableBlocksPlugin.register();
 		}
-
+		// Only process shortcodes (for analysis) in the post text for editors other than the block editor.
+		if ( ! isBlockEditor() ) {
+			window.YoastSEO.wp.shortcodePlugin = new YoastShortcodePlugin( {
+				registerPlugin: app.registerPlugin,
+				registerModification: app.registerModification,
+				pluginReady: app.pluginReady,
+				pluginReloaded: app.pluginReloaded,
+			} );
+		}
 		if ( wpseoScriptData.metabox.markdownEnabled ) {
 			const markdownPlugin = new YoastMarkdownPlugin( app.registerPlugin, app.registerModification );
 			markdownPlugin.register();


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Since words in square brackets get removed from the analysis as shortcodes, there were false negatives in the Inclusive language assessment. This issue adds an improvement that make sure non-inclusive words get targeted even if they are in square brackets.
* Note that this PR is to a large part a duplicated of: https://github.com/Yoast/wordpress-seo/pull/18845 . It was created because the previous PR was based on the wrong branch.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Includes words in square brackets to the analysis for multiple assessments in the block editor.
* [wordpress-seo-premium] Includes words in square brackets to the Inclusive language analysis in block editor.

## Relevant technical choices:

* There will be a new issue created to cover words in less common brackets ( `<>` and `{}` ) accross assessments. This issue focuses on square brackets, since they are more common in English (and since words in `()` are already covered).
* We currently remove unregistered shortcodes (shortcodes outside of a shortcode block) from being processed in `shortcode-plugin.js` . However, adding shortocodes directly is only possible in Block editor and not in Classic editor or Elementor. This is why we made the step for processing (and removing) shortcodes applicable only for editors other than Block editor.

* Unit tests were not added for this chance because we do not yet have these for `src/initializers`

* This PR also affects a lot of other assessments. An overview can be found [here](https://docs.google.com/spreadsheets/d/1295zCjPZZE8njDEFO7PB2S8gWbDMBmNn-OPmcSmN6nI/edit?usp=sharing).

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Activate Premium and enable the Inclusive language feature
* Create a post (in block editor)
* Add the following text: 
_The sea otter is a marine captured mammal native to the coasts of the northern and eastern North Pacific Ocean. Adult sea otters typically weigh between 14 and 45 kg (30 and 100 lb), making them the heaviest members of the weasel family, but among the smallest marine mammals. Unlike most marine mammals, the sea otter's primary form of insulation is an exceptionally thick coat of fur, the densest in the animal kingdom. Although it can walk on land, the sea otter is capable of living exclusively in the ocean._ 
* Add _midget_ anywhere in the text
* Make sure the Inclusive language feedback turns red and says:`Avoid using midget as it is potentially harmful. Consider using an alternative, such as little person, has short stature, someone with dwarfism. Learn more.
* Remove the word _midget_  from the text
* Make sure the Inclusive language feedback turns green says: `We haven't detected any potentially non-inclusive phrases. Great work!`
* Add _[midget]_ to the text
* Make sure the Inclusive language feedback turns red and says: `Avoid using midget as it is potentially harmful. Consider using an alternative, such as little person, has short stature, someone with dwarfism. Learn more.`
* Add _[First World]_ to the text
* Make sure a new red bullet appears in the Inclusive languag tab, and the feedback says: `Avoid using First World as it is overgeneralizing. Consider using the specific name for the region or country instead. Learn more.`
`

##### Additional tests for the other assessments:
First on `trunk` or `release/19.1` (old), then on `release/19.2` (new). Do the following:
* Add the **passive sentence** `I was killed by a sea otter.`
  * make sure that the sentence gets highlighted as passive voice.
* Change the sentence to `I was killed [by] a sea otter.`
  * [`old`]: sentence is not highlighted 
  * [`new`]: sentence is highlighted
  * NOTE: if you put the verb `was` between `[]`, the assessment still breaks

* Make sure that the following sentence is highlighted by **sentence length** assessment: `Unlike most marine mammals, the sea otter's primary form of insulation is an exceptionally thick coat of fur, the densest in the animal kingdom.`  
* Change the sentence to: `Unlike most marine mammals, the sea otter's primary form of [insulation] is an exceptionally thick coat of fur, the densest in the animal kingdom.`
  * [`old`] The sentence is not highlighted
  * [`new`] The sentence is highlighted

* Add the following three **consecutive sentences**: `This is a sentence. This is a sentence. This is a sentence.`
* Make sure they are highlighted by the consecutive sentence assessment
* Change to: `This is a sentence. [This] is a sentence. This is a sentence.`
  * [`old`] Consecutive sentence assessment turns green.
  * [`new`] Consecutive sentences stays red and sample is highlighted.

* Add this following paragraph of length 151 words. _The sea otter is a marine captured mammal native to the coasts of the northern and eastern North Pacific Ocean. Adult sea otters typically weigh between 14 and 45 kg (30 and 100 lb), making them the heaviest members of the weasel family, but among the smallest marine mammals. Unlike most marine mammals, the sea otter's primary form of insulation is an exceptionally thick coat of fur, the densest in the animal kingdom. Although it can walk on land, the sea otter is capable of living exclusively in the ocean. The sea otter is a marine captured mammal native to the coasts of the northern and eastern North Pacific Ocean. Adult sea otters typically weigh between 14 and 45 kg (30 and 100 lb), making them the heaviest members of the weasel family, but among the smallest marine mammals. Unlike most marine mammals, the sea otter's primary form of insulation is._
* Make sure the paragraph is highlighted by the paragraph length assessment.
* Put any word in the paragraph between `[]`
  * [`old`] The paragraph is no longer recognized as too long.
  * [`new`] The paragraph is still highlighted as too long.

* Go to the **Text length assessment** in the SEO tab.
* Put any word or words between [] while keeping an eye on the wordcount.
  * [`old`] The word count changes if you put words between `[]`
  * [`new`] The word count does not change if you put words between `[]`


#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes #https://yoast.atlassian.net/jira/software/c/projects/PC/boards/138?modal=detail&selectedIssue=PC-400
