### PR TITLE
Show alert informing user of disabled features

### DIFF
--- a/packages/js/src/indexables-page/components/indexables-links-card.js
+++ b/packages/js/src/indexables-page/components/indexables-links-card.js
@@ -1,13 +1,14 @@
 import PropTypes from "prop-types";
 import { LinkIcon } from "@heroicons/react/outline";
-import { __ } from "@wordpress/i18n";
+import { __, sprintf } from "@wordpress/i18n";
 import { useState, useEffect } from "@wordpress/element";
-import { Button } from "@yoast/ui-library";
+import { Alert, Button } from "@yoast/ui-library";
 
 import IndexablesPageCard from "./indexables-card";
 import IndexablesTable from "./indexables-table";
 import IndexableTitleLink from "./indexable-title-link";
 import { IndexableScore } from "./indexables-score-card";
+import { addLinkToString } from "../../helpers/stringHelpers";
 
 
 /**
@@ -46,8 +47,11 @@ function IndexablesLinksCard( {
 	listSize,
 	listKey,
 	handleLink,
+	isDisabled,
+	feature,
+	metric,
 } ) {
-	const [ isLoading, setIsLoading ] = useState( true );
+	const [ isLoading, setIsLoading ] = useState( ! isDisabled );
 	const [ oldListLength, setOldListLength ] = useState( indexablesLists[ listKey ]?.length );
 
 	const newLength = indexablesLists[ listKey ]?.length;
@@ -76,36 +80,58 @@ function IndexablesLinksCard( {
 		</div>
 		<IndexablesTable>
 			{
-				isLoading
-					? []
-					: indexablesLists[ listKey ].slice( 0, listSize ).map(
-						( indexable, position ) => {
-							return <IndexablesTable.Row
-								key={ `indexable-${ indexable.id }-row` }
-								type={ listKey }
-								indexable={ indexable }
-								addToIgnoreList={ setIgnoredIndexable }
-								position={ position }
-							>
-								{ /* @TODO: needs to be calculated */ }
-								<IndexableScore colorClass={ parseInt( indexable.is_cornerstone, 10 ) ? "yst-bg-emerald-500" : "yst-bg-red-500" } />
-								<IndexableLinkCount count={ parseInt( indexable[ countKey ], 10 ) } />
-								<IndexableTitleLink indexable={ indexable } />
-								<div key={ `least-linked-modal-button-${ indexable.id }` }  className="yst-shrink-0">
-									<Button
-										data-indexableid={ indexable.id }
-										data-incominglinkscount={ indexable.incoming_link_count === null ? 0 : indexable.incoming_link_count }
-										data-breadcrumbtitle={ indexable.breadcrumb_title }
-										data-permalink={ indexable.permalink }
-										onClick={ handleLink }
-										variant="secondary"
-									>
-										{ __( "Add links", "wordpress-seo" ) }
-									</Button>
-								</div>
-							</IndexablesTable.Row>;
+				/* eslint-disable max-len, no-nested-ternary */
+				isDisabled
+					? <Alert type={ "info" }>
+						{
+							addLinkToString(
+								// translators: %2$s is the name of the disabled feature, %2$s and %3$s are the opening and closing anchor tags, %4$s is the score of the disabled feature.
+								sprintf(
+									__(
+										"You've disabled the '%1$s' feature. " +
+										"Enable this feature on the %2$sFeatures tab%3$s if you want us to calculate the %4$s of your content",
+										"wordpress-seo"
+									),
+									feature,
+									"<a>",
+									"</a>",
+									metric
+								), "/wp-admin/admin.php?page=wpseo_dashboard#top#features"
+
+							)
+							/* eslint-enable max-len, no-nested-ternary */
 						}
-					)
+					</Alert>
+					: isLoading
+						? []
+						: indexablesLists[ listKey ].slice( 0, listSize ).map(
+							( indexable, position ) => {
+								return <IndexablesTable.Row
+									key={ `indexable-${ indexable.id }-row` }
+									type={ listKey }
+									indexable={ indexable }
+									addToIgnoreList={ setIgnoredIndexable }
+									position={ position }
+								>
+									{ /* @TODO: needs to be calculated */ }
+									<IndexableScore colorClass={ parseInt( indexable.is_cornerstone, 10 ) ? "yst-bg-emerald-500" : "yst-bg-red-500" } />
+									<IndexableLinkCount count={ parseInt( indexable[ countKey ], 10 ) } />
+									<IndexableTitleLink indexable={ indexable } />
+									<div key={ `least-linked-modal-button-${ indexable.id }` }  className="yst-shrink-0">
+										<Button
+											data-indexableid={ indexable.id }
+											data-incominglinkscount={ indexable.incoming_link_count === null ? 0 : indexable.incoming_link_count }
+											data-breadcrumbtitle={ indexable.breadcrumb_title }
+											data-permalink={ indexable.permalink }
+											onClick={ handleLink }
+											variant="secondary"
+										>
+											{ __( "Add links", "wordpress-seo" ) }
+										</Button>
+									</div>
+								</IndexablesTable.Row>;
+							}
+						)
 			}
 		</IndexablesTable>
 		<div className="yst-mt-3 yst-text-justify yst-pr-6">
@@ -125,6 +151,9 @@ IndexablesLinksCard.propTypes = {
 	scoreThresholds: PropTypes.shape( { medium: PropTypes.number.isRequired } ),
 	indexablesLists: PropTypes.object,
 	handleLink: PropTypes.func,
+	isDisabled: PropTypes.bool,
+	feature: PropTypes.string,
+	metric: PropTypes.string,
 };
 
 IndexablesLinksCard.defaultProps = {
@@ -133,6 +162,9 @@ IndexablesLinksCard.defaultProps = {
 	indexablesLists: {},
 	intro: null,
 	outro: null,
+	isDisabled: false,
+	feature: "",
+	metric: "",
 };
 
 export default IndexablesLinksCard;

--- a/packages/js/src/indexables-page/indexables-page.js
+++ b/packages/js/src/indexables-page/indexables-page.js
@@ -334,6 +334,9 @@ function IndexablesPage( { setupInfo } ) {
 		scoreKey={ "primary_focus_keyword_score" }
 		listKey={ "least_seo_score" }
 		listSize={ listSize }
+		isDisabled={ ! setupInfo.enabledFeatures.isSeoScoreEnabled }
+		feature={ __( "SEO analysis", "wordpress-seo" ) }
+		metric={ __( "SEO score", "wordpress-seo" ) }
 	/>;
 
 	const readabilityScoresCard = <IndexablesScoreCard
@@ -345,6 +348,9 @@ function IndexablesPage( { setupInfo } ) {
 		scoreKey={ "readability_score" }
 		listKey={ "least_readability" }
 		listSize={ listSize }
+		isDisabled={ ! setupInfo.enabledFeatures.isReadabilityEnabled }
+		feature={ __( "Readability analysis", "wordpress-seo" ) }
+		metric={ __( "Readability score", "wordpress-seo" ) }
 	/>;
 
 	const leastLinksCard = <IndexablesLinksCard
@@ -358,6 +364,9 @@ function IndexablesPage( { setupInfo } ) {
 		listKey={ "least_linked" }
 		listSize={ listSize }
 		handleLink={ handleLink }
+		isDisabled={ ! setupInfo.enabledFeatures.isLinkCountEnabled }
+		feature={ __( "Text link counter", "wordpress-seo" ) }
+		metric={ __( "number of links", "wordpress-seo" ) }
 	/>;
 
 	const mostLinksCard = <IndexablesLinksCard
@@ -371,6 +380,9 @@ function IndexablesPage( { setupInfo } ) {
 		listKey={ "most_linked" }
 		listSize={ listSize }
 		handleLink={ handleLink }
+		isDisabled={ ! setupInfo.enabledFeatures.isLinkCountEnabled }
+		feature={ __( "Text link counter", "wordpress-seo" ) }
+		metric={ __( "number of links", "wordpress-seo" ) }
 	/>;
 
 	const orderedCards = [ seoScoresCard, leastLinksCard, readabilityScoresCard, mostLinksCard ];

--- a/packages/js/src/indexables-page/landing-page.js
+++ b/packages/js/src/indexables-page/landing-page.js
@@ -48,9 +48,6 @@ function LandingPage() {
 		</div>;
 	} else if  ( indexingState !== "already_done" && indexingState !== "completed" ) {
 		return <IndexationView setIndexingState={ setIndexingState } />;
-	} else if ( setupInfo && Object.values( setupInfo.enabledFeatures ).every( value => value === false ) ) {
-		// @TODO: needs UX
-		return <span>All features deactivated.</span>;
 	} else if ( setupInfo && setupInfo.enoughContent === false ) {
 		return <NotEnoughContent />;
 	} else if ( setupInfo && setupInfo.enoughAnalysedContent === false ) {

--- a/src/actions/indexables-page-action.php
+++ b/src/actions/indexables-page-action.php
@@ -100,14 +100,6 @@ class Indexables_Page_Action {
 		$posts_with_readability  = 0;
 		$posts_without_keyphrase = [];
 
-		if ( ! $features['isSeoScoreEnabled'] && ! $features['isReadabilityEnabled'] && ! $features['isLinkCountEnabled'] ) {
-			return [
-				'enabledFeatures'       => $features,
-				'enoughContent'         => false,
-				'enoughAnalysedContent' => false,
-			];
-		}
-
 		$all_posts = $this->query()->count();
 
 		if ( $all_posts < 1 ) {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Informs user of deactivated features in the indexables page

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

*

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes #
