### PR TITLE
PC-418 Adds which plugins have auto updating enabled.

### DIFF
--- a/admin/tracking/class-tracking-plugin-data.php
+++ b/admin/tracking/class-tracking-plugin-data.php
@@ -11,6 +11,13 @@
 class WPSEO_Tracking_Plugin_Data implements WPSEO_Collection {
 
 	/**
+	 * Plugins with auto updating enabled.
+	 *
+	 * @var array $auto_update_plugin_list
+	 */
+	private $auto_update_plugin_list;
+
+	/**
 	 * Returns the collection data.
 	 *
 	 * @return array The collection data.
@@ -31,9 +38,10 @@ class WPSEO_Tracking_Plugin_Data implements WPSEO_Collection {
 		if ( ! function_exists( 'get_plugin_data' ) ) {
 			require_once ABSPATH . 'wp-admin/includes/plugin.php';
 		}
-
 		$plugins = wp_get_active_and_valid_plugins();
+
 		$plugins = array_map( 'get_plugin_data', $plugins );
+		$this->set_auto_update_plugin_list();
 		$plugins = array_map( [ $this, 'format_plugin' ], $plugins );
 
 		$plugin_data = [];
@@ -46,6 +54,25 @@ class WPSEO_Tracking_Plugin_Data implements WPSEO_Collection {
 	}
 
 	/**
+	 * Sets all auto updating plugin data so it can be used in the tracking list.
+	 *
+	 * @return void
+	 */
+	public function set_auto_update_plugin_list() {
+
+		$auto_update_plugins      = [];
+		$auto_update_plugin_files = \get_option( 'auto_update_plugins' );
+		if ( $auto_update_plugin_files ) {
+			foreach ( $auto_update_plugin_files as $auto_update_plugin ) {
+				$data                                 = get_plugin_data( WP_PLUGIN_DIR . DIRECTORY_SEPARATOR . $auto_update_plugin );
+				$auto_update_plugins[ $data['Name'] ] = $data;
+			}
+		}
+
+		$this->auto_update_plugin_list = $auto_update_plugins;
+	}
+
+	/**
 	 * Formats the plugin array.
 	 *
 	 * @param array $plugin The plugin details.
@@ -53,9 +80,11 @@ class WPSEO_Tracking_Plugin_Data implements WPSEO_Collection {
 	 * @return array The formatted array.
 	 */
 	protected function format_plugin( array $plugin ) {
+
 		return [
-			'name'    => $plugin['Name'],
-			'version' => $plugin['Version'],
+			'name'          => $plugin['Name'],
+			'version'       => $plugin['Version'],
+			'auto_updating' => \array_key_exists( $plugin['Name'], $this->auto_update_plugin_list ),
 		];
 	}
 }

--- a/admin/tracking/class-tracking.php
+++ b/admin/tracking/class-tracking.php
@@ -106,7 +106,7 @@ class WPSEO_Tracking implements WPSEO_WordPress_Integration {
 	 * Sends the tracking data.
 	 *
 	 * @param bool $force Whether to send the tracking data ignoring the two
-	 *                    weeks time treshhold. Default false.
+	 *                    weeks time threshold. Default false.
 	 */
 	public function send( $force = false ) {
 		if ( ! $this->should_send_tracking( $force ) ) {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to know if users have auto updating on for plugins.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds additional key to tracking data with auto updating information

## Relevant technical choices:

* None.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Make sure tacking is enabled on /admin.php?page=wpseo_dashboard#top#first-time-configuration in the personal preferences step.
* Disable all auto updating plugins and make sure query monitor is running
* Open https://basic.wordpress.test/wp-admin/options.php and look for the option wpseo_tracking_last_request
* Set the value of this option to 1600000000 and save.
* On the page that is loaded after saving open query monitor look in the HTTP API calls section and see if https://tracking.yoast.com/stats was sent.

* Enable auto updating on an active plugin
* Open https://basic.wordpress.test/wp-admin/options.php and look for the option wpseo_tracking_last_request
* Set the value of this option to 1600000000 and save.
* On the page that is loaded after saving open query monitor look in the HTTP API calls section and see if https://tracking.yoast.com/stats was sent.

*refresh again and see that no HTTP calls were sent to tracking.yoast.com

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes #
PC-418