### PR TITLE
PC-715 Do not use select2 for the breadcrumbs select and remove the library from the bundle

### DIFF
--- a/admin/class-admin-asset-dev-server-location.php
+++ b/admin/class-admin-asset-dev-server-location.php
@@ -50,14 +50,6 @@ final class WPSEO_Admin_Asset_Dev_Server_Location implements WPSEO_Admin_Asset_L
 			return $this->get_default_url( $asset, $type );
 		}
 
-		$asset_manager       = new WPSEO_Admin_Asset_Manager();
-		$flat_version        = $asset_manager->flatten_version( WPSEO_VERSION );
-		$version_less_source = str_replace( '-' . $flat_version, '', $asset->get_src() );
-
-		if ( strpos( $version_less_source, 'select2' ) !== false ) {
-			return $this->get_default_url( $asset, $type );
-		}
-
 		$path = sprintf( 'js/dist/%s%s.js', $asset->get_src(), $asset->get_suffix() );
 
 		return trailingslashit( $this->url ) . $path;

--- a/admin/class-admin-asset-manager.php
+++ b/admin/class-admin-asset-manager.php
@@ -276,7 +276,6 @@ class WPSEO_Admin_Asset_Manager {
 				self::PREFIX . 'externals-components',
 				self::PREFIX . 'externals-contexts',
 				self::PREFIX . 'externals-redux',
-				self::PREFIX . 'select2',
 			],
 			'reindex-links'            => [
 				'jquery-ui-core',
@@ -289,7 +288,6 @@ class WPSEO_Admin_Asset_Manager {
 				self::PREFIX . 'externals-components',
 				self::PREFIX . 'externals-contexts',
 				self::PREFIX . 'externals-redux',
-				self::PREFIX . 'select2',
 			],
 			'term-edit'                => [
 				self::PREFIX . 'api-client',
@@ -297,7 +295,6 @@ class WPSEO_Admin_Asset_Manager {
 				self::PREFIX . 'externals-components',
 				self::PREFIX . 'externals-contexts',
 				self::PREFIX . 'externals-redux',
-				self::PREFIX . 'select2',
 			],
 		];
 
@@ -329,14 +326,12 @@ class WPSEO_Admin_Asset_Manager {
 				'header_scripts'  => $header_scripts,
 			]
 		);
-		$select2_scripts  = $this->load_select2_scripts();
 		$renamed_scripts  = $this->load_renamed_scripts();
 
 		$scripts = array_merge(
 			$plugin_scripts,
 			$external_scripts,
 			$language_scripts,
-			$select2_scripts,
 			$renamed_scripts
 		);
 
@@ -466,60 +461,6 @@ class WPSEO_Admin_Asset_Manager {
 	}
 
 	/**
-	 * Loads the select2 scripts.
-	 *
-	 * @return array {
-	 *     The scripts to be registered.
-	 *
-	 *     @type string   $name      The name of the asset.
-	 *     @type string   $src       The src of the asset.
-	 *     @type string[] $deps      The dependenies of the asset.
-	 *     @type bool     $in_footer Whether or not the asset should be in the footer.
-	 * }
-	 */
-	protected function load_select2_scripts() {
-		$scripts          = [];
-		$select2_language = 'en';
-		$user_locale      = \get_user_locale();
-		$language         = WPSEO_Language_Utils::get_language( $user_locale );
-
-		if ( file_exists( WPSEO_PATH . "js/dist/select2/i18n/{$user_locale}.js" ) ) {
-			$select2_language = $user_locale; // Chinese and some others use full locale.
-		}
-		elseif ( file_exists( WPSEO_PATH . "js/dist/select2/i18n/{$language}.js" ) ) {
-			$select2_language = $language;
-		}
-
-		$scripts['select2']              = [
-			'name'    => 'select2',
-			'src'     => false,
-			'deps'    => [
-				self::PREFIX . 'select2-translations',
-				self::PREFIX . 'select2-core',
-			],
-		];
-		$scripts['select2-core']         = [
-			'name'    => 'select2-core',
-			'src'     => 'select2/select2.full.min.js',
-			'deps'    => [
-				'jquery',
-			],
-			'version' => '4.0.13',
-		];
-		$scripts['select2-translations'] = [
-			'name'    => 'select2-translations',
-			'src'     => 'select2/i18n/' . $select2_language . '.js',
-			'deps'    => [
-				'jquery',
-				self::PREFIX . 'select2-core',
-			],
-			'version' => '4.0.13',
-		];
-
-		return $scripts;
-	}
-
-	/**
 	 * Loads the scripts that should be renamed for BC.
 	 *
 	 * @return array {
@@ -614,7 +555,6 @@ class WPSEO_Admin_Asset_Manager {
 				'name' => 'metabox-css',
 				'src'  => 'metabox-' . $flat_version,
 				'deps' => [
-					self::PREFIX . 'select2',
 					self::PREFIX . 'admin-css',
 					'wp-components',
 				],
@@ -637,13 +577,6 @@ class WPSEO_Admin_Asset_Manager {
 			[
 				'name' => 'primary-category',
 				'src'  => 'metabox-primary-category-' . $flat_version,
-			],
-			[
-				'name'    => 'select2',
-				'src'     => 'select2/select2',
-				'suffix'  => '.min',
-				'version' => '4.0.13',
-				'rtl'     => false,
 			],
 			[
 				'name' => 'admin-global',

--- a/admin/class-config.php
+++ b/admin/class-config.php
@@ -62,7 +62,6 @@ class WPSEO_Admin_Pages {
 		wp_enqueue_style( 'thickbox' );
 		wp_enqueue_style( 'global' );
 		wp_enqueue_style( 'wp-admin' );
-		$this->asset_manager->enqueue_style( 'select2' );
 		$this->asset_manager->enqueue_style( 'admin-css' );
 		$this->asset_manager->enqueue_style( 'monorepo' );
 

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -599,7 +599,6 @@ class WPSEO_Metabox extends WPSEO_Meta {
 
 					$options_count = count( $meta_field_def['options'] );
 
-					// This select now uses Select2.
 					$content .= '<select multiple="multiple" size="' . esc_attr( $options_count ) . '" name="' . $esc_form_key . '[]" id="' . $esc_form_key . '" class="yoast' . $class . '"' . $aria_describedby . '>';
 					foreach ( $meta_field_def['options'] as $val => $option ) {
 						$selected = '';
@@ -858,7 +857,6 @@ class WPSEO_Metabox extends WPSEO_Meta {
 
 		$asset_manager->enqueue_style( 'metabox-css' );
 		$asset_manager->enqueue_style( 'scoring' );
-		$asset_manager->enqueue_style( 'select2' );
 		$asset_manager->enqueue_style( 'monorepo' );
 
 		$is_block_editor  = WP_Screen::get()->is_block_editor();

--- a/config/grunt/task-config/aliases.yaml
+++ b/config/grunt/task-config/aliases.yaml
@@ -29,13 +29,11 @@
 # Build JavaScript from assets to development
 'build:js':
   - 'clean:build-assets-js'
-  - 'copy:js-dependencies'
   - 'shell:webpack'
 
 # Build CSS for development
 'build:css':
   - 'clean:build-assets-css'
-  - 'copy:css-dependencies'
   - 'copy:css-files'
   - 'shell:postcss-dev'
   - 'rtlcss:build'
@@ -116,13 +114,11 @@ release:
 'release:packages':
   - 'shell:build-ui-library'
 'release:js':
-  - 'copy:js-dependencies'
   - 'shell:webpack-prod'
 
 # Build CSS for production
 'release:css':
   - 'clean:build-assets-css'
-  - 'copy:css-dependencies'
   - 'copy:css-files'
   - 'shell:postcss-release'
   - 'rtlcss:build'

--- a/config/grunt/task-config/clean.js
+++ b/config/grunt/task-config/clean.js
@@ -8,7 +8,6 @@ module.exports = {
 		"css/dist/*.css",
 		"!<%= paths.css %>monorepo*.css",
 		"<%= files.cssMap %>",
-		"<%= paths.css %>/select2",
 	],
 	artifact: [
 		"<%= files.artifact %>",

--- a/config/grunt/task-config/copy.js
+++ b/config/grunt/task-config/copy.js
@@ -1,25 +1,5 @@
 // See https://github.com/gruntjs/grunt-contrib-copy
 module.exports = {
-	"js-dependencies": {
-		files: [
-			{
-				expand: true,
-				cwd: "node_modules/select2/dist/js/",
-				src: [ "select2.full.min.js", "i18n/*", "!i18n/build.txt" ],
-				dest: "<%= paths.jsDist %>select2/",
-			},
-		],
-	},
-	"css-dependencies": {
-		files: [
-			{
-				expand: true,
-				cwd: "node_modules/select2/dist/css/",
-				src: [ "select2.min.css" ],
-				dest: "css/dist/select2",
-			},
-		],
-	},
 	"css-files": {
 		files: [
 			{

--- a/config/webpack/paths.js
+++ b/config/webpack/paths.js
@@ -69,6 +69,5 @@ function flattenVersionForFile( version ) {
 module.exports = {
 	entry: getEntries(),
 	jsDist: jsDistPath,
-	select2: path.resolve( "node_modules", "select2", "dist" ),
 	flattenVersionForFile,
 };

--- a/css/src/admin-global.css
+++ b/css/src/admin-global.css
@@ -55,36 +55,6 @@
   height: auto;
 }
 
-/* Select2 specific fixes for WordPress: they generally need high specificity */
-.select2-container .select2-search--dropdown .select2-search__field {
-  margin: 0;
-  padding: 0 8px;
-  min-height: 30px;
-}
-
-.select2-results__option,
-.select2-selection__choice,
-.select2-search--inline {
-  margin-bottom: 0;
-}
-
-.select2-container .select2-search--inline .select2-search__field {
-  margin-top: 6px !important;
-  line-height: inherit;
-  min-height: 0;
-}
-
-/* Turn off select2 fixed height */
-.wpseo-metabox .select2-container .select2-selection--single,
-.wpseo-admin-page .select2-container .select2-selection--single {
-  height: auto;
-}
-
-.wpseo-metabox .select2-container .select2-selection--single .select2-selection__arrow,
-.wpseo-admin-page .select2-container .select2-selection--single .select2-selection__arrow {
-  height: 100%;
-}
-
 .yoast-label-strong {
   font-weight: 600;
 }

--- a/css/src/metabox.css
+++ b/css/src/metabox.css
@@ -324,7 +324,6 @@ ul.wpseo-metabox-tabs li .wpseo-keyword {
 .wpseo-form input,
 .wpseo-form label,
 .wpseo-form textarea,
-.wpseo-form .select2-container,
 .wpseo-form p.error-message {
   max-width: 600px;
 }

--- a/css/src/yst_plugin_tools.css
+++ b/css/src/yst_plugin_tools.css
@@ -97,8 +97,7 @@ tr.yst_row.even {
 
 .wpseo_content_wrapper input.textinput,
 .wpseo_content_wrapper textarea.textinput,
-.wpseo_content_wrapper select.select,
-.wpseo_content_wrapper .select2-container {
+.wpseo_content_wrapper select.select {
   margin: 0 0 15px 0;
 }
 
@@ -915,8 +914,7 @@ body.toplevel_page_wpseo_dashboard .wp-badge {
     width: 100%;
   }
   .wpseo_content_wrapper select,
-  .wpseo_content_wrapper select.select,
-  .wpseo_content_wrapper .select2-container {
+  .wpseo_content_wrapper select.select {
     display: block;
     max-width: 100%;
     margin: 0 0 5px 0;

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -45,7 +45,6 @@
     "react-select": "^3.1.0",
     "redux": "^3.7.2",
     "redux-thunk": "^2.2.0",
-    "select2": "4.0.13",
     "styled-components": "^5.2.1",
     "yoast-components": "^5.24.0",
     "yoastseo": "^1.91.0",

--- a/packages/js/src/initializers/admin.js
+++ b/packages/js/src/initializers/admin.js
@@ -1,4 +1,4 @@
-/* global wpseoAdminGlobalL10n, ajaxurl, wpseoScriptData, ClipboardJS */
+/* global wpseoAdminGlobalL10n, ajaxurl, ClipboardJS */
 
 import { __ } from "@wordpress/i18n";
 import a11ySpeak from "a11y-speak";

--- a/packages/js/src/initializers/admin.js
+++ b/packages/js/src/initializers/admin.js
@@ -178,21 +178,6 @@ export default function initAdmin( jQuery ) {
 	 } );
 
 	/**
-	 * Adds select2 for selected fields.
-	 *
-	 * @returns {void}
-	 */
-	function initSelect2() {
-		var select2Width = "400px";
-
-		// Select2 for taxonomy breadcrumbs in Advanced
-		jQuery( "#breadcrumbs select" ).select2( {
-			width: select2Width,
-			language: wpseoScriptData.userLanguageCode,
-		} );
-	}
-
-	/**
 	 * Hides or shows the Author without posts toggle.
 	 *
 	 * @param {bool} visible Whether or not the authors without posts toggle should be visible.
@@ -491,7 +476,6 @@ export default function initAdmin( jQuery ) {
 
 		wpseoCopyHomeMeta();
 		setInitialActiveTab();
-		initSelect2();
 		initXmlSitemapsWarning();
 		// Should be called after the initial active tab has been set.
 		setFixedSubmitButtonVisibility();

--- a/packages/js/tests/components/SEMrushCountrySelector.test.js
+++ b/packages/js/tests/components/SEMrushCountrySelector.test.js
@@ -6,7 +6,6 @@ import React from "react";
 import { noop } from "lodash";
 
 window.jQuery = () => ( {
-	select2: () => {},
 	on: () => {},
 } );
 

--- a/src/integrations/third-party/elementor.php
+++ b/src/integrations/third-party/elementor.php
@@ -381,7 +381,6 @@ class Elementor implements Integration_Interface {
 		$this->asset_manager->enqueue_style( 'admin-global' );
 		$this->asset_manager->enqueue_style( 'metabox-css' );
 		$this->asset_manager->enqueue_style( 'scoring' );
-		$this->asset_manager->enqueue_style( 'select2' );
 		$this->asset_manager->enqueue_style( 'monorepo' );
 		$this->asset_manager->enqueue_style( 'admin-css' );
 		$this->asset_manager->enqueue_style( 'elementor' );

--- a/tests/integration/admin/test-class-admin-asset-dev-server-location.php
+++ b/tests/integration/admin/test-class-admin-asset-dev-server-location.php
@@ -51,24 +51,4 @@ final class Admin_Asset_Dev_Server_Location_Test extends TestCase {
 
 		$this->assertEquals( 'https://localhost:8081/js/dist/commons.js', $actual );
 	}
-
-	/**
-	 * Tests that the dev server falls back to the default asset if it isn't on the dev server.
-	 *
-	 * @covers WPSEO_Admin_Asset_Dev_Server_Location::get_url
-	 * @covers WPSEO_Admin_Asset_SEO_Location::get_url
-	 */
-	public function test_get_url_default() {
-		$asset_args        = $this->asset_defaults;
-		$asset_args['src'] = 'select2';
-		$asset             = new WPSEO_Admin_Asset( $asset_args );
-
-		$dev_server_location = new WPSEO_Admin_Asset_Dev_Server_Location();
-		$default_location    = new WPSEO_Admin_Asset_SEO_Location( WPSEO_FILE );
-
-		$actual   = $dev_server_location->get_url( $asset, WPSEO_Admin_Asset::TYPE_CSS );
-		$expected = $default_location->get_url( $asset, WPSEO_Admin_Asset::TYPE_CSS );
-
-		$this->assertEquals( $expected, $actual );
-	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -26410,11 +26410,6 @@ select-hose@^2.0.0:
   resolved "https://registry.yarnpkg.com/select-hose/-/select-hose-2.0.0.tgz#625d8658f865af43ec962bfc376a37359a4994ca"
   integrity sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo=
 
-select2@4.0.13:
-  version "4.0.13"
-  resolved "https://registry.yarnpkg.com/select2/-/select2-4.0.13.tgz#0dbe377df3f96167c4c1626033e924372d8ef44d"
-  integrity sha512-1JeB87s6oN/TDxQQYCvS5EFoQyvV6eYMZZ0AeA4tdFDYWN3BAGZ8npr17UBFddU0lgAt3H0yjX3X6/ekOj1yjw==
-
 select@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/select/-/select-1.1.2.tgz#0e7350acdec80b1108528786ec1d4418d11b396d"


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*  We want to stop using select2, since it's bad for accessibility and maintenance of our code.


## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Stops using select2 to render the selects in Search Appearance > Breadcrumbs.
* Remove select2 from the dependencies.

## Relevant technical choices:

* **Important**: this can only be released after, or in connection with, https://github.com/Yoast/wordpress-seo-premium/pull/3700 and https://github.com/Yoast/wordpress-seo-local/pull/2361
* The breadcrumbs settings are slated to be included in the new settings UI so it might just happen that the Search Appearance page is completely removed before this is merged. This is an even stronger reason to remove a dependency that's going to be useless.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* visit Search Appearance > Breadcrumbs and see that the selects are not rendered as select2 anymore
* keep the console open to spot JS errors
* smoke test and check the appearance of the following parts of the plugin which used to use or have code related to select2 but actually stopped using it already:
  * metabox/sidebar selects
  * Semrush modal
  * Elementor sidebar
* create an artifact with `grunt artifact` if you're not using a RC and check the above on e.g. a Local By Flywheel instance, to make sure we are not bundling the files anymore and everything's working fine
  * the files were: `wordpress-seo/css/dist/select2/select2.min.css`, `wordpress-seo/css/dist/select2/select2-rtl.css`, `wordpress-seo/js/dist/select2/select2.full.min.js` and the folder `wordpress-seo/js/dist/select2/i18n`
* Test with Premium and Local, referring to the instructions of https://github.com/Yoast/wordpress-seo-premium/pull/3700 and https://github.com/Yoast/wordpress-seo-local/pull/2361
* test with an old version of Premium still requiring select2:
  * visit the Redirects page with the console open and see that you have `Uncaught TypeError: $(...).select2 is not a function`
  * try to add, edit and delete a redirect (of different types) and see that you can still do it

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes [PC-715]


[PC-715]: https://yoast.atlassian.net/browse/PC-715?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ