### PR TITLE
Adds robots tag for comments feed.

### DIFF
--- a/src/integrations/front-end/feed-improvements.php
+++ b/src/integrations/front-end/feed-improvements.php
@@ -60,7 +60,7 @@ class Feed_Improvements implements Integration_Interface {
 		\add_filter( 'get_bloginfo_rss', [ $this, 'filter_bloginfo_rss' ], 10, 2 );
 		\add_filter( 'document_title_separator', [ $this, 'filter_document_title_separator' ] );
 
-		\add_action( 'do_feed_rss', [ $this, 'send_canonical_header' ], 9 );
+		\add_action( 'do_feed_rss', [ $this, 'handle_rss_feed' ], 9 );
 		\add_action( 'do_feed_rss2', [ $this, 'send_canonical_header' ], 9 );
 		\add_action( 'do_feed_rss2', [ $this, 'add_robots_headers' ], 9 );
 	}
@@ -82,15 +82,31 @@ class Feed_Improvements implements Integration_Interface {
 	}
 
 	/**
-	 * Adds a canonical link header to the main canonical URL for the requested feed object.
+	 * Makes sure send canonical header always runs, because this RRS hook does not support the for_comments parameter
+	 *
+	 * @return void
 	 */
-	public function send_canonical_header() {
-		if ( \headers_sent() ) {
+	public function handle_rss_feed() {
+		$this->send_canonical_header( false );
+	}
+
+	/**
+	 * Adds a canonical link header to the main canonical URL for the requested feed object. If it is not a comment
+	 * feed.
+	 *
+	 * @param bool $for_comments If the RRS feed is meant for a comment feed.
+	 *
+	 * @return void
+	 */
+	public function send_canonical_header( $for_comments ) {
+
+		if ( $for_comments || \headers_sent() ) {
 			return;
 		}
 
 		$url = $this->get_url_for_queried_object( $this->meta->for_home_page()->canonical );
 		if ( ! empty( $url ) ) {
+
 			\header( \sprintf( 'Link: <%s>; rel="canonical"', $url ), false );
 		}
 	}
@@ -98,13 +114,13 @@ class Feed_Improvements implements Integration_Interface {
 	/**
 	 * Adds noindex, follow tag for comment feeds.
 	 *
-	 * @param $for_comments bool If the RRS feed is meant for a comment feed.
+	 * @param bool $for_comments If the RRS feed is meant for a comment feed.
 	 *
 	 * @return void
 	 */
 	public function add_robots_headers( $for_comments ) {
 		if ( $for_comments && ! \headers_sent() ) {
-			\header( 'x-robots-tag: noindex, follow ', true );
+			\header( 'x-robots-tag: noindex, follow', true );
 		}
 	}
 

--- a/src/integrations/front-end/feed-improvements.php
+++ b/src/integrations/front-end/feed-improvements.php
@@ -62,6 +62,7 @@ class Feed_Improvements implements Integration_Interface {
 
 		\add_action( 'do_feed_rss', [ $this, 'send_canonical_header' ], 9 );
 		\add_action( 'do_feed_rss2', [ $this, 'send_canonical_header' ], 9 );
+		\add_action( 'do_feed_rss2', [ $this, 'add_robots_headers' ], 9 );
 	}
 
 	/**
@@ -91,6 +92,19 @@ class Feed_Improvements implements Integration_Interface {
 		$url = $this->get_url_for_queried_object( $this->meta->for_home_page()->canonical );
 		if ( ! empty( $url ) ) {
 			\header( \sprintf( 'Link: <%s>; rel="canonical"', $url ), false );
+		}
+	}
+
+	/**
+	 * Adds noindex, follow tag for comment feeds.
+	 *
+	 * @param $for_comments bool If the RRS feed is meant for a comment feed.
+	 *
+	 * @return void
+	 */
+	public function add_robots_headers( $for_comments ) {
+		if ( $for_comments && ! \headers_sent() ) {
+			\header( 'x-robots-tag: noindex, follow ', true );
 		}
 	}
 

--- a/src/integrations/front-end/feed-improvements.php
+++ b/src/integrations/front-end/feed-improvements.php
@@ -106,7 +106,6 @@ class Feed_Improvements implements Integration_Interface {
 
 		$url = $this->get_url_for_queried_object( $this->meta->for_home_page()->canonical );
 		if ( ! empty( $url ) ) {
-
 			\header( \sprintf( 'Link: <%s>; rel="canonical"', $url ), false );
 		}
 	}

--- a/src/integrations/front-end/feed-improvements.php
+++ b/src/integrations/front-end/feed-improvements.php
@@ -82,7 +82,7 @@ class Feed_Improvements implements Integration_Interface {
 	}
 
 	/**
-	 * Makes sure send canonical header always runs, because this RRS hook does not support the for_comments parameter
+	 * Makes sure send canonical header always runs, because this RSS hook does not support the for_comments parameter
 	 *
 	 * @return void
 	 */

--- a/src/integrations/front-end/feed-improvements.php
+++ b/src/integrations/front-end/feed-improvements.php
@@ -114,7 +114,7 @@ class Feed_Improvements implements Integration_Interface {
 	/**
 	 * Adds noindex, follow tag for comment feeds.
 	 *
-	 * @param bool $for_comments If the RRS feed is meant for a comment feed.
+	 * @param bool $for_comments If the RSS feed is meant for a comment feed.
 	 *
 	 * @return void
 	 */

--- a/src/integrations/front-end/feed-improvements.php
+++ b/src/integrations/front-end/feed-improvements.php
@@ -120,7 +120,7 @@ class Feed_Improvements implements Integration_Interface {
 	 */
 	public function add_robots_headers( $for_comments ) {
 		if ( $for_comments && ! \headers_sent() ) {
-			\header( 'x-robots-tag: noindex, follow', true );
+			\header( 'X-Robots-Tag: noindex, follow', true );
 		}
 	}
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

We should automatically noindex all comment feeds.
This will reduce duplicate content and index bloat, and improve crawl quotas for sites which do not disable comments feeds.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds a `X-Robots-Tag: noindex, follow` header to all comment feeds to prevent them to be indexed, reducing duplicate content.

## Relevant technical choices:

* I removed the canonical links from the comments feed because in https://yoast.atlassian.net/browse/PC-14 it is mentioned that this should only be added on non-comment feeds, this was not the case.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

Mainly taken from https://yoast.atlassian.net/browse/PC-14

- Make sure that all feeds are enabled in the crawl settings

- Open a comment feed e.q. http://basic.wordpress.test/2022/06/adaptive-homogeneous-challenge/feed or the gtlobal comment feed http://basic.wordpress.test/comments/feed/
- In the Network tab of your inspector, see that there is a `x-robots-tag` with `noindex, follow`

---
- Repeat the checks below for all these types of feeds:
  - category feeds e.g. http://basic.wordpress.test/category/configurable-responsive-framework/feed/
  - tag feeds e.g. http://basic.wordpress.test/tag/assimilated-dedicated-flexibility/feed/
  - custom taxonomy feeds e.g. http://basic.wordpress.test/yoast-test-book-genre/crime/feed/
  - custom post type feeds e.g. http://basic.wordpress.test/my-books/feed/
  - post author feeds e.g. http://basic.wordpress.test/author/ansel73/feed/
  - for date archives feeds e.g. http://basic.wordpress.test/2022/feed/
  - also check unpretty permalinks (first set the permalink structure to basic for example) e.g. https://basic.wordpress.test/?feed=feed&p=167
- In the Network tab of your inspector, see that there is a `Link` HTTP header with `rel="canonical"` for every RSS feed, that has the URL of the page related to the feed (i.e. without `/feed` in the end)
- See that the `<link>` element in the `<channel>` section links to the same URL
-  See that the separator used in the title is the one selected in Yoast SEO > Search Appearance
- Make sure the `x-robots-tag` with `noindex, follow` is not present.

- Repeat the above check
  - for the home page [global feed] e.g. http://basic.wordpress.test/feed/
  - for search results feeds e.g. http://basic.wordpress.test/?s=and&feed=feed
- In the Network tab of your inspector, see that there is a `Link` HTTP header with `rel="canonical"` for every RSS feed, that has the URL of the home page
- See that the `<link>` element in the `<channel>` section links to the URL of the home page
- See that the separator used in the title is the one selected in Yoast SEO > Search Appearance
- Make sure the `x-robots-tag` with `noindex, follow` is not present.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes #
PC-17 and makes a change for PC-14