### PR TITLE
PC-645 Fix the block comments in `robots.txt`

### DIFF
--- a/src/presenters/robots-txt-presenter.php
+++ b/src/presenters/robots-txt-presenter.php
@@ -9,9 +9,9 @@ use Yoast\WP\SEO\Helpers\Robots_Txt_Helper;
  */
 class Robots_Txt_Presenter extends Abstract_Presenter {
 
-	const YOAST_OUTPUT_BEFORE_COMMENT = "# START YOAST INTERNAL SEARCH BLOCK\n# ---------------------------\n";
+	const YOAST_OUTPUT_BEFORE_COMMENT = "# START YOAST BLOCK\n# ---------------------------\n";
 
-	const YOAST_OUTPUT_AFTER_COMMENT = "# ---------------------------\n# END YOAST INTERNAL SEARCH BLOCK";
+	const YOAST_OUTPUT_AFTER_COMMENT = "# ---------------------------\n# END YOAST BLOCK";
 
 	/**
 	 * Text to be outputted for the allow directive.

--- a/tests/unit/integrations/front-end/robots-txt-integration-test.php
+++ b/tests/unit/integrations/front-end/robots-txt-integration-test.php
@@ -140,14 +140,14 @@ class Robots_Txt_Integration_Test extends TestCase {
 			->andReturn( [ 'http://basic.wordpress.test/sitemap_index.xml' ] );
 
 		$this->assertSame(
-			'# START YOAST INTERNAL SEARCH BLOCK
+			'# START YOAST BLOCK
 # ---------------------------
 User-agent: *
 Disallow:
 
 Sitemap: http://basic.wordpress.test/sitemap_index.xml
 # ---------------------------
-# END YOAST INTERNAL SEARCH BLOCK',
+# END YOAST BLOCK',
 			$this->instance->filter_robots( '' )
 		);
 	}
@@ -233,14 +233,14 @@ Sitemap: http://basic.wordpress.test/sitemap_index.xml
 			->andReturn( [ 'http://basic.wordpress.test/sitemap_index.xml' ] );
 
 		$this->assertSame(
-			'# START YOAST INTERNAL SEARCH BLOCK
+			'# START YOAST BLOCK
 # ---------------------------
 User-agent: *
 Disallow:
 
 Sitemap: http://basic.wordpress.test/sitemap_index.xml
 # ---------------------------
-# END YOAST INTERNAL SEARCH BLOCK',
+# END YOAST BLOCK',
 			$this->instance->filter_robots( '' )
 		);
 	}
@@ -316,14 +316,14 @@ Sitemap: http://basic.wordpress.test/sitemap_index.xml
 			->andReturn( [ 'http://basic.wordpress.test/sitemap_index.xml' ] );
 
 		$this->assertSame(
-			'# START YOAST INTERNAL SEARCH BLOCK
+			'# START YOAST BLOCK
 # ---------------------------
 User-agent: *
 Disallow:
 
 Sitemap: http://basic.wordpress.test/sitemap_index.xml
 # ---------------------------
-# END YOAST INTERNAL SEARCH BLOCK',
+# END YOAST BLOCK',
 			$this->instance->filter_robots( '' )
 		);
 	}
@@ -398,14 +398,14 @@ Sitemap: http://basic.wordpress.test/sitemap_index.xml
 			->andReturn( [ 'http://basic.wordpress.test/sitemap_index.xml' ] );
 
 		$this->assertSame(
-			'# START YOAST INTERNAL SEARCH BLOCK
+			'# START YOAST BLOCK
 # ---------------------------
 User-agent: *
 Disallow:
 
 Sitemap: http://basic.wordpress.test/sitemap_index.xml
 # ---------------------------
-# END YOAST INTERNAL SEARCH BLOCK',
+# END YOAST BLOCK',
 			$this->instance->filter_robots( '' )
 		);
 	}
@@ -433,13 +433,13 @@ Sitemap: http://basic.wordpress.test/sitemap_index.xml
 			->andReturn( [] );
 
 		$this->assertSame(
-			'# START YOAST INTERNAL SEARCH BLOCK
+			'# START YOAST BLOCK
 # ---------------------------
 User-agent: *
 Disallow:
 
 # ---------------------------
-# END YOAST INTERNAL SEARCH BLOCK',
+# END YOAST BLOCK',
 			$this->instance->filter_robots( '' )
 		);
 	}

--- a/tests/unit/presenters/robots-txt-presenter-test.php
+++ b/tests/unit/presenters/robots-txt-presenter-test.php
@@ -79,7 +79,7 @@ class Robots_Txt_Presenter_Test extends TestCase {
 			'sitemaps'               => [
 				'http://example.com/sitemap_index.html',
 			],
-			'expected'               => "# START YOAST INTERNAL SEARCH BLOCK\n# ---------------------------\nUser-agent: *\nDisallow:\n\nSitemap: http://example.com/sitemap_index.html\n# ---------------------------\n# END YOAST INTERNAL SEARCH BLOCK",
+			'expected'               => "# START YOAST BLOCK\n# ---------------------------\nUser-agent: *\nDisallow:\n\nSitemap: http://example.com/sitemap_index.html\n# ---------------------------\n# END YOAST BLOCK",
 		];
 		$user_agent_list                         = new User_Agent_List();
 		$user_agent                              = $user_agent_list->get_user_agent( '*' );
@@ -90,7 +90,7 @@ class Robots_Txt_Presenter_Test extends TestCase {
 			'sitemaps'               => [
 				'http://example.com/sitemap_index.html',
 			],
-			'expected'               => "# START YOAST INTERNAL SEARCH BLOCK\n# ---------------------------\nUser-agent: *\nDisallow: /wp-json/\n\nSitemap: http://example.com/sitemap_index.html\n# ---------------------------\n# END YOAST INTERNAL SEARCH BLOCK",
+			'expected'               => "# START YOAST BLOCK\n# ---------------------------\nUser-agent: *\nDisallow: /wp-json/\n\nSitemap: http://example.com/sitemap_index.html\n# ---------------------------\n# END YOAST BLOCK",
 		];
 
 		$user_agent_list = new User_Agent_List();
@@ -105,7 +105,7 @@ class Robots_Txt_Presenter_Test extends TestCase {
 			'sitemaps'               => [
 				'http://example.com/sitemap_index.html',
 			],
-			'expected'               => "# START YOAST INTERNAL SEARCH BLOCK\n# ---------------------------\nUser-agent: *\nDisallow: /wp-json/\nDisallow: /search/\n\nUser-agent: Googlebot\nDisallow: /disallowed/for/googlebot\n\nSitemap: http://example.com/sitemap_index.html\n# ---------------------------\n# END YOAST INTERNAL SEARCH BLOCK",
+			'expected'               => "# START YOAST BLOCK\n# ---------------------------\nUser-agent: *\nDisallow: /wp-json/\nDisallow: /search/\n\nUser-agent: Googlebot\nDisallow: /disallowed/for/googlebot\n\nSitemap: http://example.com/sitemap_index.html\n# ---------------------------\n# END YOAST BLOCK",
 		];
 		$user_agent_list              = new User_Agent_List();
 		$user_agent                   = $user_agent_list->get_user_agent( '*' );
@@ -117,7 +117,7 @@ class Robots_Txt_Presenter_Test extends TestCase {
 			'sitemaps'               => [
 				'http://example.com/sitemap_index.html',
 			],
-			'expected'               => "# START YOAST INTERNAL SEARCH BLOCK\n# ---------------------------\nUser-agent: *\nDisallow: /wp-json/\nAllow: /search/\n\nSitemap: http://example.com/sitemap_index.html\n# ---------------------------\n# END YOAST INTERNAL SEARCH BLOCK",
+			'expected'               => "# START YOAST BLOCK\n# ---------------------------\nUser-agent: *\nDisallow: /wp-json/\nAllow: /search/\n\nSitemap: http://example.com/sitemap_index.html\n# ---------------------------\n# END YOAST BLOCK",
 		];
 
 		$user_agent_list = new User_Agent_List();
@@ -136,7 +136,7 @@ class Robots_Txt_Presenter_Test extends TestCase {
 			'sitemaps'               => [
 				'http://example.com/sitemap_index.html',
 			],
-			'expected'               => "# START YOAST INTERNAL SEARCH BLOCK\n# ---------------------------\nUser-agent: *\nDisallow: /wp-json/\nAllow: /search/\n\nUser-agent: Googlebot\nDisallow: /disallowed/for/googlebot\nDisallow: /wp-admin\n\nUser-agent: Yahoobot\nAllow: /allowed/for/yahoo\n\nSitemap: http://example.com/sitemap_index.html\n# ---------------------------\n# END YOAST INTERNAL SEARCH BLOCK",
+			'expected'               => "# START YOAST BLOCK\n# ---------------------------\nUser-agent: *\nDisallow: /wp-json/\nAllow: /search/\n\nUser-agent: Googlebot\nDisallow: /disallowed/for/googlebot\nDisallow: /wp-admin\n\nUser-agent: Yahoobot\nAllow: /allowed/for/yahoo\n\nSitemap: http://example.com/sitemap_index.html\n# ---------------------------\n# END YOAST BLOCK",
 		];
 
 		$user_agent_list = new User_Agent_List();
@@ -148,7 +148,7 @@ class Robots_Txt_Presenter_Test extends TestCase {
 			'sitemaps'               => [
 				'http://example.com/sitemap_index.html',
 			],
-			'expected'               => "# START YOAST INTERNAL SEARCH BLOCK\n# ---------------------------\nUser-agent: *\nAllow: /search/\n\nSitemap: http://example.com/sitemap_index.html\n# ---------------------------\n# END YOAST INTERNAL SEARCH BLOCK",
+			'expected'               => "# START YOAST BLOCK\n# ---------------------------\nUser-agent: *\nAllow: /search/\n\nSitemap: http://example.com/sitemap_index.html\n# ---------------------------\n# END YOAST BLOCK",
 		];
 		$multiple_sitemaps      = [
 			'robots_txt_user_agents' => ( new User_Agent_List() )->get_user_agents(),
@@ -156,7 +156,7 @@ class Robots_Txt_Presenter_Test extends TestCase {
 				'http://example.com/sitemap_index.html',
 				'http://example.com/subsite/sitemap_index.html',
 			],
-			'expected'               => "# START YOAST INTERNAL SEARCH BLOCK\n# ---------------------------\nUser-agent: *\nDisallow:\n\nSitemap: http://example.com/sitemap_index.html\nSitemap: http://example.com/subsite/sitemap_index.html\n# ---------------------------\n# END YOAST INTERNAL SEARCH BLOCK",
+			'expected'               => "# START YOAST BLOCK\n# ---------------------------\nUser-agent: *\nDisallow:\n\nSitemap: http://example.com/sitemap_index.html\nSitemap: http://example.com/subsite/sitemap_index.html\n# ---------------------------\n# END YOAST BLOCK",
 		];
 
 		return [


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to fix the comments for the Yoast SEO block in `robots.txt`, since it's not limited to internal search

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the block of directives introduced by Yoast SEO in `robots.txt` would display a wrong comment.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* visit your site's `robots.txt` and see that the opening and closing comments are fixed, e.g:
```
# START YOAST INTERNAL SEARCH BLOCK
# ---------------------------
User-agent: *
Disallow:

Sitemap: http://basic.wordpress.test/sitemap_index.xml
# ---------------------------
# END YOAST INTERNAL SEARCH BLOCK
```
is now
```
# START YOAST BLOCK
# ---------------------------
User-agent: *
Disallow:

Sitemap: http://basic.wordpress.test/sitemap_index.xml
# ---------------------------
# END YOAST BLOCK
```
* install the lates Premium, play with `robots.txt`-related toggles ("Prevent search engines from crawling site search URLs", "Prevent search engines from crawling /wp-json/") and check the above is still true

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes [PC-645]


[PC-645]: https://yoast.atlassian.net/browse/PC-645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ