### PR TITLE
Pc 759 when re sized image is added in content the full scale image is added in the schema as well

### DIFF
--- a/src/context/meta-tags-context.php
+++ b/src/context/meta-tags-context.php
@@ -53,6 +53,7 @@ use Yoast\WP\SEO\Values\Schema\Image;
  * @property bool         $has_image
  * @property int          $main_image_id
  * @property string       $main_image_url
+ * @property Image|null   $main_image
  * @property Image[]      $images
  */
 class Meta_Tags_Context extends Abstract_Presentation {
@@ -596,6 +597,15 @@ class Meta_Tags_Context extends Abstract_Presentation {
 	 */
 	public function generate_main_schema_id() {
 		return $this->permalink;
+	}
+
+	/**
+	 * Generate the main image from the main image URL.
+	 *
+	 * @return Image|null The Image object if it exists.
+	 */
+	public function generate_main_image() {
+		return $this->image->create_image_object_from_source( $this->main_image_url );
 	}
 
 	/**

--- a/src/generators/schema/images.php
+++ b/src/generators/schema/images.php
@@ -40,18 +40,9 @@ class Images extends Abstract_Schema_Piece {
 	 * @return array $graph The new graph with added image content.
 	 */
 	protected function add_primary_image( $graph ) {
-		if ( $this->context->main_image_id ) {
-			// The main image is set within the featured image.
-			$schema_id = $this->helpers->image->get_attachment_image_url( $this->context->main_image_id, 'full' );
-			$image_obj = $this->helpers->image->create_image_object_from_source( $schema_id );
-			$this->maybe_add_image_schema( $graph, $image_obj );
+		if ( ! \is_null( $this->context->main_image ) ) {
+			$graph[] = $this->helpers->schema->image->generate_from_image_object($this->context->main_image);
 		}
-		elseif ( $this->context->main_image_url ) {
-			// The main image is extracted from the post content.
-			$image_obj = $this->helpers->image->create_image_object_from_source( $this->context->main_image_url );
-			$this->maybe_add_image_schema( $graph, $image_obj );
-		}
-
 		return $graph;
 	}
 
@@ -79,19 +70,8 @@ class Images extends Abstract_Schema_Piece {
 	 *
 	 * @return array $graph The new graph with added image content.
 	 */
-	private function _add_image_schema( $graph, $image ) {
-		if ( $image->has_id() ) {
-			if ( $image->has_size() ) {
-				$graph[] = $this->helpers->schema->image->generate_from_attachment_id( $image->get_src(), $image->get_id(), '', false, [ $image->get_width(), $image->get_height() ] );
-			}
-			else {
-				$graph[] = $this->helpers->schema->image->generate_from_attachment_id( $image->get_src(), $image->get_id() );
-			}
-		}
-		else {
-			$graph[] = $this->helpers->schema->image->generate_from_url( $image->get_src(), $image->get_src() );
-		}
-
+	private function _add_image_schema($graph, $image ) {
+		$graph[] = $this->helpers->schema->image->generate_from_image_object( $image );
 		return $graph;
 	}
 

--- a/src/generators/schema/images.php
+++ b/src/generators/schema/images.php
@@ -41,7 +41,7 @@ class Images extends Abstract_Schema_Piece {
 	 */
 	protected function add_primary_image( $graph ) {
 		if ( ! \is_null( $this->context->main_image ) ) {
-			$graph[] = $this->helpers->schema->image->generate_from_image_object($this->context->main_image);
+			$graph[] = $this->helpers->schema->image->generate_from_image_object( $this->context->main_image );
 		}
 		return $graph;
 	}
@@ -59,7 +59,7 @@ class Images extends Abstract_Schema_Piece {
 			return $graph;
 		}
 
-		return $this->_add_image_schema( $graph, $image );
+		return $this->add_image_schema( $graph, $image );
 	}
 
 	/**
@@ -70,7 +70,7 @@ class Images extends Abstract_Schema_Piece {
 	 *
 	 * @return array $graph The new graph with added image content.
 	 */
-	private function _add_image_schema($graph, $image ) {
+	private function add_image_schema( $graph, $image ) {
 		$graph[] = $this->helpers->schema->image->generate_from_image_object( $image );
 		return $graph;
 	}

--- a/src/generators/schema/images.php
+++ b/src/generators/schema/images.php
@@ -41,11 +41,13 @@ class Images extends Abstract_Schema_Piece {
 	 */
 	protected function add_primary_image( $graph ) {
 		if ( $this->context->main_image_id ) {
+			// The main image is set within the featured image.
 			$schema_id        = $this->helpers->image->get_attachment_image_url( $this->context->main_image_id, 'full' );
 			$generated_schema = $this->helpers->schema->image->generate_from_attachment_id( $schema_id, $this->context->main_image_id );
 			$graph[]          = $generated_schema;
 		}
 		elseif ( $this->context->main_image_url ) {
+			// The main image is extracted from the post content.
 			$graph[] = $this->helpers->schema->image->generate_from_url( $this->context->main_image_url, $this->context->main_image_url );
 		}
 

--- a/src/generators/schema/images.php
+++ b/src/generators/schema/images.php
@@ -42,13 +42,14 @@ class Images extends Abstract_Schema_Piece {
 	protected function add_primary_image( $graph ) {
 		if ( $this->context->main_image_id ) {
 			// The main image is set within the featured image.
-			$schema_id        = $this->helpers->image->get_attachment_image_url( $this->context->main_image_id, 'full' );
-			$generated_schema = $this->helpers->schema->image->generate_from_attachment_id( $schema_id, $this->context->main_image_id );
-			$graph[]          = $generated_schema;
+			$schema_id = $this->helpers->image->get_attachment_image_url( $this->context->main_image_id, 'full' );
+			$image_obj = $this->helpers->image->create_image_object_from_source( $schema_id );
+			$this->maybe_add_image_schema( $graph, $image_obj );
 		}
 		elseif ( $this->context->main_image_url ) {
 			// The main image is extracted from the post content.
-			$graph[] = $this->helpers->schema->image->generate_from_url( $this->context->main_image_url, $this->context->main_image_url );
+			$image_obj = $this->helpers->image->create_image_object_from_source( $this->context->main_image_url );
+			$this->maybe_add_image_schema( $graph, $image_obj );
 		}
 
 		return $graph;
@@ -67,7 +68,7 @@ class Images extends Abstract_Schema_Piece {
 			return $graph;
 		}
 
-		return $this->add_image_schema( $graph, $image );
+		return $this->_add_image_schema( $graph, $image );
 	}
 
 	/**
@@ -78,7 +79,7 @@ class Images extends Abstract_Schema_Piece {
 	 *
 	 * @return array $graph The new graph with added image content.
 	 */
-	protected function add_image_schema( $graph, $image ) {
+	private function _add_image_schema( $graph, $image ) {
 		if ( $image->has_id() ) {
 			if ( $image->has_size() ) {
 				$graph[] = $this->helpers->schema->image->generate_from_attachment_id( $image->get_src(), $image->get_id(), '', false, [ $image->get_width(), $image->get_height() ] );

--- a/src/generators/schema/webpage.php
+++ b/src/generators/schema/webpage.php
@@ -115,18 +115,10 @@ class WebPage extends Abstract_Schema_Piece {
 	 * @return array $data The new graph with added image content.
 	 */
 	protected function add_primary_image( $data ) {
-		if ( $this->context->has_image ) {
-			if ( $this->context->main_image_id ) {
-				$schema_id                     = $this->helpers->image->get_attachment_image_url( $this->context->main_image_id, 'full' );
-				$data['primaryImageOfPage']    = [ '@id' => $schema_id ];
-				$data['image']                 = [ [ '@id' => $schema_id ] ];
-				$this->context->main_image_url = $schema_id;
-			}
-			elseif ( $this->context->main_image_url ) {
-				$data['primaryImageOfPage'] = [ '@id' => $this->context->main_image_url ];
-				$data['image']              = [ [ '@id' => $this->context->main_image_url ] ];
-			}
-			$data['thumbnailUrl'] = $this->context->main_image_url;
+		if ( ! \is_null( $this->context->main_image ) ) {
+			$data['primaryImageOfPage'] = [ '@id' => $this->context->main_image->get_src() ];
+			$data['image']              = [ [ '@id' => $this->context->main_image->get_src() ] ];
+			$data['thumbnailUrl']       = $this->context->main_image->get_src();
 		}
 
 		return $data;

--- a/src/generators/schema/webpage.php
+++ b/src/generators/schema/webpage.php
@@ -123,10 +123,6 @@ class WebPage extends Abstract_Schema_Piece {
 				$this->context->main_image_url = $schema_id;
 			}
 			elseif ( $this->context->main_image_url ) {
-				$image_id = $this->helpers->image->get_attachment_by_url( $this->context->main_image_url );
-				if ( $image_id !== 0 ) {
-					$this->context->main_image_url = $this->helpers->image->get_attachment_image_url( $image_id, 'full' );
-				}
 				$data['primaryImageOfPage'] = [ '@id' => $this->context->main_image_url ];
 				$data['image']              = [ [ '@id' => $this->context->main_image_url ] ];
 			}

--- a/src/helpers/image-helper.php
+++ b/src/helpers/image-helper.php
@@ -388,6 +388,8 @@ class Image_Helper {
 	/**
 	 * Get the image width and height from the image src attribute (for WordPress images).
 	 *
+	 * @todo: If the image URL does not contain width and height attributes, add the 'full' size as default.
+	 *
 	 * @param string $src The image src attribute.
 	 * @return array|null Either an array with a 'width' and 'height' key or null when no image size was found.
 	 */

--- a/src/helpers/image-helper.php
+++ b/src/helpers/image-helper.php
@@ -411,14 +411,19 @@ class Image_Helper {
 	 * @param string $src The src attribute of an img tag.
 	 * @return Image|null The generated Image object.
 	 */
-	protected function create_image_object_from_source( $src ) {
+	public function create_image_object_from_source( $src ) {
 		$width  = null;
 		$height = null;
 
 		// Extract image ID.
 		$id = $this->get_attachment_by_url( $src );
 
-		if ( $id !== 0 ) {
+		// Convert a non-existing image ID to null.
+		if ( $id === 0 ) {
+			$id = null;
+		}
+
+		if ( ! \is_null( $id ) ) {
 			// Extract image size if present in src.
 			$image_size = $this->get_image_size( $src );
 			if ( ! \is_null( $image_size ) ) {

--- a/src/helpers/schema/image-helper.php
+++ b/src/helpers/schema/image-helper.php
@@ -119,6 +119,28 @@ class Image_Helper {
 	}
 
 	/**
+	 * Generate image schema from an Image object.
+	 *
+	 * @todo: Add caption to Image object.
+	 *
+	 * @param Image $image The Image object to generate schema data for.
+	 * @return array Schema for an ImageObject.
+	 */
+	public function generate_from_image_object( $image ) {
+		$data = $this->generate_object();
+
+		$data['@id'] = $image->get_src();
+		$data['url'] = $image->get_src();
+		$data['contentUrl'] = $image->get_src();
+		if ( $image->has_size() ) {
+			$data['width'] = $image->get_width();
+			$data['height'] = $image->get_height();
+		}
+
+		return $data;
+	}
+
+	/**
 	 * If we can't find $url in our database, we output a simple ImageObject.
 	 *
 	 * @param string $schema_id The `@id` to use for the returned image.

--- a/src/helpers/schema/image-helper.php
+++ b/src/helpers/schema/image-helper.php
@@ -121,19 +121,17 @@ class Image_Helper {
 	/**
 	 * Generate image schema from an Image object.
 	 *
-	 * @todo: Add caption to Image object.
-	 *
 	 * @param Image $image The Image object to generate schema data for.
 	 * @return array Schema for an ImageObject.
 	 */
 	public function generate_from_image_object( $image ) {
 		$data = $this->generate_object();
 
-		$data['@id'] = $image->get_src();
-		$data['url'] = $image->get_src();
+		$data['@id']        = $image->get_src();
+		$data['url']        = $image->get_src();
 		$data['contentUrl'] = $image->get_src();
 		if ( $image->has_size() ) {
-			$data['width'] = $image->get_width();
+			$data['width']  = $image->get_width();
 			$data['height'] = $image->get_height();
 		}
 

--- a/src/helpers/schema/image-helper.php
+++ b/src/helpers/schema/image-helper.php
@@ -83,8 +83,8 @@ class Image_Helper {
 		$id_suffix = ( $add_hash ) ? \md5( $url ) : '';
 
 		$data['@id']        = $schema_id . $id_suffix;
-		$data['url']        = $url;
-		$data['contentUrl'] = $url;
+		$data['url']        = $schema_id;
+		$data['contentUrl'] = $schema_id;
 		$data               = $this->add_image_size( $data, $attachment_id );
 		$data               = $this->add_caption( $data, $attachment_id, $caption );
 

--- a/src/helpers/schema/image-helper.php
+++ b/src/helpers/schema/image-helper.php
@@ -83,8 +83,8 @@ class Image_Helper {
 		$id_suffix = ( $add_hash ) ? \md5( $url ) : '';
 
 		$data['@id']        = $schema_id . $id_suffix;
-		$data['url']        = $schema_id;
-		$data['contentUrl'] = $schema_id;
+		$data['url']        = $url;
+		$data['contentUrl'] = $url;
 		$data               = $this->add_image_size( $data, $attachment_id );
 		$data               = $this->add_caption( $data, $attachment_id, $caption );
 

--- a/src/helpers/schema/image-helper.php
+++ b/src/helpers/schema/image-helper.php
@@ -211,29 +211,20 @@ class Image_Helper {
 	 * @return Image The converted image.
 	 */
 	public function convert_open_graph_image( $open_graph_image ) {
-		$id     = isset( $open_graph_image['id'] ) ? intval( $open_graph_image['id'] ) : null;
-		$width  = isset( $open_graph_image['width'] ) ? intval( $open_graph_image['width'] ) : null;
-		$height = isset( $open_graph_image['height'] ) ? intval( $open_graph_image['height'] ) : null;
+		// Create an Image object from the open graph image.
+		$image_obj = $this->image->create_image_object_from_source( $open_graph_image['url'] );
 
-		$image_obj = new Image( $open_graph_image['url'], $id, $width, $height );
-
-		// Try to find the image ID of the image.
-		if ( ! $image_obj->has_id() ) {
-			$found_image_id = $this->image->get_attachment_by_url( $image_obj->get_src() );
-			if ( $found_image_id !== 0 ) {
-				$image_obj->set_id( $found_image_id );
-			}
+		// Overwrite properties if they exist.
+		if ( isset( $open_graph_image['id'] ) ) {
+			$image_obj->set_id( intval( $open_graph_image['id'] ) );
+		}
+		if ( isset( $open_graph_image['width'] ) ) {
+			$image_obj->set_width( intval( $open_graph_image['width'] ) );
+		}
+		if ( isset( $open_graph_image['height'] ) ) {
+			$image_obj->set_height( intval( $open_graph_image['height'] ) );
 		}
 
-		// $image might include an image url that does not have the correct scheme (e.g. http instead of https).
-		// We will try to convert it if possible.
-		if ( $image_obj->has_id() ) {
-			$size      = ! \is_null( $width ) && ! \is_null( $height ) ? [ $width, $height ] : 'full';
-			$image_url = $this->image->get_attachment_image_url( $image_obj->get_id(), $size );
-			if ( $image_url !== '' ) {
-				$image_obj->set_src( $image_url );
-			}
-		}
 		return $image_obj;
 	}
 }

--- a/src/values/schema/image.php
+++ b/src/values/schema/image.php
@@ -125,4 +125,24 @@ class Image {
 	public function get_height() {
 		return $this->height;
 	}
+
+	/**
+	 * Set the image width.
+	 *
+	 * @param int $width The image width in pixels.
+	 * @return void
+	 */
+	public function set_width( $width ) {
+		$this->width = $width;
+	}
+
+	/**
+	 * Set the image height.
+	 *
+	 * @param int $height The image width in pixels.
+	 * @return void
+	 */
+	public function set_height( $height ) {
+		$this->height = $height;
+	}
 }

--- a/tests/unit/generators/schema-generator-test.php
+++ b/tests/unit/generators/schema-generator-test.php
@@ -234,7 +234,7 @@ class Schema_Generator_Test extends TestCase {
 	 */
 	public function test_generate_with_no_blocks() {
 		$this->context->indexable->object_sub_type = 'super-custom-post-type';
-		$this->context->has_image                  = false;
+		$this->context->main_image                 = null;
 		$this->context->schema_page_type           = [ 'WebPage' ];
 		$this->context->presentation->breadcrumbs  = [
 			[
@@ -339,7 +339,7 @@ class Schema_Generator_Test extends TestCase {
 	 */
 	public function test_generate_with_empty_breadcrumb() {
 		$this->context->indexable->object_sub_type = 'super-custom-post-type';
-		$this->context->has_image                  = false;
+		$this->context->main_image                 = null;
 		$this->context->schema_page_type           = [ 'WebPage' ];
 		$this->current_page->expects( 'is_paged' )->andReturns( false );
 
@@ -430,7 +430,7 @@ class Schema_Generator_Test extends TestCase {
 			'post_modified_gmt' => 'date',
 			'post_content'      => '',
 		];
-		$this->context->has_image                  = false;
+		$this->context->main_image                 = null;
 
 		Monkey\Functions\expect( 'post_password_required' )
 			->once()
@@ -623,7 +623,7 @@ class Schema_Generator_Test extends TestCase {
 			'post_modified_gmt' => 'date',
 			'post_content'      => '',
 		];
-		$this->context->has_image                  = false;
+		$this->context->main_image                 = null;
 
 		Monkey\Functions\expect( 'post_password_required' )
 			->once()
@@ -686,7 +686,7 @@ class Schema_Generator_Test extends TestCase {
 			'post_modified_gmt' => 'date',
 			'post_content'      => '',
 		];
-		$this->context->has_image                  = false;
+		$this->context->main_image                 = null;
 
 		Monkey\Functions\expect( 'post_password_required' )
 			->once()
@@ -784,7 +784,7 @@ class Schema_Generator_Test extends TestCase {
 			'post_modified_gmt' => 'date',
 			'post_content'      => '',
 		];
-		$this->context->has_image                  = false;
+		$this->context->main_image                 = null;
 
 		Monkey\Functions\expect( 'post_password_required' )
 			->once()
@@ -877,7 +877,7 @@ class Schema_Generator_Test extends TestCase {
 			'post_modified_gmt' => 'date',
 			'post_content'      => '',
 		];
-		$this->context->has_image                  = false;
+		$this->context->main_image                 = null;
 
 		Monkey\Functions\expect( 'post_password_required' )
 			->once()
@@ -985,7 +985,7 @@ class Schema_Generator_Test extends TestCase {
 	 */
 	public function test_generate_with_search_page() {
 		$this->context->indexable->object_sub_type = 'super-custom-post-type';
-		$this->context->has_image                  = false;
+		$this->context->main_image                 = null;
 		$this->context->site_url                   = 'https://fake.url/';
 		$this->context->main_schema_id             = 'https://fake.url/?s=searchterm';
 

--- a/tests/unit/generators/schema/webpage-test.php
+++ b/tests/unit/generators/schema/webpage-test.php
@@ -218,11 +218,7 @@ class WebPage_Test extends TestCase {
 	 * @param string $message        The message to show in case a test fails.
 	 */
 	public function test_generate_with_provider( $values_to_test, $expected, $message ) {
-		$this->meta_tags_context->has_image = $values_to_test['has_image'];
-
-		if ( $this->meta_tags_context->has_image ) {
-			$this->meta_tags_context->main_image_url = $values_to_test['image_url'];
-		}
+		$this->meta_tags_context->main_image = $values_to_test['image'];
 
 		$this->id->breadcrumb_hash = '#breadcrumb';
 
@@ -244,6 +240,8 @@ class WebPage_Test extends TestCase {
 	 * @covers ::add_potential_action
 	 */
 	public function test_generate_on_front_page_site_does_not_represents_reference() {
+		$this->meta_tags_context->main_image = null;
+
 		$this->setup_generate_test(
 			true,
 			1,
@@ -282,6 +280,7 @@ class WebPage_Test extends TestCase {
 	 * @covers ::add_potential_action
 	 */
 	public function test_generate_on_front_page_site_represents_reference() {
+		$this->meta_tags_context->main_image                = null;
 		$this->meta_tags_context->site_represents_reference = [ '@id' => $this->meta_tags_context->site_url . '#organization' ];
 
 		$this->setup_generate_test(
@@ -324,6 +323,7 @@ class WebPage_Test extends TestCase {
 	 * @covers ::add_potential_action
 	 */
 	public function test_generate_object_post_site_represents_true() {
+		$this->meta_tags_context->main_image      = null;
 		$this->meta_tags_context->site_represents = true;
 
 		$this->meta_tags_context->indexable = (object) [
@@ -370,6 +370,7 @@ class WebPage_Test extends TestCase {
 	 * @covers ::add_potential_action
 	 */
 	public function test_generate_object_post_site_represents_false() {
+		$this->meta_tags_context->main_image      = null;
 		$this->meta_tags_context->site_represents = false;
 
 		$this->meta_tags_context->indexable = (object) [
@@ -422,6 +423,7 @@ class WebPage_Test extends TestCase {
 	 * @covers ::add_potential_action
 	 */
 	public function test_generate_description_not_empty() {
+		$this->meta_tags_context->main_image  = null;
 		$this->meta_tags_context->description = 'the-description';
 
 		$this->setup_generate_test(
@@ -469,6 +471,7 @@ class WebPage_Test extends TestCase {
 	 * @covers ::add_potential_action
 	 */
 	public function test_generate_object_type_home_page() {
+		$this->meta_tags_context->main_image       = null;
 		$this->meta_tags_context->schema_page_type = 'CollectionPage';
 		$this->meta_tags_context->indexable        = (object) [
 			'object_type' => 'home-page',
@@ -504,6 +507,7 @@ class WebPage_Test extends TestCase {
 	 * @covers ::add_potential_action
 	 */
 	public function test_generate_home_static_page() {
+		$this->meta_tags_context->main_image       = null;
 		$this->meta_tags_context->schema_page_type = 'CollectionPage';
 
 		$this->setup_generate_test(
@@ -559,7 +563,7 @@ class WebPage_Test extends TestCase {
 		return [
 			[
 				'values_to_test' => [
-					'has_image'           => false,
+					'image'           => null,
 				],
 				'expected'       => [
 					'@type'           => [ 'WebPage' ],
@@ -584,8 +588,7 @@ class WebPage_Test extends TestCase {
 			],
 			[
 				'values_to_test' => [
-					'has_image'           => true,
-					'image_url'           => 'https://example.com/image.jpg',
+					'image'           => new Image( 'https://example.com/image.jpg' ),
 				],
 				'expected'       => [
 					'@type'              => [ 'WebPage' ],
@@ -613,7 +616,7 @@ class WebPage_Test extends TestCase {
 			],
 			[
 				'values_to_test' => [
-					'has_image'           => false,
+					'image'           => null,
 				],
 				'expected'       => [
 					'@type'           => [ 'WebPage' ],
@@ -691,15 +694,7 @@ class WebPage_Test extends TestCase {
 		Monkey\Functions\expect( 'home_url' )
 			->andReturn( 'https://example.com' );
 
-		if ( isset( $featured_image ) ) {
-			$this->meta_tags_context->has_image      = true;
-			$this->meta_tags_context->main_image_id  = $featured_image['id'];
-			$this->meta_tags_context->main_image_url = $featured_image['url'];
-			$this->image
-				->expects( 'get_attachment_image_url' )
-				->with( $featured_image['id'], 'full' )
-				->andReturn( $featured_image['url'] );
-		}
+		$this->meta_tags_context->main_image                      = $featured_image;
 		$this->meta_tags_context->images                          = $content_images;
 		$this->meta_tags_context->presentation->open_graph_images = $open_graph_images;
 		$this->meta_tags_context->presentation->twitter_image     = $twitter_image;
@@ -721,10 +716,7 @@ class WebPage_Test extends TestCase {
 	 */
 	public function generate_with_images_dataprovider() {
 		$only_featured_image_set      = [
-			'featured_image'    => [
-				'id'  => 4,
-				'url' => 'https://example.com/images/image-4.jpg',
-			],
+			'featured_image'    => new Image( 'https://example.com/images/image-4.jpg', 4 ),
 			'content_images'    => [],
 			'open_graph_images' => [],
 			'twitter_image'     => null,
@@ -914,10 +906,7 @@ class WebPage_Test extends TestCase {
 			],
 		];
 		$double_images_featured_image = [
-			'featured_image'    => [
-				'id'  => 1,
-				'url' => 'https://example.com/images/image-1.jpg',
-			],
+			'featured_image'    => new Image( 'https://example.com/images/image-1.jpg', 1 ),
 			'content_images'    => [
 				new Image( 'https://example.com/images/image-1.jpg', 1 ),
 				new Image( 'https://example.com/images/image-2.jpg', 2 ),
@@ -961,10 +950,7 @@ class WebPage_Test extends TestCase {
 			],
 		];
 		$external_images_in_content   = [
-			'featured_image'    => [
-				'id'  => 1,
-				'url' => 'https://example.com/images/image-1.jpg',
-			],
+			'featured_image'    => new Image( 'https://example.com/images/image-1.jpg', 1 ),
 			'content_images'    => [
 				new Image( 'https://example.com/images/image-1.jpg', 1 ),
 				new Image( 'https://external.com/images/image-2.jpg' ),

--- a/tests/unit/generators/schema/webpage-test.php
+++ b/tests/unit/generators/schema/webpage-test.php
@@ -233,18 +233,6 @@ class WebPage_Test extends TestCase {
 			1
 		);
 
-		if ( isset( $values_to_test['image_url'] ) && ! isset( $values_to_test['image_id'] ) ) {
-			$this->image
-				->expects( 'get_attachment_by_url' )
-				->with( $values_to_test['image_url'] )
-				->andReturn( 1 );
-
-			$this->image
-				->expects( 'get_attachment_image_url' )
-				->with( 1, 'full' )
-				->andReturn( $values_to_test['image_url'] );
-		}
-
 		$this->assertEquals( $expected, $this->instance->generate(), $message );
 	}
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Schema generation does not output image sizes when a resized image is the only image in the post (content).

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Convert open graph images to `Image` objects before processing.

## Relevant technical choices:

* The `meta_tags_context` now has an added attribute `main_image` which represents the Primary Image of a page. This partially replaces `has_image`, `main_image_id` and `main_image_url` as these are all encapsulated within `main_image`. All changed code now relies on `main_image` instead of the others.
* Added a function `generate_from_image_object` which takes an `Image` object and generates the Image schema. This function partially replaces `generate_from_url`, `generate_from_attachment_meta` and `generate_from_attachment_id`. All changed code now relies on `generate_from_image_object` instead of the others.
* Made `create_image_object_from_source` public. The idea is to use this function in the future as we always either have an image ID or image URL, with `create_image_object_from_source` we can go from an image URL to a full `Image` object (with all relevant data) and from an ID we can convert to a URL which we can convert to an `Image` object.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Create a new post.
* Add an image to the post content.
* Set the image size to `Thumbnail`.
* Save the post and view the HTML output.
* Verify whether there is one `ImageObject` in the `@graph` and that the `@id` of the `ImageObject` is with size parameters (e.g. 150x150). Also verify that the `primaryImageOfPage` in `@type` `WebPage` is set to the same URL.

* Now add another image to the post content but without changing the image size.
* Verify that it also shows up (so now there are two `ImageObject`'s) but the new one has the original size of the image specified.

* Also add a primary image and verify that it shows up in the schema with its original size.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes [PC-759](https://yoast.atlassian.net/browse/PC-759)
