### PR TITLE
Add parsing site logo gutenberg blocks to image helper

### DIFF
--- a/src/helpers/image-helper.php
+++ b/src/helpers/image-helper.php
@@ -406,6 +406,17 @@ class Image_Helper {
 	}
 
 	/**
+	 * Generate an Image object from the id of an image.
+	 *
+	 * @param int $id The ID of the image.
+	 * @return Image|null The generated Image object.
+	 */
+	protected function create_image_object_from_id( $id ) {
+		$src = $this->get_attachment_image_url( $id, 'full' );
+		return $this->create_image_object_from_source( $src );
+	}
+
+	/**
 	 * Generate an Image object from the source of an image.
 	 *
 	 * @param string $src The src attribute of an img tag.
@@ -502,7 +513,29 @@ class Image_Helper {
 			}
 		}
 
-		return $images;
+		$blocks     = \parse_blocks( $content );
+		$site_logos = $this->get_site_logo_images_from_gutenberg_blocks( $blocks );
+		return \array_merge( $images, $site_logos );
+	}
+
+	/**
+	 * Get site logo images from the post content.
+	 *
+	 * @param array $blocks An array of block objects from the parse_blocks function.
+	 * @return Image[] Found site logo blocks in the blocks array.
+	 */
+	protected function get_site_logo_images_from_gutenberg_blocks( $blocks ) {
+		$site_logos = [];
+		foreach ( $blocks as $block ) {
+			if ( $block['blockName'] === 'core/site-logo' ) {
+				$custom_logo_id = \intval( \get_theme_mod( 'custom_logo' ) );
+				$image_obj      = $this->create_image_object_from_id( $custom_logo_id );
+				if ( ! \is_null( $image_obj ) ) {
+					$site_logos[] = $image_obj;
+				}
+			}
+		}
+		return $site_logos;
 	}
 
 	/**

--- a/src/helpers/image-helper.php
+++ b/src/helpers/image-helper.php
@@ -542,7 +542,7 @@ class Image_Helper {
 		$blocks     = \parse_blocks( $content );
 		foreach ( $blocks as $block ) {
 			if ( $block['blockName'] === 'core/site-logo' ) {
-				$image_obj      = $this->get_image_from_site_logo_block( $block );
+				$image_obj = $this->get_image_from_site_logo_block( $block );
 				if ( ! \is_null( $image_obj ) ) {
 					$site_logos[] = $image_obj;
 				}

--- a/src/helpers/image-helper.php
+++ b/src/helpers/image-helper.php
@@ -513,23 +513,36 @@ class Image_Helper {
 			}
 		}
 
-		$blocks     = \parse_blocks( $content );
-		$site_logos = $this->get_site_logo_images_from_gutenberg_blocks( $blocks );
-		return \array_merge( $images, $site_logos );
+		$gutenberg_images = $this->get_images_from_gutenberg_blocks( $content );
+		return \array_merge( $images, $gutenberg_images );
+	}
+
+	/**
+	 * Generate an Image object from a site logo block.
+	 *
+	 * @param array $block The site logo block.
+	 * @return Image|null An Image object generated from the site logo block.
+	 */
+	protected function get_image_from_site_logo_block( $block ) {
+		if ( $block['blockName'] !== 'core/site-logo' ) {
+			return null;
+		}
+		$custom_logo_id = \intval( \get_theme_mod( 'custom_logo' ) );
+		return $this->create_image_object_from_id( $custom_logo_id );
 	}
 
 	/**
 	 * Get site logo images from the post content.
 	 *
-	 * @param array $blocks An array of block objects from the parse_blocks function.
+	 * @param string $content The post content.
 	 * @return Image[] Found site logo blocks in the blocks array.
 	 */
-	protected function get_site_logo_images_from_gutenberg_blocks( $blocks ) {
+	protected function get_images_from_gutenberg_blocks( $content ) {
 		$site_logos = [];
+		$blocks     = \parse_blocks( $content );
 		foreach ( $blocks as $block ) {
 			if ( $block['blockName'] === 'core/site-logo' ) {
-				$custom_logo_id = \intval( \get_theme_mod( 'custom_logo' ) );
-				$image_obj      = $this->create_image_object_from_id( $custom_logo_id );
+				$image_obj      = $this->get_image_from_site_logo_block( $block );
 				if ( ! \is_null( $image_obj ) ) {
 					$site_logos[] = $image_obj;
 				}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The Site logo gutenberg block outputs an image on the page which is not yet represented in the schema.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Add a parser for the site logo image Gutenberg block such that it also appears in the schema images.

## Relevant technical choices:

* Uses `get_theme_mod` instead of `get_custom_logo` because otherwise parsing of HTML was necessary (`get_custom_logo` returns HTML). The filters that are in `get_custom_logo` are thus NOT applied on our schema output (e.g. if someone has a filter hooked into `get_custom_logo` which changes the image URL their schema will not represent the right image).

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Create a new post and add the site logo image in the post content.
* Save the post and go to the HTML view of the post.
* Check whether in the `@graph` object there is one `ImageObject` type which has the same URL as the site logo image.
* Now add a *different* image to the post content and see whether there are two `ImageObject` objects (of which one is still the site logo image).
* Now add a *different* featured image to the post and see whether there are three `ImageObject` objects (of which one is still the site logo image).
* Now alter the featured image to be the same as the site logo image. Check that there are two `ImageObject` objects (of which one is still the site logo image).

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes [PC-762](https://yoast.atlassian.net/browse/PC-762)