### PR TITLE
Enhance User Experience with separate restoring per indexables card

### DIFF
--- a/css/src/notifications.css
+++ b/css/src/notifications.css
@@ -20,6 +20,9 @@
 
 .yoast-notifications {
 	max-width: 80rem;
+	display: flex;
+	flex-direction: column;
+	gap: 1.5rem;
 }
 
 .yoast-notifications > h2:first-child {

--- a/packages/js/src/indexables-page/components/indexable-title-link.js
+++ b/packages/js/src/indexables-page/components/indexable-title-link.js
@@ -15,10 +15,10 @@ const Link = makeOutboundLink();
  * @returns {WPElement} A div with a styled link to the indexable.
  */
 export function IndexableTitleLink( { indexable, showType } ) {
-	return <div className="yst-grow yst-min-w-0 yst-flex yst-h-3/5">
+	return <div className="yst-grow yst-min-w-0 yst-flex yst-h-3/5 yst-ml-1">
 		<Link
 			href={ indexable.permalink }
-			className="yst-min-w-0 yst-rounded-md focus:yst-outline-none focus:yst-ring-2 focus:yst-ring-offset-2 focus:yst-ring-primary-500 yst-flex yst-items-center yst-gap-2 yst-no-underline yst-text-inherit hover:yst-text-indigo-500"
+			className="yst-px-2 yst-min-w-0 yst-rounded-md focus:yst-outline-none focus:yst-ring-2 focus:yst-ring-offset-2 focus:yst-ring-primary-500 yst-flex yst-items-center yst-gap-2 yst-no-underline yst-text-inherit hover:yst-text-indigo-500 yst--ml-2"
 		>
 			<span className="yst-text-ellipsis yst-whitespace-nowrap yst-overflow-hidden">{ indexable.breadcrumb_title }</span><ExternalLinkIcon className="yst-shrink-0 yst-h-[13px] yst-w-[13px]" />
 		</Link>

--- a/packages/js/src/indexables-page/components/indexables-card-options.js
+++ b/packages/js/src/indexables-page/components/indexables-card-options.js
@@ -2,8 +2,7 @@ import classNames from "classnames";
 import PropTypes from "prop-types";
 import { Fragment } from "@wordpress/element";
 import { Menu, Transition } from "@headlessui/react";
-import { DotsHorizontalIcon as DotsVerticalIcon } from "@heroicons/react/solid";
-
+import { DotsVerticalIcon } from "@heroicons/react/solid";
 
 /**
  * A notification dots element with menu.

--- a/packages/js/src/indexables-page/components/indexables-card-options.js
+++ b/packages/js/src/indexables-page/components/indexables-card-options.js
@@ -1,0 +1,85 @@
+import classNames from "classnames";
+import PropTypes from "prop-types";
+import { Fragment } from "@wordpress/element";
+import { Menu, Transition } from "@headlessui/react";
+import { DotsHorizontalIcon as DotsVerticalIcon } from "@heroicons/react/solid";
+
+
+/**
+ * A notification dots element with menu.
+ *
+ * @returns {WPElement} The notification dots element with menu.
+ */
+export default function DotsMenu( { options } ) {
+	return (
+		<Menu as="div" className="yst-relative yst-inline-block yst-text-left">
+			{
+				( { open } ) => {
+					return <Fragment>
+						<div>
+							<Menu.Button
+								className={
+									classNames(
+										"yst-bg-white yst-rounded-full yst-flex yst-items-center yst-border-none yst-text-gray-400",
+										"focus:yst-ring-primary-500 focus:yst-shadow-none focus:yst-outline-none focus:yst-ring-2 focus:yst-ring-offset-2 focus:yst-ring-offset-white focus:yst-text-primary-500",
+										"hover:yst-ring-primary-500 hover:yst-shadow-none hover:yst-outline-none hover:yst-ring-2 hover:yst-ring-offset-2 hover:yst-ring-offset-white hover:yst-text-primary-500",
+										{ "yst-ring-primary-500 yst-shadow-none yst-outline-none yst-ring-2 yst-ring-offset-2 yst-ring-offset-white yst-text-primary-500": open }
+									)
+								}
+							>
+								<span className="yst-sr-only">Open options</span>
+								<DotsVerticalIcon className="yst-h-5 yst-w-5" aria-hidden="true" />
+							</Menu.Button>
+						</div>
+
+						<Transition
+							as={ Fragment }
+							enter="yst-transition yst-ease-out yst-duration-100"
+							enterFrom="yst-transform yst-opacity-0 yst-scale-95"
+							enterTo="yst-transform yst-opacity-100 yst-scale-100"
+							leave="yst-transition yst-ease-in yst-duration-75"
+							leaveFrom="yst-transform yst-opacity-100 yst-scale-100"
+							leaveTo="yst-transform yst-opacity-0 yst-scale-95"
+						>
+							<Menu.Items className="yst-origin-top-right yst-absolute yst-right-0 yst-mt-2 yst-w-56 yst-rounded-md yst-shadow-lg yst-bg-white yst-ring-1 yst-ring-black yst-ring-opacity-5 focus:yst-outline-none">
+								<div className="yst-py-1">
+									{
+										options.map( ( option, index ) => {
+											return <Menu.Item key={ "card-option-" + index }>
+												{ ( { active } ) => (
+													<button
+														type="button"
+														onClick={ option.action }
+														className={ classNames(
+															active ? "yst-bg-gray-100 yst-text-gray-900" : "yst-text-gray-700",
+															"yst-w-full yst-block yst-px-4 yst-py-2 yst-text-sm yst-text-left"
+														) }
+														{ ...option.menuItemData }
+													>
+														{ option.title }
+													</button>
+												) }
+											</Menu.Item>;
+										} )
+									}
+								</div>
+							</Menu.Items>
+						</Transition>
+					</Fragment>;
+				}
+			}
+		</Menu>
+	);
+}
+
+DotsMenu.propTypes = {
+	options: PropTypes.arrayOf( PropTypes.shape( {
+		title: PropTypes.string.isRequired,
+		action: PropTypes.function,
+		menuItemData: PropTypes.object,
+	} ) ),
+};
+
+DotsMenu.defaultProps = {
+	options: [],
+};

--- a/packages/js/src/indexables-page/components/indexables-card-options.js
+++ b/packages/js/src/indexables-page/components/indexables-card-options.js
@@ -12,61 +12,54 @@ import { DotsVerticalIcon } from "@heroicons/react/solid";
 export default function DotsMenu( { options } ) {
 	return (
 		<Menu as="div" className="yst-relative yst-inline-block yst-text-left">
-			{
-				( { open } ) => {
-					return <Fragment>
-						<div>
-							<Menu.Button
-								className={
-									classNames(
-										"yst-bg-white yst-rounded-full yst-flex yst-items-center yst-border-none yst-text-gray-400",
-										"focus:yst-ring-primary-500 focus:yst-shadow-none focus:yst-outline-none focus:yst-ring-2 focus:yst-ring-offset-2 focus:yst-ring-offset-white focus:yst-text-primary-500",
-										"hover:yst-ring-primary-500 hover:yst-shadow-none hover:yst-outline-none hover:yst-ring-2 hover:yst-ring-offset-2 hover:yst-ring-offset-white hover:yst-text-primary-500",
-										{ "yst-ring-primary-500 yst-shadow-none yst-outline-none yst-ring-2 yst-ring-offset-2 yst-ring-offset-white yst-text-primary-500": open }
-									)
-								}
-							>
-								<span className="yst-sr-only">Open options</span>
-								<DotsVerticalIcon className="yst-h-5 yst-w-5" aria-hidden="true" />
-							</Menu.Button>
-						</div>
+			<div>
+				<Menu.Button
+					className={
+						classNames(
+							"yst-bg-white yst-rounded-full yst-flex yst-items-center yst-border-none yst-text-gray-400 yst-p-1",
+							"focus:yst-ring-primary-500 focus:yst-shadow-none focus:yst-outline-none focus:yst-ring-2 focus:yst-ring-offset-2 focus:yst-ring-offset-white focus:yst-text-gray-500",
+							"hover:yst-shadow-none hover:yst-outline-none hover:yst-text-gray-500"
+						)
+					}
+				>
+					<span className="yst-sr-only">Open options</span>
+					<DotsVerticalIcon className="yst-h-5 yst-w-5" aria-hidden="true" />
+				</Menu.Button>
+			</div>
 
-						<Transition
-							as={ Fragment }
-							enter="yst-transition yst-ease-out yst-duration-100"
-							enterFrom="yst-transform yst-opacity-0 yst-scale-95"
-							enterTo="yst-transform yst-opacity-100 yst-scale-100"
-							leave="yst-transition yst-ease-in yst-duration-75"
-							leaveFrom="yst-transform yst-opacity-100 yst-scale-100"
-							leaveTo="yst-transform yst-opacity-0 yst-scale-95"
-						>
-							<Menu.Items className="yst-origin-top-right yst-absolute yst-right-0 yst-mt-2 yst-w-56 yst-rounded-md yst-shadow-lg yst-bg-white yst-ring-1 yst-ring-black yst-ring-opacity-5 focus:yst-outline-none">
-								<div className="yst-py-1">
-									{
-										options.map( ( option, index ) => {
-											return <Menu.Item key={ "card-option-" + index }>
-												{ ( { active } ) => (
-													<button
-														type="button"
-														onClick={ option.action }
-														className={ classNames(
-															active ? "yst-bg-gray-100 yst-text-gray-900" : "yst-text-gray-700",
-															"yst-w-full yst-block yst-px-4 yst-py-2 yst-text-sm yst-text-left"
-														) }
-														{ ...option.menuItemData }
-													>
-														{ option.title }
-													</button>
-												) }
-											</Menu.Item>;
-										} )
-									}
-								</div>
-							</Menu.Items>
-						</Transition>
-					</Fragment>;
-				}
-			}
+			<Transition
+				as={ Fragment }
+				enter="yst-transition yst-ease-out yst-duration-100"
+				enterFrom="yst-transform yst-opacity-0 yst-scale-95"
+				enterTo="yst-transform yst-opacity-100 yst-scale-100"
+				leave="yst-transition yst-ease-in yst-duration-75"
+				leaveFrom="yst-transform yst-opacity-100 yst-scale-100"
+				leaveTo="yst-transform yst-opacity-0 yst-scale-95"
+			>
+				<Menu.Items className="yst-origin-top-right yst-absolute yst-right-0 yst-mt-2 yst-w-56 yst-rounded-md yst-shadow-lg yst-bg-white yst-ring-1 yst-ring-black yst-ring-opacity-5 focus:yst-outline-none">
+					<div className="yst-py-1">
+						{
+							options.map( ( option, index ) => {
+								return <Menu.Item key={ "card-option-" + index }>
+									{ ( { active } ) => (
+										<button
+											type="button"
+											onClick={ option.action }
+											className={ classNames(
+												active ? "yst-bg-gray-100 yst-text-gray-900" : "yst-text-gray-700",
+												"yst-w-full yst-block yst-px-4 yst-py-2 yst-text-sm yst-text-left"
+											) }
+											{ ...option.menuItemData }
+										>
+											{ option.title }
+										</button>
+									) }
+								</Menu.Item>;
+							} )
+						}
+					</div>
+				</Menu.Items>
+			</Transition>
 		</Menu>
 	);
 }

--- a/packages/js/src/indexables-page/components/indexables-card.js
+++ b/packages/js/src/indexables-page/components/indexables-card.js
@@ -1,23 +1,28 @@
 import PropTypes from "prop-types";
 import classNames from "classnames";
+import DotsMenu from "./indexables-card-options";
 
 /**
  * A card for the indexables page.
  *
  * @param {string}   title     The indexable title.
  * @param {boolean}  className A className string to add to a card.
+ * @param {array}    options   An array with options for the dots menu.
  * @param {JSX.node} children  The React children.
  *
  * @returns {WPElement} A card for the indexables page.
  */
-function IndexablesPageCard( { title, className, children } ) {
+function IndexablesPageCard( { title, className, options, children } ) {
 	return <div className={ classNames( "yst-w-full yst-inline-block", className ) }>
 		<div
 			className="yst-bg-white yst-rounded-lg yst-p-8 yst-shadow"
 		>
-			<h3 className="yst-mb-4 yst-text-base yst-text-gray-900 yst-font-medium">
-				{ title }
-			</h3>
+			<div className="yst-w-full yst-flex yst-justify-between">
+				<h3 className="yst-mb-4 yst-text-base yst-text-gray-900 yst-font-medium">
+					{ title }
+				</h3>
+				{ options.length > 0 && <DotsMenu options={ options } /> }
+			</div>
 			{ children }
 		</div>
 	</div>;
@@ -27,10 +32,15 @@ IndexablesPageCard.propTypes = {
 	title: PropTypes.oneOfType( [ PropTypes.string, PropTypes.object ] ).isRequired,
 	children: PropTypes.node.isRequired,
 	className: PropTypes.string,
+	options: PropTypes.arrayOf( PropTypes.shape( {
+		title: PropTypes.string,
+		action: PropTypes.function,
+	} ) ),
 };
 
 IndexablesPageCard.defaultProps = {
 	className: "",
+	options: [],
 };
 
 export default IndexablesPageCard;

--- a/packages/js/src/indexables-page/indexables-page.js
+++ b/packages/js/src/indexables-page/indexables-page.js
@@ -726,7 +726,7 @@ function IndexablesPage( { setupInfo } ) {
 			<button
 				type="button"
 				onClick={ handleRefreshLists }
-				className={ "yst-ml-6 yst-font-medium yst-text-indigo-600 hover:yst-text-indigo-500 focus:yst-ring-indigo-500 focus:yst-shadow-none focus:yst-outline-none focus:yst-ring-2 focus:yst-ring-offset-2 focus:yst-ring-offset-white yst-rounded-lg yst-py-2 yst-px-3" }
+				className={ "yst-ml-6 yst-font-medium yst-text-indigo-600 hover:yst-text-indigo-500 focus:yst-ring-indigo-500 focus:yst-shadow-none focus:yst-outline-none focus:yst-ring-2 focus:yst-ring-offset-2 focus:yst-ring-offset-[#f0f0f1] yst-rounded-lg yst-py-2 yst-px-3" }
 			>
 				<RefreshIcon className="yst-inline-block yst-align-text-bottom yst-mr-1 yst-h-4 yst-w-4" />
 				{ __( "Refresh data", "wordpress-seo" ) }

--- a/packages/js/src/indexables-page/indexables-page.js
+++ b/packages/js/src/indexables-page/indexables-page.js
@@ -493,6 +493,37 @@ function IndexablesPage( { setupInfo } ) {
 		return () => handleUndo( ignored );
 	}, [ handleUndo ] );
 
+	const onClickUndoAllList = useCallback( async( event ) => {
+		const { type } = event.target.dataset;
+		try {
+			const response = await apiFetch( {
+				path: "yoast/v1/restore_all_indexables_for_list",
+				method: "POST",
+				data: { type: type },
+			} );
+
+			const parsedResponse = await response.json;
+			if ( parsedResponse.success ) {
+				// If there is a button to ignore a single indexable, for a list for which we are removing all indexables...
+				if ( ignoredIndexable && ignoredIndexable.type === type ) {
+					// ...remove that button.
+					setIgnoredIndexable( null );
+				}
+				updateList( type, indexablesLists[ type ], true );
+				return true;
+			}
+			/* eslint-disable-next-line no-warning-comments */
+			// @TODO: Throw an error notification.
+			console.error( "Undoing all ignored indexables has failed." );
+			return false;
+		} catch ( error ) {
+			/* eslint-disable-next-line no-warning-comments */
+			// @TODO: Throw an error notification.
+			console.error( error.message );
+			return false;
+		}
+	}, [ apiFetch, updateList, indexablesLists, ignoredIndexable, setIgnoredIndexable ] );
+
 	const onClickUndoAll = useCallback( async() => {
 		try {
 			const response = await apiFetch( {
@@ -528,6 +559,9 @@ function IndexablesPage( { setupInfo } ) {
 					: __( "Lowest readability scores", "wordpress-seo" )
 			}
 			className="2xl:yst-mb-6 2xl:last:yst-mb-0"
+			options={ [
+				{ title: __( "Undo hiding of all indexables for this list", "wordpress-seo" ), action: onClickUndoAllList, menuItemData: { "data-type": "least_readability" } },
+			] }
 		>
 			{
 				shouldShowDisabledAlert( "least_readability" ) && <Alert type={ "info" }>
@@ -595,6 +629,9 @@ function IndexablesPage( { setupInfo } ) {
 					: __( "Lowest number of incoming links", "wordpress-seo" )
 			}
 			className="2xl:yst-mb-6 2xl:last:yst-mb-0"
+			options={ [
+				{ title: __( "Undo hiding of all indexables for this list", "wordpress-seo" ), action: onClickUndoAllList, menuItemData: { "data-type": "least_linked" } },
+			] }
 		>
 			{
 				shouldShowDisabledAlert( "least_linked" ) && <Alert type={ "info" }>
@@ -706,6 +743,9 @@ function IndexablesPage( { setupInfo } ) {
 						: __( "Lowest SEO scores", "wordpress-seo" )
 				}
 				className="2xl:yst-mb-6 2xl:last:yst-mb-0"
+				options={ [
+					{ title: __( "Undo hiding of all indexables for this list", "wordpress-seo" ), action: onClickUndoAllList, menuItemData: { "data-type": "least_seo_score" } },
+				] }
 			>
 				{
 					shouldShowDisabledAlert( "least_seo_score" ) && <Alert type={ "info" }>
@@ -774,6 +814,9 @@ function IndexablesPage( { setupInfo } ) {
 						: __( "Highest number of incoming links", "wordpress-seo" )
 				}
 				className="yst-mb-6"
+				options={ [
+					{ title: __( "Undo hiding of all indexables for this list", "wordpress-seo" ), action: onClickUndoAllList, menuItemData: { "data-type": "most_linked" } },
+				] }
 			>
 				{
 					shouldShowDisabledAlert( "most_linked" ) && <Alert type={ "info" }>

--- a/packages/js/src/indexables-page/indexables-page.js
+++ b/packages/js/src/indexables-page/indexables-page.js
@@ -560,7 +560,7 @@ function IndexablesPage( { setupInfo } ) {
 			}
 			className="2xl:yst-mb-6 2xl:last:yst-mb-0"
 			options={ [
-				{ title: __( "Undo hiding of all indexables for this list", "wordpress-seo" ), action: onClickUndoAllList, menuItemData: { "data-type": "least_readability" } },
+				{ title: __( "Restore hidden items", "wordpress-seo" ), action: onClickUndoAllList, menuItemData: { "data-type": "least_readability" } },
 			] }
 		>
 			{
@@ -630,7 +630,7 @@ function IndexablesPage( { setupInfo } ) {
 			}
 			className="2xl:yst-mb-6 2xl:last:yst-mb-0"
 			options={ [
-				{ title: __( "Undo hiding of all indexables for this list", "wordpress-seo" ), action: onClickUndoAllList, menuItemData: { "data-type": "least_linked" } },
+				{ title: __( "Restore hidden items", "wordpress-seo" ), action: onClickUndoAllList, menuItemData: { "data-type": "least_linked" } },
 			] }
 		>
 			{
@@ -744,7 +744,7 @@ function IndexablesPage( { setupInfo } ) {
 				}
 				className="2xl:yst-mb-6 2xl:last:yst-mb-0"
 				options={ [
-					{ title: __( "Undo hiding of all indexables for this list", "wordpress-seo" ), action: onClickUndoAllList, menuItemData: { "data-type": "least_seo_score" } },
+					{ title: __( "Restore hidden items", "wordpress-seo" ), action: onClickUndoAllList, menuItemData: { "data-type": "least_seo_score" } },
 				] }
 			>
 				{
@@ -815,7 +815,7 @@ function IndexablesPage( { setupInfo } ) {
 				}
 				className="yst-mb-6"
 				options={ [
-					{ title: __( "Undo hiding of all indexables for this list", "wordpress-seo" ), action: onClickUndoAllList, menuItemData: { "data-type": "most_linked" } },
+					{ title: __( "Restore hidden items", "wordpress-seo" ), action: onClickUndoAllList, menuItemData: { "data-type": "most_linked" } },
 				] }
 			>
 				{
@@ -888,12 +888,12 @@ function IndexablesPage( { setupInfo } ) {
 			</IndexablesPageCard>
 		</div>
 		<div className="yst-w-full yst-border-t yst-border-gray-300 yst-pb-6 yst-pt-8 yst-mt-2 yst-space-x-2">
-			<Button variant="secondary" onClick={ onClickUndoAll } disabled={ false }>{ __( "Undo hiding all items", "wordpress-seo" ) }</Button>
+			<Button variant="secondary" onClick={ onClickUndoAll } disabled={ false }>{ __( "Restore all hidden items", "wordpress-seo" ) }</Button>
 			{
 				ignoredIndexable && <Button variant="secondary" onClick={ onClickUndo( ignoredIndexable ) }>
 					{
 						/* translators: %1$s expands to the title of a post that was just just hidden. */
-						sprintf( __( "Undo hiding of: %1$s", "wordpress-seo" ), ignoredIndexable.indexable.breadcrumb_title )
+						sprintf( __( "Restore %1$s", "wordpress-seo" ), ignoredIndexable.indexable.breadcrumb_title )
 					}
 				</Button>
 			}

--- a/packages/js/src/indexables-page/indexables-page.js
+++ b/packages/js/src/indexables-page/indexables-page.js
@@ -657,7 +657,7 @@ function IndexablesPage( { setupInfo } ) {
 			}
 			{
 				shouldShowTable( "least_linked" ) && <Fragment>
-					<div className="yst-mb-3 yst-text-justify yst-pr-6">
+					<div className="yst-mb-3 yst-text-justify yst-max-w-[600px]">
 						{ leastLinkedIntro }
 					</div>
 					<IndexablesTable>
@@ -689,7 +689,7 @@ function IndexablesPage( { setupInfo } ) {
 							}
 						) }
 					</IndexablesTable>
-					<div className="yst-mt-3 yst-text-justify yst-pr-6">
+					<div className="yst-mt-3 yst-text-justify  yst-max-w-[600px]">
 						{ leastLinkedOutro }
 					</div>
 				</Fragment>
@@ -713,7 +713,7 @@ function IndexablesPage( { setupInfo } ) {
 				suggestedLinksModalData={ suggestedLinksModalData }
 			/>
 		</Modal>
-		<div className="yst-max-w-7xl yst-text-right yst-gap-6 yst-mb-3">
+		<div className="yst-max-w-7xl yst-text-right yst-gap-6 yst-mb-4">
 			<span className="yst-italic">
 				{
 					// translators: %d is the number of minutes since the last refresh.
@@ -726,9 +726,9 @@ function IndexablesPage( { setupInfo } ) {
 			<button
 				type="button"
 				onClick={ handleRefreshLists }
-				className={ "yst-ml-6 yst-font-medium yst-text-[#4F46E5]" }
+				className={ "yst-ml-6 yst-font-medium yst-text-indigo-600 hover:yst-text-indigo-500 focus:yst-ring-indigo-500 focus:yst-shadow-none focus:yst-outline-none focus:yst-ring-2 focus:yst-ring-offset-2 focus:yst-ring-offset-white yst-rounded-lg yst-py-2 yst-px-3" }
 			>
-				<RefreshIcon className="yst-inline-block yst-align-text-bottom yst-mr-1 yst-h-4 yst-w-4 yst-text-[#4F46E5]" />
+				<RefreshIcon className="yst-inline-block yst-align-text-bottom yst-mr-1 yst-h-4 yst-w-4" />
 				{ __( "Refresh data", "wordpress-seo" ) }
 			</button>
 		</div>
@@ -842,7 +842,7 @@ function IndexablesPage( { setupInfo } ) {
 				}
 				{
 					shouldShowTable( "most_linked" ) && <Fragment>
-						<div className="yst-mb-3 yst-text-justify yst-pr-6">
+						<div className="yst-mb-3 yst-text-justify yst-max-w-[600px]">
 							{ mostLinkedIntro }
 						</div>
 						<IndexablesTable>
@@ -877,7 +877,7 @@ function IndexablesPage( { setupInfo } ) {
 								}
 							) }
 						</IndexablesTable>
-						<div className="yst-mt-3 yst-text-justify yst-pr-6">
+						<div className="yst-mt-3 yst-text-justify yst-max-w-[600px]">
 							{ mostLinkedOutro }
 						</div>
 					</Fragment>


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Improved UX.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

*

## Relevant technical choices:

*

## Test instructions

* Hide one row in a certain list (List A). Then hide a row in another list (List B).
* Observe the button appearing at the bottom to undo the hiding.
* Now in List B, click the three-dot-menu, and click "restore hidden items". The aforementioned button should disappear and the row you've hidden should come back. List A should be unaffected.

* Now, again, hide a row in List A. Then hide a row in List B.
* Observe the button appearing at the bottom to undo the hiding.
* Now, in List A, click the three dot menu and click restore hidden items. The button should not disappear. Clicking it should still work. The row you've hidden in List A should be back.

* Hide various rows in all lists.
* Click the  "Restore all hidden items" button. The lists should reload (but not the whole page).

