### PR TITLE
Adds BF banner

### DIFF
--- a/css/src/yst_plugin_tools.css
+++ b/css/src/yst_plugin_tools.css
@@ -572,6 +572,8 @@ body.toplevel_page_wpseo_dashboard .wp-badge {
 }
 
 .yoast-sidebar__product .product-image {
+	position: relative;
+	z-index: 2;
 	max-width: 75px;
 	max-height: 75px;
 	margin: -50px auto 16px;
@@ -627,6 +629,41 @@ body.toplevel_page_wpseo_dashboard .wp-badge {
 	font-size: 20px;
 	line-height: 24px;
 }
+
+.yoast-sidebar__product .sidebar__sale_banner_container {
+	width: calc(100% + 48px);
+	margin-left: -24px;
+	overflow-x: hidden;
+	overflow-y: initial;
+	margin-top: -40px;
+}
+.yoast-sidebar__product .sidebar__sale_banner_container .sidebar__sale_banner {
+	background: #000;
+	width: calc(100% + 60px);
+	line-height: 36px;
+	margin-left: -30px;
+	transform: rotate(-5deg);
+	font-size: 20px;
+	font-weight: 500;
+	letter-spacing: 0.5px;
+	text-align: center;
+	z-index: 1;
+	margin-top: 20px;
+	margin-bottom: 20px;
+	box-shadow: 0 -1px 4px 0 #fff, 0 1px 4px 0 #fff, 0 -1px 0 0 #fff, 0 1px 0 0 #fff;
+
+}
+
+.yoast-sidebar__product .sidebar__sale_text {
+	text-align: center;
+	border-top: solid 1px #ffffff;
+	font-style: italic;
+}
+.yoast-sidebar__product .sidebar__sale_text p {
+	font-size: 12.5px;
+	margin: 12.5px 0;
+}
+
 
 .yoast-sidebar__section {
 	box-shadow: 0 1px 6px 0 rgba(0, 0, 0, 0.3);

--- a/src/presenters/admin/sidebar-presenter.php
+++ b/src/presenters/admin/sidebar-presenter.php
@@ -16,6 +16,10 @@ class Sidebar_Presenter extends Abstract_Presenter {
 	 * @return string The sidebar HTML.
 	 */
 	public function present() {
+		$time       = time();
+		$time_start = gmmktime( 10, 00, 00, 11, 22, 2022 );
+		$time_end   = gmmktime( 10, 00, 00, 11, 29, 2022 );
+
 		$assets_uri              = \trailingslashit( \plugin_dir_url( WPSEO_FILE ) );
 		$buy_yoast_seo_shortlink = WPSEO_Shortlinker::get( 'https://yoa.st/jj' );
 		\ob_start();
@@ -42,6 +46,13 @@ class Sidebar_Presenter extends Abstract_Presenter {
 									sizes="(min-width: 1321px) 75px">
 							</figure>
 						</figure>
+						<?php if ( ( $time > $time_start ) && ( $time < $time_end ) ) : ?>
+							<div class="sidebar__sale_banner_container">
+								<div class="sidebar__sale_banner">
+									<?php esc_html_e( 'BLACK FRIDAY - 30% OFF', 'wordpress-seo' ); ?>
+								</div>
+							</div>
+						<?php endif; ?>
 						<h2>
 							<?php
 							/* translators: %s expands to Yoast SEO Premium */
@@ -54,6 +65,16 @@ class Sidebar_Presenter extends Abstract_Presenter {
 							\printf( \esc_html__( 'Be the first to %1$s get new features & tools%2$s, before everyone else. Get %1$s 24/7 support%2$s and boost your website’s visibility.', 'wordpress-seo' ), '<strong>', '</strong>' );
 							?>
 						</p>
+						<?php if ( ( $time > $time_start ) && ( $time < $time_end ) ) : ?>
+							<div class="sidebar__sale_text">
+								<p>
+									<?php
+									/* translators: %1$s expands to an opening strong tag, %2$s expands to a closing strong tag */
+									\printf( \esc_html__( '%1$s SAVE 30%% %2$s on your 12 month subscription', 'wordpress-seo' ), '<strong>', '</strong>' );
+									?>
+								</p>
+							</div>
+						<?php endif; ?>
 						<p class="plugin-buy-button">
 							<a class="yoast-button-upsell" target="_blank" href="<?php echo \esc_url( $buy_yoast_seo_shortlink ); ?>">
 								<?php
@@ -69,14 +90,15 @@ class Sidebar_Presenter extends Abstract_Presenter {
 									<?php \esc_html_e( 'Read reviews from real users', 'wordpress-seo' ); ?>
 								</h3>
 								<span class="rating">
-								<img alt="" loading="lazy" fetchpriorty="low" decoding="async" height="22" width="22" src="<?php echo \esc_url( $assets_uri . 'packages/js/images/logo-g2-white.svg' ); ?>">
-								<img alt="" loading="lazy" fetchpriorty="low" decoding="async" height="22" width="22" src="<?php echo \esc_url( $assets_uri . 'packages/js/images/star-rating-star.svg' ); ?>">
-								<img alt="" loading="lazy" fetchpriorty="low" decoding="async" height="22" width="22" src="<?php echo \esc_url( $assets_uri . 'packages/js/images/star-rating-star.svg' ); ?>">
-								<img alt="" loading="lazy" fetchpriorty="low" decoding="async" height="22" width="22" src="<?php echo \esc_url( $assets_uri . 'packages/js/images/star-rating-star.svg' ); ?>">
-								<img alt="" loading="lazy" fetchpriorty="low" decoding="async" height="22" width="22" src="<?php echo \esc_url( $assets_uri . 'packages/js/images/star-rating-star.svg' ); ?>">
-								<img alt="" loading="lazy" fetchpriorty="low" decoding="async" height="22" width="22" src="<?php echo \esc_url( $assets_uri . 'packages/js/images/star-rating-half.svg' ); ?>">
-								<span class="rating-text">4.6 / 5</span>
-							</span>
+									<img alt="" loading="lazy" fetchpriorty="low" decoding="async" height="22" width="22" src="<?php echo \esc_url( $assets_uri . 'packages/js/images/logo-g2-white.svg' ); ?>">
+									<img alt="" loading="lazy" fetchpriorty="low" decoding="async" height="22" width="22" src="<?php echo \esc_url( $assets_uri . 'packages/js/images/star-rating-star.svg' ); ?>">
+									<img alt="" loading="lazy" fetchpriorty="low" decoding="async" height="22" width="22" src="<?php echo \esc_url( $assets_uri . 'packages/js/images/star-rating-star.svg' ); ?>">
+									<img alt="" loading="lazy" fetchpriorty="low" decoding="async" height="22" width="22" src="<?php echo \esc_url( $assets_uri . 'packages/js/images/star-rating-star.svg' ); ?>">
+									<img alt="" loading="lazy" fetchpriorty="low" decoding="async" height="22" width="22" src="<?php echo \esc_url( $assets_uri . 'packages/js/images/star-rating-star.svg' ); ?>">
+									<img alt="" loading="lazy" fetchpriorty="low" decoding="async" height="22" width="22" src="<?php echo \esc_url( $assets_uri . 'packages/js/images/star-rating-half.svg' ); ?>">
+									<span class="rating-text">4.6 / 5</span>
+
+								</span>
 							</a>
 						</div>
 					</div>

--- a/src/presenters/admin/sidebar-presenter.php
+++ b/src/presenters/admin/sidebar-presenter.php
@@ -16,9 +16,9 @@ class Sidebar_Presenter extends Abstract_Presenter {
 	 * @return string The sidebar HTML.
 	 */
 	public function present() {
-		$time       = time();
-		$time_start = gmmktime( 10, 00, 00, 11, 22, 2022 );
-		$time_end   = gmmktime( 10, 00, 00, 11, 29, 2022 );
+		$time       = \time();
+		$time_start = \gmmktime( 10, 00, 00, 11, 22, 2022 );
+		$time_end   = \gmmktime( 10, 00, 00, 11, 29, 2022 );
 
 		$assets_uri              = \trailingslashit( \plugin_dir_url( WPSEO_FILE ) );
 		$buy_yoast_seo_shortlink = WPSEO_Shortlinker::get( 'https://yoa.st/jj' );
@@ -49,7 +49,7 @@ class Sidebar_Presenter extends Abstract_Presenter {
 						<?php if ( ( $time > $time_start ) && ( $time < $time_end ) ) : ?>
 							<div class="sidebar__sale_banner_container">
 								<div class="sidebar__sale_banner">
-									<?php esc_html_e( 'BLACK FRIDAY - 30% OFF', 'wordpress-seo' ); ?>
+									<?php \esc_html_e( 'BLACK FRIDAY - 30% OFF', 'wordpress-seo' ); ?>
 								</div>
 							</div>
 						<?php endif; ?>

--- a/src/presenters/admin/sidebar-presenter.php
+++ b/src/presenters/admin/sidebar-presenter.php
@@ -17,8 +17,8 @@ class Sidebar_Presenter extends Abstract_Presenter {
 	 */
 	public function present() {
 		$time       = \time();
-		$time_start = \gmmktime( 10, 00, 00, 11, 22, 2022 );
-		$time_end   = \gmmktime( 10, 00, 00, 11, 29, 2022 );
+		$time_start = \gmmktime( 11, 00, 00, 11, 22, 2022 );
+		$time_end   = \gmmktime( 11, 00, 00, 11, 29, 2022 );
 
 		$assets_uri              = \trailingslashit( \plugin_dir_url( WPSEO_FILE ) );
 		$buy_yoast_seo_shortlink = WPSEO_Shortlinker::get( 'https://yoa.st/jj' );

--- a/src/presenters/admin/sidebar-presenter.php
+++ b/src/presenters/admin/sidebar-presenter.php
@@ -20,6 +20,9 @@ class Sidebar_Presenter extends Abstract_Presenter {
 		$time_start = \gmmktime( 11, 00, 00, 11, 22, 2022 );
 		$time_end   = \gmmktime( 11, 00, 00, 11, 29, 2022 );
 
+		$cyber_monday_start = \gmmktime( 11, 00, 00, 11, 27, 2022 );
+		$title              = ( $time > $cyber_monday_start ) ? \__( 'CYBER MONDAY - 30% OFF', 'wordpress-seo' ) : \__( 'BLACK FRIDAY - 30% OFF', 'wordpress-seo' );
+
 		$assets_uri              = \trailingslashit( \plugin_dir_url( WPSEO_FILE ) );
 		$buy_yoast_seo_shortlink = WPSEO_Shortlinker::get( 'https://yoa.st/jj' );
 		\ob_start();
@@ -49,7 +52,7 @@ class Sidebar_Presenter extends Abstract_Presenter {
 						<?php if ( ( $time > $time_start ) && ( $time < $time_end ) ) : ?>
 							<div class="sidebar__sale_banner_container">
 								<div class="sidebar__sale_banner">
-									<?php \esc_html_e( 'BLACK FRIDAY - 30% OFF', 'wordpress-seo' ); ?>
+									<?php echo \esc_html( $title ); ?>
 								</div>
 							</div>
 						<?php endif; ?>


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->
 
* We want to show a banner in our up sale sidebar at certain times.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds a sale badge to the upsell on our main settings page, that is temporarily shown.

## Relevant technical choices:

* The function used to calculate the time is `gmmktime` and it says it is in GMT so the time is 2 hours before CET.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Either change the time of you php (dev) server, or change the date and time in the code
* You can use the https://www.epochconverter.com/ site to get timestamps from Human Dates and then put them in the `$time` variable.
* When the time is within the set time window, the sidebar should change to the design in the issue.

**For 22 Nov 12.00 CET - 27 Nov 12.00 CET** - we should show `Black Friday`
**For 27 Nov 12.00 CET - 29 Nov 12.00 CET** - we should show `Cyber Monday`

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [X] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [X] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes #
