### PR TITLE
Adds new unsuned resources section and removes comment from presenter

### DIFF
--- a/src/integrations/admin/crawl-settings-integration.php
+++ b/src/integrations/admin/crawl-settings-integration.php
@@ -46,6 +46,13 @@ class Crawl_Settings_Integration implements Integration_Interface {
 	private $search_cleanup_settings;
 
 	/**
+	 * Holds the settings + labels for unused resources settings.
+	 *
+	 * @var array
+	 */
+	private $unused_resources_settings;
+
+	/**
 	 * The product helper.
 	 *
 	 * @var Product_Helper
@@ -92,6 +99,7 @@ class Crawl_Settings_Integration implements Integration_Interface {
 	 */
 	public function is_premium_upgraded() {
 		$premium_version = $this->product_helper->get_premium_version();
+
 		return $premium_version !== null && \version_compare( $premium_version, '18.6-RC1', '>=' );
 	}
 
@@ -120,7 +128,6 @@ class Crawl_Settings_Integration implements Integration_Interface {
 			'remove_rsd_wlw_links'     => \__( 'RSD / WLW links', 'wordpress-seo' ),
 			'remove_oembed_links'      => \__( 'oEmbed links', 'wordpress-seo' ),
 			'remove_generator'         => \__( 'Generator tag', 'wordpress-seo' ),
-			'remove_emoji_scripts'     => \__( 'Emoji scripts', 'wordpress-seo' ),
 			'remove_pingback_header'   => \__( 'Pingback HTTP header', 'wordpress-seo' ),
 			'remove_powered_by_header' => \__( 'Powered by HTTP header', 'wordpress-seo' ),
 		];
@@ -135,7 +142,11 @@ class Crawl_Settings_Integration implements Integration_Interface {
 			'search_cleanup_emoji'    => \__( 'Filter searches with emojis and other special characters', 'wordpress-seo' ),
 			'search_cleanup_patterns' => \__( 'Filter searches with common spam patterns', 'wordpress-seo' ),
 			'deny_search_crawling'    => \__( 'Prevent search engines from crawling site search URLs', 'wordpress-seo' ),
-			'deny_wp_json_crawling'   => \__( 'Prevent search engines from crawling /wp-json/', 'wordpress-seo' ),
+		];
+
+		$this->unused_resources_settings = [
+			'remove_emoji_scripts'  => \__( 'Emoji scripts', 'wordpress-seo' ),
+			'deny_wp_json_crawling' => \__( 'Prevent search engines from crawling /wp-json/', 'wordpress-seo' ),
 		];
 	}
 
@@ -193,6 +204,7 @@ class Crawl_Settings_Integration implements Integration_Interface {
 
 		$this->print_toggles( $this->basic_settings, $yform, $is_network, \__( 'Basic crawl settings', 'wordpress-seo' ), \__( 'Remove links added by WordPress to the header and &lt;head&gt;.', 'wordpress-seo' ) );
 		$this->print_toggles( $this->feed_settings, $yform, $is_network, \__( 'Feed crawl settings', 'wordpress-seo' ), \__( "Remove feed links added by WordPress that aren't needed for this site.", 'wordpress-seo' ) );
+		$this->print_toggles( $this->unused_resources_settings, $yform, $is_network, \__( 'Remove unused resources', 'wordpress-seo' ), \__( 'WordPress loads lots of resources, some of which your site might not need. If you’re not using these, removing them can speed up your pages and save resources.', 'wordpress-seo' ) );
 
 		$first_search_setting    = \array_slice( $this->search_cleanup_settings, 0, 1 );
 		$rest_search_settings    = \array_slice( $this->search_cleanup_settings, 1 );

--- a/src/presenters/robots-txt-presenter.php
+++ b/src/presenters/robots-txt-presenter.php
@@ -9,7 +9,7 @@ use Yoast\WP\SEO\Helpers\Robots_Txt_Helper;
  */
 class Robots_Txt_Presenter extends Abstract_Presenter {
 
-	const YOAST_OUTPUT_BEFORE_COMMENT = "# START YOAST INTERNAL SEARCH BLOCK\n# Added by Yoast SEO (see yoa.st/robots-txt-additions for more info).\n# ---------------------------\n";
+	const YOAST_OUTPUT_BEFORE_COMMENT = "# START YOAST INTERNAL SEARCH BLOCK\n# ---------------------------\n";
 
 	const YOAST_OUTPUT_AFTER_COMMENT = "# ---------------------------\n# END YOAST INTERNAL SEARCH BLOCK";
 

--- a/tests/unit/presenters/robots-txt-presenter-test.php
+++ b/tests/unit/presenters/robots-txt-presenter-test.php
@@ -79,7 +79,7 @@ class Robots_Txt_Presenter_Test extends TestCase {
 			'sitemaps'               => [
 				'http://example.com/sitemap_index.html',
 			],
-			'expected'               => "# START YOAST INTERNAL SEARCH BLOCK\n# Added by Yoast SEO (see yoa.st/robots-txt-additions for more info).\n# ---------------------------\nUser-agent: *\nDisallow:\n\nSitemap: http://example.com/sitemap_index.html\n# ---------------------------\n# END YOAST INTERNAL SEARCH BLOCK",
+			'expected'               => "# START YOAST INTERNAL SEARCH BLOCK\n# ---------------------------\nUser-agent: *\nDisallow:\n\nSitemap: http://example.com/sitemap_index.html\n# ---------------------------\n# END YOAST INTERNAL SEARCH BLOCK",
 		];
 		$user_agent_list                         = new User_Agent_List();
 		$user_agent                              = $user_agent_list->get_user_agent( '*' );
@@ -90,7 +90,7 @@ class Robots_Txt_Presenter_Test extends TestCase {
 			'sitemaps'               => [
 				'http://example.com/sitemap_index.html',
 			],
-			'expected'               => "# START YOAST INTERNAL SEARCH BLOCK\n# Added by Yoast SEO (see yoa.st/robots-txt-additions for more info).\n# ---------------------------\nUser-agent: *\nDisallow: /wp-json/\n\nSitemap: http://example.com/sitemap_index.html\n# ---------------------------\n# END YOAST INTERNAL SEARCH BLOCK",
+			'expected'               => "# START YOAST INTERNAL SEARCH BLOCK\n# ---------------------------\nUser-agent: *\nDisallow: /wp-json/\n\nSitemap: http://example.com/sitemap_index.html\n# ---------------------------\n# END YOAST INTERNAL SEARCH BLOCK",
 		];
 
 		$user_agent_list = new User_Agent_List();
@@ -105,7 +105,7 @@ class Robots_Txt_Presenter_Test extends TestCase {
 			'sitemaps'               => [
 				'http://example.com/sitemap_index.html',
 			],
-			'expected'               => "# START YOAST INTERNAL SEARCH BLOCK\n# Added by Yoast SEO (see yoa.st/robots-txt-additions for more info).\n# ---------------------------\nUser-agent: *\nDisallow: /wp-json/\nDisallow: /search/\n\nUser-agent: Googlebot\nDisallow: /disallowed/for/googlebot\n\nSitemap: http://example.com/sitemap_index.html\n# ---------------------------\n# END YOAST INTERNAL SEARCH BLOCK",
+			'expected'               => "# START YOAST INTERNAL SEARCH BLOCK\n# ---------------------------\nUser-agent: *\nDisallow: /wp-json/\nDisallow: /search/\n\nUser-agent: Googlebot\nDisallow: /disallowed/for/googlebot\n\nSitemap: http://example.com/sitemap_index.html\n# ---------------------------\n# END YOAST INTERNAL SEARCH BLOCK",
 		];
 		$user_agent_list              = new User_Agent_List();
 		$user_agent                   = $user_agent_list->get_user_agent( '*' );
@@ -117,7 +117,7 @@ class Robots_Txt_Presenter_Test extends TestCase {
 			'sitemaps'               => [
 				'http://example.com/sitemap_index.html',
 			],
-			'expected'               => "# START YOAST INTERNAL SEARCH BLOCK\n# Added by Yoast SEO (see yoa.st/robots-txt-additions for more info).\n# ---------------------------\nUser-agent: *\nDisallow: /wp-json/\nAllow: /search/\n\nSitemap: http://example.com/sitemap_index.html\n# ---------------------------\n# END YOAST INTERNAL SEARCH BLOCK",
+			'expected'               => "# START YOAST INTERNAL SEARCH BLOCK\n# ---------------------------\nUser-agent: *\nDisallow: /wp-json/\nAllow: /search/\n\nSitemap: http://example.com/sitemap_index.html\n# ---------------------------\n# END YOAST INTERNAL SEARCH BLOCK",
 		];
 
 		$user_agent_list = new User_Agent_List();
@@ -136,7 +136,7 @@ class Robots_Txt_Presenter_Test extends TestCase {
 			'sitemaps'               => [
 				'http://example.com/sitemap_index.html',
 			],
-			'expected'               => "# START YOAST INTERNAL SEARCH BLOCK\n# Added by Yoast SEO (see yoa.st/robots-txt-additions for more info).\n# ---------------------------\nUser-agent: *\nDisallow: /wp-json/\nAllow: /search/\n\nUser-agent: Googlebot\nDisallow: /disallowed/for/googlebot\nDisallow: /wp-admin\n\nUser-agent: Yahoobot\nAllow: /allowed/for/yahoo\n\nSitemap: http://example.com/sitemap_index.html\n# ---------------------------\n# END YOAST INTERNAL SEARCH BLOCK",
+			'expected'               => "# START YOAST INTERNAL SEARCH BLOCK\n# ---------------------------\nUser-agent: *\nDisallow: /wp-json/\nAllow: /search/\n\nUser-agent: Googlebot\nDisallow: /disallowed/for/googlebot\nDisallow: /wp-admin\n\nUser-agent: Yahoobot\nAllow: /allowed/for/yahoo\n\nSitemap: http://example.com/sitemap_index.html\n# ---------------------------\n# END YOAST INTERNAL SEARCH BLOCK",
 		];
 
 		$user_agent_list = new User_Agent_List();
@@ -148,7 +148,7 @@ class Robots_Txt_Presenter_Test extends TestCase {
 			'sitemaps'               => [
 				'http://example.com/sitemap_index.html',
 			],
-			'expected'               => "# START YOAST INTERNAL SEARCH BLOCK\n# Added by Yoast SEO (see yoa.st/robots-txt-additions for more info).\n# ---------------------------\nUser-agent: *\nAllow: /search/\n\nSitemap: http://example.com/sitemap_index.html\n# ---------------------------\n# END YOAST INTERNAL SEARCH BLOCK",
+			'expected'               => "# START YOAST INTERNAL SEARCH BLOCK\n# ---------------------------\nUser-agent: *\nAllow: /search/\n\nSitemap: http://example.com/sitemap_index.html\n# ---------------------------\n# END YOAST INTERNAL SEARCH BLOCK",
 		];
 		$multiple_sitemaps      = [
 			'robots_txt_user_agents' => ( new User_Agent_List() )->get_user_agents(),
@@ -156,7 +156,7 @@ class Robots_Txt_Presenter_Test extends TestCase {
 				'http://example.com/sitemap_index.html',
 				'http://example.com/subsite/sitemap_index.html',
 			],
-			'expected'               => "# START YOAST INTERNAL SEARCH BLOCK\n# Added by Yoast SEO (see yoa.st/robots-txt-additions for more info).\n# ---------------------------\nUser-agent: *\nDisallow:\n\nSitemap: http://example.com/sitemap_index.html\nSitemap: http://example.com/subsite/sitemap_index.html\n# ---------------------------\n# END YOAST INTERNAL SEARCH BLOCK",
+			'expected'               => "# START YOAST INTERNAL SEARCH BLOCK\n# ---------------------------\nUser-agent: *\nDisallow:\n\nSitemap: http://example.com/sitemap_index.html\nSitemap: http://example.com/subsite/sitemap_index.html\n# ---------------------------\n# END YOAST INTERNAL SEARCH BLOCK",
 		];
 
 		return [


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want te move some settings to another header to group them better.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds new unused resources section and moves settings. 
* Removes line from robots.txt presenter output.


## Relevant technical choices:

* None.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Test instructions are located in https://github.com/Yoast/wordpress-seo-premium/pull/3676

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes #
PC-547