### PR TITLE
PC-516 Add filters for the social templates in the metabox

### DIFF
--- a/admin/formatter/class-post-metabox-formatter.php
+++ b/admin/formatter/class-post-metabox-formatter.php
@@ -293,7 +293,7 @@ class WPSEO_Post_Metabox_Formatter implements WPSEO_Metabox_Formatter_Interface 
 		 * Filters the social template value for a given post type.
 		 *
 		 * @param string $template             The social template value, defaults to empty string.
-		 * @param string $template_option_name The name of the option in which the template you want to get is saved.
+		 * @param string $template_option_name The subname of the option in which the template you want to get is saved.
 		 * @param string $post_type            The name of the post type.
 		 */
 		return \apply_filters( 'wpseo_social_template_post_type', '', $template_option_name, $this->post->post_type );

--- a/admin/formatter/class-post-metabox-formatter.php
+++ b/admin/formatter/class-post-metabox-formatter.php
@@ -51,10 +51,7 @@ class WPSEO_Post_Metabox_Formatter implements WPSEO_Metabox_Formatter_Interface 
 	 * @return bool Whether the social templates should be used.
 	 */
 	public function use_social_templates() {
-		return YoastSEO()->helpers->product->is_premium()
-			&& defined( 'WPSEO_PREMIUM_VERSION' )
-			&& version_compare( WPSEO_PREMIUM_VERSION, '16.5-RC0', '>=' )
-			&& WPSEO_Options::get( 'opengraph', false ) === true;
+		return WPSEO_Options::get( 'opengraph', false ) === true;
 	}
 
 	/**
@@ -275,13 +272,15 @@ class WPSEO_Post_Metabox_Formatter implements WPSEO_Metabox_Formatter_Interface 
 	 * @return string
 	 */
 	private function get_template( $template_option_name ) {
-		$needed_option = $template_option_name . '-' . $this->post->post_type;
-
-		if ( WPSEO_Options::get( $needed_option, '' ) !== '' ) {
-			return WPSEO_Options::get( $needed_option );
-		}
-
-		return '';
+		/**
+		 * Filters the template value for a given post type.
+		 *
+		 * @param string $template             The template value, defaults to empty string.
+		 * @param string $template_option_name The name of the option in which the template you want to get is saved.
+		 * @param string $post_type            The name of the post type.
+		 *
+		 */
+		return \apply_filters( 'wpseo_social_template_post_type', '', $template_option_name, $this->post->post_type );
 	}
 
 	/**

--- a/admin/formatter/class-post-metabox-formatter.php
+++ b/admin/formatter/class-post-metabox-formatter.php
@@ -278,7 +278,6 @@ class WPSEO_Post_Metabox_Formatter implements WPSEO_Metabox_Formatter_Interface 
 		 * @param string $template             The template value, defaults to empty string.
 		 * @param string $template_option_name The name of the option in which the template you want to get is saved.
 		 * @param string $post_type            The name of the post type.
-		 *
 		 */
 		return \apply_filters( 'wpseo_social_template_post_type', '', $template_option_name, $this->post->post_type );
 	}

--- a/admin/formatter/class-post-metabox-formatter.php
+++ b/admin/formatter/class-post-metabox-formatter.php
@@ -232,7 +232,7 @@ class WPSEO_Post_Metabox_Formatter implements WPSEO_Metabox_Formatter_Interface 
 	 */
 	private function get_social_title_template() {
 		if ( $this->use_social_templates ) {
-			return $this->get_template( 'social-title' );
+			return $this->get_social_template( 'title' );
 		}
 
 		return '';
@@ -245,7 +245,7 @@ class WPSEO_Post_Metabox_Formatter implements WPSEO_Metabox_Formatter_Interface 
 	 */
 	private function get_social_description_template() {
 		if ( $this->use_social_templates ) {
-			return $this->get_template( 'social-description' );
+			return $this->get_social_template( 'description' );
 		}
 
 		return '';
@@ -258,7 +258,7 @@ class WPSEO_Post_Metabox_Formatter implements WPSEO_Metabox_Formatter_Interface 
 	 */
 	private function get_social_image_template() {
 		if ( $this->use_social_templates ) {
-			return $this->get_template( 'social-image-url' );
+			return $this->get_social_template( 'image-url' );
 		}
 
 		return '';
@@ -272,10 +272,27 @@ class WPSEO_Post_Metabox_Formatter implements WPSEO_Metabox_Formatter_Interface 
 	 * @return string
 	 */
 	private function get_template( $template_option_name ) {
+		$needed_option = $template_option_name . '-' . $this->post->post_type;
+
+		if ( WPSEO_Options::get( $needed_option, '' ) !== '' ) {
+			return WPSEO_Options::get( $needed_option );
+		}
+
+		return '';
+	}
+
+	/**
+	 * Retrieves a social template.
+	 *
+	 * @param string $template_option_name The name of the option in which the template you want to get is saved.
+	 *
+	 * @return string
+	 */
+	private function get_social_template( $template_option_name ) {
 		/**
-		 * Filters the template value for a given post type.
+		 * Filters the social template value for a given post type.
 		 *
-		 * @param string $template             The template value, defaults to empty string.
+		 * @param string $template             The social template value, defaults to empty string.
 		 * @param string $template_option_name The name of the option in which the template you want to get is saved.
 		 * @param string $post_type            The name of the post type.
 		 */

--- a/admin/formatter/class-term-metabox-formatter.php
+++ b/admin/formatter/class-term-metabox-formatter.php
@@ -228,7 +228,6 @@ class WPSEO_Term_Metabox_Formatter implements WPSEO_Metabox_Formatter_Interface 
 		 * @param string $template             The template value, defaults to empty string.
 		 * @param string $template_option_name The name of the option in which the template you want to get is saved.
 		 * @param string $taxonomy             The name of the taxonomy.
-		 *
 		 */
 		return \apply_filters( 'wpseo_social_template_taxonomy', '', $template_option_name, $this->term->taxonomy );
 	}

--- a/admin/formatter/class-term-metabox-formatter.php
+++ b/admin/formatter/class-term-metabox-formatter.php
@@ -57,10 +57,7 @@ class WPSEO_Term_Metabox_Formatter implements WPSEO_Metabox_Formatter_Interface 
 	 * @return bool Whether the social templates should be used.
 	 */
 	public function use_social_templates() {
-		return YoastSEO()->helpers->product->is_premium()
-			&& defined( 'WPSEO_PREMIUM_VERSION' )
-			&& version_compare( WPSEO_PREMIUM_VERSION, '16.5-RC0', '>=' )
-			&& WPSEO_Options::get( 'opengraph', false ) === true;
+		return WPSEO_Options::get( 'opengraph', false ) === true;
 	}
 
 	/**
@@ -225,8 +222,15 @@ class WPSEO_Term_Metabox_Formatter implements WPSEO_Metabox_Formatter_Interface 
 	 * @return string
 	 */
 	private function get_template( $template_option_name ) {
-		$needed_option = $template_option_name . '-tax-' . $this->term->taxonomy;
-		return WPSEO_Options::get( $needed_option, '' );
+		/**
+		 * Filters the template value for a given taxonomy.
+		 *
+		 * @param string $template             The template value, defaults to empty string.
+		 * @param string $template_option_name The name of the option in which the template you want to get is saved.
+		 * @param string $taxonomy             The name of the taxonomy.
+		 *
+		 */
+		return \apply_filters( 'wpseo_social_template_taxonomy', '', $template_option_name, $this->term->taxonomy );
 	}
 
 	/**

--- a/admin/formatter/class-term-metabox-formatter.php
+++ b/admin/formatter/class-term-metabox-formatter.php
@@ -182,7 +182,7 @@ class WPSEO_Term_Metabox_Formatter implements WPSEO_Metabox_Formatter_Interface 
 	 */
 	private function get_social_title_template() {
 		if ( $this->use_social_templates ) {
-			return $this->get_template( 'social-title' );
+			return $this->get_social_template( 'title' );
 		}
 
 		return '';
@@ -195,7 +195,7 @@ class WPSEO_Term_Metabox_Formatter implements WPSEO_Metabox_Formatter_Interface 
 	 */
 	private function get_social_description_template() {
 		if ( $this->use_social_templates ) {
-			return $this->get_template( 'social-description' );
+			return $this->get_social_template( 'description' );
 		}
 
 		return '';
@@ -208,7 +208,7 @@ class WPSEO_Term_Metabox_Formatter implements WPSEO_Metabox_Formatter_Interface 
 	 */
 	private function get_social_image_template() {
 		if ( $this->use_social_templates ) {
-			return $this->get_template( 'social-image-url' );
+			return $this->get_social_template( 'image-url' );
 		}
 
 		return '';
@@ -222,10 +222,22 @@ class WPSEO_Term_Metabox_Formatter implements WPSEO_Metabox_Formatter_Interface 
 	 * @return string
 	 */
 	private function get_template( $template_option_name ) {
+		$needed_option = $template_option_name . '-tax-' . $this->term->taxonomy;
+		return WPSEO_Options::get( $needed_option, '' );
+	}
+
+	/**
+	 * Retrieves a social template.
+	 *
+	 * @param string $template_option_name The name of the option in which the template you want to get is saved.
+	 *
+	 * @return string
+	 */
+	private function get_social_template( $template_option_name ) {
 		/**
-		 * Filters the template value for a given taxonomy.
+		 * Filters the social template value for a given taxonomy.
 		 *
-		 * @param string $template             The template value, defaults to empty string.
+		 * @param string $template             The social template value, defaults to empty string.
 		 * @param string $template_option_name The name of the option in which the template you want to get is saved.
 		 * @param string $taxonomy             The name of the taxonomy.
 		 */

--- a/admin/formatter/class-term-metabox-formatter.php
+++ b/admin/formatter/class-term-metabox-formatter.php
@@ -238,7 +238,7 @@ class WPSEO_Term_Metabox_Formatter implements WPSEO_Metabox_Formatter_Interface 
 		 * Filters the social template value for a given taxonomy.
 		 *
 		 * @param string $template             The social template value, defaults to empty string.
-		 * @param string $template_option_name The name of the option in which the template you want to get is saved.
+		 * @param string $template_option_name The subname of the option in which the template you want to get is saved.
 		 * @param string $taxonomy             The name of the taxonomy.
 		 */
 		return \apply_filters( 'wpseo_social_template_taxonomy', '', $template_option_name, $this->term->taxonomy );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to allow Premium to filter the social template values in the metabox

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds `wpseo_social_template_post_type` and `wpseo_social_template_taxonomy` filters for the social templates in the metabox.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install without Premium
* Create a new post, move to the Social tab of the metabox
* Check that the Facebook and Twitter boxes work as expected
* Create a new term in a taxonomy, move to the Social tab of the metabox
* Check that the Facebook and Twitter boxes work as expected 
* Install and activate Premium < 19.2.1
* in Search Appearance, add social templates  (image, title, description) for the post type and the taxonomy
* Create a new post, move to the Social tab of the metabox
  * see that the tab is switched into preview mode, but it's not filled in with values from the social templates
  * _side note: if you publish the post and inspect the front-end, the OG tags will display the social templates_
* Create a new term in a taxonomy, move to the Social tab of the metabox
  * see that the tab is switched into preview mode, but it's not filled in with values from the social templates
  * _side note: if you publish the term and inspect the front-end, the OG tags will display the social templates_
* downgrade to the current released Free - Social tab of the metabox should contain the same data
* test the matching Premium PR.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [x] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

* Check that it works for different post types
* Check that it works for different taxonomies
* Check the metabox in the Block editor, in Classic editor and Elementor: no need to check everything, just be sure that the template values are loaded

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes [PC-516]


[PC-516]: https://yoast.atlassian.net/browse/PC-516?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ