### PR TITLE
PC-372-canonical-url-and-related-properties-incorrect-on-attachment-pages

### DIFF
--- a/src/helpers/image-helper.php
+++ b/src/helpers/image-helper.php
@@ -239,7 +239,12 @@ class Image_Helper {
 	 * @return string The url when found, empty string otherwise.
 	 */
 	public function get_attachment_image_url( $attachment_id, $size ) {
-		$url = \wp_get_attachment_image_url( $attachment_id, $size );
+		if ( is_attachment() ) {
+			global $wp;
+			$url =  \home_url( $wp->request );
+		} else {
+			$url = \wp_get_attachment_image_url( $attachment_id, $size );
+		}
 		if ( ! $url ) {
 			return '';
 		}

--- a/src/helpers/image-helper.php
+++ b/src/helpers/image-helper.php
@@ -239,12 +239,7 @@ class Image_Helper {
 	 * @return string The url when found, empty string otherwise.
 	 */
 	public function get_attachment_image_url( $attachment_id, $size ) {
-		if ( is_attachment() ) {
-			global $wp;
-			$url =  \home_url( $wp->request );
-		} else {
-			$url = \wp_get_attachment_image_url( $attachment_id, $size );
-		}
+		$url = \wp_get_attachment_image_url( $attachment_id, $size );
 		if ( ! $url ) {
 			return '';
 		}

--- a/src/presentations/indexable-presentation.php
+++ b/src/presentations/indexable-presentation.php
@@ -233,6 +233,11 @@ class Indexable_Presentation extends Abstract_Presentation {
 			return $this->current_page->get_date_archive_permalink();
 		}
 
+		if ( \is_attachment() ) {
+			global $wp;
+			return \trailingslashit( \home_url( $wp->request ) );
+		}
+
 		return $this->model->permalink;
 	}
 

--- a/src/presentations/indexable-presentation.php
+++ b/src/presentations/indexable-presentation.php
@@ -225,11 +225,6 @@ class Indexable_Presentation extends Abstract_Presentation {
 	 * @return string The permalink.
 	 */
 	public function generate_permalink() {
-		if ( \is_attachment() ) {
-			global $wp;
-			return \home_url( $wp->request );
-		}
-
 		if ( $this->indexable_helper->dynamic_permalinks_enabled() ) {
 			return $this->permalink_helper->get_permalink_for_indexable( $this->model );
 		}

--- a/src/presentations/indexable-presentation.php
+++ b/src/presentations/indexable-presentation.php
@@ -225,6 +225,11 @@ class Indexable_Presentation extends Abstract_Presentation {
 	 * @return string The permalink.
 	 */
 	public function generate_permalink() {
+		if ( \is_attachment() ) {
+			global $wp;
+			return \home_url( $wp->request );
+		}
+
 		if ( $this->indexable_helper->dynamic_permalinks_enabled() ) {
 			return $this->permalink_helper->get_permalink_for_indexable( $this->model );
 		}

--- a/src/presenters/open-graph/image-presenter.php
+++ b/src/presenters/open-graph/image-presenter.php
@@ -43,6 +43,12 @@ class Image_Presenter extends Abstract_Indexable_Presenter {
 		$return = '';
 		foreach ( $images as $image_index => $image_meta ) {
 			$image_url = $image_meta['url'];
+
+			if ( \is_attachment() ) {
+				global $wp;
+				$image_url = \home_url( $wp->request );
+			}
+
 			$class     = \is_admin_bar_showing() ? ' class="yoast-seo-meta-tag"' : '';
 
 			$return .= '<meta property="og:image" content="' . \esc_url( $image_url, null, 'attribute' ) . '"' . $class . ' />';

--- a/tests/unit/helpers/image-helper-test.php
+++ b/tests/unit/helpers/image-helper-test.php
@@ -395,9 +395,6 @@ class Image_Helper_Test extends TestCase {
 	 * @covers ::get_attachment_image_url
 	 */
 	public function test_get_attachment_image_url() {
-		Monkey\Functions\expect( 'is_attachment' )
-			->once()
-			->andReturn( false );
 
 		Monkey\Functions\expect( 'wp_get_attachment_image_url' )
 			->once()
@@ -416,9 +413,6 @@ class Image_Helper_Test extends TestCase {
 	 * @covers ::get_attachment_image_url
 	 */
 	public function test_get_attachment_image_url_no_url_found() {
-		Monkey\Functions\expect( 'is_attachment' )
-			->once()
-			->andReturn( false );
 
 		Monkey\Functions\expect( 'wp_get_attachment_image_url' )
 			->once()

--- a/tests/unit/helpers/image-helper-test.php
+++ b/tests/unit/helpers/image-helper-test.php
@@ -395,6 +395,10 @@ class Image_Helper_Test extends TestCase {
 	 * @covers ::get_attachment_image_url
 	 */
 	public function test_get_attachment_image_url() {
+		Monkey\Functions\expect( 'is_attachment' )
+			->once()
+			->andReturn( false );
+
 		Monkey\Functions\expect( 'wp_get_attachment_image_url' )
 			->once()
 			->with( 1337, 'full' )
@@ -412,6 +416,10 @@ class Image_Helper_Test extends TestCase {
 	 * @covers ::get_attachment_image_url
 	 */
 	public function test_get_attachment_image_url_no_url_found() {
+		Monkey\Functions\expect( 'is_attachment' )
+			->once()
+			->andReturn( false );
+
 		Monkey\Functions\expect( 'wp_get_attachment_image_url' )
 			->once()
 			->with( 1337, 'full' )

--- a/tests/unit/presentations/archive-adjacent-test.php
+++ b/tests/unit/presentations/archive-adjacent-test.php
@@ -87,6 +87,10 @@ class Archive_Adjacent_Test extends TestCase {
 			->once()
 			->andReturn( false );
 
+		Monkey\Functions\expect( 'is_attachment' )
+			->once()
+			->andReturn( false );
+
 		$this->assertEquals( 'https://example.com/permalink/', $this->instance->generate_rel_prev() );
 	}
 
@@ -120,6 +124,10 @@ class Archive_Adjacent_Test extends TestCase {
 			->andReturn( 'https://example.com/permalink/page/2/' );
 
 		Monkey\Functions\expect( 'is_date' )
+			->once()
+			->andReturn( false );
+
+		Monkey\Functions\expect( 'is_attachment' )
 			->once()
 			->andReturn( false );
 
@@ -199,6 +207,10 @@ class Archive_Adjacent_Test extends TestCase {
 			->andReturn( 'https://example.com/permalink/page/6/' );
 
 		Monkey\Functions\expect( 'is_date' )
+			->once()
+			->andReturn( false );
+
+		Monkey\Functions\expect( 'is_attachment' )
 			->once()
 			->andReturn( false );
 

--- a/tests/unit/presentations/indexable-author-archive-presentation/canonical-test.php
+++ b/tests/unit/presentations/indexable-author-archive-presentation/canonical-test.php
@@ -52,6 +52,10 @@ class Canonical_Test extends TestCase {
 			->once()
 			->andReturn( false );
 
+		Monkey\Functions\expect( 'is_attachment' )
+			->once()
+			->andReturn( false );
+
 		$this->assertEmpty( $this->instance->generate_canonical() );
 	}
 
@@ -74,6 +78,10 @@ class Canonical_Test extends TestCase {
 			->andReturn( 0 );
 
 		Monkey\Functions\expect( 'is_date' )
+			->once()
+			->andReturn( false );
+
+		Monkey\Functions\expect( 'is_attachment' )
 			->once()
 			->andReturn( false );
 
@@ -108,6 +116,10 @@ class Canonical_Test extends TestCase {
 			->once()
 			->andReturn( false );
 
+		Monkey\Functions\expect( 'is_attachment' )
+			->once()
+			->andReturn( false );
+
 		$this->assertEquals( 'https://example.com/author/page/2/', $this->instance->generate_canonical() );
 	}
 
@@ -134,6 +146,10 @@ class Canonical_Test extends TestCase {
 			->expects( 'get_current_archive_page_number' )
 			->once()
 			->andReturn( 0 );
+
+		Monkey\Functions\expect( 'is_attachment' )
+			->once()
+			->andReturn( false );
 
 		$this->assertEquals( 'https://example.com/dynamic/author/', $this->instance->generate_canonical() );
 	}
@@ -167,6 +183,10 @@ class Canonical_Test extends TestCase {
 			->with( 'https://example.com/dynamic-author/', 3 )
 			->once()
 			->andReturn( 'https://example.com/dynamic-author/page/3/' );
+
+		Monkey\Functions\expect( 'is_attachment' )
+			->once()
+			->andReturn( false );
 
 		$this->assertEquals( 'https://example.com/dynamic-author/page/3/', $this->instance->generate_canonical() );
 	}

--- a/tests/unit/presentations/indexable-home-page-presentation/canonical-test.php
+++ b/tests/unit/presentations/indexable-home-page-presentation/canonical-test.php
@@ -3,6 +3,7 @@
 namespace Yoast\WP\SEO\Tests\Unit\Presentations\Indexable_Home_Page_Presentation;
 
 use Brain\Monkey;
+use Mockery;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
@@ -43,6 +44,10 @@ class Canonical_Test extends TestCase {
 	 * @covers ::generate_canonical
 	 */
 	public function test_without_permalink() {
+		Monkey\Functions\expect( 'is_attachment' )
+			->once()
+			->andReturn( false );
+
 		$this->indexable_helper
 			->expects( 'dynamic_permalinks_enabled' )
 			->once()
@@ -62,6 +67,10 @@ class Canonical_Test extends TestCase {
 	 */
 	public function test_without_pagination() {
 		$this->indexable->permalink = 'https://example.com/';
+
+		Monkey\Functions\expect( 'is_attachment' )
+			->once()
+			->andReturn( false );
 
 		$this->indexable_helper
 			->expects( 'dynamic_permalinks_enabled' )
@@ -87,6 +96,10 @@ class Canonical_Test extends TestCase {
 	 */
 	public function test_with_pagination() {
 		$this->indexable->permalink = 'https://example.com/';
+
+		Monkey\Functions\expect( 'is_attachment' )
+			->once()
+			->andReturn( false );
 
 		$this->indexable_helper
 			->expects( 'dynamic_permalinks_enabled' )
@@ -119,6 +132,10 @@ class Canonical_Test extends TestCase {
 	public function test_without_pagination_with_dynamic_permalinks() {
 		$this->indexable->permalink = 'https://example.com/';
 
+		Monkey\Functions\expect( 'is_attachment' )
+			->once()
+			->andReturn( false );
+
 		$this->indexable_helper
 			->expects( 'dynamic_permalinks_enabled' )
 			->once()
@@ -145,6 +162,10 @@ class Canonical_Test extends TestCase {
 	 */
 	public function test_with_pagination_with_dynamic_permalinks() {
 		$this->indexable->permalink = 'https://example.com/';
+
+		Monkey\Functions\expect( 'is_attachment' )
+			->once()
+			->andReturn( false );
 
 		$this->indexable_helper
 			->expects( 'dynamic_permalinks_enabled' )

--- a/tests/unit/presentations/indexable-post-type-archive-presentation/canonical-test.php
+++ b/tests/unit/presentations/indexable-post-type-archive-presentation/canonical-test.php
@@ -41,6 +41,10 @@ class Canonical_Test extends TestCase {
 			->once()
 			->andReturn( false );
 
+		Monkey\Functions\expect( 'is_attachment' )
+			->once()
+			->andReturn( false );
+
 		$this->assertEmpty( $this->instance->generate_canonical() );
 	}
 
@@ -65,6 +69,10 @@ class Canonical_Test extends TestCase {
 			->expects( 'get_current_archive_page_number' )
 			->once()
 			->andReturn( 0 );
+
+		Monkey\Functions\expect( 'is_attachment' )
+			->once()
+			->andReturn( false );
 
 		$this->assertEquals( 'https://example.com/custom-post-type/', $this->instance->generate_canonical() );
 	}
@@ -97,6 +105,10 @@ class Canonical_Test extends TestCase {
 			->once()
 			->andReturn( 'https://example.com/custom-post-type/page/2/' );
 
+		Monkey\Functions\expect( 'is_attachment' )
+			->once()
+			->andReturn( false );
+
 		$this->assertEquals( 'https://example.com/custom-post-type/page/2/', $this->instance->generate_canonical() );
 	}
 
@@ -123,6 +135,10 @@ class Canonical_Test extends TestCase {
 			->expects( 'get_current_archive_page_number' )
 			->once()
 			->andReturn( 0 );
+
+		Monkey\Functions\expect( 'is_attachment' )
+			->once()
+			->andReturn( false );
 
 		$this->assertEquals( 'https://example.com/dynamic-custom-post-type/', $this->instance->generate_canonical() );
 	}
@@ -156,6 +172,10 @@ class Canonical_Test extends TestCase {
 			->with( 'https://example.com/dynamic-custom-post-type/', 3 )
 			->once()
 			->andReturn( 'https://example.com/dynamic-custom-post-type/page/3/' );
+
+		Monkey\Functions\expect( 'is_attachment' )
+			->once()
+			->andReturn( false );
 
 		$this->assertEquals( 'https://example.com/dynamic-custom-post-type/page/3/', $this->instance->generate_canonical() );
 	}

--- a/tests/unit/presentations/indexable-post-type-presentation/canonical-test.php
+++ b/tests/unit/presentations/indexable-post-type-presentation/canonical-test.php
@@ -69,6 +69,10 @@ class Canonical_Test extends TestCase {
 			->once()
 			->andReturn( false );
 
+		Monkey\Functions\expect( 'is_attachment' )
+			->once()
+			->andReturn( false );
+
 		$this->assertEquals( 'https://example.com/permalink/', $this->instance->generate_canonical() );
 	}
 
@@ -110,6 +114,10 @@ class Canonical_Test extends TestCase {
 			->once()
 			->andReturn( false );
 
+		Monkey\Functions\expect( 'is_attachment' )
+			->once()
+			->andReturn( false );
+
 		$this->assertEquals( 'https://example.com/permalink/2/', $this->instance->generate_canonical() );
 	}
 
@@ -146,6 +154,10 @@ class Canonical_Test extends TestCase {
 					return $val;
 				}
 			);
+
+		Monkey\Functions\expect( 'is_attachment' )
+			->once()
+			->andReturn( false );
 
 		$this->assertEquals( 'https://example.com/dynamic-permalink/', $this->instance->generate_canonical() );
 	}
@@ -189,6 +201,10 @@ class Canonical_Test extends TestCase {
 					return $val;
 				}
 			);
+
+		Monkey\Functions\expect( 'is_attachment' )
+			->once()
+			->andReturn( false );
 
 		$this->assertEquals( 'https://example.com/dynamic-permalink/2/', $this->instance->generate_canonical() );
 	}

--- a/tests/unit/presentations/indexable-presentation/canonical-test.php
+++ b/tests/unit/presentations/indexable-presentation/canonical-test.php
@@ -157,6 +157,6 @@ class Canonical_Test extends TestCase {
 			->with( $wp->request )
 			->andReturnFirstArg();
 
-		$this->assertEquals( 'https://example.com/image', $this->instance->generate_canonical() );
+		$this->assertEquals( 'https://example.com/image/', $this->instance->generate_canonical() );
 	}
 }

--- a/tests/unit/presentations/indexable-presentation/canonical-test.php
+++ b/tests/unit/presentations/indexable-presentation/canonical-test.php
@@ -3,6 +3,7 @@
 namespace Yoast\WP\SEO\Tests\Unit\Presentations\Indexable_Presentation;
 
 use Brain\Monkey;
+use Mockery;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
@@ -54,6 +55,10 @@ class Canonical_Test extends TestCase {
 			->once()
 			->andReturn( false );
 
+		Monkey\Functions\expect( 'is_attachment' )
+			->once()
+			->andReturn( false );
+
 		$this->assertEquals( 'https://example.com/permalink/', $this->instance->generate_canonical() );
 	}
 
@@ -69,6 +74,10 @@ class Canonical_Test extends TestCase {
 			->andReturn( false );
 
 		Monkey\Functions\expect( 'is_date' )
+			->once()
+			->andReturn( false );
+
+		Monkey\Functions\expect( 'is_attachment' )
 			->once()
 			->andReturn( false );
 
@@ -94,6 +103,10 @@ class Canonical_Test extends TestCase {
 			->once()
 			->andReturn( 'https://example.com/dynamic-permalink/' );
 
+		Monkey\Functions\expect( 'is_attachment' )
+			->once()
+			->andReturn( false );
+
 		$this->assertEquals( 'https://example.com/dynamic-permalink/', $this->instance->generate_canonical() );
 	}
 
@@ -118,6 +131,32 @@ class Canonical_Test extends TestCase {
 			->expects( 'get_date_archive_permalink' )
 			->andReturn( 'https://example.com/2022/06' );
 
+		Monkey\Functions\expect( 'is_attachment' )
+			->once()
+			->andReturn( false );
+
 		$this->assertEquals( 'https://example.com/2022/06', $this->instance->generate_canonical() );
+	}
+
+	/**
+	 * Tests the situation where the permalink is given and we are in an attachment page.
+	 *
+	 * @covers ::generate_canonical
+	 */
+	public function test_with_permalink_on_attachment_page() {
+		$wp          = Mockery::mock();
+		$wp->request = 'https://example.com/image';
+
+		$GLOBALS['wp'] = $wp;
+
+		Monkey\Functions\expect( 'is_attachment' )
+			->once()
+			->andReturn( true );
+
+		Monkey\Functions\expect( 'home_url' )
+			->with( $wp->request )
+			->andReturnFirstArg();
+
+		$this->assertEquals( 'https://example.com/image', $this->instance->generate_canonical() );
 	}
 }

--- a/tests/unit/presentations/indexable-presentation/open-graph-url-test.php
+++ b/tests/unit/presentations/indexable-presentation/open-graph-url-test.php
@@ -55,6 +55,10 @@ class Open_Graph_URL_Test extends TestCase {
 			->once()
 			->andReturn( false );
 
+		Monkey\Functions\expect( 'is_attachment' )
+			->once()
+			->andReturn( false );
+
 		$this->assertEquals( 'http://example.com/permalink', $this->instance->generate_open_graph_url() );
 	}
 }

--- a/tests/unit/presentations/indexable-presentation/permalink-test.php
+++ b/tests/unit/presentations/indexable-presentation/permalink-test.php
@@ -42,6 +42,10 @@ class Permalink_Test extends TestCase {
 			->once()
 			->andReturn( false );
 
+		Monkey\Functions\expect( 'is_attachment' )
+			->once()
+			->andReturn( false );
+
 		$this->assertEquals( 'https://example.com/permalink/', $this->instance->permalink );
 	}
 
@@ -65,6 +69,34 @@ class Permalink_Test extends TestCase {
 			->once()
 			->andReturn( 'https://example.com/dynamic-permalink/' );
 
+		Monkey\Functions\expect( 'is_attachment' )
+			->once()
+			->andReturn( false );
+
 		$this->assertEquals( 'https://example.com/dynamic-permalink/', $this->instance->permalink );
+	}
+
+	/**
+	 * Tests the permalink getter method on attachment page.
+	 *
+	 * @covers ::generate_permalink
+	 */
+	public function test_get_permalink_on_attachment_page() {
+		$this->indexable->permalink = 'https://example.com/permalink/';
+
+		$this->indexable_helper
+			->expects( 'dynamic_permalinks_enabled' )
+			->once()
+			->andReturn( false );
+
+		Monkey\Functions\expect( 'is_date' )
+			->once()
+			->andReturn( false );
+
+		Monkey\Functions\expect( 'is_attachment' )
+			->once()
+			->andReturn( false );
+
+		$this->assertEquals( 'https://example.com/permalink/', $this->instance->permalink );
 	}
 }

--- a/tests/unit/presentations/indexable-static-home-page-presentation/canonical-test.php
+++ b/tests/unit/presentations/indexable-static-home-page-presentation/canonical-test.php
@@ -69,6 +69,10 @@ class Canonical_Test extends TestCase {
 			->once()
 			->andReturn( false );
 
+		Monkey\Functions\expect( 'is_attachment' )
+			->once()
+			->andReturn( false );
+
 		$this->assertEquals( 'https://example.com/permalink/', $this->instance->generate_canonical() );
 	}
 
@@ -111,6 +115,10 @@ class Canonical_Test extends TestCase {
 			->once()
 			->andReturn( false );
 
+		Monkey\Functions\expect( 'is_attachment' )
+			->once()
+			->andReturn( false );
+
 		$this->assertEquals( 'https://example.com/permalink/2/', $this->instance->generate_canonical() );
 	}
 
@@ -147,6 +155,10 @@ class Canonical_Test extends TestCase {
 					return $val;
 				}
 			);
+
+		Monkey\Functions\expect( 'is_attachment' )
+			->once()
+			->andReturn( false );
 
 		$this->assertEquals( 'https://example.com/dynamic-permalink/', $this->instance->generate_canonical() );
 	}
@@ -191,6 +203,10 @@ class Canonical_Test extends TestCase {
 					return $val;
 				}
 			);
+
+		Monkey\Functions\expect( 'is_attachment' )
+			->once()
+			->andReturn( false );
 
 		$this->assertEquals( 'https://example.com/dynamic-permalink/2/', $this->instance->generate_canonical() );
 	}

--- a/tests/unit/presentations/indexable-static-posts-page-presentation/canonical-test.php
+++ b/tests/unit/presentations/indexable-static-posts-page-presentation/canonical-test.php
@@ -59,6 +59,10 @@ class Canonical_Test extends TestCase {
 			->once()
 			->andReturn( false );
 
+		Monkey\Functions\expect( 'is_attachment' )
+			->once()
+			->andReturn( false );
+
 		$this->assertEquals( 'https://example.com/permalink/', $this->instance->generate_canonical() );
 	}
 
@@ -81,6 +85,10 @@ class Canonical_Test extends TestCase {
 		Monkey\Functions\expect( 'is_date' )
 			->once()
 			->andReturn( false );
+
+		Monkey\Functions\expect( 'is_attachment' )
+				->once()
+				->andReturn( false );
 
 		$this->assertEmpty( $this->instance->generate_canonical() );
 	}
@@ -113,6 +121,10 @@ class Canonical_Test extends TestCase {
 			->once()
 			->andReturn( false );
 
+		Monkey\Functions\expect( 'is_attachment' )
+			->once()
+			->andReturn( false );
+
 		$this->assertEquals( 'https://example.com/permalink/page/2/', $this->instance->generate_canonical() );
 	}
 
@@ -139,6 +151,10 @@ class Canonical_Test extends TestCase {
 			->expects( 'get_current_archive_page_number' )
 			->once()
 			->andReturn( 1 );
+
+		Monkey\Functions\expect( 'is_attachment' )
+			->once()
+			->andReturn( false );
 
 		$this->assertEquals( 'https://example.com/dynamic-permalink/', $this->instance->generate_canonical() );
 	}
@@ -172,6 +188,10 @@ class Canonical_Test extends TestCase {
 			->once()
 			->with( 'https://example.com/dynamic-permalink/', 2 )
 			->andReturn( 'https://example.com/dynamic-permalink/page/2/' );
+
+		Monkey\Functions\expect( 'is_attachment' )
+			->once()
+			->andReturn( false );
 
 		$this->assertEquals( 'https://example.com/dynamic-permalink/page/2/', $this->instance->generate_canonical() );
 	}

--- a/tests/unit/presentations/indexable-static-posts-page-presentation/open-graph-url-test.php
+++ b/tests/unit/presentations/indexable-static-posts-page-presentation/open-graph-url-test.php
@@ -42,6 +42,10 @@ class Open_Graph_URL_Test extends TestCase {
 			->once()
 			->andReturn( false );
 
+		Monkey\Functions\expect( 'is_attachment' )
+			->once()
+			->andReturn( false );
+
 		$this->assertEquals( 'https://example.com/static-posts-page', $this->instance->generate_open_graph_url() );
 	}
 }

--- a/tests/unit/presentations/indexable-term-archive-presentation/canonical-test.php
+++ b/tests/unit/presentations/indexable-term-archive-presentation/canonical-test.php
@@ -71,6 +71,10 @@ class Canonical_Test extends TestCase {
 			->once()
 			->andReturn( false );
 
+		Monkey\Functions\expect( 'is_attachment' )
+			->once()
+			->andReturn( false );
+
 		$this->assertEmpty( $this->instance->generate_canonical() );
 	}
 
@@ -96,6 +100,10 @@ class Canonical_Test extends TestCase {
 			->andReturn( 0 );
 
 		Monkey\Functions\expect( 'is_date' )
+			->once()
+			->andReturn( false );
+
+		Monkey\Functions\expect( 'is_attachment' )
 			->once()
 			->andReturn( false );
 
@@ -133,6 +141,10 @@ class Canonical_Test extends TestCase {
 			->once()
 			->andReturn( false );
 
+		Monkey\Functions\expect( 'is_attachment' )
+			->once()
+			->andReturn( false );
+
 		$this->assertEquals( 'https://example.com/term-archive/page/2/', $this->instance->generate_canonical() );
 	}
 
@@ -162,6 +174,10 @@ class Canonical_Test extends TestCase {
 			->expects( 'get_current_archive_page_number' )
 			->once()
 			->andReturn( 0 );
+
+		Monkey\Functions\expect( 'is_attachment' )
+			->once()
+			->andReturn( false );
 
 		$this->assertEquals( 'https://example.com/dynamic-term-archive/', $this->instance->generate_canonical() );
 	}
@@ -198,6 +214,10 @@ class Canonical_Test extends TestCase {
 			->with( 'https://example.com/dynamic-term-archive/', 2 )
 			->once()
 			->andReturn( 'https://example.com/dynamic-term-archive/page/2/' );
+
+		Monkey\Functions\expect( 'is_attachment' )
+			->once()
+			->andReturn( false );
 
 		$this->assertEquals( 'https://example.com/dynamic-term-archive/page/2/', $this->instance->generate_canonical() );
 	}

--- a/tests/unit/presenters/open-graph/image-presenter-test.php
+++ b/tests/unit/presenters/open-graph/image-presenter-test.php
@@ -74,6 +74,10 @@ class Image_Presenter_Test extends TestCase {
 
 		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
 
+		Monkey\Functions\expect( 'is_attachment' )
+			->once()
+			->andReturn( false );
+
 		$this->assertEquals(
 			'<meta property="og:image" content="https://example.com/image.jpg" />' . \PHP_EOL . "\t" . '<meta property="og:image:width" content="100" />' . \PHP_EOL . "\t" . '<meta property="og:image:height" content="100" />',
 			$this->instance->present()
@@ -158,8 +162,51 @@ class Image_Presenter_Test extends TestCase {
 
 		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( true );
 
+		Monkey\Functions\expect( 'is_attachment' )
+			->once()
+			->andReturn( false );
+
 		$this->assertEquals(
 			'<meta property="og:image" content="https://example.com/image.jpg" class="yoast-seo-meta-tag" />' . \PHP_EOL . "\t" . '<meta property="og:image:width" content="100" class="yoast-seo-meta-tag" />' . \PHP_EOL . "\t" . '<meta property="og:image:height" content="100" class="yoast-seo-meta-tag" />',
+			$this->instance->present()
+		);
+	}
+
+	/**
+	 * Tests the presentation with an attachment page.
+	 *
+	 * @covers ::present
+	 */
+	public function test_present_with_attachment_page() {
+		$this->stubEscapeFunctions();
+		$wp          = Mockery::mock();
+		$wp->request = 'https://example.com/image';
+
+		$GLOBALS['wp'] = $wp;
+
+		$image = [
+			'url'    => 'https://example.com/wp-content/uploads/2022/09/image.jpg',
+			'width'  => 100,
+			'height' => 100,
+		];
+
+		$this->presentation->open_graph_images = [ $image ];
+
+		Monkey\Functions\expect( 'is_admin_bar_showing' )
+			->once()
+			->andReturn( true );
+
+		Monkey\Functions\expect( 'is_attachment' )
+			->once()
+			->andReturn( true );
+
+		Monkey\Functions\expect( 'home_url' )
+			->with( $wp->request )
+			->andReturnFirstArg();
+
+
+		$this->assertEquals(
+			'<meta property="og:image" content="https://example.com/image" class="yoast-seo-meta-tag" />' . \PHP_EOL . "\t" . '<meta property="og:image:width" content="100" class="yoast-seo-meta-tag" />' . \PHP_EOL . "\t" . '<meta property="og:image:height" content="100" class="yoast-seo-meta-tag" />',
 			$this->instance->present()
 		);
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

On attachment pages the canonical URL value is incorrect, thus referencing the attachment filename.
This leads to an incorrect schema and Open Graph output.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the wrong canonical URL is set on attachment pages.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* In `Yoast SEO` -> `Search Appearance` `Media` tab, be sure to have the `Redirect attachment URLs to the attachment itself?` toggle set to `No`
* In the WordPress menu go to `Media` , select one of the image files and click on `View attachment page`: the attachment page will open
 
<img width="1042" alt="Screenshot 2022-09-27 at 10 43 27" src="https://user-images.githubusercontent.com/68744851/192478536-c7b88bd2-e203-4f29-b24e-cfc806dc95e3.png">
* Inspect the page source code and check that the URL used in:

  *   canonical URL and `og:url` property  in the meta tags 
  *   `@id` and `url` properties, `@id` in `primaryImageOfPage` property `@id` in `image` property, `@id` in `breadcrumb` property in `Webpage` schema piece
  *   `@id`property in `ImageObject` schema piece
  *   `@id` in `BreadcrumbList`schema piece
**All** use the same attachment page URL to build their value; for example, if the image file has the following URL: `https://basic.wordpress.test/wp-content/uploads/2022/09/WordPress9.jpg`, the attachment page URL will be: `https://basic.wordpress.test/wordpress9/`

* Use a tool such as [https://classyschema.org/Visualisation](https://classyschema.org/Visualisation) to validate the schema

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Schema
* Open Graph

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes [PC-372](https://yoast.atlassian.net/browse/PC-372)
