### PR TITLE
Remove inclusive language notification for the next release 19.7

### DIFF
--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -48,7 +48,6 @@ class WPSEO_Admin_Init {
 		$this->load_admin_user_class();
 		$this->load_xml_sitemaps_admin();
 		$this->load_plugin_suggestions();
-		$this->set_inclusive_language_notice();
 	}
 
 	/**
@@ -186,23 +185,6 @@ class WPSEO_Admin_Init {
 		if ( ! YoastSEO()->helpers->product->is_premium() ) {
 			$upsell_block = new WPSEO_Premium_Upsell_Admin_Block( 'wpseo_admin_promo_footer' );
 			$upsell_block->register_hooks();
-		}
-	}
-
-	/**
-	 * Sets the inclusive language notification.
-	 *
-	 * Notification should pop up if user has Premium activated, the site language is English and the feature toggle is not switched on.
-	 */
-	protected function set_inclusive_language_notice() {
-		$inclusive_language = new WPSEO_Inclusive_Language_Notice( Yoast_Notification_Center::get() );
-
-		if ( $inclusive_language->should_show_notification() ) {
-			$inclusive_language->add_notification();
-			$inclusive_language->dismiss_notice_listener();
-		}
-		else {
-			$inclusive_language->remove_notification();
 		}
 	}
 
@@ -436,5 +418,15 @@ class WPSEO_Admin_Init {
 	 */
 	public function handle_notifications() {
 		_deprecated_function( __METHOD__, 'WPSEO 14.1' );
+	}
+
+	/**
+	 * Sets the inclusive language notification.
+	 *
+	 * @deprecated 19.7
+	 * @codeCoverageIgnore
+	 */
+	protected function set_inclusive_language_notice() {
+		_deprecated_function( __METHOD__, 'WPSEO 19.7' );
 	}
 }

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -949,6 +949,13 @@ class WPSEO_Upgrade {
 	}
 
 	/**
+	 * Performs the 19.7 upgrade routine.
+	 */
+	private function upgrade_197() {
+		add_action( 'init', [ $this, 'remove_inclusive_language_notification_for_197' ] );
+	}
+
+	/**
 	 * Sets the home_url option for the 15.1 upgrade routine.
 	 *
 	 * @return void
@@ -1061,6 +1068,15 @@ class WPSEO_Upgrade {
 	 */
 	public function remove_plugin_updated_notification_for_157() {
 		Yoast_Notification_Center::get()->remove_notification_by_id( 'wpseo-plugin-updated' );
+	}
+
+	/**
+	 * Removes the wpseo-inclusive-language-notice notification from the Notification center for the 19.7 upgrade.
+	 *
+	 * @return void
+	 */
+	public function remove_inclusive_language_notification_for_197() {
+		Yoast_Notification_Center::get()->remove_notification_by_id( 'wpseo-inclusive-language-notice' );
 	}
 
 	/**

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -82,7 +82,7 @@ class WPSEO_Upgrade {
 			'19.1-RC0'   => 'upgrade_191',
 			'19.3-RC0'   => 'upgrade_193',
 			'19.6-RC0'   => 'upgrade_196',
-			'19.7-RC0'   => 'upgrade_197'
+			'19.7-RC0'   => 'upgrade_197',
 		];
 
 		array_walk( $routines, [ $this, 'run_upgrade_routine' ], $version );

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -82,6 +82,7 @@ class WPSEO_Upgrade {
 			'19.1-RC0'   => 'upgrade_191',
 			'19.3-RC0'   => 'upgrade_193',
 			'19.6-RC0'   => 'upgrade_196',
+			'19.7-RC0'   => 'upgrade_197'
 		];
 
 		array_walk( $routines, [ $this, 'run_upgrade_routine' ], $version );

--- a/src/deprecated/admin/class-inclusive-language-notice.php
+++ b/src/deprecated/admin/class-inclusive-language-notice.php
@@ -25,6 +25,16 @@ class WPSEO_Inclusive_Language_Notice {
 	const USER_META_DISMISSED = 'wpseo-remove-inclusive-language-notice';
 
 	/**
+	 * Holds the option name.
+	 *
+	 * @deprecated 19.7
+	 * @codeCoverageIgnore
+	 *
+	 * @var string
+	 */
+	const OPTION_NAME = 'wpseo';
+
+	/**
 	 * The Premium version in which the Inclusive language feature was added.
 	 *
 	 * @deprecated 19.7

--- a/src/deprecated/admin/class-inclusive-language-notice.php
+++ b/src/deprecated/admin/class-inclusive-language-notice.php
@@ -7,6 +7,8 @@
 
 /**
  * Represents the notice for the Inclusive language feature.
+ *
+ * @deprecated 19.7
  */
 class WPSEO_Inclusive_Language_Notice {
 
@@ -17,6 +19,7 @@ class WPSEO_Inclusive_Language_Notice {
 	 *
 	 * @var string
 	 */
+	// Probably don't need it.
 	const USER_META_DISMISSED = 'wpseo-remove-inclusive-language-notice';
 
 	/**
@@ -24,11 +27,13 @@ class WPSEO_Inclusive_Language_Notice {
 	 *
 	 * @var string
 	 */
+	// Keep it?
 	const OPTION_NAME = 'wpseo';
 
 	/**
 	 * The Premium version in which the Inclusive language feature was added.
 	 */
+	// Remove.
 	const PREMIUM_VERSION_ADDED = '19.2-RC1';
 
 	/**
@@ -36,6 +41,7 @@ class WPSEO_Inclusive_Language_Notice {
 	 *
 	 * @var Yoast_Notification_Center
 	 */
+	// Probably don't need it.
 	protected $notification_center;
 
 	/**
@@ -139,6 +145,9 @@ class WPSEO_Inclusive_Language_Notice {
 
 	/**
 	 * Dismisses the notice.
+	 *
+	 * @deprecated 19.7
+	 * @codeCoverageIgnore
 	 */
 	protected function dismiss_notice()
 	{

--- a/src/deprecated/admin/class-inclusive-language-notice.php
+++ b/src/deprecated/admin/class-inclusive-language-notice.php
@@ -17,35 +17,36 @@ class WPSEO_Inclusive_Language_Notice {
 	 *
 	 * The value of this database field holds whether the user has dismissed this notice or not.
 	 *
-	 * @var string
-	 */
-	// Probably don't need it.
-	const USER_META_DISMISSED = 'wpseo-remove-inclusive-language-notice';
-
-	/**
-	 * Holds the option name.
+	 * @deprecated 19.7
+	 * @codeCoverageIgnore
 	 *
 	 * @var string
 	 */
-	// Keep it?
-	const OPTION_NAME = 'wpseo';
+	const USER_META_DISMISSED = 'wpseo-remove-inclusive-language-notice';
 
 	/**
 	 * The Premium version in which the Inclusive language feature was added.
+	 *
+	 * * @deprecated 19.7
+	 * @codeCoverageIgnore
 	 */
-	// Remove.
 	const PREMIUM_VERSION_ADDED = '19.2-RC1';
 
 	/**
 	 * Holds the notification center.
 	 *
+	 * @deprecated 19.7
+	 * @codeCoverageIgnore
+	 *
 	 * @var Yoast_Notification_Center
 	 */
-	// Probably don't need it.
 	protected $notification_center;
 
 	/**
 	 * WPSEO_Inclusive_Language_Notice constructor.
+	 *
+	 * @deprecated 19.7
+	 * @codeCoverageIgnore
 	 *
 	 * @param Yoast_Notification_Center $notification_center The notification center to add notifications to.
 	 */
@@ -55,6 +56,9 @@ class WPSEO_Inclusive_Language_Notice {
 
 	/**
 	 * Listener for the notice.
+	 *
+	 * @deprecated 19.7
+	 * @codeCoverageIgnore
 	 */
 	public function dismiss_notice_listener()
 	{
@@ -70,6 +74,9 @@ class WPSEO_Inclusive_Language_Notice {
 
 	/**
 	 * Adds a notification to the notification center.
+	 *
+	 * @deprecated 19.7
+	 * @codeCoverageIgnore
 	 */
 	public function add_notification()
 	{
@@ -87,6 +94,9 @@ class WPSEO_Inclusive_Language_Notice {
 	/**
 	 * Whether the notification should be shown.
 	 *
+	 * @deprecated 19.7
+	 * @codeCoverageIgnore
+	 *
 	 * @return bool Whether or not the notification should be shown.
 	 */
 	public function should_show_notification()
@@ -101,6 +111,9 @@ class WPSEO_Inclusive_Language_Notice {
 
 	/**
 	 * Gets the notification value.
+	 *
+	 * @deprecated 19.7
+	 * @codeCoverageIgnore
 	 *
 	 * @return Yoast_Notification
 	 */

--- a/src/deprecated/admin/class-inclusive-language-notice.php
+++ b/src/deprecated/admin/class-inclusive-language-notice.php
@@ -50,29 +50,32 @@ class WPSEO_Inclusive_Language_Notice {
 	/**
 	 * Listener for the notice.
 	 */
-	public function dismiss_notice_listener() {
-		if ( filter_input( INPUT_GET, 'yoast_dismiss' ) !== 'upsell' ) {
+	public function dismiss_notice_listener()
+	{
+		if (filter_input(INPUT_GET, 'yoast_dismiss') !== 'upsell') {
 			return;
 		}
 
 		$this->dismiss_notice();
 
-		wp_safe_redirect( admin_url( 'admin.php?page=wpseo_dashboard' ) );
+		wp_safe_redirect(admin_url('admin.php?page=wpseo_dashboard'));
 		exit;
 	}
 
 	/**
 	 * Adds a notification to the notification center.
 	 */
-	public function add_notification() {
-		$this->notification_center->add_notification( $this->get_notification() );
+	public function add_notification()
+	{
+		$this->notification_center->add_notification($this->get_notification());
 	}
 
 	/**
 	 * Removes a notification from the notification center.
 	 */
-	public function remove_notification() {
-		$this->notification_center->remove_notification( $this->get_notification() );
+	public function remove_notification()
+	{
+		$this->notification_center->remove_notification($this->get_notification());
 	}
 
 	/**
@@ -80,13 +83,14 @@ class WPSEO_Inclusive_Language_Notice {
 	 *
 	 * @return bool Whether or not the notification should be shown.
 	 */
-	public function should_show_notification() {
+	public function should_show_notification()
+	{
 		$availability = new WPSEO_Metabox_Analysis_Inclusive_Language();
 
 		return YoastSEO()->helpers->product->is_premium()
-			&& YoastSEO()->helpers->language->has_inclusive_language_support( \WPSEO_Language_Utils::get_language( \get_locale() ) )
-			&& ! $availability->is_globally_enabled()
-			&& \version_compare( YoastSEO()->helpers->product->get_premium_version(), self::PREMIUM_VERSION_ADDED, '>=' );
+			&& YoastSEO()->helpers->language->has_inclusive_language_support(\WPSEO_Language_Utils::get_language(\get_locale()))
+			&& !$availability->is_globally_enabled()
+			&& \version_compare(YoastSEO()->helpers->product->get_premium_version(), self::PREMIUM_VERSION_ADDED, '>=');
 	}
 
 	/**
@@ -94,28 +98,28 @@ class WPSEO_Inclusive_Language_Notice {
 	 *
 	 * @return Yoast_Notification
 	 */
-	protected function get_notification() {
-		if ( is_multisite() && get_site_option( 'wpseo_ms' )['allow_inclusive_language_analysis_active'] === false ) {
+	protected function get_notification()
+	{
+		if (is_multisite() && get_site_option('wpseo_ms')['allow_inclusive_language_analysis_active'] === false) {
 			$message = sprintf(
 			/* translators: %1$s is a link to the Features tab on the Yoast SEO Dashboard page, %2$s is a link to the blog post about this feature, %3$s is the link closing tag. */
 				__(
 					'<strong>New in Yoast SEO Premium 19.2:</strong> Did you know that you can now get feedback on the use of inclusive language? This feature is disabled by default. Please contact your Network admin if you want to enable it. %2$sLearn more about this feature%3$s.',
 					'wordpress-seo'
 				),
-				'<a href="' . admin_url( 'admin.php?page=wpseo_dashboard#top#features' ) . '">',
-				'<a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/inclusive-language-notification' ) . '" target="_blank">',
+				'<a href="' . admin_url('admin.php?page=wpseo_dashboard#top#features') . '">',
+				'<a href="' . WPSEO_Shortlinker::get('https://yoa.st/inclusive-language-notification') . '" target="_blank">',
 				'</a>'
 			);
-		}
-		else {
+		} else {
 			$message = sprintf(
 			/* translators: %1$s is a link to the Features tab on the Yoast SEO Dashboard page, %2$s is a link to the blog post about this feature, %3$s is the link closing tag. */
 				__(
 					'<strong>New in Yoast SEO Premium 19.2:</strong> Did you know that you can now %1$senable the beta version of our inclusive language feature%3$s to get feedback on the use of inclusive language? This feature is disabled by default. %2$sLearn more about this feature%3$s.',
 					'wordpress-seo'
 				),
-				'<a href="' . admin_url( 'admin.php?page=wpseo_dashboard#top#features' ) . '">',
-				'<a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/inclusive-language-notification' ) . '" target="_blank">',
+				'<a href="' . admin_url('admin.php?page=wpseo_dashboard#top#features') . '">',
+				'<a href="' . WPSEO_Shortlinker::get('https://yoa.st/inclusive-language-notification') . '" target="_blank">',
 				'</a>'
 			);
 		}
@@ -123,10 +127,10 @@ class WPSEO_Inclusive_Language_Notice {
 		$notification = new Yoast_Notification(
 			$message,
 			[
-				'type'         => Yoast_Notification::WARNING,
-				'id'           => 'wpseo-inclusive-language-notice',
+				'type' => Yoast_Notification::WARNING,
+				'id' => 'wpseo-inclusive-language-notice',
 				'capabilities' => 'wpseo_manage_options',
-				'priority'     => 0.8,
+				'priority' => 0.8,
 			]
 		);
 
@@ -136,7 +140,8 @@ class WPSEO_Inclusive_Language_Notice {
 	/**
 	 * Dismisses the notice.
 	 */
-	protected function dismiss_notice() {
-		update_user_meta( get_current_user_id(), self::USER_META_DISMISSED, true );
+	protected function dismiss_notice()
+	{
+		update_user_meta(get_current_user_id(), self::USER_META_DISMISSED, true);
 	}
 }

--- a/src/deprecated/admin/class-inclusive-language-notice.php
+++ b/src/deprecated/admin/class-inclusive-language-notice.php
@@ -61,6 +61,8 @@ class WPSEO_Inclusive_Language_Notice {
 	 * @param Yoast_Notification_Center $notification_center The notification center to add notifications to.
 	 */
 	public function __construct( Yoast_Notification_Center $notification_center ) {
+		_deprecated_function( __METHOD__, 'WPSEO 19.7' );
+
 		$this->notification_center = $notification_center;
 	}
 
@@ -71,6 +73,8 @@ class WPSEO_Inclusive_Language_Notice {
 	 * @codeCoverageIgnore
 	 */
 	public function dismiss_notice_listener() {
+		_deprecated_function( __METHOD__, 'WPSEO 19.7' );
+
 		if ( filter_input( INPUT_GET, 'yoast_dismiss' ) !== 'upsell' ) {
 			return;
 		}
@@ -88,13 +92,20 @@ class WPSEO_Inclusive_Language_Notice {
 	 * @codeCoverageIgnore
 	 */
 	public function add_notification() {
+		_deprecated_function( __METHOD__, 'WPSEO 19.7' );
+
 		$this->notification_center->add_notification( $this->get_notification() );
 	}
 
 	/**
 	 * Removes a notification from the notification center.
+	 *
+	 * @deprecated 19.7
+	 * @codeCoverageIgnore
 	 */
 	public function remove_notification() {
+		_deprecated_function( __METHOD__, 'WPSEO 19.7' );
+
 		$this->notification_center->remove_notification( $this->get_notification() );
 	}
 
@@ -107,6 +118,8 @@ class WPSEO_Inclusive_Language_Notice {
 	 * @return bool Whether or not the notification should be shown.
 	 */
 	public function should_show_notification() {
+		_deprecated_function( __METHOD__, 'WPSEO 19.7' );
+
 		$availability = new WPSEO_Metabox_Analysis_Inclusive_Language();
 
 		return YoastSEO()->helpers->product->is_premium()
@@ -124,6 +137,8 @@ class WPSEO_Inclusive_Language_Notice {
 	 * @return Yoast_Notification
 	 */
 	protected function get_notification() {
+		_deprecated_function( __METHOD__, 'WPSEO 19.7' );
+
 		if ( is_multisite() && get_site_option( 'wpseo_ms' )['allow_inclusive_language_analysis_active'] === false ) {
 			$message = sprintf(
 			/* translators: %1$s is a link to the Features tab on the Yoast SEO Dashboard page, %2$s is a link to the blog post about this feature, %3$s is the link closing tag. */
@@ -169,6 +184,8 @@ class WPSEO_Inclusive_Language_Notice {
 	 * @codeCoverageIgnore
 	 */
 	protected function dismiss_notice() {
+		_deprecated_function( __METHOD__, 'WPSEO 19.7' );
+
 		update_user_meta( get_current_user_id(), self::USER_META_DISMISSED, true );
 	}
 }

--- a/src/deprecated/admin/class-inclusive-language-notice.php
+++ b/src/deprecated/admin/class-inclusive-language-notice.php
@@ -27,7 +27,7 @@ class WPSEO_Inclusive_Language_Notice {
 	/**
 	 * The Premium version in which the Inclusive language feature was added.
 	 *
-	 * * @deprecated 19.7
+	 * @deprecated 19.7
 	 * @codeCoverageIgnore
 	 */
 	const PREMIUM_VERSION_ADDED = '19.2-RC1';
@@ -60,15 +60,14 @@ class WPSEO_Inclusive_Language_Notice {
 	 * @deprecated 19.7
 	 * @codeCoverageIgnore
 	 */
-	public function dismiss_notice_listener()
-	{
-		if (filter_input(INPUT_GET, 'yoast_dismiss') !== 'upsell') {
+	public function dismiss_notice_listener() {
+		if ( filter_input( INPUT_GET, 'yoast_dismiss' ) !== 'upsell' ) {
 			return;
 		}
 
 		$this->dismiss_notice();
 
-		wp_safe_redirect(admin_url('admin.php?page=wpseo_dashboard'));
+		wp_safe_redirect( admin_url( 'admin.php?page=wpseo_dashboard' ) );
 		exit;
 	}
 
@@ -78,17 +77,15 @@ class WPSEO_Inclusive_Language_Notice {
 	 * @deprecated 19.7
 	 * @codeCoverageIgnore
 	 */
-	public function add_notification()
-	{
-		$this->notification_center->add_notification($this->get_notification());
+	public function add_notification() {
+		$this->notification_center->add_notification( $this->get_notification() );
 	}
 
 	/**
 	 * Removes a notification from the notification center.
 	 */
-	public function remove_notification()
-	{
-		$this->notification_center->remove_notification($this->get_notification());
+	public function remove_notification() {
+		$this->notification_center->remove_notification( $this->get_notification() );
 	}
 
 	/**
@@ -99,14 +96,13 @@ class WPSEO_Inclusive_Language_Notice {
 	 *
 	 * @return bool Whether or not the notification should be shown.
 	 */
-	public function should_show_notification()
-	{
+	public function should_show_notification() {
 		$availability = new WPSEO_Metabox_Analysis_Inclusive_Language();
 
 		return YoastSEO()->helpers->product->is_premium()
-			&& YoastSEO()->helpers->language->has_inclusive_language_support(\WPSEO_Language_Utils::get_language(\get_locale()))
-			&& !$availability->is_globally_enabled()
-			&& \version_compare(YoastSEO()->helpers->product->get_premium_version(), self::PREMIUM_VERSION_ADDED, '>=');
+			&& YoastSEO()->helpers->language->has_inclusive_language_support( \WPSEO_Language_Utils::get_language( \get_locale() ) )
+			&& ! $availability->is_globally_enabled()
+			&& \version_compare( YoastSEO()->helpers->product->get_premium_version(), self::PREMIUM_VERSION_ADDED, '>=' );
 	}
 
 	/**
@@ -117,28 +113,28 @@ class WPSEO_Inclusive_Language_Notice {
 	 *
 	 * @return Yoast_Notification
 	 */
-	protected function get_notification()
-	{
-		if (is_multisite() && get_site_option('wpseo_ms')['allow_inclusive_language_analysis_active'] === false) {
+	protected function get_notification() {
+		if ( is_multisite() && get_site_option( 'wpseo_ms' )['allow_inclusive_language_analysis_active'] === false ) {
 			$message = sprintf(
 			/* translators: %1$s is a link to the Features tab on the Yoast SEO Dashboard page, %2$s is a link to the blog post about this feature, %3$s is the link closing tag. */
 				__(
 					'<strong>New in Yoast SEO Premium 19.2:</strong> Did you know that you can now get feedback on the use of inclusive language? This feature is disabled by default. Please contact your Network admin if you want to enable it. %2$sLearn more about this feature%3$s.',
 					'wordpress-seo'
 				),
-				'<a href="' . admin_url('admin.php?page=wpseo_dashboard#top#features') . '">',
-				'<a href="' . WPSEO_Shortlinker::get('https://yoa.st/inclusive-language-notification') . '" target="_blank">',
+				'<a href="' . admin_url( 'admin.php?page=wpseo_dashboard#top#features' ) . '">',
+				'<a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/inclusive-language-notification' ) . '" target="_blank">',
 				'</a>'
 			);
-		} else {
+		}
+		else {
 			$message = sprintf(
 			/* translators: %1$s is a link to the Features tab on the Yoast SEO Dashboard page, %2$s is a link to the blog post about this feature, %3$s is the link closing tag. */
 				__(
 					'<strong>New in Yoast SEO Premium 19.2:</strong> Did you know that you can now %1$senable the beta version of our inclusive language feature%3$s to get feedback on the use of inclusive language? This feature is disabled by default. %2$sLearn more about this feature%3$s.',
 					'wordpress-seo'
 				),
-				'<a href="' . admin_url('admin.php?page=wpseo_dashboard#top#features') . '">',
-				'<a href="' . WPSEO_Shortlinker::get('https://yoa.st/inclusive-language-notification') . '" target="_blank">',
+				'<a href="' . admin_url( 'admin.php?page=wpseo_dashboard#top#features' ) . '">',
+				'<a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/inclusive-language-notification' ) . '" target="_blank">',
 				'</a>'
 			);
 		}
@@ -146,10 +142,10 @@ class WPSEO_Inclusive_Language_Notice {
 		$notification = new Yoast_Notification(
 			$message,
 			[
-				'type' => Yoast_Notification::WARNING,
-				'id' => 'wpseo-inclusive-language-notice',
+				'type'         => Yoast_Notification::WARNING,
+				'id'           => 'wpseo-inclusive-language-notice',
 				'capabilities' => 'wpseo_manage_options',
-				'priority' => 0.8,
+				'priority'     => 0.8,
 			]
 		);
 
@@ -162,8 +158,7 @@ class WPSEO_Inclusive_Language_Notice {
 	 * @deprecated 19.7
 	 * @codeCoverageIgnore
 	 */
-	protected function dismiss_notice()
-	{
-		update_user_meta(get_current_user_id(), self::USER_META_DISMISSED, true);
+	protected function dismiss_notice() {
+		update_user_meta( get_current_user_id(), self::USER_META_DISMISSED, true );
 	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We wanted to notify users about the new inclusive language feature only in the version it was released (19.6), so we need to remove the notification for 19.7. 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [wordpress-seo-premium] Removes a notification from the Notifications center that informs users about the inclusive language feature.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### In (single-site) WordPress

* For Acceptance testers: check out branch in Free, then in Premium run `composer require yoast/wordpress-seo:dev-PC-424-remove-inclusive-language-notification-for-the-next-release-19-7@dev`.  
* Actually, on second thought, it should be totally fine to test it while building the branch on Free too. You do you!
* Make sure Premium is active, site language is English and the inclusive language feature toggle is off in the Features tab of the Yoast SEO Dashboard (it's off by default). 
* You shouldn't see the notification for inclusive language in the Notifications center on the the Yoast SEO Dashboard
* The number of notifications next to the Yoast icon at the very top of the page, in the menu on the left, and in parentheses next to the notifications tab title should reflect the correct number of notifications displayed in the Notifications center 
* Go to the Features tab and turn **on** the toggle for the inclusive language analysis.
* Click Save changes
* Go back to Dashboard tab and confirm that the notification isn't there. 
* Go back to the Features tab and turn the toggle back **off**. 
* Click Save changes
* Go back to Dashboard tab and confirm the notification isn't there. 
* Deactivate Premium. Confirm you can't see the notification. 
* Activate Premium again. Confirm you can't see the notification. 
* Switch to a language other than English. Confirm you can't see the notification.

##### Upgrade & downgrade routine
* Easiest to test in Local I'd say
* Install and activate Free 19.6 and Premium 19.2
* Site language is English, toggle for Inclusive language feature is off
* Confirm Inclusive language notification is displayed in the Notification center (you can have a look at these test instructions: https://github.com/Yoast/wordpress-seo/pull/18772 )
* Install a zip for Free, containing this PR. If no changes have been made during the CR, you can use this zip: 
[artifact.zip](https://github.com/Yoast/wordpress-seo/files/9444424/artifact.zip) (updated after the 7th commit)
* Make sure Premium is active
* Follow the steps above in "In (single-site) WordPress"
* Downgrade again to Free 19.6
* Confirm Inclusive language notification is displayed in the Notification center

#### Test in Multisite
* For acceptance testers: You need to build the environment using `./start.sh multisite-wordpress`. Webpage is `multisite.wordpress.test/admin`
##### Test scenario: test in Primary site only
* Activate Yoast SEO and Yoast SEO Premium in Primary site, confirm site language is English
* Confirm control over the Inclusive language analysis feature is allowed (My sites > Network admin > Yoast SEO > Features)
* Run the testing steps "In (single-site) WordPress" and confirm that you get the same result

##### Test scenario: primary site is in English and secondary site in non-English language
* Visit secondary site
* Activate Yoast SEO and Yoast SEO Premium
* Set the site language to non-English language in secondary site
* The notification should not appear in the secondary site

##### Test scenario: primary site is in non-English language and secondary site in English
* Set the site language to non-English language in primary site
* Visit secondary site
* Set the site language to English language in secondary site
* Run the testing steps "In (single-site) WordPress" and confirm that you get the same result

##### Test scenario: both primary and secondary sites are in English
* Activate Yoast SEO and Yoast SEO Premium
* Set the site language to English both in primary and secondary sites
* Activate network for the premium plugin: My sites > Network admin > Plugins > Yoast SEO Premium > Network Activate
* Confirm that the notification is NOT displayed in all the sites that are set in English

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open. 
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers.
* [x] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [x] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes #
