### PR TITLE
Alter web stories metadata filter when Yoast title is disabled

### DIFF
--- a/src/integrations/front-end-integration.php
+++ b/src/integrations/front-end-integration.php
@@ -462,7 +462,7 @@ class Front_End_Integration implements Integration_Interface {
 	 *
 	 * @return bool True when the title presenter should be removed, false otherwise.
 	 */
-	public function title_presenter_should_be_removed() {
+	public function should_title_presenter_be_removed() {
 		return ! \get_theme_support( 'title-tag' ) && ! $this->options->get( 'forcerewritetitle', false );
 	}
 
@@ -480,7 +480,7 @@ class Front_End_Integration implements Integration_Interface {
 		}
 
 		// Remove the title presenter if the theme is hardcoded to output a title tag so we don't have two title tags.
-		if ( $this->title_presenter_should_be_removed() ) {
+		if ( $this->should_title_presenter_be_removed() ) {
 			$presenters = \array_diff( $presenters, [ 'Title' ] );
 		}
 

--- a/src/integrations/front-end-integration.php
+++ b/src/integrations/front-end-integration.php
@@ -458,6 +458,15 @@ class Front_End_Integration implements Integration_Interface {
 	}
 
 	/**
+	 * Whether the title presenter should be removed.
+	 *
+	 * @return bool True when the title presenter should be removed, false otherwise.
+	 */
+	public function title_presenter_should_be_removed() {
+		return ! \get_theme_support( 'title-tag' ) && ! $this->options->get( 'forcerewritetitle', false );
+	}
+
+	/**
 	 * Checks if the Title presenter needs to be removed.
 	 *
 	 * @param string[] $presenters The presenters.
@@ -471,7 +480,7 @@ class Front_End_Integration implements Integration_Interface {
 		}
 
 		// Remove the title presenter if the theme is hardcoded to output a title tag so we don't have two title tags.
-		if ( ! \get_theme_support( 'title-tag' ) && ! $this->options->get( 'forcerewritetitle', false ) ) {
+		if ( $this->title_presenter_should_be_removed() ) {
 			$presenters = \array_diff( $presenters, [ 'Title' ] );
 		}
 

--- a/src/integrations/third-party/web-stories.php
+++ b/src/integrations/third-party/web-stories.php
@@ -46,7 +46,10 @@ class Web_Stories implements Integration_Interface {
 	 * @return void
 	 */
 	public function register_hooks() {
-		\add_action( 'web_stories_enable_metadata', '__return_false' );
+		// If the title presenter was not removed, we will disable the web stories metadata because Yoast SEO will output the title already.
+		if ( ! $this->front_end->title_presenter_should_be_removed() ) {
+			\add_action( 'web_stories_enable_metadata', '__return_false' );
+		}
 		\add_action( 'web_stories_enable_schemaorg_metadata', '__return_false' );
 		\add_action( 'web_stories_enable_open_graph_metadata', '__return_false' );
 		\add_action( 'web_stories_enable_twitter_metadata', '__return_false' );

--- a/src/integrations/third-party/web-stories.php
+++ b/src/integrations/third-party/web-stories.php
@@ -47,7 +47,7 @@ class Web_Stories implements Integration_Interface {
 	 */
 	public function register_hooks() {
 		// If the title presenter was not removed, we will disable the web stories metadata because Yoast SEO will output the title already.
-		if ( ! $this->front_end->title_presenter_should_be_removed() ) {
+		if ( ! $this->front_end->should_title_presenter_be_removed() ) {
 			\add_action( 'web_stories_enable_metadata', '__return_false' );
 		}
 		\add_action( 'web_stories_enable_schemaorg_metadata', '__return_false' );

--- a/src/presenters/title-presenter.php
+++ b/src/presenters/title-presenter.php
@@ -21,7 +21,7 @@ class Title_Presenter extends Abstract_Indexable_Tag_Presenter {
 	 *
 	 * @var string
 	 */
-	protected $tag_format = '<title>This is the Yoast title | %s</title>';
+	protected $tag_format = '<title>%s</title>';
 
 	/**
 	 * The method of escaping to use.

--- a/src/presenters/title-presenter.php
+++ b/src/presenters/title-presenter.php
@@ -21,7 +21,7 @@ class Title_Presenter extends Abstract_Indexable_Tag_Presenter {
 	 *
 	 * @var string
 	 */
-	protected $tag_format = '<title>%s</title>';
+	protected $tag_format = '<title>This is the Yoast title | %s</title>';
 
 	/**
 	 * The method of escaping to use.

--- a/tests/unit/integrations/front-end-integration-test.php
+++ b/tests/unit/integrations/front-end-integration-test.php
@@ -610,4 +610,23 @@ class Front_End_Integration_Test extends TestCase {
 			$this->instance->filter_robots_presenter( $presenters )
 		);
 	}
+
+	/**
+	 * Tests the title_presenter_should_be_removed function.
+	 *
+	 * @covers ::title_presenter_should_be_removed
+	 */
+	public function test_title_presenter_should_be_removed() {
+		Monkey\Functions\expect( 'get_theme_support' )
+			->once()
+			->with( 'title-tag' )
+			->andReturn( false );
+
+		$this->options
+			->expects( 'get' )
+			->with( 'forcerewritetitle', false )
+			->andReturn( false );
+
+		$this->assertEquals( true, $this->instance->title_presenter_should_be_removed() );
+	}
 }

--- a/tests/unit/integrations/front-end-integration-test.php
+++ b/tests/unit/integrations/front-end-integration-test.php
@@ -612,11 +612,11 @@ class Front_End_Integration_Test extends TestCase {
 	}
 
 	/**
-	 * Tests the title_presenter_should_be_removed function.
+	 * Tests the should_title_presenter_be_removed function.
 	 *
-	 * @covers ::title_presenter_should_be_removed
+	 * @covers ::should_title_presenter_be_removed
 	 */
-	public function test_title_presenter_should_be_removed() {
+	public function test_should_title_presenter_be_removed() {
 		Monkey\Functions\expect( 'get_theme_support' )
 			->once()
 			->with( 'title-tag' )
@@ -627,6 +627,6 @@ class Front_End_Integration_Test extends TestCase {
 			->with( 'forcerewritetitle', false )
 			->andReturn( false );
 
-		$this->assertEquals( true, $this->instance->title_presenter_should_be_removed() );
+		$this->assertEquals( true, $this->instance->should_title_presenter_be_removed() );
 	}
 }

--- a/tests/unit/integrations/third-party/web-stories-test.php
+++ b/tests/unit/integrations/third-party/web-stories-test.php
@@ -64,6 +64,10 @@ class Web_Stories_Test extends TestCase {
 	 * @covers ::register_hooks
 	 */
 	public function test_register_hooks() {
+		$this->front_end
+			->expects( 'title_presenter_should_be_removed' )
+			->andReturn( false );
+
 		$this->instance->register_hooks();
 
 		$this->assertNotFalse( \has_action( 'web_stories_enable_metadata', '__return_false' ), 'The enable metadata filter is registered.' );

--- a/tests/unit/integrations/third-party/web-stories-test.php
+++ b/tests/unit/integrations/third-party/web-stories-test.php
@@ -65,7 +65,7 @@ class Web_Stories_Test extends TestCase {
 	 */
 	public function test_register_hooks() {
 		$this->front_end
-			->expects( 'title_presenter_should_be_removed' )
+			->expects( 'should_title_presenter_be_removed' )
 			->andReturn( false );
 
 		$this->instance->register_hooks();


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* No `<title>` attribute is outputted when viewing a Web Stories post type with Yoast SEO enabled.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Alter web stories metadata filter when Yoast title is disabled.

## Relevant technical choices:

* We disable the Web Stories metadata when Yoast SEO is disabled but when the theme used does not have the `title-tag` theme support we also disable the Yoast SEO title resulting in a page without a title. In this PR the metadata is only disabled when we are sure that the Yoast title is outputted.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install and activate both Yoast SEO and Web stories.
* Activate the Twenty-Twenty-Two theme.
* Go to the administration dashboard -> `Web Stories`.
* Click on `Create New Story`.
* Add some content to the story and click on `Publish`.
* Click on `View story` (in the top admin bar).
* View the page source and search for `<title>`, verify that there is only one match.
* Verify whether the page content passes the [Google Rich Result](https://search.google.com/test/rich-results) test.

Repeat the steps above for some other themes as well, some themes I used for testing are:

- Astra
- Twenty Twelve
- Spacious

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes [PC-152](https://yoast.atlassian.net/browse/PC-152)
