### PR TITLE
Pc 13 add support for blocking site search via robots txt

### DIFF
--- a/inc/options/class-wpseo-option-wpseo.php
+++ b/inc/options/class-wpseo-option-wpseo.php
@@ -122,6 +122,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 		'search_cleanup_emoji'                     => false,
 		'search_cleanup_patterns'                  => false,
 		'search_character_limit'                   => 50,
+		'deny_search_crawling'                     => false,
 		'deny_wp_json_crawling'                    => false,
 	];
 

--- a/src/integrations/admin/crawl-settings-integration.php
+++ b/src/integrations/admin/crawl-settings-integration.php
@@ -134,6 +134,7 @@ class Crawl_Settings_Integration implements Integration_Interface {
 			'search_cleanup'          => \__( 'Filter search terms', 'wordpress-seo' ),
 			'search_cleanup_emoji'    => \__( 'Filter searches with emojis and other special characters', 'wordpress-seo' ),
 			'search_cleanup_patterns' => \__( 'Filter searches with common spam patterns', 'wordpress-seo' ),
+			'deny_search_crawling'    => \__( 'Prevent search engines from crawling site search URLs', 'wordpress-seo' ),
 			'deny_wp_json_crawling'   => \__( 'Prevent search engines from crawling /wp-json/', 'wordpress-seo' ),
 		];
 	}
@@ -332,7 +333,7 @@ class Crawl_Settings_Integration implements Integration_Interface {
 	 */
 	protected function should_feature_be_disabled_multisite( $setting ) {
 		return (
-			\in_array( $setting, [ 'deny_wp_json_crawling' ], true )
+			\in_array( $setting, [ 'deny_search_crawling', 'deny_wp_json_crawling' ], true )
 			&& \is_multisite()
 		);
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Internal site search URLs (eg., example.com/?s=example or example.com/search/example) are often the target of large-scale spam link attacks, which can result in them being aggressively crawled.
* Note that [this PR](https://github.com/Yoast/wordpress-seo/pull/18854) needs to be merged first!

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Add a setting for disabling crawling of search URLs.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

Test changes on basic (wordpress basic):
* Activate Yoast SEO.
* Go to the WordPress administration and click on Yoast SEO.
* Click on `Crawl settings (beta)`.
* Scroll down and check whether you see a blurred toggle `Prevent search engines from crawling site search URLs`.

Test changes on multisite (wordpress multisite):
* Network activate Yoast SEO.
* Go to the network administration -> Yoast SEO.
* Click on `Crawl settings (beta)`.
* Scroll down and check whether you see a disabled toggle `Prevent search engines from crawling site search URLs`.
* Now go to one of the multisite administration dashboards.
* Click on Yoast SEO.
* click on `Crawl settings (beta)`.
* Scroll down and check whether you see a disabled toggle `Prevent search engines from crawling site search URLs`.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes [PC-13](https://yoast.atlassian.net/browse/PC-13)