### PR TITLE
Pc 457 add a filter on post sub types

### DIFF
--- a/packages/js/src/indexables-page/components/not-enough-analysed-content.js
+++ b/packages/js/src/indexables-page/components/not-enough-analysed-content.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import { __, sprintf } from "@wordpress/i18n";
 
 import IndexablesPageCard from "./indexables-card";
-import { useState, useCallback } from "@wordpress/element";
+import { useState, useCallback, Fragment } from "@wordpress/element";
 import { Button, Link } from "@yoast/ui-library";
 import { IndexableLinkCount } from "./indexables-links-card";
 
@@ -24,26 +24,40 @@ const NotEnoughAnalysedContent = ( { indexablesList, seoEnabled } ) => {
 		setStep( newStep );
 	}, [ numberOfVisibleIndexables, setNumberOfVisibleIndexables ] );
 
+	const title = seoEnabled
+		/* translators: %1$s expands to the number of posts without a focus keyphrase */
+		? sprintf(
+			__(
+				"Posts and pages without a focus keyphrase (%1$s)",
+				"wordpress-seo"
+			),
+			indexablesList.length
+		)
+		/* translators: %1$s expands to the number of posts which hasn't been analyzed */
+		: sprintf(
+			__(
+				"Posts and pages that haven't been analyzed (%1$s)",
+				"wordpress-seo"
+			),
+			indexablesList.length
+		);
+
+	const description = seoEnabled
+		? <Fragment>
+			<p>{ __( "Most of your posts and pages don't have a focus keyphrase yet. Help us to analyze your content by adding focus keyphrases. Below, we ordered your post and pages on the highest number of incoming links, so you can start adding focus keyphrases for your most important content first.", "wordpress-seo" ) }</p>
+			<p className="yst-mt-4">{ __( "Clicking the 'Add focus keyphrase' button will open the editor in a new browser tab. Once you're done, don't forget to click 'Update'.", "wordpress-seo" ) }</p>
+		</Fragment>
+		: <p>{ __( "Most of your posts and pages haven't been analyzed yet. Help us to analyze your content by opening and updating it. Clicking the 'Open editor' button will open the editor in a new browser tab. Make sure to click 'Update' at the top of that page.", "wordpress-seo" ) }</p>;
+
 	return <div className="yst-max-w-full yst-mt-6">
 		<div
 			id="start-writing-content"
 			className="yst-max-w-2xl"
 		>
 			<IndexablesPageCard
-				title={
-					/* translators: %1$s expands to the number of posts without a focus keyphrase */
-					sprintf(
-						__(
-							"Posts without a focus keyphrase (%1$s)",
-							"wordpress-seo"
-						),
-						indexablesList.length
-					)
-				}
+				title={ title }
 			>
-				{
-					! seoEnabled && <p>{ __( "Most of your post haven't been analyzed yet. Help us to analyze your content by opening and updating your posts. Clicking the 'Open editor' button will open the post editor in a new browser tab. Make sure to click 'Update' at the top of that page.", "wordpress-seo" ) }</p>
-				}
+				{ description }
 				<ul className="yst-divide-y yst-divide-gray-200">
 					{ indexablesList.slice( 0, numberOfVisibleIndexables ).map(
 						( indexable, index ) => {

--- a/packages/js/src/indexables-page/components/not-enough-analysed-content.js
+++ b/packages/js/src/indexables-page/components/not-enough-analysed-content.js
@@ -25,16 +25,16 @@ const NotEnoughAnalysedContent = ( { indexablesList, seoEnabled } ) => {
 	}, [ numberOfVisibleIndexables, setNumberOfVisibleIndexables ] );
 
 	const title = seoEnabled
-		/* translators: %1$s expands to the number of posts without a focus keyphrase */
 		? sprintf(
+			/* translators: %1$s expands to the number of posts without a focus keyphrase */
 			__(
 				"Posts and pages without a focus keyphrase (%1$s)",
 				"wordpress-seo"
 			),
 			indexablesList.length
 		)
-		/* translators: %1$s expands to the number of posts which hasn't been analyzed */
 		: sprintf(
+			/* translators: %1$s expands to the number of posts which hasn't been analyzed */
 			__(
 				"Posts and pages that haven't been analyzed (%1$s)",
 				"wordpress-seo"
@@ -44,7 +44,7 @@ const NotEnoughAnalysedContent = ( { indexablesList, seoEnabled } ) => {
 
 	const description = seoEnabled
 		? <Fragment>
-			<p>{ __( "Most of your posts and pages don't have a focus keyphrase yet. Help us to analyze your content by adding focus keyphrases. Below, we ordered your post and pages on the highest number of incoming links, so you can start adding focus keyphrases for your most important content first.", "wordpress-seo" ) }</p>
+			<p>{ __( "Most of your posts and pages don't have a focus keyphrase yet. Help us to analyze your content by adding focus keyphrases. Below, we ordered your posts and pages on the highest number of incoming links, so you can start adding focus keyphrases for your most important content first.", "wordpress-seo" ) }</p>
 			<p className="yst-mt-4">{ __( "Clicking the 'Add focus keyphrase' button will open the editor in a new browser tab. Once you're done, don't forget to click 'Update'.", "wordpress-seo" ) }</p>
 		</Fragment>
 		: <p>{ __( "Most of your posts and pages haven't been analyzed yet. Help us to analyze your content by opening and updating it. Clicking the 'Open editor' button will open the editor in a new browser tab. Make sure to click 'Update' at the top of that page.", "wordpress-seo" ) }</p>;

--- a/src/actions/indexables-page-action.php
+++ b/src/actions/indexables-page-action.php
@@ -58,8 +58,15 @@ class Indexables_Page_Action {
 		$object_sub_types = \array_values( $this->post_type_helper->get_public_post_types() );
 
 		$excluded_post_types = \apply_filters( 'wpseo_indexable_excluded_post_types', [ 'attachment' ] );
+		/**
+		 * Filter: 'wpseo_indexable_included_post_types' - Allow developers to specify which post types will
+		 * be shown in the indexables overview cards.
+		 *
+		 * @param array $included_post_types The currently included post types.
+		 */
+		$included_post_types = \apply_filters( 'wpseo_indexable_included_post_types', [ 'post', 'page' ] );
 		$object_sub_types    = \array_diff( $object_sub_types, $excluded_post_types );
-		$only_post_pages     = \array_intersect( $object_sub_types, [ 'post', 'page' ] );
+		$only_post_pages     = \array_intersect( $object_sub_types, $included_post_types );
 
 		$wanted_sub_types = [];
 		foreach ( $only_post_pages as $sub_type ) {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds a filter to specify which post types needs to be shown in the four tables
* Updates copy on `not-enough-analysed-content` page

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

*

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes #
