### PR TITLE
Adds filter to disable including multisite xml sitemaps in robots txt

### DIFF
--- a/src/integrations/front-end/robots-txt-integration.php
+++ b/src/integrations/front-end/robots-txt-integration.php
@@ -80,13 +80,13 @@ class Robots_Txt_Integration implements Integration_Interface {
 		$this->maybe_add_xml_sitemap();
 
 		/**
-		 * Filter: 'wpseo_ignore_multisite_subdirectory_xml_sitemaps' - Enabling this filter removes subdirectory sites from xml sitemaps.
+		 * Filter: 'wpseo_should_add_subdirectory_multisite_xml_sitemaps' - Disabling this filter removes subdirectory sites from xml sitemaps.
 		 *
 		 * @since 19.8
 		 *
 		 * @param bool $show Whether to display multisites in the xml sitemaps.
 		 */
-		if ( ! \apply_filters( 'wpseo_ignore_multisite_subdirectory_xml_sitemaps', false ) ) {
+		if ( \apply_filters( 'wpseo_should_add_subdirectory_multisite_xml_sitemaps', true ) ) {
 			$this->add_subdirectory_multisite_xml_sitemaps();
 		}
 

--- a/src/integrations/front-end/robots-txt-integration.php
+++ b/src/integrations/front-end/robots-txt-integration.php
@@ -124,8 +124,20 @@ class Robots_Txt_Integration implements Integration_Interface {
 	 * @return void
 	 */
 	protected function add_subdirectory_multisite_xml_sitemaps() {
+
 		// If not on a multisite subdirectory, bail.
 		if ( ! \is_multisite() || \is_subdomain_install() ) {
+			return;
+		}
+		/**
+		 * Filter: 'wpseo_ignore_multisite_subdirectory_xml_sitemaps' - Enabling this filter removes subdirectory sites from xml sitemaps.
+		 *
+		 *
+		 * @since 19.8
+		 *
+		 * @param bool $show Whether to display multisites in the xml sitemaps.
+		 */
+		if ( \apply_filters( 'wpseo_ignore_multisite_subdirectory_xml_sitemaps', false ) ) {
 			return;
 		}
 

--- a/src/integrations/front-end/robots-txt-integration.php
+++ b/src/integrations/front-end/robots-txt-integration.php
@@ -78,7 +78,17 @@ class Robots_Txt_Integration implements Integration_Interface {
 	public function filter_robots( $robots_txt ) {
 		$robots_txt = $this->remove_default_robots( $robots_txt );
 		$this->maybe_add_xml_sitemap();
-		$this->add_subdirectory_multisite_xml_sitemaps();
+
+		/**
+		 * Filter: 'wpseo_ignore_multisite_subdirectory_xml_sitemaps' - Enabling this filter removes subdirectory sites from xml sitemaps.
+		 *
+		 * @since 19.8
+		 *
+		 * @param bool $show Whether to display multisites in the xml sitemaps.
+		 */
+		if ( ! \apply_filters( 'wpseo_ignore_multisite_subdirectory_xml_sitemaps', false ) ) {
+			$this->add_subdirectory_multisite_xml_sitemaps();
+		}
 
 		/**
 		 * Allow registering custom robots rules to be outputted within the Yoast content block in robots.txt.
@@ -127,17 +137,6 @@ class Robots_Txt_Integration implements Integration_Interface {
 
 		// If not on a multisite subdirectory, bail.
 		if ( ! \is_multisite() || \is_subdomain_install() ) {
-			return;
-		}
-		/**
-		 * Filter: 'wpseo_ignore_multisite_subdirectory_xml_sitemaps' - Enabling this filter removes subdirectory sites from xml sitemaps.
-		 *
-		 *
-		 * @since 19.8
-		 *
-		 * @param bool $show Whether to display multisites in the xml sitemaps.
-		 */
-		if ( \apply_filters( 'wpseo_ignore_multisite_subdirectory_xml_sitemaps', false ) ) {
 			return;
 		}
 

--- a/src/integrations/front-end/robots-txt-integration.php
+++ b/src/integrations/front-end/robots-txt-integration.php
@@ -134,7 +134,6 @@ class Robots_Txt_Integration implements Integration_Interface {
 	 * @return void
 	 */
 	protected function add_subdirectory_multisite_xml_sitemaps() {
-
 		// If not on a multisite subdirectory, bail.
 		if ( ! \is_multisite() || \is_subdomain_install() ) {
 			return;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Some users don't want all multisite XML links visible in the robots.txt this PR provides a way to filter them.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds a filter to remove subdirectory sites from the robots.txt

## Relevant technical choices:

* The choice was made to only make a turn on or off feature, instead of a filter to actually filter the list of subsites.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Start the multisite docker (not multidomain)
* Open https://multisitedomain.wordpress.test/robots.txt you should see 3 entries
* Sitemap: http://multisitedomain.wordpress.test/sitemap_index.xml
Sitemap: https://multisitedomain.wordpress.test/sitemap_index.xml
Sitemap: https://multisitedomain.wordpress.test/site2/sitemap_index.xml
* add `add_filter( 'wpseo_should_add_subdirectory_multisite_xml_sitemaps', __return_false ); ` as a code snippet and refresh the .txt file. It should now only show Sitemap: http://multisitedomain.wordpress.test/sitemap_index.xml
* Stop multisite docker and start multidomain docker
* Open the robots.txt with and without the code snippet there should one be 1 entry `Sitemap: http://multisitedomain.wordpress.test/sitemap_index.xml`
* Stop multisite docker and start basic docker 
* Open the robots.txt with and without the code snippet there should one be 1 entry `Sitemap: http://basic.wordpress.test/sitemap_index.xml`

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [X] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes #
PC-393