### PR TITLE
Pc 822 add company alternate name

### DIFF
--- a/admin/tracking/class-tracking-settings-data.php
+++ b/admin/tracking/class-tracking-settings-data.php
@@ -26,6 +26,7 @@ class WPSEO_Tracking_Settings_Data implements WPSEO_Collection {
 		'alternate_website_name',
 		'company_logo',
 		'company_name',
+		'company_alternate_name',
 		'person_name',
 		'person_logo',
 		'person_logo_id',

--- a/admin/views/tabs/metas/paper-content/general/knowledge-graph.php
+++ b/admin/views/tabs/metas/paper-content/general/knowledge-graph.php
@@ -21,6 +21,7 @@ $yform->textinput(
 	'alternate_website_name',
 	__( 'Alternate website name', 'wordpress-seo' )
 );
+echo '<p style="margin-bottom: 2em;">', esc_html__( 'Use the alternate website name for acronyms, or a shorter version of your website\'s name.', 'wordpress-seo' ), '</p>';
 
 echo '<h3>', esc_html__( 'Organization or Person', 'wordpress-seo' ), '</h3>';
 echo '<p>', sprintf(

--- a/admin/views/tabs/metas/paper-content/general/knowledge-graph.php
+++ b/admin/views/tabs/metas/paper-content/general/knowledge-graph.php
@@ -7,12 +7,28 @@
  * @uses    Yoast_Form $yform Form object.
  */
 
-echo sprintf(
+echo '<h3>', __( 'Website', 'wordpress-seo' ),'</h3>';
+echo '<p>', __( 'This name is shown for your site in the search results.', 'wordpress-seo' ), '</p>';
+$yform->textinput(
+	'website_name',
+	__( 'Website name', 'wordpress-seo' ),
+	[
+		'placeholder'  => \get_bloginfo( 'name' ),
+	]
+);
+
+$yform->textinput(
+	'alternate_website_name',
+	__( 'Alternate website name', 'wordpress-seo' )
+);
+
+echo '<h3>', __( 'Organization or Person', 'wordpress-seo' ), '</h3>';
+echo '<p>', sprintf(
 	/* translators: %1$s opens the link to the Yoast.com article about Google's Knowledge Graph, %2$s closes the link, */
 	esc_html__( 'This data is shown as metadata in your site. It is intended to appear in %1$sGoogle\'s Knowledge Graph%2$s. You can be either an organization, or a person.', 'wordpress-seo' ),
 	'<a href="' . esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/1-p' ) ) . '" target="_blank" rel="noopener noreferrer">',
 	'</a>'
-);
+), '</p>';
 
 /**
  * Retrieve the site logo ID from WordPress settings.

--- a/admin/views/tabs/metas/paper-content/general/knowledge-graph.php
+++ b/admin/views/tabs/metas/paper-content/general/knowledge-graph.php
@@ -7,8 +7,8 @@
  * @uses    Yoast_Form $yform Form object.
  */
 
-echo '<h3>', __( 'Website', 'wordpress-seo' ),'</h3>';
-echo '<p>', __( 'This name is shown for your site in the search results.', 'wordpress-seo' ), '</p>';
+echo '<h3>', esc_html__( 'Website', 'wordpress-seo' ),'</h3>';
+echo '<p>', esc_html__( 'This name is shown for your site in the search results.', 'wordpress-seo' ), '</p>';
 $yform->textinput(
 	'website_name',
 	__( 'Website name', 'wordpress-seo' ),
@@ -22,7 +22,7 @@ $yform->textinput(
 	__( 'Alternate website name', 'wordpress-seo' )
 );
 
-echo '<h3>', __( 'Organization or Person', 'wordpress-seo' ), '</h3>';
+echo '<h3>', esc_html__( 'Organization or Person', 'wordpress-seo' ), '</h3>';
 echo '<p>', sprintf(
 	/* translators: %1$s opens the link to the Yoast.com article about Google's Knowledge Graph, %2$s closes the link, */
 	esc_html__( 'This data is shown as metadata in your site. It is intended to appear in %1$sGoogle\'s Knowledge Graph%2$s. You can be either an organization, or a person.', 'wordpress-seo' ),
@@ -101,7 +101,7 @@ $yform->select( 'company_or_person', __( 'Organization or person', 'wordpress-se
 		'company_alternate_name',
 		__( 'Alternate organization name', 'wordpress-seo' )
 	);
-	echo '<p>', __( 'Use the alternate organization name for acronyms, or a shorter version of your organization\'s name.', 'wordpress-seo' ), '</p>';
+	echo '<p>', esc_html__( 'Use the alternate organization name for acronyms, or a shorter version of your organization\'s name.', 'wordpress-seo' ), '</p>';
 	$yform->hidden( 'company_logo', 'company_logo' );
 	$yform->hidden( 'company_logo_id', 'company_logo_id' );
 	?>

--- a/admin/views/tabs/metas/paper-content/general/knowledge-graph.php
+++ b/admin/views/tabs/metas/paper-content/general/knowledge-graph.php
@@ -81,6 +81,11 @@ $yform->select( 'company_or_person', __( 'Organization or person', 'wordpress-se
 			'placeholder'  => $yoast_seo_site_name,
 		]
 	);
+	$yform->textinput(
+		'company_alternate_name',
+		__( 'Alternate organization name', 'wordpress-seo' )
+	);
+	echo '<p>', __( 'Use the alternate organization name for acronyms, or a shorter version of your organization\'s name.', 'wordpress-seo' ), '</p>';
 	$yform->hidden( 'company_logo', 'company_logo' );
 	$yform->hidden( 'company_logo_id', 'company_logo_id' );
 	?>

--- a/inc/options/class-wpseo-option-titles.php
+++ b/inc/options/class-wpseo-option-titles.php
@@ -82,6 +82,7 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 		'company_logo_meta'                => false,
 		'person_logo_meta'                 => false,
 		'company_name'                     => '',
+		'company_alternate_name'           => '',
 		'company_or_person'                => 'company',
 		'company_or_person_user_id'        => false,
 
@@ -469,6 +470,7 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 				case 'metadesc-':
 				case 'bctitle-ptarchive-':
 				case 'company_name':
+				case 'company_alternate_name':
 				case 'person_name':
 				case 'social-description-':
 				case 'open_graph_frontpage_desc':

--- a/src/context/meta-tags-context.php
+++ b/src/context/meta-tags-context.php
@@ -34,6 +34,7 @@ use Yoast\WP\SEO\Repositories\Indexable_Repository;
  * @property string       $wordpress_site_name
  * @property string       $site_url
  * @property string       $company_name
+ * @property string       $company_alternate_name
  * @property int          $company_logo_id
  * @property array        $company_logo_meta
  * @property int          $person_logo_id
@@ -303,6 +304,22 @@ class Meta_Tags_Context extends Abstract_Presentation {
 		}
 
 		return $company_name;
+	}
+
+	/**
+	 * Generates the alternate company name.
+	 *
+	 * @return string
+	 */
+	public function generate_company_alternate_name() {
+		/**
+		 * Filter: 'wpseo_schema_company_alternate_name' - Allows filtering the alternate company name
+		 *
+		 * @api string $company_name.
+		 */
+		$company_alt_name = (string) \apply_filters( 'wpseo_schema_company_alternate_name', $this->options->get( 'company_alternate_name' ) );
+
+		return $company_alt_name;
 	}
 
 	/**

--- a/src/context/meta-tags-context.php
+++ b/src/context/meta-tags-context.php
@@ -264,9 +264,9 @@ class Meta_Tags_Context extends Abstract_Presentation {
 	}
 
 	/**
-	 * Generates the site name.
+	 * Generates the alternate site name.
 	 *
-	 * @return string The site name.
+	 * @return string The alternate site name.
 	 */
 	public function generate_alternate_site_name() {
 		return (string) $this->options->get( 'alternate_website_name', '' );
@@ -325,11 +325,11 @@ class Meta_Tags_Context extends Abstract_Presentation {
 		/**
 		 * Filter: 'wpseo_schema_company_alternate_name' - Allows filtering the alternate company name
 		 *
-		 * @api string $company_name.
+		 * @api string $company_alternate_name.
 		 */
-		$company_alt_name = (string) \apply_filters( 'wpseo_schema_company_alternate_name', $this->options->get( 'company_alternate_name' ) );
+		$company_alternate_name = (string) \apply_filters( 'wpseo_schema_company_alternate_name', $this->options->get( 'company_alternate_name' ) );
 
-		return $company_alt_name;
+		return $company_alternate_name;
 	}
 
 	/**

--- a/src/context/meta-tags-context.php
+++ b/src/context/meta-tags-context.php
@@ -31,6 +31,7 @@ use Yoast\WP\SEO\Repositories\Indexable_Repository;
  * @property string       $description
  * @property string       $id
  * @property string       $site_name
+ * @property string       $alternate_site_name
  * @property string       $wordpress_site_name
  * @property string       $site_url
  * @property string       $company_name
@@ -260,6 +261,15 @@ class Meta_Tags_Context extends Abstract_Presentation {
 		}
 
 		return \get_bloginfo( 'name' );
+	}
+
+	/**
+	 * Generates the site name.
+	 *
+	 * @return string The site name.
+	 */
+	public function generate_alternate_site_name() {
+		return (string) $this->options->get( 'alternate_website_name', '' );
 	}
 
 	/**

--- a/src/generators/schema/organization.php
+++ b/src/generators/schema/organization.php
@@ -33,15 +33,26 @@ class Organization extends Abstract_Schema_Piece {
 			$logo = $this->helpers->schema->image->generate_from_attachment_id( $logo_schema_id, $this->context->company_logo_id, $this->context->company_name );
 		}
 
-		return [
-			'@type'  => 'Organization',
-			'@id'    => $this->context->site_url . Schema_IDs::ORGANIZATION_HASH,
-			'name'   => $this->helpers->schema->html->smart_strip_tags( $this->context->company_name ),
-			'url'    => $this->context->site_url,
-			'sameAs' => \array_values( \array_unique( $this->fetch_social_profiles() ) ),
-			'logo'   => $logo,
-			'image'  => [ '@id' => $logo['@id'] ],
+		$organization = [
+			'@type' => 'Organization',
+			'@id'   => $this->context->site_url . Schema_IDs::ORGANIZATION_HASH,
+			'name'  => $this->helpers->schema->html->smart_strip_tags( $this->context->company_name ),
 		];
+
+		if ( ! empty( $this->context->company_alternate_name ) ) {
+			$organization['alternateName'] = $this->context->company_alternate_name;
+		}
+
+		$organization['url']   = $this->context->site_url;
+		$organization['logo']  = $logo;
+		$organization['image'] = [ '@id' => $logo['@id'] ];
+
+		$same_as = \array_values( \array_unique( $this->fetch_social_profiles() ) );
+		if ( ! empty( $same_as ) ) {
+			$organization['sameAs'] = $same_as;
+		}
+
+		return $organization;
 	}
 
 	/**

--- a/src/generators/schema/website.php
+++ b/src/generators/schema/website.php
@@ -51,9 +51,8 @@ class Website extends Abstract_Schema_Piece {
 	 * @return array
 	 */
 	private function add_alternate_name( $data ) {
-		$alternate_name = $this->helpers->options->get( 'alternate_website_name', '' );
-		if ( $alternate_name !== '' ) {
-			$data['alternateName'] = $this->helpers->schema->html->smart_strip_tags( $alternate_name );
+		if ( $this->context->alternate_site_name !== '' ) {
+			$data['alternateName'] = $this->helpers->schema->html->smart_strip_tags( $this->context->alternate_site_name );
 		}
 
 		return $data;

--- a/tests/unit/generators/schema-generator-test.php
+++ b/tests/unit/generators/schema-generator-test.php
@@ -229,6 +229,7 @@ class Schema_Generator_Test extends TestCase {
 	public function test_generate_with_no_blocks() {
 		$this->context->indexable->object_sub_type = 'super-custom-post-type';
 		$this->context->has_image                  = false;
+		$this->context->alternate_site_name        = '';
 		$this->context->schema_page_type           = [ 'WebPage' ];
 		$this->context->presentation->breadcrumbs  = [
 			[
@@ -334,6 +335,7 @@ class Schema_Generator_Test extends TestCase {
 	public function test_generate_with_empty_breadcrumb() {
 		$this->context->indexable->object_sub_type = 'super-custom-post-type';
 		$this->context->has_image                  = false;
+		$this->context->alternate_site_name        = 'Alt Name';
 		$this->context->schema_page_type           = [ 'WebPage' ];
 		$this->current_page->expects( 'is_paged' )->andReturns( false );
 
@@ -387,6 +389,7 @@ class Schema_Generator_Test extends TestCase {
 						'@id'             => '#website',
 						'url'             => null,
 						'name'            => '',
+						'alternateName'   => 'Alt Name',
 						'description'     => 'description',
 						'potentialAction' => [
 							[
@@ -417,6 +420,7 @@ class Schema_Generator_Test extends TestCase {
 		$this->stubEscapeFunctions();
 		$this->current_page->expects( 'is_paged' )->andReturns( false );
 
+		$this->context->alternate_site_name        = '';
 		$this->context->indexable->object_type     = 'post';
 		$this->context->indexable->object_sub_type = 'post';
 		$this->context->post                       = (object) [
@@ -609,6 +613,7 @@ class Schema_Generator_Test extends TestCase {
 		$this->stubEscapeFunctions();
 		$this->current_page->expects( 'is_paged' )->andReturns( false );
 
+		$this->context->alternate_site_name        = '';
 		$this->context->indexable->object_type     = 'post';
 		$this->context->indexable->object_sub_type = 'post';
 		$this->context->post                       = (object) [
@@ -671,6 +676,7 @@ class Schema_Generator_Test extends TestCase {
 		$this->context->blocks = [];
 		$this->current_page->expects( 'is_paged' )->andReturns( false );
 
+		$this->context->alternate_site_name        = '';
 		$this->context->indexable->object_type     = 'post';
 		$this->context->indexable->object_sub_type = 'post';
 		$this->context->post                       = (object) [
@@ -768,6 +774,7 @@ class Schema_Generator_Test extends TestCase {
 		$this->context->blocks = [];
 		$this->current_page->expects( 'is_paged' )->andReturns( false );
 
+		$this->context->alternate_site_name        = '';
 		$this->context->indexable->object_type     = 'post';
 		$this->context->indexable->object_sub_type = 'post';
 		$this->context->post                       = (object) [
@@ -860,6 +867,7 @@ class Schema_Generator_Test extends TestCase {
 	 * @covers ::get_graph_pieces
 	 */
 	public function test_get_graph_pieces_on_single_post_with_password_required() {
+		$this->context->alternate_site_name        = '';
 		$this->context->indexable->object_type     = 'post';
 		$this->context->indexable->object_sub_type = 'post';
 		$this->context->post                       = (object) [
@@ -973,6 +981,7 @@ class Schema_Generator_Test extends TestCase {
 	 * @covers ::get_graph_pieces
 	 */
 	public function test_generate_with_search_page() {
+		$this->context->alternate_site_name        = '';
 		$this->context->indexable->object_sub_type = 'super-custom-post-type';
 		$this->context->has_image                  = false;
 		$this->context->site_url                   = 'https://fake.url/';

--- a/tests/unit/generators/schema/organization-test.php
+++ b/tests/unit/generators/schema/organization-test.php
@@ -103,6 +103,7 @@ class Organization_Test extends TestCase {
 	 * @param array $profiles_expected The social profiles expected output.
 	 */
 	public function test_generate( $profiles_input, $profiles_expected ) {
+		$this->context->company_alternate_name      = '';
 		$this->context->site_url                    = 'https://yoast.com/';
 		$this->context->company_name                = 'Yoast';
 		$this->instance->context->company_logo_meta = [
@@ -166,6 +167,7 @@ class Organization_Test extends TestCase {
 	 * @param array $profiles_expected The social profiles expected output.
 	 */
 	public function test_generate_without_logo_meta( $profiles_input, $profiles_expected ) {
+		$this->context->company_alternate_name      = 'Alt Company Name';
 		$this->context->site_url                    = 'https://yoast.com/';
 		$this->context->company_name                = 'Yoast';
 		$this->instance->context->company_logo_meta = false;
@@ -207,13 +209,14 @@ class Organization_Test extends TestCase {
 			->andReturn( $logo );
 
 		$expected = [
-			'@type'  => 'Organization',
-			'@id'    => $schema_id,
-			'name'   => $this->context->company_name,
-			'url'    => $this->context->site_url,
-			'sameAs' => $profiles_expected,
-			'logo'   => $logo,
-			'image'  => [ '@id' => $schema_logo_id ],
+			'@type'         => 'Organization',
+			'@id'           => $schema_id,
+			'name'          => $this->context->company_name,
+			'alternateName' => 'Alt Company Name',
+			'url'           => $this->context->site_url,
+			'sameAs'        => $profiles_expected,
+			'logo'          => $logo,
+			'image'         => [ '@id' => $schema_logo_id ],
 		];
 
 		$this->assertEquals( $expected, $this->instance->generate() );

--- a/tests/unit/generators/schema/website-test.php
+++ b/tests/unit/generators/schema/website-test.php
@@ -90,13 +90,14 @@ class Website_Test extends TestCase {
 	 * @covers ::internal_search_section
 	 */
 	public function test_generate() {
+		$this->meta_tags_context->alternate_site_name       = '';
 		$this->meta_tags_context->site_url                  = 'https://example.com/';
 		$this->meta_tags_context->site_name                 = 'My site';
 		$this->meta_tags_context->site_represents_reference = 'https://example.com/#publisher';
 
 		$this->html
 			->expects( 'smart_strip_tags' )
-			->twice()
+			->once()
 			->andReturnArg( 0 );
 
 		$this->language->expects( 'add_piece_language' )
@@ -109,18 +110,12 @@ class Website_Test extends TestCase {
 				}
 			);
 
-		$this->options->expects( 'get' )
-			->with( 'alternate_website_name', '' )
-			->once()
-			->andReturn( 'Alternate site name' );
-
 		$expected = [
 			'@type'           => 'WebSite',
 			'@id'             => 'https://example.com/#website',
 			'url'             => 'https://example.com/',
 			'name'            => 'My site',
 			'publisher'       => 'https://example.com/#publisher',
-			'alternateName'   => 'Alternate site name',
 			'description'     => 'description',
 			'potentialAction' => [
 				[
@@ -151,13 +146,14 @@ class Website_Test extends TestCase {
 			->with( false )
 			->andReturn( true );
 
+		$this->meta_tags_context->alternate_site_name       = '';
 		$this->meta_tags_context->site_url                  = 'https://example.com/';
 		$this->meta_tags_context->site_name                 = 'My site';
 		$this->meta_tags_context->site_represents_reference = 'https://example.com/#publisher';
 
 		$this->html
 			->expects( 'smart_strip_tags' )
-			->twice()
+			->once()
 			->andReturnArg( 0 );
 
 		$this->language->expects( 'add_piece_language' )
@@ -170,18 +166,12 @@ class Website_Test extends TestCase {
 				}
 			);
 
-		$this->options->expects( 'get' )
-			->with( 'alternate_website_name', '' )
-			->once()
-			->andReturn( 'Alternate site name' );
-
 		$expected = [
 			'@type'           => 'WebSite',
 			'@id'             => 'https://example.com/#website',
 			'url'             => 'https://example.com/',
 			'name'            => 'My site',
 			'publisher'       => 'https://example.com/#publisher',
-			'alternateName'   => 'Alternate site name',
 			'description'     => 'description',
 			'inLanguage'      => 'language',
 		];


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Cherry-picked from the original https://github.com/Yoast/wordpress-seo/pull/19060 PR, that is now closed because of inadvertently merging trunk in that one 
* Given Google's new support for [site names in Google Search](https://developers.google.com/search/blog/2022/10/introducing-site-names-on-search), we want to increase the control site owners have over this value.

Output:
![name-alternateName](https://user-images.githubusercontent.com/487629/196006788-eb57f1f7-0018-4230-8dfa-e6c75dfac95f.jpeg)

Input fields:
![image](https://user-images.githubusercontent.com/12400734/196174079-ad5331c0-7f2a-489b-9ae4-ac26b0369a56.png)


## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Google introduced new support for [site names in Google Search](https://developers.google.com/search/blog/2022/10/introducing-site-names-on-search). Yoast SEO already outputs this value correctly, using the WordPress site name. With this change we have increased the control site owners have over this value by adding input fields to overwrite the site name, as well as an extra input field for a (potentially shorter) alternate name.
* If no social profiles have been added for an Organization, we no longer output an empty array.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

**For the main change:**
* In a clean setup, set the Site Title in Settings->General, eg. `Test Site`
* Go to a frontend page, be it the homepage, a post, an archive or a taxonomy and confirm that the `Website` node has the name attribute set to the Site Title you set in the previous step, aka `"name": "Test Site",`. This is what happens already with our live version as well and it is independent on whether the site is Organization/Person
* Go to Yoast SEO->Search Appearance, set the representation as Organization and confirm that the placeholders for `Website Name` and `Organization Name` are the Site Title you set in the previous step. Also confirm that in the schema, the Organization node has also the `"name": "Test Site",` attribute.
* In the settings now, change the website name and the organization name, add an alternate website name and add an alternate organization name. Confirm that the `Website` node has the new website name, the `Organization` node has the new organization name and both nodes have the `alternateName` attribute set as the respective value from the settings.
* Also add the following filter in your functions.php or in a mu-plugin:
```
add_filter( 'wpseo_schema_company_alternate_name', 'schema_company_alternate_name' );
function schema_company_alternate_name( $alternate_name ) {
    return "this is new";
}
```
and confirm in the schema that the `alternateName` of the organization became `this is new`
**For the empty social profiles change**:
* Make sure you have set `Organization` as site representation (for Person, nothing has changed, we don't show empty `sameAs` attibutes already)
* In the Yoast SEO->Social->Accounts page, add one URL in at least one of those accounts.
* Confirm that in the schema, you see those URLs in an array in the `sameAs` attribute of the Organization node:
```
"sameAs": [
    "https://social-platform.com/yoast",
    "https://facebook.com/yoast",
    "https://twitter.com/yoast"
]
```
* Now, in the Yoast SEO->Social->Accounts page, delete all URLs from the accounts
* Confirm that in the schema, you dont see the `sameAs` attribute in the Organization node at all. With the previous versions, we used to show it as an empty array.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [x] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

**Impact Check**

* For Local SEO: check that the `alternateName` for website/organization is getting output in Location CPT and also in the homepage regardless whether the `All locations are part of the same business` setting is enabled or not
* For Woo SEO, check a product page for the same
* For News SEO, check a post for the same (after activating posts for news)
* For Video SEO, check a post with a video in it for the same

## UI changes

* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.