### PR TITLE
Conditionally align to the left the indexables titles when no stars a…

### DIFF
--- a/packages/js/src/indexables-page/indexables-page.js
+++ b/packages/js/src/indexables-page/indexables-page.js
@@ -195,24 +195,28 @@ function IndexablesPage( { setupInfo } ) {
 		return isListFeatureEnabled( listName ) && ! isListLoaded( listName );
 	}, [ isListLoaded, isListFeatureEnabled ] );
 
-
 	const shouldShowTable = useCallback( listName => {
 		// If a fetch has been completed, the feature for the list is enabled, and the list is not empty.
 		return isListFeatureEnabled( listName ) && isListLoaded( listName ) && ! isListEmpty( listName );
 	}, [ isListFeatureEnabled, isListLoaded, isListEmpty ] );
-
 
 	const shouldShowEmptyAlert = useCallback( listName => {
 		// If a fetch has been completed, the feature for the list is enabled, but the list is empty.
 		return isListFeatureEnabled( listName ) && isListLoaded( listName ) && isListEmpty( listName );
 	}, [ isListFeatureEnabled, isListLoaded, isListEmpty ] );
 
-
 	const shouldShowErrorAlert = useCallback( listName => {
 		// If the feature for the list is enabled but the fetch has failed.
 		return isListErrored( listName );
 	}, [ isListErrored ] );
 
+	const shouldDisplayStars =  useCallback( () => {
+		const numberOfStars = indexablesLists.most_linked
+			.slice( 0, 5 )
+			.filter( indexable => !! parseInt( indexable.is_cornerstone, 10 ) )
+			.length;
+		return numberOfStars > 0;
+	}, [ indexablesLists.most_linked ] );
 
 	/**
 	 * Fetches a list of indexables.
@@ -952,13 +956,15 @@ function IndexablesPage( { setupInfo } ) {
 										position={ position }
 										setErrorMessage={ setErrorMessage }
 									>
-										<div className="yst-flex yst-items-center">
-											{
-												( !! parseInt( indexable.is_cornerstone, 10 ) === true )
-													? <StarIcon className="yst-h-4 yst-w-4 yst-text-gray-700" />
-													: <div className="yst-w-4" />
-											}
-										</div>
+										{ 
+											( shouldDisplayStars() ) && <div className="yst-flex yst-items-center">
+												{
+													( !! parseInt( indexable.is_cornerstone, 10 ) === true )
+														? <StarIcon className="yst-h-4 yst-w-4 yst-text-gray-700" />
+														: <div className="yst-w-4" />
+												}
+											</div> 
+										}
 										<IndexableLinkCount count={ parseInt( indexable.incoming_link_count, 10 ) } />
 										<IndexableTitleLink indexable={ indexable } />
 										<div>


### PR DESCRIPTION
…re present

## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* When no stars are present in the `Highest number of incoming links` card, we want the indexable titles to be left-aligned with the card's border

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Left-align indexables titles in the `Highest number of incoming links` card when no stars are displayed

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Make sure you have at least 6 posts which are referred by some other posts
* The indexables titles in the `Highest number of incoming links` card should be left-aligned:
<img width="696" alt="Screenshot 2022-09-02 at 12 19 35" src="https://user-images.githubusercontent.com/68744851/188118984-9fb60145-2354-4f71-a771-a84bdab25ebe.png">
* Set flag one of the 5 indexables present in the list as cornerstone content: verify that the star appears beside its title and all the other titles are shifted to the right:
<img width="663" alt="Screenshot 2022-09-02 at 12 21 44" src="https://user-images.githubusercontent.com/68744851/188119295-8a3c0604-4e02-4238-b1aa-e47609c15c78.png">
* Now un-set that indexable as cornerstone content and set as cornerstone content one of the indexables that do not appear in the `Highest number of incoming links` card
* Verify that the titles are left-aligned:
<img width="696" alt="Screenshot 2022-09-02 at 12 19 35" src="https://user-images.githubusercontent.com/68744851/188118984-9fb60145-2354-4f71-a771-a84bdab25ebe.png">

Also verify the below case:
* No cornerstone content within your 6 posts.
* Check in the Most Linked list, which post is outside the list and mark *that* as cornerstone, but not any other ones.
* Ignore 1 post from that list
* Confirm that the 6th post (that now got into the list) is starred but the rest aren't.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.

Fixes [PC-535](https://yoast.atlassian.net/browse/PC-535)
