### PR TITLE
PC-445 Remove Twitter small preview

### DIFF
--- a/admin/formatter/class-metabox-formatter.php
+++ b/admin/formatter/class-metabox-formatter.php
@@ -94,7 +94,7 @@ class WPSEO_Metabox_Formatter {
 				'pageTypeOptions'    => $schema_types->get_page_type_options(),
 				'articleTypeOptions' => $schema_types->get_article_type_options(),
 			],
-			'twitterCardType'                 => YoastSEO()->helpers->options->get( 'twitter_card_type' ),
+			'twitterCardType'                 => 'summary_large_image',
 
 			/**
 			 * Filter to determine if the markers should be enabled or not.

--- a/admin/views/tabs/social/twitterbox.php
+++ b/admin/views/tabs/social/twitterbox.php
@@ -27,8 +27,4 @@ echo '<p>';
 esc_html_e( 'Enable this feature if you want Twitter to display a preview with images and a text excerpt when a link to your site is shared.', 'wordpress-seo' );
 echo '</p>';
 
-echo '<br />';
-
-$yform->select( 'twitter_card_type', __( 'The default card type to use', 'wordpress-seo' ), WPSEO_Option_Social::$twitter_card_types );
-
 do_action( 'wpseo_admin_twitter_section' );

--- a/inc/options/class-wpseo-option-social.php
+++ b/inc/options/class-wpseo-option-social.php
@@ -69,7 +69,7 @@ class WPSEO_Option_Social extends WPSEO_Option {
 	 * @var array
 	 */
 	public static $twitter_card_types = [
-		'summary'             => '',
+		// 'summary'             => '',
 		'summary_large_image' => '',
 		// 'photo'               => '',
 		// 'gallery'             => '',
@@ -106,7 +106,6 @@ class WPSEO_Option_Social extends WPSEO_Option {
 	 * @return void
 	 */
 	public function translate_defaults() {
-		self::$twitter_card_types['summary']             = __( 'Summary', 'wordpress-seo' );
 		self::$twitter_card_types['summary_large_image'] = __( 'Summary with large image', 'wordpress-seo' );
 	}
 

--- a/inc/options/class-wpseo-option-social.php
+++ b/inc/options/class-wpseo-option-social.php
@@ -69,8 +69,8 @@ class WPSEO_Option_Social extends WPSEO_Option {
 	 * @var array
 	 */
 	public static $twitter_card_types = [
-		// 'summary'             => '',
 		'summary_large_image' => '',
+		// 'summary'             => '',
 		// 'photo'               => '',
 		// 'gallery'             => '',
 		// 'app'                 => '',

--- a/packages/js/src/initializers/admin.js
+++ b/packages/js/src/initializers/admin.js
@@ -185,12 +185,6 @@ export default function initAdmin( jQuery ) {
 	function initSelect2() {
 		var select2Width = "400px";
 
-		// Select2 for Twitter card meta data in Settings
-		jQuery( "#twitter_card_type" ).select2( {
-			width: select2Width,
-			language: wpseoScriptData.userLanguageCode,
-		} );
-
 		// Select2 for taxonomy breadcrumbs in Advanced
 		jQuery( "#breadcrumbs select" ).select2( {
 			width: select2Width,

--- a/src/context/meta-tags-context.php
+++ b/src/context/meta-tags-context.php
@@ -472,7 +472,7 @@ class Meta_Tags_Context extends Abstract_Presentation {
 	 * @return string The twitter card type.
 	 */
 	public function generate_twitter_card() {
-		return $this->options->get( 'twitter_card_type' );
+		return 'summary_large_image';
 	}
 
 	/**

--- a/src/presenters/twitter/card-presenter.php
+++ b/src/presenters/twitter/card-presenter.php
@@ -26,10 +26,13 @@ class Card_Presenter extends Abstract_Indexable_Tag_Presenter {
 		/**
 		 * Filter: 'wpseo_twitter_card_type' - Allow changing the Twitter card type.
 		 *
-		 * @api string $card_type The card type.
+		 * @deprecated 19.8
 		 *
+		 * @param string $card_type The card type.
 		 * @param Indexable_Presentation $presentation The presentation of an indexable.
 		 */
-		return \trim( \apply_filters( 'wpseo_twitter_card_type', $this->presentation->twitter_card, $this->presentation ) );
+		\apply_filters_deprecated( 'wpseo_twitter_card_type', [ $this->presentation->twitter_card, $this->presentation ], 'WPSEO 19.8', '', 'The only supported value is summary_large_image' );
+
+		return $this->presentation->twitter_card;
 	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to force the `summary_large_image` type of card, being the only one supported by Twitter now.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Forces the use of the large card, which is the only supported format by Twitter.
* Deprecates the `wpseo_twitter_card_type` filter.

## Relevant technical choices:

I decided to have a "light" approach about the removal, to keep the scope and impact low instead of erasing all the mechanisms triggered by the former choice between a small and a large image card:
* I've remove the select2 from the Social settings: this is a page that's going to be replaces soon anyway by the new UI, but it's still one occurrence of a library that we want to get rid of soon. No hidden field has been placed in the page, so saving the options will force the value of `twitter_card_type` to the default `summary_large_image` value.
* The `summary_large_image` is also the only accepted value by the option validation code.
* Where the option is read to, I've forced the value to `summary_large_image` overriding any value still stored in the DB. This avoids introducing an upgrade routine, and helps with downgrading (provided that the user has not saved the options yet, see above). 
* Forcing the value when reading it means that the `twitter:card` tag will always have the `summary_large_image` value, while the `isLarge` prop used by the Twitter preview will always be `true`. I considered the idea of getting rid of this prop but it would have made the issue too complicated and impactful, for no real improvement.
* I've deprecated and made useless the `wpseo_twitter_card_type` which was used to change the value.


## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install and activate a previous version of Yoast SEO and make sure you set "Summary" (not "Summary with large image") in Social > Twitter, then Save
* make sure Premium is inactive for the moment
* switch to this branch/RC
* visit Social >Twitter again, and see there is no select anymore
  * **don't** save the options
* optional: inspect `wpseo_social` in the `options` table and see that `twitter_card_type` is still set to the `summary` (small) value.
* visit any page on the front-end (provided that it has an image do display), inspect the `twitter:card` meta tag
  * check that it has the `summary_large_image` value
  * optional: if the site is reachabled from the outside network, test the page with the [Card validator](https://cards-dev.twitter.com/validator)
* create/edit a post
* smoke test the Twitter section in the Social tab of the metabox, check that it's still working fine (it's not been touched at all, actually)
* activate Premium
* create/edit a post
* check the Twitter preview both in the metabox and in the Sidebar (modal), check that it displays a large preview
  * check that you don't get any console errors
  * check that if you upload a too small image you get a warning suggesting to increase the size beyond a minimum.

#### Downgrading
* Downgrade to the previous Yoast SEO version (and previous Premium version if needed)
* check that the select in Social > Twitter still has the "Summary" value
* check that the `twitter:card` meta tag now has the value `summary`
* check the Twitter preview in the different cases and see that it's using the small type
* Upgrade again to this branch/RC
* visit the Social page and save
* inspect the `wpseo_social` in the `options` table and see that `twitter_card_type` is now set to the `summary_large_image` value.
* if you downgrade now the previews/tag should be set to the "large` values.

#### Deprecating the filter
* With the old version install, add the following filter in your functions.php (or in a mu-plugin):
```
add_filter( 'wpseo_twitter_card_type', 'twitter_card_type' );
function twitter_card_type( $type ) {
    return 'whatever';
}
```
* Visit the frontend of any post and regardless of the social settings, confirm that the `twitter:card` tag has a value of `whatever`
* Now switch to the current PR/RC
* Visit the frontend of any post and confirm that the `twitter:card` tag has not a value of `whatever` but rather of `summary_large_image` 
* Also confirm that you get a deprecation message: `PHP Deprecated:  Hook wpseo_twitter_card_type is <strong>deprecated</strong> since version WPSEO 19.8 with no alternative available. The only supported value is summary_large_image`

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [x] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

The above checks in the preview should be performed
- in the Block editor (metabox+sidebar)
- in the Classic editor (only metabox, though it's not expected to work in a different way from the Block editor)
- on Elementor (the Twitter preview in a modal from the Yoast sidebar)

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes [PC-445]


[PC-445]: https://yoast.atlassian.net/browse/PC-445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ