### PR TITLE
Put Indexable Overview behind a feature flag

### DIFF
--- a/admin/class-admin-asset-manager.php
+++ b/admin/class-admin-asset-manager.php
@@ -595,6 +595,10 @@ class WPSEO_Admin_Asset_Manager {
 				'src'  => 'notifications-' . $flat_version,
 			],
 			[
+				'name' => 'notifications-new',
+				'src'  => 'notifications-new-' . $flat_version,
+			],
+			[
 				'name' => 'alert',
 				'src'  => 'alerts-' . $flat_version,
 			],

--- a/admin/class-yoast-notifications.php
+++ b/admin/class-yoast-notifications.php
@@ -102,7 +102,8 @@ class Yoast_Notifications {
 
 		if ( YoastSEO()->classes->get( Indexables_Page_Conditional::class )->is_met() ) {
 			$asset_manager->enqueue_style( 'notifications-new' );
-		} else {
+		}
+		else {
 			$asset_manager->enqueue_style( 'notifications' );
 		}
 	}

--- a/admin/class-yoast-notifications.php
+++ b/admin/class-yoast-notifications.php
@@ -5,6 +5,8 @@
  * @package WPSEO\Admin\Notifications
  */
 
+use Yoast\WP\SEO\Conditionals\Indexables_Page_Conditional;
+
 /**
  * Class Yoast_Notifications.
  */
@@ -96,9 +98,13 @@ class Yoast_Notifications {
 	 * Enqueue assets.
 	 */
 	public function enqueue_assets() {
-
 		$asset_manager = new WPSEO_Admin_Asset_Manager();
-		$asset_manager->enqueue_style( 'notifications' );
+
+		if ( YoastSEO()->classes->get( Indexables_Page_Conditional::class )->is_met() ) {
+			$asset_manager->enqueue_style( 'notifications-new' );
+		} else {
+			$asset_manager->enqueue_style( 'notifications' );
+		}
 	}
 
 	/**

--- a/admin/views/tabs/dashboard/dashboard.php
+++ b/admin/views/tabs/dashboard/dashboard.php
@@ -5,6 +5,7 @@
  * @package WPSEO\Admin
  */
 
+use Yoast\WP\SEO\Conditionals\Indexables_Page_Conditional;
 /**
  * Notifications template variables.
  *
@@ -36,9 +37,15 @@ $wpseo_contributors_phrase = sprintf(
 	</div>
 </div>
 
+<?php
+if( YoastSEO()->classes->get( Indexables_Page_Conditional::class )->is_met() ) {
+?>
 <div class="tab-block">
 	<div id="wpseo-indexables-page"></div>
 </div>
+<?php
+}
+?>
 
 <div class="tab-block">
 	<h2><?php esc_html_e( 'Credits', 'wordpress-seo' ); ?></h2>

--- a/admin/views/tabs/dashboard/dashboard.php
+++ b/admin/views/tabs/dashboard/dashboard.php
@@ -38,7 +38,7 @@ $wpseo_contributors_phrase = sprintf(
 </div>
 
 <?php
-if( YoastSEO()->classes->get( Indexables_Page_Conditional::class )->is_met() ) {
+if ( YoastSEO()->classes->get( Indexables_Page_Conditional::class )->is_met() ) {
 ?>
 <div class="tab-block">
 	<div id="wpseo-indexables-page"></div>

--- a/admin/views/tabs/dashboard/dashboard.php
+++ b/admin/views/tabs/dashboard/dashboard.php
@@ -39,11 +39,11 @@ $wpseo_contributors_phrase = sprintf(
 
 <?php
 if ( YoastSEO()->classes->get( Indexables_Page_Conditional::class )->is_met() ) {
-?>
+	?>
 <div class="tab-block">
 	<div id="wpseo-indexables-page"></div>
 </div>
-<?php
+	<?php
 }
 ?>
 

--- a/composer.json
+++ b/composer.json
@@ -85,7 +85,7 @@
 		],
 		"check-cs-thresholds": [
 			"@putenv YOASTCS_THRESHOLD_ERRORS=144",
-			"@putenv YOASTCS_THRESHOLD_WARNINGS=209",
+			"@putenv YOASTCS_THRESHOLD_WARNINGS=208",
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_cs_thresholds"
 		],
 		"check-cs": [

--- a/css/src/notifications-new.css
+++ b/css/src/notifications-new.css
@@ -2,19 +2,27 @@
 @import "../../node_modules/yoast-components/css/accessibility.css";
 .yoast-notification {
 	padding: 0 12px;
-	border-left: 4px solid #fff;
+	border: 1px solid #e5e7eb;
+	border-left: 4px solid #e5e7eb;
 	background: #fff;
-	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+	border-radius: 0.5rem;
 }
 
 .yoast-container {
 	position: relative;
 	max-width: 1280px;
-	margin: 20px 0 1px;
-	padding: 20px 20px 0;
+	padding: 32px;
 	border: 1px solid #e5e5e5;
 	background-color: #fdfdfd;
 	box-shadow: 0 1px 1px rgba(0, 0, 0, 0.04);
+	border-radius: 0.5rem;
+}
+
+.yoast-notifications {
+	max-width: 80rem;
+	display: flex;
+	flex-direction: column;
+	gap: 1.5rem;
 }
 
 .yoast-notifications > h2:first-child {
@@ -28,9 +36,25 @@
 .yoast-notifications .yoast-container h3 {
 	margin: -20px -20px 0;
 	padding: 1em;
-	border-bottom: 1px solid #ccc;
 	background-color: #fdfdfd;
 	font-size: 1.4em;
+	border-top-left-radius: 0.5rem;
+	border-top-right-radius: 0.5rem;
+	color: rgb(17,24,39);
+	font-weight: 500;
+	font-size: 1rem;
+}
+
+@media screen and (min-width: 1536px) {
+	.yoast-notifications {
+		display: grid;
+		grid-template-columns: 1fr 1fr;
+		grid-gap: 1.5rem;
+	}
+
+	.yoast-container {
+		align-self: start;
+	}
 }
 
 .yoast-container .container {
@@ -68,6 +92,13 @@
 	border: none;
 	box-shadow: none;
 	border-radius: 0;
+}
+
+.yoast-notifications button.toggleable-container-trigger {
+	color: rgb(55,65,81);
+	font-weight: 500;
+	line-height: 1.25rem;
+	font-size: 0.875rem !important;
 }
 
 .yoast-notifications .button.restore:hover,
@@ -151,11 +182,16 @@
 }
 
 .yoast-notifications-active .yoast-notification-holder {
-	margin-bottom: 20px;
+	margin-top: 20px;
+}
+
+.yoast-notifications-active .yoast-notification-holder:first-of-type {
+	margin-top: 0;
 }
 
 .yoast-notifications-dismissed.paper.tab-block {
-	margin: 20px 0 20px 0;
+	margin-top: 20px;
+	margin-bottom: 0px;
 }
 
 .yoast-notifications-dismissed.paper.tab-block .paper-container.toggleable-container {

--- a/src/conditionals/indexables-page-conditional.php
+++ b/src/conditionals/indexables-page-conditional.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Yoast\WP\SEO\Conditionals;
+
+/**
+ * Feature flag conditional for the new indexables page.
+ */
+class Indexables_Page_Conditional extends Feature_Flag_Conditional {
+
+	/**
+	 * Returns the name of the feature flag.
+	 *
+	 * @return string The name of the feature flag.
+	 */
+	protected function get_feature_flag() {
+		return 'INDEXABLES_PAGE';
+	}
+}

--- a/src/integrations/admin/indexables-page-integration.php
+++ b/src/integrations/admin/indexables-page-integration.php
@@ -7,6 +7,7 @@ use WPSEO_Addon_Manager;
 
 use WPSEO_Shortlinker;
 use Yoast\WP\SEO\Conditionals\Admin_Conditional;
+use Yoast\WP\SEO\Conditionals\Indexables_Page_Conditional;
 use Yoast\WP\SEO\Helpers\Indexables_Page_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Product_Helper;
@@ -72,7 +73,10 @@ class Indexables_Page_Integration implements Integration_Interface {
 	 * {@inheritDoc}
 	 */
 	public static function get_conditionals() {
-		return [ Admin_Conditional::class ];
+		return [
+			Admin_Conditional::class,
+			Indexables_Page_Conditional::class,
+		];
 	}
 
 	/**

--- a/src/presenters/admin/notice-presenter.php
+++ b/src/presenters/admin/notice-presenter.php
@@ -3,6 +3,7 @@
 namespace Yoast\WP\SEO\Presenters\Admin;
 
 use WPSEO_Admin_Asset_Manager;
+use Yoast\WP\SEO\Conditionals\Indexables_Page_Conditional;
 use Yoast\WP\SEO\Presenters\Abstract_Presenter;
 
 /**
@@ -83,7 +84,11 @@ class Notice_Presenter extends Abstract_Presenter {
 			$this->asset_manager = new WPSEO_Admin_Asset_Manager();
 		}
 
-		$this->asset_manager->enqueue_style( 'notifications' );
+		if ( YoastSEO()->classes->get( Indexables_Page_Conditional::class )->is_met() ) {
+			$this->asset_manager->enqueue_style( 'notifications-new' );
+		} else {
+			$this->asset_manager->enqueue_style( 'notifications' );
+		}
 	}
 
 	/**

--- a/src/presenters/admin/notice-presenter.php
+++ b/src/presenters/admin/notice-presenter.php
@@ -84,9 +84,10 @@ class Notice_Presenter extends Abstract_Presenter {
 			$this->asset_manager = new WPSEO_Admin_Asset_Manager();
 		}
 
-		if ( YoastSEO()->classes->get( Indexables_Page_Conditional::class )->is_met() ) {
+		if ( \YoastSEO()->classes->get( Indexables_Page_Conditional::class )->is_met() ) {
 			$this->asset_manager->enqueue_style( 'notifications-new' );
-		} else {
+		}
+		else {
 			$this->asset_manager->enqueue_style( 'notifications' );
 		}
 	}

--- a/src/routes/indexables-page-route.php
+++ b/src/routes/indexables-page-route.php
@@ -6,7 +6,7 @@ use WP_REST_Request;
 use WP_REST_Response;
 use WP_Error;
 use Yoast\WP\SEO\Actions\Indexables_Page_Action;
-use Yoast\WP\SEO\Conditionals\No_Conditionals;
+use Yoast\WP\SEO\Conditionals\Indexables_Page_Conditional;
 use Yoast\WP\SEO\Helpers\Indexables_Page_Helper;
 use Yoast\WP\SEO\Main;
 
@@ -14,8 +14,6 @@ use Yoast\WP\SEO\Main;
  * Indexables_Page_Route class.
  */
 class Indexables_Page_Route implements Route_Interface {
-
-	use No_Conditionals;
 
 	/**
 	 * Represents the route that retrieves the neccessary information for setting up the Indexables Page.
@@ -117,6 +115,15 @@ class Indexables_Page_Route implements Route_Interface {
 	public function __construct( Indexables_Page_Action $indexables_page_action, Indexables_Page_Helper $indexables_page_helper ) {
 		$this->indexables_page_action = $indexables_page_action;
 		$this->indexables_page_helper = $indexables_page_helper;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_conditionals() {
+		return [
+			Indexables_Page_Conditional::class,
+		];
 	}
 
 	/**

--- a/tests/unit/integrations/admin/deactivated-premium-integration-test.php
+++ b/tests/unit/integrations/admin/deactivated-premium-integration-test.php
@@ -6,6 +6,7 @@ use Brain\Monkey;
 use Mockery;
 use WPSEO_Admin_Asset_Manager;
 use Yoast\WP\SEO\Conditionals\Admin_Conditional;
+use Yoast\WP\SEO\Conditionals\Indexables_Page_Conditional;
 use Yoast\WP\SEO\Conditionals\Non_Multisite_Conditional;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Integrations\Admin\Deactivated_Premium_Integration;
@@ -98,6 +99,18 @@ class Deactivated_Premium_Integration_Test extends TestCase {
 		Monkey\Functions\expect( 'wp_nonce_url' )->with( 'https://example.org/wp-admin/plugins.php?action=activate&plugin=' . $premium_file, 'activate-plugin_' . $premium_file )->andReturnFirstArg();
 		Monkey\Functions\expect( 'wp_enqueue_style' )->with( 'yoast-seo-notifications' );
 		Monkey\Functions\expect( 'plugin_dir_url' )->andReturn( 'https://example.org/wp-content/plugins/' );
+
+		$conditional = Mockery::mock( Indexables_Page_Conditional::class );
+		$conditional->expects( 'is_met' )->once()->andReturnFalse();
+
+		$classes = Mockery::mock();
+		$classes->expects( 'get' )->once()->with( Indexables_Page_Conditional::class )->andReturn( $conditional );
+
+		Monkey\Functions\expect( 'YoastSEO' )->once()->andReturn(
+			(object) [
+				'classes' => $classes,
+			]
+		);
 
 		// Output should contain the nonce URL.
 		$this->expectOutputContains( 'plugins.php?action=activate&plugin=' . $premium_file );

--- a/tests/unit/presenters/admin/notice-presenter-test.php
+++ b/tests/unit/presenters/admin/notice-presenter-test.php
@@ -3,7 +3,9 @@
 namespace Yoast\WP\SEO\Tests\Unit\Presenters\Admin;
 
 use Brain\Monkey;
+use Mockery;
 use WPSEO_Admin_Asset_Manager;
+use Yoast\WP\SEO\Conditionals\Indexables_Page_Conditional;
 use Yoast\WP\SEO\Presenters\Admin\Notice_Presenter;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
@@ -35,6 +37,18 @@ class Notice_Presenter_Test extends TestCase {
 	public function test_construct() {
 		Monkey\Functions\expect( 'wp_enqueue_style' )->once();
 
+		$conditional = Mockery::mock( Indexables_Page_Conditional::class );
+		$conditional->expects( 'is_met' )->once()->andReturnFalse();
+
+		$classes = Mockery::mock();
+		$classes->expects( 'get' )->once()->with( Indexables_Page_Conditional::class )->andReturn( $conditional );
+
+		Monkey\Functions\expect( 'YoastSEO' )->once()->andReturn(
+			(object) [
+				'classes' => $classes,
+			]
+		);
+
 		$test = new Notice_Presenter( 'title', 'content', 'image.png', null, true );
 
 		$this->assertSame( 'title', $this->getPropertyValue( $test, 'title' ) );
@@ -55,6 +69,18 @@ class Notice_Presenter_Test extends TestCase {
 	 */
 	public function test_default_notice() {
 		Monkey\Functions\expect( 'wp_enqueue_style' )->once();
+
+		$conditional = Mockery::mock( Indexables_Page_Conditional::class );
+		$conditional->expects( 'is_met' )->once()->andReturnFalse();
+
+		$classes = Mockery::mock();
+		$classes->expects( 'get' )->once()->with( Indexables_Page_Conditional::class )->andReturn( $conditional );
+
+		Monkey\Functions\expect( 'YoastSEO' )->once()->andReturn(
+			(object) [
+				'classes' => $classes,
+			]
+		);
 
 		$test = new Notice_Presenter( 'title', 'content' );
 
@@ -81,6 +107,18 @@ class Notice_Presenter_Test extends TestCase {
 	 */
 	public function test_notice_with_image() {
 		Monkey\Functions\expect( 'wp_enqueue_style' )->once();
+
+		$conditional = Mockery::mock( Indexables_Page_Conditional::class );
+		$conditional->expects( 'is_met' )->once()->andReturnFalse();
+
+		$classes = Mockery::mock();
+		$classes->expects( 'get' )->once()->with( Indexables_Page_Conditional::class )->andReturn( $conditional );
+
+		Monkey\Functions\expect( 'YoastSEO' )->once()->andReturn(
+			(object) [
+				'classes' => $classes,
+			]
+		);
 
 		$test = new Notice_Presenter( 'title', 'content', 'image.png' );
 
@@ -110,6 +148,18 @@ class Notice_Presenter_Test extends TestCase {
 	public function test_dismissble_notice() {
 		Monkey\Functions\expect( 'wp_enqueue_style' )->once();
 
+		$conditional = Mockery::mock( Indexables_Page_Conditional::class );
+		$conditional->expects( 'is_met' )->once()->andReturnFalse();
+
+		$classes = Mockery::mock();
+		$classes->expects( 'get' )->once()->with( Indexables_Page_Conditional::class )->andReturn( $conditional );
+
+		Monkey\Functions\expect( 'YoastSEO' )->once()->andReturn(
+			(object) [
+				'classes' => $classes,
+			]
+		);
+
 		$test = new Notice_Presenter( 'title', 'content', null, null, true );
 
 		$expected = '<div class="notice notice-yoast yoast is-dismissible"><div class="notice-yoast__container">'
@@ -136,6 +186,18 @@ class Notice_Presenter_Test extends TestCase {
 	 */
 	public function test_dismissble_notice_with_image() {
 		Monkey\Functions\expect( 'wp_enqueue_style' )->once();
+
+		$conditional = Mockery::mock( Indexables_Page_Conditional::class );
+		$conditional->expects( 'is_met' )->once()->andReturnFalse();
+
+		$classes = Mockery::mock();
+		$classes->expects( 'get' )->once()->with( Indexables_Page_Conditional::class )->andReturn( $conditional );
+
+		Monkey\Functions\expect( 'YoastSEO' )->once()->andReturn(
+			(object) [
+				'classes' => $classes,
+			]
+		);
 
 		$test = new Notice_Presenter( 'title', 'content', 'image.png', null, true );
 
@@ -164,6 +226,18 @@ class Notice_Presenter_Test extends TestCase {
 	 */
 	public function test_dismissble_notice_with_image_and_button() {
 		Monkey\Functions\expect( 'wp_enqueue_style' )->once();
+
+		$conditional = Mockery::mock( Indexables_Page_Conditional::class );
+		$conditional->expects( 'is_met' )->once()->andReturnFalse();
+
+		$classes = Mockery::mock();
+		$classes->expects( 'get' )->once()->with( Indexables_Page_Conditional::class )->andReturn( $conditional );
+
+		Monkey\Functions\expect( 'YoastSEO' )->once()->andReturn(
+			(object) [
+				'classes' => $classes,
+			]
+		);
 
 		$button = '<a class="yoast-button yoast-button-upsell" href="https://yoa.st/somewhere">Some text</a>';
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Puts the Indexable Overview behind a feature flag.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

Note: You can add the following line in your wp-config.php to enabled the feature flag:
`define('YOAST_SEO_INDEXABLES_PAGE', true );`

Without the Feature Flag:
* Visit Yoast SEO->Dashboard and confirm that the Indexables Overview is not shown under the Notifications
* Do a GET request via Postman to http://basic.wordpress.test/wp-json/yoast/v1/get_reading_list and confirm that you get a 404 response ([Helping article](https://www.oasisworkflow.com/how-to-authenticate-wp-rest-apis-with-postman) on doing WP REST API requests via Postman)
* Confirm that the Notifications look like this:
![image](https://user-images.githubusercontent.com/12400734/189314261-9c59e088-6a02-4ea3-8170-edbf439f9e56.png)

With the Feature Flag:
* Visit Yoast SEO->Dashboard, confirm that the Indexables Overview is shown under the Notifications and smoke test it.
* Do a GET request via Postman to http://basic.wordpress.test/wp-json/yoast/v1/get_reading_list and confirm that you get a 200 response ([Helping article](https://www.oasisworkflow.com/how-to-authenticate-wp-rest-apis-with-postman) on doing WP REST API requests via Postman)
* Confirm that the Notifications look like this:
![image](https://user-images.githubusercontent.com/12400734/189314470-9a91d4be-8f20-4bc6-9095-299b6bd9db91.png)

With the Feature Flag both enabled and disabled:
* We have refactored the Indexation component a bit so it can be ready to accept multiple SEO optimization button in the same page. It's counter-productive to put this change behind a feature flag, so we're going to keep it as is, refactored. So, smoke test the SEO optimization process both in the Tools page and the FTC.
* Smoke test the notices that we output in the WP admin (for example the `Activate Yoast SEO Premium!` one) and verify they have the same styling with the Feature Flag both enabled and disabled
* Clicking the Go to the SEO Dashboard button in the FTC will reload the page to the Dashboard tab

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [x] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes #
