### PR TITLE
PC-389 Improve FRE call to action feedback

### DIFF
--- a/packages/js/src/insights/components/flesch-reading-ease.js
+++ b/packages/js/src/insights/components/flesch-reading-ease.js
@@ -48,7 +48,6 @@ function getDifficultyFeedback( difficulty ) {
 function getCallToAction( difficulty ) {
 	switch ( difficulty ) {
 		case DIFFICULTY.FAIRLY_DIFFICULT:
-			return __( "Try to make shorter sentences to improve readability", "wordpress-seo" );
 		case DIFFICULTY.DIFFICULT:
 		case DIFFICULTY.VERY_DIFFICULT:
 			return __( "Try to make shorter sentences, using less difficult words to improve readability", "wordpress-seo" );

--- a/packages/js/tests/insights/components/flesch-reading-ease.test.js
+++ b/packages/js/tests/insights/components/flesch-reading-ease.test.js
@@ -51,68 +51,99 @@ describe( "The FleschReadingEase component", () => {
 
 		const element = shallow( <FleschReadingEase /> );
 
+		const description = element.prop( "description" ).props.children;
+
+		// Test the description feedback string.
+		expect( description ).toContain(
+			"The copy scores 10 in the test, which is considered very difficult to read."
+		);
+		// Test the call to action string of the feedback.
+		expect( description[ 2 ].props.children ).toContain( "Try to make shorter sentences, using less difficult words to improve readability." );
+
 		expect( element.prop( "amount" ) ).toEqual( 10 );
 		expect( element.prop( "unit" ) ).toEqual( "out of 100" );
 		expect( element.prop( "title" ) ).toEqual( "Flesch reading ease" );
 		expect( element.prop( "linkTo" ) ).toEqual( "https://example.org/link" );
 		expect( element.prop( "linkText" ) ).toEqual( "Learn more about Flesch reading ease" );
-		expect( element.prop( "description" ).props.children ).toContain(
-			"The copy scores 10 in the test, which is considered very difficult to read."
-		);
 	} );
 	it( "renders the component when the text is considered very easy.", () => {
 		mockSelect( 90, DIFFICULTY.VERY_EASY );
 
 		const element = shallow( <FleschReadingEase /> );
 
-		expect( element.prop( "amount" ) ).toEqual( 90 );
-		expect( element.prop( "description" ).props.children ).toContain(
+		const description = element.prop( "description" ).props.children;
+
+		// Test the description feedback string.
+		expect( description ).toContain(
 			"The copy scores 90 in the test, which is considered very easy to read."
 		);
+		// Test the call to action string of the feedback.
+		expect( description ).toContain( "Good job!" );
+		expect( element.prop( "amount" ) ).toEqual( 90 );
 	} );
 	it( "renders the component when the text is considered easy.", () => {
 		mockSelect( 80, DIFFICULTY.EASY );
 
 		const element = shallow( <FleschReadingEase /> );
+		const description = element.prop( "description" ).props.children;
 
-		expect( element.prop( "description" ).props.children ).toContain(
+		// Test the description feedback string.
+		expect( description ).toContain(
 			"The copy scores 80 in the test, which is considered easy to read."
 		);
+		// Test the call to action string of the feedback.
+		expect( description[ 2 ] ).toContain( "Good job!" );
 	} );
 	it( "renders the component when the text is considered fairly easy.", () => {
 		mockSelect( 70, DIFFICULTY.FAIRLY_EASY );
 
 		const element = shallow( <FleschReadingEase /> );
+		const description = element.prop( "description" ).props.children;
 
-		expect( element.prop( "description" ).props.children ).toContain(
+		// Test the description feedback string.
+		expect( description ).toContain(
 			"The copy scores 70 in the test, which is considered fairly easy to read."
 		);
+		// Test the call to action string of the feedback.
+		expect( description[ 2 ] ).toContain( "Good job!" );
 	} );
 	it( "renders the component when the text is considered okay.", () => {
 		mockSelect( 60, DIFFICULTY.OKAY );
 
 		const element = shallow( <FleschReadingEase /> );
+		const description = element.prop( "description" ).props.children;
 
-		expect( element.prop( "description" ).props.children ).toContain(
+		// Test the description feedback string.
+		expect( description ).toContain(
 			"The copy scores 60 in the test, which is considered okay to read."
 		);
+		// Test the call to action string of the feedback.
+		expect( description[ 2 ] ).toContain( "Good job!" );
 	} );
 	it( "renders the component when the text is considered fairly difficult.", () => {
 		mockSelect( 50, DIFFICULTY.FAIRLY_DIFFICULT );
 
 		const element = shallow( <FleschReadingEase /> );
+		const description = element.prop( "description" ).props.children;
 
-		expect( element.prop( "description" ).props.children ).toContain(
+		// Test the description feedback string.
+		expect( description ).toContain(
 			"The copy scores 50 in the test, which is considered fairly difficult to read."
 		);
+		// Test the call to action string of the feedback.
+		expect( description[ 2 ].props.children ).toContain( "Try to make shorter sentences, using less difficult words to improve readability." );
 	} );
 	it( "renders the component when the text is considered difficult.", () => {
 		mockSelect( 30, DIFFICULTY.DIFFICULT );
 
 		const element = shallow( <FleschReadingEase /> );
+		const description = element.prop( "description" ).props.children;
 
-		expect( element.prop( "description" ).props.children ).toContain(
+		// Test the description feedback string.
+		expect( description ).toContain(
 			"The copy scores 30 in the test, which is considered difficult to read."
 		);
+		// Test the call to action string of the feedback.
+		expect( description[ 2 ].props.children ).toContain( "Try to make shorter sentences, using less difficult words to improve readability." );
 	} );
 } );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The call-to-action feedback string for Flesch Reading Ease (FRE) analysis when the text is recognized as "fairly difficult" is not representative of how the FRE score is being calculated. 
   * The string: `Try to make shorter sentences to improve readability` 
   * NOTE: a text is fairly difficult if the score is between 50 - 60 (see [this doc](https://yoast.atlassian.net/wiki/spaces/LIN/pages/1627324605/Flesch+Reading+Ease+Score+General+Overview#Scale))
* This is because the FRE score is influenced by both sentence length, as well as the use of complex (i.e., long) words. 
* In this PR, we want to return the same call-to-action feedback string for Flesch Reading Ease analysis when the text is recognized as "fairly difficult", "difficult", or "very difficult".
   * The string: `Try to make shorter sentences, using less difficult words to improve readability` 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves the call-to-action feedback string of Flesch Reading Ease insight when the text is recognized as fairly difficult.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### With the previous version of Yoast SEO
* Install and activate Yoast SEO version that doesn't include this fix, e.g. 19.8
   * If building the plugin, you can use the version in `main`
 
##### Test in English
* Set the site language to English
* Create a post
* Add content
   * Below you can find text examples with varying difficulty levels:
   [Very easy.txt](https://github.com/Yoast/wordpress-seo/files/9787003/Very.easy.txt)
   [Easy to read.txt](https://github.com/Yoast/wordpress-seo/files/9787007/easy.to.read.txt)
   [Fairly easy.txt](https://github.com/Yoast/wordpress-seo/files/9787009/Fairly.easy.txt)
   [Okay to read.txt](https://github.com/Yoast/wordpress-seo/files/9787012/Okay.to.read.txt)
   [Fairly difficult to read.txt](https://github.com/Yoast/wordpress-seo/files/9787013/Fairly.difficult.to.read.txt)
   [Difficult.txt](https://github.com/Yoast/wordpress-seo/files/9787016/difficult.txt)
   [Very difficult to read.txt](https://github.com/Yoast/wordpress-seo/files/9787018/Very.difficult.to.read.txt)

* Open the Insights tab and confirm that the feedback returns as expected in the table below:

Score | Interpretation | Feedback string
-- | -- | --
90 to 100 | Very Easy | The copy scores X in the test, which is considered very easy to read. Good job!
80 to 90 | Easy | The copy scores X in the test, which is considered easy to read. Good job!
70 to 80 | Fairly easy | The copy scores X in the test, which is considered fairly easy to read. Good job!
60 to 70 | Standard | The copy scores X in the test, which is considered okay to read. Good job!
50 to 60 | Fairly difficult | The copy scores X in the test, which is considered fairly difficult to read. Try to make shorter sentences to improve readability.
30 to 50 | Difficult | The copy scores X in the test, which is considered difficult to read. Try to make shorter sentences, using less difficult words to improve readability.
0 to 30 | Very difficult | The copy scores X in the test, which is considered very difficult to read. Try to make shorter sentences, using less difficult words to improve readability.

* When the text is recognized as "fairly difficult", hover over "Try to make shorter sentences to improve readability."
* Confirm that you can see the shortlink `https://yoa.st/34s` together with the other parameters

##### Test in other language
* Set the site language to one of the languages that have Flesch Reading Ease support, e.g. Dutch
   * Refer to [this doc](https://github.com/Yoast/wordpress-seo/tree/trunk/packages/yoastseo#supported-languages) for the complete list of languages that have Flesch Reading Ease support
* Run the same test steps as in **Test in English** and confirm that you get the same result
* NOTE: Other languages have different formula for calculating Flesch Reading Ease score, hence the same text that scores "difficult" in English, for instance, won't necessarily score the same in Dutch

#### With the current version of Yoast SEO that includes this fix
* Install and activate Yoast SEO that includes this fix

##### Test in English
* Set the site language to English
* Create a post
* Add content
* Open the Insights tab and confirm that the feedback returns as expected in the table below
   

Score | Interpretation | Feedback string
-- | -- | --
90 to 100 | Very Easy | The copy scores X in the test, which is considered very easy to read. Good job!
80 to 90 | Easy | The copy scores X in the test, which is considered easy to read. Good job!
70 to 80 | Fairly easy | The copy scores X in the test, which is considered fairly easy to read. Good job!
60 to 70 | Standard | The copy scores X in the test, which is considered okay to read. Good job!
50 to 60 | Fairly difficult | The copy scores X in the test, which is considered fairly difficult to read. Try to make shorter sentences, using less difficult words to improve readability.
30 to 50 | Difficult | The copy scores X in the test, which is considered difficult to read. Try to make shorter sentences, using less difficult words to improve readability.
0 to 30 | Very difficult | The copy scores X in the test, which is considered very difficult to read. Try to make shorter sentences, using less difficult words to improve readability.

 * When the text is recognized as "fairly difficult", "difficult" or "very difficult", hover over "Try to make shorter sentences, using less difficult words to improve readability."
 * Confirm that you can see the shortlink `https://yoa.st/34s` together with the other parameters
##### Test in other language
* Set the site language to one of the languages that have Flesch Reading Ease support, e.g. Dutch
   * Refer to [this doc](https://github.com/Yoast/wordpress-seo/tree/trunk/packages/yoastseo#supported-languages) for the complete list of languages that have Flesch Reading Ease support
* Run the same test steps as in **Test in English** and confirm that you get the same result

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [x] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes #
