### PR TITLE
Fix undefined url variable and translation of h3 title

### DIFF
--- a/src/presenters/admin/sidebar-presenter.php
+++ b/src/presenters/admin/sidebar-presenter.php
@@ -16,7 +16,7 @@ class Sidebar_Presenter extends Abstract_Presenter {
 	 * @return string The sidebar HTML.
 	 */
 	public function present() {
-		$assets_uri              = trailingslashit( plugin_dir_url( WPSEO_FILE ) );
+		$assets_uri              = \trailingslashit( \plugin_dir_url( WPSEO_FILE ) );
 		$buy_yoast_seo_shortlink = WPSEO_Shortlinker::get( 'https://yoa.st/17h' );
 		\ob_start();
 		?>
@@ -25,7 +25,7 @@ class Sidebar_Presenter extends Abstract_Presenter {
 					<div class="wpseo_content_cell_title yoast-sidebar__title">
 						<?php
 						/* translators: %1$s expands to Yoast */
-						printf( esc_html__( '%1$s recommendations for you', 'wordpress-seo' ), 'Yoast' );
+						\printf( \esc_html__( '%1$s recommendations for you', 'wordpress-seo' ), 'Yoast' );
 						?>
 					</div>
 					<div class="yoast-sidebar__product">
@@ -33,7 +33,7 @@ class Sidebar_Presenter extends Abstract_Presenter {
 							<figure class="product-image">
 								<img
 									width="75" height="75"
-									src="<?php echo esc_url( $assets_uri . 'packages/js/images/Yoast_SEO_Icon.svg' ); ?>"
+									src="<?php echo \esc_url( $assets_uri . 'packages/js/images/Yoast_SEO_Icon.svg' ); ?>"
 									class="attachment-full size-full content-visible"
 									alt="Yoast SEO logo"
 									loading="lazy"
@@ -45,17 +45,17 @@ class Sidebar_Presenter extends Abstract_Presenter {
 						<h2>
 							<?php
 							/* translators: %s expands to Yoast SEO Premium */
-							printf( esc_html__( 'Get %s', 'wordpress-seo' ), 'Yoast SEO Premium' );
+							\printf( \esc_html__( 'Get %s', 'wordpress-seo' ), 'Yoast SEO Premium' );
 							?>
 						</h2>
 						<p>
-							<?php esc_html_e( 'Be the first to get new features & tools, before everyone else. Get 24/7 support and boost your website’s visibility.', 'wordpress-seo' ); ?>
+							<?php \esc_html_e( 'Be the first to get new features & tools, before everyone else. Get 24/7 support and boost your website’s visibility.', 'wordpress-seo' ); ?>
 						</p>
 						<p class="plugin-buy-button">
-							<a class="yoast-button-upsell" target="_blank" href="<?php echo esc_url( $buy_yoast_seo_shortlink ); ?>">
+							<a class="yoast-button-upsell" target="_blank" href="<?php echo \esc_url( $buy_yoast_seo_shortlink ); ?>">
 								<?php
 								/* translators: %s expands to Yoast SEO Premium */
-								printf( esc_html__( 'Get %s', 'wordpress-seo' ), 'Yoast SEO Premium' );
+								\printf( \esc_html__( 'Get %s', 'wordpress-seo' ), 'Yoast SEO Premium' );
 								?>
 								<span aria-hidden="true" class="yoast-button-upsell__caret"></span>
 							</a>
@@ -63,15 +63,15 @@ class Sidebar_Presenter extends Abstract_Presenter {
 						<div class="review-container">
 							<a href="https://www.g2.com/products/yoast-yoast/reviews" target="_blank" rel="noopener">
 								<h3 class="title">
-									Read reviews from real users
+									<?php echo \esc_html__( 'Read reviews from real users', 'wordpress-seo' ); ?>
 								</h3>
 								<span class="rating">
-								<img alt="" loading="lazy" fetchpriorty="low" decoding="async" height="22" width="22" src="<?php echo esc_url( $assets_uri . 'packages/js/images/logo-g2-white.svg' ); ?>">
-								<img alt="" loading="lazy" fetchpriorty="low" decoding="async" height="22" width="22" src="<?php echo esc_url( $assets_uri . 'packages/js/images/star-rating-star.svg' ); ?>">
-								<img alt="" loading="lazy" fetchpriorty="low" decoding="async" height="22" width="22" src="<?php echo esc_url( $assets_uri . 'packages/js/images/star-rating-star.svg' ); ?>">
-								<img alt="" loading="lazy" fetchpriorty="low" decoding="async" height="22" width="22" src="<?php echo esc_url( $assets_uri . 'packages/js/images/star-rating-star.svg' ); ?>">
-								<img alt="" loading="lazy" fetchpriorty="low" decoding="async" height="22" width="22" src="<?php echo esc_url( $assets_uri . 'packages/js/images/star-rating-star.svg' ); ?>">
-								<img alt="" loading="lazy" fetchpriorty="low" decoding="async" height="22" width="22" src="<?php echo esc_url( $assets_uri . 'packages/js/images/star-rating-half.svg' ); ?>">
+								<img alt="" loading="lazy" fetchpriorty="low" decoding="async" height="22" width="22" src="<?php echo \esc_url( $assets_uri . 'packages/js/images/logo-g2-white.svg' ); ?>">
+								<img alt="" loading="lazy" fetchpriorty="low" decoding="async" height="22" width="22" src="<?php echo \esc_url( $assets_uri . 'packages/js/images/star-rating-star.svg' ); ?>">
+								<img alt="" loading="lazy" fetchpriorty="low" decoding="async" height="22" width="22" src="<?php echo \esc_url( $assets_uri . 'packages/js/images/star-rating-star.svg' ); ?>">
+								<img alt="" loading="lazy" fetchpriorty="low" decoding="async" height="22" width="22" src="<?php echo \esc_url( $assets_uri . 'packages/js/images/star-rating-star.svg' ); ?>">
+								<img alt="" loading="lazy" fetchpriorty="low" decoding="async" height="22" width="22" src="<?php echo \esc_url( $assets_uri . 'packages/js/images/star-rating-star.svg' ); ?>">
+								<img alt="" loading="lazy" fetchpriorty="low" decoding="async" height="22" width="22" src="<?php echo \esc_url( $assets_uri . 'packages/js/images/star-rating-half.svg' ); ?>">
 								<span class="rating-text">4.6 / 5</span>
 							</span>
 							</a>
@@ -81,7 +81,7 @@ class Sidebar_Presenter extends Abstract_Presenter {
 				<div class="yoast-sidebar__section">
 					<h2>
 						<?php
-						esc_html_e( 'Learn SEO', 'wordpress-seo' );
+						\esc_html_e( 'Learn SEO', 'wordpress-seo' );
 						?>
 					</h2>
 					<p>
@@ -89,16 +89,16 @@ class Sidebar_Presenter extends Abstract_Presenter {
 						$academy_shortlink = WPSEO_Shortlinker::get( 'https://yoa.st/3t6' );
 
 						/* translators: %1$s expands to Yoast SEO academy, which is a clickable link. */
-						printf( esc_html__( 'Want to learn SEO from Team Yoast? Check out our %1$s!', 'wordpress-seo' ), '<a href="' . esc_url( $url ) . '"><strong>Yoast SEO academy</strong></a>' );
+						\printf( \esc_html__( 'Want to learn SEO from Team Yoast? Check out our %1$s!', 'wordpress-seo' ), '<a href="' . \esc_url( $buy_yoast_seo_shortlink ) . '"><strong>Yoast SEO academy</strong></a>' );
 						echo '<br/>';
-						esc_html_e( 'We have both free and premium online courses to learn everything you need to know about SEO.', 'wordpress-seo' );
+						\esc_html_e( 'We have both free and premium online courses to learn everything you need to know about SEO.', 'wordpress-seo' );
 						?>
 					</p>
 					<p>
-						<a href="<?php echo esc_url( $academy_shortlink ); ?>" target="_blank">
+						<a href="<?php echo \esc_url( $academy_shortlink ); ?>" target="_blank">
 							<?php
 							/* translators: %1$s expands to Yoast SEO academy */
-							printf( esc_html__( 'Check out %1$s', 'wordpress-seo' ), 'Yoast SEO academy' );
+							\printf( \esc_html__( 'Check out %1$s', 'wordpress-seo' ), 'Yoast SEO academy' );
 							?>
 						</a>
 					</p>

--- a/src/presenters/admin/sidebar-presenter.php
+++ b/src/presenters/admin/sidebar-presenter.php
@@ -63,7 +63,7 @@ class Sidebar_Presenter extends Abstract_Presenter {
 						<div class="review-container">
 							<a href="https://www.g2.com/products/yoast-yoast/reviews" target="_blank" rel="noopener">
 								<h3 class="title">
-									<?php echo \esc_html__( 'Read reviews from real users', 'wordpress-seo' ); ?>
+									<?php \esc_html_e( 'Read reviews from real users', 'wordpress-seo' ); ?>
 								</h3>
 								<span class="rating">
 								<img alt="" loading="lazy" fetchpriorty="low" decoding="async" height="22" width="22" src="<?php echo \esc_url( $assets_uri . 'packages/js/images/logo-g2-white.svg' ); ?>">
@@ -89,7 +89,7 @@ class Sidebar_Presenter extends Abstract_Presenter {
 						$academy_shortlink = WPSEO_Shortlinker::get( 'https://yoa.st/3t6' );
 
 						/* translators: %1$s expands to Yoast SEO academy, which is a clickable link. */
-						\printf( \esc_html__( 'Want to learn SEO from Team Yoast? Check out our %1$s!', 'wordpress-seo' ), '<a href="' . \esc_url( $buy_yoast_seo_shortlink ) . '"><strong>Yoast SEO academy</strong></a>' );
+						\printf( \esc_html__( 'Want to learn SEO from Team Yoast? Check out our %1$s!', 'wordpress-seo' ), '<a href="' . \esc_url( $academy_shortlink ) . '" target="_blank"><strong>Yoast SEO academy</strong></a>' );
 						echo '<br/>';
 						\esc_html_e( 'We have both free and premium online courses to learn everything you need to know about SEO.', 'wordpress-seo' );
 						?>


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the `$url` variable in the `sidebar-presenter.php` was undefined.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Activate Yoast SEO.
* Go to the administration dashboard and click on "Yoast SEO".
* Check that the premium upsell banner is still there (and uses the new styling).

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes #
