### PR TITLE
edit feedback strings for SKU and PI assessment and test files

### DIFF
--- a/packages/yoastseo/spec/scoring/assessments/seo/ProductIdentifiersAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/ProductIdentifiersAssessmentSpec.js
@@ -45,7 +45,8 @@ describe( "a test for Product identifiers assessment for WooCommerce", function(
 
 		expect( assessmentResult.getScore() ).toEqual( 6 );
 		expect( assessmentResult.getText() ).toEqual( "<a href='https://yoa.st/4ly' target='_blank'>Product identifier</a>:" +
-			" Your product is missing an identifier (like a GTIN code). <a href='https://yoa.st/4lz' target='_blank'>Include" +
+			" Your product is missing an identifier (like a GTIN code). You can add the product identifier via the \"Yoast SEO\" tab " +
+			"in Product Data box. <a href='https://yoa.st/4lz' target='_blank'>Include" +
 			" this if you can, as it will help search engines to better understand your content.</a>" );
 	} );
 
@@ -59,8 +60,9 @@ describe( "a test for Product identifiers assessment for WooCommerce", function(
 
 		expect( assessmentResult.getScore() ).toEqual( 6 );
 		expect( assessmentResult.getText() ).toEqual( "<a href='https://yoa.st/4ly' target='_blank'>Product identifier</a>:" +
-			" Not all your product variants have an identifier. <a href='https://yoa.st/4lz' target='_blank'>Include" +
-			" this if you can, as it will help search engines to better understand your content.</a>" );
+			" Not all your product variants have an identifier. You can add the product identifier via the \"Variations\" tab. " +
+			"<a href='https://yoa.st/4lz' target='_blank'>Include this if you can, as it will help search engines to better " +
+			"understand your content.</a>" );
 	} );
 
 	it( "returns the score 6 when a product has no global identifier, but has variants and not all variants have an identifier", function() {
@@ -73,7 +75,8 @@ describe( "a test for Product identifiers assessment for WooCommerce", function(
 
 		expect( assessmentResult.getScore() ).toEqual( 6 );
 		expect( assessmentResult.getText() ).toEqual( "<a href='https://yoa.st/4ly' target='_blank'>Product identifier</a>:" +
-			" Not all your product variants have an identifier. <a href='https://yoa.st/4lz' target='_blank'>Include" +
+			" Not all your product variants have an identifier. You can add the product identifier via the \"Variations\" tab. " +
+			"<a href='https://yoa.st/4lz' target='_blank'>Include" +
 			" this if you can, as it will help search engines to better understand your content.</a>" );
 	} );
 
@@ -101,7 +104,8 @@ describe( "a test for Product identifiers assessment for WooCommerce", function(
 
 		expect( assessmentResult.getScore() ).toEqual( 6 );
 		expect( assessmentResult.getText() ).toEqual( "<a href='https://yoa.st/4ly' target='_blank'>Product identifier</a>:" +
-			" Your product is missing an identifier (like a GTIN code). <a href='https://yoa.st/4lz' target='_blank'>Include" +
+			" Your product is missing an identifier (like a GTIN code). You can add the product identifier via the \"Yoast SEO\" tab " +
+			"in Product Data box. <a href='https://yoa.st/4lz' target='_blank'>Include" +
 			" this if you can, as it will help search engines to better understand your content.</a>" );
 	} );
 } );

--- a/packages/yoastseo/spec/scoring/assessments/seo/ProductIdentifiersAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/ProductIdentifiersAssessmentSpec.js
@@ -45,9 +45,9 @@ describe( "a test for Product identifiers assessment for WooCommerce", function(
 
 		expect( assessmentResult.getScore() ).toEqual( 6 );
 		expect( assessmentResult.getText() ).toEqual( "<a href='https://yoa.st/4ly' target='_blank'>Product identifier</a>:" +
-			" Your product is missing an identifier (like a GTIN code). You can add the product identifier via the \"Yoast SEO\" tab " +
-			"in Product Data box. <a href='https://yoa.st/4lz' target='_blank'>Include" +
-			" this if you can, as it will help search engines to better understand your content.</a>" );
+			" Your product is missing an identifier (like a GTIN code). You can add a product identifier via the \"Yoast SEO\" tab " +
+			"in the Product data box. <a href='https://yoa.st/4lz' target='_blank'>Include" +
+			" it if you can, as it will help search engines to better understand your content.</a>" );
 	} );
 
 	it( "returns the score 6 when a product has a global identifier and variants, but not all variants have an identifier", function() {
@@ -60,9 +60,9 @@ describe( "a test for Product identifiers assessment for WooCommerce", function(
 
 		expect( assessmentResult.getScore() ).toEqual( 6 );
 		expect( assessmentResult.getText() ).toEqual( "<a href='https://yoa.st/4ly' target='_blank'>Product identifier</a>:" +
-			" Not all your product variants have an identifier. You can add the product identifier via the \"Variations\" tab. " +
-			"<a href='https://yoa.st/4lz' target='_blank'>Include this if you can, as it will help search engines to better " +
-			"understand your content.</a>" );
+			" Not all your product variants have an identifier. You can add a product identifier via the \"Variations\" " +
+			"tab in the Product data box. <a href='https://yoa.st/4lz' target='_blank'>Include it if you can, as it " +
+			"will help search engines to better understand your content.</a>" );
 	} );
 
 	it( "returns the score 6 when a product has no global identifier, but has variants and not all variants have an identifier", function() {
@@ -75,9 +75,9 @@ describe( "a test for Product identifiers assessment for WooCommerce", function(
 
 		expect( assessmentResult.getScore() ).toEqual( 6 );
 		expect( assessmentResult.getText() ).toEqual( "<a href='https://yoa.st/4ly' target='_blank'>Product identifier</a>:" +
-			" Not all your product variants have an identifier. You can add the product identifier via the \"Variations\" tab. " +
-			"<a href='https://yoa.st/4lz' target='_blank'>Include" +
-			" this if you can, as it will help search engines to better understand your content.</a>" );
+			" Not all your product variants have an identifier. You can add a product identifier via the \"Variations\"" +
+			" tab in the Product data box. <a href='https://yoa.st/4lz' target='_blank'>Include" +
+			" it if you can, as it will help search engines to better understand your content.</a>" );
 	} );
 
 
@@ -104,9 +104,9 @@ describe( "a test for Product identifiers assessment for WooCommerce", function(
 
 		expect( assessmentResult.getScore() ).toEqual( 6 );
 		expect( assessmentResult.getText() ).toEqual( "<a href='https://yoa.st/4ly' target='_blank'>Product identifier</a>:" +
-			" Your product is missing an identifier (like a GTIN code). You can add the product identifier via the \"Yoast SEO\" tab " +
-			"in Product Data box. <a href='https://yoa.st/4lz' target='_blank'>Include" +
-			" this if you can, as it will help search engines to better understand your content.</a>" );
+			" Your product is missing an identifier (like a GTIN code). You can add a product identifier via the \"Yoast SEO\" tab " +
+			"in the Product data box. <a href='https://yoa.st/4lz' target='_blank'>Include" +
+			" it if you can, as it will help search engines to better understand your content.</a>" );
 	} );
 } );
 
@@ -137,7 +137,7 @@ xdescribe( "a test for Product identifiers assessment for Shopify", () => {
 		expect( assessmentResult.getScore() ).toEqual( 6 );
 		expect( assessmentResult.getText() ).toEqual( "<a href='https://yoa.st/shopify81' target='_blank'>Barcode</a>:" +
 			" Your product is missing a barcode (like a GTIN code). <a href='https://yoa.st/shopify82' target='_blank'>Include" +
-			" this if you can, as it will help search engines to better understand your content.</a>" );
+			" it if you can, as it will help search engines to better understand your content.</a>" );
 	} );
 
 	it( "should not return a score if the product has variants", () => {

--- a/packages/yoastseo/spec/scoring/assessments/seo/ProductSKUAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/ProductSKUAssessmentSpec.js
@@ -40,12 +40,14 @@ describe( "a test for SKU assessment for WooCommerce", function() {
 			hasVariants: false,
 			doAllVariantsHaveSKU: false,
 			productType: "simple",
+			addSKULocation: true,
 		} ) );
 
 		expect( assessmentResult.getScore() ).toEqual( 6 );
 		expect( assessmentResult.getText() ).toEqual( "<a href='https://yoa.st/4lw' target='_blank'>SKU</a>:" +
-			" Your product is missing a SKU. You can add the SKU via the \"Inventory\" tab. <a href='https://yoa.st/4lx' target='_blank'>Include" +
-			" this if you can, as it will help search engines to better understand your content.</a>" );
+			" Your product is missing a SKU. You can add a SKU via the \"Inventory\" tab in the Product data box. " +
+			"<a href='https://yoa.st/4lx' target='_blank'>Include it if you can, as it will help search engines " +
+			"to better understand your content.</a>" );
 	} );
 
 	it( "returns the score 6 when a product has a global SKU and variants, but not all variants have a SKU", function() {
@@ -58,8 +60,9 @@ describe( "a test for SKU assessment for WooCommerce", function() {
 
 		expect( assessmentResult.getScore() ).toEqual( 6 );
 		expect( assessmentResult.getText() ).toEqual( "<a href='https://yoa.st/4lw' target='_blank'>SKU</a>:" +
-			" Not all your product variants have a SKU. You can add the SKU via the \"Variations\" tab. <a href='https://yoa.st/4lx' target='_blank'>Include" +
-			" this if you can, as it will help search engines to better understand your content.</a>" );
+			" Not all your product variants have a SKU. You can add a SKU via the \"Variations\" tab in the Product " +
+			"data box. <a href='https://yoa.st/4lx' target='_blank'>Include it if you can, as it will help search " +
+			"engines to better understand your content.</a>" );
 	} );
 
 	it( "returns the score 6 when a product has no global SKU, but has variants and not all variants have a SKU", function() {
@@ -72,8 +75,9 @@ describe( "a test for SKU assessment for WooCommerce", function() {
 
 		expect( assessmentResult.getScore() ).toEqual( 6 );
 		expect( assessmentResult.getText() ).toEqual( "<a href='https://yoa.st/4lw' target='_blank'>SKU</a>:" +
-			" Not all your product variants have a SKU. You can add the SKU via the \"Variations\" tab. <a href='https://yoa.st/4lx' target='_blank'>Include" +
-			" this if you can, as it will help search engines to better understand your content.</a>" );
+			" Not all your product variants have a SKU. You can add a SKU via the \"Variations\" tab in the Product " +
+			"data box. <a href='https://yoa.st/4lx' target='_blank'>Include it if you can, as it will help search " +
+			"engines to better understand your content.</a>" );
 	} );
 
 	it( "returns the score 9 with the feedback for a simple product when a variable product has no variants but has a global SKU", function() {
@@ -98,8 +102,9 @@ describe( "a test for SKU assessment for WooCommerce", function() {
 
 		expect( assessmentResult.getScore() ).toEqual( 6 );
 		expect( assessmentResult.getText() ).toEqual( "<a href='https://yoa.st/4lw' target='_blank'>SKU</a>:" +
-			" Your product is missing a SKU. You can add the SKU via the \"Inventory\" tab. <a href='https://yoa.st/4lx' target='_blank'>Include" +
-			" this if you can, as it will help search engines to better understand your content.</a>" );
+			" Your product is missing a SKU. You can add a SKU via the \"Inventory\" tab in the Product data box. " +
+			"<a href='https://yoa.st/4lx' target='_blank'>Include it if you can, as it will help search engines to " +
+			"better understand your content.</a>" );
 	} );
 } );
 

--- a/packages/yoastseo/spec/scoring/assessments/seo/ProductSKUAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/ProductSKUAssessmentSpec.js
@@ -44,7 +44,7 @@ describe( "a test for SKU assessment for WooCommerce", function() {
 
 		expect( assessmentResult.getScore() ).toEqual( 6 );
 		expect( assessmentResult.getText() ).toEqual( "<a href='https://yoa.st/4lw' target='_blank'>SKU</a>:" +
-			" Your product is missing a SKU. <a href='https://yoa.st/4lx' target='_blank'>Include" +
+			" Your product is missing a SKU. You can add the SKU via the \"Inventory\" tab. <a href='https://yoa.st/4lx' target='_blank'>Include" +
 			" this if you can, as it will help search engines to better understand your content.</a>" );
 	} );
 
@@ -58,7 +58,7 @@ describe( "a test for SKU assessment for WooCommerce", function() {
 
 		expect( assessmentResult.getScore() ).toEqual( 6 );
 		expect( assessmentResult.getText() ).toEqual( "<a href='https://yoa.st/4lw' target='_blank'>SKU</a>:" +
-			" Not all your product variants have a SKU. <a href='https://yoa.st/4lx' target='_blank'>Include" +
+			" Not all your product variants have a SKU. You can add the SKU via the \"Variations\" tab. <a href='https://yoa.st/4lx' target='_blank'>Include" +
 			" this if you can, as it will help search engines to better understand your content.</a>" );
 	} );
 
@@ -72,7 +72,7 @@ describe( "a test for SKU assessment for WooCommerce", function() {
 
 		expect( assessmentResult.getScore() ).toEqual( 6 );
 		expect( assessmentResult.getText() ).toEqual( "<a href='https://yoa.st/4lw' target='_blank'>SKU</a>:" +
-			" Not all your product variants have a SKU. <a href='https://yoa.st/4lx' target='_blank'>Include" +
+			" Not all your product variants have a SKU. You can add the SKU via the \"Variations\" tab. <a href='https://yoa.st/4lx' target='_blank'>Include" +
 			" this if you can, as it will help search engines to better understand your content.</a>" );
 	} );
 
@@ -98,7 +98,7 @@ describe( "a test for SKU assessment for WooCommerce", function() {
 
 		expect( assessmentResult.getScore() ).toEqual( 6 );
 		expect( assessmentResult.getText() ).toEqual( "<a href='https://yoa.st/4lw' target='_blank'>SKU</a>:" +
-			" Your product is missing a SKU. <a href='https://yoa.st/4lx' target='_blank'>Include" +
+			" Your product is missing a SKU. You can add the SKU via the \"Inventory\" tab. <a href='https://yoa.st/4lx' target='_blank'>Include" +
 			" this if you can, as it will help search engines to better understand your content.</a>" );
 	} );
 } );

--- a/packages/yoastseo/spec/scoring/productPages/fullTextTests/testTexts/en/englishPaper2.js
+++ b/packages/yoastseo/spec/scoring/productPages/fullTextTests/testTexts/en/englishPaper2.js
@@ -101,15 +101,16 @@ const expectedResults = {
 		isApplicable: true,
 		score: 6,
 		resultText: "<a href='https://yoa.st/4ly' target='_blank'>Product identifier</a>: Your product is missing an identifier " +
-			"(like a GTIN code). You can add the product identifier via the \"Yoast SEO\" tab in Product Data box." +
-			" <a href='https://yoa.st/4lz' target='_blank'>Include this if you can, as it will " +
+			"(like a GTIN code). You can add a product identifier via the \"Yoast SEO\" tab in the Product data box." +
+			" <a href='https://yoa.st/4lz' target='_blank'>Include it if you can, as it will " +
 			"help search engines to better understand your content.</a>",
 	},
 	productSKU: {
 		isApplicable: true,
 		score: 6,
 		resultText: "<a href='https://yoa.st/4lw' target='_blank'>SKU</a>: Your product is missing a SKU. " +
-			"You can add the SKU via the \"Inventory\" tab. <a href='https://yoa.st/4lx' target='_blank'>Include this if you can, as it will " +
+			"You can add a SKU via the \"Inventory\" tab in the Product data box. " +
+			"<a href='https://yoa.st/4lx' target='_blank'>Include it if you can, as it will " +
 			"help search engines to better understand your content.</a>",
 	},
 	imageKeyphrase: {

--- a/packages/yoastseo/spec/scoring/productPages/fullTextTests/testTexts/en/englishPaper2.js
+++ b/packages/yoastseo/spec/scoring/productPages/fullTextTests/testTexts/en/englishPaper2.js
@@ -101,14 +101,15 @@ const expectedResults = {
 		isApplicable: true,
 		score: 6,
 		resultText: "<a href='https://yoa.st/4ly' target='_blank'>Product identifier</a>: Your product is missing an identifier " +
-			"(like a GTIN code). <a href='https://yoa.st/4lz' target='_blank'>Include this if you can, as it will " +
+			"(like a GTIN code). You can add the product identifier via the \"Yoast SEO\" tab in Product Data box." +
+			" <a href='https://yoa.st/4lz' target='_blank'>Include this if you can, as it will " +
 			"help search engines to better understand your content.</a>",
 	},
 	productSKU: {
 		isApplicable: true,
 		score: 6,
-		resultText: "<a href='https://yoa.st/4lw' target='_blank'>SKU</a>: Your product is missing a SKU." +
-			" <a href='https://yoa.st/4lx' target='_blank'>Include this if you can, as it will " +
+		resultText: "<a href='https://yoa.st/4lw' target='_blank'>SKU</a>: Your product is missing a SKU. " +
+			"You can add the SKU via the \"Inventory\" tab. <a href='https://yoa.st/4lx' target='_blank'>Include this if you can, as it will " +
 			"help search engines to better understand your content.</a>",
 	},
 	imageKeyphrase: {

--- a/packages/yoastseo/spec/scoring/productPages/fullTextTests/testTexts/en/englishPaper3.js
+++ b/packages/yoastseo/spec/scoring/productPages/fullTextTests/testTexts/en/englishPaper3.js
@@ -101,16 +101,16 @@ const expectedResults = {
 		isApplicable: true,
 		score: 6,
 		resultText: "<a href='https://yoa.st/4ly' target='_blank'>Product identifier</a>: Not all your product variants" +
-			" have an identifier. You can add the product identifier via the \"Variations\" tab. " +
-			"<a href='https://yoa.st/4lz' target='_blank'>Include this if you can, as it" +
+			" have an identifier. You can add a product identifier via the \"Variations\" tab in the Product data box. " +
+			"<a href='https://yoa.st/4lz' target='_blank'>Include it if you can, as it" +
 			" will help search engines to better understand your content.</a>",
 	},
 	productSKU: {
 		isApplicable: true,
 		score: 6,
-		resultText: "<a href='https://yoa.st/4lw' target='_blank'>SKU</a>: Not all your product variants have a SKU. You can add the SKU via " +
-			"the \"Variations\" tab. <a href='https://yoa.st/4lx' target='_blank'>Include this if you can, as it will help search engines to" +
-			" better understand your content.</a>",
+		resultText: "<a href='https://yoa.st/4lw' target='_blank'>SKU</a>: Not all your product variants have a SKU. You can add a SKU via " +
+			"the \"Variations\" tab in the Product data box. <a href='https://yoa.st/4lx' target='_blank'>Include " +
+			"it if you can, as it will help search engines to better understand your content.</a>",
 	},
 	imageKeyphrase: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/scoring/productPages/fullTextTests/testTexts/en/englishPaper3.js
+++ b/packages/yoastseo/spec/scoring/productPages/fullTextTests/testTexts/en/englishPaper3.js
@@ -101,14 +101,15 @@ const expectedResults = {
 		isApplicable: true,
 		score: 6,
 		resultText: "<a href='https://yoa.st/4ly' target='_blank'>Product identifier</a>: Not all your product variants" +
-			" have an identifier. <a href='https://yoa.st/4lz' target='_blank'>Include this if you can, as it" +
+			" have an identifier. You can add the product identifier via the \"Variations\" tab. " +
+			"<a href='https://yoa.st/4lz' target='_blank'>Include this if you can, as it" +
 			" will help search engines to better understand your content.</a>",
 	},
 	productSKU: {
 		isApplicable: true,
 		score: 6,
-		resultText: "<a href='https://yoa.st/4lw' target='_blank'>SKU</a>: Not all your product variants have a SKU." +
-			" <a href='https://yoa.st/4lx' target='_blank'>Include this if you can, as it will help search engines to" +
+		resultText: "<a href='https://yoa.st/4lw' target='_blank'>SKU</a>: Not all your product variants have a SKU. You can add the SKU via " +
+			"the \"Variations\" tab. <a href='https://yoa.st/4lx' target='_blank'>Include this if you can, as it will help search engines to" +
 			" better understand your content.</a>",
 	},
 	imageKeyphrase: {

--- a/packages/yoastseo/src/scoring/assessments/seo/ProductIdentifiersAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/ProductIdentifiersAssessment.js
@@ -81,9 +81,11 @@ export default class ProductIdentifiersAssessment extends Assessment {
 
 		if ( this._config.productIdentifierOrBarcode === "Product identifier" ) {
 			feedbackStrings = {
-				okNoVariants: __( "Your product is missing an identifier (like a GTIN code)", "wordpress-seo" ),
+				okNoVariants: __( "Your product is missing an identifier (like a GTIN code). " +
+					"You can add the product identifier via the \"Yoast SEO\" tab in Product Data box", "wordpress-seo" ),
 				goodNoVariants: __( "Your product has an identifier", "wordpress-seo" ),
-				okWithVariants: __( "Not all your product variants have an identifier", "wordpress-seo" ),
+				okWithVariants: __( "Not all your product variants have an identifier. " +
+					"You can add the product identifier via the \"Variations\" tab", "wordpress-seo" ),
 				goodWithVariants: __( "All your product variants have an identifier", "wordpress-seo" ),
 			};
 		} else {

--- a/packages/yoastseo/src/scoring/assessments/seo/ProductIdentifiersAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/ProductIdentifiersAssessment.js
@@ -82,10 +82,10 @@ export default class ProductIdentifiersAssessment extends Assessment {
 		if ( this._config.productIdentifierOrBarcode === "Product identifier" ) {
 			feedbackStrings = {
 				okNoVariants: __( "Your product is missing an identifier (like a GTIN code). " +
-					"You can add the product identifier via the \"Yoast SEO\" tab in Product Data box", "wordpress-seo" ),
+					"You can add a product identifier via the \"Yoast SEO\" tab in the Product data box", "wordpress-seo" ),
 				goodNoVariants: __( "Your product has an identifier", "wordpress-seo" ),
 				okWithVariants: __( "Not all your product variants have an identifier. " +
-					"You can add the product identifier via the \"Variations\" tab", "wordpress-seo" ),
+					"You can add a product identifier via the \"Variations\" tab in the Product data box", "wordpress-seo" ),
 				goodWithVariants: __( "All your product variants have an identifier", "wordpress-seo" ),
 			};
 		} else {
@@ -109,7 +109,7 @@ export default class ProductIdentifiersAssessment extends Assessment {
 						* "Your product is missing a product identifier (like a GTIN code)"
 						* or "Your product is missing a barcode (like a GTIN code)" */
 						__(
-							"%1$s%2$s%5$s: %3$s. %4$sInclude this if you can, as it " +
+							"%1$s%2$s%5$s: %3$s. %4$sInclude it if you can, as it " +
 							"will help search engines to better understand your content.%5$s",
 							"wordpress-seo"
 						),
@@ -148,9 +148,9 @@ export default class ProductIdentifiersAssessment extends Assessment {
 						/* Translators: %1$s and %4$s expand to links on yoast.com, %5$s expands to the anchor end tag,
 						* %2$s expands to the string "Barcode" or "Product identifier", %3$s expands to the string
 						* "Not all your product variants have a product identifier"
-						* or "ot all your product variants have a barcode" */
+						* or "Not all your product variants have a barcode" */
 						__(
-							"%1$s%2$s%5$s: %3$s. %4$sInclude this if you can, as it will help search engines to better understand your content.%5$s",
+							"%1$s%2$s%5$s: %3$s. %4$sInclude it if you can, as it will help search engines to better understand your content.%5$s",
 							"wordpress-seo"
 						),
 						this._config.urlTitle,

--- a/packages/yoastseo/src/scoring/assessments/seo/ProductSKUAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/ProductSKUAssessment.js
@@ -92,7 +92,7 @@ export default class ProductSKUAssessment extends Assessment {
 		// Check if we want to add information about where to add the SKU in the feedback string or not.
 		// Currently we want to implement it only for Woo Product pages.
 		let feedbackString = "";
-		if ( this._config.addSKULocation = true ) {
+		if ( this._config.addSKULocation === true ) {
 			feedbackString = __( "You can add a SKU via the \"Inventory\" tab in the Product data box.", "wordpress-seo" );
 		}
 

--- a/packages/yoastseo/src/scoring/assessments/seo/ProductSKUAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/ProductSKUAssessment.js
@@ -11,7 +11,7 @@ export default class ProductSKUAssessment extends Assessment {
 	/**
 	 * Constructs a product SKU assessment.
 	 *
-	 * @param {Object} config   Potential additional config for the assessment.
+	 * @param {Object} 		config   		Potential additional config for the assessment.
 	 *
 	 * @returns {void}
 	 */
@@ -26,6 +26,7 @@ export default class ProductSKUAssessment extends Assessment {
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/4lw" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/4lx" ),
 			assessVariants: false,
+			addSKULocation: false,
 		};
 
 		this.identifier = "productSKU";
@@ -88,6 +89,13 @@ export default class ProductSKUAssessment extends Assessment {
 	 * 													or empty object if no score should be returned.
 	 */
 	scoreProductSKU( productSKUData, config ) {
+		// Check if we want to add information about where to add the SKU in the feedback string or not.
+		// Currently we want to implement it only for Woo Product pages.
+		let feedbackString = "";
+		if ( this._config.addSKULocation = true ) {
+			feedbackString = __( "You can add a SKU via the \"Inventory\" tab in the Product data box.", "wordpress-seo" );
+		}
+
 		// Apply the following scoring conditions to products without variants.
 		if ( [ "simple", "external" ].includes( productSKUData.productType ) ||
 			( productSKUData.productType === "variable" && ! productSKUData.hasVariants ) ) {
@@ -96,14 +104,16 @@ export default class ProductSKUAssessment extends Assessment {
 					score: config.scores.ok,
 					text: sprintf(
 						// Translators: %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag.
+						// %4$s expands to "You can add a SKU via the "Inventory" tab in the Product data box." or to an empty string.
 						__(
-							"%1$sSKU%3$s: Your product is missing a SKU. You can add the SKU via the \"Inventory\" tab." +
-							" %2$sInclude this if you can, as it will help search engines to better understand your content.%3$s",
+							"%1$sSKU%3$s: Your product is missing a SKU. %4$s" +
+							" %2$sInclude it if you can, as it will help search engines to better understand your content.%3$s",
 							"wordpress-seo"
 						),
 						this._config.urlTitle,
 						this._config.urlCallToAction,
-						"</a>"
+						"</a>",
+						feedbackString
 					),
 				};
 			}
@@ -128,8 +138,9 @@ export default class ProductSKUAssessment extends Assessment {
 					text: sprintf(
 						// Translators: %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag.
 						__(
-							"%1$sSKU%3$s: Not all your product variants have a SKU. You can add the SKU via the \"Variations\" tab." +
-							" %2$sInclude this if you can, as it will help search engines to better understand your content.%3$s",
+							"%1$sSKU%3$s: Not all your product variants have a SKU. " +
+							"You can add a SKU via the \"Variations\" tab in the Product data box." +
+							" %2$sInclude it if you can, as it will help search engines to better understand your content.%3$s",
 							"wordpress-seo"
 						),
 						this._config.urlTitle,

--- a/packages/yoastseo/src/scoring/assessments/seo/ProductSKUAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/ProductSKUAssessment.js
@@ -97,8 +97,8 @@ export default class ProductSKUAssessment extends Assessment {
 					text: sprintf(
 						// Translators: %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag.
 						__(
-							"%1$sSKU%3$s: Your product is missing a SKU. %2$sInclude this if you can, as it" +
-							" will help search engines to better understand your content.%3$s",
+							"%1$sSKU%3$s: Your product is missing a SKU. You can add the SKU via the \"Inventory\" tab." +
+							" %2$sInclude this if you can, as it will help search engines to better understand your content.%3$s",
 							"wordpress-seo"
 						),
 						this._config.urlTitle,
@@ -128,8 +128,8 @@ export default class ProductSKUAssessment extends Assessment {
 					text: sprintf(
 						// Translators: %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag.
 						__(
-							"%1$sSKU%3$s: Not all your product variants have a SKU. %2$sInclude this if you can, as it" +
-							" will help search engines to better understand your content.%3$s",
+							"%1$sSKU%3$s: Not all your product variants have a SKU. You can add the SKU via the \"Variations\" tab." +
+							" %2$sInclude this if you can, as it will help search engines to better understand your content.%3$s",
 							"wordpress-seo"
 						),
 						this._config.urlTitle,

--- a/packages/yoastseo/src/scoring/productPages/cornerstone/seoAssessor.js
+++ b/packages/yoastseo/src/scoring/productPages/cornerstone/seoAssessor.js
@@ -152,6 +152,7 @@ const ProductCornerstoneSEOAssessor = function( researcher, options ) {
 			urlTitle: createAnchorOpeningTag( options.productSKUUrlTitle ),
 			urlCallToAction: createAnchorOpeningTag( options.productSKUCTAUrl ),
 			assessVariants: options.assessVariants,
+			addSKULocation: options.addSKULocation,
 		} ),
 		new TextTitleAssessment( {
 			urlTitle: createAnchorOpeningTag( options.textTitleUrlTitle ),

--- a/packages/yoastseo/src/scoring/productPages/seoAssessor.js
+++ b/packages/yoastseo/src/scoring/productPages/seoAssessor.js
@@ -132,6 +132,7 @@ const ProductSEOAssessor = function( researcher, options ) {
 			urlTitle: createAnchorOpeningTag( options.productSKUUrlTitle ),
 			urlCallToAction: createAnchorOpeningTag( options.productSKUCTAUrl ),
 			assessVariants: options.assessVariants,
+			addSKULocation: options.addSKULocation,
 		} ),
 		new TextTitleAssessment( {
 			urlTitle: createAnchorOpeningTag( options.textTitleUrlTitle ),


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Makes the feedback strings for the Product Identifier and SKU assessment more explicit and actionable.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Build and activate the Free plugin/ the branch in Free
* Activate WooCommerce
* Build and activate the Woo plugin
* For Developers: use [the branch in Woo](https://github.com/Yoast/wpseo-woocommerce/pull/828), and then require the branch in this PR (by running `composer require yoast/wordpress-seo:dev-PC-552-make-SKU-and-PI-feedback-more-explicit@dev --dev`)
* Open or create a new product 

**Product without variants:**
* Confirm that the product identifier assessment bullet is orange and reads as follows: `Your product is missing an identifier (like a GTIN code). You can add a product identifier via the "Yoast SEO" tab in the Product data box. Include it if you can, as it will help search engines to better understand your content.`
* And the SKU assessment bullet is also orange and reads as follows: `Your product is missing a SKU. You can add a SKU via the "Inventory" tab in the Product data box. Include it if you can, as it will help search engines to better understand your content.`

* Add a product identifier and a SKU and confirm that the bullets turn green with the following feedback: `Product identifier: Your product has an identifier. Good job!` and `SKU: Your product has a SKU. Good job!`

* Delete the product identifier and the SKU, and confirm that the bullets are back to orange and read the same as the first point above. 

**Product with variants:**
* Add an attribute with at least two values and create some variations from those
* Confirm that the product identifier assessment bullet is orange and reads as follows: `Not all your product variants have an identifier. You can add a product identifier via the "Variations" tab in the Product data box. Include it if you can, as it will help search engines to better understand your content.`
* And the SKU assessment bullet is also orange and reads as follows: `Not all your product variants have a SKU. You can add a SKU via the "Variations" tab in the Product data box. Include it if you can, as it will help search engines to better understand your content.`

* Add a product identifier and a SKU to each variation and confirm that the bullets turns green with the following feedback: 
`Product identifier: All your product variants have an identifier. Good job!` and `SKU: All your product variants have a SKU. Good job!`

* Delete the product identifiers and SKUs of all variations and confirm that the bullets are back to orange and reads as before.



#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [x] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes #https://yoast.atlassian.net/browse/PC-552
