### PR TITLE
Add SKU and Product identifiers assessment for grouped products

### DIFF
--- a/packages/yoastseo/spec/scoring/assessments/seo/ProductIdentifiersAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/ProductIdentifiersAssessmentSpec.js
@@ -22,6 +22,30 @@ describe( "a test for Product identifiers assessment for WooCommerce", function(
 			"Your product has an identifier. Good job!" );
 	} );
 
+	it( "returns the score 9 when a grouped product has a global identifier and no variants", function() {
+		const assessmentResult = assessment.getResult( paper, Factory.buildMockResearcher( {
+			hasGlobalIdentifier: true,
+			hasVariants: false,
+			doAllVariantsHaveIdentifier: false,
+			productType: "grouped",
+		} ) );
+		expect( assessmentResult.getScore() ).toEqual( 9 );
+		expect( assessmentResult.getText() ).toEqual( "<a href='https://yoa.st/4ly' target='_blank'>Product identifier</a>: " +
+			"Your product has an identifier. Good job!" );
+	} );
+
+	it( "returns the score 9 when an external product has a global identifier and no variants", function() {
+		const assessmentResult = assessment.getResult( paper, Factory.buildMockResearcher( {
+			hasGlobalIdentifier: true,
+			hasVariants: false,
+			doAllVariantsHaveIdentifier: false,
+			productType: "external",
+		} ) );
+		expect( assessmentResult.getScore() ).toEqual( 9 );
+		expect( assessmentResult.getText() ).toEqual( "<a href='https://yoa.st/4ly' target='_blank'>Product identifier</a>: " +
+			"Your product has an identifier. Good job!" );
+	} );
+
 	it( "returns the score 9 when a product has no global identifier, but has variants and all variants have an identifier", function() {
 		const assessmentResult = assessment.getResult( paper, Factory.buildMockResearcher( {
 			hasGlobalIdentifier: false,

--- a/packages/yoastseo/spec/scoring/assessments/seo/ProductSKUAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/ProductSKUAssessmentSpec.js
@@ -21,12 +21,24 @@ describe( "a test for SKU assessment for WooCommerce", function() {
 		expect( assessmentResult.getText() ).toEqual( "<a href='https://yoa.st/4lw' target='_blank'>SKU</a>: Your product has a SKU. Good job!" );
 	} );
 
-	it( "returns the score 9 when a product has a global SKU and no variants", function() {
+	it( "returns the score 9 when a grouped product has a global SKU and no variants", function() {
 		const assessmentResult = assessment.getResult( paper, Factory.buildMockResearcher( {
 			hasGlobalSKU: true,
 			hasVariants: false,
 			doAllVariantsHaveSKU: false,
 			productType: "grouped",
+		} ) );
+
+		expect( assessmentResult.getScore() ).toEqual( 9 );
+		expect( assessmentResult.getText() ).toEqual( "<a href='https://yoa.st/4lw' target='_blank'>SKU</a>: Your product has a SKU. Good job!" );
+	} );
+
+	it( "returns the score 9 when an external product has a global SKU and no variants", function() {
+		const assessmentResult = assessment.getResult( paper, Factory.buildMockResearcher( {
+			hasGlobalSKU: true,
+			hasVariants: false,
+			doAllVariantsHaveSKU: false,
+			productType: "external",
 		} ) );
 
 		expect( assessmentResult.getScore() ).toEqual( 9 );

--- a/packages/yoastseo/spec/scoring/assessments/seo/ProductSKUAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/ProductSKUAssessmentSpec.js
@@ -21,6 +21,18 @@ describe( "a test for SKU assessment for WooCommerce", function() {
 		expect( assessmentResult.getText() ).toEqual( "<a href='https://yoa.st/4lw' target='_blank'>SKU</a>: Your product has a SKU. Good job!" );
 	} );
 
+	it( "returns the score 9 when a product has a global SKU and no variants", function() {
+		const assessmentResult = assessment.getResult( paper, Factory.buildMockResearcher( {
+			hasGlobalSKU: true,
+			hasVariants: false,
+			doAllVariantsHaveSKU: false,
+			productType: "grouped",
+		} ) );
+
+		expect( assessmentResult.getScore() ).toEqual( 9 );
+		expect( assessmentResult.getText() ).toEqual( "<a href='https://yoa.st/4lw' target='_blank'>SKU</a>: Your product has a SKU. Good job!" );
+	} );
+
 	it( "returns the score 9 when a product has no global SKU, but has variants and all variants have a SKU", function() {
 		const assessmentResult = assessment.getResult( paper, Factory.buildMockResearcher( {
 			hasGlobalSKU: false,

--- a/packages/yoastseo/src/scoring/assessments/seo/ProductIdentifiersAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/ProductIdentifiersAssessment.js
@@ -96,7 +96,7 @@ export default class ProductIdentifiersAssessment extends Assessment {
 		}
 
 		// Apply the following scoring conditions to products without variants.
-		if ( [ "simple", "external" ].includes( productIdentifierData.productType ) ||
+		if ( [ "simple", "grouped", "external" ].includes( productIdentifierData.productType ) ||
 			( productIdentifierData.productType === "variable" && ! productIdentifierData.hasVariants ) ) {
 			if ( ! productIdentifierData.hasGlobalIdentifier ) {
 				return {

--- a/packages/yoastseo/src/scoring/assessments/seo/ProductSKUAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/ProductSKUAssessment.js
@@ -88,8 +88,9 @@ export default class ProductSKUAssessment extends Assessment {
 	 * 													or empty object if no score should be returned.
 	 */
 	scoreProductSKU( productSKUData, config ) {
+		console.log( productSKUData );
 		// Apply the following scoring conditions to products without variants.
-		if ( [ "simple", "external" ].includes( productSKUData.productType ) ||
+		if ( [ "simple", "grouped", "external" ].includes( productSKUData.productType ) ||
 			( productSKUData.productType === "variable" && ! productSKUData.hasVariants ) ) {
 			if ( ! productSKUData.hasGlobalSKU ) {
 				return {

--- a/packages/yoastseo/src/scoring/assessments/seo/ProductSKUAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/ProductSKUAssessment.js
@@ -88,7 +88,6 @@ export default class ProductSKUAssessment extends Assessment {
 	 * 													or empty object if no score should be returned.
 	 */
 	scoreProductSKU( productSKUData, config ) {
-		console.log( productSKUData );
 		// Apply the following scoring conditions to products without variants.
 		if ( [ "simple", "grouped", "external" ].includes( productSKUData.productType ) ||
 			( productSKUData.productType === "variable" && ! productSKUData.hasVariants ) ) {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where the SKU and Product identifier assessments did not work for Grouped products

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Activate Yoast SEO Free, Woocommerce and Yoast SEO for Woocommerce
For devs: Run composer require yoast/wordpress-seo:dev-PC-522-add-SKU-identifiers-assessment-for-grouped-products@dev --dev before building in Free
* Create a new product
* Check that the SKU assessment shows orange and says: `Your product is missing a SKU. Include this if you can, as it will help search engines to better understand your content. `
* Hover over the links in the feedback strings. Confirm that the first link starts with `<https://yoa.st/4lw>` and the second one with `<https://yoa.st/4lx>`
* Change the product type to Grouped product in `Product data`
* Check that the assessment results do not change
* Add a SKU to the product 
* Check that the SKU assessment says `Your product has a SKU. Good job!`
* Remove the SKU
* Check that the SKU assessment shows orange and says `Your product is missing a SKU. Include this if you can, as it will help search engines to better understand your content. `
* Save the product as a draft
* Check that the assessment still shows up and the result does not change
* Repeat the same steps for the Product identifiers assessment. (NOTE: for this assessment the feedback strings are expected to be `<https://yoa.st/4ly>` for the first link and `<https://yoa.st/4lz> `for the second link)

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes #https://yoast.atlassian.net/jira/software/c/projects/PC/boards/138?modal=detail&selectedIssue=PC-522
