### PR TITLE
Pc 536 seo optimization flow improvement

### DIFF
--- a/packages/js/src/first-time-configuration/tailwind-components/steps/finish/finish-step.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/steps/finish/finish-step.js
@@ -9,8 +9,7 @@ import { ReactComponent as ConfigurationFinishImage } from "../../../../../image
  * @returns {void}
  */
 function goToSEODashboard() {
-	document.getElementById( "dashboard-tab" ).click();
-	window.scrollTo( 0, 0 );
+	window.location.href = "admin.php?page=wpseo_dashboard";
 }
 
 /**

--- a/packages/js/src/indexables-page/components/indexation-view.js
+++ b/packages/js/src/indexables-page/components/indexation-view.js
@@ -25,7 +25,7 @@ function IndexationView( { setIndexingState } ) {
 					{ __( "We would like to show you insights into content that we feel could use improving.", "wordpress-seo" ) }
 				</p>
 				<p className="yst-gray-500 yst-font-normal yst-leading-normal yst-mb-6">
-					{ __( "Help us to analyze your site by running the SEO data optimization below.", "wordpress-seo" ) }
+					{ __( "Help us to analyze your site by running the site analysis below.", "wordpress-seo" ) }
 				</p>
 				<Indexation
 					preIndexingActions={ window.yoast.indexing.preIndexingActions }

--- a/packages/js/src/indexables-page/components/indexation.js
+++ b/packages/js/src/indexables-page/components/indexation.js
@@ -210,7 +210,7 @@ export class Indexation extends Component {
 	}
 
 	/**
-	 * Start indexation on mount, when redirected from the "Start SEO data optimization" button in the dashboard notification.
+	 * Start indexation on mount, when redirected from the "Start site analysis" button in the dashboard notification.
 	 *
 	 * @returns {void}
 	 */
@@ -280,7 +280,7 @@ export class Indexation extends Component {
 			className="yst-button yst-button--primary"
 			onClick={ this.startIndexing }
 		>
-			{ __( "Start SEO data optimization", "wordpress-seo" ) }
+			{ __( "Start site analysis", "wordpress-seo" ) }
 		</button>;
 	}
 
@@ -295,7 +295,7 @@ export class Indexation extends Component {
 			className="yst-button yst-button--secondary"
 			onClick={ this.stopIndexing }
 		>
-			{ __( "Stop SEO data optimization", "wordpress-seo" ) }
+			{ __( "Stop site analysis", "wordpress-seo" ) }
 		</button>;
 	}
 
@@ -312,11 +312,11 @@ export class Indexation extends Component {
 					className="yst-button yst-button--secondary yst-button--disabled"
 					disabled={ true }
 				>
-					{ __( "Start SEO data optimization", "wordpress-seo" ) }
+					{ __( "Start site analysis", "wordpress-seo" ) }
 				</button>
 			</p>
 			<Alert type={ "info" } className="yst-mt-6">
-				{ __( "SEO data optimization is disabled for non-production environments.", "wordpress-seo" ) }
+				{ __( "Site analysis is disabled for non-production environments.", "wordpress-seo" ) }
 			</Alert>
 		</Fragment>;
 	}

--- a/packages/js/src/indexables-page/indexables-page.js
+++ b/packages/js/src/indexables-page/indexables-page.js
@@ -982,7 +982,7 @@ function IndexablesPage( { setupInfo } ) {
 				ignoredIndexable && <Button variant="secondary" onClick={ onClickUndo( ignoredIndexable ) }>
 					{
 						/* translators: %1$s expands to the title of a post that was just just hidden. */
-						sprintf( __( "Restore %1$s", "wordpress-seo" ), ignoredIndexable.indexable.breadcrumb_title )
+						sprintf( __( 'Restore "%1$s"', "wordpress-seo" ), ignoredIndexable.indexable.breadcrumb_title )
 					}
 				</Button>
 			}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improve the relation between the Indexables Overview and the FTC, in regards to the SEO optimization

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

**For the copy change:**
* Visit the Indexables page with Indexables cleaned out. Verify the copy is like below:
![image](https://user-images.githubusercontent.com/12400734/188398841-475976db-8918-4f0e-afb2-b6b44a35368c.png)
* When that button is clicked, it should then change its copy to this:
![image](https://user-images.githubusercontent.com/12400734/188399609-d4b86377-c90f-48ce-ba24-91327b9234f3.png)

**For the reloading of the page from the FTC:**
* Make sure that the SEO optimization in the first step of the FTC, is complete.
* When visiting the last step of the FTC, click on the `Go to your SEO dashboard` button
* Do that for Premium both active and inactive

**For the small part of adding quotes around the post title in the restore button** (no need for separate PR, tiny change):
* In the Indexables Page, ignore a post from one of the lists
* Confirm that the button shown at the bottom, has the title of the ignored post around quotes:
![image](https://user-images.githubusercontent.com/12400734/188418223-a1306aef-802c-4f3b-afad-21361d091ff9.png)


#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [x] Changes should be tested on different browsers
* [x] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes #
