### PR TITLE
Deprecate WPSEO_Role_Manager_VIP

### DIFF
--- a/admin/roles/class-role-manager-factory.php
+++ b/admin/roles/class-role-manager-factory.php
@@ -19,13 +19,7 @@ class WPSEO_Role_Manager_Factory {
 		static $manager = null;
 
 		if ( $manager === null ) {
-			if ( function_exists( 'wpcom_vip_add_role' ) ) {
-				$manager = new WPSEO_Role_Manager_VIP();
-			}
-
-			if ( ! function_exists( 'wpcom_vip_add_role' ) ) {
-				$manager = new WPSEO_Role_Manager_WP();
-			}
+			$manager = new WPSEO_Role_Manager_WP();
 		}
 
 		return $manager;

--- a/admin/roles/class-role-manager-vip.php
+++ b/admin/roles/class-role-manager-vip.php
@@ -7,11 +7,17 @@
 
 /**
  * VIP implementation of the Role Manager.
+ *
+ * @deprecated 19.7
+ * @codeCoverageIgnore
  */
 final class WPSEO_Role_Manager_VIP extends WPSEO_Abstract_Role_Manager {
 
 	/**
 	 * Adds a role to the system.
+	 *
+	 * @deprecated 19.7
+	 * @codeCoverageIgnore
 	 *
 	 * @param string $role         Role to add.
 	 * @param string $display_name Name to display for the role.
@@ -20,6 +26,8 @@ final class WPSEO_Role_Manager_VIP extends WPSEO_Abstract_Role_Manager {
 	 * @return void
 	 */
 	protected function add_role( $role, $display_name, array $capabilities = [] ) {
+		_deprecated_function( __METHOD__, 'WPSEO 19.7' );
+
 		$enabled_capabilities  = [];
 		$disabled_capabilities = [];
 
@@ -43,11 +51,16 @@ final class WPSEO_Role_Manager_VIP extends WPSEO_Abstract_Role_Manager {
 	/**
 	 * Removes a role from the system.
 	 *
+	 * @deprecated 19.7
+	 * @codeCoverageIgnore
+	 *
 	 * @param string $role Role to remove.
 	 *
 	 * @return void
 	 */
 	protected function remove_role( $role ) {
+		_deprecated_function( __METHOD__, 'WPSEO 19.7' );
+
 		remove_role( $role );
 	}
 }


### PR DESCRIPTION
## Summary
Fixes https://github.com/Yoast/wordpress-seo/issues/16993 by deprecating the special code paths that were made specifically for WP VIP.

Usage of VIP-specific role functions is no longer necessary, as they are effectively just wrappers around the same core methods now. So rather than fixing the bug/incorrect usage of `wpcom_vip_add_role()`, I think it will be best to just remove the edge case altogether.

## Technical Decisions

Ideally we remove the whole `WPSEO_Role_Manager_VIP` class eventually, but I figure deprecating first is safer just in case something is calling the code directly.

Should I also add a constructor to the class w/ a deprecation notice inside to help catch if something is instantiating but not using a method directly for some reason? I didn't see this pattern used elsewhere, so opted to not go that route for now.

## Test instructions

- Use a test site running [vip-go-mu-plugins](https://github.com/Automattic/vip-go-mu-plugins), or more simply just drop in [this one file](https://github.com/Automattic/vip-go-mu-plugins/blob/fdd99cf535e55eeda46d7a11a4cbb1603d8bc666/vip-helpers/vip-roles.php) into your mu-plugins.
- Activate WordPress SEO without this PR, run `wp cap list wpseo_editor`, and notice the incorrect listing.
- Apply the PR and then deactivate/activate WordPress SEO again. Run `wp cap list wpseo_editor`, and notice the correct listing. Everything role-related works as needed.

This PR won't affect the large majority of sites, only those with a function called `wpcom_vip_add_role()`. And even for those, all notable behavior is the same.