### PR TITLE
Do not show SKU assessment when we cannot retrieve SKU

### DIFF
--- a/packages/yoastseo/spec/scoring/assessments/seo/ProductSKUAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/ProductSKUAssessmentSpec.js
@@ -157,4 +157,46 @@ describe( "a test for the applicability of the assessment", function() {
 
 		expect( isApplicable ).toBe( false );
 	} );
+
+	it( "is applicable when the SKU can be detected", function() {
+		const assessment = new ProductSKUAssessment( { assessVariants: true } );
+		const customData = {
+			canRetrieveSku: true,
+			hasGlobalSKU: false,
+			hasVariants: false,
+			productType: "simple"
+		};
+		const paperWithCustomData = new Paper( "", { customData } );
+		const isApplicable = assessment.isApplicable( paperWithCustomData );
+
+		expect( isApplicable ).toBe( true );
+	} );
+
+	it( "is not applicable when the SKU cannot be detected on product without variants", function() {
+		const assessment = new ProductSKUAssessment( { assessVariants: true } );
+		const customData = {
+			canRetrieveSku: false,
+			hasGlobalSKU: false,
+			hasVariants: false,
+			productType: "simple"
+		};
+		const paperWithCustomData = new Paper( "", { customData } );
+		const isApplicable = assessment.isApplicable( paperWithCustomData );
+
+		expect( isApplicable ).toBe( false );
+	} );
+
+	it( "is applicable when the SKU cannot be detected on product with variants", function() {
+		const assessment = new ProductSKUAssessment( { assessVariants: true } );
+		const customData = {
+			canRetrieveSku: false,
+			hasGlobalSKU: false,
+			hasVariants: true,
+			productType: "variable"
+		};
+		const paperWithCustomData = new Paper( "", { customData } );
+		const isApplicable = assessment.isApplicable( paperWithCustomData );
+
+		expect( isApplicable ).toBe( true );
+	} );
 } );

--- a/packages/yoastseo/spec/scoring/assessments/seo/ProductSKUAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/ProductSKUAssessmentSpec.js
@@ -164,7 +164,7 @@ describe( "a test for the applicability of the assessment", function() {
 			canRetrieveSku: true,
 			hasGlobalSKU: false,
 			hasVariants: false,
-			productType: "simple"
+			productType: "simple",
 		};
 		const paperWithCustomData = new Paper( "", { customData } );
 		const isApplicable = assessment.isApplicable( paperWithCustomData );
@@ -178,7 +178,7 @@ describe( "a test for the applicability of the assessment", function() {
 			canRetrieveSku: false,
 			hasGlobalSKU: false,
 			hasVariants: false,
-			productType: "simple"
+			productType: "simple",
 		};
 		const paperWithCustomData = new Paper( "", { customData } );
 		const isApplicable = assessment.isApplicable( paperWithCustomData );
@@ -192,7 +192,7 @@ describe( "a test for the applicability of the assessment", function() {
 			canRetrieveSku: false,
 			hasGlobalSKU: false,
 			hasVariants: true,
-			productType: "variable"
+			productType: "variable",
 		};
 		const paperWithCustomData = new Paper( "", { customData } );
 		const isApplicable = assessment.isApplicable( paperWithCustomData );

--- a/packages/yoastseo/src/scoring/assessments/seo/ProductSKUAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/ProductSKUAssessment.js
@@ -68,7 +68,7 @@ export default class ProductSKUAssessment extends Assessment {
 		 * Do not show the assessment when we cannot retrieve the SKU (problems with this have been specifically found for
 		 * products without variants, so the check doesn't apply to products with variants).
 		*/
-		if ( ! customData.canRetrieveSku && customData.hasVariants === false ) {
+		if ( customData.canRetrieveSku === false && customData.hasVariants === false ) {
 			return false;
 		}
 

--- a/packages/yoastseo/src/scoring/assessments/seo/ProductSKUAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/ProductSKUAssessment.js
@@ -69,7 +69,7 @@ export default class ProductSKUAssessment extends Assessment {
 			return false;
 		}
 
-		// For now the assessment is not applicable in Shopify, where we also don't want to assess variants (hence the applicability condition based on that).
+		// For now the assessment is not applicable in Shopify, where we also don't want to assess variants.
 		return this._config.assessVariants;
 	}
 

--- a/packages/yoastseo/src/scoring/assessments/seo/ProductSKUAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/ProductSKUAssessment.js
@@ -64,8 +64,11 @@ export default class ProductSKUAssessment extends Assessment {
 	 */
 	isApplicable( paper ) {
 		const customData = paper.getCustomData();
-		// Do not show the assessment when we cannot retrieve the SKU (e.g. when a plugin that automatically generates SKU is used).
-		if ( ! customData.canRetrieveSku && customData.productType !== "variable"  ) {
+		/*
+		 * Do not show the assessment when we cannot retrieve the SKU (problems with this have been specifically found for
+		 * products without variants, so the check doesn't apply to products with variants).
+		*/
+		if ( ! customData.canRetrieveSku && customData.hasVariants === false ) {
 			return false;
 		}
 

--- a/packages/yoastseo/src/scoring/assessments/seo/ProductSKUAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/ProductSKUAssessment.js
@@ -68,6 +68,11 @@ export default class ProductSKUAssessment extends Assessment {
 			return false;
 		}
 
+		// Do not show the assessment when we cannot retrieve the SKU (e.g. when a plugin that automatically generates SKU is used).
+		if ( ! customData.canRetrieveSku ) {
+			return false;
+		}
+
 		// If we have a variable product with no (active) variants. (active variant = variant with a price)
 		if (  customData.productType === "variable" && ! customData.hasVariants ) {
 			return false;

--- a/packages/yoastseo/src/scoring/assessments/seo/ProductSKUAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/ProductSKUAssessment.js
@@ -69,7 +69,7 @@ export default class ProductSKUAssessment extends Assessment {
 		}
 
 		// Do not show the assessment when we cannot retrieve the SKU (e.g. when a plugin that automatically generates SKU is used).
-		if ( ! customData.canRetrieveSku && ! customData.productType === "variable"  ) {
+		if ( ! customData.canRetrieveSku && customData.productType !== "variable"  ) {
 			return false;
 		}
 

--- a/packages/yoastseo/src/scoring/assessments/seo/ProductSKUAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/ProductSKUAssessment.js
@@ -69,7 +69,7 @@ export default class ProductSKUAssessment extends Assessment {
 		}
 
 		// Do not show the assessment when we cannot retrieve the SKU (e.g. when a plugin that automatically generates SKU is used).
-		if ( ! customData.canRetrieveSku ) {
+		if ( ! customData.canRetrieveSku && ! customData.productType === "variable"  ) {
 			return false;
 		}
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The WooCommerce Yoast SEO analysis was not working and there was a console error when the Product SKU Generator for WooCommerce plugin was used on products without variants.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Does not show the SKU assessment when we cannot detect a SKU on products without variants. This prevents the analysis from breaking when using the Product SKU Generator for WooCommerce plugin (and possibly other plugins that touch the SKU).
* [yoastseo] Makes the SKU assessment not applicable when we cannot detect the SKU on products without variants.


## Relevant technical choices:

* There is an accompanying Woo PR https://github.com/Yoast/wpseo-woocommerce/pull/820 
* Using the Product SKU Generator for WooCommerce plugin on products with variants does not cause problems. However, it is possible that other plugins can manipulate the SKU of variants in such a way that they do break the analysis. We should consider adding a safeguard that prevents the analysis from showing in such cases also for products with variants. But it was decided to be outside of the scope of this PR.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install and activate Yoast SEO Free, WooCommerce, Yoast SEO: WooCommerce, and the [Product SKU Generator](https://wordpress.org/plugins/woocommerce-product-sku-generator/) plugin
     * For acceptance tester: Make sure to require the Free branch when building the WooCommerce branch (composer require yoast/wordpress-seo:dev-PC-501-disabled-sku-assessment-when-sku-cannot-be-retrieved@dev --dev) 

#### Test product without variants
* Create a new product
* Confirm that the SKU assessment does not show up
* Change the product to a external/affiliate product
* Confirm that the SKU assessment still does not show up
* Change the product to a variable product (but do not add any variants yet)
* Confirm that the SKU assessment still does not show up
* Add text and title, and save the draft
* Confirm that the SKU assessment still does not show up
* Publish the product
* Confirm that the SKU assessment still does not show up

#### Test product with variants
* Create a new product
* Add variants (Go to the Attributes tab and add some attributes. Check the 'Use for variations' checkbox. Then go to the Variations tab and create variants from the attributes.)
* Confirm that the SKU assessment shows up with an orange bullet and the following feedback: `SKU: Not all your product variants have a SKU. Include this if you can, as it will help search engines to better understand your content.` 
* Save the product and confirm that the SKU assessment result doesn't change.
* Add text and title to the Product and publish it
* Confirm that the SKU assessment returns a green bullet with the following feedback: `SKU: All your product variants have a SKU. Good job!`
* Delete all variants
* Confirm that the SKU assessment does not show up

#### Test with the  Product SKU Generator plugin disabled
* Disable the Product SKU Generator plugin
* Open a new product and confirm that the SKU assessment appears with an orange bullet and the following feedback: `SKU: Your product is missing a SKU. Include this if you can, as it will help search engines to better understand your content.`


#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Follow the steps for acceptance testers with the Product SKU Generator plugin activated. Additionally, re-test the SKU and Product identifier assessments with the Product SKU Generator plugin de-activated according to [these instructions](https://yoast.atlassian.net/browse/PC-369).

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [x] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes https://yoast.atlassian.net/browse/PC-501