### PR TITLE
Don't encode '@' in URL path

### DIFF
--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -207,7 +207,7 @@ class WPSEO_Utils {
 		if ( isset( $parts['path'] ) && strpos( $parts['path'], '/' ) === 0 ) {
 			$path = explode( '/', wp_strip_all_tags( $parts['path'] ) );
 			$path = self::sanitize_encoded_text_field( $path );
-			$url .= implode( '/', $path );
+			$url .= str_replace( '%40', '@', implode( '/', $path ) );
 		}
 
 		if ( ! $url ) {

--- a/tests/integration/test-class-wpseo-utils.php
+++ b/tests/integration/test-class-wpseo-utils.php
@@ -197,7 +197,7 @@ class WPSEO_Utils_Test extends WPSEO_UnitTestCase {
 	 */
 	public function sanitize_url_provider() {
 		return [
-			// Related issue: https://github.com/Yoast/wordpress-seo/issues/17099
+			// Related issue: https://github.com/Yoast/wordpress-seo/issues/17099.
 			'with_at_sign_in_url_path'       => [
 				'expected'        => 'https://example.org/test1/@test2',
 				'url_to_sanitize' => 'https://example.org/test1/@test2',

--- a/tests/integration/test-class-wpseo-utils.php
+++ b/tests/integration/test-class-wpseo-utils.php
@@ -197,6 +197,11 @@ class WPSEO_Utils_Test extends WPSEO_UnitTestCase {
 	 */
 	public function sanitize_url_provider() {
 		return [
+			// Related issue: https://github.com/Yoast/wordpress-seo/issues/17099
+			'with_at_sign_in_url_path'       => [
+				'expected'        => 'https://example.org/test1/@test2',
+				'url_to_sanitize' => 'https://example.org/test1/@test2',
+			],
 			// Related issue: https://github.com/Yoast/wordpress-seo/issues/14476.
 			'with_encoded_url'               => [
 				'expected'        => 'https://example.com/%da%af%d8%b1%d9%88%d9%87-%d8%aa%d9%84%da%af%d8%b1%d8%a7%d9%85-%d8%b3%d8%a6%d9%88/',


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* According [RFC3986](https://datatracker.ietf.org/doc/html/rfc3986), prevent encoding at sign (`@`) in an URL path.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where social or canonical URLs containing `@` would lead to encoding issues. Props to @stodorovic.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:


* Save a Tiktok user URL into the Organization's social profiles field. Refresh the page and view the saved URL.
* Save a canonical URL (which contains `@`) into a page and view the saved URL.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [X] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes #18764, #17099
