### PR TITLE
Update the title, description and slug on the store whenever the repl…

### DIFF
--- a/packages/search-metadata-previews/src/snippet-editor/SnippetEditor.js
+++ b/packages/search-metadata-previews/src/snippet-editor/SnippetEditor.js
@@ -164,6 +164,7 @@ class SnippetEditor extends React.Component {
 		this.close = this.close.bind( this );
 		this.setEditButtonRef = this.setEditButtonRef.bind( this );
 		this.handleChange = this.handleChange.bind( this );
+		this.haveReplaceVarsChanged = this.haveReplaceVarsChanged.bind( this );
 	}
 
 	/**
@@ -190,11 +191,23 @@ class SnippetEditor extends React.Component {
 		   The replacement variables are converted from an array of objects to a string for easier and more consistent
 		   comparison.
 		 */
-		if ( JSON.stringify( prevProps.replacementVariables ) !== JSON.stringify( nextProps.replacementVariables ) ) {
+		if ( this.haveReplaceVarsChanged( prevProps.replacementVariables, nextProps.replacementVariables ) ) {
 			isDirty = true;
 		}
 
 		return isDirty;
+	}
+
+	/**
+	 * Checks if the replacement variables have changed.
+	 *
+	 * @param {ReplaceVar[]} oldReplaceVars The old replacement variables.
+	 * @param {ReplaceVar[]} newReplaceVars The new replacement variables.
+	 *
+	 * @returns {boolean} If there is a difference between the old replacement variables and the new ones.
+	 */
+	haveReplaceVarsChanged( oldReplaceVars, newReplaceVars ) {
+		return JSON.stringify( oldReplaceVars ) !== JSON.stringify( newReplaceVars );
 	}
 
 	/**
@@ -218,6 +231,14 @@ class SnippetEditor extends React.Component {
 						nextProps.locale ),
 				}
 			);
+
+			if ( this.haveReplaceVarsChanged( this.props.replacementVariables, nextProps.replacementVariables ) ) {
+				/*
+				 * Make sure that changes to the replace vars (e.g. title, category, tags) get reflected on the
+				 * analysis data on the store (used in, among other things, the SEO analysis).
+				 */
+				this.props.onChangeAnalysisData( data );
+			}
 		}
 	}
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* **Note**: This fix applies when the user opens the post in the editor. The SEO score as shown in the post overview page (and the Indexable overview page) only gets updated after the post is opened and resaved.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where changes in the replacement variables (e.g. the value of the `%%title%%` replacement variable when the post title changes) would not be reflected in the Meta description length, the SEO title width, and the Keyphrase in SEO title assessments.

## Relevant technical choices:

* 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

_(Replace vars are a bit tricky and have lots of exceptions, so please read once through all the testing instructions before you start testing!)_

#### `%%title%%` replace var
* Open a post in the editor.
* Make sure that the `%%title%%` replace var is in the SEO title.
* Make sure that the `%%title%%` replace var is in the meta description.
* Add just enough extra text to the meta description such that the length bar just below it turns from orange to green.
* Add a focus keyphrase.
* Add the focus keyphrase to the beginning of the post title.
* You should get this result on the _Keyphrase in SEO title_ assessment:
  > Keyphrase in SEO title: The exact match of the focus keyphrase appears at the beginning of the SEO title. Good job!
* You should get this result on the _Keyphrase in meta description_ assessment:
  > Keyphrase in meta description: Keyphrase or synonym appear in the meta description. Well done!
* You should get this result on the _Meta description length_ assessment:
  > Meta description length: Well done!
* You should get this result on the _SEO title width_ assessment:
  > SEO title width: Good job!
* The _ Keyphrase in slug_ assessment should work as expected.
* * Save the post.
* Reload or reopen the post.
* Make sure the assessments give the same feedback as before. 

#### Related keyphrase
* Follow the same steps as in **`%%title%%` replace var**, but for a related keyphrase and its SEO analysis results.
* Note: The only assessment that appears in the analysis results of the Related keyphrase tab from the ones above is the Keyphrase in meta description assessment 
* Keep in mind that Keyphrase in SEO title, Meta description length and SEO title width appear in the main analysis results and apply only to the focus keyphrase, so their feedback will rely on whether you've kept the keyphrase or not. Also, Keyphrase in SEO title assessment doesn't appear at all if no focus keyphrase has been set.

#### Custom field replace var
* Follow the same steps as in **`%%title%%` replace var**, but for a custom field replace var:
   * To add a custom field in Block editor, make sure that _Custom fields_ panel is shown in the post editor:
      * Click on the button with three dots in the top-right corner.
      * Click on the menu item labeled _Preferences_.
      * Click on the tab named _Panels_.
      * Enable the _Custom fields_ toggle under the _Additional_ heading.  
   * Add a custom field in the metabox that is added to the post editor.
   * The value of the custom filed should be your focus keyphrase
   * Add the `%%cf_{custom-field-name}%%` to the SEO title and metadescription (`{custom-field-name}` is the name of the custom field you added. 
   * Confirm that the value of the custom field appears in the **Preview** for title and metadescription
* Note: according to our documentation, custom field replace vars need the post to saved and reloaded for them to be reflected in the assessments and the Preview.
* Custom field replace vars don't work in Elementor, and apparently this has been the case for some time. An issue has been created about this problem.

#### Other replace vars
* Test a few other replace vars. 
* The [other replace vars](https://yoast.com/help/list-available-snippet-variables-yoast-seo/) can be tested in a similar way as the ones described above:
  * Because the value of the replace var needs to include the keyphrase, you can use these ones: Excerpt, Date, %%focuskw%%, where for the Excerpt the keyphrase needs to be included in the introduction of the text, while for Date the keyphrase needs to be the date (this is the format: September 21 2022)
  * Add the replace var to the front of the SEO title and meta description.
  * Pad the content of the meta description such that the meta description length bar is barely green.
  * Save the post.
  * Reload the post. 
  * Check that the assessments that assess the SEO title or meta description take the replace var into account.
     * The keyphrase in the replace var you added should get recognized in the _Keyphrase in SEO title_ assessment and the _Keyphrase in meta description_ assessment.
     * The length of the replace var value should be taken into account in the _Meta description length_ and _SEO title width_ assessments.
        * E.g. the _Meta description length_ assessment should still give a green bullet if without the replace var it would give an orange bullet (for too little content) instead.
    *  Make sure that the value of the replace var (e.g. excerpt, date, %%focuskw%%) starts with the focus keyphrase. And if it doesn't, that this is reflected in the Keyphrase in SEO title with an orange bullet and this feedback:
 > The exact match of the focus keyphrase appears in the SEO title, but not at the beginning.
   * When testing the Date replace var, the keyphrase can't completely match the output of the variable because of the comma (September 21, 2022) so the Keyphrase in SEO title should give this feedback:
 > Does not contain the exact match. Try to write the exact match of your keyphrase in the SEO title and put it at the beginning of the title.

**Additional notes for testers:** 
* Because the behaviour of replace vars is particularly idiosyncratic, we have based the desired behaviour on the 19.0 version of the Free plugin, i.e. if it happens in 19.0 then it's acceptable.
* No testing of custom field variables added using the ACF plugin necessary (so no need to test custom field replace vars in Taxonomies)
* The behaviour of snippet variables in Taxonomies is inconsistent, this is expected behaviour. Sometimes the assessments and Preview get updated immediately, and sometimes (and most often) it's necessary to save and reload he page before changes are reflected. An issue was created to tackle this problem at a later point.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
  * Also test this on taxonomies (note: some replacement variables are not available on taxonomies).
* [x] Changes should be tested on different editors (Block/Classic/Elementor/other)
  * Also test this in the Classic and Elementor editors. 
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The _ Keyphrase in slug_ assessment should still work as expected.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [x] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes #
