### PR TITLE
PC-669 Fixes the Yoast_Admin_And_Dashboard_Conditional

### DIFF
--- a/src/conditionals/yoast-admin-and-dashboard-conditional.php
+++ b/src/conditionals/yoast-admin-and-dashboard-conditional.php
@@ -15,6 +15,11 @@ class Yoast_Admin_And_Dashboard_Conditional implements Conditional {
 	public function is_met() {
 		global $pagenow;
 
+		// Bail out early if we're not on the front-end.
+		if ( ! \is_admin() ) {
+			return false;
+		}
+
 		// Do not output on plugin / theme upgrade pages or when WordPress is upgrading.
 		if ( ( \defined( 'IFRAME_REQUEST' ) && \IFRAME_REQUEST ) || $this->on_upgrade_page() || \wp_installing() ) {
 			return false;

--- a/tests/unit/conditionals/yoast-admin-and-dashboard-conditional-test.php
+++ b/tests/unit/conditionals/yoast-admin-and-dashboard-conditional-test.php
@@ -42,6 +42,9 @@ class Yoast_Admin_And_Dashboard_Conditional_Test extends TestCase {
 		global $pagenow;
 		$pagenow = 'admin.php';
 
+		Monkey\Functions\when( 'is_admin' )
+			->justReturn( true );
+
 		Monkey\Functions\expect( 'wp_installing' )
 			->andReturn( false );
 
@@ -63,6 +66,9 @@ class Yoast_Admin_And_Dashboard_Conditional_Test extends TestCase {
 		global $pagenow;
 		$pagenow = 'update-core.php';
 
+		Monkey\Functions\when( 'is_admin' )
+			->justReturn( true );
+
 		Monkey\Functions\expect( 'wp_installing' )
 			->andReturn( false );
 
@@ -80,6 +86,9 @@ class Yoast_Admin_And_Dashboard_Conditional_Test extends TestCase {
 		// We are on the plugins page.
 		global $pagenow;
 		$pagenow = 'plugins.php';
+
+		Monkey\Functions\when( 'is_admin' )
+			->justReturn( true );
 
 		Monkey\Functions\expect( 'wp_installing' )
 			->andReturn( false );
@@ -99,12 +108,35 @@ class Yoast_Admin_And_Dashboard_Conditional_Test extends TestCase {
 		global $pagenow;
 		$pagenow = 'index.php';
 
+		Monkey\Functions\when( 'is_admin' )
+			->justReturn( true );
+
 		Monkey\Functions\expect( 'wp_installing' )
 			->andReturn( false );
 
 		$is_met = $this->instance->is_met();
 
 		$this->assertEquals( true, $is_met );
+	}
+
+	/**
+	 * Tests that the conditional is not met when on the front-end.
+	 *
+	 * @covers ::is_met
+	 */
+	public function test_is_not_met_on_the_frontend() {
+		global $pagenow;
+		$pagenow = 'index.php';
+
+		Monkey\Functions\when( 'is_admin' )
+			->justReturn( false );
+
+		Monkey\Functions\expect( 'wp_installing' )
+			->andReturn( false );
+
+		$is_met = $this->instance->is_met();
+
+		$this->assertEquals( false, $is_met );
 	}
 
 	/**
@@ -116,6 +148,9 @@ class Yoast_Admin_And_Dashboard_Conditional_Test extends TestCase {
 		// We are on the update core page.
 		global $pagenow;
 		$pagenow = 'some-other-page.php';
+
+		Monkey\Functions\when( 'is_admin' )
+			->justReturn( true );
 
 		Monkey\Functions\expect( 'wp_installing' )
 			->andReturn( false );
@@ -134,6 +169,9 @@ class Yoast_Admin_And_Dashboard_Conditional_Test extends TestCase {
 		// We are on an admin page.
 		global $pagenow;
 		$pagenow = 'admin.php';
+
+		Monkey\Functions\when( 'is_admin' )
+			->justReturn( true );
 
 		Monkey\Functions\expect( 'wp_installing' )
 			->andReturn( false );
@@ -156,6 +194,9 @@ class Yoast_Admin_And_Dashboard_Conditional_Test extends TestCase {
 		global $pagenow;
 		$pagenow = 'admin.php';
 
+		Monkey\Functions\when( 'is_admin' )
+			->justReturn( true );
+
 		// But WordPress is currently installing.
 		Monkey\Functions\expect( 'wp_installing' )
 			->andReturn( true );
@@ -175,6 +216,9 @@ class Yoast_Admin_And_Dashboard_Conditional_Test extends TestCase {
 		// We are on an admin page.
 		global $pagenow;
 		$pagenow = 'admin.php';
+
+		Monkey\Functions\when( 'is_admin' )
+			->justReturn( true );
 
 		// But WordPress is currently installing.
 		Monkey\Functions\expect( 'wp_installing' )
@@ -198,6 +242,9 @@ class Yoast_Admin_And_Dashboard_Conditional_Test extends TestCase {
 		global $pagenow;
 		$pagenow = 'admin.php';
 
+		Monkey\Functions\when( 'is_admin' )
+			->justReturn( true );
+
 		// But WordPress is currently installing.
 		Monkey\Functions\expect( 'wp_installing' )
 			->andReturn( false );
@@ -220,6 +267,9 @@ class Yoast_Admin_And_Dashboard_Conditional_Test extends TestCase {
 		global $pagenow;
 		$pagenow = 'admin.php';
 
+		Monkey\Functions\when( 'is_admin' )
+			->justReturn( true );
+
 		// But WordPress is currently installing.
 		Monkey\Functions\expect( 'wp_installing' )
 			->andReturn( false );
@@ -241,6 +291,9 @@ class Yoast_Admin_And_Dashboard_Conditional_Test extends TestCase {
 		// We are on an admin page.
 		global $pagenow;
 		$pagenow = 'admin.php';
+
+		Monkey\Functions\when( 'is_admin' )
+			->justReturn( true );
 
 		// But WordPress is currently installing.
 		Monkey\Functions\expect( 'wp_installing' )


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to fix the `Yoast_Admin_And_Dashboard_Conditional` so it doesn't run on the front-end's home page

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes the `Yoast_Admin_And_Dashboard_Conditional` to work only on the back Props to @mweimerskirch.

## Relevant technical choices:

* this is in place of #18088 because removing `index.php` would not target the site's dashboard anymore

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Put a breakpoint in the `Yoast_Admin_And_Dashboard_Conditional::is_met()`, or something similar, and check it doesn't return `true` in the site's home page but it does on the site's dashboard

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* NA just a change that has no effect outside

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes [PC-669]


[PC-669]: https://yoast.atlassian.net/browse/PC-669?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ