### PR TITLE
Indexables page: add undo hide for all indexables

### DIFF
--- a/packages/js/src/indexables-page/indexables-page.js
+++ b/packages/js/src/indexables-page/indexables-page.js
@@ -480,22 +480,17 @@ function IndexablesPage( { setupInfo } ) {
 		return () => handleUndo( ignored );
 	}, [ handleUndo ] );
 
-	const onClickUndoAll = useCallback( async( event ) => {
-		const { type } = event.target.dataset;
+	const onClickUndoAll = useCallback( async() => {
 		try {
 			const response = await apiFetch( {
 				path: "yoast/v1/restore_all_indexables",
 				method: "POST",
-				data: { type: type },
 			} );
 
 			const parsedResponse = await response.json;
 			if ( parsedResponse.success ) {
-				// If there is a button to ignore a single indexable, for a list for which we are removing all indexables...
-				if ( ignoredIndexable && ignoredIndexable.type === type ) {
-					// ...remove that button.
-					setIgnoredIndexable( null );
-				}
+				// If there is a button to ignore a single indexable, unmount it.
+				setIgnoredIndexable( null );
 				handleRefreshLists();
 				return true;
 			}
@@ -509,7 +504,7 @@ function IndexablesPage( { setupInfo } ) {
 			console.error( error.message );
 			return false;
 		}
-	}, [ apiFetch, handleRefreshLists, ignoredIndexable ] );
+	}, [ apiFetch, handleRefreshLists, setIgnoredIndexable ] );
 
 	const singleColumn = [
 		<IndexablesPageCard
@@ -833,13 +828,13 @@ function IndexablesPage( { setupInfo } ) {
 			</IndexablesPageCard>
 		</div>
 		<div className="yst-w-full yst-border-t yst-border-gray-300 yst-pb-6 yst-pt-8 yst-mt-2 yst-space-x-2">
-			<Button variant="secondary" onClick={ onClickUndoAll } data-type={ "least_seo_score" } disabled={ false }>{ __( "Undo hiding of all seo indexables", "wordpress-seo" ) }</Button>
-			<Button variant="secondary" onClick={ onClickUndoAll } data-type={ "least_readability" } disabled={ false }>{ __( "Undo hiding of all readability indexables", "wordpress-seo" ) }</Button>
-			<Button variant="secondary" onClick={ onClickUndoAll } data-type={ "least_linked" } disabled={ false }>{ __( "Undo hiding of all least linked indexables", "wordpress-seo" ) }</Button>
-			<Button variant="secondary" onClick={ onClickUndoAll } data-type={ "most_linked" } disabled={ false }>{ __( "Undo hiding of all most linked indexables", "wordpress-seo" ) }</Button>
+			<Button variant="secondary" onClick={ onClickUndoAll } disabled={ false }>{ __( "Undo hiding all items", "wordpress-seo" ) }</Button>
 			{
 				ignoredIndexable && <Button variant="secondary" onClick={ onClickUndo( ignoredIndexable ) }>
-					{ `Undo ignore ${ignoredIndexable.indexable.id}` }
+					{
+						/* translators: %1$s expands to the title of a post that was just just hidden. */
+						sprintf( __( "Undo hiding of: %1$s", "wordpress-seo" ), ignoredIndexable.indexable.breadcrumb_title )
+					}
 				</Button>
 			}
 		</div>

--- a/src/actions/indexables-page-action.php
+++ b/src/actions/indexables-page-action.php
@@ -43,9 +43,10 @@ class Indexables_Page_Action {
 	/**
 	 * Indexable_Action constructor.
 	 *
-	 * @param Indexable_Repository $indexable_repository The indexable repository.
-	 * @param Post_Type_Helper     $post_type_helper The post type helper.
-	 * @param Options_Helper       $options_helper The options helper.
+	 * @param Indexable_Repository   $indexable_repository The indexable repository.
+	 * @param Post_Type_Helper       $post_type_helper The post type helper.
+	 * @param Options_Helper         $options_helper The options helper.
+	 * @param Indexables_Page_Helper $indexables_page_helper The indexables page helper.
 	 */
 	public function __construct(
 		Indexable_Repository $indexable_repository,
@@ -53,9 +54,9 @@ class Indexables_Page_Action {
 		Options_Helper $options_helper,
 		Indexables_Page_Helper $indexables_page_helper
 	) {
-		$this->indexable_repository = $indexable_repository;
-		$this->post_type_helper     = $post_type_helper;
-		$this->options_helper       = $options_helper;
+		$this->indexable_repository   = $indexable_repository;
+		$this->post_type_helper       = $post_type_helper;
+		$this->options_helper         = $options_helper;
 		$this->indexables_page_helper = $indexables_page_helper;
 	}
 

--- a/src/actions/indexables-page-action.php
+++ b/src/actions/indexables-page-action.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\WP\SEO\Actions;
 
+use Yoast\WP\SEO\Helpers\Indexables_Page_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Post_Type_Helper;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
@@ -33,6 +34,13 @@ class Indexables_Page_Action {
 	private $options_helper;
 
 	/**
+	 * The indexables page helper.
+	 *
+	 * @var Indexables_Page_Helper
+	 */
+	private $indexables_page_helper;
+
+	/**
 	 * Indexable_Action constructor.
 	 *
 	 * @param Indexable_Repository $indexable_repository The indexable repository.
@@ -42,11 +50,13 @@ class Indexables_Page_Action {
 	public function __construct(
 		Indexable_Repository $indexable_repository,
 		Post_Type_Helper $post_type_helper,
-		Options_Helper $options_helper
+		Options_Helper $options_helper,
+		Indexables_Page_Helper $indexables_page_helper
 	) {
 		$this->indexable_repository = $indexable_repository;
 		$this->post_type_helper     = $post_type_helper;
 		$this->options_helper       = $options_helper;
+		$this->indexables_page_helper = $indexables_page_helper;
 	}
 
 	/**
@@ -274,6 +284,10 @@ class Indexables_Page_Action {
 	 * @return boolean Whether saving the ignore-list to the database succeeded.
 	 */
 	public function add_indexable_to_ignore_list( $ignore_list_name, $indexable_id ) {
+		if ( ! $this->indexables_page_helper->is_valid_ignore_list_name( $ignore_list_name ) ) {
+			return false;
+		};
+
 		$ignore_list = $this->options_helper->get( $ignore_list_name, [] );
 		if ( ! in_array( $indexable_id, $ignore_list, true ) ) {
 			$ignore_list[] = $indexable_id;
@@ -291,6 +305,10 @@ class Indexables_Page_Action {
 	 * @return boolean Whether saving the ignore-list to the database succeeded.
 	 */
 	public function remove_indexable_from_ignore_list( $ignore_list_name, $indexable_id ) {
+		if ( ! $this->indexables_page_helper->is_valid_ignore_list_name( $ignore_list_name ) ) {
+			return false;
+		};
+
 		$ignore_list = $this->options_helper->get( $ignore_list_name, [] );
 
 		$ignore_list = \array_values(
@@ -303,6 +321,20 @@ class Indexables_Page_Action {
 		);
 
 		return $this->options_helper->set( $ignore_list_name, $ignore_list );
+	}
+
+	/**
+	 * Removes all indexables from an ignore-list.
+	 *
+	 * @param string $ignore_list_name The name of the ignore-list.
+	 *
+	 * @return boolean Whether saving the ignore-list to the database succeeded.
+	 */
+	public function remove_all_indexables_from_ignore_list( $ignore_list_name ) {
+		if ( ! $this->indexables_page_helper->is_valid_ignore_list_name( $ignore_list_name ) ) {
+			return false;
+		};
+		return $this->options_helper->set( $ignore_list_name, [] );
 	}
 
 	/**

--- a/src/helpers/indexables-page-helper.php
+++ b/src/helpers/indexables-page-helper.php
@@ -35,7 +35,7 @@ class Indexables_Page_Helper {
 	 *
 	 * @var float
 	 */
-	const ANALYSED_POSTS_THRESHOLD = 0;
+	const ANALYSED_POSTS_THRESHOLD = 0.5;
 
 	/**
 	 * Indexables_Page_Helper constructor.

--- a/src/helpers/indexables-page-helper.php
+++ b/src/helpers/indexables-page-helper.php
@@ -117,17 +117,43 @@ class Indexables_Page_Helper {
 	}
 
 	/**
+	 * Returns the list names that are valid.
+	 * 
+	 * @return array An array with valid list names.
+	 */
+	public function get_list_names() {
+		$valid_list_names = [
+			'least_readability',
+			'least_seo_score',
+			'most_linked',
+			'least_linked',
+		];
+
+		return $valid_list_names;
+	}
+
+	/**
+	 * Returns the ignore list names that are valid.
+	 * 
+	 * @return array An array with valid ignore list names.
+	 */
+	public function get_ignore_list_names() {
+		$valid_list_names = $this->get_list_names();
+		$valid_ignore_list_names = [];
+		foreach( $valid_list_names as $valid_list_name ) {
+			$valid_ignore_list_names[] = $valid_list_name . '_ignore_list';
+		}
+
+		return $valid_ignore_list_names;
+	}
+
+	/**
 	 * Checks if the ignore list name is a valid list name
 	 *
 	 * @return bool Wether the list name is valid or not.
 	 */
 	public function is_valid_ignore_list_name( $list_name ) {
-		$valid_list_names = [
-			'least_readability_ignore_list',
-			'least_seo_score_ignore_list',
-			'most_linked_ignore_list',
-			'least_linked_ignore_list',
-		];
+		$valid_list_names = $this->get_ignore_list_names();
 
 		return in_array( $list_name, $valid_list_names, true );
 	}

--- a/src/helpers/indexables-page-helper.php
+++ b/src/helpers/indexables-page-helper.php
@@ -118,7 +118,7 @@ class Indexables_Page_Helper {
 
 	/**
 	 * Returns the list names that are valid.
-	 * 
+	 *
 	 * @return array An array with valid list names.
 	 */
 	public function get_list_names() {
@@ -134,13 +134,13 @@ class Indexables_Page_Helper {
 
 	/**
 	 * Returns the ignore list names that are valid.
-	 * 
+	 *
 	 * @return array An array with valid ignore list names.
 	 */
 	public function get_ignore_list_names() {
-		$valid_list_names = $this->get_list_names();
+		$valid_list_names        = $this->get_list_names();
 		$valid_ignore_list_names = [];
-		foreach( $valid_list_names as $valid_list_name ) {
+		foreach ( $valid_list_names as $valid_list_name ) {
 			$valid_ignore_list_names[] = $valid_list_name . '_ignore_list';
 		}
 
@@ -149,6 +149,8 @@ class Indexables_Page_Helper {
 
 	/**
 	 * Checks if the ignore list name is a valid list name
+	 *
+	 * @param string $list_name The list name.
 	 *
 	 * @return bool Wether the list name is valid or not.
 	 */

--- a/src/helpers/indexables-page-helper.php
+++ b/src/helpers/indexables-page-helper.php
@@ -35,7 +35,7 @@ class Indexables_Page_Helper {
 	 *
 	 * @var float
 	 */
-	const ANALYSED_POSTS_THRESHOLD = 0.5;
+	const ANALYSED_POSTS_THRESHOLD = 0;
 
 	/**
 	 * Indexables_Page_Helper constructor.
@@ -114,5 +114,21 @@ class Indexables_Page_Helper {
 	 */
 	public function get_link_suggestions_enabled() {
 		return $this->options->get( 'enable_link_suggestions', false ) === true;
+	}
+
+	/**
+	 * Checks if the ignore list name is a valid list name
+	 *
+	 * @return bool Wether the list name is valid or not.
+	 */
+	public function is_valid_ignore_list_name( $list_name ) {
+		$valid_list_names = [
+			'least_readability_ignore_list',
+			'least_seo_score_ignore_list',
+			'most_linked_ignore_list',
+			'least_linked_ignore_list',
+		];
+
+		return in_array( $list_name, $valid_list_names, true );
 	}
 }

--- a/src/routes/indexables-page-route.php
+++ b/src/routes/indexables-page-route.php
@@ -455,8 +455,8 @@ class Indexables_Page_Route implements Route_Interface {
 	 */
 	public function restore_all_indexables() {
 		$list_names = $this->indexables_page_helper->get_ignore_list_names();
-		$success = true;
-		foreach( $list_names as $list_name ) {
+		$success    = true;
+		foreach ( $list_names as $list_name ) {
 			$result = $this->indexables_page_action->remove_all_indexables_from_ignore_list( $list_name );
 
 			if ( $result === false ) {

--- a/src/routes/indexables-page-route.php
+++ b/src/routes/indexables-page-route.php
@@ -239,17 +239,6 @@ class Indexables_Page_Route implements Route_Interface {
 				'methods'             => 'POST',
 				'callback'            => [ $this, 'restore_all_indexables' ],
 				'permission_callback' => [ $this, 'permission_edit_others_posts' ],
-				'args'                => [
-					'type' => [
-						'type'     => 'string',
-						'enum'     => [
-							'least_readability',
-							'least_seo_score',
-							'most_linked',
-							'least_linked',
-						],
-					],
-				],
 			],
 		];
 

--- a/src/routes/indexables-page-route.php
+++ b/src/routes/indexables-page-route.php
@@ -66,11 +66,18 @@ class Indexables_Page_Route implements Route_Interface {
 	const RESTORE_INDEXABLE_ROUTE = '/restore_indexable';
 
 	/**
-	 * Allows to restore all indexables previously ignored for a certain list.
+	 * Allows to restore all indexables previously ignored.
 	 *
 	 * @var string
 	 */
 	const RESTORE_ALL_INDEXABLES_ROUTE = '/restore_all_indexables';
+
+	/**
+	 * Allows to restore all indexables previously ignored for a certain list.
+	 *
+	 * @var string
+	 */
+	const RESTORE_ALL_INDEXABLES_FOR_LIST_ROUTE = '/restore_all_indexables_for_list';
 
 	/**
 	 * Gets the reading list state.
@@ -248,6 +255,27 @@ class Indexables_Page_Route implements Route_Interface {
 
 		\register_rest_route( Main::API_V1_NAMESPACE, self::RESTORE_ALL_INDEXABLES_ROUTE, $restore_all_indexables_route );
 
+		$restore_all_indexables_for_list_route = [
+			[
+				'methods'             => 'POST',
+				'callback'            => [ $this, 'restore_all_indexables_for_list' ],
+				'permission_callback' => [ $this, 'permission_edit_others_posts' ],
+				'args'                => [
+					'type' => [
+						'type'     => 'string',
+						'enum'     => [
+							'least_readability',
+							'least_seo_score',
+							'most_linked',
+							'least_linked',
+						],
+					],
+				],
+			],
+		];
+
+		\register_rest_route( Main::API_V1_NAMESPACE, self::RESTORE_ALL_INDEXABLES_FOR_LIST_ROUTE, $restore_all_indexables_for_list_route );
+
 		$get_reading_list_route = [
 			[
 				'methods'             => 'GET',
@@ -421,13 +449,49 @@ class Indexables_Page_Route implements Route_Interface {
 	}
 
 	/**
-	 * Restores an indexable id from the ignore list.
+	 * Restores all indexables from all ignore lists.
+	 *
+	 * @return WP_REST_Response The success or failure response.
+	 */
+	public function restore_all_indexables() {
+		$list_names = $this->indexables_page_helper->get_ignore_list_names();
+		$success = true;
+		foreach( $list_names as $list_name ) {
+			$result = $this->indexables_page_action->remove_all_indexables_from_ignore_list( $list_name );
+
+			if ( $result === false ) {
+				$success = false;
+			}
+		}
+
+		if ( $success === true ) {
+			return new WP_REST_Response(
+				[
+					'json' => (object) [ 'success' => true ],
+				],
+				200
+			);
+		}
+
+		return new WP_REST_Response(
+			[
+				'json' => (object) [
+					'success' => false,
+					'error'   => 'Could not save the option in the database',
+				],
+			],
+			500
+		);
+	}
+
+	/**
+	 * Restores all indexables from a specific ignore list.
 	 *
 	 * @param WP_REST_Request $request The request object.
 	 *
 	 * @return WP_REST_Response The success or failure response.
 	 */
-	public function restore_all_indexables( WP_REST_Request $request ) {
+	public function restore_all_indexables_for_list( WP_REST_Request $request ) {
 		$params           = $request->get_json_params();
 		$ignore_list_name = $params['type'] . '_ignore_list';
 

--- a/src/routes/indexables-page-route.php
+++ b/src/routes/indexables-page-route.php
@@ -66,6 +66,13 @@ class Indexables_Page_Route implements Route_Interface {
 	const RESTORE_INDEXABLE_ROUTE = '/restore_indexable';
 
 	/**
+	 * Allows to restore all indexables previously ignored for a certain list.
+	 *
+	 * @var string
+	 */
+	const RESTORE_ALL_INDEXABLES_ROUTE = '/restore_all_indexables';
+
+	/**
 	 * Gets the reading list state.
 	 *
 	 * @var string
@@ -220,6 +227,27 @@ class Indexables_Page_Route implements Route_Interface {
 
 		\register_rest_route( Main::API_V1_NAMESPACE, self::RESTORE_INDEXABLE_ROUTE, $restore_indexable_route );
 
+		$restore_all_indexables_route = [
+			[
+				'methods'             => 'POST',
+				'callback'            => [ $this, 'restore_all_indexables' ],
+				'permission_callback' => [ $this, 'permission_edit_others_posts' ],
+				'args'                => [
+					'type' => [
+						'type'     => 'string',
+						'enum'     => [
+							'least_readability',
+							'least_seo_score',
+							'most_linked',
+							'least_linked',
+						],
+					],
+				],
+			],
+		];
+
+		\register_rest_route( Main::API_V1_NAMESPACE, self::RESTORE_ALL_INDEXABLES_ROUTE, $restore_all_indexables_route );
+
 		$get_reading_list_route = [
 			[
 				'methods'             => 'GET',
@@ -373,6 +401,37 @@ class Indexables_Page_Route implements Route_Interface {
 		$indexable_id     = intval( $params['id'] );
 
 		if ( $this->indexables_page_action->remove_indexable_from_ignore_list( $ignore_list_name, $indexable_id ) ) {
+			return new WP_REST_Response(
+				[
+					'json' => (object) [ 'success' => true ],
+				],
+				200
+			);
+		}
+
+		return new WP_REST_Response(
+			[
+				'json' => (object) [
+					'success' => false,
+					'error'   => 'Could not save the option in the database',
+				],
+			],
+			500
+		);
+	}
+
+	/**
+	 * Restores an indexable id from the ignore list.
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 *
+	 * @return WP_REST_Response The success or failure response.
+	 */
+	public function restore_all_indexables( WP_REST_Request $request ) {
+		$params           = $request->get_json_params();
+		$ignore_list_name = $params['type'] . '_ignore_list';
+
+		if ( $this->indexables_page_action->remove_all_indexables_from_ignore_list( $ignore_list_name ) ) {
 			return new WP_REST_Response(
 				[
 					'json' => (object) [ 'success' => true ],

--- a/tests/unit/actions/indexables-page-action-test.php
+++ b/tests/unit/actions/indexables-page-action-test.php
@@ -5,6 +5,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Actions;
 use Mockery;
 use Yoast\WP\Lib\ORM;
 use Yoast\WP\SEO\Actions\Indexables_Page_Action;
+use Yoast\WP\SEO\Helpers\Indexables_Page_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Post_Type_Helper;
 use Yoast\WP\SEO\Models\Indexable;
@@ -57,19 +58,27 @@ class Indexables_Page_Action_Test extends TestCase {
 	protected $options_helper;
 
 	/**
+	 * The options helper.
+	 *
+	 * @var Mockery\MockInterface|Options_Helper
+	 */
+	protected $indexables_page_helper;
+
+	/**
 	 * Sets up the test class.
 	 */
 	protected function set_up() {
 		parent::set_up();
 
-		$this->indexable_repository = Mockery::mock( Indexable_Repository::class );
-		$this->post_type_helper     = Mockery::mock( Post_Type_Helper::class );
-		$this->options_helper       = Mockery::mock( Options_Helper::class );
+		$this->indexable_repository   = Mockery::mock( Indexable_Repository::class );
+		$this->post_type_helper       = Mockery::mock( Post_Type_Helper::class );
+		$this->options_helper         = Mockery::mock( Options_Helper::class );
+		$this->indexables_page_helper = Mockery::mock( Indexables_Page_Helper::class );
 
-		$this->instance      = new Indexables_Page_Action( $this->indexable_repository, $this->post_type_helper, $this->options_helper );
+		$this->instance      = new Indexables_Page_Action( $this->indexable_repository, $this->post_type_helper, $this->options_helper, $this->indexables_page_helper );
 		$this->mock_instance = Mockery::mock(
 			Indexables_Page_Action::class,
-			[ $this->indexable_repository, $this->post_type_helper, $this->options_helper ]
+			[ $this->indexable_repository, $this->post_type_helper, $this->options_helper, $this->indexables_page_helper ]
 		)
 			->makePartial()
 			->shouldAllowMockingProtectedMethods();
@@ -741,6 +750,11 @@ class Indexables_Page_Action_Test extends TestCase {
 			->with( 'test_ignore_list_name', $expected_result )
 			->andReturns();
 
+		$this->indexables_page_helper
+			->expects( 'is_valid_ignore_list_name' )
+			->with( 'test_ignore_list_name' )
+			->andReturns( true );
+
 		$this->instance->add_indexable_to_ignore_list( 'test_ignore_list_name', $indexable_id );
 	}
 
@@ -788,6 +802,11 @@ class Indexables_Page_Action_Test extends TestCase {
 			->expects( 'set' )
 			->with( 'test_ignore_list_name', $expected_result )
 			->andReturns();
+
+		$this->indexables_page_helper
+			->expects( 'is_valid_ignore_list_name' )
+			->with( 'test_ignore_list_name' )
+			->andReturns( true );
 
 		$this->instance->remove_indexable_from_ignore_list( 'test_ignore_list_name', $indexable_id );
 	}

--- a/tests/unit/routes/indexables-page-route-test.php
+++ b/tests/unit/routes/indexables-page-route-test.php
@@ -185,6 +185,43 @@ class Indexables_Page_Route_Test extends TestCase {
 		Monkey\Functions\expect( 'register_rest_route' )
 			->with(
 				'yoast/v1',
+				'/restore_all_indexables',
+				[
+					[
+						'methods'             => 'POST',
+						'callback'            => [ $this->instance, 'restore_all_indexables' ],
+						'permission_callback' => [ $this->instance, 'permission_edit_others_posts' ],
+					],
+				]
+			);
+
+		Monkey\Functions\expect( 'register_rest_route' )
+			->with(
+				'yoast/v1',
+				'/restore_all_indexables_for_list',
+				[
+					[
+						'methods'             => 'POST',
+						'callback'            => [ $this->instance, 'restore_all_indexables_for_list' ],
+						'permission_callback' => [ $this->instance, 'permission_edit_others_posts' ],
+						'args'                => [
+							'type' => [
+								'type'     => 'string',
+								'enum'     => [
+									'least_readability',
+									'least_seo_score',
+									'most_linked',
+									'least_linked',
+								],
+							],
+						],
+					],
+				]
+			);
+
+		Monkey\Functions\expect( 'register_rest_route' )
+			->with(
+				'yoast/v1',
 				'/setup_info',
 				[
 					[


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* A version of the undo hiding of all items that "un-ignores" all indexables for all lists at once.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds a button to undo the hiding of all indexables on the Indexables Page.

## Relevant technical choices:

* This is a version where there is only one button. If there is time to spare we will implement a version where there is an ignore option _per list_.


Fixes PC-342
