### PR TITLE
Pc 478 use stars in mostly linked table

### DIFF
--- a/packages/js/src/indexables-page/assessment-functions.js
+++ b/packages/js/src/indexables-page/assessment-functions.js
@@ -46,22 +46,10 @@ function leastLinkedAssessment( indexable ) {
 	return "yst-bg-red-500";
 }
 
-/**
- * Assessment function for the most linked indexables card.
- *
- * @param {object} indexable The indexable to be assessed.
- *
- * @returns {string} The bullet color.
- */
-function mostLinkedAssessment( indexable ) {
-	return parseInt( indexable.is_cornerstone, 10 ) ? "yst-bg-emerald-500" : "yst-bg-red-500";
-}
-
 export {
 	SEOScoreThresholds,
 	readabilityScoreThresholds,
 	seoScoreAssessment,
 	readabilityScoreAssessment,
 	leastLinkedAssessment,
-	mostLinkedAssessment,
 };

--- a/packages/js/src/indexables-page/indexables-page.js
+++ b/packages/js/src/indexables-page/indexables-page.js
@@ -84,7 +84,7 @@ const mostLinkedIntro = <Fragment>
 	{
 		createInterpolateElement(
 			// translators: %1$s and %2$s are replaced by opening and closing span tags.
-			// %3$s is replaced by the StarIcon component.
+			// %3$s is replaced by an icon of a star.
 			// %4$s and %5$s are replaced by opening and closing anchor tags.
 			sprintf(
 				__( "Make sure to mark this content as cornerstone content %1$s(%3$s)%2$s. %4$sLearn more about cornerstone content%5$s.", "wordpress-seo" ),
@@ -97,7 +97,7 @@ const mostLinkedIntro = <Fragment>
 			{
 				span: <span className="yst-whitespace-nowrap" />,
 				// eslint-disable-next-line jsx-a11y/anchor-has-content
-				a: <a id="kek" href="https://www.yoast.com" target="_blank" rel="noopener noreferrer" />,
+				a: <a id="indexables-page-cornerstone-link" href="https://www.yoast.com" target="_blank" rel="noopener noreferrer" />,
 				StarIcon: <StarIcon className="yst-h-4 yst-w-4 yst-text-gray-700 yst-inline" />,
 			}
 		)

--- a/packages/js/src/indexables-page/indexables-page.js
+++ b/packages/js/src/indexables-page/indexables-page.js
@@ -2,6 +2,7 @@
 import PropTypes from "prop-types";
 import apiFetch from "@wordpress/api-fetch";
 import { LinkIcon, RefreshIcon } from "@heroicons/react/outline";
+import { StarIcon } from "@heroicons/react/solid";
 import { __, _n, sprintf } from "@wordpress/i18n";
 import { useEffect, useState, useCallback, useMemo, Fragment } from "@wordpress/element";
 import { Button, Modal, useMediaQuery, Alert } from "@yoast/ui-library";
@@ -11,7 +12,7 @@ import SuggestedLinksModal from "./components/suggested-links-modal";
 import IndexableTitleLink from "./components/indexable-title-link";
 import IndexablesPageCard from "./components/indexables-card";
 import IndexablesTable from "./components/indexables-table";
-import { SEOScoreThresholds, readabilityScoreThresholds, seoScoreAssessment, readabilityScoreAssessment, mostLinkedAssessment } from "./assessment-functions";
+import { SEOScoreThresholds, readabilityScoreThresholds, seoScoreAssessment, readabilityScoreAssessment } from "./assessment-functions";
 
 const Link = makeOutboundLink();
 
@@ -74,20 +75,32 @@ const leastLinkedOutro = addLinkToString(
 	"https://www.yoast.com"
 );
 
-const mostLinkedIntro = addLinkToString(
-	// translators: %1$s and %2$s are replaced by opening and closing anchor tags.
-	sprintf(
+const mostLinkedIntro = <Fragment>
+	{
 		__(
 			"The content below is supposed to be your cornerstone content: the most important and extensive articles on your site. " +
-			"Make sure to mark this content as cornerstone content to get all bullets green. " +
-			"%1$sLearn more about cornerstone content%2$s.",
-			"wordpress-seo"
-		),
-		"<a>",
-		"</a>"
-	),
-	"https://www.yoast.com"
-);
+			"Make sure to mark this content as cornerstone content (", "wordpress-seo"
+		)
+	}
+	{
+		<StarIcon className="yst-h-4 yst-w-4 yst-text-gray-700 yst-inline" />
+	}
+	{
+		addLinkToString(
+			// translators: %1$s and %2$s are replaced by opening and closing anchor tags.
+			sprintf(
+				__(
+					"). %1$sLearn more about cornerstone content%2$s.",
+					"wordpress-seo"
+				),
+				"<a>",
+				"</a>"
+			),
+			"https://www.yoast.com"
+		)
+	}
+
+</Fragment>;
 
 const mostLinkedOutro = addLinkToString(
 	// translators: %1$s and %2$s are replaced by opening and closing anchor tags.
@@ -775,7 +788,13 @@ function IndexablesPage( { setupInfo } ) {
 										addToIgnoreList={ setIgnoredIndexable }
 										position={ position }
 									>
-										<IndexableScore colorClass={ mostLinkedAssessment( indexable ) } />
+										<div className="yst-flex yst-items-center">
+											{
+												( !! parseInt( indexable.is_cornerstone, 10 ) === true )
+													? <StarIcon className="yst-h-4 yst-w-4 yst-text-gray-700" />
+													: <div className="yst-w-4" />
+											}
+										</div>
 										<IndexableLinkCount count={ parseInt( indexable.incoming_link_count, 10 ) } />
 										<IndexableTitleLink indexable={ indexable } />
 										<div>

--- a/packages/js/src/indexables-page/indexables-page.js
+++ b/packages/js/src/indexables-page/indexables-page.js
@@ -4,7 +4,7 @@ import apiFetch from "@wordpress/api-fetch";
 import { LinkIcon, RefreshIcon } from "@heroicons/react/outline";
 import { StarIcon } from "@heroicons/react/solid";
 import { __, _n, sprintf } from "@wordpress/i18n";
-import { useEffect, useState, useCallback, useMemo, Fragment } from "@wordpress/element";
+import { createInterpolateElement, useEffect, useState, useCallback, useMemo, Fragment } from "@wordpress/element";
 import { Button, Modal, useMediaQuery, Alert } from "@yoast/ui-library";
 import { makeOutboundLink } from "@yoast/helpers";
 import { addLinkToString } from "../helpers/stringHelpers";
@@ -78,28 +78,30 @@ const leastLinkedOutro = addLinkToString(
 const mostLinkedIntro = <Fragment>
 	{
 		__(
-			"The content below is supposed to be your cornerstone content: the most important and extensive articles on your site. " +
-			"Make sure to mark this content as cornerstone content (", "wordpress-seo"
+			"The content below is supposed to be your cornerstone content: the most important and extensive articles on your site. ", "wordpress-seo"
 		)
 	}
 	{
-		<StarIcon className="yst-h-4 yst-w-4 yst-text-gray-700 yst-inline" />
-	}
-	{
-		addLinkToString(
-			// translators: %1$s and %2$s are replaced by opening and closing anchor tags.
+		createInterpolateElement(
+			// translators: %1$s and %2$s are replaced by opening and closing span tags.
+			// %3$s is replaced by the StarIcon component.
+			// %4$s and %5$s are replaced by opening and closing anchor tags.
 			sprintf(
-				__(
-					"). %1$sLearn more about cornerstone content%2$s.",
-					"wordpress-seo"
-				),
+				__( "Make sure to mark this content as cornerstone content %1$s(%3$s)%2$s. %4$sLearn more about cornerstone content%5$s.", "wordpress-seo" ),
+				"<span>",
+				"</span>",
+				"<StarIcon />",
 				"<a>",
 				"</a>"
 			),
-			"https://www.yoast.com"
+			{
+				span: <span className="yst-whitespace-nowrap" />,
+				// eslint-disable-next-line jsx-a11y/anchor-has-content
+				a: <a id="kek" href="https://www.yoast.com" target="_blank" rel="noopener noreferrer" />,
+				StarIcon: <StarIcon className="yst-h-4 yst-w-4 yst-text-gray-700 yst-inline" />,
+			}
 		)
 	}
-
 </Fragment>;
 
 const mostLinkedOutro = addLinkToString(


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Use the star symbol instead of coloured bullets for the `Highest number of incoming links` card.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Uses the star symbol instead of coloured bullets for the `Highest number of incoming links` card.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

*

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes [PC-478](https://yoast.atlassian.net/browse/PC-478)
