### PR TITLE
PC-829 - SEO Optimisation errors when trying to get the file size of an non-existing image

### DIFF
--- a/src/builders/indexable-link-builder.php
+++ b/src/builders/indexable-link-builder.php
@@ -304,12 +304,14 @@ class Indexable_Link_Builder {
 
 		if ( $is_image && $model->target_post_id ) {
 			$file = \get_attached_file( $model->target_post_id );
-			if ( $file && \file_exists( $file ) ) {
+			if ( $file ) {
 				list( , $width, $height ) = \wp_get_attachment_image_src( $model->target_post_id, 'full' );
 
 				$model->width  = $width;
 				$model->height = $height;
-				$model->size   = \filesize( $file );
+				if ( \file_exists( $file ) ) {
+					$model->size = \filesize( $file );
+				}
 			}
 			else {
 				$model->width  = 0;

--- a/src/builders/indexable-link-builder.php
+++ b/src/builders/indexable-link-builder.php
@@ -304,7 +304,7 @@ class Indexable_Link_Builder {
 
 		if ( $is_image && $model->target_post_id ) {
 			$file = \get_attached_file( $model->target_post_id );
-			if ( \file_exists( $file ) ) {
+			if ( $file && \file_exists( $file ) ) {
 				list( , $width, $height ) = \wp_get_attachment_image_src( $model->target_post_id, 'full' );
 
 				$model->width  = $width;

--- a/src/builders/indexable-link-builder.php
+++ b/src/builders/indexable-link-builder.php
@@ -304,7 +304,7 @@ class Indexable_Link_Builder {
 
 		if ( $is_image && $model->target_post_id ) {
 			$file = \get_attached_file( $model->target_post_id );
-			if ( $file ) {
+			if ( \file_exists( $file ) ) {
 				list( , $width, $height ) = \wp_get_attachment_image_src( $model->target_post_id, 'full' );
 
 				$model->width  = $width;

--- a/src/builders/indexable-link-builder.php
+++ b/src/builders/indexable-link-builder.php
@@ -312,6 +312,9 @@ class Indexable_Link_Builder {
 				if ( \file_exists( $file ) ) {
 					$model->size = \filesize( $file );
 				}
+				else {
+					$model->size = null;
+				}
 			}
 			else {
 				$model->width  = 0;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* When saving a post (or optimising a post within the SEO optimisation routine) we look through its contents for internal and external links (to other webpages or to images) and save information about it in the database.
   * When we would encounter a link to an image, we try to retrieve its file size and save it. However, if this failed, PHP would give a warning.
   * When WordPress debugging is on, this warning was output in the response to a REST-request in the SEO optimisation.
   * Since this response was expected to be JSON, but now included a warning in HTML, the SEO optimisation gave an error.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the SEO optimization routine would give an error when an image file of an image linked in a post could not be retrieved.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Make sure that your WordPress environment displays PHP warnings by making sure that `WP_DEBUG` is set to `TRUE` in your environment.
  * For the plugin development docker: 
    * Open the `.env` file in the root of the `plugin-development-docker` folder and make sure `WORDPRESS_DEBUG=TRUE` is there.
    * **Note**: This file is hidden, so access it via the terminal.  
      * If you have Sublime installed, you can use `subl .env` (in the root of plugin-development-docker) to open the `.env` file in Sublime. 
    * Alternatively: replace `define( 'WP_DEBUG', !!getenv_docker('WORDPRESS_DEBUG', '') );` with `define( 'WP_DEBUG', true );`
* Make sure that you have the Yoast test helper plugin installed and activated.

#### SEO Optimisation
* Create a post and add an image to it.
* Save or publish the post.
* Remove the image file of the image you added to the post, manually, from your environment, so the image (and its size) can't be retrieved.
   * Navigate (in your Finder application) to `wp-content/uploads` and remove some images (most likely located in some subfolders). 
* Make sure that your site is **not** SEO optimised by resetting your indexables table and migrations using the Yoast test helper.
   * Go to _Tools_ > _Yoast Test_. Click on the button titled _Reset Indexables tables & migrations_ in the Yoast SEO box.
* Rerun the SEO Optimisation by going to the Yoast SEO Tools page (_Yoast SEO_ > _Tools_) and clicking on the _Start SEO data optimisation_ button.
* The SEO data optimisation should complete without giving any errors. 

#### Post editor
* Create a post and add an image to it.
* Publish the post.
* Remove the image file of the image you added to the post, manually, from your environment, so the image (and its size) can't be retrieved.
   * Navigate (in your Finder application) to `wp-content/uploads` and remove some images (most likely located in some subfolders). 
* Remove the image from the `yoast_seo_links` table in your database (using your favourite database tool of choice). 
    * Locate the row in the table that corresponds with the image in the post.
       * The value in the `post_id` column should be the ID of the post.
       * The value in the `url` column should be the URL of the image.
* Open the post in the post editor again.
* There's probably a 404 error in the console because the image can't be retrieved, that's expected.
* Save / publish the post again (you may need to change the post a bit for the _Update_ button to reappear. The block editor does not let you resave when the post has not changed).
* The size of the image in the post you just saved should be set to `null` inside of the `yoast_seo_links` table in the database. This indicates that we could not get its size.
    * The value in the `size` column of the image should be `NULL`.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
  * Switch over to the network tab in your browser tools. 
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Please run the SEO optimisation again on staging, to make sure that [the error that was shared in #test](https://yoast.slack.com/archives/C027BFR5L/p1665990100931139) does not happen with this fix.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The impact is limited to internal links to images inside of posts, pages and custom post types. 
   * The added code checks if the image file references in the internal link exists. If it does, we check its file size, if not, we set file size to `null`.
   * In this sense, there are only two conditions which behaviour is impacted: if an internal link to an image links to an existing local image, or this image does not exist (or can't be retrieved locally). 

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes #
