### PR TITLE
PC-518  Add filters for the keyphrases collected by Wincher

### DIFF
--- a/src/actions/wincher/wincher-keyphrases-action.php
+++ b/src/actions/wincher/wincher-keyphrases-action.php
@@ -261,14 +261,14 @@ class Wincher_Keyphrases_Action {
 			$keyphrases[] = $primary_keyphrase->primary_focus_keyword;
 		}
 
-		if ( \YoastSEO()->helpers->product->is_premium() ) {
-			$additional_keywords = \json_decode( WPSEO_Meta::get_value( 'focuskeywords', $post->ID ), true );
-
-			$keyphrases = \array_merge( $keyphrases, $additional_keywords );
-		}
-
-		return $keyphrases;
-	}
+		/**
+		 * Filters the keyphrases collected by the Wincher integration from the post.
+		 *
+		 * @param array $keyphrases The keyphrases array.
+		 * @param int   $post_id    The ID of the post.
+		 */
+		return \apply_filters( 'wpseo_wincher_keyphrases_from_post', $keyphrases, $post->ID );
+}
 
 	/**
 	 * Collects all keyphrases known to Yoast.
@@ -291,30 +291,12 @@ class Wincher_Keyphrases_Action {
 			'primary_focus_keyword'
 		);
 
-		if ( \YoastSEO()->helpers->product->is_premium() ) {
-			// Collect all related keyphrases.
-			$meta_key = WPSEO_Meta::$meta_prefix . 'focuskeywords';
-
-			$query = "
-				SELECT meta_value
-				FROM $wpdb->postmeta
-				JOIN $wpdb->posts ON {$wpdb->posts}.id = {$wpdb->postmeta}.post_id
-				WHERE meta_key = '$meta_key' AND post_status != 'trash'
-			";
-
-			// phpcs:ignore -- ignoring since it's complaining about not using prepare when it's perfectly safe here.
-			$results = $wpdb->get_results( $query );
-
-			if ( $results ) {
-				foreach ( $results as $row ) {
-					$additional_keywords = \json_decode( $row->meta_value, true );
-					if ( $additional_keywords !== null ) {
-						$additional_keywords = \array_column( $additional_keywords, 'keyword' );
-						$keyphrases          = \array_merge( $keyphrases, $additional_keywords );
-					}
-				}
-			}
-		}
+		/**
+		 * Filters the keyphrases collected by the Wincher integration from all the posts.
+		 *
+		 * @param array $keyphrases The keyphrases array.
+		 */
+		$keyphrases = \apply_filters( 'wpseo_wincher_all_keyphrases', $keyphrases );
 
 		// Filter out empty entries.
 		return \array_filter( $keyphrases );

--- a/src/actions/wincher/wincher-keyphrases-action.php
+++ b/src/actions/wincher/wincher-keyphrases-action.php
@@ -268,7 +268,7 @@ class Wincher_Keyphrases_Action {
 		 * @param int   $post_id    The ID of the post.
 		 */
 		return \apply_filters( 'wpseo_wincher_keyphrases_from_post', $keyphrases, $post->ID );
-}
+	}
 
 	/**
 	 * Collects all keyphrases known to Yoast.

--- a/tests/unit/actions/wincher/wincher-keyphrases-action-test.php
+++ b/tests/unit/actions/wincher/wincher-keyphrases-action-test.php
@@ -254,15 +254,7 @@ class Wincher_Keyphrases_Action_Test extends TestCase {
 				]
 			);
 
-		$product_helper_mock = Mockery::mock( Product_Helper::class );
-		$product_helper_mock->expects( 'is_premium' )->once()->andReturn( false );
-		$helpers_mock = (object) [ 'product' => $product_helper_mock ];
-
-		Monkey\Functions\expect( 'YoastSEO' )->once()->andReturn(
-			(object) [
-				'helpers' => $helpers_mock,
-			]
-		);
+		Monkey\Filters\expectApplied( 'wpseo_wincher_all_keyphrases' );
 
 		$this->client_instance
 			->expects( 'post' )


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to allow Premium to filter the keyphrases collected by the Wincher integration

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds `wpseo_wincher_keyphrases_from_post` and `wpseo_wincher_all_keyphrases` filters to enhance the collected keyphrases arrays

## Relevant technical choices:

* **Note:** one of the part that have been touched is used by code which is currently not working, because it's behind a conditional related to the automated tracking feature which cannot be turned on. There is no way to test it then at the moment.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install without Premium active
* Check that Wincher is working as expected (adding/removing keyphrases in post edit screen, checking the tracked keyphrases in the dashboard widget)
* activate Premium < 19.2.1
* add some additional keyphrases and track them in Wincher, then publish the post
* visit the WordPress Dashboard and see that no additional keyphrases are displayed, only primary ones. 
* downgrade to current Free and see that the WordPress Dashboard widget displays all the keyphrases.
* Test the matching Premium PR https://github.com/Yoast/wordpress-seo-premium/pull/3666

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [x] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

No change is related to any of the editors, but we should test on Block editor, Classic Editor and Elementor anyway

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes [PC-518]


[PC-518]: https://yoast.atlassian.net/browse/PC-518?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ