### PR TITLE
Adds option whenever a user toggles the tracking preferences.

### DIFF
--- a/inc/options/class-wpseo-option-wpseo.php
+++ b/inc/options/class-wpseo-option-wpseo.php
@@ -27,6 +27,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 	protected $defaults = [
 		// Non-form fields, set via (ajax) function.
 		'tracking'                                 => null,
+		'toggled_tracking'                         => false,
 		'license_server_version'                   => false,
 		'ms_defaults_set'                          => false,
 		'ignore_search_engines_discouraged_notice' => false,

--- a/src/actions/configuration/first-time-configuration-action.php
+++ b/src/actions/configuration/first-time-configuration-action.php
@@ -86,6 +86,7 @@ class First_Time_Configuration_Action {
 				'status'  => 200,
 			];
 		}
+
 		return (object) [
 			'success'  => false,
 			'status'   => 500,
@@ -143,6 +144,7 @@ class First_Time_Configuration_Action {
 				'status'  => 200,
 			];
 		}
+
 		return (object) [
 			'success'  => false,
 			'status'   => 200,
@@ -179,6 +181,7 @@ class First_Time_Configuration_Action {
 		$option_value = $this->options_helper->get( 'tracking' );
 
 		if ( $option_value !== $params['tracking'] ) {
+			$this->options_helper->set( 'toggled_tracking', true );
 			$success = $this->options_helper->set( 'tracking', $params['tracking'] );
 		}
 
@@ -188,6 +191,7 @@ class First_Time_Configuration_Action {
 				'status'  => 200,
 			];
 		}
+
 		return (object) [
 			'success' => false,
 			'status'  => 500,

--- a/src/integrations/watchers/option-wpseo-watcher.php
+++ b/src/integrations/watchers/option-wpseo-watcher.php
@@ -42,6 +42,7 @@ class Option_Wpseo_Watcher implements Integration_Interface {
 		\add_action( 'update_option_wpseo', [ $this, 'check_semrush_option_disabled' ], 10, 2 );
 		\add_action( 'update_option_wpseo', [ $this, 'check_wincher_option_disabled' ], 10, 2 );
 		\add_action( 'update_option_wpseo', [ $this, 'check_wordproof_option_disabled' ], 10, 2 );
+		\add_action( 'update_option_wpseo', [ $this, 'check_toggle_usage_tracking' ], 10, 2 );
 	}
 
 	/**
@@ -76,6 +77,7 @@ class Option_Wpseo_Watcher implements Integration_Interface {
 		if ( $disabled ) {
 			\YoastSEO()->helpers->options->set( 'wincher_website_id', '' );
 		}
+
 		return $disabled;
 	}
 
@@ -95,7 +97,28 @@ class Option_Wpseo_Watcher implements Integration_Interface {
 		if ( $disabled ) {
 			$this->wordproof->remove_site_options();
 		}
+
 		return $disabled;
+	}
+
+	/**
+	 * Checks if the usage tracking feature is toggled; if so, set an option to stop us from messing with it.
+	 *
+	 * @param array $old_value The old value of the option.
+	 * @param array $new_value The new value of the option.
+	 *
+	 * @return bool Whether the option is set.
+	 */
+	public function check_toggle_usage_tracking( $old_value, $new_value ) {
+		$option_name = 'tracking';
+
+		if ( \array_key_exists( $option_name, $old_value ) && \array_key_exists( $option_name, $new_value ) && $old_value[ $option_name ] !== $new_value[ $option_name ] && $old_value['toggled_tracking'] === false ) {
+			\YoastSEO()->helpers->options->set( 'toggled_tracking', true );
+
+			return true;
+		}
+
+		return false;
 	}
 
 	/**
@@ -113,8 +136,10 @@ class Option_Wpseo_Watcher implements Integration_Interface {
 	protected function check_token_option_disabled( $integration_option, $target_option, $new_value ) {
 		if ( \array_key_exists( $integration_option, $new_value ) && $new_value[ $integration_option ] === false ) {
 			\YoastSEO()->helpers->options->set( $target_option, [] );
+
 			return true;
 		}
+
 		return false;
 	}
 }

--- a/tests/unit/actions/configuration/first-time-configuration-action-test.php
+++ b/tests/unit/actions/configuration/first-time-configuration-action-test.php
@@ -296,7 +296,7 @@ class First_Time_Configuration_Action_Test extends TestCase {
 				'tracking' => true,
 			],
 			'old_value'             => false,
-			'times'                 => 1,
+			'times'                 => 2,
 			'option_result'         => true,
 			'expected'              => (object) [
 				'success' => true,
@@ -309,7 +309,7 @@ class First_Time_Configuration_Action_Test extends TestCase {
 				'tracking' => true,
 			],
 			'old_value'             => false,
-			'times'                 => 1,
+			'times'                 => 2,
 			'option_result'         => true,
 			'expected'              => (object) [
 				'success' => true,
@@ -348,7 +348,7 @@ class First_Time_Configuration_Action_Test extends TestCase {
 				'tracking' => true,
 			],
 			'old_value'             => false,
-			'times'                 => 1,
+			'times'                 => 2,
 			'option_result'         => false,
 			'expected'              => (object) [
 				'success' => false,

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -213,7 +213,7 @@ function _wpseo_activate() {
 	}
 
 	// Reset tracking to be disabled by default.
-	if ( ! YoastSEO()->helpers->product->is_premium() ) {
+	if ( ! YoastSEO()->helpers->product->is_premium() && WPSEO_Options::get( 'toggled_tracking' ) !== true ) {
 		WPSEO_Options::set( 'tracking', false );
 	}
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Adds a check to make sure we don't overwrite tracking preferences when a user chooses them.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds a check to make sure we don't overwrite tracking preferences when a user chooses them.

## Relevant technical choices:

* None

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

*

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [X] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes #
