### PR TITLE
Adds immediate key phrase tracking after connecting to Wincher.

### DIFF
--- a/packages/js/src/containers/WincherSEOPerformance.js
+++ b/packages/js/src/containers/WincherSEOPerformance.js
@@ -39,6 +39,7 @@ export default compose( [
 			setWincherRequestSucceeded,
 			setWincherRequestFailed,
 			setWincherTrackingForKeyphrase,
+			setWincherSetKeyphraseLimitReached,
 			setWincherLoginStatus,
 		} = dispatch( "yoast-seo/editor" );
 
@@ -51,6 +52,9 @@ export default compose( [
 			},
 			addTrackedKeyphrase: ( keyphraseObject ) => {
 				setWincherTrackingForKeyphrase( keyphraseObject );
+			},
+			setKeyphraseLimitReached: ( limit ) => {
+				setWincherSetKeyphraseLimitReached( limit );
 			},
 			onAuthentication: ( status, newlyAuthenticated, websiteId ) => {
 				setWincherWebsiteId( websiteId );

--- a/packages/js/src/containers/WincherSEOPerformance.js
+++ b/packages/js/src/containers/WincherSEOPerformance.js
@@ -38,6 +38,7 @@ export default compose( [
 			setWincherWebsiteId,
 			setWincherRequestSucceeded,
 			setWincherRequestFailed,
+			setWincherTrackingForKeyphrase,
 			setWincherLoginStatus,
 		} = dispatch( "yoast-seo/editor" );
 
@@ -47,6 +48,9 @@ export default compose( [
 			},
 			setRequestFailed: ( response ) => {
 				setWincherRequestFailed( response );
+			},
+			addTrackedKeyphrase: ( keyphraseObject ) => {
+				setWincherTrackingForKeyphrase( keyphraseObject );
 			},
 			onAuthentication: ( status, newlyAuthenticated, websiteId ) => {
 				setWincherWebsiteId( websiteId );


### PR DESCRIPTION
## Context

* When someone connects to Wincher we wat to start tracking their keyphrases.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds immediate key phrase tracking after connecting to Wincher

## Relevant technical choices:

* None.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Make sure Wincher is enabled.
* Make sure you do not have Wincher connected. If this is the case toggle the integration in the integration page.
* Create a fresh post and add a keyword for example `wincher intregration example` Add a title and save the post.
* Hit connect with Wincher in the meta box in the track SEO performance tab and complete all the steps
* Make sure your keyphrase is present in the Wincher dashboard.
* Make sure your keyphrase is 'on' in the metabox.
---
* Slightly change your keyphrase and save. for example  `wincher intregration test` 
* Toggle the integration again to reset the connection.
* Hit connect with Wincher in the track SEO performance sidebar pop-up and complete all the steps.
* Make sure your keyphrase is present in the Wincher dashboard.
* Make sure your keyphrase is 'on' in the metabox.
---
* Open a post in elementor
* Slightly change your keyphrase and save. for example  `wincher intregration another test` 
* Toggle the integration again to reset the connection.
* Hit connect with Wincher in the track SEO performance sidebar pop-up and complete all the steps.
* Make sure your keyphrase is present in the Wincher dashboard.
* Make sure your keyphrase is 'on' in the metabox.
---
* Activate premium
* Open a post with a keyphrase
* Add one or more additional keyphrase(s)
* Toggle the integration again to reset the connection.
* Hit connect with Wincher in the track SEO performance sidebar pop-up and complete all the steps.
* Make sure your keyphrase and additional keyphrase(s) are present in the Wincher dashboard.
* Make sure your keyphrase  and additional keyphrase(s) is 'on' in the metabox.
---

* Make sure you have atleast 2-3 keyphrases in your Wincher dashboard (and no premium account)
* Open a post with a keyphrase
* Add 3 additional keyphrase(s)
* Toggle the integration again to reset the connection.
* Hit connect with Wincher in the track SEO performance sidebar pop-up and complete all the steps.
* Make sure the red error about to many keyphrases shows up.
---
* Downgrade to a previous RC of checkout trunk
* Create a new post and add a keyphrase
* Toggle the integration again to reset the connection.
* Hit connect with Wincher in the track SEO performance sidebar pop-up and complete all the steps.
* Your keyphrase should not be present in Wincher and the toggle should be off.
* Update to this PR and check the same post. Nothing should be changed. The toggle should still be off and the keyphrase should not be present in Wincher.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [X] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes #
