### PR TITLE
Remove list item in breadcrumps schema if it has an empty text

### DIFF
--- a/src/generators/schema/breadcrumb.php
+++ b/src/generators/schema/breadcrumb.php
@@ -82,6 +82,9 @@ class Breadcrumb extends Abstract_Schema_Piece {
 			}
 		}
 
+		$breadcrumbs = \array_filter( $breadcrumbs, [ $this, 'not_empty_text' ] );
+		$breadcrumbs = \array_values( $breadcrumbs );
+
 		// Create intermediate breadcrumbs.
 		foreach ( $breadcrumbs as $index => $breadcrumb ) {
 			$list_elements[] = $this->create_breadcrumb( $index, $breadcrumb );
@@ -92,6 +95,17 @@ class Breadcrumb extends Abstract_Schema_Piece {
 			'@id'             => $this->context->canonical . Schema_IDs::BREADCRUMB_HASH,
 			'itemListElement' => $list_elements,
 		];
+	}
+
+	/**
+	 * Checks whether the breadcrumb has a not empty text.
+	 *
+	 * @param array $breadcrumb The breadcrumb array.
+	 *
+	 * @return bool If the breadcrumb has a not empty text.
+	 */
+	private function not_empty_text( $breadcrumb ) {
+		return ! empty( $breadcrumb['text'] );
 	}
 
 	/**

--- a/src/generators/schema/breadcrumb.php
+++ b/src/generators/schema/breadcrumb.php
@@ -98,17 +98,6 @@ class Breadcrumb extends Abstract_Schema_Piece {
 	}
 
 	/**
-	 * Checks whether the breadcrumb has a not empty text.
-	 *
-	 * @param array $breadcrumb The breadcrumb array.
-	 *
-	 * @return bool If the breadcrumb has a not empty text.
-	 */
-	private function not_empty_text( $breadcrumb ) {
-		return ! empty( $breadcrumb['text'] );
-	}
-
-	/**
 	 * Returns a breadcrumb array.
 	 *
 	 * @param int   $index      The position in the list.
@@ -178,5 +167,16 @@ class Breadcrumb extends Abstract_Schema_Piece {
 	 */
 	private function not_hidden( $breadcrumb ) {
 		return empty( $breadcrumb['hide_in_schema'] );
+	}
+
+	/**
+	 * Checks whether the breadcrumb has a not empty text.
+	 *
+	 * @param array $breadcrumb The breadcrumb array.
+	 *
+	 * @return bool If the breadcrumb has a not empty text.
+	 */
+	private function not_empty_text( $breadcrumb ) {
+		return ! empty( $breadcrumb['text'] );
 	}
 }

--- a/tests/unit/generators/schema/breadcrumb-test.php
+++ b/tests/unit/generators/schema/breadcrumb-test.php
@@ -523,9 +523,8 @@ class Breadcrumb_Test extends TestCase {
 	}
 
 	/**
-	 * Generate method should fall back to the page title when the
-	 * text is empty, but only for the current page.
-	 * (last item in the breadcrumb list).
+	 * Generate method should omit the entity when
+	 * text is empty.
 	 *
 	 * @covers ::generate
 	 * @covers ::not_hidden
@@ -557,11 +556,6 @@ class Breadcrumb_Test extends TestCase {
 			->once()
 			->with( 'Home' )
 			->andReturn( 'Home' );
-		$this->html
-			->expects( 'smart_strip_tags' )
-			->once()
-			->with( '' )
-			->andReturn( '' );
 
 		$expected = [
 			'@type'           => 'BreadcrumbList',
@@ -572,11 +566,6 @@ class Breadcrumb_Test extends TestCase {
 					'position' => 1,
 					'name'     => 'Home',
 					'item'     => 'https://wordpress.example.com/',
-				],
-				[
-					'@type'    => 'ListItem',
-					'position' => 2,
-					'name'     => '',
 				],
 			],
 		];


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We check each ListItem in a breadcrump object whether it has valid Text value and if not we remove it from schema.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where `ListItem` entries would be output in a `BreadcrumbList` even if their text was empty, resulting in Schema validation errors.

## Relevant technical choices:

* This fix "masks" the underlying issues, but it does introduce graceful failure when a breadcrumb item has an empty text to avoid GSC errors

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Have the Twenty Nineteen theme enabled (that way, you're able to have empty title for a page)
* Create a page, lets call it Page1
* Now create a second page, lets call it Page2 and make it as children of Page1. Add a Yoast's breadcrumb block there.
* Now, go to Page1's edit page and change its title to an empty string
**Without this PR/RC:**
* The schema for the breadcrumb block in the frontend of Page2 would look something like this:
```
	        {
	            "@type": "BreadcrumbList",
	            "@id": "http://basic.wordpress.test/page1/page2/#breadcrumb",
	            "itemListElement": [
	                {
	                    "@type": "ListItem",
	                    "position": 1,
	                    "name": "Home",
	                    "item": "http://basic.wordpress.test/"
	                },
	                {
	                    "@type": "ListItem",
	                    "position": 2,
	                    "name": "",
	                    "item": "http://basic.wordpress.test/page1/"
	                },
	                {
	                    "@type": "ListItem",
	                    "position": 3,
	                    "name": "Page2"
	                }
	            ]
	        },
```
(notice the 2nd ListItem, with the empty name - that shouldnt be displayed at all because it has an invalid name, thus throwing errors in https://search.google.com/test/rich-results )
**With this PR:**
* The schema for the breadcrumb block should look something like this
```
	        {
	            "@type": "BreadcrumbList",
	            "@id": "http://basic.wordpress.test/page1/page2/#breadcrumb",
	            "itemListElement": [
	                {
	                    "@type": "ListItem",
	                    "position": 1,
	                    "name": "Home",
	                    "item": "http://basic.wordpress.test/"
	                },
	                {
	                    "@type": "ListItem",
	                    "position": 2,
	                    "name": "Page2"
	                }
	            ]
	        },
```
(notice that the 2nd ListItem, with the empty name has been removed - and also the `position` of the rest of the items have been adjusted)

Additionally, you can test the following tasks that are being solved with this:
* https://yoast.atlassian.net/browse/PC-189
* https://yoast.atlassian.net/browse/IM-788 (I couldn't reproduce or test, see [my last comment there](https://yoast.atlassian.net/browse/IM-788?focusedCommentId=51868)) (partial fix, only the schema breadcrumb issue)
* https://yoast.atlassian.net/browse/IM-1595 (partial fix, only the schema breadcrumb issue)

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes #
