### PR TITLE
PC-660 remove formality

### DIFF
--- a/packages/js/src/insights/components/insights-collapsible.js
+++ b/packages/js/src/insights/components/insights-collapsible.js
@@ -1,6 +1,7 @@
 import { __ } from "@wordpress/i18n";
 import { useSelect } from "@wordpress/data";
 import PropTypes from "prop-types";
+import { isFeatureEnabled } from "@yoast/feature-flag";
 import MetaboxCollapsible from "../../components/MetaboxCollapsible";
 import EstimatedReadingTime from "./estimated-reading-time";
 import FleschReadingEase from "./flesch-reading-ease";
@@ -31,7 +32,8 @@ const InsightsCollapsible = ( { location } ) => {
 					<EstimatedReadingTime />
 					<TextLength />
 				</div>
-				<TextFormality location={ location } name={ "YoastTextFormalityMetabox" } />
+				{ isFeatureEnabled( "TEXT_FORMALITY" ) &&
+				<TextFormality location={ location } name={ "YoastTextFormalityMetabox" } /> }
 			</div>
 		</MetaboxCollapsible>
 	);

--- a/packages/js/src/insights/components/insights-modal.js
+++ b/packages/js/src/insights/components/insights-modal.js
@@ -1,5 +1,6 @@
 import { useSelect } from "@wordpress/data";
 import { __ } from "@wordpress/i18n";
+import { isFeatureEnabled } from "@yoast/feature-flag";
 import PropTypes from "prop-types";
 import EditorModal from "../../containers/EditorModal";
 import EstimatedReadingTime from "./estimated-reading-time";
@@ -34,7 +35,8 @@ const InsightsModal = ( { location } ) => {
 						<EstimatedReadingTime />
 						<TextLength />
 					</div>
-					<TextFormality location={ location } name={ "YoastTextFormalitySidebar" } />
+					{ isFeatureEnabled( "TEXT_FORMALITY" ) &&
+					<TextFormality location={ location } name={ "YoastTextFormalityMetabox" } /> }
 				</div>
 			</div>
 		</EditorModal>

--- a/packages/js/tests/insights/components/insights-collapsible.test.js
+++ b/packages/js/tests/insights/components/insights-collapsible.test.js
@@ -1,5 +1,6 @@
 import React from "react";
 import { useSelect } from "@wordpress/data";
+import { enableFeatures } from "@yoast/feature-flag";
 import InsightsCollapsible from "../../../src/insights/components/insights-collapsible";
 import { shallow } from "enzyme";
 import FleschReadingEase from "../../../src/insights/components/flesch-reading-ease";
@@ -51,7 +52,14 @@ describe( "The insights collapsible component", () => {
 
 		expect( render.find( TextLength ) ).toHaveLength( 1 );
 	} );
-	it( "renders the Text formality component", () => {
+	it( "does not render the Text formality component when the feature is disabled", () => {
+		mockSelect( true );
+		const render = shallow( <InsightsCollapsible location={ "sidebar" } /> );
+
+		expect( render.find( TextFormality ) ).toHaveLength( 0 );
+	} );
+	it( "renders the Text formality component when the feature is enabled", () => {
+		enableFeatures( [ "TEXT_FORMALITY" ] );
 		mockSelect( true );
 		const render = shallow( <InsightsCollapsible location={ "sidebar" } /> );
 

--- a/packages/js/tests/insights/components/insights-modal.test.js
+++ b/packages/js/tests/insights/components/insights-modal.test.js
@@ -5,7 +5,7 @@ import FleschReadingEase from "../../../src/insights/components/flesch-reading-e
 import InsightsModal from "../../../src/insights/components/insights-modal";
 import TextFormality from "../../../src/insights/components/text-formality";
 import TextLength from "../../../src/insights/components/text-length";
-
+import { enableFeatures } from "@yoast/feature-flag";
 
 jest.mock( "@wordpress/data", () => (
 	{
@@ -58,7 +58,14 @@ describe( "The insights collapsible component", () => {
 
 		expect( render.find( TextLength ) ).toHaveLength( 1 );
 	} );
-	it( "renders the Text formality component", () => {
+	it( "does not render the Text formality component when the feature is disabled", () => {
+		mockSelect( true, true );
+		const render = shallow( <InsightsModal location={ "sidebar" } /> );
+
+		expect( render.find( TextFormality ) ).toHaveLength( 0 );
+	} );
+	it( "renders the Text formality component when the feature is enabled", () => {
+		enableFeatures( [ "TEXT_FORMALITY" ] );
 		mockSelect( true, true );
 		const render = shallow( <InsightsModal location={ "sidebar" } /> );
 

--- a/src/conditionals/text-formality-conditional.php
+++ b/src/conditionals/text-formality-conditional.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Yoast\WP\SEO\Conditionals;
+
+/**
+ * Checks if the YOAST_SEO_TEXT_FORMALITY constant is set.
+ */
+class Text_Formality_Conditional extends Feature_Flag_Conditional {
+
+	/**
+	 * Returns the name of the feature flag.
+	 * 'YOAST_SEO_' is automatically prepended to it and it will be uppercased.
+	 *
+	 * @return string the name of the feature flag.
+	 */
+	public function get_feature_flag() {
+		return 'TEXT_FORMALITY';
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Puts Text formality feature behind a flag.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### With Formality feature disabled
* Disable the feature by adding `define( 'YOAST_SEO_TEXT_FORMALITY', false );` in `wp-config.php` file of your site
   * If using Rancher, you can find the config file in `plugin-development-docker/config/basic/wp-config.php` 
* Install and activate Yoast SEO
* Set the site language to English
* Open a post and confirm that the Formality upsell is not shown when opening `Insights` tab
   * Repeat this step in **all other content types** and confirm that you get the same result
   * Repeat this step in **Classic, Block, and Elementor** and confirm that you get the same result
* Install and activate Yoast SEO Premium
   * The premium PR: https://github.com/Yoast/wordpress-seo-premium/pull/3691
   * From the premium branch, run `composer require yoast/wordpress-seo:dev-PC-660-remove-formality@dev`
* Open a post and confirm that the Formality feature is not shown when opening `Insights` tab
   * Repeat this step in **all other content types** and confirm that you get the same result
   * Repeat this step in **Classic, Block, and Elementor** and confirm that you get the same result
   
#### With Formality feature enabled
* Enable the feature by adding `define( 'YOAST_SEO_TEXT_FORMALITY', true );` in `wp-config.php` file of your site
   * If using Rancher, you can find the config file in `plugin-development-docker/config/basic/wp-config.php` 
* Follow the test instruction in [this document ](https://docs.google.com/document/d/1idmIXZQnTXWDdxjxEfrLzRcG1NSgKBx5iWcZsEMxBag/edit#)and confirm that the feature still works as expected

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [x] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unit tests to verify the code works as intended
* [x] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes #
