### PR TITLE
Select only columns that are used for indexables

### DIFF
--- a/src/actions/indexables-page-action.php
+++ b/src/actions/indexables-page-action.php
@@ -176,7 +176,7 @@ class Indexables_Page_Action {
 		$ignore_list                   = empty( $least_readability_ignore_list ) ? [ -1 ] : $least_readability_ignore_list;
 
 		$least_readable = $this->query()
-			->select_many( 'id', 'object_id', 'object_sub_type', 'permalink', 'breadcrumb_title', 'readability_score'  )
+			->select_many( 'id', 'object_id', 'object_sub_type', 'permalink', 'breadcrumb_title', 'readability_score' )
 			->where_not_in( 'id', $ignore_list )
 			->where_not_equal( 'readability_score', 0 )
 			->order_by_asc( 'readability_score' )
@@ -199,7 +199,7 @@ class Indexables_Page_Action {
 		$ignore_list                 = empty( $least_seo_score_ignore_list ) ? [ -1 ] : $least_seo_score_ignore_list;
 
 		$least_seo_score = $this->query()
-			->select_many( 'id', 'object_id', 'object_sub_type', 'permalink', 'breadcrumb_title', 'primary_focus_keyword', 'primary_focus_keyword_score'  )
+			->select_many( 'id', 'object_id', 'object_sub_type', 'permalink', 'breadcrumb_title', 'primary_focus_keyword', 'primary_focus_keyword_score' )
 			->where_not_in( 'id', $ignore_list )
 			->where_not_equal( 'primary_focus_keyword', 0 )
 			->order_by_asc( 'primary_focus_keyword_score' )

--- a/src/actions/indexables-page-action.php
+++ b/src/actions/indexables-page-action.php
@@ -176,6 +176,7 @@ class Indexables_Page_Action {
 		$ignore_list                   = empty( $least_readability_ignore_list ) ? [ -1 ] : $least_readability_ignore_list;
 
 		$least_readable = $this->query()
+			->select_many( 'id', 'object_id', 'object_sub_type', 'permalink', 'breadcrumb_title', 'readability_score'  )
 			->where_not_in( 'id', $ignore_list )
 			->where_not_equal( 'readability_score', 0 )
 			->order_by_asc( 'readability_score' )
@@ -198,6 +199,7 @@ class Indexables_Page_Action {
 		$ignore_list                 = empty( $least_seo_score_ignore_list ) ? [ -1 ] : $least_seo_score_ignore_list;
 
 		$least_seo_score = $this->query()
+			->select_many( 'id', 'object_id', 'object_sub_type', 'permalink', 'breadcrumb_title', 'primary_focus_keyword', 'primary_focus_keyword_score'  )
 			->where_not_in( 'id', $ignore_list )
 			->where_not_equal( 'primary_focus_keyword', 0 )
 			->order_by_asc( 'primary_focus_keyword_score' )
@@ -220,6 +222,7 @@ class Indexables_Page_Action {
 		$ignore_list             = empty( $most_linked_ignore_list ) ? [ -1 ] : $most_linked_ignore_list;
 
 		$most_linked = $this->query()
+			->select_many( 'id', 'object_id', 'object_sub_type', 'permalink', 'breadcrumb_title', 'incoming_link_count', 'is_cornerstone' )
 			->where_gt( 'incoming_link_count', 0 )
 			->where_not_null( 'incoming_link_count' )
 			->where_not_in( 'id', $ignore_list )
@@ -243,6 +246,7 @@ class Indexables_Page_Action {
 		$ignore_list              = empty( $least_linked_ignore_list ) ? [ -1 ] : $least_linked_ignore_list;
 
 		$least_linked = $this->query()
+			->select_many( 'id', 'object_id', 'object_sub_type', 'permalink', 'breadcrumb_title', 'incoming_link_count' )
 			->where_not_in( 'id', $ignore_list )
 			->order_by_asc( 'incoming_link_count' )
 			->limit( $limit )

--- a/tests/unit/actions/indexables-page-action-test.php
+++ b/tests/unit/actions/indexables-page-action-test.php
@@ -367,6 +367,11 @@ class Indexables_Page_Action_Test extends TestCase {
 			->andReturnSelf();
 
 		$this->indexable_repository
+			->expects( 'select_many' )
+			->with( 'id', 'object_id', 'object_sub_type', 'permalink', 'breadcrumb_title', 'readability_score' )
+			->andReturnSelf();
+
+		$this->indexable_repository
 			->expects( 'where_raw' )
 			->with( '( post_status = \'publish\' OR post_status IS NULL )' )
 			->andReturnSelf();
@@ -460,6 +465,11 @@ class Indexables_Page_Action_Test extends TestCase {
 			->andReturnSelf();
 
 		$this->indexable_repository
+			->expects( 'select_many' )
+			->with( 'id', 'object_id', 'object_sub_type', 'permalink', 'breadcrumb_title', 'primary_focus_keyword', 'primary_focus_keyword_score' )
+			->andReturnSelf();
+
+		$this->indexable_repository
 			->expects( 'where_raw' )
 			->with( '( post_status = \'publish\' OR post_status IS NULL )' )
 			->andReturnSelf();
@@ -550,6 +560,11 @@ class Indexables_Page_Action_Test extends TestCase {
 
 		$this->indexable_repository
 			->expects( 'query' )
+			->andReturnSelf();
+
+		$this->indexable_repository
+			->expects( 'select_many' )
+			->with( 'id', 'object_id', 'object_sub_type', 'permalink', 'breadcrumb_title', 'incoming_link_count', 'is_cornerstone' )
 			->andReturnSelf();
 
 		$this->indexable_repository
@@ -657,6 +672,11 @@ class Indexables_Page_Action_Test extends TestCase {
 
 		$this->indexable_repository
 			->expects( 'query' )
+			->andReturnSelf();
+
+		$this->indexable_repository
+			->expects( 'select_many' )
+			->with( 'id', 'object_id', 'object_sub_type', 'permalink', 'breadcrumb_title', 'incoming_link_count' )
 			->andReturnSelf();
 
 		$this->indexable_repository


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Select only columns that are used for indexables

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

*

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes #
