### PR TITLE
Improves the relation between the sidebar and the adminbar notifications

### DIFF
--- a/inc/class-wpseo-admin-bar-menu.php
+++ b/inc/class-wpseo-admin-bar-menu.php
@@ -659,7 +659,7 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 		/* translators: %s: number of notifications */
 		$counter_screen_reader_text = sprintf( _n( '%s notification', '%s notifications', $notification_count, 'wordpress-seo' ), number_format_i18n( $notification_count ) );
 
-		return sprintf( ' <div class="wp-core-ui wp-ui-notification yoast-issue-counter"><span aria-hidden="true">%d</span><span class="screen-reader-text">%s</span></div>', $notification_count, $counter_screen_reader_text );
+		return sprintf( ' <div class="wp-core-ui wp-ui-notification yoast-issue-counter"><span class="yoast-issues-count" aria-hidden="true">%d</span><span class="screen-reader-text">%s</span></div>', $notification_count, $counter_screen_reader_text );
 	}
 
 	/**

--- a/packages/js/src/admin-global.js
+++ b/packages/js/src/admin-global.js
@@ -367,6 +367,23 @@ import jQuery from "jquery";
 		} );
 	}
 
+	/**
+	 * Resolves potential mismatches in the notification counts between the sidebar and the adminbar.
+	 *
+	 * @returns {void}
+	 */
+	function resolveNotificationMismatch() {
+		const $adminbarCount = jQuery( ".yoast-issue-counter .yoast-issues-count" ).first();
+		const $sidebarCount = jQuery( "#toplevel_page_wpseo_dashboard .plugin-count" );
+
+		if ( $adminbarCount.length ) {
+			$sidebarCount.text( $adminbarCount.text() );
+			return;
+		}
+
+		$sidebarCount.text( "0" );
+	}
+
 	/*
 	 * When the viewport size changes, check again the scrollable tables width.
 	 * About the events: technically `wp-window-resized` is triggered on the
@@ -409,5 +426,6 @@ import jQuery from "jquery";
 		hookDismissRestoreButtons();
 		setPremiumIndicatorColor();
 		createScrollableTables();
+		resolveNotificationMismatch();
 	} );
 }( jQuery ) );

--- a/packages/js/src/admin-global.js
+++ b/packages/js/src/admin-global.js
@@ -377,7 +377,6 @@ import jQuery from "jquery";
 		const sidebarCounts = jQuery( "#toplevel_page_wpseo_dashboard .plugin-count" );
 
 		if ( adminbarCount.text() === sidebarCounts.first().text() ) {
-			console.log('resolveNotificationMismatch1');
 			return;
 		}
 

--- a/packages/js/src/admin-global.js
+++ b/packages/js/src/admin-global.js
@@ -373,15 +373,29 @@ import jQuery from "jquery";
 	 * @returns {void}
 	 */
 	function resolveNotificationMismatch() {
-		const $adminbarCount = jQuery( ".yoast-issue-counter .yoast-issues-count" ).first();
-		const $sidebarCount = jQuery( "#toplevel_page_wpseo_dashboard .plugin-count" );
+		const adminbarCount = jQuery( ".yoast-issue-counter .yoast-issues-count" ).first();
+		const sidebarCounts = jQuery( "#toplevel_page_wpseo_dashboard .plugin-count" );
 
-		if ( $adminbarCount.length ) {
-			$sidebarCount.text( $adminbarCount.text() );
+		if ( adminbarCount.text() === sidebarCounts.first().text() ) {
+			console.log('resolveNotificationMismatch1');
 			return;
 		}
 
-		$sidebarCount.text( "0" );
+		const sidebarClass = jQuery( "#toplevel_page_wpseo_dashboard .update-plugins" );
+		const adminbarScreenReader = jQuery( ".yoast-issue-counter .screen-reader-text" ).first();
+		const sidebarScreenReader = jQuery( "#toplevel_page_wpseo_dashboard .update-plugins .screen-reader-text" );
+
+		if ( adminbarCount.length ) {
+			sidebarCounts.text( adminbarCount.text() );
+			sidebarClass.removeClass().addClass( "update-plugins count-" + adminbarCount.text() );
+			sidebarScreenReader.text( adminbarScreenReader.text() );
+
+			return;
+		}
+
+		sidebarCounts.text( "0" );
+		sidebarClass.removeClass().addClass( "update-plugins count-0" );
+		sidebarScreenReader.remove();
 	}
 
 	/*


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to avoid mismatches between the issue counters in the adminbar and the sidebar, so we're forcing the latter get the value of the former on page load.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the sidebar issue counter would show a wrong number of issues, on the first page load after an issue was resolved.

## Relevant technical choices:

* Because of timing issues, the sidebar issue counter gets the old issue count on the first page load after an issue gets resolved.
* In order to fix that properly, it would require a radical transformation of the whole notification system, which doesnt make much sense, considering that we're probably going to scrap it soon.
* Which meant that I could just resort in jQuery to make the value of the sidebar issue counter same with the value of the admin issue counter (along with its screen reader values).

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Have Free SEO 19.7.1 (or master checked out if you're a dev) active and Woo SEO installed but NOT active
* Have auto-updates NOT active for Yoast SEO and also go to Settings->Reading and check the `Discourage search engines from indexing this site` option
* Ignore the `Huge SEO Issue: You're blocking access to robots` issue and then confirm that the issues you see in the notifications are 2, one for Woo and one for auto-updates:
![image](https://user-images.githubusercontent.com/12400734/192727411-4b3db290-bc46-43f6-968e-e85c3dbd546a.png)
* Upgrade to this current RC (or checkout this PR if you're a dev) and in **the first** page load after upgrade (or checkout), you will see the same number of issues in the sidebar and the admin bar, which is no issues (which makes sense because we removed those 2 issues from 19.8) (if you had upgraded with the previous RC (or checked out the release branch), you would have seen `2` in the sidebar and no issues in the admin bar):
![image](https://user-images.githubusercontent.com/12400734/192732171-6f391584-3e82-4bb0-b76a-c3d7b26ea13e.png)
* Confirm that re-enabling the `Huge SEO Issue: You're blocking access to robots` issue, makes the adminbar and the sidebar show `1` as the current issue count.

Now repeat the test, with one change:
* Have Free SEO 19.7.1 (or master checked out if you're a dev) active and Woo SEO installed but NOT active
* Have auto-updates NOT active for Yoast SEO and also go to Settings->Reading and check the `Discourage search engines from indexing this site` option.
* DONT ignore the `Huge SEO Issue: You're blocking access to robots` issue and confirm that the issues you see in the notifications are 3, one for Woo and one for auto-updates and one for the Huge SEO Issue:
![image](https://user-images.githubusercontent.com/12400734/192733473-03ffd255-e882-475c-8e7a-77bfdd2144aa.png)
* Upgrade to this current RC (or checkout this PR if you're a dev) and in **the first** page load after upgrade (or checkout), you will see the same number of issues in the sidebar and the admin bar, which is `1` (which makes sense because we removed the 2 issues from 19.8, so the only issue remaining is the ) -  (if you had upgraded with the previous RC (or checked out the release branch), you would have seen `3` in the sidebar and `1` in the admin bar):
![image](https://user-images.githubusercontent.com/12400734/192733786-1c99c3b9-da0f-4b64-b6fa-81d8ec703fe2.png)

Alternative/easier Test Instructions:
* Install this RC (or checkout this PR)
* Go to Settings->Reading and check the `Discourage search engines from indexing this site` option.
* Confirm that the issues in both the adminbar and the sidebar are the correct number, once the page is reloaded
* Now uncheck the `Discourage search engines from indexing this site` option
* Confirm that the issues in both the adminbar and the sidebar are the correct number, once the page is reloaded
* With the current RC (and previous versions, the above test is failing because the sidebar counter is always wrong in the first page load after save and only gets the correct number in next page loads.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [x] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes #
