### PR TITLE
Make SKU and product identifier assessments price independent

### DIFF
--- a/packages/yoastseo/spec/scoring/assessments/seo/ProductIdentifiersAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/ProductIdentifiersAssessmentSpec.js
@@ -76,6 +76,34 @@ describe( "a test for Product identifiers assessment for WooCommerce", function(
 			" Not all your product variants have an identifier. <a href='https://yoa.st/4lz' target='_blank'>Include" +
 			" this if you can, as it will help search engines to better understand your content.</a>" );
 	} );
+
+
+	it( "returns the score 9 with the feedback for a simple product when a variable product has no variants but has a global identifier", function() {
+		const assessmentResult = assessment.getResult( paper, Factory.buildMockResearcher( {
+			hasGlobalIdentifier: true,
+			hasVariants: false,
+			doAllVariantsHaveIdentifier: false,
+			productType: "variable",
+		} ) );
+
+		expect( assessmentResult.getScore() ).toEqual( 9 );
+		expect( assessmentResult.getText() ).toEqual( "<a href='https://yoa.st/4ly' target='_blank'>Product identifier</a>: " +
+			"Your product has an identifier. Good job!" );
+	} );
+
+	it( "returns the score 6 with the feedback for a simple product when a variable product has no variants and no global identifier", function() {
+		const assessmentResult = assessment.getResult( paper, Factory.buildMockResearcher( {
+			hasGlobalIdentifier: false,
+			hasVariants: false,
+			doAllVariantsHaveIdentifier: false,
+			productType: "variable",
+		} ) );
+
+		expect( assessmentResult.getScore() ).toEqual( 6 );
+		expect( assessmentResult.getText() ).toEqual( "<a href='https://yoa.st/4ly' target='_blank'>Product identifier</a>:" +
+			" Your product is missing an identifier (like a GTIN code). <a href='https://yoa.st/4lz' target='_blank'>Include" +
+			" this if you can, as it will help search engines to better understand your content.</a>" );
+	} );
 } );
 
 // Ignore the shopify specs as long as it is not yet implemented for shopify.
@@ -119,96 +147,16 @@ xdescribe( "a test for Product identifiers assessment for Shopify", () => {
 } );
 
 describe( "a test for the applicability of the assessment", function() {
-	it( "is not applicable when there is no price and no variants", function() {
+	it( "is applicable when the assessVariants variable is set to true", function() {
 		const assessment = new ProductIdentifiersAssessment( { assessVariants: true } );
-		const customData = {
-			hasPrice: false,
-			hasGlobalIdentifier: true,
-			hasVariants: false,
-		};
-		const paperWithCustomData = new Paper( "", { customData } );
-		const isApplicable = assessment.isApplicable( paperWithCustomData );
-
-		expect( isApplicable ).toBe( false );
-	} );
-
-	it( "is applicable when there is a price and no variants", function() {
-		const assessment = new ProductIdentifiersAssessment( { assessVariants: true } );
-		const customData = {
-			hasPrice: true,
-			hasGlobalIdentifier: true,
-			hasVariants: false,
-		};
-		const paperWithCustomData = new Paper( "", { customData } );
-		const isApplicable = assessment.isApplicable( paperWithCustomData );
+		const isApplicable = assessment.isApplicable( paper );
 
 		expect( isApplicable ).toBe( true );
 	} );
 
-	it( "is applicable when there is no price but there are variants", function() {
-		const assessment = new ProductIdentifiersAssessment( { assessVariants: true } );
-		const customData = {
-			hasPrice: false,
-			hasGlobalIdentifier: false,
-			hasVariants: true,
-		};
-		const paperWithCustomData = new Paper( "", { customData } );
-		const isApplicable = assessment.isApplicable( paperWithCustomData );
-
-		expect( isApplicable ).toBe( true );
-	} );
-
-	it( "returns false when assessVariants is false", () => {
-		const assessment = new ProductIdentifiersAssessment( { assessVariants: false } );
-		const customData = {
-			hasPrice: true,
-			hasGlobalIdentifier: true,
-			hasVariants: false,
-		};
-		const paperWithCustomData = new Paper( "", { customData } );
-		const isApplicable = assessment.isApplicable( paperWithCustomData );
-
-		expect( isApplicable ).toBe( false );
-	} );
-
-	it( "returns false variable product has no variants.", () => {
-		const assessment = new ProductIdentifiersAssessment( { assessVariants: true } );
-		const customData = {
-			hasPrice: true,
-			hasGlobalIdentifier: true,
-			hasVariants: false,
-			productType: "variable",
-		};
-		const paperWithCustomData = new Paper( "", { customData } );
-		const isApplicable = assessment.isApplicable( paperWithCustomData );
-
-		expect( isApplicable ).toBe( false );
-	} );
-
-	it( "returns true variable product has variants.", () => {
-		const assessment = new ProductIdentifiersAssessment( { assessVariants: true } );
-		const customData = {
-			hasPrice: true,
-			hasGlobalIdentifier: true,
-			hasVariants: true,
-			productType: "variable",
-		};
-		const paperWithCustomData = new Paper( "", { customData } );
-		const isApplicable = assessment.isApplicable( paperWithCustomData );
-
-		expect( isApplicable ).toBe( true );
-	} );
-
-	it( "returns false variable product has no price and no variants.", () => {
-		const assessment = new ProductIdentifiersAssessment( { assessVariants: true } );
-		const customData = {
-			hasPrice: false,
-			hasGlobalIdentifier: true,
-			hasVariants: false,
-			productType: "variable",
-		};
-		const paperWithCustomData = new Paper( "", { customData } );
-		const isApplicable = assessment.isApplicable( paperWithCustomData );
+	it( "is not applicable when the assessVariants variable is set to false", function() {
+		const assessment = new ProductIdentifiersAssessment();
+		const isApplicable = assessment.isApplicable( paper );
 
 		expect( isApplicable ).toBe( false );
 	} );

--- a/packages/yoastseo/spec/scoring/assessments/seo/ProductSKUAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/ProductSKUAssessmentSpec.js
@@ -75,6 +75,32 @@ describe( "a test for SKU assessment for WooCommerce", function() {
 			" Not all your product variants have a SKU. <a href='https://yoa.st/4lx' target='_blank'>Include" +
 			" this if you can, as it will help search engines to better understand your content.</a>" );
 	} );
+
+	it( "returns the score 9 with the feedback for a simple product when a variable product has no variants but has a global SKU", function() {
+		const assessmentResult = assessment.getResult( paper, Factory.buildMockResearcher( {
+			hasGlobalSKU: true,
+			hasVariants: false,
+			doAllVariantsHaveSKU: false,
+			productType: "variable",
+		} ) );
+
+		expect( assessmentResult.getScore() ).toEqual( 9 );
+		expect( assessmentResult.getText() ).toEqual( "<a href='https://yoa.st/4lw' target='_blank'>SKU</a>: Your product has a SKU. Good job!" );
+	} );
+
+	it( "returns the score 6 with the feedback for a simple product when a variable product has no variants and no global SKU", function() {
+		const assessmentResult = assessment.getResult( paper, Factory.buildMockResearcher( {
+			hasGlobalSKU: false,
+			hasVariants: false,
+			doAllVariantsHaveSKU: false,
+			productType: "variable",
+		} ) );
+
+		expect( assessmentResult.getScore() ).toEqual( 6 );
+		expect( assessmentResult.getText() ).toEqual( "<a href='https://yoa.st/4lw' target='_blank'>SKU</a>:" +
+			" Your product is missing a SKU. <a href='https://yoa.st/4lx' target='_blank'>Include" +
+			" this if you can, as it will help search engines to better understand your content.</a>" );
+	} );
 } );
 
 // Ignore the shopify specs as long as it is not yet implemented for shopify.
@@ -118,96 +144,16 @@ xdescribe( "a test for SKU assessment for Shopify", () => {
 } );
 
 describe( "a test for the applicability of the assessment", function() {
-	it( "is not applicable when there is no price and no variants", function() {
+	it( "is applicable when the assessVariants variable is set to true", function() {
 		const assessment = new ProductSKUAssessment( { assessVariants: true } );
-		const customData = {
-			hasPrice: false,
-			hasGlobalIdentifier: true,
-			hasVariants: false,
-		};
-		const paperWithCustomData = new Paper( "", { customData } );
-		const isApplicable = assessment.isApplicable( paperWithCustomData );
-
-		expect( isApplicable ).toBe( false );
-	} );
-
-	it( "is applicable when there is a price and no variants", function() {
-		const assessment = new ProductSKUAssessment( { assessVariants: true } );
-		const customData = {
-			hasPrice: true,
-			hasGlobalIdentifier: true,
-			hasVariants: false,
-		};
-		const paperWithCustomData = new Paper( "", { customData } );
-		const isApplicable = assessment.isApplicable( paperWithCustomData );
+		const isApplicable = assessment.isApplicable( paper );
 
 		expect( isApplicable ).toBe( true );
 	} );
 
-	it( "is applicable when there is no price but there are variants", function() {
-		const assessment = new ProductSKUAssessment( { assessVariants: true } );
-		const customData = {
-			hasPrice: false,
-			hasGlobalIdentifier: false,
-			hasVariants: true,
-		};
-		const paperWithCustomData = new Paper( "", { customData } );
-		const isApplicable = assessment.isApplicable( paperWithCustomData );
-
-		expect( isApplicable ).toBe( true );
-	} );
-
-	it( "returns false when assessVariants is false", () => {
-		const assessment = new ProductSKUAssessment( { assessVariants: false } );
-		const customData = {
-			hasPrice: true,
-			hasGlobalIdentifier: true,
-			hasVariants: false,
-		};
-		const paperWithCustomData = new Paper( "", { customData } );
-		const isApplicable = assessment.isApplicable( paperWithCustomData );
-
-		expect( isApplicable ).toBe( false );
-	} );
-
-	it( "returns false variable product has no variants.", () => {
-		const assessment = new ProductSKUAssessment( { assessVariants: true } );
-		const customData = {
-			hasPrice: true,
-			hasGlobalIdentifier: true,
-			hasVariants: false,
-			productType: "variable",
-		};
-		const paperWithCustomData = new Paper( "", { customData } );
-		const isApplicable = assessment.isApplicable( paperWithCustomData );
-
-		expect( isApplicable ).toBe( false );
-	} );
-
-	it( "returns true variable product has variants.", () => {
-		const assessment = new ProductSKUAssessment( { assessVariants: true } );
-		const customData = {
-			hasPrice: true,
-			hasGlobalIdentifier: true,
-			hasVariants: true,
-			productType: "variable",
-		};
-		const paperWithCustomData = new Paper( "", { customData } );
-		const isApplicable = assessment.isApplicable( paperWithCustomData );
-
-		expect( isApplicable ).toBe( true );
-	} );
-
-	it( "returns false variable product has no price and no variants.", () => {
-		const assessment = new ProductSKUAssessment( { assessVariants: true } );
-		const customData = {
-			hasPrice: false,
-			hasGlobalIdentifier: true,
-			hasVariants: false,
-			productType: "variable",
-		};
-		const paperWithCustomData = new Paper( "", { customData } );
-		const isApplicable = assessment.isApplicable( paperWithCustomData );
+	it( "is not applicable when the assessVariants variable is set to false", function() {
+		const assessment = new ProductSKUAssessment();
+		const isApplicable = assessment.isApplicable( paper );
 
 		expect( isApplicable ).toBe( false );
 	} );

--- a/packages/yoastseo/src/scoring/assessments/seo/ProductIdentifiersAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/ProductIdentifiersAssessment.js
@@ -60,12 +60,10 @@ export default class ProductIdentifiersAssessment extends Assessment {
 	/**
 	 * Checks whether the assessment is applicable (for now it is not applicable in Shopify where we also don't want to
 	 * assess variants; hence the applicability condition based on that).
-	 *
-	 * @param {Paper} paper The paper to check.
-	 *
+	 **
 	 * @returns {Boolean} Whether the assessment is applicable.
 	 */
-	isApplicable( paper ) {
+	isApplicable() {
 		return this._config.assessVariants;
 	}
 

--- a/packages/yoastseo/src/scoring/assessments/seo/ProductIdentifiersAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/ProductIdentifiersAssessment.js
@@ -97,7 +97,9 @@ export default class ProductIdentifiersAssessment extends Assessment {
 			};
 		}
 
-		if ( [ "simple", "external" ].includes( productIdentifierData.productType ) ) {
+		// Apply the following scoring conditions to products without variants.
+		if ( [ "simple", "external" ].includes( productIdentifierData.productType ) ||
+			( productIdentifierData.productType === "variable" && ! productIdentifierData.hasVariants ) ) {
 			if ( ! productIdentifierData.hasGlobalIdentifier ) {
 				return {
 					score: config.scores.ok,
@@ -136,7 +138,7 @@ export default class ProductIdentifiersAssessment extends Assessment {
 					"</a>"
 				),
 			};
-		} else if ( productIdentifierData.productType === "variable" ) {
+		} else if ( productIdentifierData.productType === "variable" && productIdentifierData.hasVariants ) {
 			if ( ! productIdentifierData.doAllVariantsHaveIdentifier ) {
 				// If we want to assess variants, and if product has variants but not all variants have an identifier, return orange bullet.
 				// If all variants have an identifier, return green bullet.

--- a/packages/yoastseo/src/scoring/assessments/seo/ProductIdentifiersAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/ProductIdentifiersAssessment.js
@@ -58,38 +58,15 @@ export default class ProductIdentifiersAssessment extends Assessment {
 	}
 
 	/**
-	 * Contains extra logic for the isApplicable method.
-	 *
-	 * @param {object} customData The custom data part of the Paper object.
-	 *
-	 * @returns {bool} Whether the productIdentifierAssessment is applicable.
-	 */
-	applicabilityHelper( customData ) {
-		// Checks if we are in Woo or Shopify. assessVariants is always true in Woo
-		// Don't return a score if the product has variants but we don't want to assess variants for this product.
-		// This is currently the case for Shopify products because we don't have access data about product variant identifiers in Shopify.
-		if ( ! this._config.assessVariants ) {
-			return false;
-		}
-
-		// If we have a variable product with no (active) variants. (active variant = variant with a price)
-		if (  customData.productType === "variable" && ! customData.hasVariants  ) {
-			return false;
-		}
-
-		return ( customData.hasPrice || customData.hasVariants );
-	}
-
-	/**
-	 * Checks whether the assessment is applicable.
+	 * Checks whether the assessment is applicable (for now it is not applicable in Shopify where we also don't want to
+	 * assess variants; hence the applicability condition based on that).
 	 *
 	 * @param {Paper} paper The paper to check.
 	 *
 	 * @returns {Boolean} Whether the assessment is applicable.
 	 */
 	isApplicable( paper ) {
-		const customData = paper.getCustomData();
-		return this.applicabilityHelper( customData );
+		return this._config.assessVariants;
 	}
 
 	/**

--- a/packages/yoastseo/src/scoring/assessments/seo/ProductSKUAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/ProductSKUAssessment.js
@@ -58,12 +58,10 @@ export default class ProductSKUAssessment extends Assessment {
 	/**
 	 * Checks whether the assessment is applicable (for now it is not applicable in Shopify where we also don't want to
 	 * assess variants; hence the applicability condition based on that).
-	 *
-	 * @param {Paper} paper The paper to check.
-	 *
+	 **
 	 * @returns {Boolean} Whether the assessment is applicable.
 	 */
-	isApplicable( paper ) {
+	isApplicable() {
 		return this._config.assessVariants;
 	}
 

--- a/packages/yoastseo/src/scoring/assessments/seo/ProductSKUAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/ProductSKUAssessment.js
@@ -56,35 +56,15 @@ export default class ProductSKUAssessment extends Assessment {
 	}
 
 	/**
-	 * Contains extra logic for the isApplicable method.
-	 *
-	 * @param {object} customData The custom data part of the Paper object.
-	 *
-	 * @returns {bool} Whether the productSKUAssessment is applicable.
-	 */
-	applicabilityHelper( customData ) {
-		// Checks if we are in Woo or Shopify. assessVariants is always true in Woo
-		if ( ! this._config.assessVariants ) {
-			return false;
-		}
-
-		// If we have a variable product with no (active) variants. (active variant = variant with a price)
-		if (  customData.productType === "variable" && ! customData.hasVariants ) {
-			return false;
-		}
-		return ( customData.hasPrice || customData.hasVariants );
-	}
-
-	/**
-	 * Checks whether the assessment is applicable.
+	 * Checks whether the assessment is applicable (for now it is not applicable in Shopify where we also don't want to
+	 * assess variants; hence the applicability condition based on that).
 	 *
 	 * @param {Paper} paper The paper to check.
 	 *
 	 * @returns {Boolean} Whether the assessment is applicable.
 	 */
 	isApplicable( paper ) {
-		const customData = paper.getCustomData();
-		return this.applicabilityHelper( customData );
+		return this._config.assessVariants;
 	}
 
 	/**

--- a/packages/yoastseo/src/scoring/assessments/seo/ProductSKUAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/ProductSKUAssessment.js
@@ -77,9 +77,9 @@ export default class ProductSKUAssessment extends Assessment {
 	 * 													or empty object if no score should be returned.
 	 */
 	scoreProductSKU( productSKUData, config ) {
-		// NOTE: product types might not be available in shopify or they might differ.
-		// So take this into account when implementing SKUAssessment for shopify.
-		if (  [ "simple", "external" ].includes( productSKUData.productType ) ) {
+		// Apply the following scoring conditions to products without variants.
+		if ( [ "simple", "external" ].includes( productSKUData.productType ) ||
+			( productSKUData.productType === "variable" && ! productSKUData.hasVariants ) ) {
 			if ( ! productSKUData.hasGlobalSKU ) {
 				return {
 					score: config.scores.ok,
@@ -108,7 +108,7 @@ export default class ProductSKUAssessment extends Assessment {
 					"</a>"
 				),
 			};
-		} else if ( productSKUData.productType === "variable" ) {
+		} else if ( productSKUData.productType === "variable" && productSKUData.hasVariants ) {
 			// If we want to assess variants, if product has variants and not all variants have a SKU, return orange bullet.
 			// If all variants have a SKU, return green bullet.
 			if ( ! productSKUData.doAllVariantsHaveSKU ) {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Before, we wouldn't show the SKU or product identifiers assessment results for products/variants without a price. We don't want to have this preconditions for showing the assessment results anymore. Also, when a variable product has no variants we decided to show the same assessment results that we show for simple products.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Shows the SKU and product identifiers assessment results also when the product or variants don't have a price.

## Relevant technical choices:

* There is an accompanying WooCommerce PR https://github.com/Yoast/wpseo-woocommerce/pull/819

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Activate Yoast SEO Free, WooCommerce, and Yoast SEO: WooCommerce plugins
     *  Make sure to link the Free branch before building Woo (composer require yoast/wordpress-seo:dev-PC-500-make-sku-and-product-identifier-assessments-price-independent@dev --dev)
 
#### Simple product
* Create a new product
* Confirm that the SKU assessment shows an orange bullet with the following feedback `SKU: Your product is missing a SKU. Include this if you can, as it will help search engines to better understand your content.`
* Confirm that the product identifiers assessment shows an orange bullet with the following feedback `Product identifier: Your product is missing an identifier (like a GTIN code). Include this if you can, as it will help search engines to better understand your content.`
* Add a price to the product. Confirm that the assessment results stays the same
* Remove the price and confirm that the assessment results still stays the same
* Add a product identifier and SKU and confirm that the assessments return a green bullet with the following feedback `Product identifier/SKU: Your product has an identifier/SKU. Good job!`

#### Variable product
* Change the product to a variable product
* Confirm that the assessment results still stay the same
* Add variants to the product (first go to the Attributes tab and add some attributes (make sure to check the Used for variations). Then click on the Variants tab that appears and create variants from the attributes.)
* Confirm that the SKU and product identifier assessments return an orange bullet with the following feedback: `SKU/Product identifier: Not all your product variants have a SKU/identifier. Include this if you can, as it will help search engines to better understand your content.`
* Add a SKU and identifier to each variant and confirm that the assessments return a green bullet with the following feedback `SKU/Product identifier: All your product variants have a SKU/identifier. Good job!`
* Add prices to the variants and confirm that the assessment results stay the same.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Follow the test instructions from this task https://yoast.atlassian.net/browse/PC-369 

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes #
