### PR TITLE
Move inclusive language assessment and assessor from Premium to Free

### DIFF
--- a/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/InclusiveLanguageAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/InclusiveLanguageAssessmentSpec.js
@@ -1,0 +1,25 @@
+import InclusiveLanguageAssessment from "../../../../src/scoring/assessments/inclusiveLanguage/InclusiveLanguageAssessment";
+import assessments from "../../../../src/scoring/assessments/inclusiveLanguage/configuration/cultureAssessments";
+import { values } from "yoastseo";
+
+const { Paper } = values;
+
+describe( "inclusive Language Assessments", () => {
+	it( "should signal it does not have enough content for assessment for short texts", () => {
+		const assessment = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "firstWorld" ) );
+
+		const mockPaper = new Paper( "These are my First World problems." );
+		expect( assessment.hasEnoughContentForAssessment( mockPaper ) ).toBe( false );
+	} );
+
+	it( "should signal it does have enough content for assessment for longer texts", () => {
+		const assessment = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "firstWorld" ) );
+
+		const mockPaper = new Paper( "Alice was beginning to get very tired of sitting by her sister on the\n" +
+			"bank, and of having nothing to do: once or twice she had peeped into\n" +
+			"the book her sister was reading, but it had no pictures or\n" +
+			"conversations in it, “and what is the use of a book,” thought Alice\n" +
+			"“without pictures or conversations?”" );
+		expect( assessment.hasEnoughContentForAssessment( mockPaper ) ).toBe( true );
+	} );
+} );

--- a/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/ageAssessmentsSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/ageAssessmentsSpec.js
@@ -1,0 +1,85 @@
+import Paper from "../../../../../src/values/Paper";
+import Mark from "../../../../../src/values/Mark";
+import InclusiveLanguageAssessment from "../../../../../src/scoring/assessments/inclusiveLanguage/InclusiveLanguageAssessment";
+import assessments from "../../../../../src/scoring/assessments/inclusiveLanguage/configuration/ageAssessments";
+import Factory from "../../../../specHelpers/factory.js";
+
+describe( "Age assessments", function() {
+	it( "should target non-inclusive phrases", function() {
+		const mockText = "This ad is aimed at aging dependants";
+		const mockPaper = new Paper( mockText );
+		const mockResearcher = Factory.buildMockResearcher( [ mockText ] );
+		const assessor = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "agingDependants" ) );
+
+		const isApplicable = assessor.isApplicable( mockPaper, mockResearcher );
+		const assessmentResult = assessor.getResult();
+
+		expect( isApplicable ).toBeTruthy();
+		expect( assessmentResult.getScore() ).toEqual( 3 );
+		expect( assessmentResult.getText() ).toEqual(
+			"Avoid using <i>aging dependants</i> as it is potentially harmful. Consider using an alternative," +
+			" such as <i>older people</i>, unless referring to someone who explicitly wants to be referred to with this term." +
+			" Or, if possible, be specific about the group you are referring to (e.g. <i>people older than 70</i>)." +
+			" <a href='https://yoa.st/inclusive-language-age' target='_blank'>Learn more.</a>" );
+		expect( assessmentResult.hasMarks() ).toBeTruthy();
+		expect( assessor.getMarks() ).toEqual( [ new Mark( {
+			original: mockText,
+			marked: "<yoastmark class='yoast-text-mark'>" + mockText + "</yoastmark>",
+		} ) ] );
+	} );
+
+	it( "should target potentially non-inclusive phrases", function() {
+		const mockPaper = new Paper( "This ad is aimed at senior citizens. But this ad is aimed at the youth." );
+		const mockResearcher = Factory.buildMockResearcher( [ "This ad is aimed at senior citizens.", "But this ad is aimed at the youth." ] );
+		const assessor = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "seniorCitizens" ) );
+
+		const isApplicable = assessor.isApplicable( mockPaper, mockResearcher );
+		const assessmentResult = assessor.getResult();
+
+		expect( isApplicable ).toBeTruthy();
+		expect( assessmentResult.getScore() ).toEqual( 6 );
+		expect( assessmentResult.getText() ).toEqual(
+			"Be careful when using <i>senior citizens</i> as it is potentially harmful. Consider using an alternative," +
+			" such as <i>older citizen(s)</i>, unless referring to someone who explicitly wants to be referred to with this term." +
+			" Or, if possible, be specific about the group you are referring to (e.g. <i>people older than 70</i>)." +
+			" <a href='https://yoa.st/inclusive-language-age' target='_blank'>Learn more.</a>" );
+		expect( assessmentResult.hasMarks() ).toBeTruthy();
+		expect( assessor.getMarks() ).toEqual( [ new Mark( {
+			original: "This ad is aimed at senior citizens.",
+			marked: "<yoastmark class='yoast-text-mark'>This ad is aimed at senior citizens.</yoastmark>",
+		} ) ] );
+	} );
+
+	it( "should not target phrases preceded by certain words", function() {
+		const mockPaper = new Paper( "This ad is aimed at high school seniors." );
+		const mockResearcher = Factory.buildMockResearcher( [ "This ad is aimed at high school seniors." ] );
+		const assessor = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "seniors" ) );
+
+		const isApplicable = assessor.isApplicable( mockPaper, mockResearcher );
+
+		expect( isApplicable ).toBeFalsy();
+		expect( assessor.getMarks() ).toEqual( [] );
+	} );
+
+	it( "should not target phrases followed by by certain words", function() {
+		const mockPaper = new Paper( "This ad is aimed at seniors who are graduating." );
+		const mockResearcher = Factory.buildMockResearcher( [ "This ad is aimed at seniors who are graduating." ] );
+		const assessor = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "seniors" ) );
+
+		const isApplicable = assessor.isApplicable( mockPaper, mockResearcher );
+
+		expect( isApplicable ).toBeFalsy();
+		expect( assessor.getMarks() ).toEqual( [] );
+	} );
+
+	it( "should not target other phrases", function() {
+		const mockPaper = new Paper( "This ad is aimed at the youth" );
+		const mockResearcher = Factory.buildMockResearcher( [ "This ad is aimed at the youth" ] );
+		const assessor = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "seniorCitizens" ) );
+
+		const isApplicable = assessor.isApplicable( mockPaper, mockResearcher );
+
+		expect( isApplicable ).toBeFalsy();
+		expect( assessor.getMarks() ).toEqual( [] );
+	} );
+} );

--- a/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/appearanceAssessmentsSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/appearanceAssessmentsSpec.js
@@ -1,0 +1,89 @@
+import Paper from "../../../../../src/values/Paper";
+import EnglishResearcher from "../../../../../src/languageProcessing/languages/en/Researcher";
+import InclusiveLanguageAssessment from "../../../../../src/scoring/assessments/inclusiveLanguage/InclusiveLanguageAssessment";
+import assessments from "../../../../../src/scoring/assessments/inclusiveLanguage/configuration/appearanceAssessments";
+
+describe( "Appearance assessments", function() {
+	it( "should target non-inclusive phrases",
+		function() {
+			const mockPaper = new Paper( "This ad is aimed at albinos" );
+			const mockResearcher = new EnglishResearcher( mockPaper );
+			const assessor = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "albinos" ) );
+
+			const isApplicable = assessor.isApplicable( mockPaper, mockResearcher );
+			const assessmentResult = assessor.getResult();
+
+			expect( isApplicable ).toBeTruthy();
+			expect( assessmentResult.getScore() ).toEqual( 6 );
+			expect( assessmentResult.getText() ).toEqual(
+				"Be careful when using <i>albinos</i> as it is potentially harmful. " +
+				"Consider using an alternative, such as people with albinism, albino people, " +
+				"unless referring to someone who explicitly wants to be referred to with this term. " +
+				"<a href='https://yoa.st/inclusive-language-appearance' target='_blank'>Learn more.</a>" );
+			expect( assessmentResult.hasMarks() ).toBeTruthy();
+			expect( assessor.getMarks() ).toEqual( [ { _properties:
+					{ marked: "<yoastmark class='yoast-text-mark'>This ad is aimed at albinos</yoastmark>",
+						original: "This ad is aimed at albinos",
+					} } ] );
+		} );
+
+	it( "should target potentially non-inclusive phrases", function() {
+		const mockPaper = new Paper( "This ad is aimed at obese citizens." );
+		const mockResearcher = new EnglishResearcher( mockPaper );
+		const assessor = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "obese" )  );
+
+		const isApplicable = assessor.isApplicable( mockPaper, mockResearcher );
+		const assessmentResult = assessor.getResult();
+
+		expect( isApplicable ).toBeTruthy();
+		expect( assessmentResult.getScore() ).toEqual( 6 );
+		expect( assessmentResult.getText() ).toEqual(
+			"Avoid using <i>obese</i> as it is potentially harmful. " +
+			"Consider using an alternative, such as " +
+			"<i>has/have a higher weight, higher-weight person/people, person/people in higher weight body/bodies, heavier person/people</i>. " +
+			"Alternatively, if talking about a specific person, use their preferred descriptor if known. " +
+			"<a href='https://yoa.st/inclusive-language-appearance' target='_blank'>Learn more.</a>" );
+		expect( assessmentResult.hasMarks() ).toBeTruthy();
+		expect( assessor.getMarks() ).toEqual( [
+			{ _properties: {
+				marked: "<yoastmark class='yoast-text-mark'>This ad is aimed at obese citizens.</yoastmark>",
+				original: "This ad is aimed at obese citizens.",
+			} } ] );
+	} );
+
+	it( "should not target phrases preceded by certain words", function() {
+		const mockPaper = new Paper( "This ad is aimed at high vertically challenged." );
+		const mockResearcher = new EnglishResearcher( mockPaper );
+		const assessor = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "verticallyChallenged" )  );
+
+		const isApplicable = assessor.isApplicable( mockPaper, mockResearcher );
+
+		expect( isApplicable ).toBeTruthy();
+		expect( assessor.getMarks() ).toEqual(  [
+			{ _properties: {
+				marked: "<yoastmark class='yoast-text-mark'>This ad is aimed at high vertically challenged.</yoastmark>",
+				original: "This ad is aimed at high vertically challenged." } } ] );
+	} );
+
+	it( "should not target phrases followed by by certain words", function() {
+		const mockPaper = new Paper( "This ad is aimed at seniors midgets." );
+		const mockResearcher = new EnglishResearcher( mockPaper );
+		const assessor = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "midget" )  );
+
+		const isApplicable = assessor.isApplicable( mockPaper, mockResearcher );
+
+		expect( isApplicable ).toBeFalsy();
+		expect( assessor.getMarks() ).toEqual( [] );
+	} );
+
+	it( "should not target other phrases", function() {
+		const mockPaper = new Paper( "This ad is aimed at harelips" );
+		const mockResearcher = new EnglishResearcher( mockPaper );
+		const assessor = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "harelip" )  );
+
+		const isApplicable = assessor.isApplicable( mockPaper, mockResearcher );
+
+		expect( isApplicable ).toBeFalsy();
+		expect( assessor.getMarks() ).toEqual( [] );
+	} );
+} );

--- a/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/cultureAssessmentsSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/cultureAssessmentsSpec.js
@@ -1,0 +1,56 @@
+import Paper from "../../../../../src/values/Paper";
+import InclusiveLanguageAssessment from "../../../../../src/scoring/assessments/inclusiveLanguage/InclusiveLanguageAssessment";
+import assessments from "../../../../../src/scoring/assessments/inclusiveLanguage/configuration/cultureAssessments";
+import Factory from "../../../../specHelpers/factory.js";
+
+describe( "Culture Assessments", () => {
+	it( "should target only capitalized non-inclusive phrases when the caseSensitive flag is set", () => {
+		const assessment = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "firstWorld" ) );
+
+		const mockPaper = new Paper( "These are my First World problems." );
+		const mockResearcher = Factory.buildMockResearcher( [ "These are my First World problems." ] );
+
+		expect( assessment.isApplicable( mockPaper, mockResearcher ) ).toBe( true );
+	} );
+	it( "should not target non-capitalized phrases when the caseSensitive flag is set", () => {
+		const assessment = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "firstWorld" ) );
+
+		const mockPaper = new Paper( "This is the first world I created." );
+		const mockResearcher = Factory.buildMockResearcher( [ "This is the first world I created." ] );
+
+		expect( assessment.isApplicable( mockPaper, mockResearcher ) ).toBe( false );
+	} );
+
+	it( "should not target First World when followed by exception words.", () => {
+		const assessment = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "firstWorld" ) );
+		[ "War", "war", "Assembly", "assembly" ].map( ( exceptionWord ) => {
+			const testSentence = `This is the First World ${exceptionWord}.`;
+			const mockPaper = new Paper( testSentence );
+			const mockResearcher = Factory.buildMockResearcher( [ testSentence ] );
+
+			expect( assessment.isApplicable( mockPaper, mockResearcher ) ).toBe( false );
+		} );
+	} );
+
+	it( "should not target Third World when followed by exception words.", () => {
+		const assessment = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "thirdWorld" ) );
+		[ "War", "war", "Quarterly", "quarterly", "country" ].map( ( exceptionWord ) => {
+			const testSentence = `This is the Third World ${exceptionWord}.`;
+			const mockPaper = new Paper( testSentence );
+			const mockResearcher = Factory.buildMockResearcher( [ testSentence ] );
+
+			expect( assessment.isApplicable( mockPaper, mockResearcher ) ).toBe( false );
+		} );
+	} );
+
+	it( "should not target gyp when it is a noun.", () => {
+		const assessment = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "gypVerb" ) );
+		[ "a", "the" ].map( ( article ) => {
+			const testSentence = `This is ${article} gyp.`;
+			const mockPaper = new Paper( testSentence );
+			const mockResearcher = Factory.buildMockResearcher( [ testSentence ] );
+
+			expect( assessment.isApplicable( mockPaper, mockResearcher ) ).toBe( false );
+		} );
+	} );
+} );

--- a/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessmentsSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessmentsSpec.js
@@ -1,0 +1,124 @@
+import Paper from "../../../../../src/values/Paper";
+import Mark from "../../../../../src/values/Mark";
+import InclusiveLanguageAssessment from "../../../../../src/scoring/assessments/inclusiveLanguage/InclusiveLanguageAssessment";
+import assessments from "../../../../../src/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessments";
+import Factory from "../../../../specHelpers/factory.js";
+
+describe( "Disability assessments", function() {
+	it( "should return proper feedback with two inclusive alternatives", function() {
+		const mockPaper = new Paper( "Look at that sociopath." );
+		const mockResearcher = Factory.buildMockResearcher( [ "Look at that sociopath." ] );
+		const assessor = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "sociopath" ) );
+		const isApplicable = assessor.isApplicable( mockPaper, mockResearcher );
+		const assessmentResult = assessor.getResult();
+
+		expect( isApplicable ).toBeTruthy();
+		expect( assessmentResult.getScore() ).toEqual( 6 );
+		expect( assessmentResult.getText() ).toEqual(
+			"Be careful when using <i>sociopath</i> as it is potentially harmful. If you are referencing the medical condition, use " +
+			"<i>person with antisocial personality disorder</i> instead, " +
+			"unless referring to someone who explicitly wants to be referred to with this term. " +
+			"If you are not referencing the medical condition, consider other alternatives to describe the trait or behavior, such as " +
+			"<i>toxic, manipulative, cruel</i>. <a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>" );
+		expect( assessmentResult.hasMarks() ).toBeTruthy();
+		expect( assessor.getMarks() ).toEqual( [ new Mark( {
+			original: "Look at that sociopath.",
+			marked: "<yoastmark class='yoast-text-mark'>Look at that sociopath.</yoastmark>",
+		} ) ] );
+	} );
+
+	it( "should target potentially non-inclusive phrases", function() {
+		const mockPaper = new Paper( "An alcoholic should just drink less." );
+		const mockResearcher = Factory.buildMockResearcher( [ "An alcoholic should just drink less." ] );
+		const assessor = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "alcoholic" ) );
+
+		const isApplicable = assessor.isApplicable( mockPaper, mockResearcher );
+		const assessmentResult = assessor.getResult();
+
+		expect( isApplicable ).toBeTruthy();
+		expect( assessmentResult.getScore() ).toEqual( 6 );
+		expect( assessmentResult.getText() ).toEqual(
+			"Be careful when using <i>an alcoholic</i> as it is potentially harmful. " +
+			"Consider using an alternative, such as <i>person with alcohol use disorder</i>, " +
+			"unless referring to someone who explicitly wants to be referred to with this term. " +
+			"<a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>" );
+		expect( assessmentResult.hasMarks() ).toBeTruthy();
+		expect( assessor.getMarks() ).toEqual( [ new Mark( {
+			original: "An alcoholic should just drink less.",
+			marked: "<yoastmark class='yoast-text-mark'>An alcoholic should just drink less.</yoastmark>",
+		} ) ] );
+	} );
+
+	it( "should not target phrases followed by by certain words", function() {
+		const mockPaper = new Paper( "An alcoholic drink a day keeps the doctor away." );
+		const mockResearcher = Factory.buildMockResearcher( [ "An alcoholic drink a day keeps the doctor away." ] );
+		const assessor = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "alcoholic" ) );
+
+		const isApplicable = assessor.isApplicable( mockPaper, mockResearcher );
+
+		expect( isApplicable ).toBeFalsy();
+		expect( assessor.getMarks() ).toEqual( [] );
+	} );
+
+	it( "should only target retarded if preceded by mentally.", () => {
+		const assessment = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "retarded" ) );
+
+		let testSentence = "He is mentally retarded";
+		let mockPaper = new Paper( testSentence );
+		let mockResearcher = Factory.buildMockResearcher( [ testSentence ] );
+
+		expect( assessment.isApplicable( mockPaper, mockResearcher ) ).toBe( false );
+
+		testSentence = "He is retarded";
+		mockPaper = new Paper( testSentence );
+		mockResearcher = Factory.buildMockResearcher( [ testSentence ] );
+
+		expect( assessment.isApplicable( mockPaper, mockResearcher ) ).toBe( true );
+	} );
+
+
+	it( "should not target alcoholics if followed by anonymous.", () => {
+		const assessment = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "alcoholics" ) );
+
+		const testSentence = "This is alcoholics anonymous.";
+		const mockPaper = new Paper( testSentence );
+		const mockResearcher = Factory.buildMockResearcher( [ testSentence ] );
+
+		expect( assessment.isApplicable( mockPaper, mockResearcher ) ).toBe( false );
+	} );
+
+	it( "should not target handicap when followed with exception words.", () => {
+		[ "toilet", "toilets", "parking", "bathroom", "bathrooms", "stall", "stalls" ].map( exceptionWord => {
+			const assessment = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "handicap" ) );
+			const testSentence = `This is the handicap ${ exceptionWord }.`;
+
+			const mockPaper = new Paper( testSentence );
+			const mockResearcher = Factory.buildMockResearcher( [ testSentence ] );
+
+			expect( assessment.isApplicable( mockPaper, mockResearcher ) ).toBe( false );
+		} );
+	} );
+
+	it( "should not target functioning when followed by autism.", () => {
+		[ "high functioning", "low functioning" ].map( trigger => {
+			const assessment = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "functioning" ) );
+			const testSentence = `They have ${ trigger } autism.`;
+
+			const mockPaper = new Paper( testSentence );
+			const mockResearcher = Factory.buildMockResearcher( [ testSentence ] );
+
+			expect( assessment.isApplicable( mockPaper, mockResearcher ) ).toBe( false );
+		} );
+	} );
+
+	it( "should not dumb if preceded by 'deaf and'.", () => {
+		const assessment = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "dumb" ) );
+
+		const testSentence = "He is deaf and dumb.";
+		const mockPaper = new Paper( testSentence );
+		const mockResearcher = Factory.buildMockResearcher( [ testSentence ] );
+
+		expect( assessment.isApplicable( mockPaper, mockResearcher ) ).toBe( false );
+	} );
+} );
+

--- a/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/genderAssessmentsSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/genderAssessmentsSpec.js
@@ -1,0 +1,80 @@
+import Paper from "../../../../../src/values/Paper";
+import Mark from "../../../../../src/values/Mark";
+import InclusiveLanguageAssessment from "../../../../../src/scoring/assessments/inclusiveLanguage/InclusiveLanguageAssessment";
+import assessments from "../../../../../src/scoring/assessments/inclusiveLanguage/configuration/genderAssessments";
+import Factory from "../../../../specHelpers/factory.js";
+
+describe( "Gender assessments", function() {
+	it( "should target non-inclusive phrases", function() {
+		const mockPaper = new Paper( "Mankind is so great! I could talk for hours about it." );
+		const mockResearcher = Factory.buildMockResearcher( [ "Mankind is so great!", "I could talk for hours about it." ] );
+		const assessor = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "mankind" )  );
+
+		const isApplicable = assessor.isApplicable( mockPaper, mockResearcher );
+		const assessmentResult = assessor.getResult();
+
+		expect( isApplicable ).toBeTruthy();
+		expect( assessmentResult.getScore() ).toEqual( 3 );
+		expect( assessmentResult.getText() ).toEqual(
+			"Avoid using <i>mankind</i> as it is exclusionary. Consider using an alternative, such as " +
+			"<i>individuals, people, persons, human beings, humanity</i>. " +
+			"<a href='https://yoa.st/inclusive-language-gender' target='_blank'>Learn more.</a>" );
+		expect( assessmentResult.hasMarks() ).toBeTruthy();
+		expect( assessor.getMarks() ).toEqual( [ new Mark( {
+			original: "Mankind is so great!",
+			marked: "<yoastmark class='yoast-text-mark'>Mankind is so great!</yoastmark>",
+		} ) ] );
+	} );
+
+	it( "should target potentially non-inclusive phrases", function() {
+		const mockPaper = new Paper( "Look at those firemen! They're putting out the fire." );
+		const mockResearcher = Factory.buildMockResearcher( [ "Look at those firemen!", "They're putting out the fire." ] );
+		const assessor = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "firemen" )  );
+
+		const isApplicable = assessor.isApplicable( mockPaper, mockResearcher );
+		const assessmentResult = assessor.getResult();
+
+		expect( isApplicable ).toBeTruthy();
+		expect( assessmentResult.getScore() ).toEqual( 6 );
+		expect( assessmentResult.getText() ).toEqual(
+			"Be careful when using <i>firemen</i> as it can be exclusionary. " +
+			"Unless you are sure that the group you refer to only consists of men, use an alternative, such as <i>firefighters</i>. " +
+			"<a href='https://yoa.st/inclusive-language-gender' target='_blank'>Learn more.</a>" );
+		expect( assessmentResult.hasMarks() ).toBeTruthy();
+		expect( assessor.getMarks() ).toEqual( [ new Mark( {
+			original: "Look at those firemen!",
+			marked: "<yoastmark class='yoast-text-mark'>Look at those firemen!</yoastmark>",
+		} ) ] );
+	} );
+
+	it( "should not target other phrases", function() {
+		const mockPaper = new Paper( "Look at those firefighters! They're putting out the fire." );
+		const mockResearcher = Factory.buildMockResearcher( [ "Look at those firefighters!", "They're putting out the fire." ] );
+		const assessor = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "firemen" )  );
+
+		const isApplicable = assessor.isApplicable( mockPaper, mockResearcher );
+
+		expect( isApplicable ).toBeFalsy();
+		expect( assessor.getMarks() ).toEqual( [] );
+	} );
+
+	it( "should return proper feedback without an alternative given", function() {
+		const mockPaper = new Paper( "She's acting like a shemale." );
+		const mockResearcher = Factory.buildMockResearcher( [ "She's acting like a shemale." ] );
+		const assessor = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "shemale" )  );
+
+		const isApplicable = assessor.isApplicable( mockPaper, mockResearcher );
+		const assessmentResult = assessor.getResult();
+
+		expect( isApplicable ).toBeTruthy();
+		expect( assessmentResult.getScore() ).toEqual( 3 );
+		expect( assessmentResult.getText() ).toEqual(
+			"Avoid using <i>shemale</i> as it is derogatory. " +
+			"<a href='https://yoa.st/inclusive-language-gender' target='_blank'>Learn more.</a>" );
+		expect( assessmentResult.hasMarks() ).toBeTruthy();
+		expect( assessor.getMarks() ).toEqual( [ new Mark( {
+			original: "She's acting like a shemale.",
+			marked: "<yoastmark class='yoast-text-mark'>She's acting like a shemale.</yoastmark>",
+		} ) ] );
+	} );
+} );

--- a/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/otherAssessmentsSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/otherAssessmentsSpec.js
@@ -1,0 +1,63 @@
+import Paper from "../../../../../src/values/Paper";
+import EnglishResearcher from "../../../../../src/languageProcessing/languages/en/Researcher";
+import InclusiveLanguageAssessment from "../../../../../src/scoring/assessments/inclusiveLanguage/InclusiveLanguageAssessment";
+import assessments from "../../../../../src/scoring/assessments/inclusiveLanguage/configuration/otherAssessments";
+
+describe( "Other assessments", function() {
+	it( "should target potentially non-inclusive phrases",
+		function() {
+			const mockPaper = new Paper( "This ad is aimed at homosexuals" );
+			const mockResearcher = new EnglishResearcher( mockPaper );
+			const assessor = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "homosexuals" ) );
+
+			const isApplicable = assessor.isApplicable( mockPaper, mockResearcher );
+			const assessmentResult = assessor.getResult();
+
+			expect( isApplicable ).toBeTruthy();
+			expect( assessmentResult.getScore() ).toEqual( 6 );
+			expect( assessmentResult.getText() ).toEqual(
+				"Be careful when using <i>homosexuals</i> as it may overgeneralize or be harmful. " +
+				"Instead, be specific about the group you are referring to (e.g. <i>gay men, queer people, lesbians</i>). " +
+				"<a href='https://yoa.st/inclusive-language-other' target='_blank'>Learn more.</a>" );
+			expect( assessmentResult.hasMarks() ).toBeTruthy();
+			expect( assessor.getMarks() ).toEqual( [
+				{ _properties: {
+					marked: "<yoastmark class='yoast-text-mark'>This ad is aimed at homosexuals</yoastmark>",
+					original: "This ad is aimed at homosexuals",
+				} } ] );
+		} );
+
+	it( "should target potentially non-inclusive phrases", function() {
+		const mockPaper = new Paper( "This ad is aimed at minorities." );
+		const mockResearcher = new EnglishResearcher( mockPaper );
+		const assessor = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "minorities" )  );
+
+		const isApplicable = assessor.isApplicable( mockPaper, mockResearcher );
+		const assessmentResult = assessor.getResult();
+
+		expect( isApplicable ).toBeTruthy();
+		expect( assessmentResult.getScore() ).toEqual( 6 );
+		expect( assessmentResult.getText() ).toEqual(
+			"Be careful when using <i>minorities</i> as it is potentially overgeneralizing. " +
+			"Consider using an alternative, such as <i>marginalized groups</i>, <i>underrepresented groups</i> or specific minorities, " +
+			"such as <i>gender and sexuality minorities</i>. <a href='https://yoa.st/inclusive-language-other' target='_blank'>Learn more.</a>" );
+		expect( assessmentResult.hasMarks() ).toBeTruthy();
+		expect( assessor.getMarks() ).toEqual(  [
+			{ _properties:
+					{
+						marked: "<yoastmark class='yoast-text-mark'>This ad is aimed at minorities.</yoastmark>",
+						original: "This ad is aimed at minorities.",
+					} } ] );
+	} );
+
+	it( "should not target phrases preceded by certain words", function() {
+		const mockPaper = new Paper( "This ad is aimed at high school seniors." );
+		const mockResearcher = new EnglishResearcher( mockPaper );
+		const assessor = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "ex-con" )  );
+
+		const isApplicable = assessor.isApplicable( mockPaper, mockResearcher );
+
+		expect( isApplicable ).toBeFalsy();
+		expect( assessor.getMarks() ).toEqual( [] );
+	} );
+} );

--- a/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/sesAssessmentsSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/sesAssessmentsSpec.js
@@ -1,0 +1,62 @@
+import Paper from "../../../../../src/values/Paper";
+import EnglishResearcher from "../../../../../src/languageProcessing/languages/en/Researcher";
+import InclusiveLanguageAssessment from "../../../../../src/scoring/assessments/inclusiveLanguage/InclusiveLanguageAssessment";
+import assessments from "../../../../../src/scoring/assessments/inclusiveLanguage/configuration/sesAssessments";
+
+describe( "SES assessments", function() {
+	it( "should target non-inclusive phrases",
+		function() {
+			const mockPaper = new Paper( "This ad is aimed at illegal immigrants" );
+			const mockResearcher = new EnglishResearcher( mockPaper );
+			const assessor = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "illegalImmigrants" ) );
+
+			const isApplicable = assessor.isApplicable( mockPaper, mockResearcher );
+			const assessmentResult = assessor.getResult();
+
+			expect( isApplicable ).toBeTruthy();
+			expect( assessmentResult.getScore() ).toEqual( 3 );
+			expect( assessmentResult.getText() ).toEqual(
+				"Avoid using <i>illegal immigrants</i> as it is potentially harmful. " +
+				"Consider using an alternative, such as <i>undocumented people</i>. " +
+				"<a href='https://yoa.st/inclusive-language-ses' target='_blank'>Learn more.</a>" );
+			expect( assessmentResult.hasMarks() ).toBeTruthy();
+			expect( assessor.getMarks() ).toEqual( [
+				{ _properties:
+						{ marked: "<yoastmark class='yoast-text-mark'>This ad is aimed at illegal immigrants</yoastmark>",
+							original: "This ad is aimed at illegal immigrants",
+						} } ] );
+		} );
+
+	it( "should target non-inclusive phrases", function() {
+		const mockPaper = new Paper( "This ad is aimed at poverty stricken." );
+		const mockResearcher = new EnglishResearcher( mockPaper );
+		const assessor = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "povertyStricken" )  );
+
+		const isApplicable = assessor.isApplicable( mockPaper, mockResearcher );
+		const assessmentResult = assessor.getResult();
+
+		expect( isApplicable ).toBeTruthy();
+		expect( assessmentResult.getScore() ).toEqual( 3 );
+		expect( assessmentResult.getText() ).toEqual(
+			"Avoid using <i>poverty stricken</i> as it is potentially harmful. " +
+			"Consider using an alternative, such as <i>people whose income is below the poverty threshold, people with low-income</i>. " +
+			"<a href='https://yoa.st/inclusive-language-ses' target='_blank'>Learn more.</a>" );
+		expect( assessmentResult.hasMarks() ).toBeTruthy();
+		expect( assessor.getMarks() ).toEqual(  [
+			{ _properties:
+					{ marked: "<yoastmark class='yoast-text-mark'>This ad is aimed at poverty stricken.</yoastmark>",
+						original: "This ad is aimed at poverty stricken.",
+					} } ] );
+	} );
+
+	it( "should not target phrases preceded by certain words", function() {
+		const mockPaper = new Paper( "This ad is aimed at high school seniors." );
+		const mockResearcher = new EnglishResearcher( mockPaper );
+		const assessor = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "welfareReliant" )  );
+
+		const isApplicable = assessor.isApplicable( mockPaper, mockResearcher );
+
+		expect( isApplicable ).toBeFalsy();
+		expect( assessor.getMarks() ).toEqual( [] );
+	} );
+} );

--- a/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/helpers/includesConsecutiveWordsSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/helpers/includesConsecutiveWordsSpec.js
@@ -1,0 +1,19 @@
+import { includesConsecutiveWords } from "../../../../../src/scoring/assessments/inclusiveLanguage/helpers/includesConsecutiveWords";
+
+describe( "The includesConsecutiveWords helper", () => {
+	it( "should check whether an array of words occurs consecutively in another array of words", () => {
+		const sentence = "a sentence with some words".split( " " );
+		const words = "with some".split( " " );
+		expect( includesConsecutiveWords( sentence, words ) ).toEqual( [ 2 ] );
+	} );
+	it( "should check whether an array of words occurs consecutively multiple times in another array of words", () => {
+		const sentence = "a sentence with some words and with some other words".split( " " );
+		const words = "with some".split( " " );
+		expect( includesConsecutiveWords( sentence, words ) ).toEqual( [ 2, 6 ] );
+	} );
+	it( "should return an empty array when no consecutive words are found", () => {
+		const sentence = "a sentence with some words".split( " " );
+		const words = "no other words".split( " " );
+		expect( includesConsecutiveWords( sentence, words ) ).toEqual( [] );
+	} );
+} );

--- a/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/helpers/includesWordsAtPositionSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/helpers/includesWordsAtPositionSpec.js
@@ -1,0 +1,24 @@
+import { includesWordsAtPosition } from "../../../../../src/scoring/assessments/inclusiveLanguage/helpers/includesWordsAtPosition";
+
+describe( "The includesWordsAtPosition helper", () => {
+	it( "checks whether an array of words occurs at a given position in another array of words", () => {
+		const sentence = "This is a sentence containing some words".split( " " );
+		const wordsToFind = "a sentence".split( " " );
+
+		expect( includesWordsAtPosition( wordsToFind, 2, sentence ) ).toBe( true );
+	} );
+	it( "returns false when an array of words does not occur at a given position", () => {
+		const sentence = "This is a sentence containing some words".split( " " );
+		const wordsToFind = "a sentence".split( " " );
+
+		// Words occur, but at the wrong position.
+		expect( includesWordsAtPosition( wordsToFind, 4, sentence ) ).toBe( false );
+	} );
+	it( "returns false when an array of words does not occur at all", () => {
+		const sentence = "This is a sentence containing some words".split( " " );
+		const wordsToFind = "does not occur at all".split( " " );
+
+		// Words do not occur at all.
+		expect( includesWordsAtPosition( wordsToFind, 5, sentence ) ).toBe( false );
+	} );
+} );

--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/InclusiveLanguageAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/InclusiveLanguageAssessment.js
@@ -1,0 +1,147 @@
+import { sprintf } from "@wordpress/i18n";
+import { isString } from "lodash-es";
+
+import AssessmentResult from "../../../values/AssessmentResult";
+import Mark from "../../../values/Mark";
+import addMark from "../../../markers/addMark";
+import { createAnchorOpeningTag } from "../../../helpers/shortlinker";
+import { getWords, sanitizeString } from "../../../languageProcessing";
+
+import { includesConsecutiveWords } from "./helpers/includesConsecutiveWords";
+import { isUndefined } from "lodash";
+
+/**
+ * An inclusive language assessment.
+ *
+ * Based on the configuration given to it in the constructor, it assesses
+ * whether a paper's text contains potentially non-inclusive phrases and
+ * suggests a potentially more inclusive alternative.
+ */
+export default class InclusiveLanguageAssessment {
+	/**
+	 * Creates a new inclusive language assessment.
+	 *
+	 * @param {object} config The assessment configuration.
+	 *
+	 * @param {string} config.identifier The identifier of this assessment.
+	 * @param {string[]} config.nonInclusivePhrases The non-inclusive phrases.
+	 * @param {string|array} config.inclusiveAlternatives The suggested alternative, more inclusive, phrase(s).
+	 * @param {number} config.score The score to give if the non-inclusive phrase is recognized in the text.
+	 * @param {string} config.feedbackFormat The feedback format string,
+	 * 									should include a `%1$s` placeholder for the non-inclusive phrase
+	 * 									and `%2$s` (and potentially further replacements) for the suggested alternative(s).
+	 * @param {string} config.learnMoreUrl The URL to an article explaining more about this specific assessment.
+	 * @param {function} [config.rule] A potential additional rule for targeting the non-inclusive phrases.
+	 * @param {boolean} [config.caseSensitive=false] If the inclusive phrase is case-sensitive, defaults to `false`.
+	 *
+	 * @returns {void}
+	 */
+	constructor( { identifier, nonInclusivePhrases, inclusiveAlternatives,
+					 score, feedbackFormat, learnMoreUrl, rule, caseSensitive } ) {
+		this.identifier = identifier;
+		this.nonInclusivePhrases = nonInclusivePhrases;
+		this.inclusiveAlternatives = inclusiveAlternatives;
+		if ( isString( this.inclusiveAlternatives ) ) {
+			this.inclusiveAlternatives = [ this.inclusiveAlternatives ];
+		}
+		this.score = score;
+		this.feedbackFormat = feedbackFormat;
+		this.learnMoreUrl = createAnchorOpeningTag( learnMoreUrl );
+
+		this.rule = rule || includesConsecutiveWords;
+		this.caseSensitive = caseSensitive || false;
+	}
+
+	/**
+	 * Checks whether the assessment is applicable for the given paper.
+	 *
+	 * @param {Paper} paper The paper to check.
+	 * @param {Researcher} researcher The researcher.
+	 *
+	 * @returns {boolean} Whether the assessment is applicable for the given paper.
+	 */
+	isApplicable( paper, researcher ) {
+		const sentences = researcher.getResearch( "sentences" );
+
+		// Also include the text title in the analysis as a separate sentence.
+		const textTitle = paper.getTextTitle();
+		sentences.push( textTitle );
+
+		this.foundPhrases = [];
+
+		sentences.forEach( sentence => {
+			let words = getWords( sentence );
+			if ( ! this.caseSensitive ) {
+				words = words.map( word => word.toLocaleLowerCase() );
+			}
+			const foundPhrase = this.nonInclusivePhrases.find( phrase => this.rule( words, phrase.split( " " ) ).length >= 1 );
+
+			if ( foundPhrase ) {
+				this.foundPhrases.push( {
+					sentence: sentence,
+					phrase: foundPhrase,
+				} );
+			}
+		} );
+
+		return this.foundPhrases.length >= 1;
+	}
+
+	/**
+	 * Execute the Assessment and return a result.
+	 *
+	 * @returns {AssessmentResult} The result of the assessment, containing both a score and a descriptive text.
+	 */
+	getResult() {
+		const link = sprintf(
+			"%1$sLearn more.%2$s",
+			this.learnMoreUrl,
+			"</a>"
+		);
+
+		const text = sprintf(
+			this.feedbackFormat,
+			this.foundPhrases[ 0 ].phrase,
+			...this.inclusiveAlternatives
+		);
+
+		const result = new AssessmentResult( {
+			score: this.score,
+			text: `${ text } ${ link }`,
+		} );
+
+		result.setIdentifier( this.identifier );
+		result.setHasMarks( true );
+
+		return result;
+	}
+
+	/**
+	 * Tests whether a paper object has enough content for assessments to be displayed.
+	 *
+	 * @param {Paper} paper 						A Paper.js object that will be tested.
+	 * @param {number} contentNeededForAssessment	The minimum length in characters a text must have for assessments to be displayed.
+	 *
+	 * @returns {boolean} true if the text is of the required length, false otherwise.
+	 */
+	hasEnoughContentForAssessment( paper, contentNeededForAssessment = 50 ) {
+		// The isUndefined check is necessary, because if paper is undefined .getText will throw a typeError.
+		return  ! isUndefined( paper ) && sanitizeString( paper.getText() ).length >= contentNeededForAssessment;
+	}
+
+	/**
+	 * Marks text for the inclusive language assessment.
+	 *
+	 * @returns {Array<Mark>} A list of marks that should be applied.
+	 */
+	getMarks() {
+		if ( ! this.foundPhrases ) {
+			return [];
+		}
+		return this.foundPhrases.map( foundPhrase =>
+			new Mark( {
+				original: foundPhrase.sentence,
+				marked: addMark( foundPhrase.sentence ),
+			} ) );
+	}
+}

--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/ageAssessments.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/ageAssessments.js
@@ -1,0 +1,69 @@
+import { potentiallyHarmful, potentiallyHarmfulUnless, potentiallyHarmfulUnlessNonInclusive, harmfulNonInclusive } from "./feedbackStrings";
+import { isPrecededByException } from "../helpers/isPrecededByException";
+import { isFollowedByException } from "../helpers/isFollowedByException";
+import { includesConsecutiveWords } from "../helpers/includesConsecutiveWords";
+import { SCORES } from "./scores";
+
+const specificAgeGroup = "Or, if possible, be specific about the group you are referring to (e.g. <i>people older than 70</i>).";
+const characteristicIfKnown = "Consider using an alternative, such as a specific characteristic or experience if it is known" +
+	" (e.g. <i>has Alzheimer's</i>).";
+
+const learnMoreUrl = "https://yoa.st/inclusive-language-age";
+
+const assessments = [
+	{
+		identifier: "seniorCitizens",
+		nonInclusivePhrases: [ "senior citizen", "senior citizens" ],
+		inclusiveAlternatives: "<i>older citizen(s)</i>",
+		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
+		feedbackFormat: [ potentiallyHarmfulUnless, specificAgeGroup ].join( " " ),
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "agingDependants",
+		nonInclusivePhrases: [ "aging dependants" ],
+		inclusiveAlternatives: "<i>older people</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: [ potentiallyHarmfulUnlessNonInclusive, specificAgeGroup ].join( " " ),
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "elderly",
+		nonInclusivePhrases: [ "elderly" ],
+		inclusiveAlternatives: "<i>older people</i>",
+		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
+		feedbackFormat: [ potentiallyHarmfulUnless, specificAgeGroup ].join( " " ),
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "senile",
+		nonInclusivePhrases: [ "senile" ],
+		inclusiveAlternatives: "",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: [ harmfulNonInclusive, characteristicIfKnown ].join( " " ),
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "senility",
+		nonInclusivePhrases: [ "senility" ],
+		inclusiveAlternatives: "<i>dementia</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmful,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "seniors",
+		nonInclusivePhrases: [ "seniors" ],
+		inclusiveAlternatives: "<i>older people</i>",
+		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
+		feedbackFormat: [ potentiallyHarmfulUnless, specificAgeGroup ].join( " " ),
+		learnMoreUrl: learnMoreUrl,
+		rule: ( words, inclusivePhrases ) => {
+			return includesConsecutiveWords( words, inclusivePhrases )
+				.filter( isPrecededByException( words, [ "high school", "college", "graduating", "juniors and" ] ) )
+				.filter( isFollowedByException( words, inclusivePhrases, [ "in high school", "in college", "who are graduating" ] ) );
+		},
+	},
+];
+
+export default assessments;

--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/appearanceAssessments.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/appearanceAssessments.js
@@ -1,0 +1,59 @@
+import { potentiallyHarmful, potentiallyHarmfulUnless, preferredDescriptorIfKnown } from "./feedbackStrings";
+import { SCORES } from "./scores";
+
+const learnMoreUrl = "https://yoa.st/inclusive-language-appearance";
+
+const appearanceAssessments = [
+	{
+		identifier: "albinos",
+		nonInclusivePhrases: [ "albinos" ],
+		inclusiveAlternatives: "people with albinism, albino people",
+		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmfulUnless,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "obese",
+		nonInclusivePhrases: [ "obese", "overweight" ],
+		inclusiveAlternatives: "<i>has/have a higher weight, " +
+			"higher-weight person/people, person/people in higher weight body/bodies, heavier person/people</i>",
+		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
+		feedbackFormat: [ potentiallyHarmful, preferredDescriptorIfKnown ].join( " " ),
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "obesity",
+		nonInclusivePhrases: [ "person with obesity", "people with obesity", "fat person", "fat people" ],
+		inclusiveAlternatives: "<i>person/people who has/have a higher weight, " +
+			"higher-weight person/people, person/people in higher weight body/bodies, heavier person/people</i>",
+		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
+		feedbackFormat: [ potentiallyHarmful, preferredDescriptorIfKnown ].join( " " ),
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "verticallyChallenged",
+		nonInclusivePhrases: [ "vertically challenged" ],
+		inclusiveAlternatives: "<i>little person, has short stature, someone with dwarfism</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmful,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "midget",
+		nonInclusivePhrases: [ "midget" ],
+		inclusiveAlternatives: "<i>little person, has short stature, someone with dwarfism</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmful,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "harelip",
+		nonInclusivePhrases: [ "harelip" ],
+		inclusiveAlternatives: "<i>cleft lip, cleft palate</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmful,
+		learnMoreUrl: learnMoreUrl,
+	},
+];
+
+export default appearanceAssessments;

--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/cultureAssessments.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/cultureAssessments.js
@@ -1,0 +1,303 @@
+import { SCORES } from "./scores";
+import { includesConsecutiveWords } from "../helpers/includesConsecutiveWords";
+import { isFollowedByException } from "../helpers/isFollowedByException";
+import { potentiallyHarmful, potentiallyHarmfulCareful, potentiallyHarmfulUnless, harmfulNonInclusive } from "./feedbackStrings";
+import { isPrecededByException } from "../helpers/isPrecededByException";
+
+const potentiallyHarmfulUnlessCulture = "Be careful when using <i>%1$s</i> as it is potentially harmful. " +
+										"Consider using an alternative, such as %2$s instead, unless you are referring to the culture " +
+										"in which this term originated.";
+const overgeneralizing = "Avoid using <i>%1$s</i> as it is overgeneralizing. Consider using %2$s instead. ";
+
+const learnMoreUrl = "https://yoa.st/inclusive-language-culture";
+
+const cultureAssessments = [
+	{
+		identifier: "firstWorld",
+		nonInclusivePhrases: [ "First World" ],
+		inclusiveAlternatives: "the specific name for the region or country",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: overgeneralizing,
+		learnMoreUrl: learnMoreUrl,
+		caseSensitive: true,
+		rule: ( words, inclusivePhrase ) => includesConsecutiveWords( words, inclusivePhrase )
+			.filter( isFollowedByException( words, inclusivePhrase, [ "War", "war", "Assembly", "assembly" ] ) ),
+	},
+	{
+		identifier: "thirdWorld",
+		nonInclusivePhrases: [ "Third World" ],
+		inclusiveAlternatives: "the specific name for the region or country",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: overgeneralizing,
+		learnMoreUrl: learnMoreUrl,
+		caseSensitive: true,
+		rule: ( words, inclusivePhrase ) => includesConsecutiveWords( words, inclusivePhrase )
+			.filter( isFollowedByException( words, inclusivePhrase, [ "War", "war", "Quarterly", "quarterly", "country" ] ) ),
+	},
+	{
+		identifier: "tribe",
+		nonInclusivePhrases: [ "tribe" ],
+		inclusiveAlternatives: "<i>group, cohort, crew, league, guild</i>",
+		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
+		/*
+		 * Replace 'the culture in which this term originated' with 'a culture that uses this term' in the 'unless you are
+		 * referring to...' part of the potentiallyHarmfulUnlessCulture string.
+		 */
+		feedbackFormat: potentiallyHarmfulUnlessCulture.slice( 0, -42 ) + "a culture that uses this term.",
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "exotic",
+		nonInclusivePhrases: [ "exotic" ],
+		inclusiveAlternatives: "<i>unfamiliar, foreign, peculiar, fascinating, alluring, bizzarre</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmful,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "sherpa",
+		nonInclusivePhrases: [ "sherpa" ],
+		inclusiveAlternatives: "<i>commander, coach, mastermind, coach, mentor</i>",
+		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmfulUnlessCulture,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "guru",
+		nonInclusivePhrases: [ "guru" ],
+		inclusiveAlternatives: "<i>mentor, doyen, coach, mastermind, virtuoso</i>",
+		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmfulUnlessCulture,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "nonWhite",
+		nonInclusivePhrases: [ "non-white" ],
+		inclusiveAlternatives: "<i>people of color, POC, BIPOC</i> or specifying the racial groups mentioned",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmful,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "oriental",
+		nonInclusivePhrases: [ "oriental" ],
+		inclusiveAlternatives: "<i>Asian</i>. When possible, be more specific (e.g. <i>East Asian</i>)",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmful,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "asianAmerican",
+		nonInclusivePhrases: [ "Asian-American" ],
+		inclusiveAlternatives: "<i>Asian American</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmful,
+		learnMoreUrl: learnMoreUrl,
+		caseSensitive: true,
+	},
+	{
+		identifier: "africanAmerican",
+		nonInclusivePhrases: [ "African-American" ],
+		inclusiveAlternatives: "<i>African American, Black, Americans of African descent</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmful,
+		learnMoreUrl: learnMoreUrl,
+		caseSensitive: true,
+	},
+	{
+		identifier: "whiteRace",
+		nonInclusivePhrases: [ "the White race" ],
+		inclusiveAlternatives: "",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: harmfulNonInclusive,
+		learnMoreUrl: learnMoreUrl,
+		caseSensitive: true,
+	},
+	{
+		identifier: "whitelist",
+		nonInclusivePhrases: [ "whitelist" ],
+		inclusiveAlternatives: "<i>allowlist</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmful,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "blacklist",
+		nonInclusivePhrases: [ "blacklist" ],
+		inclusiveAlternatives: "<i>blocklist, denylist, faillist, redlist</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmful,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "gypVerb",
+		nonInclusivePhrases: [ "gyp" ],
+		inclusiveAlternatives: "<i>to cheat someone</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmful,
+		learnMoreUrl: learnMoreUrl,
+		rule: ( words, inclusivePhrases ) => {
+			return includesConsecutiveWords( words, inclusivePhrases )
+				.filter( isPrecededByException( words, [ "a", "the" ] ) );
+		},
+	},
+	{
+		identifier: "gypNoun",
+		nonInclusivePhrases: [ "a gyp" ],
+		inclusiveAlternatives: "<i>a fraud</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmful,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "gypsy",
+		nonInclusivePhrases: [ "gypsy", "gypsies" ],
+		inclusiveAlternatives: [ "<i>Romani, Romani person, Romani people</i>", "<i>traveler, wanderer, free-spirited</i>" ],
+		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
+		feedbackFormat: [ potentiallyHarmfulUnless, "If you are referring to a lifestyle rather than the ethnic group or " +
+						"their music, consider using an alternative such as <i>%3$s</i>." ].join( " " ),
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "eskimo",
+		nonInclusivePhrases: [ "eskimo" ],
+		inclusiveAlternatives: "the specific name of the Indigenous community (for example, <i>Inuit</i>)",
+		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmfulUnless,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "coloredPeople",
+		nonInclusivePhrases: [ "colored people" ],
+		inclusiveAlternatives: "<i>people of color, POC, BIPOC</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmful,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "americanIndians",
+		nonInclusivePhrases: [ "American Indian", "American Indians" ],
+		inclusiveAlternatives: "<i>Native American(s), Indigenous peoples of America</i>",
+		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmfulUnless,
+		learnMoreUrl: learnMoreUrl,
+		caseSensitive: true,
+	},
+	{
+		identifier: "mulatto",
+		nonInclusivePhrases: [ "mulatto" ],
+		inclusiveAlternatives: "<i>mixed, biracial, multiracial</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmful,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "savage",
+		nonInclusivePhrases: [ "savage" ],
+		inclusiveAlternatives: "<i>severe, dreadful, untamed</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmful,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "civilized",
+		nonInclusivePhrases: [ "civilized" ],
+		inclusiveAlternatives: "<i>proper, well-mannered, enlightened, respectful</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmful,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "primitive",
+		nonInclusivePhrases: [ "primitive" ],
+		inclusiveAlternatives: "<i>early, rudimentary</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmful,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "africanAmericanVernacularEnglish",
+		nonInclusivePhrases: [ "African American Vernacular English" ],
+		inclusiveAlternatives: "<i>African American English, African American Language</i>",
+		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmfulCareful,
+		learnMoreUrl: learnMoreUrl,
+		caseSensitive: true,
+	},
+	{
+		identifier: "ebonics",
+		nonInclusivePhrases: [ "Ebonics" ],
+		inclusiveAlternatives: "<i>African American English, African American Language</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmful,
+		learnMoreUrl: learnMoreUrl,
+		caseSensitive: true,
+	},
+	{
+		identifier: "powWow",
+		nonInclusivePhrases: [ "pow-wow" ],
+		inclusiveAlternatives: "<i>chat, brief conversation, brainstorm, huddle</i>",
+		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmfulUnlessCulture,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "lowManOnTheTotemPole",
+		nonInclusivePhrases: [ "low man on the totem pole" ],
+		inclusiveAlternatives: "<i>person of lower rank, junior-level</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmful,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "spiritAnimal",
+		nonInclusivePhrases: [ "spirit animal" ],
+		inclusiveAlternatives: "<i>inspiration, hero, icon, idol</i>",
+		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmfulUnlessCulture,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "firstWorldCountries",
+		nonInclusivePhrases: [ "first world countries" ],
+		inclusiveAlternatives: "specific name for the countries or regions",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: overgeneralizing,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "firstWorld",
+		nonInclusivePhrases: [ "first-world" ],
+		inclusiveAlternatives: "specific name for the country or region",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: overgeneralizing,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "third-worldCountry",
+		nonInclusivePhrases: [ "third-world country" ],
+		inclusiveAlternatives: "<i>low-income country, developing country</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmful,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "third-worldCountry",
+		nonInclusivePhrases: [ "third world country" ],
+		inclusiveAlternatives: "<i>low-income country, developing country</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmful,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "underdevelopedCountry",
+		nonInclusivePhrases: [ "underdeveloped country", "underdeveloped countries" ],
+		inclusiveAlternatives: "developing country/countries",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: "Avoid using <i>%1$s</i> as it is potentially harmful. Consider using an alternative, " +
+						"such as <i>%2$s</i> instead or be more specific about what aspect this word refers to.",
+		learnMoreUrl: learnMoreUrl,
+	},
+];
+
+export default cultureAssessments;

--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessments.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessments.js
@@ -1,0 +1,419 @@
+import {
+	potentiallyHarmful,
+	potentiallyHarmfulCareful,
+	potentiallyHarmfulUnless,
+} from "./feedbackStrings";
+import { isFollowedByException } from "../helpers/isFollowedByException";
+import { isPrecededByException } from "../helpers/isPrecededByException";
+import { includesConsecutiveWords } from "../helpers/includesConsecutiveWords";
+import { SCORES } from "./scores";
+
+const derogatory = "Avoid using <i>%1$s</i> as it is derogatory. Consider using an alternative, such as %2$s instead.";
+
+const medicalCondition = "Avoid using <i>%1$s</i>, unless talking about the specific medical condition. " +
+	"If you are not referencing the medical condition, consider other alternatives to describe the trait or behavior, such as %2$s.";
+const potentiallyHarmfulTwoAlternatives = "Avoid using <i>%1$s</i> as it is potentially harmful. " +
+	"Consider using an alternative, such as %2$s when referring to someone's needs, or %3$s when referring to a person.";
+
+const learnMoreUrl = "https://yoa.st/inclusive-language-disability";
+
+const disabilityAssessments =  [
+	{
+		identifier: "binge",
+		nonInclusivePhrases: [ "bingeing", "binge" ],
+		inclusiveAlternatives: "<i>indulging, satuating, wallowing</i>",
+		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
+		feedbackFormat: medicalCondition,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "wheelchairBound",
+		nonInclusivePhrases: [ "wheelchair-bound", "wheelchair bound", "confined to a wheelchair" ],
+		inclusiveAlternatives: "<i>uses a wheelchair, is a wheelchair user</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmful,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "mentallyRetarded",
+		nonInclusivePhrases: [ "mentally retarded" ],
+		inclusiveAlternatives: "<i>person with an intellectual disability</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmful,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "retarded",
+		nonInclusivePhrases: [ "retarded" ],
+		inclusiveAlternatives: "<i>uninformed, ignorant, foolish, irrational, insensible</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: derogatory,
+		learnMoreUrl: learnMoreUrl,
+		rule: ( words, inclusivePhrases ) => {
+			return includesConsecutiveWords( words, inclusivePhrases )
+				.filter( isPrecededByException( words, [ "mentally" ] ) );
+		},
+	},
+	{
+		identifier: "alcoholic",
+		nonInclusivePhrases: [ "an alcoholic" ],
+		inclusiveAlternatives: "<i>person with alcohol use disorder</i>",
+		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmfulUnless,
+		learnMoreUrl: learnMoreUrl,
+		rule: ( words, inclusivePhrase ) => includesConsecutiveWords( words, inclusivePhrase )
+			.filter( isFollowedByException( words, inclusivePhrase, [ "drink", "beverage" ] ) ),
+	},
+	{
+		identifier: "alcoholics",
+		nonInclusivePhrases: [ "alcoholics" ],
+		inclusiveAlternatives: "<i>people with alcohol use disorder</i>",
+		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmfulUnless,
+		learnMoreUrl: learnMoreUrl,
+		rule: ( words, inclusivePhrase ) => includesConsecutiveWords( words, inclusivePhrase )
+			.filter( isFollowedByException( words, inclusivePhrase, [ "anonymous" ] ) ),
+	},
+	{
+		identifier: "cripple",
+		nonInclusivePhrases: [ "a cripple" ],
+		inclusiveAlternatives: "<i>person with a physical disability, a physically disabled person</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: derogatory,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "crippled",
+		nonInclusivePhrases: [ "crippled" ],
+		inclusiveAlternatives: "<i>has a physical disability, is physically disabled</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmful,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "daft",
+		nonInclusivePhrases: [ "daft" ],
+		inclusiveAlternatives: "<i>dense, ignorant, foolish</i>",
+		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmfulCareful,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "handicapped",
+		nonInclusivePhrases: [ "handicapped" ],
+		inclusiveAlternatives: "<i>disabled, person with a disability</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmful,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "handicap",
+		nonInclusivePhrases: [ "handicap" ],
+		inclusiveAlternatives: "<i>disability</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmful,
+		learnMoreUrl: learnMoreUrl,
+		rule: ( words, inclusivePhrase ) => includesConsecutiveWords( words, inclusivePhrase )
+			.filter( isFollowedByException( words, inclusivePhrase, [ "toilet", "toilets", "parking", "bathroom",
+				"bathrooms", "stall", "stalls" ] ) ),
+	},
+	{
+		identifier: "insane",
+		nonInclusivePhrases: [ "insane" ],
+		inclusiveAlternatives: "<i>wild, confusing, unpredictable, impulsive, reckless, out of control, " +
+			"unbelievable, incomprehensible, irrational, nonsensical, outrageous, ridiculous</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmful,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "imbecile",
+		nonInclusivePhrases: [ "imbecile" ],
+		inclusiveAlternatives: "<i>uninformed, ignorant, foolish</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: derogatory,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "specialNeeds",
+		nonInclusivePhrases: [ "special needs" ],
+		inclusiveAlternatives: [ "<i>functional needs, support needs</i>", "<i>disabled, person with a disability</i>" ],
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmfulTwoAlternatives,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "hardOfHearing",
+		nonInclusivePhrases: [ "hard-of-hearing" ],
+		inclusiveAlternatives: "<i>hard of hearing, partially deaf, has partial hearing loss</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmful,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "hearingImpaired",
+		nonInclusivePhrases: [ "hearing impaired" ],
+		inclusiveAlternatives: "<i>deaf or hard of hearing, partially deaf, has partial hearing loss</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmful,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "functioning",
+		nonInclusivePhrases: [ "high functioning", "low functioning" ],
+		inclusiveAlternatives: "describing the specific characteristic or experience",
+		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
+		feedbackFormat: "Be careful when using <i>%1$s</i> as it is potentially harmful. " +
+			"Consider using an alternative, such as %2$s, unless referring to how you characterize your own condition.",
+		learnMoreUrl: learnMoreUrl,
+		rule: ( words, inclusivePhrase ) => includesConsecutiveWords( words, inclusivePhrase )
+			.filter( isFollowedByException( words, inclusivePhrase, [ "autism" ] ) ),
+	},
+	{
+		identifier: "autismHigh",
+		nonInclusivePhrases: [ "high functioning autism", "high-functioning autism" ],
+		inclusiveAlternatives: "<i>autism with high support needs</i> or describing the specific characteristic or experience",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: "Avoid using <i>%1$s</i> as it is potentially harmful. " +
+			"Consider using an alternative, such as %2$s, unless referring to how you characterize your own condition.",
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "autismLow",
+		nonInclusivePhrases: [ "low functioning autism", "low-functioning autism" ],
+		inclusiveAlternatives: "<i>autism with low support needs</i> or describing the specific characteristic or experience",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: "Avoid using <i>%1$s</i> as it is potentially harmful. " +
+			"Consider using an alternative, such as %2$s, unless referring to how you characterize your own condition.",
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "lame",
+		nonInclusivePhrases: [ "lame" ],
+		inclusiveAlternatives: "<i>boring, lousy, unimpressive, sad, corny</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmful,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "suicide",
+		nonInclusivePhrases: [ "commit suicide", "committing suicide", "commits suicide", "committed suicide" ],
+		inclusiveAlternatives: "<i>took their life, died by suicide, killed themself</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmful,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "handicapParking",
+		nonInclusivePhrases: [ "handicap parking" ],
+		inclusiveAlternatives: "<i>accessible parking</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmful,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "fellOnDeafEars",
+		nonInclusivePhrases: [ "fell on deaf ears" ],
+		inclusiveAlternatives: "<i>was not addressed, was ignored, was disregarded</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmful,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "turnOnBlindEye",
+		nonInclusivePhrases: [ "turn a blind eye" ],
+		inclusiveAlternatives: "<i>ignore, pretend not to notice</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmful,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "blindLeadingBlind",
+		nonInclusivePhrases: [ "the blind leading the blind" ],
+		inclusiveAlternatives: "<i>ignorant, misguided, incompetent, unqualified, insensitive, unaware</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmful,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "handicapBathroom",
+		nonInclusivePhrases: [ "handicap bathroom", "handicap bathrooms" ],
+		inclusiveAlternatives: "<i>accessible bathroom(s)</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmful,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "handicapToilet",
+		nonInclusivePhrases: [ "handicap toilet", "handicap toilets" ],
+		inclusiveAlternatives: "<i>accessible toilet(s)</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmful,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "handicapStall",
+		nonInclusivePhrases: [ "handicap stall", "handicap stalls" ],
+		inclusiveAlternatives: "<i>accessible stall(s)</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmful,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "dumb",
+		nonInclusivePhrases: [ "dumb" ],
+		inclusiveAlternatives: [ "<i>uninformed, ignorant, foolish, inconsiderate, irrational, reckless</i>" ],
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmful,
+		learnMoreUrl: learnMoreUrl,
+		rule: ( words, inclusivePhrases ) => {
+			return includesConsecutiveWords( words, inclusivePhrases )
+				.filter( isPrecededByException( words, [ "deaf and" ] ) );
+		},
+	},
+	{
+		identifier: "deaf",
+		nonInclusivePhrases: [ "deaf-mute", "deaf and dumb" ],
+		inclusiveAlternatives: "<i>deaf</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmful,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "addict",
+		nonInclusivePhrases: [ "addict" ],
+		inclusiveAlternatives: "<i>person with a (drug, alcohol, ...) addiction, person with substance abuse disorder</i>",
+		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmfulUnless,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "addicts",
+		nonInclusivePhrases: [ "addicts" ],
+		inclusiveAlternatives: "<i>people with a (drug, alcohol, ...) addiction, people with substance abuse disorder</i>",
+		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmfulUnless,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "brainDamaged",
+		nonInclusivePhrases: [ "brain-damaged" ],
+		inclusiveAlternatives: "<i>person with a (traumatic) brain injury</i>",
+		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmfulUnless,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "differentlyAbled",
+		nonInclusivePhrases: [ "differently abled", "differently-abled" ],
+		inclusiveAlternatives: "<i>disabled, person with a disability</i>",
+		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmfulUnless,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "epilepticFit",
+		nonInclusivePhrases: [ "epileptic fit" ],
+		inclusiveAlternatives: "<i>epileptic seizure</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmful,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "sanityCheck",
+		nonInclusivePhrases: [ "sanity check" ],
+		inclusiveAlternatives: "<i>final check, confidence check, rationality check, soundness check</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmful,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "crazy",
+		nonInclusivePhrases: [ "crazy" ],
+		inclusiveAlternatives: "<i>wild, baffling, startling, chaotic, shocking, confusing, reckless, unpredictable</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmful,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "psychopathic",
+		nonInclusivePhrases: [ "psychopath", "psychopathic" ],
+		inclusiveAlternatives: "<i>toxic, manipulative, unpredictable, impulsive, reckless, out of control</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmful,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "schizophrenic",
+		nonInclusivePhrases: [ "schizophrenic", "bipolar" ],
+		inclusiveAlternatives: "<i>of two minds, chaotic, confusing</i>",
+		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
+		feedbackFormat: medicalCondition,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "paranoid",
+		nonInclusivePhrases: [ "paranoid" ],
+		inclusiveAlternatives: "<i>overly suspicious, unreasonable, defensive</i>",
+		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
+		feedbackFormat: medicalCondition,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "manic",
+		nonInclusivePhrases: [ "manic" ],
+		inclusiveAlternatives: "<i>excited, raving, unbalanced, wild</i>",
+		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
+		feedbackFormat: medicalCondition,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "hysterical",
+		nonInclusivePhrases: [ "hysterical" ],
+		inclusiveAlternatives: "<i>intense, vehement, piercing, chaotic</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmful,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "psycho",
+		nonInclusivePhrases: [ "psycho" ],
+		inclusiveAlternatives: "<i>toxic, distraught, unpredictable, reckless, out of control</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmful,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "neurotic",
+		nonInclusivePhrases: [ "neurotic", "lunatic" ],
+		inclusiveAlternatives: "<i>distraught, unstable, startling, confusing, baffling</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmful,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "sociopath",
+		nonInclusivePhrases: [ "sociopath" ],
+		inclusiveAlternatives: [ "<i>person with antisocial personality disorder</i>",
+			"<i>toxic, manipulative, cruel</i>" ],
+		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
+		feedbackFormat: "Be careful when using <i>%1$s</i> as it is potentially harmful. If you are referencing the " +
+			"medical condition, use %2$s instead, unless referring to someone who explicitly wants to be referred to with this term. " +
+			"If you are not referencing the medical condition, consider other alternatives to describe the trait or behavior, such as %3$s.",
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "narcissistic",
+		nonInclusivePhrases: [ "narcissistic" ],
+		inclusiveAlternatives: [ "<i>person with narcissistic personality disorder</i>",
+			"<i>selfish, egotistical, self-centered, self-absorbed, vain, toxic, manipulative</i>" ],
+		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
+		feedbackFormat: "Be careful when using <i>%1$s</i> as it is potentially harmful. If you are referencing the " +
+			"medical condition, use %2$s instead. If you are not referencing the medical condition, consider other" +
+			" alternatives to describe the trait or behavior, such as %3$s.",
+		learnMoreUrl: learnMoreUrl,
+	},
+];
+
+export default disabilityAssessments;
+

--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/feedbackStrings.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/feedbackStrings.js
@@ -1,0 +1,14 @@
+export const alternative = "Consider using an alternative, such as %2$s.";
+const alternativeUnless = "Consider using an alternative, such as %2$s, unless referring to " +
+	"someone who explicitly wants to be referred to with this term.";
+
+export const harmfulNonInclusive = "Avoid using <i>%1$s</i> as it is potentially harmful.";
+const harmfulPotentiallyNonInclusive = "Be careful when using <i>%1$s</i> as it is potentially harmful.";
+
+export const potentiallyHarmful = [ harmfulNonInclusive, alternative ].join( " " );
+export const potentiallyHarmfulCareful = [ harmfulPotentiallyNonInclusive, alternative ].join( " " );
+
+export const potentiallyHarmfulUnless = [ harmfulPotentiallyNonInclusive, alternativeUnless ].join( " " );
+export const potentiallyHarmfulUnlessNonInclusive = [ harmfulNonInclusive, alternativeUnless ].join( " " );
+
+export const preferredDescriptorIfKnown = "Alternatively, if talking about a specific person, use their preferred descriptor if known.";

--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/genderAssessments.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/genderAssessments.js
@@ -1,0 +1,281 @@
+import { alternative, potentiallyHarmful, potentiallyHarmfulUnless } from "./feedbackStrings";
+import { SCORES } from "./scores";
+
+const exclusionary = "Avoid using <i>%1$s</i> as it is exclusionary. " +
+	"Consider using an alternative, such as %2$s.";
+const potentiallyExclusionary = "Be careful when using <i>%1$s</i> as it is potentially exclusionary. " +
+	"Consider using an alternative, such as %2$s.";
+const potentiallyExclusionaryAvoid = "Avoid using <i>%1$s</i> as it is potentially exclusionary. " +
+	"Consider using an alternative, such as %2$s.";
+const exclusionaryUnless = "Be careful when using <i>%1$s</i> as it can be exclusionary. " +
+	"Unless you are sure that the group you refer to only consists of %1$s, use an alternative, such as %2$s.";
+const exclusionaryUnlessMen = "Be careful when using <i>%1$s</i> as it can be exclusionary. " +
+	"Unless you are sure that the group you refer to only consists of men, use an alternative, such as %2$s.";
+const exclusionaryUnlessTwoGenders = "Be careful when using <i>%1$s</i> as it can be exclusionary. " +
+	"Unless you are sure that the group you refer to only consists of two genders, use an alternative, such as %2$s.";
+const exclusionaryUnlessUseTheTerm = "Be careful when using <i>%1$s</i> as it can be exclusionary. " +
+	"Unless you are sure that the group you refer to only consists of people who use this term, use an alternative, such as %2$s.";
+const derogatory = "Avoid using <i>%1$s</i> as it is derogatory.";
+
+const learnMoreUrl = "https://yoa.st/inclusive-language-gender";
+
+const genderAssessments = [
+	{
+		identifier: "firemen",
+		nonInclusivePhrases: [ "firemen" ],
+		inclusiveAlternatives: "<i>firefighters</i>",
+		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
+		feedbackFormat: exclusionaryUnlessMen,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "policemen",
+		nonInclusivePhrases: [ "policemen" ],
+		inclusiveAlternatives: "<i>police officers</i>",
+		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
+		feedbackFormat: exclusionaryUnlessMen,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "menAndWomen",
+		nonInclusivePhrases: [ "men and women", "women and men" ],
+		inclusiveAlternatives: "<i>people, people of all genders, individuals, human beings</i>",
+		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
+		feedbackFormat: exclusionaryUnless,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "boysAndGirls",
+		nonInclusivePhrases: [ "boys and girls", "girls and boys" ],
+		inclusiveAlternatives: "<i>kids, children</i>",
+		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
+		feedbackFormat: exclusionaryUnless,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "heOrShe",
+		nonInclusivePhrases: [ "he/she", "he or she", "she or he", "(s)he" ],
+		inclusiveAlternatives: "<i>they</i>",
+		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
+		feedbackFormat: potentiallyExclusionary,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "birthSex",
+		nonInclusivePhrases: [ "birth sex", "natal sex" ],
+		inclusiveAlternatives: "<i>assigned sex, assigned sex at birth</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmful,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "mankind",
+		nonInclusivePhrases: [ "mankind" ],
+		inclusiveAlternatives: "<i>individuals, people, persons, human beings, humanity</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: exclusionary,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "preferredPronouns",
+		nonInclusivePhrases: [ "preferred pronouns" ],
+		inclusiveAlternatives: "<i>pronouns</i>",
+		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
+		feedbackFormat: [ potentiallyHarmful.slice( 0, -1 ), ", unless referring to someone who explicitly wants to use" +
+		" this term to describe their own pronouns." ].join( "" ),
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "oppositeGender",
+		nonInclusivePhrases: [ "opposite gender" ],
+		inclusiveAlternatives: "<i>another gender</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: exclusionary,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "oppositeSex",
+		nonInclusivePhrases: [ "opposite sex" ],
+		inclusiveAlternatives: "<i>another sex</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: exclusionary,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "femaleBodied",
+		nonInclusivePhrases: [ "female-bodied" ],
+		inclusiveAlternatives: "<i>assigned female at birth</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: potentiallyExclusionaryAvoid.slice( 0, -1 ) +
+			" if you are discussing a person based on their sex or assigned gender at birth. " +
+			"If talking about human anatomy, use the specific anatomical phrase as opposed to <i>%1$s</i>.",
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "maleBodied",
+		nonInclusivePhrases: [ "male-bodied" ],
+		inclusiveAlternatives: "<i>assigned male at birth</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: potentiallyExclusionaryAvoid.slice( 0, -1 ) +
+			" if you are discussing a person based on their sex or assigned gender at birth. " +
+			"If talking about human anatomy, use the specific anatomical phrase as opposed to <i>%1$s</i>.",
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "hermaphrodite",
+		nonInclusivePhrases: [ "hermaphrodite" ],
+		inclusiveAlternatives: "<i>intersex</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmful,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "bothGenders",
+		nonInclusivePhrases: [ "both genders" ],
+		inclusiveAlternatives: "<i>people, folks, human beings, all genders</i>",
+		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
+		feedbackFormat: exclusionaryUnlessTwoGenders,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "ladiesAndGentleman",
+		nonInclusivePhrases: [ "ladies and gentlemen" ],
+		inclusiveAlternatives: "<i>everyone, folks, honored guests</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: exclusionaryUnless,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "husbandAndWife",
+		nonInclusivePhrases: [ "husband and wife" ],
+		inclusiveAlternatives: "<i>spouses, partners</i>",
+		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
+		feedbackFormat: potentiallyExclusionary.slice( 0, -1 ) +
+			", unless referring to someone who explicitly wants to be referred to with this term.",
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "mothersAndFathers",
+		nonInclusivePhrases: [ "mothers and fathers", "fathers and mothers" ],
+		inclusiveAlternatives: "<i>parents</i>",
+		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
+		feedbackFormat: exclusionaryUnlessUseTheTerm,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "manHours",
+		nonInclusivePhrases: [ "man-hours" ],
+		inclusiveAlternatives: "<i>person-hours, business hours</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: exclusionary,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "preferredName",
+		nonInclusivePhrases: [ "preferred name" ],
+		inclusiveAlternatives: "<i>name, affirming name</i>",
+		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
+		feedbackFormat: [ potentiallyHarmful.slice( 0, -1 ), ", unless referring to someone who explicitly wants to use" +
+		" this term to describe their own name." ].join( "" ),
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "transgenders",
+		nonInclusivePhrases: [ "transgenders" ],
+		inclusiveAlternatives: "<i>trans people, transgender people</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: [ derogatory, alternative ].join( " " ),
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "transsexual",
+		nonInclusivePhrases: [ "transsexual" ],
+		inclusiveAlternatives: "<i>transgender</i>",
+		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmfulUnless,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "transWoman",
+		nonInclusivePhrases: [ "transwoman" ],
+		inclusiveAlternatives: "<i>trans woman, transgender woman</i>",
+		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmfulUnless,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "transMan",
+		nonInclusivePhrases: [ "transman" ],
+		inclusiveAlternatives: "<i>trans man, transgender man</i>",
+		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmfulUnless,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "transgendered",
+		nonInclusivePhrases: [ "transgendered" ],
+		inclusiveAlternatives: [ "<i>transgender, trans</i>", "transitioned, went through a gender transition" ],
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: [ potentiallyHarmful.slice( 0, -1 ), "if referring to a person. If referring to a transition process," +
+		" consider using an alternative such as <i>%3$s</i>." ].join( " " ),
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "maleToFemale",
+		nonInclusivePhrases: [ "male-to-female", "MTF" ],
+		inclusiveAlternatives: "<i>trans woman, transgender woman</i>",
+		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmfulUnless,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "femaleToMale",
+		nonInclusivePhrases: [ "female-to-male", "FTM" ],
+		inclusiveAlternatives: "<i>trans man, transgender man</i>",
+		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmfulUnless,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "heShe",
+		nonInclusivePhrases: [ "he-she" ],
+		inclusiveAlternatives: "",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: derogatory,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "shemale",
+		nonInclusivePhrases: [ "shemale", "she-male" ],
+		inclusiveAlternatives: "",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: derogatory,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "manMade",
+		nonInclusivePhrases: [ "man-made", "manmade" ],
+		inclusiveAlternatives: "<i>artificial, synthetic, machine-made</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: exclusionary,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "toEachTheirOwn",
+		nonInclusivePhrases: [ "to each his own" ],
+		inclusiveAlternatives: "<i>to each their own</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: exclusionary,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "manned",
+		nonInclusivePhrases: [ "manned" ],
+		inclusiveAlternatives: "<i>crewed</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: exclusionary,
+		learnMoreUrl: learnMoreUrl,
+	},
+];
+
+export default genderAssessments;

--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/index.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/index.js
@@ -1,0 +1,17 @@
+import ageAssessments from "./ageAssessments";
+import appearanceAssessments from "./appearanceAssessments";
+import disabilityAssessments from "./disabilityAssessments";
+import genderAssessments from "./genderAssessments";
+import cultureAssessments from "./cultureAssessments";
+import sesAssessments from "./sesAssessments";
+import otherAssessments from "./otherAssessments";
+
+export default [
+	...ageAssessments,
+	...appearanceAssessments,
+	...disabilityAssessments,
+	...genderAssessments,
+	...cultureAssessments,
+	...sesAssessments,
+	...otherAssessments,
+];

--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/otherAssessments.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/otherAssessments.js
@@ -1,0 +1,51 @@
+import { SCORES } from "./scores";
+import { potentiallyHarmful, potentiallyHarmfulCareful } from "./feedbackStrings";
+
+const learnMoreUrl = "https://yoa.st/inclusive-language-other";
+
+const otherAssessments = [
+	{
+		identifier: "homosexuals",
+		nonInclusivePhrases: [ "homosexuals" ],
+		inclusiveAlternatives: "<i>gay men, queer people, lesbians</i>",
+		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
+		feedbackFormat: "Be careful when using <i>%1$s</i> as it may overgeneralize or be harmful. " +
+						"Instead, be specific about the group you are referring to (e.g. %2$s).",
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "minorities",
+		nonInclusivePhrases: [ "minorities" ],
+		inclusiveAlternatives: [ "<i>marginalized groups</i>", "<i>underrepresented groups</i>", "<i>gender and sexuality minorities</i>" ],
+		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
+		feedbackFormat: "Be careful when using <i>%1$s</i> as it is potentially overgeneralizing. " +
+						"Consider using an alternative, such as %2$s, %3$s or specific minorities, such as %4$s.",
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "ex-con",
+		nonInclusivePhrases: [ "ex-con", "ex-cons" ],
+		inclusiveAlternatives: "<i>people who have had felony convictions, people who have been incarcerated</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmful,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "felon",
+		nonInclusivePhrases: [ "felon", "felons" ],
+		inclusiveAlternatives: "<i>people with felony convictions, people who have been incarcerated</i>",
+		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmfulCareful,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "ex-offender",
+		nonInclusivePhrases: [ "ex-offender", "ex-offenders" ],
+		inclusiveAlternatives: "<i>formerly incarcerated person</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmful,
+		learnMoreUrl: learnMoreUrl,
+	},
+];
+
+export default otherAssessments;

--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/scores.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/scores.js
@@ -1,0 +1,14 @@
+/**
+ * Scores for inclusive language.
+ * @enum
+ */
+export const SCORES = {
+	/**
+	 * Score given to a phrase that is generally considered non-inclusive.
+	 */
+	NON_INCLUSIVE: 3,
+	/**
+	 * Score given to a phrase that is potentially non-inclusive.
+	 */
+	POTENTIALLY_NON_INCLUSIVE: 6,
+};

--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/sesAssessments.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/sesAssessments.js
@@ -1,0 +1,41 @@
+import { potentiallyHarmful, potentiallyHarmfulUnless } from "./feedbackStrings";
+import { SCORES } from "./scores";
+
+const learnMoreUrl = "https://yoa.st/inclusive-language-ses";
+
+const sesAssessments = [
+	{
+		identifier: "illegalImmigrants",
+		nonInclusivePhrases: [ "illegal immigrants", "illegal aliens" ],
+		inclusiveAlternatives: "<i>undocumented people</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmful,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "povertyStricken",
+		nonInclusivePhrases: [ "poverty stricken" ],
+		inclusiveAlternatives: "<i>people whose income is below the poverty threshold, people with low-income</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmful,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "welfareReliant",
+		nonInclusivePhrases: [ "welfare reliant" ],
+		inclusiveAlternatives: "<i>receiving welfare</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmful,
+		learnMoreUrl: learnMoreUrl,
+	},
+	{
+		identifier: "prostitute",
+		nonInclusivePhrases: [ "prostitute" ],
+		inclusiveAlternatives: "<i>sex worker</i>",
+		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmfulUnless,
+		learnMoreUrl: learnMoreUrl,
+	},
+];
+
+export default sesAssessments;

--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/helpers/includesConsecutiveWords.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/helpers/includesConsecutiveWords.js
@@ -1,0 +1,19 @@
+import { includesWordsAtPosition } from "./includesWordsAtPosition";
+
+/**
+ * Checks whether the given list of words contains another list of words in the given order.
+ *
+ * @param {string[]} words The list of words.
+ * @param {string[]} consecutiveWords The list of words to find.
+ *
+ * @returns {number[]} The indices where the given list of words is contained in another list of words in the given order.
+ */
+export function includesConsecutiveWords( words, consecutiveWords ) {
+	const foundIndices = [];
+	words.forEach( ( _, i ) => {
+		if ( includesWordsAtPosition( consecutiveWords, i, words ) ) {
+			foundIndices.push( i );
+		}
+	} );
+	return foundIndices;
+}

--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/helpers/includesWordsAtPosition.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/helpers/includesWordsAtPosition.js
@@ -1,0 +1,12 @@
+/**
+ * Checks whether consecutiveWords can be found at the given index in words.
+ *
+ * @param {string[]} consecutiveWords The needle.
+ * @param {number} index The position at which to find the needle in the haystack.
+ * @param {string[]} words The haystack.
+ *
+ * @returns {boolean} Whether consecutiveWords can be found at the given index in words.
+ */
+export function includesWordsAtPosition( consecutiveWords, index, words ) {
+	return consecutiveWords.every( ( word, j ) => words[ index + j ] === word );
+}

--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/helpers/isFollowedByException.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/helpers/isFollowedByException.js
@@ -1,0 +1,22 @@
+import { includesWordsAtPosition } from "./includesWordsAtPosition";
+
+/**
+ * Checks whether the given list of words contains another list of words in the given order,
+ * but not when they are followed by one of the exceptions.
+ *
+ * @param {string[]} words The list of words.
+ * @param {string[]} consecutiveWords The list of words to find.
+ * @param {string[]} exceptions The list of exception phrases.
+ *
+ * @returns {function} A function that checks whether the given list of words is contained in another list of words in the given order.
+ */
+export function isFollowedByException( words, consecutiveWords, exceptions ) {
+	const splitExceptions = exceptions.map( exception => exception.split( " " ) );
+	return index => ! splitExceptions.some( exception => {
+		const startIndex = index + consecutiveWords.length;
+		if ( startIndex >= 0 ) {
+			return includesWordsAtPosition( exception, startIndex, words );
+		}
+		return false;
+	} );
+}

--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/helpers/isPrecededByException.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/helpers/isPrecededByException.js
@@ -1,0 +1,21 @@
+import { includesWordsAtPosition } from "./includesWordsAtPosition";
+
+/**
+ * Checks whether the given list of words contains another list of words in the given order,
+ * but not when they are preceded by one of the exceptions.
+ *
+ * @param {string[]} words The list of words.
+ * @param {string[]} exceptions The list of exception phrases.
+ *
+ * @returns {function} A function that checks whether the given list of words is contained in another list of words in the given order.
+ */
+export function isPrecededByException( words, exceptions ) {
+	const splitExceptions = exceptions.map( exception => exception.split( " " ) );
+	return index => ! splitExceptions.some( exception => {
+		const startIndex = index - exception.length;
+		if ( startIndex >= 0 ) {
+			return includesWordsAtPosition( exception, startIndex, words );
+		}
+		return false;
+	} );
+}

--- a/packages/yoastseo/src/scoring/assessments/index.js
+++ b/packages/yoastseo/src/scoring/assessments/index.js
@@ -32,6 +32,8 @@ import ImageAltTagsAssessment from "./seo/ImageAltTagsAssessment";
 import ProductIdentifiersAssessment from "./seo/ProductIdentifiersAssessment";
 import ProductSKUAssessment from "./seo/ProductSKUAssessment";
 
+import InclusiveLanguageAssessment from "./inclusiveLanguage/InclusiveLanguageAssessment";
+
 const readability = {
 	ListAssessment,
 	ParagraphTooLongAssessment,
@@ -70,7 +72,12 @@ const seo = {
 	ProductSKUAssessment,
 };
 
+const inclusiveLanguage = {
+	InclusiveLanguageAssessment,
+};
+
 export {
 	readability,
 	seo,
+	inclusiveLanguage,
 };

--- a/packages/yoastseo/src/scoring/inclusiveLanguageAssessor.js
+++ b/packages/yoastseo/src/scoring/inclusiveLanguageAssessor.js
@@ -1,0 +1,44 @@
+import Assessor from "./assessor";
+import inclusiveLanguageAssessmentsConfigs from	"./assessments/inclusiveLanguage/configuration";
+import InclusiveLanguageAssessment from "./assessments/inclusiveLanguage/InclusiveLanguageAssessment";
+
+/**
+ * An assessor that assesses a paper for potentially non-inclusive language.
+ */
+class InclusiveLanguageAssessor extends Assessor {
+	/**
+	 * Creates a new inclusive language assessor.
+	 *
+	 * @param {Researcher} researcher The researcher to use.
+	 * @param {Object} options The assessor options.
+	 */
+	constructor( researcher, options ) {
+		super( researcher, options );
+		this.type  = "inclusiveLanguageAssessor";
+		this._assessments = inclusiveLanguageAssessmentsConfigs.map(
+			config => new InclusiveLanguageAssessment( config )
+		);
+	}
+
+	/**
+	 * Calculates the overall score.
+	 *
+	 * @returns {number} The overall score.
+	 */
+	calculateOverallScore() {
+		const results = this.getValidResults();
+
+		const improvementResults = results.filter( result => result.getScore() === 6 );
+		const problemResults = results.filter( result => result.getScore() === 3 );
+
+		if ( problemResults.length >= 1 ) {
+			return 30;
+		} else if ( improvementResults.length >= 1 ) {
+			return 60;
+		}
+
+		return 90;
+	}
+}
+
+export default InclusiveLanguageAssessor;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* This PR is part of the issue to move inclusive language from Premium to Free.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Moves the inclusive language assessment and assessor from Premium to Free.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Confirm that all unit tests pass.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes https://yoast.atlassian.net/browse/PC-766
