### PR TITLE
Remove all deprecated ryte code.

### DIFF
--- a/src/deprecated/admin/ryte/class-ryte-option.php
+++ b/src/deprecated/admin/ryte/class-ryte-option.php
@@ -16,20 +16,23 @@ class WPSEO_Ryte_Option {
 	/**
 	 * Indicates the data is not fetched.
 	 *
+	 * @deprecated 19.6
 	 * @var int
 	 */
-	const NOT_FETCHED = 99;
+	const NOT_FETCHED = 0;
 
 	/**
 	 * Indicates the option is indexable.
 	 *
+	 * @deprecated 19.6
 	 * @var int
 	 */
-	const IS_INDEXABLE = 1;
+	const IS_INDEXABLE = 0;
 
 	/**
 	 * Indicates the option is not indexable.
 	 *
+	 * @deprecated 19.6
 	 * @var int
 	 */
 	const IS_NOT_INDEXABLE = 0;
@@ -37,6 +40,7 @@ class WPSEO_Ryte_Option {
 	/**
 	 * Indicates the data could not be fetched.
 	 *
+	 * @deprecated 19.6
 	 * @var int
 	 */
 	const CANNOT_FETCH = -1;
@@ -44,37 +48,34 @@ class WPSEO_Ryte_Option {
 	/**
 	 * The name of the option where data will be stored.
 	 *
+	 * @deprecated 19.6
 	 * @var string
 	 */
-	const OPTION_NAME = 'wpseo_ryte';
+	const OPTION_NAME = '';
 
 	/**
 	 * The key of the status in the option.
 	 *
+	 * @deprecated 19.6
 	 * @var string
 	 */
-	const STATUS = 'status';
+	const STATUS = '';
 
 	/**
 	 * The key of the last fetch date in the option.
 	 *
+	 * @deprecated 19.6
 	 * @var string
 	 */
-	const LAST_FETCH = 'last_fetch';
+	const LAST_FETCH = '';
 
 	/**
 	 * The limit for fetching the status manually.
 	 *
+	 * @deprecated 19.6
 	 * @var int
 	 */
-	const FETCH_LIMIT = 15;
-
-	/**
-	 * The Ryte option stored in the database.
-	 *
-	 * @var array
-	 */
-	private $ryte_option;
+	const FETCH_LIMIT = 0;
 
 	/**
 	 * Setting the object by setting the properties.
@@ -83,7 +84,7 @@ class WPSEO_Ryte_Option {
 	 * @codeCoverageIgnore
 	 */
 	public function __construct() {
-		$this->ryte_option = $this->get_option();
+		\_deprecated_function( __METHOD__, 'Yoast SEO 19.6' );
 	}
 
 	/**
@@ -95,11 +96,9 @@ class WPSEO_Ryte_Option {
 	 * @return int|string
 	 */
 	public function get_status() {
-		if ( array_key_exists( self::STATUS, $this->ryte_option ) ) {
-			return $this->ryte_option[ self::STATUS ];
-		}
+		\_deprecated_function( __METHOD__, 'Yoast SEO 19.6' );
 
-		return self::CANNOT_FETCH;
+		return -1;
 	}
 
 	/**
@@ -111,7 +110,7 @@ class WPSEO_Ryte_Option {
 	 * @param string $status The status to save.
 	 */
 	public function set_status( $status ) {
-		$this->ryte_option[ self::STATUS ] = $status;
+		\_deprecated_function( __METHOD__, 'Yoast SEO 19.6' );
 	}
 
 	/**
@@ -123,7 +122,7 @@ class WPSEO_Ryte_Option {
 	 * @param int $timestamp Timestamp with the new value.
 	 */
 	public function set_last_fetch( $timestamp ) {
-		$this->ryte_option[ self::LAST_FETCH ] = $timestamp;
+		\_deprecated_function( __METHOD__, 'Yoast SEO 19.6' );
 	}
 
 	/**
@@ -139,11 +138,9 @@ class WPSEO_Ryte_Option {
 	 * @return bool Whether the indexability status should be fetched.
 	 */
 	public function should_be_fetched() {
-		if ( ! isset( $this->ryte_option[ self::LAST_FETCH ] ) ) {
-			return true;
-		}
+		\_deprecated_function( __METHOD__, 'Yoast SEO 19.6' );
 
-		return ( ( time() - $this->ryte_option[ self::LAST_FETCH ] ) > self::FETCH_LIMIT );
+		return false;
 	}
 
 	/**
@@ -153,7 +150,7 @@ class WPSEO_Ryte_Option {
 	 * @codeCoverageIgnore
 	 */
 	public function save_option() {
-		update_option( self::OPTION_NAME, $this->ryte_option );
+		\_deprecated_function( __METHOD__, 'Yoast SEO 19.6' );
 	}
 
 	/**
@@ -165,23 +162,8 @@ class WPSEO_Ryte_Option {
 	 * @return bool
 	 */
 	public function is_enabled() {
-		return WPSEO_Options::get( 'ryte_indexability' );
-	}
+		\_deprecated_function( __METHOD__, 'Yoast SEO 19.6' );
 
-	/**
-	 * Getting the option with the Ryte data.
-	 *
-	 * @deprecated 19.6
-	 * @codeCoverageIgnore
-	 *
-	 * @return array
-	 */
-	private function get_option() {
-		$default = [
-			self::STATUS     => self::NOT_FETCHED,
-			self::LAST_FETCH => 0,
-		];
-
-		return get_option( self::OPTION_NAME, $default );
+		return false;
 	}
 }

--- a/src/deprecated/admin/ryte/class-ryte-request.php
+++ b/src/deprecated/admin/ryte/class-ryte-request.php
@@ -16,41 +16,6 @@
 class WPSEO_Ryte_Request {
 
 	/**
-	 * The endpoint where the request will be send to.
-	 *
-	 * @var string
-	 */
-	private $ryte_endpoint = 'https://indexability.yoast.onpage.org/';
-
-	/**
-	 * Gets the response from the Ryte API and returns the body.
-	 *
-	 * @deprecated 19.6
-	 * @codeCoverageIgnore
-	 *
-	 * @param string $target_url The URL to check indexability for.
-	 * @param array  $parameters Array of extra parameters to send to the Ryte API.
-	 *
-	 * @return array The successful response or the error details.
-	 */
-	protected function get_remote( $target_url, $parameters = [] ) {
-		$defaults = [
-			'url'          => $target_url,
-			'wp_version'   => $GLOBALS['wp_version'],
-			'yseo_version' => WPSEO_VERSION,
-		];
-
-		$parameters = array_merge( $defaults, $parameters );
-		$url        = add_query_arg( $parameters, $this->ryte_endpoint );
-
-		// Decrease a chance of "cURL 28 (timeout)" errors by increasing the timeout to 10 seconds.
-		$args     = [ 'timeout' => 10 ];
-		$response = wp_remote_get( $url, $args );
-
-		return $this->process_response( $response );
-	}
-
-	/**
 	 * Sends a request to the Ryte API to check whether a URL is indexable.
 	 *
 	 * @deprecated 19.6
@@ -62,58 +27,8 @@ class WPSEO_Ryte_Request {
 	 * @return array
 	 */
 	public function do_request( $target_url, $parameters = [] ) {
-		$json_body = $this->get_remote( $target_url, $parameters );
+		\_deprecated_function( __METHOD__, 'Yoast SEO 19.6' );
 
-		// Ryte recognized a redirect, fetch the data of that URL by calling this method with the value from Ryte.
-		if ( ! empty( $json_body['passes_juice_to'] ) ) {
-			return $this->do_request( $json_body['passes_juice_to'], $parameters );
-		}
-
-		return $json_body;
-	}
-
-	/**
-	 * Processes the given Ryte response.
-	 *
-	 * @deprecated 19.6
-	 * @codeCoverageIgnore
-	 *
-	 * @param array|WP_Error $response The response or WP_Error to process.
-	 *
-	 * @return array The response body or the error detaiils on failure.
-	 */
-	protected function process_response( $response ) {
-		// Most of the potential errors are WP_Error(s).
-		if ( is_wp_error( $response ) ) {
-			return [
-				'is_error'       => true,
-				'raw_error_code' => '',
-				// WP_Error codes aren't that helpful for users, let's display them in a less prominent way.
-				'wp_error_code'  => '(' . $response->get_error_code() . ')',
-				'message'        => $response->get_error_message(),
-			];
-		}
-
-		/*
-		 * As of February 2020 the Ryte API returns an error 500 for non-reachable
-		 * sites. There's also the need to handle any potential raw HTTP error.
-		 */
-		if ( wp_remote_retrieve_response_code( $response ) !== 200 ) {
-			// Not all HTTP errors may have a response message. Let's provide a default one.
-			$response_message = wp_remote_retrieve_response_message( $response );
-			$message          = ( $response_message ) ? $response_message : __( 'The request to Ryte returned an error.', 'wordpress-seo' );
-
-			return [
-				'is_error'       => true,
-				'raw_error_code' => wp_remote_retrieve_response_code( $response ),
-				'wp_error_code'  => '',
-				'message'        => $message,
-			];
-		}
-
-		// When the request is successful, the response code will be 200.
-		$response_body = wp_remote_retrieve_body( $response );
-
-		return json_decode( $response_body, true );
+		return [];
 	}
 }

--- a/src/deprecated/src/integrations/admin/ryte-integration.php
+++ b/src/deprecated/src/integrations/admin/ryte-integration.php
@@ -5,7 +5,6 @@ namespace Yoast\WP\SEO\Integrations\Admin;
 use wfConfig;
 use WP_Error;
 use WPSEO_Ryte_Option;
-use WPSEO_Ryte_Request;
 use Yoast\WP\SEO\Conditionals\Admin_Conditional;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
@@ -19,20 +18,6 @@ use Yoast\WP\SEO\Integrations\Integration_Interface;
 class Ryte_Integration implements Integration_Interface {
 
 	/**
-	 * Holds the Ryte API response.
-	 *
-	 * @var array
-	 */
-	private $ryte_response = null;
-
-	/**
-	 * The options helper object used to determine if Ryte is active or not.
-	 *
-	 * @var Options_Helper
-	 */
-	private $options_helper;
-
-	/**
 	 * Constructor.
 	 *
 	 * @deprecated 19.6
@@ -40,11 +25,8 @@ class Ryte_Integration implements Integration_Interface {
 	 *
 	 * @param Options_Helper $options_helper The options helper object used to determine if Ryte is active or not.
 	 */
-	public function __construct(
-		Options_Helper $options_helper
-	) {
-		$this->options_helper = $options_helper;
-		$this->maybe_add_weekly_schedule();
+	public function __construct( Options_Helper $options_helper ) {
+		\_deprecated_function( __METHOD__, 'Yoast SEO 19.6' );
 	}
 
 	/**
@@ -56,12 +38,7 @@ class Ryte_Integration implements Integration_Interface {
 	 * @return void
 	 */
 	public function register_hooks() {
-		if ( ! $this->is_active() ) {
-			return;
-		}
-
-		// Sets the action for the Ryte fetch cron job.
-		\add_action( 'wpseo_ryte_fetch', [ $this, 'fetch_from_ryte' ] );
+		\_deprecated_function( __METHOD__, 'Yoast SEO 19.6' );
 	}
 
 	/**
@@ -87,15 +64,9 @@ class Ryte_Integration implements Integration_Interface {
 	 * @return bool True if this functionality can be used.
 	 */
 	public function is_active() {
-		if ( \wp_doing_ajax() ) {
-			return false;
-		}
+		\_deprecated_function( __METHOD__, 'Yoast SEO 19.6' );
 
-		if ( ! $this->options_helper->get( 'ryte_indexability' ) ) {
-			return false;
-		}
-
-		return true;
+		return false;
 	}
 
 	/**
@@ -105,13 +76,7 @@ class Ryte_Integration implements Integration_Interface {
 	 * @codeCoverageIgnore
 	 */
 	public function activate_hooks() {
-		if ( $this->get_option()->is_enabled() ) {
-			$this->schedule_cron();
-
-			return;
-		}
-
-		$this->unschedule_cron();
+		\_deprecated_function( __METHOD__, 'Yoast SEO 19.6' );
 	}
 
 	/**
@@ -123,8 +88,7 @@ class Ryte_Integration implements Integration_Interface {
 	 * @return void
 	 */
 	public function maybe_add_weekly_schedule() {
-		// If there's no default cron weekly schedule, add a custom one.
-		\add_filter( 'cron_schedules', [ $this, 'add_weekly_schedule' ] );
+		\_deprecated_function( __METHOD__, 'Yoast SEO 19.6' );
 	}
 
 	/**
@@ -138,25 +102,9 @@ class Ryte_Integration implements Integration_Interface {
 	 * @return array Enriched list of custom cron schedules.
 	 */
 	public function add_weekly_schedule( $schedules ) {
-		if ( ! \is_array( $schedules ) ) {
-			$schedules = [];
-		}
+		\_deprecated_function( __METHOD__, 'Yoast SEO 19.6' );
 
-		/*
-		 * Starting with version 5.4, WordPress does have a default weekly cron
-		 * schedule. See https://core.trac.wordpress.org/changeset/47062.
-		 * We need to add a custom one only if the default one doesn't exist.
-		 */
-		if ( isset( $schedules['weekly'] ) ) {
-			return $schedules;
-		}
-
-		$schedules['weekly'] = [
-			'interval' => WEEK_IN_SECONDS,
-			'display'  => \__( 'Once Weekly', 'wordpress-seo' ),
-		];
-
-		return $schedules;
+		return [];
 	}
 
 	/**
@@ -168,23 +116,7 @@ class Ryte_Integration implements Integration_Interface {
 	 * @return bool Whether the request ran.
 	 */
 	public function fetch_from_ryte() {
-		// Don't do anything when the WordPress environment type isn't "production".
-		if ( \wp_get_environment_type() !== 'production' ) {
-			return false;
-		}
-
-		$ryte_option = $this->get_option();
-		if ( ! $ryte_option->should_be_fetched() ) {
-			return false;
-		}
-
-		$new_status = $this->request_indexability();
-
-		// Updates the timestamp in the option.
-		$ryte_option->set_last_fetch( \time() );
-
-		$ryte_option->set_status( $new_status );
-		$ryte_option->save_option();
+		\_deprecated_function( __METHOD__, 'Yoast SEO 19.6' );
 
 		return true;
 	}
@@ -198,6 +130,8 @@ class Ryte_Integration implements Integration_Interface {
 	 * @return WPSEO_Ryte_Option The option.
 	 */
 	public function get_option() {
+		\_deprecated_function( __METHOD__, 'Yoast SEO 19.6' );
+
 		return new WPSEO_Ryte_Option();
 	}
 
@@ -210,83 +144,9 @@ class Ryte_Integration implements Integration_Interface {
 	 * @return int The indexability status value.
 	 */
 	protected function request_indexability() {
-		$parameters = [];
-		if ( $this->wordfence_protection_enabled() ) {
-			$parameters['wf_strict'] = 1;
-		}
+		\_deprecated_function( __METHOD__, 'Yoast SEO 19.6' );
 
-		$request = new WPSEO_Ryte_Request();
-
-		/**
-		 * Filter: 'wpseo_change_home_url' - Allow filtering the home URL that is used by our integrations, eg. the Ryte integration for indexability.
-		 *
-		 * @param string $site_url The home URL that is used by our integrations, eg. the Ryte integration for indexability.
-		 */
-		$site_url = \apply_filters( 'wpseo_change_home_url', \get_option( 'home' ) );
-		$response = $request->do_request( $site_url, $parameters );
-
-		// Populate the ryte_response property.
-		$this->ryte_response = $response;
-
-		// It's a valid Ryte response because the array contains an `is_indexable` element.
-		if ( isset( $response['is_indexable'] ) ) {
-			return (int) $response['is_indexable'];
-		}
-
-		// It's not a valid Ryte response.
-		return WPSEO_Ryte_Option::CANNOT_FETCH;
-	}
-
-	/**
-	 * Schedules the cronjob to get the new indexability status.
-	 *
-	 * @deprecated 19.6
-	 * @codeCoverageIgnore
-	 *
-	 * @return void
-	 */
-	private function schedule_cron() {
-		if ( \wp_next_scheduled( 'wpseo_ryte_fetch' ) ) {
-			return;
-		}
-
-		\wp_schedule_event( \time(), 'weekly', 'wpseo_ryte_fetch' );
-	}
-
-	/**
-	 * Unschedules the cronjob to get the new indexability status.
-	 *
-	 * @deprecated 19.6
-	 * @codeCoverageIgnore
-	 *
-	 * @return void
-	 */
-	private function unschedule_cron() {
-		if ( ! \wp_next_scheduled( 'wpseo_ryte_fetch' ) ) {
-			return;
-		}
-
-		\wp_clear_scheduled_hook( 'wpseo_ryte_fetch' );
-	}
-
-	/**
-	 * Checks if WordFence protects the site against 'fake' Google crawlers.
-	 *
-	 * @deprecated 19.6
-	 * @codeCoverageIgnore
-	 *
-	 * @return bool True if WordFence protects the site.
-	 */
-	private function wordfence_protection_enabled() {
-		if ( ! \class_exists( wfConfig::class ) ) {
-			return false;
-		}
-
-		if ( ! \method_exists( wfConfig::class, 'get' ) ) {
-			return false;
-		}
-
-		return (bool) wfConfig::get( 'blockFakeBots' );
+		return -1;
 	}
 
 	/**
@@ -298,6 +158,8 @@ class Ryte_Integration implements Integration_Interface {
 	 * @return array|WP_Error The response or WP_Error on failure.
 	 */
 	public function get_response() {
-		return $this->ryte_response;
+		\_deprecated_function( __METHOD__, 'Yoast SEO 19.6' );
+
+		return [];
 	}
 }

--- a/src/deprecated/src/services/health-check/ryte-check.php
+++ b/src/deprecated/src/services/health-check/ryte-check.php
@@ -11,20 +11,6 @@ namespace Yoast\WP\SEO\Services\Health_Check;
 class Ryte_Check extends Health_Check {
 
 	/**
-	 * Runs the health check.
-	 *
-	 * @var Ryte_Runner
-	 */
-	private $runner;
-
-	/**
-	 * Generates WordPress-friendly health check results.
-	 *
-	 * @var Ryte_Reports
-	 */
-	private $reports;
-
-	/**
 	 * Constructor.
 	 *
 	 * @deprecated 19.6
@@ -32,17 +18,14 @@ class Ryte_Check extends Health_Check {
 	 *
 	 * @param Ryte_Runner  $runner  The object that implements the actual health check.
 	 * @param Ryte_Reports $reports The object that generates WordPress-friendly results.
+	 *
 	 * @return void
 	 */
 	public function __construct(
 		Ryte_Runner $runner,
 		Ryte_Reports $reports
 	) {
-		$this->runner  = $runner;
-		$this->reports = $reports;
-		$this->reports->set_test_identifier( $this->get_test_identifier() );
-
-		$this->set_runner( $this->runner );
+		\_deprecated_function( __METHOD__, 'Yoast SEO 19.6' );
 	}
 
 	/**
@@ -54,7 +37,9 @@ class Ryte_Check extends Health_Check {
 	 * @return string The human-readable label.
 	 */
 	public function get_test_label() {
-		return \__( 'Ryte', 'wordpress-seo' );
+		\_deprecated_function( __METHOD__, 'Yoast SEO 19.6' );
+
+		return '';
 	}
 
 	/**
@@ -66,28 +51,8 @@ class Ryte_Check extends Health_Check {
 	 * @return string[] The WordPress-friendly health check result.
 	 */
 	protected function get_result() {
-		if ( ! $this->runner->should_run() ) {
-			return [];
-		}
+		\_deprecated_function( __METHOD__, 'Yoast SEO 19.6' );
 
-		if ( $this->runner->got_response_error() ) {
-			$error_response = $this->runner->get_error_response();
-
-			if ( $error_response === null ) {
-				return $this->reports->get_unknown_indexability_result();
-			}
-
-			return $this->reports->get_response_error_result( $error_response );
-		}
-
-		if ( $this->runner->has_unknown_indexability() ) {
-			return $this->reports->get_unknown_indexability_result();
-		}
-
-		if ( ! $this->runner->is_successful() ) {
-			return $this->reports->get_not_indexable_result();
-		}
-
-		return $this->reports->get_success_result();
+		return [];
 	}
 }

--- a/src/deprecated/src/services/health-check/ryte-reports.php
+++ b/src/deprecated/src/services/health-check/ryte-reports.php
@@ -2,9 +2,7 @@
 
 namespace Yoast\WP\SEO\Services\Health_Check;
 
-use WPSEO_Admin_Utils;
 use WPSEO_Shortlinker;
-use Yoast\WP\SEO\Presenters\Admin\Alert_Presenter;
 
 /**
  * Presents a set of different messages for the Ryte health check.
@@ -17,30 +15,24 @@ class Ryte_Reports {
 	use Reports_Trait;
 
 	/**
-	 * The WPSEO_Shortlinker object used to generate short links.
-	 *
-	 * @var WPSEO_Shortlinker
-	 */
-	private $shortlinker;
-
-	/**
 	 * Constructor
 	 *
 	 * @deprecated 19.6
 	 * @codeCoverageIgnore
 	 *
-	 * @param  Report_Builder_Factory $report_builder_factory The factory for result builder objects.
-	 *                                                        This class uses the report builder to generate WordPress-friendly
-	 *                                                        health check results.
-	 * @param  WPSEO_Shortlinker      $shortlinker            The WPSEO_Shortlinker object used to generate short links.
+	 * @param Report_Builder_Factory $report_builder_factory  The factory for result builder objects.
+	 *                                                        This class uses the report builder to generate
+	 *                                                        WordPress-friendly health check results.
+	 * @param WPSEO_Shortlinker      $shortlinker             The WPSEO_Shortlinker object used to generate short
+	 *                                                        links.
+	 *
 	 * @return void
 	 */
 	public function __construct(
 		Report_Builder_Factory $report_builder_factory,
 		WPSEO_Shortlinker $shortlinker
 	) {
-		$this->report_builder_factory = $report_builder_factory;
-		$this->shortlinker            = $shortlinker;
+		\_deprecated_function( __METHOD__, 'Yoast SEO 19.6' );
 	}
 
 	/**
@@ -52,13 +44,9 @@ class Ryte_Reports {
 	 * @return string[] The message as a WordPress site status report.
 	 */
 	public function get_success_result() {
-		return $this->get_report_builder()
-			/* translators: %1$s expands to 'Yoast'. */
-			->set_label( \__( 'Your site can be found by search engines', 'wordpress-seo' ) )
-			->set_status_good()
-			->set_description( $this->get_success_result_description() )
-			->set_actions( $this->get_ryte_actions() )
-			->build();
+		\_deprecated_function( __METHOD__, 'Yoast SEO 19.6' );
+
+		return [];
 	}
 
 	/**
@@ -70,12 +58,9 @@ class Ryte_Reports {
 	 * @return string[] The message as a WordPress site status report.
 	 */
 	public function get_not_indexable_result() {
-		return $this->get_report_builder()
-			->set_label( \__( 'Your site cannot be found by search engines', 'wordpress-seo' ) )
-			->set_status_critical()
-			->set_description( $this->get_not_indexable_result_description() )
-			->set_actions( $this->get_not_indexable_result_actions() . $this->get_ryte_actions() )
-			->build();
+		\_deprecated_function( __METHOD__, 'Yoast SEO 19.6' );
+
+		return [];
 	}
 
 	/**
@@ -87,13 +72,9 @@ class Ryte_Reports {
 	 * @return string[] The message as a WordPress site status report.
 	 */
 	public function get_unknown_indexability_result() {
-		return $this->get_report_builder()
-			/* translators: %1$s: Expands to 'Ryte'. */
-			->set_label( \sprintf( \__( '%1$s cannot determine whether your site can be found by search engines', 'wordpress-seo' ), 'Ryte' ) )
-			->set_status_recommended()
-			->set_description( $this->get_unknown_indexability_result_description() )
-			->set_actions( $this->get_ryte_actions() )
-			->build();
+		\_deprecated_function( __METHOD__, 'Yoast SEO 19.6' );
+
+		return [];
 	}
 
 	/**
@@ -103,175 +84,12 @@ class Ryte_Reports {
 	 * @codeCoverageIgnore
 	 *
 	 * @param array $response_error The error response from Ryte.
+	 *
 	 * @return string[] The message as a WordPress site status report.
 	 */
 	public function get_response_error_result( $response_error ) {
-		return $this->get_report_builder()
-			->set_label( \__( 'An error occurred while checking whether your site can be found by search engines', 'wordpress-seo' ) )
-			->set_status_recommended()
-			->set_description( $this->get_response_error_result_description( $response_error ) )
-			->set_actions( $this->get_response_error_result_actions() . $this->get_ryte_actions() )
-			->build();
-	}
+		\_deprecated_function( __METHOD__, 'Yoast SEO 19.6' );
 
-	/**
-	 * Returns the description for a successful result.
-	 *
-	 * @deprecated 19.6
-	 * @codeCoverageIgnore
-	 *
-	 * @return string The description for a successful result.
-	 */
-	private function get_success_result_description() {
-		return \sprintf(
-			/* translators: %1$s: Expands to 'Ryte', %2$s: Expands to 'Yoast SEO'. */
-			\__( '%1$s offers a free indexability check for %2$s users, and it shows that your site can be found by search engines.', 'wordpress-seo' ),
-			'Ryte',
-			'Yoast SEO'
-		);
-	}
-
-	/**
-	 * Returns the description for when the site is not indexable.
-	 *
-	 * @deprecated 19.6
-	 * @codeCoverageIgnore
-	 *
-	 * @return string The description for when the site is not indexable.
-	 */
-	private function get_not_indexable_result_description() {
-		return \sprintf(
-			/* translators: %1$s: Expands to 'Ryte', %2$s: Expands to 'Yoast SEO'. */
-			\__( '%1$s offers a free indexability check for %2$s users and it has determined that your site cannot be found by search engines. If this site is live or about to become live, this should be fixed.', 'wordpress-seo' ),
-			'Ryte',
-			'Yoast SEO'
-		);
-	}
-
-	/**
-	 * Returns the actions for when the site is not indexable.
-	 *
-	 * @deprecated 19.6
-	 * @codeCoverageIgnore
-	 *
-	 * @return string The actions for when the site is not indexable.
-	 */
-	private function get_not_indexable_result_actions() {
-		return \sprintf(
-			/* translators: %1$s: Opening tag of the link to the Yoast help center, %2$s: Link closing tag. */
-			\esc_html__( '%1$sRead more about troubleshooting search engine visibility.%2$s', 'wordpress-seo' ),
-			'<a href="' . \esc_url( $this->shortlinker->get( 'https://yoa.st/onpageindexerror' ) ) . '" target="_blank">',
-			WPSEO_Admin_Utils::get_new_tab_message() . '</a>'
-		) . '<br /><br />';
-	}
-
-	/**
-	 * Returns the description for when the site's indexability couldn't be determined.
-	 *
-	 * @deprecated 19.6
-	 * @codeCoverageIgnore
-	 *
-	 * @return string The description for when the site's indexability couldn't be determined.
-	 */
-	private function get_unknown_indexability_result_description() {
-		return \sprintf(
-			/* translators: %1$s: Expands to 'Ryte', %2$s: Expands to 'Yoast SEO'. */
-			\__(
-				'%1$s offers a free indexability check for %2$s users and right now it has trouble determining whether search engines can find your site. This could have several (legitimate) reasons and is not a problem in itself. If this is a live site, it is recommended that you figure out why the %1$s check failed.',
-				'wordpress-seo'
-			),
-			'Ryte',
-			'Yoast SEO'
-		) . '<br />' . $this->get_unknown_indexability_description_alert();
-	}
-
-	/**
-	 * Returns an alert for when the health check was unable to determine indexability.
-	 *
-	 * @deprecated 19.6
-	 * @codeCoverageIgnore
-	 *
-	 * @return string An alert for when the health check was unable to determine indexability.
-	 */
-	private function get_unknown_indexability_description_alert() {
-		/* translators: %1$s: Expands to 'Ryte', %2$s: Link start tag to the Yoast help center, %3$s: Link closing tag. */
-		$alert_text    = \esc_html__(
-			'As the indexability status of your website can only be fetched from %1$s every 15 seconds,
-			a first step could be to wait at least 15 seconds and refresh the Site Health page. If that did not help,
-			%2$sread more about troubleshooting search engine visibility%3$s.',
-			'wordpress-seo'
-		);
-		$alert_content = \sprintf(
-			$alert_text,
-			'Ryte',
-			'<a href="' . \esc_url( $this->shortlinker->get( 'https://yoa.st/onpagerequestfailed' ) ) . '" target="_blank">',
-			WPSEO_Admin_Utils::get_new_tab_message() . '</a>'
-		);
-
-		$alert = new Alert_Presenter( $alert_content, 'info' );
-		return $alert->present();
-	}
-
-	/**
-	 * Returns the description for when the health check got an error response from Ryte.
-	 *
-	 * @deprecated 19.6
-	 * @codeCoverageIgnore
-	 *
-	 * @param array $error_response The error response from Ryte.
-	 * @return string The description.
-	 */
-	private function get_response_error_result_description( $error_response ) {
-		return \sprintf(
-			'%s<br><br>%s',
-			\sprintf(
-			/* translators: %1$s: Expands to 'Ryte', %2$s: Expands to 'Yoast SEO'. */
-				\esc_html__( '%1$s offers a free indexability check for %2$s users. The request to %1$s to check whether your site can be found by search engines failed due to an error.', 'wordpress-seo' ),
-				'Ryte',
-				'Yoast SEO'
-			),
-			\sprintf(
-			/* translators: 1: The Ryte response raw error code, if any. 2: The error message. 3: The WordPress error code, if any. */
-				\__( 'Error details: %1$s %2$s %3$s', 'wordpress-seo' ),
-				$error_response['raw_error_code'],
-				$error_response['message'],
-				$error_response['wp_error_code']
-			)
-		);
-	}
-
-	/**
-	 * Returns the actions for when the health check got an error response from Ryte.
-	 *
-	 * @deprecated 19.6
-	 * @codeCoverageIgnore
-	 *
-	 * @return string The actions for when the health check got an error response from Ryte.
-	 */
-	private function get_response_error_result_actions() {
-		return \sprintf(
-		/* translators: %1$s: Opening tag of the link to the Yoast help center, %2$s: Link closing tag. */
-			\esc_html__( 'If this is a live site, %1$sit is recommended that you figure out why the check failed.%2$s', 'wordpress-seo' ),
-			'<a href="' . \esc_url( $this->shortlinker->get( 'https://yoa.st/onpagerequestfailed' ) ) . '" target="_blank">',
-			WPSEO_Admin_Utils::get_new_tab_message() . '</a>'
-		) . '<br /><br />';
-	}
-
-	/**
-	 * Returns the link to Ryte that's appended to every report.
-	 *
-	 * @deprecated 19.6
-	 * @codeCoverageIgnore
-	 *
-	 * @return string The link to Ryte as an action.
-	 */
-	private function get_ryte_actions() {
-		return \sprintf(
-		/* translators: %1$s: Opening tag of the link to the Yoast Ryte website, %2$s: Expands to 'Ryte', %3$s: Link closing tag. */
-			\esc_html__( '%1$sGo to %2$s to analyze your entire site%3$s', 'wordpress-seo' ),
-			'<a href="' . \esc_url( $this->shortlinker->get( 'https://yoa.st/rytelp' ) ) . '" target="_blank">',
-			'Ryte',
-			WPSEO_Admin_Utils::get_new_tab_message() . '</a>'
-		);
+		return [];
 	}
 }

--- a/src/deprecated/src/services/health-check/ryte-runner.php
+++ b/src/deprecated/src/services/health-check/ryte-runner.php
@@ -2,7 +2,6 @@
 
 namespace Yoast\WP\SEO\Services\Health_Check;
 
-use WPSEO_Ryte_Option;
 use WPSEO_Utils;
 use Yoast\WP\SEO\Integrations\Admin\Ryte_Integration;
 
@@ -13,41 +12,6 @@ use Yoast\WP\SEO\Integrations\Admin\Ryte_Integration;
  * @codeCoverageIgnore
  */
 class Ryte_Runner implements Runner_Interface {
-
-	/**
-	 * The Ryte_Integration object that the health check uses to check the site's indexability.
-	 *
-	 * @var Ryte_Integration
-	 */
-	private $ryte;
-
-	/**
-	 * Set to true when the health check gets a valid response from Ryte.
-	 *
-	 * @var bool
-	 */
-	private $got_valid_response;
-
-	/**
-	 * The error that is set when the health check gets a response error from Ryte.
-	 *
-	 * @var array|null
-	 */
-	private $response_error;
-
-	/**
-	 * The Ryte option that represents the site's indexability.
-	 *
-	 * @var WPSEO_Ryte_Option
-	 */
-	private $ryte_option;
-
-	/**
-	 * The WPSEO_Utils class used to determine whether the site is in development mode.
-	 *
-	 * @var WPSEO_Utils
-	 */
-	private $utils;
 
 	/**
 	 * Constructor.
@@ -62,10 +26,7 @@ class Ryte_Runner implements Runner_Interface {
 		Ryte_Integration $ryte,
 		WPSEO_Utils $utils
 	) {
-		$this->ryte               = $ryte;
-		$this->utils              = $utils;
-		$this->got_valid_response = false;
-		$this->ryte_option        = $ryte->get_option();
+		\_deprecated_function( __METHOD__, 'Yoast SEO 19.6' );
 	}
 
 	/**
@@ -77,50 +38,7 @@ class Ryte_Runner implements Runner_Interface {
 	 * @return void
 	 */
 	public function run() {
-		if ( ! $this->should_run() ) {
-			return;
-		}
-
-		$this->fetch_from_ryte();
-
-		if ( ! $this->got_valid_response ) {
-			return;
-		}
-
-		$this->set_ryte_option();
-	}
-
-	/**
-	 * Attempts to get a new indexability status from Ryte.
-	 *
-	 * @deprecated 19.6
-	 * @codeCoverageIgnore
-	 *
-	 * @return void
-	 */
-	private function fetch_from_ryte() {
-		$this->ryte->fetch_from_ryte();
-		$response = $this->ryte->get_response();
-
-		if ( \is_array( $response ) && isset( $response['is_error'] ) ) {
-			$this->got_valid_response = false;
-			$this->response_error     = $response;
-			return;
-		}
-
-		$this->got_valid_response = true;
-	}
-
-	/**
-	 * Sets the Ryte option based on the response from Ryte.
-	 *
-	 * @deprecated 19.6
-	 * @codeCoverageIgnore
-	 *
-	 * @return void
-	 */
-	private function set_ryte_option() {
-		$this->ryte_option = $this->ryte->get_option();
+		\_deprecated_function( __METHOD__, 'Yoast SEO 19.6' );
 	}
 
 	/**
@@ -132,24 +50,9 @@ class Ryte_Runner implements Runner_Interface {
 	 * @return bool
 	 */
 	public function should_run() {
-		if ( \wp_get_environment_type() !== 'production' ) {
-			return false;
-		}
+		\_deprecated_function( __METHOD__, 'Yoast SEO 19.6' );
 
-		if ( \wp_debug_mode() || $this->utils->is_development_mode() ) {
-			return false;
-		}
-
-		if ( \get_option( 'blog_public' ) === '0' ) {
-			return false;
-		}
-
-		$ryte_option = $this->ryte->get_option();
-		if ( ! $ryte_option->is_enabled() ) {
-			return false;
-		}
-
-		return true;
+		return false;
 	}
 
 	/**
@@ -161,17 +64,9 @@ class Ryte_Runner implements Runner_Interface {
 	 * @return bool
 	 */
 	public function is_successful() {
-		if ( ! $this->could_fetch() ) {
-			return false;
-		}
+		\_deprecated_function( __METHOD__, 'Yoast SEO 19.6' );
 
-		$ryte_status = $this->ryte_option->get_status();
-
-		if ( $ryte_status === WPSEO_Ryte_Option::IS_INDEXABLE ) {
-			return true;
-		}
-
-		return false;
+		return true;
 	}
 
 	/**
@@ -180,47 +75,13 @@ class Ryte_Runner implements Runner_Interface {
 	 * @deprecated 19.6
 	 * @codeCoverageIgnore
 	 *
-	 * @return bool Returns true if the site indexability is unknown even though getting a response from Ryte was successful.
+	 * @return bool Returns true if the site indexability is unknown even though getting a response from Ryte was
+	 *              successful.
 	 */
 	public function has_unknown_indexability() {
-		if ( ! $this->could_fetch() ) {
-			return true;
-		}
+		\_deprecated_function( __METHOD__, 'Yoast SEO 19.6' );
 
-		$ryte_status = $this->ryte_option->get_status();
-
-		if ( $ryte_status === WPSEO_Ryte_Option::IS_INDEXABLE ) {
-			return false;
-		}
-
-		if ( $ryte_status === WPSEO_Ryte_Option::IS_NOT_INDEXABLE ) {
-			return false;
-		}
-
-		// This return statement should never be reached.
-		return true;
-	}
-
-	/**
-	 * Checks if the health check was able to get a valid response from Ryte.
-	 *
-	 * @deprecated 19.6
-	 * @codeCoverageIgnore
-	 *
-	 * @return bool
-	 */
-	private function could_fetch() {
-		if ( ! $this->got_valid_response ) {
-			return false;
-		}
-
-		$ryte_status = $this->ryte_option->get_status();
-
-		if ( $ryte_status === WPSEO_Ryte_Option::CANNOT_FETCH ) {
-			return false;
-		}
-
-		return true;
+		return false;
 	}
 
 	/**
@@ -232,7 +93,9 @@ class Ryte_Runner implements Runner_Interface {
 	 * @return bool True if the health check got a valid error response.
 	 */
 	public function got_response_error() {
-		return isset( $this->response_error );
+		\_deprecated_function( __METHOD__, 'Yoast SEO 19.6' );
+
+		return true;
 	}
 
 	/**
@@ -244,10 +107,8 @@ class Ryte_Runner implements Runner_Interface {
 	 * @return array|null
 	 */
 	public function get_error_response() {
-		if ( ! $this->got_response_error() ) {
-			return null;
-		}
+		\_deprecated_function( __METHOD__, 'Yoast SEO 19.6' );
 
-		return $this->response_error;
+		return [];
 	}
 }


### PR DESCRIPTION
## Context

* To make extra sure that there is no chance of the integration still being used, we want to also remove the code

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Emptys deprecated Ryte classes

## Relevant technical choices:

* None.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* NA we're removing code that has not purpose currently.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes [PC-747]


[PC-747]: https://yoast.atlassian.net/browse/PC-747?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ