### PR TITLE
Disable SKU assessment when variant SKU cannot be detected

### DIFF
--- a/packages/yoastseo/spec/scoring/assessments/seo/ProductSKUAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/ProductSKUAssessmentSpec.js
@@ -161,7 +161,7 @@ describe( "a test for the applicability of the assessment", function() {
 	it( "is applicable when the SKU can be detected", function() {
 		const assessment = new ProductSKUAssessment( { assessVariants: true } );
 		const customData = {
-			canRetrieveSku: true,
+			canRetrieveGlobalSku: true,
 			hasGlobalSKU: false,
 			hasVariants: false,
 			productType: "simple",
@@ -175,7 +175,7 @@ describe( "a test for the applicability of the assessment", function() {
 	it( "is not applicable when the SKU cannot be detected on product without variants", function() {
 		const assessment = new ProductSKUAssessment( { assessVariants: true } );
 		const customData = {
-			canRetrieveSku: false,
+			canRetrieveGlobalSku: false,
 			hasGlobalSKU: false,
 			hasVariants: false,
 			productType: "simple",
@@ -189,7 +189,7 @@ describe( "a test for the applicability of the assessment", function() {
 	it( "is applicable when the SKU cannot be detected on product with variants", function() {
 		const assessment = new ProductSKUAssessment( { assessVariants: true } );
 		const customData = {
-			canRetrieveSku: false,
+			canRetrieveGlobalSku: false,
 			hasGlobalSKU: false,
 			hasVariants: true,
 			productType: "variable",
@@ -198,5 +198,19 @@ describe( "a test for the applicability of the assessment", function() {
 		const isApplicable = assessment.isApplicable( paperWithCustomData );
 
 		expect( isApplicable ).toBe( true );
+	} );
+
+	it( "is not applicable when the SKU of at least one variant cannot be detected on product with variants", function() {
+		const assessment = new ProductSKUAssessment( { assessVariants: true } );
+		const customData = {
+			canRetrieveVariantSkus: false,
+			hasGlobalSKU: false,
+			hasVariants: true,
+			productType: "variable",
+		};
+		const paperWithCustomData = new Paper( "", { customData } );
+		const isApplicable = assessment.isApplicable( paperWithCustomData );
+
+		expect( isApplicable ).toBe( false );
 	} );
 } );

--- a/packages/yoastseo/src/scoring/assessments/seo/ProductSKUAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/ProductSKUAssessment.js
@@ -64,11 +64,13 @@ export default class ProductSKUAssessment extends Assessment {
 	 */
 	isApplicable( paper ) {
 		const customData = paper.getCustomData();
-		/*
-		 * Do not show the assessment when we cannot retrieve the SKU (problems with this have been specifically found for
-		 * products without variants, so the check doesn't apply to products with variants).
-		*/
-		if ( customData.canRetrieveSku === false && customData.hasVariants === false ) {
+
+		 // Do not show the assessment when we cannot retrieve the SKU.
+		if ( customData.canRetrieveGlobalSku === false && customData.hasVariants === false ) {
+			return false;
+		}
+
+		if ( customData.canRetrieveVariantSkus === false && customData.hasVariants === true ) {
 			return false;
 		}
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* In a previous [PR](https://github.com/Yoast/wordpress-seo/pull/18905), the SKU assessment was disabled when we couldn't detect the SKU field. This would happen when the Product SKU generator plugin was used, which would override the input field. While that plugin didn't cause the same issue for the SKU fields of variants, there may be other plugins that do that. So to be on the safe side, in this PR we disable the SKU assessment if the SKU of a variant is not accessible.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Disables the SKU assessment for products with variants when the SKU of at least one variant cannot be detected.

## Relevant technical choices:

* There is an accompanying Woo PR: https://github.com/Yoast/wpseo-woocommerce/pull/821

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

Since we haven't found a plugin that would actually break the SKU variant fields, the way the fix can be tested is by manually deleting the SKU variant fields from the DOM.

* Activate Yoast SEO Free, WooCommerce, and YoastSEO: WooCommerce
     * For acceptance tester: Make sure to link the Free branch when building the Woo branch (composer require yoast/wordpress-seo:dev-PC-504-disabled-sku-assessment-when-cannot-detect-variants-sku@dev --dev)  
* Create a variable product and add two variants ([here's the documentation on how to add variants](https://yoast.atlassian.net/wiki/spaces/LIN/pages/2564686155/How+to+add+variants+to+a+product))
* Delete the DOM element of one variant's SKU. Check this video on how to do it:

https://user-images.githubusercontent.com/32479012/187397211-d156dd5a-72a8-4ca8-91aa-f88236134372.mov


* Open the console and make sure that you do _not_ get the following error (or any other errors):
<img width="521" alt="Screenshot 2022-08-30 at 10 56 47" src="https://user-images.githubusercontent.com/32479012/187397450-14cd53fd-c982-4028-a28f-f16fce2c25e8.png">

* Confirm that the SKU assessment doesn't show up.
* Repeat these steps also with the second variant

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* In addition to the acceptance test steps, re-test the rest of the assessments by following these steps https://yoast.atlassian.net/browse/PC-369

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [x] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes #https://yoast.atlassian.net/jira/software/c/projects/PC/boards/138?modal=detail&selectedIssue=PC-504
