### PR TITLE
Add filter for related keyphrases

### DIFF
--- a/admin/formatter/class-post-metabox-formatter.php
+++ b/admin/formatter/class-post-metabox-formatter.php
@@ -158,34 +158,7 @@ class WPSEO_Post_Metabox_Formatter implements WPSEO_Metabox_Formatter_Interface 
 		$keyword = WPSEO_Meta::get_value( 'focuskw', $this->post->ID );
 		$usage   = [ $keyword => $this->get_keyword_usage_for_current_post( $keyword ) ];
 
-		if ( YoastSEO()->helpers->product->is_premium() ) {
-			return $this->get_premium_keywords( $usage );
-		}
-
-		return $usage;
-	}
-
-	/**
-	 * Retrieves the additional keywords from Premium, that are associated with the post.
-	 *
-	 * @param array $usage The original keyword usage for the main keyword.
-	 *
-	 * @return array The keyword usage, including the additional keywords.
-	 */
-	protected function get_premium_keywords( $usage ) {
-		$additional_keywords = json_decode( WPSEO_Meta::get_value( 'focuskeywords', $this->post->ID ), true );
-
-		if ( empty( $additional_keywords ) ) {
-			return $usage;
-		}
-
-		foreach ( $additional_keywords as $additional_keyword ) {
-			$keyword = $additional_keyword['keyword'];
-
-			$usage[ $keyword ] = $this->get_keyword_usage_for_current_post( $keyword );
-		}
-
-		return $usage;
+		return apply_filters( 'wpseo_posts_for_related_keywords', $usage, $this->post->ID );
 	}
 
 	/**

--- a/admin/formatter/class-post-metabox-formatter.php
+++ b/admin/formatter/class-post-metabox-formatter.php
@@ -158,6 +158,12 @@ class WPSEO_Post_Metabox_Formatter implements WPSEO_Metabox_Formatter_Interface 
 		$keyword = WPSEO_Meta::get_value( 'focuskw', $this->post->ID );
 		$usage   = [ $keyword => $this->get_keyword_usage_for_current_post( $keyword ) ];
 
+		/**
+		* Allows enhancing the array of posts' that share their focus keywords with the post's related keywords.
+		*
+		* @param array $usage   The array of posts' ids that share their focus keywords with the post.
+		* @param int   $post_id The id of the post we're finding the usage of related keywords for.
+		*/
 		return apply_filters( 'wpseo_posts_for_related_keywords', $usage, $this->post->ID );
 	}
 

--- a/inc/class-wpseo-meta.php
+++ b/inc/class-wpseo-meta.php
@@ -1046,7 +1046,7 @@ class WPSEO_Meta {
 			 * @param string $keyword  The keyword to search for.
 			 * @param int    $post_id  The id of the post the keyword is associated to.
 			 */
-			$post_ids = apply_filters( 'wpseo_posts_of_additional_keywords', $post_ids, $keyword, $post_id );
+			$post_ids = apply_filters( 'wpseo_posts_for_focus_keyword', $post_ids, $keyword, $post_id );
 		}
 
 		return $post_ids;

--- a/inc/class-wpseo-meta.php
+++ b/inc/class-wpseo-meta.php
@@ -1040,9 +1040,9 @@ class WPSEO_Meta {
 		 */
 		if ( count( $post_ids ) < 2 ) {
 			/**
-			 * Allows to add the additional keywords.
+			 * Allows enhancing the array of posts' that share their focus keywords with the post's focus keywords.
 			 *
-			 * @param array  $post_ids The array of posts ids to be filtered.
+			 * @param array  $post_ids The array of posts' ids that share their related keywords with the post.
 			 * @param string $keyword  The keyword to search for.
 			 * @param int    $post_id  The id of the post the keyword is associated to.
 			 */


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Remove Premium code regarding the related keyphrases' assessment

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Follow Test Instructions of https://github.com/Yoast/wordpress-seo-premium/pull/3667

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes #
