### PR TITLE
PC-6-add-internal-linking-suggestions-in-post-editor-in-free

### DIFF
--- a/packages/js/src/components/fills/MetaboxFill.js
+++ b/packages/js/src/components/fills/MetaboxFill.js
@@ -23,6 +23,8 @@ import { isWordProofIntegrationActive } from "../../helpers/wordproof";
 import WordProofAuthenticationModals from "../../components/modals/WordProofAuthenticationModals";
 import PremiumSEOAnalysisModal from "../modals/PremiumSEOAnalysisModal";
 import KeywordUpsell from "../KeywordUpsell";
+import LinkSuggestions from "../link-suggestions";
+import getL10nObject from "../../analysis/getL10nObject";
 
 /* eslint-disable complexity */
 /**
@@ -45,6 +47,8 @@ export default function MetaboxFill( { settings, wincherKeyphrases, setWincherNo
 			return false;
 		}
 	}, [ wincherKeyphrases, setWincherNoKeyphrase ] );
+
+	const isPremium = getL10nObject().isPremium;
 
 	return (
 		<>
@@ -102,6 +106,11 @@ export default function MetaboxFill( { settings, wincherKeyphrases, setWincherNo
 						onToggle={ onToggleWincher }
 					>
 						<WincherSEOPerformance />
+					</MetaboxCollapsible>
+				</SidebarItem> }
+				{ ! isPremium && <SidebarItem key="internal-linking-suggestions-upsell" renderPriority={ 27 }>
+					<MetaboxCollapsible id={ "internal-linking-suggestions-upsell" } title={ __( "Internal linking suggestions", "wordpress-seo" ) }>
+						<LinkSuggestions />
 					</MetaboxCollapsible>
 				</SidebarItem> }
 				{ settings.isCornerstoneActive && <SidebarItem key="cornerstone" renderPriority={ 30 }>

--- a/packages/js/src/components/fills/MetaboxFill.js
+++ b/packages/js/src/components/fills/MetaboxFill.js
@@ -23,6 +23,7 @@ import { isWordProofIntegrationActive } from "../../helpers/wordproof";
 import WordProofAuthenticationModals from "../../components/modals/WordProofAuthenticationModals";
 import PremiumSEOAnalysisModal from "../modals/PremiumSEOAnalysisModal";
 import KeywordUpsell from "../KeywordUpsell";
+import LinkSuggestions from "../link-suggestions";
 
 /* eslint-disable complexity */
 /**
@@ -56,7 +57,7 @@ export default function MetaboxFill( { settings, wincherKeyphrases, setWincherNo
 				>
 					<Warning />
 				</SidebarItem>
-				{ settings.isKeywordAnalysisActive && <SidebarItem key="keyword-input" renderPriority={ 8 }>
+				{ settings.isKeywordAnalysisActive && <SidebarItem key="keyword-input" renderPriority={ 7 }>
 					<KeywordInput
 						isSEMrushIntegrationActive={ settings.isSEMrushIntegrationActive }
 					/>
@@ -104,6 +105,15 @@ export default function MetaboxFill( { settings, wincherKeyphrases, setWincherNo
 						<WincherSEOPerformance />
 					</MetaboxCollapsible>
 				</SidebarItem> }
+				{ ! window.wpseoScriptData.metabox.isPremium &&
+					<SidebarItem key="internal-linking-suggestions-upsell-metabox" renderPriority={ 26 }>
+						<MetaboxCollapsible
+							title={ __( "Internal linking suggestions", "wordpress-seo" ) }
+						>
+							<LinkSuggestions />
+						</MetaboxCollapsible>
+					</SidebarItem>
+				}
 				{ settings.isCornerstoneActive && <SidebarItem key="cornerstone" renderPriority={ 30 }>
 					<CollapsibleCornerstone />
 				</SidebarItem> }

--- a/packages/js/src/components/fills/MetaboxFill.js
+++ b/packages/js/src/components/fills/MetaboxFill.js
@@ -110,7 +110,7 @@ export default function MetaboxFill( { settings, wincherKeyphrases, setWincherNo
 						<MetaboxCollapsible
 							title={ __( "Internal linking suggestions", "wordpress-seo" ) }
 						>
-							<LinkSuggestions />
+							<LinkSuggestions  location="metabox" />
 						</MetaboxCollapsible>
 					</SidebarItem>
 				}

--- a/packages/js/src/components/fills/MetaboxFill.js
+++ b/packages/js/src/components/fills/MetaboxFill.js
@@ -23,8 +23,6 @@ import { isWordProofIntegrationActive } from "../../helpers/wordproof";
 import WordProofAuthenticationModals from "../../components/modals/WordProofAuthenticationModals";
 import PremiumSEOAnalysisModal from "../modals/PremiumSEOAnalysisModal";
 import KeywordUpsell from "../KeywordUpsell";
-import LinkSuggestions from "../link-suggestions";
-import getL10nObject from "../../analysis/getL10nObject";
 
 /* eslint-disable complexity */
 /**
@@ -47,8 +45,6 @@ export default function MetaboxFill( { settings, wincherKeyphrases, setWincherNo
 			return false;
 		}
 	}, [ wincherKeyphrases, setWincherNoKeyphrase ] );
-
-	const isPremium = getL10nObject().isPremium;
 
 	return (
 		<>
@@ -106,11 +102,6 @@ export default function MetaboxFill( { settings, wincherKeyphrases, setWincherNo
 						onToggle={ onToggleWincher }
 					>
 						<WincherSEOPerformance />
-					</MetaboxCollapsible>
-				</SidebarItem> }
-				{ ! isPremium && <SidebarItem key="internal-linking-suggestions-upsell" renderPriority={ 27 }>
-					<MetaboxCollapsible id={ "internal-linking-suggestions-upsell" } title={ __( "Internal linking suggestions", "wordpress-seo" ) }>
-						<LinkSuggestions />
 					</MetaboxCollapsible>
 				</SidebarItem> }
 				{ settings.isCornerstoneActive && <SidebarItem key="cornerstone" renderPriority={ 30 }>

--- a/packages/js/src/components/fills/SidebarFill.js
+++ b/packages/js/src/components/fills/SidebarFill.js
@@ -59,7 +59,7 @@ export default function SidebarFill( { settings } ) {
 						<SidebarCollapsible
 							title={ __( "Internal linking suggestions", "wordpress-seo" ) }
 						>
-							<LinkSuggestions />
+							<LinkSuggestions location="sidebar" />
 						</SidebarCollapsible>
 					</SidebarItem>
 				}

--- a/packages/js/src/components/fills/SidebarFill.js
+++ b/packages/js/src/components/fills/SidebarFill.js
@@ -21,6 +21,8 @@ import AdvancedSettings from "../../containers/AdvancedSettings";
 import WincherSEOPerformanceModal from "../../containers/WincherSEOPerformanceModal";
 import WebinarPromoNotification from "../WebinarPromoNotification";
 import KeywordUpsell from "../KeywordUpsell";
+import LinkSuggestions from "../link-suggestions";
+import getL10nObject from "../../analysis/getL10nObject";
 
 /* eslint-disable complexity */
 /**
@@ -36,6 +38,7 @@ import KeywordUpsell from "../KeywordUpsell";
  */
 export default function SidebarFill( { settings } ) {
 	const webinarIntroBlockEditorUrl = get( window, "wpseoScriptData.webinarIntroBlockEditorUrl", "https://yoa.st/webinar-intro-block-editor" );
+	const isPremium = getL10nObject().isPremium;
 
 	return (
 		<Fragment>
@@ -51,6 +54,15 @@ export default function SidebarFill( { settings } ) {
 						isSEMrushIntegrationActive={ settings.isSEMrushIntegrationActive }
 					/>
 				</SidebarItem> }
+				{ ! isPremium &&
+					<SidebarItem key="internal-linking-suggestions-upsell" renderPriority={ 24 }>
+						<SidebarCollapsible
+							title={ __( "Internal linking suggestions", "wordpress-seo" ) }
+						>
+							<LinkSuggestions />
+						</SidebarCollapsible>
+					</SidebarItem>
+				}
 				<SidebarItem key="google-preview" renderPriority={ 25 }>
 					<GooglePreviewModal />
 				</SidebarItem>

--- a/packages/js/src/components/link-suggestion.js
+++ b/packages/js/src/components/link-suggestion.js
@@ -1,6 +1,7 @@
 import PropTypes from "prop-types";
 import styled from "styled-components";
 import { __, sprintf } from "@wordpress/i18n";
+import { useCallback } from "@wordpress/element";
 import { colors } from "@yoast/style-guide";
 import { ScreenReaderText } from "@yoast/components";
 import { makeOutboundLink, createSvgIconComponent } from "@yoast/helpers";
@@ -151,10 +152,10 @@ const LinkSuggestion = ( { value, url, isActive, labels, isEnabled } ) => {
 	 *
 	 * @returns {void}
 	 */
-	const resetLabels = ( evt ) => {
+	const resetLabels = useCallback( ( evt ) => {
 		evt.nativeEvent.target.setAttribute( "aria-label", ariaLabel );
 		evt.nativeEvent.target.setAttribute( "data-label", label );
-	};
+	} );
 
 	let icon = "copy";
 	let iconColor = colors.$color_black;

--- a/packages/js/src/components/link-suggestion.js
+++ b/packages/js/src/components/link-suggestion.js
@@ -1,0 +1,211 @@
+import PropTypes from "prop-types";
+import styled from "styled-components";
+import { __, sprintf } from "@wordpress/i18n";
+import { colors } from "@yoast/style-guide";
+import { ScreenReaderText } from "@yoast/components";
+import { makeOutboundLink, createSvgIconComponent } from "@yoast/helpers";
+
+const LinkSuggestionWrapper = styled.div`
+	display: flex;
+	align-items: normal;
+	min-height: 40px;
+	margin: 10px 0 5px;
+`;
+
+/* eslint-disable max-len, quote-props */
+const LinkSuggestionSVGIcon = createSvgIconComponent( {
+	"copy": { viewbox: "0 0 448 512", path: "M433.941 65.941l-51.882-51.882A48 48 0 0 0 348.118 0H176c-26.51 0-48 21.49-48 48v48H48c-26.51 0-48 21.49-48 48v320c0 26.51 21.49 48 48 48h224c26.51 0 48-21.49 48-48v-48h80c26.51 0 48-21.49 48-48V99.882a48 48 0 0 0-14.059-33.941zM266 464H54a6 6 0 0 1-6-6V150a6 6 0 0 1 6-6h74v224c0 26.51 21.49 48 48 48h96v42a6 6 0 0 1-6 6zm128-96H182a6 6 0 0 1-6-6V54a6 6 0 0 1 6-6h106v88c0 13.255 10.745 24 24 24h88v202a6 6 0 0 1-6 6zm6-256h-64V48h9.632c1.591 0 3.117.632 4.243 1.757l48.368 48.368a6 6 0 0 1 1.757 4.243V112z" },
+	"check": { viewbox: "0 0 512 512", path: "M173.898 439.404l-166.4-166.4c-9.997-9.997-9.997-26.206 0-36.204l36.203-36.204c9.997-9.998 26.207-9.998 36.204 0L192 312.69 432.095 72.596c9.997-9.997 26.207-9.997 36.204 0l36.203 36.204c9.997 9.997 9.997 26.206 0 36.204l-294.4 294.401c-9.998 9.997-26.207 9.997-36.204-.001z" },
+} );
+/* eslint-enable */
+
+const LinkSuggestionDivider = styled.div`
+   background-color: #e5e5e5;
+   width: 100%;
+   height: 1px;
+`;
+
+const LinkSuggestionIcon = styled.button`
+	box-sizing: border-box;
+	flex: 0 0 30px;
+	height: 30px;
+	width: 30px;
+	background-color: ${ props => props.iconBackground };
+	border-radius: 5px;
+	outline:none;
+	border: 1px solid ${ props => props.iconBorder };
+	margin-left: 3px;
+	cursor: ${props => props.isEnabled ? "pointer" : "default"};
+	pointer-events: ${props => props.isEnabled ? "all" : "none"};
+
+	&:focus {
+		box-shadow: 0 0 0 1px #5b9dd9, 0 0 2px 1px rgba(30, 140, 190, 0.8);
+	}
+`;
+
+LinkSuggestionIcon.props = {
+	iconBackground: PropTypes.string,
+	iconBorder: PropTypes.string,
+};
+
+LinkSuggestionIcon.defaultProps = {
+	iconBackground: colors.$color_button,
+	iconBorder: colors.$color_button_border,
+};
+
+const LinkContainer = styled.div`
+	flex: auto;
+	max-width: 200px;
+`;
+
+const Link = makeOutboundLink( styled.a`
+    text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    /* -webkit-box-orient: vertical; */
+    /* -moz-box-orient: vertical; */
+    max-height: 40px;
+    margin-bottom: 4px;
+    -webkit-box-orient: vertical;
+	overflow: hidden;
+	padding: 0 0 4px;
+` );
+
+const DisabledLink = styled( Link )`
+	pointer-events: none;
+	cursor: default;
+`;
+
+const BadgesWrapper = styled.div`
+    flex-wrap: wrap;
+    display: flex;
+    flex-direction: row;
+    justify-content: unset;
+    margin-top: 4px;
+	cursor: ${props => props.isEnabled ? "auto" : "default"};
+`;
+
+const Badge = styled.span`
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	text-align: center;
+	padding: 3px 8px;
+	font-size: 0.85em;
+	background-color: #f3f4f5;
+	border-radius: 2px;
+	margin-bottom: 4px;
+	margin-right: 4px;
+	text-transform: lowercase;
+	cursor: ${props => props.isEnabled ? "auto" : "default"};
+
+`;
+
+/**
+ * Represents a list of badges.
+ *
+ * @param {string[]} badges The badges.
+ *
+ * @returns {React.Element} The rendered badges.
+ */
+const Badges = ( { badges, isEnabled } ) =>  {
+	return ( <BadgesWrapper isEnabled={ isEnabled }>
+		{ badges.map( ( badge, key ) => <Badge key={ key }>{ badge }</Badge> ) }
+	</BadgesWrapper> );
+};
+
+Badges.propTypes = {
+	badges: PropTypes.array.isRequired,
+	isEnabled: PropTypes.bool,
+};
+
+Badges.defaultProps = {
+	isEnabled: true,
+};
+
+/**
+ * Represents a suggestion component with a copy url to clipboard icon and a text value.
+ *
+ * @param {string}   value    The text value.
+ * @param {string}   url      The URL.
+ * @param {boolean}  isActive Whether the URL is already in use in the text.
+ * @param {string[]} labels   The labels of suggested object (e.g. cornerstone, post, movie, category, etc.).
+ * @param {boolean}  isEnabled Whether the link should be clickable.
+ *
+ * @returns {React.Element} The rendered suggestion.
+ *
+ * @constructor
+ */
+const LinkSuggestion = ( { value, url, isActive, labels, isEnabled } ) => {
+	const label = __( "Copy link", "wordpress-seo" );
+	const ariaLabel = sprintf(
+		/* translators: %s expands to the link value */
+		__( "Copy link to suggested article: %s", "wordpress-seo" ),
+		value
+	);
+
+	/**
+	 * Resets the button aria-label and data-label to their default values.
+	 *
+	 * @param {Object} evt The blur SyntheticEvent on the button.
+	 *
+	 * @returns {void}
+	 */
+	const resetLabels = ( evt ) => {
+		evt.nativeEvent.target.setAttribute( "aria-label", ariaLabel );
+		evt.nativeEvent.target.setAttribute( "data-label", label );
+	};
+
+	let icon = "copy";
+	let iconColor = colors.$color_black;
+	let iconBackground = colors.$color_button;
+	let iconBorder = "#979797";
+	if ( isActive ) {
+		icon = "check";
+		iconColor = colors.$color_alert_success_text;
+		iconBackground = colors.$color_alert_success_background;
+		iconBorder = colors.$color_alert_success_background;
+	}
+
+	return (
+		<div>
+			<LinkSuggestionDivider />
+			<LinkSuggestionWrapper className="yoast-link-suggestion__wrapper">
+				<LinkContainer className="yoast-link-suggestion__container">
+					{ isEnabled && <Link href={ url }>{ value }</Link> }
+					{ ! isEnabled && <DisabledLink href={ url }>{ value }</DisabledLink> }
+					<Badges badges={ labels } />
+				</LinkContainer>
+				<LinkSuggestionIcon
+					type="button"
+					className="yoast-link-suggestion__copy yoast-tooltip yoast-tooltip-alt yoast-tooltip-s"
+					onBlur={ resetLabels }
+					data-clipboard-text={ url }
+					aria-label={ ariaLabel }
+					data-label={ label }
+					iconBackground={ iconBackground }
+					iconBorder={ iconBorder }
+					isEnabled={ isEnabled }
+				>
+					<LinkSuggestionSVGIcon icon={ icon } color={ iconColor } />
+					<ScreenReaderText>{ label }</ScreenReaderText>
+				</LinkSuggestionIcon>
+			</LinkSuggestionWrapper>
+		</div>
+	);
+};
+
+LinkSuggestion.propTypes = {
+	value: PropTypes.string.isRequired,
+	url: PropTypes.string.isRequired,
+	isActive: PropTypes.bool,
+	labels: PropTypes.array.isRequired,
+	isEnabled: PropTypes.bool,
+};
+
+LinkSuggestion.defaultProps = {
+	isActive: false,
+	isEnabled: true,
+};
+
+export default LinkSuggestion;

--- a/packages/js/src/components/link-suggestions.js
+++ b/packages/js/src/components/link-suggestions.js
@@ -1,0 +1,63 @@
+import styled from "styled-components";
+import { __, sprintf } from "@wordpress/i18n";
+import { createInterpolateElement } from "@wordpress/element";
+import { makeOutboundLink } from "@yoast/helpers";
+
+import LinkSuggestion from "./link-suggestion";
+
+const introMessage =  createInterpolateElement(
+	sprintf(
+		/**
+		 * translators: %1$s expands to an opening anchor tag.
+		 * %2$s expands to a closing anchor tag.
+		 */
+		__( "To improve your site structure, consider linking to other relevant posts or pages on your website. %1$sRead our guide on internal linking for SEO%2$s to learn more.", "wordpress-seo" ),
+		"<a>",
+		"</a>"
+	),
+	{
+		// eslint-disable-next-line jsx-a11y/anchor-has-content, jsx-a11y/anchor-is-valid
+		a: <a href="#" target="_blank" rel="noreferrer" style={ { cursor: "default", pointerEvents: "none" } } />,
+	}
+);
+
+const OutboundLink = makeOutboundLink();
+const upsellLink = "#";
+const LinkSuggestionsWrapper = styled.div`
+display: table-cell;
+`;
+
+const suggestions = [
+	{ value: "Upgrade to", url: "#", isActive: false, labels: [ "post" ], isEnabled: false },
+	{ value: "Yoast SEO Premium", url: "#", isActive: false, labels: [ "post" ], isEnabled: false },
+	{ value: "To make use of", url: "#", isActive: false, labels: [ "post" ], isEnabled: false },
+	{ value: "Internal linking suggestions", url: "#", isActive: false, labels: [ "post" ], isEnabled: false },
+	{ value: "For this post", url: "#", isActive: false, labels: [ "post" ], isEnabled: false },
+];
+
+/**
+ *
+ * @returns {void}
+ */
+const LinkSuggestions = () => {
+	return (
+		<LinkSuggestionsWrapper>
+			<OutboundLink href={ upsellLink } className="yoast-button yoast-button-upsell">
+				{ sprintf(
+					// translators: %s expands to `Premium` (part of add-on name).
+					__( "Unlock with %s", "wordpress-seo" ),
+					"Premium"
+				) }
+				<span aria-hidden="true" className="yoast-button-upsell__caret" />
+			</OutboundLink>
+			<div style={ { opacity: 0.5 } }>
+				<p style={ { marginTop: 10 } }>{ introMessage }</p>
+				<div>
+					{ suggestions.map( ( suggestion, key ) => <LinkSuggestion key={ key } { ...suggestion } /> ) }
+				</div>
+			</div>
+		</LinkSuggestionsWrapper>
+	);
+};
+
+export default LinkSuggestions;

--- a/packages/js/src/components/link-suggestions.js
+++ b/packages/js/src/components/link-suggestions.js
@@ -22,7 +22,8 @@ const introMessage =  createInterpolateElement(
 );
 
 const OutboundLink = makeOutboundLink();
-const upsellLink = "#";
+const upsellLink = "http://yoa.st/link-suggestions-upsell";
+
 const LinkSuggestionsWrapper = styled.div`
 display: table-cell;
 `;

--- a/packages/js/src/components/link-suggestions.js
+++ b/packages/js/src/components/link-suggestions.js
@@ -1,3 +1,5 @@
+import PropTypes from "prop-types";
+
 import styled from "styled-components";
 import { __, sprintf } from "@wordpress/i18n";
 import { createInterpolateElement } from "@wordpress/element";
@@ -40,10 +42,14 @@ const suggestions = [
  *
  * @returns {void}
  */
-const LinkSuggestions = () => {
+const LinkSuggestions = ( { location } ) => {
+	const additionalStyle = { minHeight: "revert", maxHeight: "30px" };
+	if ( location === "metabox" ) {
+		additionalStyle.marginTop = "8px";
+	}
 	return (
 		<LinkSuggestionsWrapper>
-			<OutboundLink href={ upsellLink } className="yoast-button yoast-button-upsell">
+			<OutboundLink href={ upsellLink } className="yoast-button yoast-button-upsell" style={ additionalStyle }>
 				{ sprintf(
 					// translators: %s expands to `Premium` (part of add-on name).
 					__( "Unlock with %s", "wordpress-seo" ),
@@ -59,6 +65,14 @@ const LinkSuggestions = () => {
 			</div>
 		</LinkSuggestionsWrapper>
 	);
+};
+
+LinkSuggestions.propTypes = {
+	location: PropTypes.string,
+};
+
+LinkSuggestions.defaultProps = {
+	location: "sidebar",
 };
 
 export default LinkSuggestions;

--- a/packages/js/src/components/link-suggestions.js
+++ b/packages/js/src/components/link-suggestions.js
@@ -24,7 +24,7 @@ const introMessage =  createInterpolateElement(
 );
 
 const OutboundLink = makeOutboundLink();
-const upsellLink = "http://yoa.st/link-suggestions-upsell";
+const upsellLink = "https://yoa.st/link-suggestions-upsell";
 
 const LinkSuggestionsWrapper = styled.div`
 display: table-cell;

--- a/packages/js/src/editor-modules.js
+++ b/packages/js/src/editor-modules.js
@@ -31,6 +31,7 @@ import * as replacementVariableHelpers from "./helpers/replacementVariableHelper
 import { update as updateAdminBar } from "./ui/adminBar";
 import { updateScore, createScoresInPublishBox, scrollToCollapsible } from "./ui/publishBox";
 import { update as updateTrafficLight } from "./ui/trafficLight";
+import LinkSuggestion from "./components/link-suggestion";
 
 window.yoast = window.yoast || {};
 window.yoast.editorModules = {
@@ -68,6 +69,7 @@ window.yoast.editorModules = {
 			ImageSelectPortal,
 			ScoreIconPortal,
 		},
+		LinkSuggestion,
 	},
 	containers: {
 		EditorModal,

--- a/packages/js/src/elementor/components/fills/ElementorFill.js
+++ b/packages/js/src/elementor/components/fills/ElementorFill.js
@@ -25,6 +25,7 @@ import { isWordProofIntegrationActive } from "../../../helpers/wordproof";
 import WordProofAuthenticationModals from "../../../components/modals/WordProofAuthenticationModals";
 import WebinarPromoNotification from "../../../components/WebinarPromoNotification";
 import KeywordUpsell from "../../../components/KeywordUpsell";
+import LinkSuggestions from "../../../components/link-suggestions";
 
 /* eslint-disable complexity */
 /**
@@ -66,6 +67,13 @@ export default function ElementorFill( { isLoading, onLoad, settings } ) {
 					{ ! window.wpseoScriptData.metabox.isPremium && <Fill name="YoastRelatedKeyphrases">
 						<SEMrushRelatedKeyphrases />
 					</Fill> }
+				</SidebarItem> }
+				{ ! window.wpseoScriptData.metabox.isPremium && <SidebarItem renderPriority={ 24 }>
+					<SidebarCollapsible
+						title={ __( "Internal linking suggestions", "wordpress-seo" ) }
+					>
+						<LinkSuggestions />
+					</SidebarCollapsible>
 				</SidebarItem> }
 				<SidebarItem renderPriority={ 25 }>
 					<GooglePreviewModal />


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to add an upsell for the `Internal linking suggestions functionality` both in the sidebar and in the metabox

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds an upsell for the `Internal linking suggestions` in metabox and sidebar.

## Relevant technical choices:

* This PR must be tested and merged together with its [Yoast SEO Premium accompanying one](https://github.com/Yoast/wordpress-seo-premium/pull/3703)

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Make sure you don't have Yoast SEO Premium activated
* Open a post for edit
* Check that in the sidebar you have an `Internal linking suggestions` collapsible, and click it: it should display as in picture:

<img width="338" alt="Screenshot 2022-10-07 at 09 49 11" src="https://user-images.githubusercontent.com/68744851/194501001-a635c943-5130-4215-aa38-d30c0a2551f9.png">

* Make sure the upsell button takes you to the right page, that is: [https://yoast.com/reasons-to-upgrade](https://yoast.com/reasons-to-upgrade)
* Perform the checks above also for the metabox, which should display exactly the same thing:

<img width="677" alt="Screenshot 2022-10-07 at 09 54 03" src="https://user-images.githubusercontent.com/68744851/194502001-35d62d3f-e703-47d8-9b66-bde37e3d6a68.png">

* Check the upsell is also present in the Elementor sidebar

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [X] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [X] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.

Fixes [PC-6](https://yoast.atlassian.net/browse/PC-6)
