### PR TITLE
Pc 537 layout of the new indexables page is off

### DIFF
--- a/packages/js/src/indexables-page/components/not-enough-analysed-content.js
+++ b/packages/js/src/indexables-page/components/not-enough-analysed-content.js
@@ -53,7 +53,7 @@ const NotEnoughAnalysedContent = ( { indexablesList, seoEnabled } ) => {
 	return <div className="yst-max-w-full">
 		<div
 			id="start-writing-content"
-			className="yst-max-w-2xl"
+			className="yst-max-w-7xl yst-grid yst-grid-cols-1 2xl:yst-grid-cols-2 2xl:yst-grid-flow-row yst-gap-6"
 		>
 			<IndexablesPageCard
 				title={ title }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The card displayed in the `Posts and pages without a focus keyphrase/Posts and pages that haven't been analyzed` page is misaligned

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Correctly aligns the card in the `Posts and pages without a focus keyphrase/Posts and pages that haven't been analyzed` page

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Make sure you have more than 20 public posts/pages but less that 50% of them analysed; alternatively use the filters described in [this PR](https://github.com/Yoast/wordpress-seo/pull/18660) to adjust the threshold as needed to get to the `Posts and pages without a focus keyphrase/Posts and pages that haven't been analyzed` page
* Without this PR, the card is displayed as follows:
<img width="1009" alt="Screenshot 2022-09-02 at 14 53 27" src="https://user-images.githubusercontent.com/68744851/188151002-2339d721-5046-49ed-b248-c80540c8ed58.png">

* With this PR, the card is displayed as follows:
<img width="1369" alt="Screenshot 2022-09-02 at 14 52 31" src="https://user-images.githubusercontent.com/68744851/188151022-1b0d08c7-5b7f-4a6e-92f4-e601c954dd47.png">

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [X] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes [PC-537](https://yoast.atlassian.net/browse/PC-537)
