### PR TITLE
Improve user select component

### DIFF
--- a/packages/js/src/settings/components/formik-user-select-field.js
+++ b/packages/js/src/settings/components/formik-user-select-field.js
@@ -99,7 +99,8 @@ const FormikUserSelectField = ( { name, id, className = "", ...props } ) => {
 			// Hack to force re-render of Headless UI Combobox.Input component when selectedUser changes.
 			value={ selectedUser ? value : 0 }
 			onChange={ handleChange }
-			selectedLabel={ selectedUser?.name || __( "Select a user...", "wordpress-seo" ) }
+			placeholder={ __( "Select a user...", "wordpress-seo" ) }
+			selectedLabel={ selectedUser?.name }
 			onQueryChange={ handleQueryChange }
 			className={ className }
 		>
@@ -114,7 +115,7 @@ const FormikUserSelectField = ( { name, id, className = "", ...props } ) => {
 							const user = users?.[ id ];
 							return user ? (
 								<AutocompleteField.Option key={ user?.id } value={ user?.id }>
-									{ user?.name }
+									{ user?.name || user?.username }
 								</AutocompleteField.Option>
 							) : null;
 						} ) }

--- a/packages/js/src/settings/store/users.js
+++ b/packages/js/src/settings/store/users.js
@@ -18,7 +18,10 @@ export function* fetchUsers( queryData ) {
 		// Trigger the fetch users control flow.
 		const users = yield{
 			type: FETCH_USERS_ACTION_NAME,
-			payload: queryData,
+			payload: {
+				context: "edit",
+				...queryData,
+			},
 		};
 		return { type: `${ FETCH_USERS_ACTION_NAME }/${ ASYNC_ACTION_NAMES.success }`, payload: users };
 	} catch ( error ) {

--- a/packages/ui-library/src/elements/autocomplete/index.js
+++ b/packages/ui-library/src/elements/autocomplete/index.js
@@ -53,6 +53,7 @@ Option.propTypes = optionPropType;
  * @param {Function} onChange Change callback.
  * @param {Function} onQueryChange Query change callback.
  * @param {boolean} [isError] Error message.
+ * @param {string} [placeholder] Input placeholder.
  * @param {string} [className] CSS class.
  * @param {Object} [buttonProps] Any extra props for the button.
  * @param {Object} [props] Any extra props.
@@ -69,6 +70,7 @@ const Autocomplete = ( {
 	onChange,
 	onQueryChange,
 	isError = false,
+	placeholder = "",
 	className = "",
 	buttonProps = {},
 	...props
@@ -102,6 +104,7 @@ const Autocomplete = ( {
 					>
 						<Combobox.Input
 							className="yst-autocomplete__input"
+							placeholder={ placeholder }
 							displayValue={ getDisplayValue }
 							onChange={ onQueryChange }
 						/>
@@ -141,6 +144,7 @@ Autocomplete.propTypes = {
 	onChange: PropTypes.func.isRequired,
 	onQueryChange: PropTypes.func.isRequired,
 	isError: PropTypes.bool,
+	placeholder: PropTypes.string,
 	className: PropTypes.string,
 	buttonProps: PropTypes.object,
 };


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves the user select component in the new settings UI.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Verify [PC-658](https://yoast.atlassian.net/browse/PC-658) is no longer reproducible.
* Also verify that the `Select a user...` placeholder when the field is empty disappears when you focus the field and start typing. So you don't have to manually delete the placeholder before typing.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes #
