### PR TITLE
Remove empty breadcrumb schema if not on homepage

### DIFF
--- a/src/generators/schema-generator.php
+++ b/src/generators/schema-generator.php
@@ -75,6 +75,7 @@ class Schema_Generator implements Generator_Interface {
 		$pieces_to_generate = $this->filter_graph_pieces_to_generate( $pieces );
 		$graph              = $this->generate_graph( $pieces_to_generate, $context );
 		$graph              = $this->add_schema_blocks_graph_pieces( $graph, $context );
+		$graph              = $this->finalize_graph( $graph );
 
 		return [
 			'@context' => 'https://schema.org',
@@ -191,6 +192,57 @@ class Schema_Generator implements Generator_Interface {
 
 				if ( isset( $block['attrs']['yoast-schema'] ) ) {
 					$graph[] = $this->schema_replace_vars_helper->replace( $block['attrs']['yoast-schema'], $context->presentation );
+				}
+			}
+		}
+
+		return $graph;
+	}
+
+	/**
+	 * Finalizes the schema graph after all filtering is done.
+	 *
+	 * @param array $graph The current schema graph.
+	 *
+	 * @return array The schema graph.
+	 */
+	protected function finalize_graph( $graph ) {
+		$graph = $this->remove_empty_breadcrumb( $graph );
+
+		return $graph;
+	}
+
+	/**
+	 * Removes the breadcrumb schema if empty.
+	 *
+	 * @param array $graph The current schema graph.
+	 *
+	 * @return array The schema graph with empty breadcrumpbs taken out.
+	 */
+	protected function remove_empty_breadcrumb( $graph ) {
+		if ( $this->helpers->current_page->is_home_static_page() || $this->helpers->current_page->is_home_posts_page() ) {
+			return $graph;
+		}
+
+		// Remove the breadcrumb piece, if it's empty.
+		$index_to_remove = 0;
+		foreach ( $graph as $key => $piece ) {
+			if ( \in_array( 'BreadcrumbList', $this->get_type_from_piece( $piece ), true ) ) {
+				if ( isset( $piece['itemListElement'] ) && is_array( $piece['itemListElement'] ) && count( $piece['itemListElement'] ) === 1 ) {
+					$index_to_remove = $key;
+					break;
+				}
+			}
+		}
+
+		// If the breadcrumb piece has been removed, we should remove its reference from the WebPage node.
+		if ( $index_to_remove !== 0 ) {
+			\array_splice( $graph, $index_to_remove, 1 );
+
+			foreach ( $graph as $key => $piece ) {
+				if ( \in_array( 'WebPage', $this->get_type_from_piece( $piece ), true ) && isset( $piece['breadcrumb'] ) ) {
+					unset( $piece['breadcrumb'] );
+					$graph[ $key ] = $piece;
 				}
 			}
 		}

--- a/src/generators/schema-generator.php
+++ b/src/generators/schema-generator.php
@@ -242,13 +242,7 @@ class Schema_Generator implements Generator_Interface {
 			\array_splice( $graph, $index_to_remove, 1 );
 
 			// Get the type of the WebPage node.
-			$webpage_type = $context->schema_page_type;
-			if ( ! \is_array( $webpage_type ) ) {
-				$webpage_types = [ $webpage_type ];
-			}
-			else {
-				$webpage_types = $webpage_type;
-			}
+			$webpage_types = \is_array( $context->schema_page_type ) ? $context->schema_page_type : [ $context->schema_page_type ];
 
 			foreach ( $graph as $key => $piece ) {
 				if ( ! empty( \array_intersect( $webpage_types, $this->get_type_from_piece( $piece ) ) ) && isset( $piece['breadcrumb'] ) ) {

--- a/src/generators/schema-generator.php
+++ b/src/generators/schema-generator.php
@@ -230,7 +230,7 @@ class Schema_Generator implements Generator_Interface {
 		$index_to_remove = 0;
 		foreach ( $graph as $key => $piece ) {
 			if ( \in_array( 'BreadcrumbList', $this->get_type_from_piece( $piece ), true ) ) {
-				if ( isset( $piece['itemListElement'] ) && is_array( $piece['itemListElement'] ) && count( $piece['itemListElement'] ) === 1 ) {
+				if ( isset( $piece['itemListElement'] ) && \is_array( $piece['itemListElement'] ) && \count( $piece['itemListElement'] ) === 1 ) {
 					$index_to_remove = $key;
 					break;
 				}
@@ -243,7 +243,7 @@ class Schema_Generator implements Generator_Interface {
 
 			// Get the type of the WebPage node.
 			$webpage_type = $context->schema_page_type;
-			if ( ! is_array( $webpage_type ) ) {
+			if ( ! \is_array( $webpage_type ) ) {
 				$webpage_types = [ $webpage_type ];
 			}
 			else {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* With [PC-190](https://yoast.atlassian.net/browse/PC-190) we addresses a range of edge-cases where our breadcrumb schema contains empty or invalid ‘levels’ (by filtering them out). As a side-effect, we may now find many such scenarios misrepresent a page as only having the homepage in the breadcrumb structure.
* With this PR, we address those scenarios by omitting the breadcrumb schema if it contains only the homepage and we're not on the homepage.
* We also remove the reference of the breadcrumb node from the WebPage node.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Removes empty breadcrumb schemas if not on homepage.

## Relevant technical choices:

* The removal of the empty breadcrumb schema happens late in the process of generating the schema, so that it is performed after all the filtering.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Have the Twenty Nineteen theme enabled (that way, you're able to have empty title for a page)
* Create a page/post/CPT and after you publish it, edit it to have an empty title
* Go to the frontend and check the page source for the schema.
* **Without this PR (but on trunk - that's for devs testing the PR)**, the schema would contain a `"@type": "BreadcrumbList",` with only onè `itemListElement`. It would also contain a `"@type": "WebPage",` with a `"breadcrumb"` property
* **Without this RC (that's for QA)**, the schema would contain a `"@type": "BreadcrumbList",` with two `itemListElement` items and the second of which would have an empty `"name"`. It would also contain a `"@type": "WebPage",` with a `"breadcrumb"` property
* Confirm that with this PR/RC, the schema would NOT contain a `"@type": "BreadcrumbList",` at all and also the `"@type": "WebPage",` item would NOT contain the `"breadcrumb"` property
* Also confirm that the above is the ONLY change between the 2 versions.
* Also confirm that you don't get validation errors with [the schema tools](https://yoast.slack.com/archives/C03KU0EHCNQ/p1663226777618409).
* Repeat the same test, but after you have set a different Page type for that page/post/CPT than the default `Web Page` one. The same difference that we mention above should still exist
* Repeat the same test but after you have added the following filter:
```
add_filter( 'wpseo_schema_webpage_type', 'custom_schema_webpage_type', 10, 1 );
function custom_schema_webpage_type( $type ) {
    return "weirdPage";
}
```
The same difference that we mention above should still exist.

Also confirm that:
* The homepage has the exact same schema with this PR/RC and without
* A random post/page/custom post type that does have a title, has the exact same schema with this PR/RC and without

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [x] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

Smoke test schema with [the schema tools] for:
* Search pages
* Author pages
* Date archives
* 404 pages
* Post types archives
* Categories

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes #
