### PR TITLE
Pc 513 show title in loading state

### DIFF
--- a/packages/js/src/indexables-page/components/indexables-card.js
+++ b/packages/js/src/indexables-page/components/indexables-card.js
@@ -18,7 +18,7 @@ function IndexablesPageCard( { title, className, options, children } ) {
 			className="yst-bg-white yst-rounded-lg yst-p-8 yst-shadow"
 		>
 			<div className="yst-w-full yst-flex yst-justify-between">
-				<h3 className="yst-mb-4 yst-text-base yst-text-gray-900 yst-font-medium">
+				<h3 className="yst-mb-4 yst-text-base yst-text-gray-900 yst-font-medium yst-w-full">
 					{ title }
 				</h3>
 				{ options.length > 0 && <DotsMenu options={ options } /> }

--- a/packages/js/src/indexables-page/indexables-page.js
+++ b/packages/js/src/indexables-page/indexables-page.js
@@ -942,14 +942,14 @@ function IndexablesPage( { setupInfo } ) {
 										position={ position }
 										setErrorMessage={ setErrorMessage }
 									>
-										{ 
+										{
 											( shouldDisplayStars() ) && <div className="yst-flex yst-items-center">
 												{
 													( !! parseInt( indexable.is_cornerstone, 10 ) === true )
 														? <StarIcon className="yst-h-4 yst-w-4 yst-text-gray-700" />
 														: <div className="yst-w-4" />
 												}
-											</div> 
+											</div>
 										}
 										<IndexableLinkCount count={ parseInt( indexable.incoming_link_count, 10 ) } />
 										<IndexableTitleLink indexable={ indexable } />


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Add loading state in the cards' titles when loading.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Quickly smoke test that when the lists are loading, the titles of the lists are also in a loading state:
![image](https://user-images.githubusercontent.com/12400734/188139754-ed469d8d-9cff-4793-86b2-e93f3bd41590.png)


#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes #
