### PR TITLE
Check if post is not its own parent

### DIFF
--- a/src/builders/indexable-post-builder.php
+++ b/src/builders/indexable-post-builder.php
@@ -250,7 +250,7 @@ class Indexable_Post_Builder {
 		}
 
 		// The attachment should have a post parent.
-		if ( empty( $indexable->post_parent ) ) {
+		if ( empty( $indexable->post_parent ) || $indexable->post_parent === $indexable->object_id ) {
 			return false;
 		}
 


### PR DESCRIPTION
## Context

If any post is it's own parent (could be wrongly set in database) running indexing action will loop itself indefinitely.

## Summary

`changelog: bugfix`

This PR can be summarized in the following changelog entry:

* Bugfix

