### PR TITLE
Fixes a bug where ID is not a property of $GLOBALS['wp_query']->posts[0]

### DIFF
--- a/src/context/meta-tags-context.php
+++ b/src/context/meta-tags-context.php
@@ -622,6 +622,10 @@ class Meta_Tags_Context extends Abstract_Presentation {
 			case is_date():
 			case is_post_type_archive():
 				if ( ! empty( $GLOBALS['wp_query']->posts ) ) {
+					if ( $GLOBALS['wp_query']->get( 'fields', 'all' ) == 'ids' ) {
+						return $this->get_singular_post_image( $GLOBALS['wp_query']->posts[0] );
+					}
+					
 					return $this->get_singular_post_image( $GLOBALS['wp_query']->posts[0]->ID );
 				}
 				return null;

--- a/src/context/meta-tags-context.php
+++ b/src/context/meta-tags-context.php
@@ -625,7 +625,7 @@ class Meta_Tags_Context extends Abstract_Presentation {
 					if ( $GLOBALS['wp_query']->get( 'fields', 'all' ) === 'ids' ) {
 						return $this->get_singular_post_image( $GLOBALS['wp_query']->posts[0] );
 					}
-					
+
 					return $this->get_singular_post_image( $GLOBALS['wp_query']->posts[0]->ID );
 				}
 				return null;

--- a/src/context/meta-tags-context.php
+++ b/src/context/meta-tags-context.php
@@ -622,7 +622,7 @@ class Meta_Tags_Context extends Abstract_Presentation {
 			case is_date():
 			case is_post_type_archive():
 				if ( ! empty( $GLOBALS['wp_query']->posts ) ) {
-					if ( $GLOBALS['wp_query']->get( 'fields', 'all' ) == 'ids' ) {
+					if ( $GLOBALS['wp_query']->get( 'fields', 'all' ) === 'ids' ) {
 						return $this->get_singular_post_image( $GLOBALS['wp_query']->posts[0] );
 					}
 					


### PR DESCRIPTION
Allow WP Queries where the parameter "fields" is set to "ids".
Otherwise ID is not a property of $GLOBALS['wp_query']->posts[0].

## Context
I was getting a PHP notice in one of my personal projects.
So I tried to resolve it.


## Summary

* Fixes a bug where a warning would be thrown on archive and search pages when the main query is set to return IDs instead of post objects. Props to @mathiasdb.

## Relevant technical choices:

The line `return $this->get_singular_post_image( $GLOBALS['wp_query']->posts[0]->ID );` is guesswork. You don't know if $posts[0] is null, false, "", an object.

## Test instructions

* Add this code at the end of your theme's `functions.php`:
```
function use_ids_in_archive( $query ) {
    if ( ! is_admin() && ( is_archive() || is_search() ) && $query->is_main_query() ) {
	    $query->set( "fields", "ids" );
    }
}
add_action( 'pre_get_posts', 'use_ids_in_archive' );
```
* Visit an archive (date, author, taxonomy, post type) or perform a search:
  * without this patch, you would get a `Warning: Attempt to read property "ID" on int in /var/www/html/wp-content/plugins/wordpress-seo/src/context/meta-tags-context.php on line 626` and the `CollectionPage` Schema piece would not have a `primaryImageOfPage` property set
  * with this patch, you should get  the warning above and the `CollectionPage` Schema piece should have a `primaryImageOfPage` property set to the main image of the first post (make sure it has one)
* check that single post or pages or the home page are unaffected.

### Test instructions for the acceptance test before the PR gets merged

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

### Test instructions for QA when the code is in the RC

See above

## Impact check

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes #
