### PR TITLE
Make di container more robust

### DIFF
--- a/src/loader.php
+++ b/src/loader.php
@@ -53,12 +53,23 @@ class Loader {
 	protected $container;
 
 	/**
+	 * The invalid behavior to use when fetching classes from the container.
+	 *
+	 * @var int
+	 */
+	protected $invalid_behavior = ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE;
+
+	/**
 	 * Loader constructor.
 	 *
 	 * @param ContainerInterface $container The dependency injection container.
 	 */
 	public function __construct( ContainerInterface $container ) {
 		$this->container = $container;
+
+		if ( YOAST_ENVIRONMENT === 'production' ) {
+			$this->invalid_behavior = ContainerInterface::NULL_ON_INVALID_REFERENCE;
+		}
 	}
 
 	/**
@@ -166,7 +177,7 @@ class Loader {
 	 */
 	protected function load_commands() {
 		foreach ( $this->commands as $class ) {
-			$command = $this->container->get( $class, ContainerInterface::NULL_ON_INVALID_REFERENCE );
+			$command = $this->container->get( $class, $this->invalid_behavior );
 
 			if ( $command === null ) {
 				continue;
@@ -187,7 +198,7 @@ class Loader {
 				continue;
 			}
 
-			$initializer = $this->container->get( $class, ContainerInterface::NULL_ON_INVALID_REFERENCE );
+			$initializer = $this->container->get( $class, $this->invalid_behavior );
 
 			if ( $initializer === null ) {
 				continue;
@@ -208,7 +219,7 @@ class Loader {
 				continue;
 			}
 
-			$integration = $this->container->get( $class, ContainerInterface::NULL_ON_INVALID_REFERENCE );
+			$integration = $this->container->get( $class, $this->invalid_behavior );
 
 			if ( $integration === null ) {
 				continue;
@@ -229,7 +240,7 @@ class Loader {
 				continue;
 			}
 
-			$route = $this->container->get( $class, ContainerInterface::NULL_ON_INVALID_REFERENCE );
+			$route = $this->container->get( $class, $this->invalid_behavior );
 
 			if ( $route === null ) {
 				continue;
@@ -253,7 +264,7 @@ class Loader {
 
 		$conditionals = $loadable_class::get_conditionals();
 		foreach ( $conditionals as $class ) {
-			$conditional = $this->container->get( $class, ContainerInterface::NULL_ON_INVALID_REFERENCE );
+			$conditional = $this->container->get( $class, $this->invalid_behavior );
 			if ( $conditional === null || ! $conditional->is_met() ) {
 				return false;
 			}

--- a/src/loader.php
+++ b/src/loader.php
@@ -246,14 +246,14 @@ class Loader {
 	 *
 	 * @param string $loadable_class The class name of the loadable.
 	 *
-	 * @return bool Whether or not all conditionals of the loadable are met.
+	 * @return bool Whether all conditionals of the loadable are met.
 	 */
 	protected function conditionals_are_met( $loadable_class ) {
 		// In production environments do not fatal if the class does not exist but log and fail gracefully.
 		if ( YOAST_ENVIRONMENT === 'production' && ! \class_exists( $loadable_class ) ) {
-			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+			if ( \defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-				error_log(
+				\error_log(
 					\sprintf(
 						/* translators: %1$s expands to Yoast SEO, %2$s expands to the name of the class that could not be found. */
 						\__( '%1$s attempted to load the class %2$s but it could not be found.', 'wordpress-seo' ),
@@ -290,7 +290,7 @@ class Loader {
 		try {
 			return $this->container->get( $class );
 		} catch ( Throwable $e ) {
-			// In production environments do not fatal if the class could not be constructred but log and fail gracefully.
+			// In production environments do not fatal if the class could not be constructed but log and fail gracefully.
 			if ( YOAST_ENVIRONMENT === 'production' ) {
 				if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 					// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
@@ -300,7 +300,7 @@ class Loader {
 			}
 			throw $e;
 		} catch ( Exception $e ) { // Also catch Exception for PHP 5.6 compatibility.
-			// In production environments do not fatal if the class could not be constructred but log and fail gracefully.
+			// In production environments do not fatal if the class could not be constructed but log and fail gracefully.
 			if ( YOAST_ENVIRONMENT === 'production' ) {
 				if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 					// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log

--- a/tests/unit/loader-test.php
+++ b/tests/unit/loader-test.php
@@ -66,19 +66,19 @@ class Loader_Test extends TestCase {
 	 * @covers ::load
 	 */
 	public function test_loading_unconditional_integration() {
-		$integration_mock = Mockery::mock( 'alias:Unconditional_Integration', Integration_Interface::class );
+		$integration_mock = Mockery::mock( Integration_Interface::class );
 		$integration_mock->expects( 'get_conditionals' )->once()->andReturn( [] );
 		$integration_mock->expects( 'register_hooks' )->once();
 
 		$container_mock = Mockery::mock( ContainerInterface::class );
-		$container_mock->expects( 'get' )->once()->with( 'Unconditional_Integration' )->andReturn( $integration_mock );
+		$container_mock->expects( 'get' )->once()->with( \get_class( $integration_mock ), ContainerInterface::NULL_ON_INVALID_REFERENCE )->andReturn( $integration_mock );
 
 		Monkey\Functions\expect( 'did_action' )
 			->with( 'init' )
 			->andReturn( 1 );
 
 		$loader = new Loader( $container_mock );
-		$loader->register_integration( 'Unconditional_Integration' );
+		$loader->register_integration( \get_class( $integration_mock ) );
 		$loader->load();
 	}
 
@@ -93,20 +93,20 @@ class Loader_Test extends TestCase {
 		$conditional_mock = Mockery::mock( Conditional::class );
 		$conditional_mock->expects( 'is_met' )->once()->andReturn( true );
 
-		$integration_mock = Mockery::mock( 'alias:Met_Conditional_Integration', Integration_Interface::class );
+		$integration_mock = Mockery::mock( Integration_Interface::class );
 		$integration_mock->expects( 'get_conditionals' )->once()->andReturn( [ 'Conditional_Class' ] );
 		$integration_mock->expects( 'register_hooks' )->once();
 
 		$container_mock = Mockery::mock( ContainerInterface::class );
-		$container_mock->expects( 'get' )->once()->with( 'Conditional_Class' )->andReturn( $conditional_mock );
-		$container_mock->expects( 'get' )->once()->with( 'Met_Conditional_Integration' )->andReturn( $integration_mock );
+		$container_mock->expects( 'get' )->once()->with( 'Conditional_Class', ContainerInterface::NULL_ON_INVALID_REFERENCE )->andReturn( $conditional_mock );
+		$container_mock->expects( 'get' )->once()->with( \get_class( $integration_mock ), ContainerInterface::NULL_ON_INVALID_REFERENCE )->andReturn( $integration_mock );
 
 		Monkey\Functions\expect( 'did_action' )
 			->with( 'init' )
 			->andReturn( 1 );
 
 		$loader = new Loader( $container_mock );
-		$loader->register_integration( 'Met_Conditional_Integration' );
+		$loader->register_integration( \get_class( $integration_mock ) );
 		$loader->load();
 	}
 
@@ -121,20 +121,45 @@ class Loader_Test extends TestCase {
 		$conditional_mock = Mockery::mock( Conditional::class );
 		$conditional_mock->expects( 'is_met' )->once()->andReturn( false );
 
-		$integration_mock = Mockery::mock( 'alias:Unmet_Conditional_Integration', Integration_Interface::class );
+		$integration_mock = Mockery::mock( Integration_Interface::class );
 		$integration_mock->expects( 'get_conditionals' )->once()->andReturn( [ 'Conditional_Class' ] );
 		$integration_mock->expects( 'register_hooks' )->never();
 
 		$container_mock = Mockery::mock( ContainerInterface::class );
-		$container_mock->expects( 'get' )->once()->with( 'Conditional_Class' )->andReturn( $conditional_mock );
-		$container_mock->expects( 'get' )->never()->with( 'Unmet_Conditional_Integration' );
+		$container_mock->expects( 'get' )->once()->with( 'Conditional_Class', ContainerInterface::NULL_ON_INVALID_REFERENCE )->andReturn( $conditional_mock );
+		$container_mock->expects( 'get' )->never()->with( \get_class( $integration_mock ), ContainerInterface::NULL_ON_INVALID_REFERENCE );
 
 		Monkey\Functions\expect( 'did_action' )
 			->with( 'init' )
 			->andReturn( 1 );
 
 		$loader = new Loader( $container_mock );
-		$loader->register_integration( 'Unmet_Conditional_Integration' );
+		$loader->register_integration( \get_class( $integration_mock ) );
+		$loader->load();
+	}
+
+	/**
+	 * Tests loading an integration with an conditional that doesn't exist.
+	 *
+	 * @covers ::__construct
+	 * @covers ::register_integration
+	 * @covers ::load
+	 */
+	public function test_loading_not_exisisting_conditional_integration() {
+		$integration_mock = Mockery::mock( Integration_Interface::class );
+		$integration_mock->expects( 'get_conditionals' )->once()->andReturn( [ 'Conditional_Class' ] );
+		$integration_mock->expects( 'register_hooks' )->never();
+
+		$container_mock = Mockery::mock( ContainerInterface::class );
+		$container_mock->expects( 'get' )->once()->with( 'Conditional_Class', ContainerInterface::NULL_ON_INVALID_REFERENCE )->andReturn( null );
+		$container_mock->expects( 'get' )->never()->with( \get_class( $integration_mock ), ContainerInterface::NULL_ON_INVALID_REFERENCE );
+
+		Monkey\Functions\expect( 'did_action' )
+			->with( 'init' )
+			->andReturn( 1 );
+
+		$loader = new Loader( $container_mock );
+		$loader->register_integration( \get_class( $integration_mock ) );
 		$loader->load();
 	}
 
@@ -146,15 +171,15 @@ class Loader_Test extends TestCase {
 	 * @covers ::load
 	 */
 	public function test_loading_unconditional_initializer() {
-		$integration_mock = Mockery::mock( 'alias:Unconditional_Initializer', Initializer_Interface::class );
-		$integration_mock->expects( 'get_conditionals' )->once()->andReturn( [] );
-		$integration_mock->expects( 'initialize' )->once();
+		$initializer_mock = Mockery::mock( Initializer_Interface::class );
+		$initializer_mock->expects( 'get_conditionals' )->once()->andReturn( [] );
+		$initializer_mock->expects( 'initialize' )->once();
 
 		$container_mock = Mockery::mock( ContainerInterface::class );
-		$container_mock->expects( 'get' )->once()->with( 'Unconditional_Initializer' )->andReturn( $integration_mock );
+		$container_mock->expects( 'get' )->once()->with( \get_class( $initializer_mock ), ContainerInterface::NULL_ON_INVALID_REFERENCE )->andReturn( $initializer_mock );
 
 		$loader = new Loader( $container_mock );
-		$loader->register_initializer( 'Unconditional_Initializer' );
+		$loader->register_initializer( \get_class( $initializer_mock ) );
 		$loader->load();
 	}
 
@@ -169,16 +194,16 @@ class Loader_Test extends TestCase {
 		$conditional_mock = Mockery::mock( Conditional::class );
 		$conditional_mock->expects( 'is_met' )->once()->andReturn( true );
 
-		$integration_mock = Mockery::mock( 'alias:Met_Conditional_Initializer', Initializer_Interface::class );
-		$integration_mock->expects( 'get_conditionals' )->once()->andReturn( [ 'Conditional_Class' ] );
-		$integration_mock->expects( 'initialize' )->once();
+		$initializer_mock = Mockery::mock( Initializer_Interface::class );
+		$initializer_mock->expects( 'get_conditionals' )->once()->andReturn( [ 'Conditional_Class' ] );
+		$initializer_mock->expects( 'initialize' )->once();
 
 		$container_mock = Mockery::mock( ContainerInterface::class );
-		$container_mock->expects( 'get' )->once()->with( 'Conditional_Class' )->andReturn( $conditional_mock );
-		$container_mock->expects( 'get' )->once()->with( 'Met_Conditional_Initializer' )->andReturn( $integration_mock );
+		$container_mock->expects( 'get' )->once()->with( 'Conditional_Class', ContainerInterface::NULL_ON_INVALID_REFERENCE )->andReturn( $conditional_mock );
+		$container_mock->expects( 'get' )->once()->with( \get_class( $initializer_mock ), ContainerInterface::NULL_ON_INVALID_REFERENCE )->andReturn( $initializer_mock );
 
 		$loader = new Loader( $container_mock );
-		$loader->register_initializer( 'Met_Conditional_Initializer' );
+		$loader->register_initializer( \get_class( $initializer_mock ) );
 		$loader->load();
 	}
 
@@ -193,16 +218,52 @@ class Loader_Test extends TestCase {
 		$conditional_mock = Mockery::mock( Conditional::class );
 		$conditional_mock->expects( 'is_met' )->once()->andReturn( false );
 
-		$integration_mock = Mockery::mock( 'alias:Unmet_Conditional_Initializer', Initializer_Interface::class );
-		$integration_mock->expects( 'get_conditionals' )->once()->andReturn( [ 'Conditional_Class' ] );
-		$integration_mock->expects( 'initialize' )->never();
+		$initializer_mock = Mockery::mock( Initializer_Interface::class );
+		$initializer_mock->expects( 'get_conditionals' )->once()->andReturn( [ 'Conditional_Class' ] );
+		$initializer_mock->expects( 'initialize' )->never();
 
 		$container_mock = Mockery::mock( ContainerInterface::class );
-		$container_mock->expects( 'get' )->once()->with( 'Conditional_Class' )->andReturn( $conditional_mock );
-		$container_mock->expects( 'get' )->never()->with( 'Unmet_Conditional_Initializer' );
+		$container_mock->expects( 'get' )->once()->with( 'Conditional_Class', ContainerInterface::NULL_ON_INVALID_REFERENCE )->andReturn( $conditional_mock );
+		$container_mock->expects( 'get' )->never()->with( \get_class( $initializer_mock ), ContainerInterface::NULL_ON_INVALID_REFERENCE );
 
 		$loader = new Loader( $container_mock );
-		$loader->register_initializer( 'Unmet_Conditional_Initializer' );
+		$loader->register_initializer( \get_class( $initializer_mock ) );
+		$loader->load();
+	}
+
+	/**
+	 * Tests loading an initializer with an conditional that doesn't exist.
+	 *
+	 * @covers ::__construct
+	 * @covers ::register_initializer
+	 * @covers ::load
+	 */
+	public function test_loading_not_exisisting_conditional_initializer() {
+		$initializer_mock = Mockery::mock( Initializer_Interface::class );
+		$initializer_mock->expects( 'get_conditionals' )->once()->andReturn( [ 'Conditional_Class' ] );
+		$initializer_mock->expects( 'initialize' )->never();
+
+		$container_mock = Mockery::mock( ContainerInterface::class );
+		$container_mock->expects( 'get' )->once()->with( 'Conditional_Class', ContainerInterface::NULL_ON_INVALID_REFERENCE )->andReturn( null );
+		$container_mock->expects( 'get' )->never()->with( \get_class( $initializer_mock ), ContainerInterface::NULL_ON_INVALID_REFERENCE );
+
+		$loader = new Loader( $container_mock );
+		$loader->register_initializer( \get_class( $initializer_mock ) );
+		$loader->load();
+	}
+
+	/**
+	 * Tests loading an initializer that doesn't exist.
+	 *
+	 * @covers ::__construct
+	 * @covers ::register_initializer
+	 * @covers ::load
+	 */
+	public function test_loading_not_exisisting_initializer() {
+		$container_mock = Mockery::mock( ContainerInterface::class );
+
+		$loader = new Loader( $container_mock );
+		$loader->register_initializer( 'Not_Existing_Conditional_Initializer' );
 		$loader->load();
 	}
 }

--- a/tests/unit/loader-test.php
+++ b/tests/unit/loader-test.php
@@ -71,7 +71,7 @@ class Loader_Test extends TestCase {
 		$integration_mock->expects( 'register_hooks' )->once();
 
 		$container_mock = Mockery::mock( ContainerInterface::class );
-		$container_mock->expects( 'get' )->once()->with( \get_class( $integration_mock ), ContainerInterface::NULL_ON_INVALID_REFERENCE )->andReturn( $integration_mock );
+		$container_mock->expects( 'get' )->once()->with( \get_class( $integration_mock ) )->andReturn( $integration_mock );
 
 		Monkey\Functions\expect( 'did_action' )
 			->with( 'init' )
@@ -98,8 +98,8 @@ class Loader_Test extends TestCase {
 		$integration_mock->expects( 'register_hooks' )->once();
 
 		$container_mock = Mockery::mock( ContainerInterface::class );
-		$container_mock->expects( 'get' )->once()->with( 'Conditional_Class', ContainerInterface::NULL_ON_INVALID_REFERENCE )->andReturn( $conditional_mock );
-		$container_mock->expects( 'get' )->once()->with( \get_class( $integration_mock ), ContainerInterface::NULL_ON_INVALID_REFERENCE )->andReturn( $integration_mock );
+		$container_mock->expects( 'get' )->once()->with( 'Conditional_Class' )->andReturn( $conditional_mock );
+		$container_mock->expects( 'get' )->once()->with( \get_class( $integration_mock ) )->andReturn( $integration_mock );
 
 		Monkey\Functions\expect( 'did_action' )
 			->with( 'init' )
@@ -126,8 +126,8 @@ class Loader_Test extends TestCase {
 		$integration_mock->expects( 'register_hooks' )->never();
 
 		$container_mock = Mockery::mock( ContainerInterface::class );
-		$container_mock->expects( 'get' )->once()->with( 'Conditional_Class', ContainerInterface::NULL_ON_INVALID_REFERENCE )->andReturn( $conditional_mock );
-		$container_mock->expects( 'get' )->never()->with( \get_class( $integration_mock ), ContainerInterface::NULL_ON_INVALID_REFERENCE );
+		$container_mock->expects( 'get' )->once()->with( 'Conditional_Class' )->andReturn( $conditional_mock );
+		$container_mock->expects( 'get' )->never()->with( \get_class( $integration_mock ) );
 
 		Monkey\Functions\expect( 'did_action' )
 			->with( 'init' )
@@ -151,8 +151,8 @@ class Loader_Test extends TestCase {
 		$integration_mock->expects( 'register_hooks' )->never();
 
 		$container_mock = Mockery::mock( ContainerInterface::class );
-		$container_mock->expects( 'get' )->once()->with( 'Conditional_Class', ContainerInterface::NULL_ON_INVALID_REFERENCE )->andReturn( null );
-		$container_mock->expects( 'get' )->never()->with( \get_class( $integration_mock ), ContainerInterface::NULL_ON_INVALID_REFERENCE );
+		$container_mock->expects( 'get' )->once()->with( 'Conditional_Class' )->andReturn( null );
+		$container_mock->expects( 'get' )->never()->with( \get_class( $integration_mock ) );
 
 		Monkey\Functions\expect( 'did_action' )
 			->with( 'init' )
@@ -176,7 +176,7 @@ class Loader_Test extends TestCase {
 		$initializer_mock->expects( 'initialize' )->once();
 
 		$container_mock = Mockery::mock( ContainerInterface::class );
-		$container_mock->expects( 'get' )->once()->with( \get_class( $initializer_mock ), ContainerInterface::NULL_ON_INVALID_REFERENCE )->andReturn( $initializer_mock );
+		$container_mock->expects( 'get' )->once()->with( \get_class( $initializer_mock ) )->andReturn( $initializer_mock );
 
 		$loader = new Loader( $container_mock );
 		$loader->register_initializer( \get_class( $initializer_mock ) );
@@ -199,8 +199,8 @@ class Loader_Test extends TestCase {
 		$initializer_mock->expects( 'initialize' )->once();
 
 		$container_mock = Mockery::mock( ContainerInterface::class );
-		$container_mock->expects( 'get' )->once()->with( 'Conditional_Class', ContainerInterface::NULL_ON_INVALID_REFERENCE )->andReturn( $conditional_mock );
-		$container_mock->expects( 'get' )->once()->with( \get_class( $initializer_mock ), ContainerInterface::NULL_ON_INVALID_REFERENCE )->andReturn( $initializer_mock );
+		$container_mock->expects( 'get' )->once()->with( 'Conditional_Class' )->andReturn( $conditional_mock );
+		$container_mock->expects( 'get' )->once()->with( \get_class( $initializer_mock ) )->andReturn( $initializer_mock );
 
 		$loader = new Loader( $container_mock );
 		$loader->register_initializer( \get_class( $initializer_mock ) );
@@ -223,8 +223,8 @@ class Loader_Test extends TestCase {
 		$initializer_mock->expects( 'initialize' )->never();
 
 		$container_mock = Mockery::mock( ContainerInterface::class );
-		$container_mock->expects( 'get' )->once()->with( 'Conditional_Class', ContainerInterface::NULL_ON_INVALID_REFERENCE )->andReturn( $conditional_mock );
-		$container_mock->expects( 'get' )->never()->with( \get_class( $initializer_mock ), ContainerInterface::NULL_ON_INVALID_REFERENCE );
+		$container_mock->expects( 'get' )->once()->with( 'Conditional_Class' )->andReturn( $conditional_mock );
+		$container_mock->expects( 'get' )->never()->with( \get_class( $initializer_mock ) );
 
 		$loader = new Loader( $container_mock );
 		$loader->register_initializer( \get_class( $initializer_mock ) );
@@ -244,26 +244,11 @@ class Loader_Test extends TestCase {
 		$initializer_mock->expects( 'initialize' )->never();
 
 		$container_mock = Mockery::mock( ContainerInterface::class );
-		$container_mock->expects( 'get' )->once()->with( 'Conditional_Class', ContainerInterface::NULL_ON_INVALID_REFERENCE )->andReturn( null );
-		$container_mock->expects( 'get' )->never()->with( \get_class( $initializer_mock ), ContainerInterface::NULL_ON_INVALID_REFERENCE );
+		$container_mock->expects( 'get' )->once()->with( 'Conditional_Class' )->andReturn( null );
+		$container_mock->expects( 'get' )->never()->with( \get_class( $initializer_mock ) );
 
 		$loader = new Loader( $container_mock );
 		$loader->register_initializer( \get_class( $initializer_mock ) );
-		$loader->load();
-	}
-
-	/**
-	 * Tests loading an initializer that doesn't exist.
-	 *
-	 * @covers ::__construct
-	 * @covers ::register_initializer
-	 * @covers ::load
-	 */
-	public function test_loading_not_exisisting_initializer() {
-		$container_mock = Mockery::mock( ContainerInterface::class );
-
-		$loader = new Loader( $container_mock );
-		$loader->register_initializer( 'Not_Existing_Conditional_Initializer' );
 		$loader->load();
 	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* This PR ensures that, if for some reason such as plugin incompatibility, a class requested from the container does not exist when requested by the loader that no exception is thrown in production but loading is failed gracefully.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Ensures that the loader class fails gracefully in production when classes do not exist.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:


* Open the `src/conditionals/front-end-conditional.php` file
* Remove all the lines except the first one (`<?php`) and save
* Make sure your `YOAST_ENVIRONMENT` is set to `development`. This should be the case if you are building the plugin from the repo, otherwise if you are using a zip this may mean adding `define( 'YOAST_ENVIRONMENT', 'development' );` to your WordPress config.
* Visit the frontend.
* Check that you get a fatal error ("There has been a critical error on this website.") preventi you to see the site.
* Make sure your `YOAST_ENVIRONMENT` is set to `production`. In development builds of the plugin this may mean adding `define( 'YOAST_ENVIRONMENT', 'production' );` to your WordPress config.
* Visit the frontend.
* There should not be a fatal error, so you should see the normal output
* It's expected that there is no SEO output (no tags, no Schema, no Yoast SEO comment)
* If you have `define( 'WP_DEBUG', true );` in your WordPress config then you should see logs describing a the error. In our Docker setup that should be visible in the output of your `start` script.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Loading classes that, for example, do not exist any more or have other errors.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
