### PR TITLE
Move schema generation to bottom of page content

### DIFF
--- a/src/context/meta-tags-context.php
+++ b/src/context/meta-tags-context.php
@@ -221,14 +221,13 @@ class Meta_Tags_Context extends Abstract_Presentation {
 	/**
 	 * Generates the images.
 	 *
+	 * Note that the array returned here will get filled with images in the Front_End_Integration with the
+	 * wp_content_img_tag filter so the array of images is filled only after the page content has been loaded.
+	 *
 	 * @return Image[] the images.
 	 */
 	public function generate_images() {
-		if ( $this->post instanceof WP_Post === false ) {
-			return [];
-		}
-
-		return $this->image->get_images_from_post_content( $this->post->post_content );
+		return [];
 	}
 
 	/**

--- a/src/helpers/image-helper.php
+++ b/src/helpers/image-helper.php
@@ -411,7 +411,7 @@ class Image_Helper {
 	 * @param string $src The src attribute of an img tag.
 	 * @return Image|null The generated Image object.
 	 */
-	protected function create_image_object_from_source( $src ) {
+	public function create_image_object_from_source( $src ) {
 		$width  = null;
 		$height = null;
 

--- a/src/integrations/front-end-integration.php
+++ b/src/integrations/front-end-integration.php
@@ -525,6 +525,7 @@ class Front_End_Integration implements Integration_Interface {
 			if ( $this->options->get( 'opengraph' ) === true ) {
 				$presenters = \array_merge( $presenters, $this->open_graph_error_presenters );
 			}
+			return $presenters;
 		}
 
 		$presenters = $this->get_all_presenters();

--- a/tests/unit/integrations/front-end-integration-test.php
+++ b/tests/unit/integrations/front-end-integration-test.php
@@ -237,7 +237,6 @@ class Front_End_Integration_Test extends TestCase {
 			'Yoast\WP\SEO\Presenters\Twitter\Creator_Presenter',
 			'Yoast\WP\SEO\Presenters\Twitter\Site_Presenter',
 			'Yoast\WP\SEO\Presenters\Slack\Enhanced_Data_Presenter',
-			'Yoast\WP\SEO\Presenters\Schema_Presenter',
 			'Yoast\WP\SEO\Presenters\Debug\Marker_Close_Presenter',
 		];
 
@@ -291,7 +290,6 @@ class Front_End_Integration_Test extends TestCase {
 				'Yoast\WP\SEO\Presenters\Open_Graph\Locale_Presenter',
 				'Yoast\WP\SEO\Presenters\Open_Graph\Title_Presenter',
 				'Yoast\WP\SEO\Presenters\Open_Graph\Site_Name_Presenter',
-				'Yoast\WP\SEO\Presenters\Schema_Presenter',
 				'Yoast\WP\SEO\Presenters\Debug\Marker_Close_Presenter',
 			],
 			$expected
@@ -360,7 +358,6 @@ class Front_End_Integration_Test extends TestCase {
 				'Yoast\WP\SEO\Presenters\Twitter\Description_Presenter',
 				'Yoast\WP\SEO\Presenters\Twitter\Image_Presenter',
 				'Yoast\WP\SEO\Presenters\Twitter\Site_Presenter',
-				'Yoast\WP\SEO\Presenters\Schema_Presenter',
 				'Yoast\WP\SEO\Presenters\Debug\Marker_Close_Presenter',
 			],
 			$expected
@@ -412,7 +409,6 @@ class Front_End_Integration_Test extends TestCase {
 				'Yoast\WP\SEO\Presenters\Open_Graph\Locale_Presenter',
 				'Yoast\WP\SEO\Presenters\Open_Graph\Title_Presenter',
 				'Yoast\WP\SEO\Presenters\Open_Graph\Site_Name_Presenter',
-				'Yoast\WP\SEO\Presenters\Schema_Presenter',
 				'Yoast\WP\SEO\Presenters\Debug\Marker_Close_Presenter',
 			],
 			$actual
@@ -458,7 +454,6 @@ class Front_End_Integration_Test extends TestCase {
 				'Yoast\WP\SEO\Presenters\Open_Graph\Locale_Presenter',
 				'Yoast\WP\SEO\Presenters\Open_Graph\Title_Presenter',
 				'Yoast\WP\SEO\Presenters\Open_Graph\Site_Name_Presenter',
-				'Yoast\WP\SEO\Presenters\Schema_Presenter',
 				'Yoast\WP\SEO\Presenters\Debug\Marker_Close_Presenter',
 			],
 			$actual
@@ -511,7 +506,6 @@ class Front_End_Integration_Test extends TestCase {
 				'Yoast\WP\SEO\Presenters\Open_Graph\Locale_Presenter',
 				'Yoast\WP\SEO\Presenters\Open_Graph\Title_Presenter',
 				'Yoast\WP\SEO\Presenters\Open_Graph\Site_Name_Presenter',
-				'Yoast\WP\SEO\Presenters\Schema_Presenter',
 				'Yoast\WP\SEO\Presenters\Debug\Marker_Close_Presenter',
 			],
 			$expected


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Images from Gutenberg blocks are now not processed by our image parser because our image parser parses unprocessed page content.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Move the schema generation to the bottom of the page such that we can use information from the page content to generate images.

## Relevant technical choices:

* The `Front_End_Integration` class now outputs the schema at the bottom of the page instead of the top where it used to output.
* The `wp_content_img_tag` is used to collect images from the page content and display them in the schema.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

*Test whether schema is outputted in the same way*
* Make sure to checkout the repository on `feature/schema-images`.
* Create some posts without images and change some Yoast SEO settings and some page content settings.
* Load the posts and show the HTML source, keep them somewhere in your tabs.
* Now checkout to this branch and load the HTML for the same posts in different tabs.
* Use something like [JSON diff](https://www.jsondiff.com/) to compare the old and the new Schema output. They should be the same.
* Also check whether `meta property="og:image"`, `meta property="og:image:width"`, `meta property="og:image:height"`, `meta property="og:image:type"` show the same values.

*Test whether image schema is outputted for all block types*
* Checkout the repository on this branch.
* Add images to a new post in several different ways (e.g. by using the normal image block, using the site logo Gutenberg block, etc.).
* Save and check the HTML source of the page, verify that the schema has an `ImageObject` for each unique image that was added to the post.
* Test this with Elementor and the classic editor as well.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [x] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [x] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes [PC-774](https://yoast.atlassian.net/browse/PC-774)
