### PR TITLE
Aadd back grey bullet for SKU and product identifiers assessments

### DIFF
--- a/packages/yoastseo/src/languageProcessing/researches/getProductIdentifierData.js
+++ b/packages/yoastseo/src/languageProcessing/researches/getProductIdentifierData.js
@@ -18,5 +18,8 @@ export default function( paper ) {
 	if ( customData.hasOwnProperty( "productType" ) ) {
 		productData.productType = customData.productType;
 	}
+	if ( customData.hasOwnProperty( "variantIdentifierDataIsValid" ) ) {
+		productData.isVariantIdentifierDataValid = customData.isVariantIdentifierDataValid;
+	}
 	return productData;
 }

--- a/packages/yoastseo/src/languageProcessing/researches/getProductIdentifierData.js
+++ b/packages/yoastseo/src/languageProcessing/researches/getProductIdentifierData.js
@@ -18,8 +18,8 @@ export default function( paper ) {
 	if ( customData.hasOwnProperty( "productType" ) ) {
 		productData.productType = customData.productType;
 	}
-	if ( customData.hasOwnProperty( "variantIdentifierDataIsValid" ) ) {
-		productData.isVariantIdentifierDataValid = customData.isVariantIdentifierDataValid;
+	if ( customData.hasOwnProperty( "isVariantDataValid" ) ) {
+		productData.isVariantDataValid = customData.isVariantDataValid;
 	}
 	return productData;
 }

--- a/packages/yoastseo/src/languageProcessing/researches/getProductSKUData.js
+++ b/packages/yoastseo/src/languageProcessing/researches/getProductSKUData.js
@@ -18,5 +18,8 @@ export default function( paper ) {
 	if ( customData.hasOwnProperty( "productType" ) ) {
 		productData.productType = customData.productType;
 	}
+	if ( customData.hasOwnProperty( "variantIdentifierDataIsValid" ) ) {
+		productData.isVariantIdentifierDataValid = customData.isVariantIdentifierDataValid;
+	}
 	return productData;
 }

--- a/packages/yoastseo/src/languageProcessing/researches/getProductSKUData.js
+++ b/packages/yoastseo/src/languageProcessing/researches/getProductSKUData.js
@@ -18,8 +18,8 @@ export default function( paper ) {
 	if ( customData.hasOwnProperty( "productType" ) ) {
 		productData.productType = customData.productType;
 	}
-	if ( customData.hasOwnProperty( "variantIdentifierDataIsValid" ) ) {
-		productData.isVariantIdentifierDataValid = customData.isVariantIdentifierDataValid;
+	if ( customData.hasOwnProperty( "isVariantDataValid" ) ) {
+		productData.isVariantDataValid = customData.isVariantDataValid;
 	}
 	return productData;
 }

--- a/packages/yoastseo/src/scoring/assessments/seo/ProductIdentifiersAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/ProductIdentifiersAssessment.js
@@ -78,6 +78,10 @@ export default class ProductIdentifiersAssessment extends Assessment {
 			return false;
 		}
 
+		if ( customData.productType === "variable" && ! customData.isVariantDataValid ) {
+			return true;
+		}
+
 		return ( customData.hasPrice || customData.hasVariants );
 	}
 

--- a/packages/yoastseo/src/scoring/assessments/seo/ProductIdentifiersAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/ProductIdentifiersAssessment.js
@@ -78,7 +78,7 @@ export default class ProductIdentifiersAssessment extends Assessment {
 			return false;
 		}
 
-		return ( customData.hasPrice || customData.hasVariants || ! customData.isVariantIdentifierDataValid );
+		return ( customData.hasPrice || customData.hasVariants );
 	}
 
 	/**

--- a/packages/yoastseo/src/scoring/assessments/seo/ProductIdentifiersAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/ProductIdentifiersAssessment.js
@@ -22,6 +22,7 @@ export default class ProductIdentifiersAssessment extends Assessment {
 			scores: {
 				good: 9,
 				ok: 6,
+				invalidVariantData: 0,
 			},
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/4ly" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/4lz" ),
@@ -102,6 +103,24 @@ export default class ProductIdentifiersAssessment extends Assessment {
 	 * 													or empty object if no score should be returned.
 	 */
 	scoreProductIdentifier( productIdentifierData, config ) {
+		// Return a grey bullet if the variant identifier data is not valid (i.e. when we are not able to detect a change to the data).
+		if ( productIdentifierData.isVariantIdentifierDataValid === false  ) {
+			return {
+				score: config.scores.invalidVariantData,
+				text: sprintf(
+					/* Translators: %1$s expands to a link on yoast.com, %3$s expands to the anchor end tag,
+					* %2$s expands to the string "Barcode" or "Product identifier". */
+					__(
+						"%1$s%2$s%3$s: Please save and refresh the page to view the result for this assessment.",
+						"wordpress-seo"
+					),
+					this._config.urlTitle,
+					this.name,
+					"</a>"
+				),
+			};
+		}
+
 		let feedbackStrings;
 
 		if ( this._config.productIdentifierOrBarcode === "Product identifier" ) {

--- a/packages/yoastseo/src/scoring/assessments/seo/ProductIdentifiersAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/ProductIdentifiersAssessment.js
@@ -74,7 +74,7 @@ export default class ProductIdentifiersAssessment extends Assessment {
 		}
 
 		// If we have a variable product with no (active) variants. (active variant = variant with a price)
-		if (  customData.productType === "variable" && ! customData.hasVariants && customData.isVariantIdentifierDataValid  ) {
+		if (  customData.productType === "variable" && ! customData.hasVariants && customData.isVariantDataValid  ) {
 			return false;
 		}
 
@@ -104,7 +104,7 @@ export default class ProductIdentifiersAssessment extends Assessment {
 	 */
 	scoreProductIdentifier( productIdentifierData, config ) {
 		// Return a grey bullet if the variant identifier data is not valid (i.e. when we are not able to detect a change to the data).
-		if ( productIdentifierData.isVariantIdentifierDataValid === false  ) {
+		if ( productIdentifierData.isVariantDataValid === false  ) {
 			return {
 				score: config.scores.invalidVariantData,
 				text: sprintf(

--- a/packages/yoastseo/src/scoring/assessments/seo/ProductIdentifiersAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/ProductIdentifiersAssessment.js
@@ -74,11 +74,11 @@ export default class ProductIdentifiersAssessment extends Assessment {
 		}
 
 		// If we have a variable product with no (active) variants. (active variant = variant with a price)
-		if (  customData.productType === "variable" && ! customData.hasVariants  ) {
+		if (  customData.productType === "variable" && ! customData.hasVariants && customData.isVariantIdentifierDataValid  ) {
 			return false;
 		}
 
-		return ( customData.hasPrice || customData.hasVariants );
+		return ( customData.hasPrice || customData.hasVariants || ! customData.isVariantIdentifierDataValid );
 	}
 
 	/**

--- a/packages/yoastseo/src/scoring/assessments/seo/ProductSKUAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/ProductSKUAssessment.js
@@ -70,10 +70,10 @@ export default class ProductSKUAssessment extends Assessment {
 		}
 
 		// If we have a variable product with no (active) variants. (active variant = variant with a price)
-		if (  customData.productType === "variable" && ! customData.hasVariants ) {
+		if (  customData.productType === "variable" && ! customData.hasVariants && customData.isVariantIdentifierDataValid ) {
 			return false;
 		}
-		return ( customData.hasPrice || customData.hasVariants );
+		return ( customData.hasPrice || customData.hasVariants || ! customData.isVariantIdentifierDataValid );
 	}
 
 	/**

--- a/packages/yoastseo/src/scoring/assessments/seo/ProductSKUAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/ProductSKUAssessment.js
@@ -22,6 +22,7 @@ export default class ProductSKUAssessment extends Assessment {
 			scores: {
 				good: 9,
 				ok: 6,
+				invalidVariantData: 0,
 			},
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/4lw" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/4lx" ),
@@ -97,6 +98,22 @@ export default class ProductSKUAssessment extends Assessment {
 	 * 													or empty object if no score should be returned.
 	 */
 	scoreProductSKU( productSKUData, config ) {
+		// Return a grey bullet if the variant identifier data is not valid (i.e. when we are not able to detect a change to the data).
+		if ( productSKUData.isVariantIdentifierDataValid === false  ) {
+			return {
+				score: config.scores.invalidVariantData,
+				text: sprintf(
+					// Translators: %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag,
+					__(
+						"%1$sSKU%2$s: Please save and refresh the page to view the result for this assessment.",
+						"wordpress-seo"
+					),
+					this._config.urlTitle,
+					"</a>"
+				),
+			};
+		}
+
 		// NOTE: product types might not be available in shopify or they might differ.
 		// So take this into account when implementing SKUAssessment for shopify.
 		if (  [ "simple", "external" ].includes( productSKUData.productType ) ) {

--- a/packages/yoastseo/src/scoring/assessments/seo/ProductSKUAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/ProductSKUAssessment.js
@@ -73,7 +73,7 @@ export default class ProductSKUAssessment extends Assessment {
 		if (  customData.productType === "variable" && ! customData.hasVariants && customData.isVariantIdentifierDataValid ) {
 			return false;
 		}
-		return ( customData.hasPrice || customData.hasVariants || ! customData.isVariantIdentifierDataValid );
+		return ( customData.hasPrice || customData.hasVariants );
 	}
 
 	/**

--- a/packages/yoastseo/src/scoring/assessments/seo/ProductSKUAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/ProductSKUAssessment.js
@@ -73,6 +73,11 @@ export default class ProductSKUAssessment extends Assessment {
 		if (  customData.productType === "variable" && ! customData.hasVariants && customData.isVariantDataValid ) {
 			return false;
 		}
+
+		if ( customData.productType === "variable" && ! customData.isVariantDataValid ) {
+			return true;
+		}
+
 		return ( customData.hasPrice || customData.hasVariants );
 	}
 

--- a/packages/yoastseo/src/scoring/assessments/seo/ProductSKUAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/ProductSKUAssessment.js
@@ -70,7 +70,7 @@ export default class ProductSKUAssessment extends Assessment {
 		}
 
 		// If we have a variable product with no (active) variants. (active variant = variant with a price)
-		if (  customData.productType === "variable" && ! customData.hasVariants && customData.isVariantIdentifierDataValid ) {
+		if (  customData.productType === "variable" && ! customData.hasVariants && customData.isVariantDataValid ) {
 			return false;
 		}
 		return ( customData.hasPrice || customData.hasVariants );
@@ -99,7 +99,7 @@ export default class ProductSKUAssessment extends Assessment {
 	 */
 	scoreProductSKU( productSKUData, config ) {
 		// Return a grey bullet if the variant identifier data is not valid (i.e. when we are not able to detect a change to the data).
-		if ( productSKUData.isVariantIdentifierDataValid === false  ) {
+		if ( productSKUData.isVariantDataValid === false  ) {
 			return {
 				score: config.scores.invalidVariantData,
 				text: sprintf(


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [wpseo-woocommerce] Adds a grey bullet to the Product identifiers and SKU assessments that appears when the page needs to be refreshed in order for us to retrieve the product data.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

*

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes #
