### PR TITLE
Adds local seo tracking and prepares file for all other addon tracking.

### DIFF
--- a/admin/tracking/class-tracking-addon-data.php
+++ b/admin/tracking/class-tracking-addon-data.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * WPSEO plugin file.
+ *
+ * @package WPSEO\Admin\Tracking
+ */
+
+/**
+ * Represents the addon option data.
+ */
+class WPSEO_Tracking_Addon_Data implements WPSEO_Collection {
+
+	/**
+	 * The local options we want to track.
+	 *
+	 * @var string[] The option_names for the options we want to track.
+	 */
+	private $local_include_list = [
+		'use_multiple_locations',
+		'multiple_locations_same_organization',
+		'business_type',
+		'woocommerce_local_pickup_setting',
+	];
+
+	/**
+	 * The woo options we want to track.
+	 *
+	 * @var string[] The option_names for the options we want to track.
+	 */
+	private $woo_include_list = [];
+
+	/**
+	 * The news options we want to track.
+	 *
+	 * @var string[] The option_names for the options we want to track.
+	 */
+	private $news_include_list = [];
+
+	/**
+	 * The video options we want to track.
+	 *
+	 * @var string[] The option_names for the options we want to track.
+	 */
+	private $video_include_list = [];
+
+	/**
+	 * Returns the collection data.
+	 *
+	 * @return array The collection data.
+	 */
+	public function get() {
+
+		$addon_settings = [];
+		$addon_manager  = new WPSEO_Addon_Manager();
+
+		if ( $addon_manager->is_installed( WPSEO_Addon_Manager::LOCAL_SLUG ) ) {
+			$addon_settings = $this->get_addon_settings( $addon_settings, 'wpseo_local', WPSEO_Addon_Manager::LOCAL_SLUG, $this->local_include_list );
+		}
+
+		if ( $addon_manager->is_installed( WPSEO_Addon_Manager::WOOCOMMERCE_SLUG ) ) {
+			$addon_settings = $this->get_addon_settings( $addon_settings, 'wpseo_woo', WPSEO_Addon_Manager::WOOCOMMERCE_SLUG, $this->woo_include_list );
+		}
+
+		if ( $addon_manager->is_installed( WPSEO_Addon_Manager::NEWS_SLUG ) ) {
+			$addon_settings = $this->get_addon_settings( $addon_settings, 'wpseo_news', WPSEO_Addon_Manager::NEWS_SLUG, $this->news_include_list );
+		}
+
+		if ( $addon_manager->is_installed( WPSEO_Addon_Manager::VIDEO_SLUG ) ) {
+			$addon_settings = $this->get_addon_settings( $addon_settings, 'wpseo_video', WPSEO_Addon_Manager::VIDEO_SLUG, $this->video_include_list );
+		}
+
+		return $addon_settings;
+	}
+
+	/**
+	 * Gets the tracked options from the addon
+	 *
+	 * @param array  $addon_settings      The current list of addon settings.
+	 * @param string $source_name         The option key of the addon.
+	 * @param string $slug                The addon slug.
+	 * @param array  $option_include_list All the options to be included in tracking.
+	 *
+	 * @return array
+	 */
+	public function get_addon_settings( array $addon_settings, $source_name, $slug, $option_include_list ) {
+		$source_options          = \get_option( $source_name );
+		$addon_settings[ $slug ] = array_intersect_key( $source_options, array_flip( $option_include_list ) );
+
+		return $addon_settings;
+	}
+}

--- a/admin/tracking/class-tracking-addon-data.php
+++ b/admin/tracking/class-tracking-addon-data.php
@@ -83,7 +83,7 @@ class WPSEO_Tracking_Addon_Data implements WPSEO_Collection {
 	 * @return array
 	 */
 	public function get_addon_settings( array $addon_settings, $source_name, $slug, $option_include_list ) {
-		$source_options          = \get_option( $source_name );
+		$source_options          = get_option( $source_name );
 		$addon_settings[ $slug ] = array_intersect_key( $source_options, array_flip( $option_include_list ) );
 
 		return $addon_settings;

--- a/admin/tracking/class-tracking.php
+++ b/admin/tracking/class-tracking.php
@@ -188,6 +188,7 @@ class WPSEO_Tracking implements WPSEO_WordPress_Integration {
 		$collector->add_collection( new WPSEO_Tracking_Theme_Data() );
 		$collector->add_collection( new WPSEO_Tracking_Plugin_Data() );
 		$collector->add_collection( new WPSEO_Tracking_Settings_Data() );
+		$collector->add_collection( new WPSEO_Tracking_Addon_Data() );
 
 		return $collector;
 	}


### PR DESCRIPTION
## Context

* We want to add some addon options to the tracking.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds tracking for multiple options from the local addon.

## Relevant technical choices:

* I also implemented the option tracking for the other addons (if they are enabled)

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* make sure local is enabled.
*  edit `/admin/class-admin.php`, and at the end of the constructor (should be line 115) add the following lines:
```
		if ( filter_input( INPUT_GET, 'action' ) === 'test' ) {
			$collector = new WPSEO_Collector();
			$collector->add_collection( new WPSEO_Tracking_Addon_Data() );
			echo '<pre>';
			print_r( $collector->collect() );
			echo '</pre>';
		}
		die;
```
* test the tracking of the setting: visit http://basic.wordpress.test/wp-admin/admin.php?page=wpseo_dashboard&action=test and see that among the lines in the array there is:

 ` [use_multiple_locations] => this should contain what you set for the option 'My business has multiple locations'`
   
`[multiple_locations_same_organization] => this should contain what you set for the option 'All locations are part of the same business'`

 ` [business_type] => this should contain the business type. Empty if use multiple is true`

` [woocommerce_local_pickup_setting] => this should contain if the local pickup setting is enabled in woocommerce` or empty as value depending on how the setting is set in your config.`

For my installation the array looks like 
```
[yoast-seo-local] => Array
        (
            [use_multiple_locations] => off
            [multiple_locations_same_organization] => off
            [business_type] => Library
            [woocommerce_local_pickup_setting] => 1
        )
```

* Remove the die; in `/admin/class-admin`. Disable local and re-add the die;
* The array should now be completely empty. When local is disabled the addon collector should always just provide an empty array.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes #
