### PR TITLE
Pc 661 id props ftc

### DIFF
--- a/packages/js/src/first-time-configuration/first-time-configuration-steps.js
+++ b/packages/js/src/first-time-configuration/first-time-configuration-steps.js
@@ -570,6 +570,7 @@ export default function FirstTimeConfigurationSteps() {
 							isFinished={ isIndexationStepFinished }
 						>
 							<EditButton
+								id={ `button-${ STEPS.optimizeSeoData }-edit` }
 								beforeGo={ beforeEditing }
 								isVisible={ showEditButton }
 								additionalClasses={ "yst-ml-auto" }
@@ -580,6 +581,7 @@ export default function FirstTimeConfigurationSteps() {
 						<Step.Content>
 							<IndexationStep setIndexingState={ setIndexingState } indexingState={ indexingState } showRunIndexationAlert={ showRunIndexationAlert } isStepperFinished={ isStepperFinished } />
 							<ContinueButton
+								id={ `button-${ STEPS.optimizeSeoData }-continue` }
 								additionalClasses="yst-mt-12"
 								beforeGo={ beforeContinueIndexationStep }
 								destination={ stepperFinishedOnce ? "last" : 1 }
@@ -594,6 +596,7 @@ export default function FirstTimeConfigurationSteps() {
 							isFinished={ isStep2Finished }
 						>
 							<EditButton
+								id={ `button-${ STEPS.siteRepresentation }-edit` }
 								beforeGo={ beforeEditing }
 								isVisible={ showEditButton }
 								additionalClasses={ "yst-ml-auto" }
@@ -610,6 +613,7 @@ export default function FirstTimeConfigurationSteps() {
 							/>
 							<Step.Error id="yoast-site-representation-step-error" message={ state.stepErrors[ STEPS.siteRepresentation ] || "" } />
 							<ConfigurationStepButtons
+								stepId={ STEPS.siteRepresentation }
 								stepperFinishedOnce={ stepperFinishedOnce }
 								saveFunction={ updateOnFinishSiteRepresentation }
 								setEditState={ setIsStepBeingEdited }
@@ -622,6 +626,7 @@ export default function FirstTimeConfigurationSteps() {
 							isFinished={ isStep3Finished }
 						>
 							<EditButton
+								id={ `button-${ STEPS.socialProfiles }-edit` }
 								beforeGo={ beforeEditing }
 								isVisible={ showEditButton }
 								additionalClasses={ "yst-ml-auto" }
@@ -632,7 +637,12 @@ export default function FirstTimeConfigurationSteps() {
 						<Step.Content>
 							<SocialProfilesStep state={ state } dispatch={ dispatch } setErrorFields={ setErrorFields } />
 							<Step.Error id="yoast-social-profiles-step-error" message={ state.stepErrors[ STEPS.socialProfiles ] || "" } />
-							<ConfigurationStepButtons stepperFinishedOnce={ stepperFinishedOnce } saveFunction={ updateOnFinishSocialProfiles } setEditState={ setIsStepBeingEdited } />
+							<ConfigurationStepButtons
+								stepId={ STEPS.socialProfiles }
+								stepperFinishedOnce={ stepperFinishedOnce }
+								saveFunction={ updateOnFinishSocialProfiles }
+								setEditState={ setIsStepBeingEdited }
+							/>
 						</Step.Content>
 					</Step>
 					<Step>
@@ -641,6 +651,7 @@ export default function FirstTimeConfigurationSteps() {
 							isFinished={ isStep4Finished }
 						>
 							<EditButton
+								id={ `button-${ STEPS.personalPreferences }-edit` }
 								beforeGo={ beforeEditing }
 								isVisible={ showEditButton }
 								additionalClasses={ "yst-ml-auto" }
@@ -651,7 +662,12 @@ export default function FirstTimeConfigurationSteps() {
 						<Step.Content>
 							<PersonalPreferencesStep state={ state } setTracking={ setTracking } />
 							<Step.Error id="yoast-personal-preferences-step-error" message={ state.stepErrors[ STEPS.personalPreferences ] || "" } />
-							<ConfigurationStepButtons stepperFinishedOnce={ stepperFinishedOnce } saveFunction={ updateOnFinishPersonalPreferences } setEditState={ setIsStepBeingEdited } />
+							<ConfigurationStepButtons
+								stepId={ STEPS.personalPreferences }
+								stepperFinishedOnce={ stepperFinishedOnce }
+								saveFunction={ updateOnFinishPersonalPreferences }
+								setEditState={ setIsStepBeingEdited }
+							/>
 						</Step.Content>
 					</Step>
 					<Step>

--- a/packages/js/src/first-time-configuration/tailwind-components/configuration-stepper-buttons.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/configuration-stepper-buttons.js
@@ -129,6 +129,7 @@ export function StepButtons( { stepId, beforeContinue, continueLabel, beforeBack
 }
 
 StepButtons.propTypes = {
+	stepId: PropTypes.string.isRequired,
 	beforeContinue: PropTypes.func,
 	continueLabel: PropTypes.string,
 	beforeBack: PropTypes.func,
@@ -173,6 +174,7 @@ export function ConfigurationStepButtons( { stepId, stepperFinishedOnce, saveFun
 }
 
 ConfigurationStepButtons.propTypes = {
+	stepId: PropTypes.string.isRequired,
 	stepperFinishedOnce: PropTypes.bool.isRequired,
 	saveFunction: PropTypes.func.isRequired,
 	setEditState: PropTypes.func.isRequired,

--- a/packages/js/src/first-time-configuration/tailwind-components/configuration-stepper-buttons.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/configuration-stepper-buttons.js
@@ -113,6 +113,7 @@ BackButton.defaultProps = {
  * A convenience class for the most common configuration of Stepper buttons: continue and back.
  *
  * @param {Object}   props                The props for the StepButtons.
+ * @param {string}   props.stepId         The step id.
  * @param {function} props.beforeContinue A function to call before continueing. Should return true when ready to continue.
  * @param {function} props.beforeBack     A function to call before going back. Should return true when ready to go back.
  * @param {string}   props.continueLabel  A label to display on the Continue Button.
@@ -120,10 +121,10 @@ BackButton.defaultProps = {
  *
  * @returns {WPElement} The most common stepper buttons: continue and back.
  */
-export function StepButtons( { beforeContinue, continueLabel, beforeBack, backLabel } ) {
+export function StepButtons( { stepId, beforeContinue, continueLabel, beforeBack, backLabel } ) {
 	return <div className="yst-mt-12">
-		<ContinueButton beforeGo={ beforeContinue }>{ continueLabel }</ContinueButton>
-		<BackButton additionalClasses="yst-ml-3" beforeGo={ beforeBack }>{ backLabel }</BackButton>
+		<ContinueButton id={ `button-${ stepId }-continue` } beforeGo={ beforeContinue }>{ continueLabel }</ContinueButton>
+		<BackButton id={ `button-${ stepId }-back` } additionalClasses="yst-ml-3" beforeGo={ beforeBack }>{ backLabel }</BackButton>
 	</div>;
 }
 
@@ -146,13 +147,14 @@ StepButtons.defaultProps = {
  * "Save and continue" and "Go back" when the stepper is in progress, "Save changes" when the Stepper has been completed once.
  *
  * @param {Object}   props                     The props for the StepButtons.
+ * @param {string}   props.stepId              The step id.
  * @param {boolean}  props.stepperFinishedOnce Whether the stepper has been completed once.
  * @param {function} props.saveFunction        A function to call upon clicking the "Save Changes" button.
  * @param {string}   props.setEditState        A function to set the edit state of the Stepper.
  *
  * @returns {WPElement} The most common stepper buttons: continue and back.
  */
-export function ConfigurationStepButtons( { stepperFinishedOnce, saveFunction, setEditState } ) {
+export function ConfigurationStepButtons( { stepId, stepperFinishedOnce, saveFunction, setEditState } ) {
 	const onSaveClick = useCallback( async() => {
 		const saveSuccesful = await saveFunction();
 
@@ -162,12 +164,12 @@ export function ConfigurationStepButtons( { stepperFinishedOnce, saveFunction, s
 	} );
 
 	if ( stepperFinishedOnce ) {
-		return <Step.GoButton className="yst-button yst-button--primary yst-mt-12" destination="last" beforeGo={ onSaveClick }>
+		return <Step.GoButton id={ `button-${ stepId }-go` } className="yst-button yst-button--primary yst-mt-12" destination="last" beforeGo={ onSaveClick }>
 			{ __( "Save changes", "wordpress-seo" ) }
 		</Step.GoButton>;
 	}
 
-	return <StepButtons beforeContinue={ saveFunction } continueLabel={ __( "Save and continue", "wordpress-seo" ) } />;
+	return <StepButtons stepId={ stepId } beforeContinue={ saveFunction } continueLabel={ __( "Save and continue", "wordpress-seo" ) } />;
 }
 
 ConfigurationStepButtons.propTypes = {

--- a/packages/js/src/first-time-configuration/tailwind-components/steps/finish/finish-step.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/steps/finish/finish-step.js
@@ -21,6 +21,7 @@ function regularContent() {
 			<p className="yst-text-sm yst-mb-6">{ __( "That’s it! By providing this information our indexables squad has been able to do a lot of optimization for your site already. Now, let's have a look at the SEO fitness of your site!", "wordpress-seo" ) }</p>
 			<button
 				type="button"
+				id="button-seo-dashboard"
 				onClick={ goToSEODashboard }
 				className={ "yst-button yst-button--primary" }
 			>{ __( "Go to your SEO dashboard", "wordpress-seo" ) }</button>
@@ -42,11 +43,12 @@ function webinarPromoContent() {
 			<p className="yst-text-sm yst-mb-6">
 				{ __( "Want to optimize even further and get the most out of Yoast SEO? Make sure you don't miss our free weekly webinar!", "wordpress-seo" ) }
 			</p>
-			<a href={ webinarIntroSettingsUrl } target="_blank" rel="noreferrer" className="yst-button yst-button--primary yst-text-white">
+			<a href={ webinarIntroSettingsUrl } id="link-webinar-register" target="_blank" rel="noreferrer" className="yst-button yst-button--primary yst-text-white">
 				{ __( "Register now!", "wordpress-seo" ) }
 			</a>
 			<button
 				type="button"
+				id="button-webinar-seo-dashboard"
 				onClick={ goToSEODashboard }
 				className={ "yst-ml-4 yst-text-indigo-600 hover:yst-text-indigo-500" }
 			>{ __( "Or visit your SEO dashboard", "wordpress-seo" ) }</button>


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Add more `id` props to buttons in FTC for easy selecting in automated tests.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds `id` props to back and continue buttons for each step in FTC.
* Adds `id` props to finish step buttons in FTC.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Visit the FTC.
* Verify that in each step the `Back` and `Continue` buttons have unique `id` attributes based on the step identifier, ie. `button-siteRepresentation-continue`.
* Verify that in the finish step buttons have unique `id` attributes based on Premium active state, ie. `button-seo-dashboard` on Premium active and `button-webinar-seo-dashboard` on Premium inactive.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes #
