### PR TITLE
PC-688 Cast `Uri` to `string` to for PHP 8 compatibility

### DIFF
--- a/packages/js/src/settings/components/formik-user-select-field.js
+++ b/packages/js/src/settings/components/formik-user-select-field.js
@@ -4,7 +4,7 @@ import PropTypes from "prop-types";
 import { __ } from "@wordpress/i18n";
 import { buildQueryString } from "@wordpress/url";
 import { useDispatch } from "@wordpress/data";
-import { map, values, debounce, find, isEmpty } from "lodash";
+import { map, values, debounce, find, isEmpty, trim } from "lodash";
 import apiFetch from "@wordpress/api-fetch";
 import { AutocompleteField, Spinner } from "@yoast/ui-library";
 import { useField } from "formik";
@@ -111,11 +111,11 @@ const FormikUserSelectField = ( { name, id, className = "", ...props } ) => {
 							<UserSelectOptionsContent>
 								{ __( "No users found.", "wordpress-seo" ) }
 							</UserSelectOptionsContent>
-						) : map( queriedUserIds, id => {
-							const user = users?.[ id ];
+						) : map( queriedUserIds, userId => {
+							const user = users?.[ userId ];
 							return user ? (
 								<AutocompleteField.Option key={ user?.id } value={ user?.id }>
-									{ user?.name || user?.username }
+									{ trim( user?.name ) || user?.username }
 								</AutocompleteField.Option>
 							) : null;
 						} ) }

--- a/src/wrappers/wp-remote-handler.php
+++ b/src/wrappers/wp-remote-handler.php
@@ -46,7 +46,7 @@ class WP_Remote_Handler {
 			$args['timeout'] = ( $options['timeout'] * 1000 );
 		}
 
-		$raw_response = \wp_remote_request( $request->getUri(), $args );
+		$raw_response = \wp_remote_request( (string) $request->getUri(), $args );
 		if ( \is_wp_error( $raw_response ) ) {
 			$exception = new Exception( $raw_response->get_error_message() );
 			return new RejectedPromise( $exception );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where a fatal error would be thrown on WordPress.com using PHP 8.0 in connection with the Debug Bar.

## Relevant technical choices:

* [`wp_remote_request`](https://developer.wordpress.org/reference/functions/wp_remote_request/) expects a string as its first parameter but we were passing a `UriInterface`. This was breaking

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Check that the Semrush integration flow is working as expected.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes [PC-688]


[PC-688]: https://yoast.atlassian.net/browse/PC-688?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ