### PR TITLE
Force tree-shaking for Heroicons some of the features

### DIFF
--- a/packages/js/src/first-time-configuration/tailwind-components/base/alert.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/base/alert.js
@@ -2,7 +2,10 @@
 // Addition: "success" case, fade in alert.
 
 import { useCallback, useState } from "@wordpress/element";
-import { InformationCircleIcon, ExclamationIcon, XCircleIcon, CheckCircleIcon } from "@heroicons/react/solid";
+import CheckCircleIcon from "@heroicons/react/solid/CheckCircleIcon";
+import ExclamationIcon from "@heroicons/react/solid/ExclamationIcon";
+import InformationCircleIcon from "@heroicons/react/solid/InformationCircleIcon";
+import XCircleIcon from "@heroicons/react/solid/XCircleIcon";
 import { PropTypes } from "prop-types";
 import classNames from "classnames";
 import AnimateHeight from "react-animate-height";

--- a/packages/js/src/first-time-configuration/tailwind-components/base/combo-box.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/base/combo-box.js
@@ -1,5 +1,6 @@
 import { Combobox } from "@headlessui/react";
-import { CheckIcon, SelectorIcon } from "@heroicons/react/solid";
+import CheckIcon from "@heroicons/react/solid/CheckIcon";
+import SelectorIcon from "@heroicons/react/solid/SelectorIcon";
 import { __ } from "@wordpress/i18n";
 import { Fragment, useState, useEffect, useCallback } from "@wordpress/element";
 import classNames from "classnames";

--- a/packages/js/src/first-time-configuration/tailwind-components/base/image-select.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/base/image-select.js
@@ -1,4 +1,4 @@
-import { PhotographIcon } from "@heroicons/react/outline";
+import PhotographIcon from "@heroicons/react/outline/PhotographIcon";
 import { useCallback } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
 import classNames from "classnames";

--- a/packages/js/src/first-time-configuration/tailwind-components/base/single-select.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/base/single-select.js
@@ -1,5 +1,7 @@
 import { Listbox, Transition } from "@headlessui/react";
-import { CheckIcon, ExclamationCircleIcon, SelectorIcon } from "@heroicons/react/solid";
+import CheckIcon from "@heroicons/react/solid/CheckIcon";
+import ExclamationCircleIcon from "@heroicons/react/solid/ExclamationCircleIcon";
+import SelectorIcon from "@heroicons/react/solid/SelectorIcon";
 import { Fragment, useMemo } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
 import classNames from "classnames";

--- a/packages/js/src/first-time-configuration/tailwind-components/base/text-input.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/base/text-input.js
@@ -1,4 +1,5 @@
-import { ExclamationCircleIcon, CheckCircleIcon } from "@heroicons/react/solid";
+import ExclamationCircleIcon from "@heroicons/react/solid/ExclamationCircleIcon";
+import CheckCircleIcon from "@heroicons/react/solid/CheckCircleIcon";
 import classNames from "classnames";
 import { PropTypes } from "prop-types";
 import { useMemo } from "@wordpress/element";

--- a/packages/js/src/first-time-configuration/tailwind-components/step-circle.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/step-circle.js
@@ -1,4 +1,4 @@
-import { CheckIcon } from "@heroicons/react/solid";
+import CheckIcon from "@heroicons/react/solid/CheckIcon";
 import { useState, useEffect } from "@wordpress/element";
 import PropTypes from "prop-types";
 import { stepperTimingClasses } from "../stepper-helper";

--- a/packages/js/src/first-time-configuration/tailwind-components/steps/social-profiles/social-field-array.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/steps/social-profiles/social-field-array.js
@@ -1,5 +1,5 @@
-import { TrashIcon } from "@heroicons/react/outline";
-import { PlusIcon } from "@heroicons/react/solid";
+import TrashIcon from "@heroicons/react/outline/TrashIcon";
+import PlusIcon from "@heroicons/react/solid/PlusIcon";
 import { useCallback } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
 import { PropTypes } from "prop-types";

--- a/packages/js/src/first-time-configuration/tailwind-components/tailwind-modal.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/tailwind-modal.js
@@ -1,5 +1,5 @@
 import { Dialog, Transition } from "@headlessui/react";
-import { XIcon } from "@heroicons/react/outline";
+import XIcon from "@heroicons/react/outline/XIcon";
 import { Fragment } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
 import { noop } from "lodash";

--- a/packages/js/src/indexables-page/components/indexable-title-link.js
+++ b/packages/js/src/indexables-page/components/indexable-title-link.js
@@ -1,4 +1,4 @@
-import { ExternalLinkIcon } from "@heroicons/react/outline";
+import ExternalLinkIcon from "@heroicons/react/outline/ExternalLinkIcon";
 import PropTypes from "prop-types";
 
 import { makeOutboundLink } from "@yoast/helpers";

--- a/packages/js/src/indexables-page/components/indexables-card-options.js
+++ b/packages/js/src/indexables-page/components/indexables-card-options.js
@@ -2,7 +2,7 @@ import classNames from "classnames";
 import PropTypes from "prop-types";
 import { Fragment } from "@wordpress/element";
 import { Menu, Transition } from "@headlessui/react";
-import { DotsVerticalIcon } from "@heroicons/react/solid";
+import DotsVerticalIcon from "@heroicons/react/solid/DotsVerticalIcon";
 
 /**
  * A notification dots element with menu.

--- a/packages/js/src/indexables-page/components/indexables-table.js
+++ b/packages/js/src/indexables-page/components/indexables-table.js
@@ -3,7 +3,7 @@ import { union } from "lodash";
 import { __ } from "@wordpress/i18n";
 import PropTypes from "prop-types";
 import { useState, useCallback } from "@wordpress/element";
-import { EyeOffIcon } from "@heroicons/react/outline";
+import EyeOffIcon from "@heroicons/react/outline/EyeOffIcon";
 
 import { Button, Spinner } from "@yoast/ui-library";
 

--- a/packages/js/src/indexables-page/components/not-enough-content.js
+++ b/packages/js/src/indexables-page/components/not-enough-content.js
@@ -1,6 +1,7 @@
 /* global wpseoIndexablesPageData */
 import apiFetch from "@wordpress/api-fetch";
-import { ExternalLinkIcon, PlusIcon } from "@heroicons/react/outline";
+import ExternalLinkIcon from "@heroicons/react/outline/ExternalLinkIcon";
+import PlusIcon from "@heroicons/react/outline/PlusIcon";
 import { useEffect, useState, useCallback, Fragment } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
 import { makeOutboundLink } from "@yoast/helpers";

--- a/packages/js/src/indexables-page/components/refresh-button.js
+++ b/packages/js/src/indexables-page/components/refresh-button.js
@@ -1,5 +1,5 @@
 import PropTypes from "prop-types";
-import { RefreshIcon } from "@heroicons/react/outline";
+import RefreshIcon from "@heroicons/react/outline/RefreshIcon";
 import { __, _n, sprintf } from "@wordpress/i18n";
 
 /**

--- a/packages/js/src/indexables-page/components/suggested-links-modal.js
+++ b/packages/js/src/indexables-page/components/suggested-links-modal.js
@@ -5,7 +5,8 @@ import { IndexableTitleLink } from "./indexable-title-link";
 import SvgIcon from "../../../../components/src/SvgIcon";
 import { range } from "lodash";
 import { __, sprintf } from "@wordpress/i18n";
-import { ArrowNarrowRightIcon, ExternalLinkIcon } from "@heroicons/react/outline";
+import ArrowNarrowRightIcon from "@heroicons/react/outline/ArrowNarrowRightIcon";
+import ExternalLinkIcon from "@heroicons/react/outline/ExternalLinkIcon";
 import { Alert, Badge, Button } from "@yoast/ui-library";
 import { addLinkToString } from "../../helpers/stringHelpers";
 

--- a/packages/js/src/indexables-page/indexables-page.js
+++ b/packages/js/src/indexables-page/indexables-page.js
@@ -1,8 +1,8 @@
 /* global wpseoIndexablesPageData */
 import PropTypes from "prop-types";
 import apiFetch from "@wordpress/api-fetch";
-import { LinkIcon } from "@heroicons/react/outline";
-import { StarIcon } from "@heroicons/react/solid";
+import LinkIcon from "@heroicons/react/outline/LinkIcon";
+import StarIcon from "@heroicons/react/solid/StarIcon";
 import { __, sprintf } from "@wordpress/i18n";
 import { createInterpolateElement, useEffect, useState, useCallback, useMemo, Fragment } from "@wordpress/element";
 import { Button, Modal, useMediaQuery, Alert } from "@yoast/ui-library";

--- a/packages/js/src/integrations-page/acf-integration.js
+++ b/packages/js/src/integrations-page/acf-integration.js
@@ -1,7 +1,8 @@
 /* eslint-disable complexity */
 import { Button } from "@yoast/ui-library";
 import { __, sprintf } from "@wordpress/i18n";
-import { CheckIcon, XIcon } from "@heroicons/react/solid";
+import CheckIcon from "@heroicons/react/solid/CheckIcon";
+import XIcon from "@heroicons/react/solid/XIcon";
 import { PropTypes } from "prop-types";
 import { Fragment } from "@wordpress/element";
 import { SimpleIntegration } from "./simple-integration";

--- a/packages/js/src/integrations-page/algolia-integration.js
+++ b/packages/js/src/integrations-page/algolia-integration.js
@@ -3,8 +3,9 @@ import { Card } from "./tailwind-components/card";
 import { getIsCardActive, getIsFreeIntegrationOrPremiumAvailable, getIsMultisiteAvailable } from "./helper";
 import { Badge, Button, Link, ToggleField } from "@yoast/ui-library";
 import { __, sprintf } from "@wordpress/i18n";
-import { ArrowSmRightIcon, XIcon } from "@heroicons/react/solid";
-import { LockOpenIcon } from "@heroicons/react/outline";
+import ArrowSmRightIcon from "@heroicons/react/solid/ArrowSmRightIcon";
+import XIcon from "@heroicons/react/solid/XIcon";
+import LockOpenIcon from "@heroicons/react/outline/LockOpenIcon";
 import { PropTypes } from "prop-types";
 import { Slot } from "@wordpress/components";
 

--- a/packages/js/src/integrations-page/plugin-integration.js
+++ b/packages/js/src/integrations-page/plugin-integration.js
@@ -1,5 +1,6 @@
 import { __ } from "@wordpress/i18n";
-import { CheckIcon, XIcon } from "@heroicons/react/solid";
+import CheckIcon from "@heroicons/react/solid/CheckIcon";
+import XIcon from "@heroicons/react/solid/XIcon";
 import { PropTypes } from "prop-types";
 import { Fragment } from "@wordpress/element";
 import { SimpleIntegration } from "./simple-integration";

--- a/packages/js/src/integrations-page/simple-integration.js
+++ b/packages/js/src/integrations-page/simple-integration.js
@@ -1,7 +1,8 @@
 import { Card } from "./tailwind-components/card";
 import { Badge, Link } from "@yoast/ui-library";
 import { __ } from "@wordpress/i18n";
-import { ArrowSmRightIcon, CheckIcon } from "@heroicons/react/solid";
+import ArrowSmRightIcon from "@heroicons/react/solid/ArrowSmRightIcon";
+import CheckIcon from "@heroicons/react/solid/CheckIcon";
 import { PropTypes } from "prop-types";
 
 /* eslint-disable complexity */

--- a/packages/js/src/integrations-page/toggleable-integration.js
+++ b/packages/js/src/integrations-page/toggleable-integration.js
@@ -3,8 +3,9 @@ import { Card } from "./tailwind-components/card";
 import { getIsCardActive, getIsFreeIntegrationOrPremiumAvailable, getIsMultisiteAvailable } from "./helper";
 import { Badge, Button, Link, ToggleField } from "@yoast/ui-library";
 import { __, sprintf } from "@wordpress/i18n";
-import { ArrowSmRightIcon, XIcon } from "@heroicons/react/solid";
-import { LockOpenIcon } from "@heroicons/react/outline";
+import ArrowSmRightIcon from "@heroicons/react/solid/ArrowSmRightIcon";
+import XIcon from "@heroicons/react/solid/XIcon";
+import LockOpenIcon from "@heroicons/react/outline/LockOpenIcon";
 import { PropTypes } from "prop-types";
 import { Slot } from "@wordpress/components";
 

--- a/packages/js/src/integrations-page/woocommerce-integration.js
+++ b/packages/js/src/integrations-page/woocommerce-integration.js
@@ -1,9 +1,10 @@
 /* eslint-disable complexity */
 import { Button } from "@yoast/ui-library";
 import { __, sprintf } from "@wordpress/i18n";
-import { CheckIcon, XIcon } from "@heroicons/react/solid";
+import CheckIcon from "@heroicons/react/solid/CheckIcon";
+import XIcon from "@heroicons/react/solid/XIcon";
+import LockOpenIcon from "@heroicons/react/outline/LockOpenIcon";
 import { PropTypes } from "prop-types";
-import { LockOpenIcon } from "@heroicons/react/outline";
 import { Fragment } from "@wordpress/element";
 import { SimpleIntegration } from "./simple-integration";
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Forces tree-shaking for Heroicons in the Integrations page to shrink the zipsize.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* The integrations page (namely the icons) should be displayed as expected

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes #
