### PR TITLE
PC-717-401-unauthorized-when-editing-a-page-with-elementor

### DIFF
--- a/src/integrations/third-party/elementor.php
+++ b/src/integrations/third-party/elementor.php
@@ -238,8 +238,8 @@ class Elementor implements Integration_Interface {
 
 		$post_id = \filter_input( \INPUT_POST, 'post_id', \FILTER_SANITIZE_NUMBER_INT );
 
-		if ( ! \current_user_can( 'manage_options' ) ) {
-			\wp_send_json_error( 'Unauthorized', 401 );
+		if ( ! \current_user_can( 'edit_post', $post_id ) ) {
+			\wp_send_json_error( 'Forbidden', 403 );
 		}
 
 		\check_ajax_referer( 'wpseo_elementor_save', '_wpseo_elementor_nonce' );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*  If a site is configured to use basic access authentication through `.htaccess`, users which don't have the `manage_options` capability will be prompt to insert their credentials when trying to save a post in Elementor. Moreover, the meta options related to that post will not be saved. 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where users with site-wide basic access authentication are prompted to insert their credentials when saving a post in Elementor if they don't have the `manage_options` capability.
* Fixes a bug where Yoast SEO-related post meta data is not saved if a user without the `manage_options` capability saves a post in Elementor.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Be sure your dev env (Rancher/Docker) is already running
* Open a console terminal and go into your WordPress installation directory (e.g. `/Users/pls/Development/Yoast/plugin-development-docker/wordpress`)
* Type `htpasswd -c ./.htpasswd admin`: you will be prompted to specify a password twice
* In the same directory, edit the `.htaccess` file (it should already exist, if not create it)
* Add the following lines to the file:
```
AuthName "Dialog prompt"
AuthType Basic
AuthUserFile YOUR_SERVER_DOCUMENT_ROOT/.htpasswd
Require valid-user
```
* For Yoast dev env `YOUR_SERVER_DOCUMENT_ROOT` is `/var/www/html`
* If you're unsure about what your server document root is, create a file named `info.php` in the same directory and add the following to it:
```
<?php
echo $_SERVER['DOCUMENT_ROOT'];
```
* Visit that file, e.g. by visiting `https://basic.wordpress.test/info.php` in your browser: the string you see is your document root
* Now visit your site: you should be prompted to insert your credentials
* Insert `admin` as username and the password you have specified with `htpasswd`
* Switch your user to a user with `Editor` role
* Edit a post with Elementor and click `Update`
  * With this PR you shouldn't see any authentication prompt
  * Without this PR an authentication prompt should appear before the post is saved
 ---
**Check if post metadata is saved**
* Switch your user to a user with `Editor` role (you can use the [user switching](https://wordpress.org/plugins/user-switching/) plugin for this)
* Edit a post with Elementor
* In the Yoast section of the Elementor sidebar specify a focus keyphrase for this post and save 
* With a MySQL client of your choice, look for the `_postmeta` table and find the tuple where `meta_key` = `_yoast_wpseo_focuskw` and `post_id` = the id of the post you edited
  * With this PR you should see the value you've specified in the Elementor sidebar
  * Without this PR the value would not be saved 

 * When you're done, **remember to remove the `.htpasswd` file and the lines you've added to the `.htacces` file!!**

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [x] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [X] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->
* Please test it in Firefox, too: sometimes the authentication dialog is triggered, sometimes it's not (not a biggie, though...)
### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.

Fixes [PC-717](https://yoast.atlassian.net/browse/PC-717), #18594 
