### PR TITLE
PC 298 improve faq page schema page type selection interface

### DIFF
--- a/css/src/metabox.css
+++ b/css/src/metabox.css
@@ -855,4 +855,12 @@ div.interface-pinned-items button.components-button.is-pressed[aria-label="Yoast
 	background: #fdf4f8;
 }
 
+.yoast .yoast-schema-faq-alert-active {
+	margin-bottom: 16px;
+}
+
+.yoast .yoast-schema-faq-alert {
+	margin-bottom: 24px;
+}
+
 /*# sourceMappingURL=metabox.css.map */

--- a/packages/js/src/components/SchemaTab.js
+++ b/packages/js/src/components/SchemaTab.js
@@ -213,10 +213,11 @@ const Content = ( props ) => {
 				label={ __( "Page type", "wordpress-seo" ) }
 				onChange={ props.schemaPageTypeChange }
 				selected={ props.schemaPageTypeSelected }
+				wrapperClassName={ props.schemaPageTypeSelected === "FAQPage" && ! props.hasFAQBlock ? "yoast-field-group yoast-schema-faq-alert-active" : "yoast-field-group" }
 			/>
 			{ props.schemaPageTypeSelected === "FAQPage" && ! props.hasFAQBlock && <Alert
 				type={ "warning" }
-				style={ { margin: "16px 0px 24px 0px" } }
+				className="yoast-schema-faq-alert"
 			>
 				{ addLinkToString(
 					sprintf(

--- a/packages/js/src/components/SchemaTab.js
+++ b/packages/js/src/components/SchemaTab.js
@@ -8,6 +8,7 @@ import PropTypes from "prop-types";
 import styled from "styled-components";
 import { schemaTypeOptionsPropType } from "./SchemaSettings";
 import { isFeatureEnabled } from "@yoast/feature-flag";
+import { addLinkToString } from "../helpers/stringHelpers";
 
 const NewsLandingPageLink = makeOutboundLink();
 
@@ -204,6 +205,7 @@ const Content = ( props ) => {
 				label={ __( "What type of page or content is this?", "wordpress-seo" ) }
 				linkTo={ props.additionalHelpTextLink }
 				linkText={ __( "Learn more about page or content types", "wordpress-seo" ) }
+				style={ { margin: "0" } }
 			/>
 			<Select
 				id={ join( [ "yoast-schema-page-type", props.location ] ) }
@@ -212,10 +214,26 @@ const Content = ( props ) => {
 				onChange={ props.schemaPageTypeChange }
 				selected={ props.schemaPageTypeSelected }
 			/>
+			{ props.schemaPageTypeSelected === "FAQPage" && ! props.hasFAQBlock && <Alert
+				type={ "warning" }
+				style={ { margin: "16px 0px 24px 0px" } }
+			>
+				{ addLinkToString(
+					sprintf(
+						/* translators: %1$s and %2$s are replaced by opening and closing <a> tags. */
+						__( "You have selected 'FAQ page', but you haven't added an FAQ block to your content. Please %1$sadd an FAQ block%2$s or select another page type.", "wordpress-seo" ),
+						"<a>",
+						"</a>"
+					),
+					"https://yoa.st/add-faq-block"
+				)
+				}
+			</Alert>
+			 }
 			{ props.showArticleTypeInput && <Select
 				id={ join( [ "yoast-schema-article-type", props.location ] ) }
 				options={ schemaArticleTypeOptions }
-				label={ __( "Article type", "wordpress-seo" ) }
+				label={ __(  "Article type", "wordpress-seo" ) }
 				onChange={ props.schemaArticleTypeChange }
 				selected={ props.schemaArticleTypeSelected }
 				onOptionFocus={ handleOptionChange }
@@ -247,6 +265,7 @@ Content.propTypes = {
 	defaultArticleType: PropTypes.string.isRequired,
 	location: PropTypes.string.isRequired,
 	isNewsEnabled: PropTypes.bool,
+	hasFAQBlock: PropTypes.bool.isRequired,
 };
 
 Content.defaultProps = {
@@ -294,6 +313,7 @@ SchemaTab.propTypes = {
 	loadSchemaArticleData: PropTypes.func.isRequired,
 	loadSchemaPageData: PropTypes.func.isRequired,
 	location: PropTypes.string.isRequired,
+	hasFAQBlock: PropTypes.bool.isRequired,
 };
 
 SchemaTab.defaultProps = {

--- a/packages/js/src/containers/SchemaTab.js
+++ b/packages/js/src/containers/SchemaTab.js
@@ -1,6 +1,6 @@
 /* global wpseoAdminL10n */
 import { compose } from "@wordpress/compose";
-import { withDispatch, withSelect } from "@wordpress/data";
+import { withDispatch, withSelect, select, subscribe } from "@wordpress/data";
 import { useEffect } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
 import PropTypes from "prop-types";
@@ -32,6 +32,13 @@ const getLocationBasedProps = ( location ) => {
 };
 
 /**
+ * Function to get blocks from the block editor.
+ *
+ * @returns {[object]} A list of blocks in the block editor.
+ */
+const getBlockList = () => select( "core/block-editor" ).getBlocks();
+
+/**
  * Renders the SchemaComponent.
  *
  * @param {Object} props The props.
@@ -48,6 +55,11 @@ const SchemaTabContainer = ( props ) => {
 		}
 	}, [] );
 
+	let blocks = getBlockList();
+	subscribe( () => {
+		blocks = getBlockList();
+	} );
+
 	const { pageTypeOptions, articleTypeOptions } = window.wpseoScriptData.metabox.schema;
 
 	const baseProps = {
@@ -59,6 +71,9 @@ const SchemaTabContainer = ( props ) => {
 			"This helps search engines understand your website and your content. You can change some of your settings for this page below.",
 			"wordpress-seo"
 		),
+		hasFAQBlock: blocks.filter( ( block ) => {
+			return block.name === "yoast/faq-block";
+		} ).length > 0,
 		showArticleTypeInput,
 		pageTypeOptions,
 		articleTypeOptions,
@@ -84,6 +99,7 @@ SchemaTabContainer.propTypes = {
 	schemaPageTypeChange: PropTypes.func.isRequired,
 	schemaArticleTypeChange: PropTypes.func.isRequired,
 	location: PropTypes.string.isRequired,
+	hasFAQBlock: PropTypes.bool,
 };
 
 export default compose( [

--- a/packages/js/src/containers/SchemaTab.js
+++ b/packages/js/src/containers/SchemaTab.js
@@ -1,6 +1,6 @@
 /* global wpseoAdminL10n */
 import { compose } from "@wordpress/compose";
-import { withDispatch, withSelect, select, subscribe } from "@wordpress/data";
+import { withDispatch, withSelect } from "@wordpress/data";
 import { useEffect } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
 import PropTypes from "prop-types";
@@ -32,13 +32,6 @@ const getLocationBasedProps = ( location ) => {
 };
 
 /**
- * Function to get blocks from the block editor.
- *
- * @returns {[object]} A list of blocks in the block editor.
- */
-const getBlockList = () => select( "core/block-editor" ).getBlocks();
-
-/**
  * Renders the SchemaComponent.
  *
  * @param {Object} props The props.
@@ -55,11 +48,6 @@ const SchemaTabContainer = ( props ) => {
 		}
 	}, [] );
 
-	let blocks = getBlockList();
-	subscribe( () => {
-		blocks = getBlockList();
-	} );
-
 	const { pageTypeOptions, articleTypeOptions } = window.wpseoScriptData.metabox.schema;
 
 	const baseProps = {
@@ -71,9 +59,7 @@ const SchemaTabContainer = ( props ) => {
 			"This helps search engines understand your website and your content. You can change some of your settings for this page below.",
 			"wordpress-seo"
 		),
-		hasFAQBlock: blocks.filter( ( block ) => {
-			return block.name === "yoast/faq-block";
-		} ).length > 0,
+		hasFAQBlock: props.editorContent.includes( "<!-- wp:yoast/faq-block" ),
 		showArticleTypeInput,
 		pageTypeOptions,
 		articleTypeOptions,
@@ -99,7 +85,7 @@ SchemaTabContainer.propTypes = {
 	schemaPageTypeChange: PropTypes.func.isRequired,
 	schemaArticleTypeChange: PropTypes.func.isRequired,
 	location: PropTypes.string.isRequired,
-	hasFAQBlock: PropTypes.bool,
+	editorContent: PropTypes.string.isRequired,
 };
 
 export default compose( [
@@ -110,6 +96,7 @@ export default compose( [
 			getDefaultPageType,
 			getArticleType,
 			getDefaultArticleType,
+			getEditorDataContent,
 		} = select( "yoast-seo/editor" );
 
 		const { displaySchemaSettingsFooter: displayFooter, isNewsEnabled } = getPreferences();
@@ -121,6 +108,7 @@ export default compose( [
 			schemaArticleTypeSelected: getArticleType(),
 			defaultArticleType: getDefaultArticleType(),
 			defaultPageType: getDefaultPageType(),
+			editorContent: getEditorDataContent(),
 		};
 	} ),
 	withDispatch( ( dispatch ) => {

--- a/src/context/meta-tags-context.php
+++ b/src/context/meta-tags-context.php
@@ -501,20 +501,19 @@ class Meta_Tags_Context extends Abstract_Presentation {
 				$type = 'CollectionPage';
 				break;
 			default:
-				$additional_type = $this->indexable->schema_page_type;
-				if ( \is_null( $additional_type ) ) {
-					$additional_type = $this->options->get( 'schema-page-type-' . $this->indexable->object_sub_type );
+				$additional_type = $this->get_additional_type();
+				$type            = [ 'WebPage' ];
+				if ( ! \is_null( $additional_type ) ) {
+					$type = [ 'WebPage', $additional_type ];
 				}
-
-				$type = [ 'WebPage', $additional_type ];
 
 				// Is this indexable set as a page for posts, e.g. in the WordPress reading settings as a static homepage?
 				if ( (int) \get_option( 'page_for_posts' ) === $this->indexable->object_id ) {
 					$type[] = 'CollectionPage';
 				}
 
-				// Ensure we get only unique values, and remove any null values and the index.
-				$type = \array_filter( \array_values( \array_unique( $type ) ) );
+				// Ensure we get only unique values.
+				$type = \array_unique( $type );
 		}
 
 		/**
@@ -649,6 +648,28 @@ class Meta_Tags_Context extends Abstract_Presentation {
 			'indexable'    => $this->indexable,
 			'presentation' => $this->presentation,
 		];
+	}
+
+	/**
+	 * Get the additional page type (set in page settings).
+	 *
+	 * @return string|null The additional type as a string, null if no additional type was selected as page type.
+	 */
+	protected function get_additional_type() {
+		// Get the page type as set in the page settings.
+		$additional_type = $this->indexable->schema_page_type;
+
+		if ( \is_null( $additional_type ) ) {
+			// Get the page type as set in the global settings.
+			$additional_type = strval( $this->options->get( 'schema-page-type-' . $this->indexable->object_sub_type ) );
+		}
+
+		if ( $additional_type === 'FAQPage' ) {
+			// Do not output FAQPage page type if it is set because this is already outputted in faq.php.
+			$additional_type = null;
+		}
+
+		return $additional_type;
 	}
 
 	/**

--- a/src/generators/schema/faq.php
+++ b/src/generators/schema/faq.php
@@ -8,7 +8,7 @@ namespace Yoast\WP\SEO\Generators\Schema;
 class FAQ extends Abstract_Schema_Piece {
 
 	/**
-	 * Determines whether or not a piece should be added to the graph.
+	 * Determines whether a piece should be added to the graph.
 	 *
 	 * @return bool
 	 */


### PR DESCRIPTION
- Disable FAQ schema type output when no FAQ block is present
- Add warning to page type selector
- Add respond to page content

## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

*

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

*

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes #
