### PR TITLE
Do not complain about curl version

### DIFF
--- a/src/services/health-check/curl-runner.php
+++ b/src/services/health-check/curl-runner.php
@@ -158,7 +158,7 @@ class Curl_Runner implements Runner_Interface {
 	 * @return bool True if all the routines for this health check were successful.
 	 */
 	public function is_successful() {
-		return $this->has_installed_addons && $this->curl_is_recent && $this->got_my_yoast_api_response;
+		return $this->has_installed_addons && $this->got_my_yoast_api_response;
 	}
 
 	/**

--- a/tests/unit/services/health-check/curl-check-test.php
+++ b/tests/unit/services/health-check/curl-check-test.php
@@ -11,7 +11,7 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
 /**
  * Curl_Check
  *
- * @coversDefaultClass Yoast\WP\SEO\Services\Health_Check\Curl_Check
+ * @coversDefaultClass \Yoast\WP\SEO\Services\Health_Check\Curl_Check
  */
 class Curl_Check_Test extends TestCase {
 
@@ -97,6 +97,12 @@ class Curl_Check_Test extends TestCase {
 			->shouldReceive( 'get_success_result' )
 			->once()
 			->andReturn( $expected_result );
+		$this->runner_mock
+			->shouldReceive( 'has_recent_curl_version_installed' )
+			->never();
+		$this->reports_mock
+			->shouldReceive( 'get_no_recent_curl_version_installed_result' )
+			->never();
 
 		$actual_result = $this->instance->run_and_get_result();
 
@@ -130,7 +136,7 @@ class Curl_Check_Test extends TestCase {
 	}
 
 	/**
-	 * Checks if the health check returns the correct report when the health check's runner didn't find a recent cURL verison.
+	 * Checks if the health check returns the correct report when the health check's runner failed and didn't find a recent cURL version.
 	 *
 	 * @covers ::__construct
 	 * @covers ::run_and_get_result

--- a/tests/unit/services/health-check/curl-runner-test.php
+++ b/tests/unit/services/health-check/curl-runner-test.php
@@ -13,7 +13,7 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
 /**
  * Curl_Runner
  *
- * @coversDefaultClass Yoast\WP\SEO\Services\Health_Check\Curl_Runner
+ * @coversDefaultClass \Yoast\WP\SEO\Services\Health_Check\Curl_Runner
  */
 class Curl_Runner_Test extends TestCase {
 
@@ -141,7 +141,7 @@ class Curl_Runner_Test extends TestCase {
 	}
 
 	/**
-	 * Checks if the health check quits early when the installed cURL version is unknown.
+	 * Checks that the health check doesn't quit early when the installed cURL version is unknown but the API could be reached.
 	 *
 	 * @covers ::__construct
 	 * @covers ::run
@@ -177,7 +177,7 @@ class Curl_Runner_Test extends TestCase {
 
 		$this->assertFalse( $this->instance->has_recent_curl_version_installed() );
 		$this->assertTrue( $this->instance->can_reach_my_yoast_api() );
-		$this->assertFalse( $this->instance->is_successful() );
+		$this->assertTrue( $this->instance->is_successful() );
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We don't want to complain about a too old curl version in the health Check when the API call is succeeding. Enhances https://github.com/Yoast/wordpress-seo/pull/18824 to fix the unit tests.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Relaxes the requirement about cURL version if MyYoast API can be successfully reached. Props to @tomsommer.

## Relevant technical choices:

* 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

It's not so easy to test the actual condition with an outdated but patched cURL version, so most importanto of all is to make sure that successful API checks are still working:
* visit Tools > Site Health 
* expand the "Passed tests"
* look for this section:
![Screenshot 2022-09-29 at 13-09-02 Site Health - Status ‹ Basic — WordPress](https://user-images.githubusercontent.com/15989132/193016361-8698dd13-ccd1-467c-8113-409eb107636c.png)
* if you could see it without the patch, you should still be able to see it with this patch.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes #
