### PR TITLE
Do not show Product identifier assessment when the identifiers cannot be retrieved

### DIFF
--- a/packages/yoastseo/spec/scoring/assessments/seo/ProductIdentifiersAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/ProductIdentifiersAssessmentSpec.js
@@ -160,5 +160,118 @@ describe( "a test for the applicability of the assessment", function() {
 
 		expect( isApplicable ).toBe( false );
 	} );
+
+	it( "is applicable when the global identifier of a simple product can be detected", function() {
+		const assessment = new ProductIdentifiersAssessment( { assessVariants: true } );
+		const customData = {
+			canRetrieveGlobalIdentifier: true,
+			hasGlobalIdentifier: false,
+			hasVariants: false,
+			productType: "simple",
+		};
+		const paperWithCustomData = new Paper( "", { customData } );
+		const isApplicable = assessment.isApplicable( paperWithCustomData );
+
+		expect( isApplicable ).toBe( true );
+	} );
+
+	it( "is applicable when the global identifier of an external product can be detected", function() {
+		const assessment = new ProductIdentifiersAssessment( { assessVariants: true } );
+		const customData = {
+			canRetrieveGlobalIdentifier: true,
+			hasGlobalIdentifier: false,
+			hasVariants: false,
+			productType: "external",
+		};
+		const paperWithCustomData = new Paper( "", { customData } );
+		const isApplicable = assessment.isApplicable( paperWithCustomData );
+
+		expect( isApplicable ).toBe( true );
+	} );
+
+	it( "is not applicable when the global identifier of a simple product cannot be detected", function() {
+		const assessment = new ProductIdentifiersAssessment( { assessVariants: true } );
+		const customData = {
+			canRetrieveGlobalIdentifier: false,
+			hasGlobalIdentifier: false,
+			hasVariants: false,
+			productType: "simple",
+		};
+		const paperWithCustomData = new Paper( "", { customData } );
+		const isApplicable = assessment.isApplicable( paperWithCustomData );
+
+		expect( isApplicable ).toBe( false );
+	} );
+
+	it( "is not applicable when the global identifier of an external product cannot be detected", function() {
+		const assessment = new ProductIdentifiersAssessment( { assessVariants: true } );
+		const customData = {
+			canRetrieveGlobalIdentifier: false,
+			hasGlobalIdentifier: false,
+			hasVariants: false,
+			productType: "external",
+		};
+		const paperWithCustomData = new Paper( "", { customData } );
+		const isApplicable = assessment.isApplicable( paperWithCustomData );
+
+		expect( isApplicable ).toBe( false );
+	} );
+
+	it( "is applicable when the global identifier cannot be detected on a product with variants", function() {
+		const assessment = new ProductIdentifiersAssessment( { assessVariants: true } );
+		const customData = {
+			canRetrieveGlobalIdentifier: false,
+			hasGlobalIdentifier: false,
+			hasVariants: true,
+			productType: "variable",
+		};
+		const paperWithCustomData = new Paper( "", { customData } );
+		const isApplicable = assessment.isApplicable( paperWithCustomData );
+
+		expect( isApplicable ).toBe( true );
+	} );
+
+	it( "is not applicable when the identifiers of at least one variant cannot be detected on product with variants", function() {
+		const assessment = new ProductIdentifiersAssessment( { assessVariants: true } );
+		const customData = {
+			canRetrieveVariantIdentifiers: false,
+			hasGlobalIdentifier: false,
+			hasVariants: true,
+			productType: "variable",
+		};
+		const paperWithCustomData = new Paper( "", { customData } );
+		const isApplicable = assessment.isApplicable( paperWithCustomData );
+
+		expect( isApplicable ).toBe( false );
+	} );
+
+	it( "is applicable when variant identifiers can be detected on product with variants", function() {
+		const assessment = new ProductIdentifiersAssessment( { assessVariants: true } );
+		const customData = {
+			canRetrieveVariantIdentifiers: true,
+			hasGlobalIdentifier: false,
+			hasVariants: true,
+			productType: "variable",
+		};
+		const paperWithCustomData = new Paper( "", { customData } );
+		const isApplicable = assessment.isApplicable( paperWithCustomData );
+
+		expect( isApplicable ).toBe( true );
+	} );
+
+	it( "is applicable when variant identifiers can be detected on a simple product with variants (case when" +
+		"hasVariants variable doesn't update correctly", function() {
+		const assessment = new ProductIdentifiersAssessment( { assessVariants: true } );
+		const customData = {
+			canRetrieveVariantIdentifiers: false,
+			hasGlobalIdentifier: false,
+			hasVariants: true,
+			productType: "simple",
+		};
+		const paperWithCustomData = new Paper( "", { customData } );
+		const isApplicable = assessment.isApplicable( paperWithCustomData );
+
+		expect( isApplicable ).toBe( true );
+	} );
 } );
 

--- a/packages/yoastseo/spec/scoring/assessments/seo/ProductSKUAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/ProductSKUAssessmentSpec.js
@@ -158,7 +158,7 @@ describe( "a test for the applicability of the assessment", function() {
 		expect( isApplicable ).toBe( false );
 	} );
 
-	it( "is applicable when the SKU can be detected", function() {
+	it( "is applicable when the SKU of a simple product can be detected", function() {
 		const assessment = new ProductSKUAssessment( { assessVariants: true } );
 		const customData = {
 			canRetrieveGlobalSku: true,
@@ -172,13 +172,41 @@ describe( "a test for the applicability of the assessment", function() {
 		expect( isApplicable ).toBe( true );
 	} );
 
-	it( "is not applicable when the SKU cannot be detected on product without variants", function() {
+	it( "is applicable when the SKU of an external product can be detected", function() {
+		const assessment = new ProductSKUAssessment( { assessVariants: true } );
+		const customData = {
+			canRetrieveGlobalSku: true,
+			hasGlobalSKU: false,
+			hasVariants: false,
+			productType: "external",
+		};
+		const paperWithCustomData = new Paper( "", { customData } );
+		const isApplicable = assessment.isApplicable( paperWithCustomData );
+
+		expect( isApplicable ).toBe( true );
+	} );
+
+	it( "is not applicable when the SKU of a simple product cannot be detected", function() {
 		const assessment = new ProductSKUAssessment( { assessVariants: true } );
 		const customData = {
 			canRetrieveGlobalSku: false,
 			hasGlobalSKU: false,
 			hasVariants: false,
 			productType: "simple",
+		};
+		const paperWithCustomData = new Paper( "", { customData } );
+		const isApplicable = assessment.isApplicable( paperWithCustomData );
+
+		expect( isApplicable ).toBe( false );
+	} );
+
+	it( "is not applicable when the SKU of an external product cannot be detected", function() {
+		const assessment = new ProductSKUAssessment( { assessVariants: true } );
+		const customData = {
+			canRetrieveGlobalSku: false,
+			hasGlobalSKU: false,
+			hasVariants: false,
+			productType: "external",
 		};
 		const paperWithCustomData = new Paper( "", { customData } );
 		const isApplicable = assessment.isApplicable( paperWithCustomData );
@@ -212,5 +240,34 @@ describe( "a test for the applicability of the assessment", function() {
 		const isApplicable = assessment.isApplicable( paperWithCustomData );
 
 		expect( isApplicable ).toBe( false );
+	} );
+
+	it( "is applicable when variant SKUs can be detected on product with variants", function() {
+		const assessment = new ProductSKUAssessment( { assessVariants: true } );
+		const customData = {
+			canRetrieveVariantSkus: true,
+			hasGlobalSKU: false,
+			hasVariants: true,
+			productType: "variable",
+		};
+		const paperWithCustomData = new Paper( "", { customData } );
+		const isApplicable = assessment.isApplicable( paperWithCustomData );
+
+		expect( isApplicable ).toBe( true );
+	} );
+
+	it( "is applicable when variant SKUs can be detected on a simple product with variants" +
+		" (case when hasVariants variable doesn't update correctly", function() {
+		const assessment = new ProductSKUAssessment( { assessVariants: true } );
+		const customData = {
+			canRetrieveVariantSkus: false,
+			hasGlobalSKU: false,
+			hasVariants: true,
+			productType: "simple",
+		};
+		const paperWithCustomData = new Paper( "", { customData } );
+		const isApplicable = assessment.isApplicable( paperWithCustomData );
+
+		expect( isApplicable ).toBe( true );
 	} );
 } );

--- a/packages/yoastseo/src/scoring/assessments/seo/ProductIdentifiersAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/ProductIdentifiersAssessment.js
@@ -66,7 +66,7 @@ export default class ProductIdentifiersAssessment extends Assessment {
 	isApplicable( paper ) {
 		const customData = paper.getCustomData();
 
-		// Do not show the assessment when we cannot retrieve the SKU.
+		// Do not show the assessment when we cannot retrieve the identifiers.
 		if ( customData.canRetrieveGlobalIdentifier === false && ( customData.productType === "simple" || customData.hasVariants === false ) ) {
 			return false;
 		}

--- a/packages/yoastseo/src/scoring/assessments/seo/ProductIdentifiersAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/ProductIdentifiersAssessment.js
@@ -66,11 +66,18 @@ export default class ProductIdentifiersAssessment extends Assessment {
 	isApplicable( paper ) {
 		const customData = paper.getCustomData();
 
-		// Do not show the assessment when we cannot retrieve the identifiers.
-		if ( customData.canRetrieveGlobalIdentifier === false && ( customData.productType === "simple" || customData.hasVariants === false ) ) {
+		/*
+		 * If the global identifier cannot be retrieved, the assessment shouldn't be applicable if the product is a simple
+		 * or external product, or doesn't have variants. Even though in reality a simple or external product doesn't have variants,
+		 * this double check is added because the hasVariants variable doesn't always update correctly when changing product type.
+		 */
+		if ( customData.canRetrieveGlobalIdentifier === false &&
+			( [ "simple", "external" ].includes( customData.productType ) || customData.hasVariants === false ) ) {
 			return false;
 		}
 
+
+		// If variant identifiers cannot be retrieved for a variable product with variants, the assessment shouldn't be applicable.
 		if ( customData.canRetrieveVariantIdentifiers === false && customData.hasVariants === true && customData.productType === "variable" ) {
 			return false;
 		}

--- a/packages/yoastseo/src/scoring/assessments/seo/ProductIdentifiersAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/ProductIdentifiersAssessment.js
@@ -60,6 +60,8 @@ export default class ProductIdentifiersAssessment extends Assessment {
 	/**
 	 * Checks whether the assessment is applicable (for now it is not applicable in Shopify where we also don't want to
 	 * assess variants; hence the applicability condition based on that).
+	 *
+	 * @param {Paper} paper The paper to check.
 	 **
 	 * @returns {Boolean} Whether the assessment is applicable.
 	 */

--- a/packages/yoastseo/src/scoring/assessments/seo/ProductIdentifiersAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/ProductIdentifiersAssessment.js
@@ -63,7 +63,18 @@ export default class ProductIdentifiersAssessment extends Assessment {
 	 **
 	 * @returns {Boolean} Whether the assessment is applicable.
 	 */
-	isApplicable() {
+	isApplicable( paper ) {
+		const customData = paper.getCustomData();
+
+		// Do not show the assessment when we cannot retrieve the SKU.
+		if ( customData.canRetrieveGlobalIdentifier === false && customData.hasVariants === false ) {
+			return false;
+		}
+
+		if ( customData.canRetrieveVariantIdentifiers === false && customData.hasVariants === true ) {
+			return false;
+		}
+
 		return this._config.assessVariants;
 	}
 

--- a/packages/yoastseo/src/scoring/assessments/seo/ProductIdentifiersAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/ProductIdentifiersAssessment.js
@@ -67,11 +67,11 @@ export default class ProductIdentifiersAssessment extends Assessment {
 		const customData = paper.getCustomData();
 
 		// Do not show the assessment when we cannot retrieve the SKU.
-		if ( customData.canRetrieveGlobalIdentifier === false && customData.hasVariants === false ) {
+		if ( customData.canRetrieveGlobalIdentifier === false && ( customData.productType === "simple" || customData.hasVariants === false ) ) {
 			return false;
 		}
 
-		if ( customData.canRetrieveVariantIdentifiers === false && customData.hasVariants === true ) {
+		if ( customData.canRetrieveVariantIdentifiers === false && customData.hasVariants === true && customData.productType === "variable" ) {
 			return false;
 		}
 

--- a/packages/yoastseo/src/scoring/assessments/seo/ProductSKUAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/ProductSKUAssessment.js
@@ -65,12 +65,19 @@ export default class ProductSKUAssessment extends Assessment {
 	isApplicable( paper ) {
 		const customData = paper.getCustomData();
 
-		 // Do not show the assessment when we cannot retrieve the SKU.
-		if ( customData.canRetrieveGlobalSku === false && customData.hasVariants === false ) {
+		/*
+	    * If the global SKU cannot be retrieved, the assessment shouldn't be applicable if the product is a simple
+	    * or external product, or doesn't have variants. Even though in reality a simple or external product doesn't have variants,
+	    * this double check is added because the hasVariants variable doesn't always update correctly when changing product type.
+	    */
+		if ( customData.canRetrieveGlobalSku === false &&
+			( [ "simple", "external" ].includes( customData.productType ) || customData.hasVariants === false ) ) {
 			return false;
 		}
 
-		if ( customData.canRetrieveVariantSkus === false && customData.hasVariants === true ) {
+
+		// If variant identifiers cannot be retrieved for a variable product with variants, the assessment shouldn't be applicable.
+		if ( customData.canRetrieveVariantSkus === false && customData.hasVariants === true && customData.productType === "variable" ) {
 			return false;
 		}
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* It is possible to remove the product identifier input fields, see https://yoast.atlassian.net/browse/PC-511. This breaks the analysis. As a solution, we want to disable the Product identifier assessment when the identifiers cannot be retrieved.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Does not show the Product identifier assessment when the identifiers cannot be retrieved.

## Relevant technical choices:

* When you change a variable product with variants to a simple or external product, the variants disappear. However, the hasVariants variable doesn't get updated correctly - it remains `true`. That's why in the applicability check, to check whether a product has variants just checking the hasVariants is not enough. Instead, we also have to check whether the product is a simple or grouped product, since those can never have variants. This was also an issue with the SKU assessment, so the applicability condition is also adapted for that assessment.
* There is an accompanying Woo PR https://github.com/Yoast/wpseo-woocommerce/pull/827 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Activate Yoast SEO Free, WooCommerce, and Yoast SEO WooCommerce
     * For acceptance tester: make sure to link the Free branch when building the WooCommerce branch (composer require yoast/wordpress-seo:dev-PC-532-add-safeguard-in-case-product-identifiers-are-missing@dev --dev) 
    
#### Products without variants
* Create a new product
* Confirm that the Product identifier assessment shows up in the SEO assessments with an orange bullet and the following feedback: `Product identifier: Your product is missing an identifier (like a GTIN code). Include this if you can, as it will help search engines to better understand your content.`
* Add a product identifier
* Confirm that the Product identifier assessment returns a green bullet with the following feedback: `Product identifier: Your product has an identifier. Good job!`
* Remove one of the not filled in identifier fields from the DOM. See this video for how to do it:

https://user-images.githubusercontent.com/32479012/188608241-fcada0f3-f683-413c-9b6f-d03ad7d96a9d.mov

* Add some text to the product description or elsewhere (this is needed for the removal of the field to be registered)
* Confirm that the Product identifier assessment still returns a green bullet
* Remove the filled in product identifier field from the DOM
* Add some text to the product description or elsewhere (this is needed for the removal of the field to be registered)
* Confirm that the Product identifier assessment disappears
* Refresh the page
* Change the product type to an external product
* Repeat the previous steps
* Refresh the page
* Change the product type to a variable product
* Repeat the previous steps
* Refresh the page
* Change the product type to a grouped product
* Repeat the previous steps
* Add variants to the product ([see documentation on how to do that](https://yoast.atlassian.net/wiki/spaces/LIN/pages/2564686155/How+to+add+variants+to+a+product))
* Change the product to a simple product
* Make sure that at least one of the product identifiers fields is deleted, and no identifier field is filled in
* Confirm that the Product identifier assessment does not appear.

#### Products with variants
* Change the product to a variable product and add variants
* Confirm that the Product identifier assessment shows up in the SEO assessments with an orange bullet and the following feedback: `Product identifier: Not all your product variants have an identifier. Include this if you can, as it will help search engines to better understand your content. `
* Confirm that the assessment result stays the same when at least one of the global product identifiers fields is deleted, and no global identifier field is filled in
* Add an identifier to every variant
* Confirm that the Product identifier assessment returns a green bullet with the following feedback: 
`Product identifier: All your product variants have an identifier identifier. Good job!`
* Delete the filled in product identifier field of one variant
* Add some text to the product description or elsewhere (this is needed for the removal of the field to be registered)
* Confirm that the Product identifier assessment disappears
* Fill in another identifier field for the variant with a removed field
* For every variant, delete one _not_ filled in field
* Add some text to the product description or elsewhere (this is needed for the removal of the field to be registered)
* Confirm that the Product identifier assessment returns a green bullet with the following feedback: 
`Product identifier: All your product variants have an identifier identifier. Good job!`
* Delete all variants 
* Confirm that the Product identifier assessment doesn't show up (assuming that a global identifier field is still removed - if it isn't, then the assessment should return an orange bullet with the feedback `Product identifier: Your product is missing an identifier (like a GTIN code). Include this if you can, as it will help search engines to better understand your content.`)

#### Test a SKU assessment bugfix
* Create a variable product with variants
* Confirm that the SKU assessment shows up with an orange bullet and the following feedback: `SKU: Not all your product variants have a SKU. Include this if you can, as it will help search engines to better understand your content.`
* Change the product to a simple product
* Remove the global SKU field
* Confirm that the SKU assessment disappears
* Repeat the above steps, but instead of changing the variable product to a simple product, change to an external product.


#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* The same instructions as for acceptance testing can be used, except that instead of removing product identifier fields from the DOM, they can be removed using the steps listed in this comment: https://yoast.atlassian.net/browse/PC-511?focusedCommentId=51122 

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [x] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes #
