### PR TITLE
PC-413 Adapt inclusive language notification for subsites with feature disabled by admin

### DIFF
--- a/admin/class-inclusive-language-notice.php
+++ b/admin/class-inclusive-language-notice.php
@@ -95,7 +95,7 @@ class WPSEO_Inclusive_Language_Notice {
 	 * @return Yoast_Notification
 	 */
 	protected function get_notification() {
-		if ( is_multisite() && get_site_option( 'wpseo_ms' )[ 'allow_inclusive_language_analysis_active' ] === false ) {
+		if ( is_multisite() && get_site_option( 'wpseo_ms' )['allow_inclusive_language_analysis_active'] === false ) {
 			$message = sprintf(
 			/* translators: %1$s is a link to the Features tab on the Yoast SEO Dashboard page, %2$s is a link to the blog post about this feature, %3$s is the link closing tag. */
 				__(
@@ -106,7 +106,8 @@ class WPSEO_Inclusive_Language_Notice {
 				'<a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/inclusive-language-notification' ) . '">',
 				'</a>'
 			);
-		} else {
+		}
+		else {
 			$message = sprintf(
 			/* translators: %1$s is a link to the Features tab on the Yoast SEO Dashboard page, %2$s is a link to the blog post about this feature, %3$s is the link closing tag. */
 				__(

--- a/admin/class-inclusive-language-notice.php
+++ b/admin/class-inclusive-language-notice.php
@@ -95,16 +95,29 @@ class WPSEO_Inclusive_Language_Notice {
 	 * @return Yoast_Notification
 	 */
 	protected function get_notification() {
-		$message = sprintf(
+		if ( is_multisite() && get_site_option( 'wpseo_ms' )[ 'allow_inclusive_language_analysis_active' ] === false ) {
+			$message = sprintf(
 			/* translators: %1$s is a link to the Features tab on the Yoast SEO Dashboard page, %2$s is a link to the blog post about this feature, %3$s is the link closing tag. */
-			__(
-				'<strong>New in Yoast SEO Premium 19.2:</strong> Did you know that you can now %1$senable the beta version of our inclusive language feature%3$s to get feedback on the use of inclusive language? This feature is disabled by default. %2$sLearn more about this feature%3$s.',
-				'wordpress-seo'
-			),
-			'<a href="' . admin_url( 'admin.php?page=wpseo_dashboard#top#features' ) . '">',
-			'<a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/inclusive-language-notification' ) . '">',
-			'</a>'
-		);
+				__(
+					'<strong>New in Yoast SEO Premium 19.2:</strong> Did you know that you can now get feedback on the use of inclusive language? This feature is disabled by default. Please contact your Network admin to enable it. %2$sLearn more about this feature%3$s.',
+					'wordpress-seo'
+				),
+				'<a href="' . admin_url( 'admin.php?page=wpseo_dashboard#top#features' ) . '">',
+				'<a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/inclusive-language-notification' ) . '">',
+				'</a>'
+			);
+		} else {
+			$message = sprintf(
+			/* translators: %1$s is a link to the Features tab on the Yoast SEO Dashboard page, %2$s is a link to the blog post about this feature, %3$s is the link closing tag. */
+				__(
+					'<strong>New in Yoast SEO Premium 19.2:</strong> Did you know that you can now %1$senable the beta version of our inclusive language feature%3$s to get feedback on the use of inclusive language? This feature is disabled by default. %2$sLearn more about this feature%3$s.',
+					'wordpress-seo'
+				),
+				'<a href="' . admin_url( 'admin.php?page=wpseo_dashboard#top#features' ) . '">',
+				'<a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/inclusive-language-notification' ) . '">',
+				'</a>'
+			);
+		}
 
 		$notification = new Yoast_Notification(
 			$message,

--- a/admin/class-inclusive-language-notice.php
+++ b/admin/class-inclusive-language-notice.php
@@ -99,7 +99,7 @@ class WPSEO_Inclusive_Language_Notice {
 			$message = sprintf(
 			/* translators: %1$s is a link to the Features tab on the Yoast SEO Dashboard page, %2$s is a link to the blog post about this feature, %3$s is the link closing tag. */
 				__(
-					'<strong>New in Yoast SEO Premium 19.2:</strong> Did you know that you can now get feedback on the use of inclusive language? This feature is disabled by default. Please contact your Network admin to enable it. %2$sLearn more about this feature%3$s.',
+					'<strong>New in Yoast SEO Premium 19.2:</strong> Did you know that you can now get feedback on the use of inclusive language? This feature is disabled by default. Please contact your Network admin if you want to enable it. %2$sLearn more about this feature%3$s.',
 					'wordpress-seo'
 				),
 				'<a href="' . admin_url( 'admin.php?page=wpseo_dashboard#top#features' ) . '">',


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [wordpress-seo-premium] Adds an accurate inclusive language notification for subsites with the Inclusive language feature disabled by admin

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

**On single site**

* Build free and premium
* Enter the main site
* Go to yoastseo > general > features and check that the Inclusive language feature is disabled by the admin
* Go yoastseo > general > dashboard
* Find the notification on Inclusive language, and confirm that it says `New in Yoast SEO Premium 19.2: Did you know that you can now get feedback on the use of inclusive language? This feature is disabled by default. [Learn more about this feature]`

**On multisite**

_Using subdirectories_
* Build a multisite installation using subdirectories using the command `./start.sh  multisite-wordpress` (for docker) and domain http://multisite.wordpress.test/
* Build free and premium
* Enter the main site
* Go to yoastseo > general > features and check that the Inclusive language feature is disabled by the admin
* Go yoastseo > general > dashboard
* Find the notification on Inclusive language, and confirm that it says `New in Yoast SEO Premium 19.2: Did you know that you can now get feedback on the use of inclusive language? This feature is disabled by default. Please contact your Network admin if you want to enable it. [Learn more about this feature]`

_Using subdomains_
* Build a multisite installation using subdirectories using the command `./start.sh multisitedomain-wordpress` (for docker) and the domain http://multisite.wordpress.test/
* Build free and premium
* Enter the main site
* Go to yoastseo > general > features and check that the Inclusive language feature is disabled by the admin
* Go yoastseo > general > dashboard
* Find the notification on Inclusive language, and confirm that it says `New in Yoast SEO Premium 19.2: Did you know that you can now get feedback on the use of inclusive language? This feature is disabled by default. Please contact your Network admin if you want to enable it. [Learn more about this feature]`

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [x] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes #
