### PR TITLE
PC-705 add type label when registering an assessment

### DIFF
--- a/packages/yoastseo/spec/worker/AnalysisWebWorkerSpec.js
+++ b/packages/yoastseo/spec/worker/AnalysisWebWorkerSpec.js
@@ -1528,13 +1528,34 @@ describe( "AnalysisWebWorker", () => {
 			expect( actualAssessment ).toBe( assessment );
 		} );
 
-		test( "add the assessment to the registered assessments", () => {
+		test( "add the seo assessment to the registered assessments", () => {
 			scope.onmessage( createMessage( "initialize" ) );
 			expect( worker._seoAssessor ).not.toBeNull();
 
 			worker.registerAssessment( assessmentName, assessment, pluginName );
 			expect( worker._registeredAssessments.length ).toBe( 1 );
 			expect( worker._registeredAssessments[ 0 ].assessment ).toBe( assessment );
+			expect( worker._registeredAssessments[ 0 ].type ).toBe( "seo" );
+		} );
+
+		test( "add the readability assessment to the registered assessments", () => {
+			scope.onmessage( createMessage( "initialize" ) );
+			expect( worker._contentAssessor ).not.toBeNull();
+
+			worker.registerAssessment( assessmentName, assessment, pluginName, "readability" );
+			expect( worker._registeredAssessments.length ).toBe( 1 );
+			expect( worker._registeredAssessments[ 0 ].assessment ).toBe( assessment );
+			expect( worker._registeredAssessments[ 0 ].type ).toBe( "readability" );
+		} );
+
+		test( "add the related keyphrase assessment to the registered assessments", () => {
+			scope.onmessage( createMessage( "initialize" ) );
+			expect( worker._relatedKeywordAssessor ).not.toBeNull();
+
+			worker.registerAssessment( assessmentName, assessment, pluginName, "relatedKeyphrase" );
+			expect( worker._registeredAssessments.length ).toBe( 1 );
+			expect( worker._registeredAssessments[ 0 ].assessment ).toBe( assessment );
+			expect( worker._registeredAssessments[ 0 ].type ).toBe( "relatedKeyphrase" );
 		} );
 
 		test( "call refresh assessment", () => {

--- a/packages/yoastseo/src/worker/AnalysisWebWorker.js
+++ b/packages/yoastseo/src/worker/AnalysisWebWorker.js
@@ -445,8 +445,8 @@ export default class AnalysisWebWorker {
 			}
 		}
 
-		this._registeredAssessments.forEach( ( { name, assessment } ) => {
-			if ( isUndefined( assessor.getAssessment( name ) ) ) {
+		this._registeredAssessments.forEach( ( { name, assessment, type } ) => {
+			if ( isUndefined( assessor.getAssessment( name ) ) && type === "readability" ) {
 				assessor.addAssessment( name, assessment );
 			}
 		} );
@@ -503,8 +503,8 @@ export default class AnalysisWebWorker {
 			assessor.addAssessment( "keyphraseDistribution", keyphraseDistribution );
 		}
 
-		this._registeredAssessments.forEach( ( { name, assessment } ) => {
-			if ( isUndefined( assessor.getAssessment( name ) ) ) {
+		this._registeredAssessments.forEach( ( { name, assessment, type } ) => {
+			if ( isUndefined( assessor.getAssessment( name ) ) && type === "seo" ) {
 				assessor.addAssessment( name, assessment );
 			}
 		} );
@@ -555,8 +555,8 @@ export default class AnalysisWebWorker {
 			}
 		}
 
-		this._registeredAssessments.forEach( ( { name, assessment } ) => {
-			if ( isUndefined( assessor.getAssessment( name ) ) ) {
+		this._registeredAssessments.forEach( ( { name, assessment, type } ) => {
+			if ( isUndefined( assessor.getAssessment( name ) ) && type === "relatedKeyphrase" ) {
 				assessor.addAssessment( name, assessment );
 			}
 		} );
@@ -734,10 +734,11 @@ export default class AnalysisWebWorker {
 	 * @param {string}   name       The name of the assessment.
 	 * @param {function} assessment The function to run as an assessment.
 	 * @param {string}   pluginName The name of the plugin associated with the assessment.
+	 * @param {string}   type       The type of the assessment. The default type is seo.
 	 *
 	 * @returns {boolean} Whether registering the assessment was successful.
 	 */
-	registerAssessment( name, assessment, pluginName ) {
+	registerAssessment( name, assessment, pluginName, type = "seo" ) {
 		if ( ! isString( name ) ) {
 			throw new InvalidTypeError( "Failed to register assessment for plugin " + pluginName + ". Expected parameter `name` to be a string." );
 		}
@@ -755,10 +756,16 @@ export default class AnalysisWebWorker {
 		// Prefix the name with the pluginName so the test name is always unique.
 		const combinedName = pluginName + "-" + name;
 
-		if ( this._seoAssessor !== null ) {
+		if ( this._seoAssessor !== null && type === "seo" ) {
 			this._seoAssessor.addAssessment( combinedName, assessment );
 		}
-		this._registeredAssessments.push( { combinedName, assessment } );
+		if ( this._seoAssessor !== null && type === "readability" ) {
+			this._contentAssessor.addAssessment( combinedName, assessment );
+		}
+		if ( this._seoAssessor !== null && type === "relatedKeyphrase" ) {
+			this._relatedKeywordAssessor.addAssessment( combinedName, assessment );
+		}
+		this._registeredAssessments.push( { combinedName, assessment, type } );
 
 		this.refreshAssessment( name, pluginName );
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [yoastseo] Adds type label when registering a new assessment using `registerAssessment` function in `AnalysisWebWorker`.
* Fixes a bug where previously used keyphrase assessment also appeared under Readability analysis tab when the cornerstone content toggle is switched on.
* [wpseo-woocommerce] Fixes a bug where product description assessment also appeared under Readability analysis tab when the cornerstone content toggle is switched on.
* [wordpress-seo-local] Fixes a bug where location-specific assessments also appeared under Readability analysis tab when the cornerstone content toggle is switched on.
* [wpseo-video] Fixes a bug where `VideoTitleAssessment` and `VideoBodyAssessment` also appeared under Readability analysis tab when the cornerstone content toggle is switched on.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### With previous version of Free plugin and add-ons
* Install and activate previous version of Free plugin
* Create a post
* Add a keyphrase
* Confirm that the previously used keyphrase assessment is shown under SEO analysis
* Confirm that the previously used keyphrase assessment is not shown under Readability analysis
* Switch the cornerstone content toggle on
* Confirm that the previously used keyphrase assessment is shown both under SEO analysis and Readability analysis

##### in WooCommerce
* Install and activate WooCommerce plugin
* Install and activate previous version Yoast SEO for Woocommerce plugin
   * If building the plugin, run `composer require yoast/wordpress-seo:dev-PC-705-new-registered-assessments-are-also-added-in-the-wrong-assessor-when-cornerstone-content-toggle-is-switched-on-or-off@dev --dev` before running the build commands.
* Create a product
* Add a keyphrase
* Confirm that the previously used keyphrase assessment and Product description assessment are shown under SEO analysis
* Confirm that the previously used keyphrase assessment and Product description assessment are not shown under Readability analysis
* Switch the cornerstone content toggle on
* Confirm that the previously used keyphrase assessment  and Product description assessment are shown both under SEO analysis and Readability analysis

##### with Local SEO
* Install and activate previous version Yoast Local SEO
   * If building the plugin, run `composer require yoast/wordpress-seo:dev-PC-705-new-registered-assessments-are-also-added-in-the-wrong-assessor-when-cornerstone-content-toggle-is-switched-on-or-off@dev --dev` before running the build commands.
* Configure your local SEO and fill in the Google Map API (the API should be available in the shared-development folder in LastPass)
* Enable multiple locations
* Go to create Location
* Add content, fill in address in Local SEO metabox
* Confirm that the location-specific assessments are shown under SEO analysis
* Confirm that the location-specific assessments are not shown under Readability analysis
* Switch the cornerstone content toggle on
* Confirm that the location-specific assessments are shown both under SEO analysis and Readability analysis

##### with Video SEO
* Install and activate previous version Video SEO
   * If building the plugin, run `composer require yoast/wordpress-seo:dev-PC-705-new-registered-assessments-are-also-added-in-the-wrong-assessor-when-cornerstone-content-toggle-is-switched-on-or-off@dev --dev` before running the build commands.
* Create a post
* Add a video
* Confirm that the video title and video body assessments are shown under SEO analysis
* Confirm that the video title and video body assessments are not shown under Readability analysis
* Switch the cornerstone content toggle on
* Confirm that the video title and video body assessments are shown both under SEO analysis and Readability analysis

#### With the version of Free plugin and add-ons that has this bugfix
* Install and activate Free plugin
* Create a post
* Add a keyphrase
* Confirm that the previously used keyphrase assessment is shown under SEO analysis
* Confirm that the previously used keyphrase assessment is not shown under Readability analysis
* Switch the cornerstone content toggle on
* Confirm that the previously used keyphrase assessment is only shown under SEO analysis and NOT shown under Readability analysis
* Switch the cornerstone content toggle off
* Confirm that the previously used keyphrase assessment is still only shown under SEO analysis and NOT shown under Readability analysis

##### in WooCommerce
* Install and activate WooCommerce plugin
* Install and activate Yoast SEO for Woocommerce plugin
   * If building the plugin, run `composer require yoast/wordpress-seo:dev-PC-705-new-registered-assessments-are-also-added-in-the-wrong-assessor-when-cornerstone-content-toggle-is-switched-on-or-off@dev --dev` before running the build commands.
* Create a product
* Add a keyphrase
* Confirm that the previously used keyphrase assessment and Product description assessment are shown under SEO analysis
* Confirm that the previously used keyphrase assessment and Product description assessment are not shown under Readability analysis
* Switch the cornerstone content toggle on
* Confirm that the previously used keyphrase assessment  and Product description assessment are only shown under SEO analysis and NOT under Readability analysis
* Switch the cornerstone content toggle off
* Confirm that the previously used keyphrase assessment  and Product description assessment are still only shown under SEO analysis and NOT under Readability analysis

##### with Local SEO
* Install and activate Yoast Local SEO
   * If building the plugin, run `composer require yoast/wordpress-seo:dev-PC-705-new-registered-assessments-are-also-added-in-the-wrong-assessor-when-cornerstone-content-toggle-is-switched-on-or-off@dev --dev` before running the build commands.
* Configure your local SEO and fill in the Google Map API (the API should be available in the shared-development folder in LastPass)
* Enable multiple locations
* Go to create Location
* Add content, fill in address in Local SEO metabox
* Confirm that the location-specific assessments are shown under SEO analysis
* Confirm that the location-specific assessments are not shown under Readability analysis
* Switch the cornerstone content toggle on
* Confirm that the location-specific assessments are only shown under SEO analysis and NOT under Readability analysis
* Switch the cornerstone content toggle off
* Confirm that the location-specific assessments are still only shown under SEO analysis and NOT under Readability analysis

##### with Video SEO
* Install and activate Video SEO
   * If building the plugin, run `composer require yoast/wordpress-seo:dev-PC-705-new-registered-assessments-are-also-added-in-the-wrong-assessor-when-cornerstone-content-toggle-is-switched-on-or-off@dev --dev` before running the build commands.
* Create a post
* Add a video
* Confirm that the video title and video body assessments are shown under SEO analysis
* Confirm that the video title and video body assessments are not shown under Readability analysis
* Switch the cornerstone content toggle on
* Confirm that the video title and video body assessments are only shown both under SEO analysis and NOT under Readability analysis
* Switch the cornerstone content toggle off
* Confirm that the video title and video body assessments are still only shown both under SEO analysis and NOT under Readability analysis


#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [x] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes https://yoast.atlassian.net/browse/PC-705
