### PR TITLE
Allow adding submenu items in the admin bar via action

### DIFF
--- a/inc/class-wpseo-admin-bar-menu.php
+++ b/inc/class-wpseo-admin-bar-menu.php
@@ -28,13 +28,6 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 	const KEYWORD_RESEARCH_SUBMENU_IDENTIFIER = 'wpseo-kwresearch';
 
 	/**
-	 * The identifier used for the frontend inspector submenu.
-	 *
-	 * @var string
-	 */
-	const FRONTEND_INSPECTOR_SUBMENU_IDENTIFIER = 'wpseo-frontend-inspector';
-
-	/**
 	 * The identifier used for the Analysis submenu.
 	 *
 	 * @var string
@@ -126,9 +119,14 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 
 		$this->add_root_menu( $wp_admin_bar );
 
-		if ( ! is_admin() && YoastSEO()->helpers->product->is_premium() ) {
-			$this->add_frontend_inspector_submenu( $wp_admin_bar );
-		}
+		/**
+		* Adds a submenu item in the top of the adminbar.
+		*
+		* @param WP_Admin_Bar $wp_admin_bar    Admin bar instance to add the menu to.
+		* @param string       $menu_identifier The menu identifier.
+		*/
+		do_action( 'wpseo_add_adminbar_submenu', $wp_admin_bar, self::MENU_IDENTIFIER );
+
 		$this->add_keyword_research_submenu( $wp_admin_bar );
 
 		if ( ! is_admin() ) {
@@ -307,30 +305,6 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 			];
 			$wp_admin_bar->add_menu( $menu_args );
 		}
-	}
-
-	/**
-	 * Adds the frontend inspector submenu.
-	 *
-	 * @param WP_Admin_Bar $wp_admin_bar The admin bar.
-	 *
-	 * @return void
-	 */
-	protected function add_frontend_inspector_submenu( WP_Admin_Bar $wp_admin_bar ) {
-		$menu_args = [
-			'parent' => self::MENU_IDENTIFIER,
-			'id'     => self::FRONTEND_INSPECTOR_SUBMENU_IDENTIFIER,
-			'title'  => sprintf(
-				'%1$s <span class="yoast-badge yoast-beta-badge">%2$s</span>',
-				__( 'Front-end SEO inspector', 'wordpress-seo' ),
-				__( 'Beta', 'wordpress-seo' )
-			),
-			'href'   => '#wpseo-frontend-inspector',
-			'meta'   => [
-				'tabindex' => '0',
-			],
-		];
-		$wp_admin_bar->add_menu( $menu_args );
 	}
 
 	/**

--- a/inc/class-wpseo-meta.php
+++ b/inc/class-wpseo-meta.php
@@ -1032,6 +1032,12 @@ class WPSEO_Meta {
 		};
 		$post_ids = array_map( $callback, $post_ids );
 
+		/*
+		 * If Premium is installed, get the additional keywords as well.
+		 * We only check for the additional keywords if we've not already found two.
+		 * In that case there's no use for an additional query as we already know
+		 * that the keyword has been used multiple times before.
+		 */
 		if ( count( $post_ids ) < 2 ) {
 			/**
 			 * Allows to add the additional keywords.

--- a/inc/class-wpseo-meta.php
+++ b/inc/class-wpseo-meta.php
@@ -1032,35 +1032,15 @@ class WPSEO_Meta {
 		};
 		$post_ids = array_map( $callback, $post_ids );
 
-		/*
-		 * If Yoast SEO Premium is active, get the additional keywords as well.
-		 * We only check for the additional keywords if we've not already found two.
-		 * In that case there's no use for an additional query as we already know
-		 * that the keyword has been used multiple times before.
-		 */
-		if ( YoastSEO()->helpers->product->is_premium() && count( $post_ids ) < 2 ) {
-			$query = [
-				'meta_query'     => [
-					[
-						'key'     => '_yoast_wpseo_focuskeywords',
-						'value'   => sprintf( '"keyword":"%s"', $keyword ),
-						'compare' => 'LIKE',
-					],
-				],
-				'post__not_in'   => [ $post_id ],
-				'fields'         => 'ids',
-				'post_type'      => 'any',
-
-				/*
-				 * We only need to return zero, one or two results:
-				 * - Zero: keyword hasn't been used before
-				 * - One: Keyword has been used once before
-				 * - Two or more: Keyword has been used twice or more before
-				 */
-				'posts_per_page' => 2,
-			];
-			$get_posts = new WP_Query( $query );
-			$post_ids  = array_merge( $post_ids, $get_posts->posts );
+		if ( count( $post_ids ) < 2 ) {
+			/**
+			 * Allows to add the additional keywords.
+			 *
+			 * @param array  $post_ids The array of posts ids to be filtered.
+			 * @param string $keyword  The keyword to search for.
+			 * @param int    $post_id  The id of the post the keyword is associated to.
+			 */
+			$post_ids = apply_filters( 'wpseo_posts_of_additional_keywords', $post_ids, $keyword, $post_id );
 		}
 
 		return $post_ids;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Remove Premium code regarding the Frontend Inspector, the additional focus keyphrases and the wincher analysis of additional focus keyphrases

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Follow Test Instructions in https://github.com/Yoast/wordpress-seo-premium/pull/3663

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [x] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes #
