### PR TITLE
Remove unused code that breaks the Elementor container feature

### DIFF
--- a/packages/js/src/ui/publishBox.js
+++ b/packages/js/src/ui/publishBox.js
@@ -5,17 +5,6 @@ var scoreDescriptionClass = "score-text";
 var imageScoreClass = "image yoast-logo svg";
 var $ = jQuery;
 
-/* eslint-disable no-extend-native */
-/**
- * Converts the first letter to uppercase in a string.
- *
- * @returns {string} The string with the first letter uppercased.
- */
-String.prototype.ucfirst = function() {
-	return this.charAt( 0 ).toUpperCase() + this.substr( 1 );
-};
-/* eslint-enable no-extend-native */
-
 /**
  * Creates a text with the label and description for a seo score.
  *


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to stop a console error from appearing when working with Elementor's containers

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where Yoast would conflict with Elementor, when Yoast Premium or Yoast News or Yoast Video is active, throwing console errors.

## Relevant technical choices:

* Some unused code was removed in the `packages\js\src\ui\publishBox.js` file
* That file got referenced in the Editor Modules with https://github.com/Yoast/wordpress-seo/pull/18922
* Any add-on that uses the Editor Modules in the Elementor editor, aka Premium, News, Video, caused a console error in Elementor editor's when active

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Activate Free and either one of Premium, News, Video
* Have Elementor active and enable the Containers feature like described [here](https://elementor.com/help/the-container/).
* Go to create a new post with Elementor
* Click on the + icon to create a new container:
![image](https://user-images.githubusercontent.com/12400734/192295355-e1a41516-e704-4cd0-9208-0983e941eb37.png)
* and when prompted to “SELECT YOUR STRUCTURE”, select anything except the first two options:
![image](https://user-images.githubusercontent.com/12400734/192295502-3bd5fbc6-8b37-40e0-9ae0-aada3f5a5091.png)

**Without this PR/RC**:
* once you have selected a structure, the console error will be displayed:
```
Error: noUiSlider (13.0.0): 'start' option is incorrect.
```
**With this PR/RC**:
* once you have selected a structure, no console errors should be displayed
* Repeat the test with Containers turned off, you should still get no console errors.


#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [x] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

The removed code wasn't used anywhere, so there shouldn't be any regression, but just to be on the safe side:
* Quickly smoke test the Inclusive Language feature in all editors
* Quickly smoke test the SEO Score analysis in all editors

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes #
