### PR TITLE
Pc 835 add support to company alternate name to first time configuration

### DIFF
--- a/packages/js/src/first-time-configuration/first-time-configuration-steps.js
+++ b/packages/js/src/first-time-configuration/first-time-configuration-steps.js
@@ -43,6 +43,7 @@ async function updateSiteRepresentation( state ) {
 		/* eslint-disable camelcase */
 		company_or_person: state.companyOrPerson === "emptyChoice" ? "company" : state.companyOrPerson,
 		company_name: state.companyName,
+		company_alternate_name: state.companyAlternateName,
 		company_logo: state.companyLogo,
 		company_logo_id: state.companyLogoId ? state.companyLogoId : 0,
 		person_logo: state.personLogo,

--- a/packages/js/src/first-time-configuration/tailwind-components/helpers/index.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/helpers/index.js
@@ -135,6 +135,10 @@ export function configurationReducer( state, action ) {
 			newState = handleStepEdit( newState, 2 );
 			newState.companyName = action.payload;
 			return newState;
+		case "CHANGE_COMPANY_ALTERNATE_NAME":
+			newState = handleStepEdit( newState, 2 );
+			newState.companyAlternateName = action.payload;
+			return newState;
 		case "SET_COMPANY_LOGO":
 			newState = handleStepEdit( newState, 2 );
 			newState.companyLogo = action.payload.url;

--- a/packages/js/src/first-time-configuration/tailwind-components/steps/site-representation/organization-section.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/steps/site-representation/organization-section.js
@@ -6,6 +6,7 @@ import ImageSelect from "../../base/image-select";
 
 import { openMedia } from "../../../../helpers/selectMedia";
 
+/* eslint-disable max-len */
 /**
  * The Organization section.
  *
@@ -13,11 +14,12 @@ import { openMedia } from "../../../../helpers/selectMedia";
  * @param {string}   imageUrl                   The image URL.
  * @param {string}   fallbackImageUrl           The fallback image URL for when there is no image.
  * @param {string}   organizationName           The name of the organization.
+ * @param {string}   organizationAlternateName  An alternate name of the organization.
  * @param {string}   fallbackOrganizationName   The fallback name of the organization.
  * @param {bool}     isDisabled                 A flag to disable the field.
  * @returns {WPElement} The organization section.
  */
-export function OrganizationSection( { dispatch, imageUrl, fallbackImageUrl, organizationName, fallbackOrganizationName, errorFields } ) {
+export function OrganizationSection( { dispatch, imageUrl, fallbackImageUrl, organizationName, organizationAlternateName, fallbackOrganizationName, errorFields } ) {
 	const openImageSelect = useCallback( () => {
 		openMedia( ( selectedImage ) => {
 			dispatch( { type: "SET_COMPANY_LOGO", payload: { ...selectedImage } } );
@@ -28,8 +30,12 @@ export function OrganizationSection( { dispatch, imageUrl, fallbackImageUrl, org
 		dispatch( { type: "REMOVE_COMPANY_LOGO" } );
 	} );
 
-	const handleChange = useCallback( ( event ) => {
+	const handleNameChange = useCallback( ( event ) => {
 		dispatch( { type: "CHANGE_COMPANY_NAME", payload: event.target.value } );
+	} );
+
+	const handleAlternateNameChange = useCallback( ( event ) => {
+		dispatch( { type: "CHANGE_COMPANY_ALTERNATE_NAME", payload: event.target.value } );
 	} );
 
 	return (
@@ -40,10 +46,23 @@ export function OrganizationSection( { dispatch, imageUrl, fallbackImageUrl, org
 				name="organization-name"
 				label={ __( "Organization name", "wordpress-seo" ) }
 				value={ ( organizationName === "" ) ? fallbackOrganizationName : organizationName }
-				onChange={ handleChange }
+				onChange={ handleNameChange }
 				feedback={ {
 					isVisible: errorFields.includes( "company_name" ),
 					message: [ __( "We could not save the organization name. Please check the value.", "wordpress-seo" ) ],
+					type: "error",
+				} }
+			/>
+			<TextInput
+				className="yst-mt-6"
+				id="organization-alternate-name-input"
+				name="organization-alternate-name"
+				label={ __( "Organization alternate name", "wordpress-seo" ) }
+				value={ organizationAlternateName }
+				onChange={ handleAlternateNameChange }
+				feedback={ {
+					isVisible: errorFields.includes( "company_alternate_name" ),
+					message: [ __( "We could not save the organization alternate name. Please check the value.", "wordpress-seo" ) ],
 					type: "error",
 				} }
 			/>
@@ -67,6 +86,7 @@ OrganizationSection.propTypes = {
 	imageUrl: PropTypes.string,
 	fallbackImageUrl: PropTypes.string,
 	organizationName: PropTypes.string,
+	organizationAlternateName: PropTypes.string,
 	fallbackOrganizationName: PropTypes.string,
 	errorFields: PropTypes.array,
 };
@@ -75,6 +95,8 @@ OrganizationSection.defaultProps = {
 	imageUrl: "",
 	fallbackImageUrl: "",
 	organizationName: "",
+	organizationAlternateName: "",
 	fallbackOrganizationName: "",
 	errorFields: [],
 };
+/* eslint-enable max-len */

--- a/packages/js/src/first-time-configuration/tailwind-components/steps/site-representation/organization-section.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/steps/site-representation/organization-section.js
@@ -14,12 +14,12 @@ import { openMedia } from "../../../../helpers/selectMedia";
  * @param {string}   imageUrl                   The image URL.
  * @param {string}   fallbackImageUrl           The fallback image URL for when there is no image.
  * @param {string}   organizationName           The name of the organization.
- * @param {string}   organizationAlternateName  An alternate name of the organization.
+ * @param {string}   alternateOrganizationName  An alternate name of the organization.
  * @param {string}   fallbackOrganizationName   The fallback name of the organization.
  * @param {bool}     isDisabled                 A flag to disable the field.
  * @returns {WPElement} The organization section.
  */
-export function OrganizationSection( { dispatch, imageUrl, fallbackImageUrl, organizationName, organizationAlternateName, fallbackOrganizationName, errorFields } ) {
+export function OrganizationSection( { dispatch, imageUrl, fallbackImageUrl, organizationName, alternateOrganizationName, fallbackOrganizationName, errorFields } ) {
 	const openImageSelect = useCallback( () => {
 		openMedia( ( selectedImage ) => {
 			dispatch( { type: "SET_COMPANY_LOGO", payload: { ...selectedImage } } );
@@ -55,10 +55,10 @@ export function OrganizationSection( { dispatch, imageUrl, fallbackImageUrl, org
 			/>
 			<TextInput
 				className="yst-mt-6"
-				id="organization-alternate-name-input"
-				name="organization-alternate-name"
-				label={ __( "Organization alternate name", "wordpress-seo" ) }
-				value={ organizationAlternateName }
+				id="alternate-organization-name-input"
+				name="alternate-organization-name"
+				label={ __( "Alternate organization name", "wordpress-seo" ) }
+				value={ alternateOrganizationName }
 				onChange={ handleAlternateNameChange }
 				feedback={ {
 					isVisible: errorFields.includes( "company_alternate_name" ),
@@ -86,7 +86,7 @@ OrganizationSection.propTypes = {
 	imageUrl: PropTypes.string,
 	fallbackImageUrl: PropTypes.string,
 	organizationName: PropTypes.string,
-	organizationAlternateName: PropTypes.string,
+	alternateOrganizationName: PropTypes.string,
 	fallbackOrganizationName: PropTypes.string,
 	errorFields: PropTypes.array,
 };
@@ -95,7 +95,7 @@ OrganizationSection.defaultProps = {
 	imageUrl: "",
 	fallbackImageUrl: "",
 	organizationName: "",
-	organizationAlternateName: "",
+	alternateOrganizationName: "",
 	fallbackOrganizationName: "",
 	errorFields: [],
 };

--- a/packages/js/src/first-time-configuration/tailwind-components/steps/site-representation/site-representation-step.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/steps/site-representation/site-representation-step.js
@@ -105,7 +105,7 @@ export default function SiteRepresentationStep( { onOrganizationOrPersonChange, 
 					imageUrl={ state.companyLogo }
 					fallbackImageUrl={ state.companyLogoFallback }
 					organizationName={ state.companyName }
-					organizationAlternateName={ state.companyAlternateName }
+					alternateOrganizationName={ state.companyAlternateName }
 					fallbackOrganizationName={ state.fallbackCompanyName }
 					errorFields={ state.errorFields }
 				/> }

--- a/packages/js/src/first-time-configuration/tailwind-components/steps/site-representation/site-representation-step.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/steps/site-representation/site-representation-step.js
@@ -105,6 +105,7 @@ export default function SiteRepresentationStep( { onOrganizationOrPersonChange, 
 					imageUrl={ state.companyLogo }
 					fallbackImageUrl={ state.companyLogoFallback }
 					organizationName={ state.companyName }
+					organizationAlternateName={ state.companyAlternateName }
 					fallbackOrganizationName={ state.fallbackCompanyName }
 					errorFields={ state.errorFields }
 				/> }

--- a/src/actions/configuration/first-time-configuration-action.php
+++ b/src/actions/configuration/first-time-configuration-action.php
@@ -16,6 +16,7 @@ class First_Time_Configuration_Action {
 	const SITE_REPRESENTATION_FIELDS = [
 		'company_or_person',
 		'company_name',
+		'company_alternate_name',
 		'company_logo',
 		'company_logo_id',
 		'person_logo',

--- a/src/integrations/admin/first-time-configuration-integration.php
+++ b/src/integrations/admin/first-time-configuration-integration.php
@@ -192,6 +192,7 @@ class First_Time_Configuration_Integration implements Integration_Interface {
 					"companyOrPerson": "%s",
 					"companyOrPersonLabel": "%s",
 					"companyName": "%s",
+					"companyAlternateName": "%s",
 					"fallbackCompanyName": "%s",
 					"companyLogo": "%s",
 					"companyLogoFallback": "%s",
@@ -225,6 +226,7 @@ class First_Time_Configuration_Integration implements Integration_Interface {
 				$this->is_company_or_person(),
 				$selected_option_label,
 				$this->get_company_name(),
+				$this->get_company_alternate_name(),
 				$this->get_fallback_company_name( $this->get_company_name() ),
 				$this->get_company_logo(),
 				$this->get_company_fallback_logo( $this->get_company_logo() ),
@@ -305,6 +307,15 @@ class First_Time_Configuration_Integration implements Integration_Interface {
 	 */
 	private function get_company_name() {
 		return $this->options_helper->get( 'company_name', '' );
+	}
+
+	/**
+	 * Gets the company alternate name from the option in the database.
+	 *
+	 * @return string The company alternate name.
+	 */
+	private function get_company_alternate_name() {
+		return $this->options_helper->get( 'company_alternate_name', '' );
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to add support for the `Alternate organization name` property to the `Site representation` step of the `First-time configuration`

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds an `Alternate organization name` field to the `Site representation` step of the `First-time configuration`.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Go to `Yoast SEO` -> `General` -> `First-time configuration` tab
* Navigate to the `Site representation` step and insert a value in the `Alternate organization name` field
* Proceed to the next step
* Go back to the previous step and verify the specified value is retained
* Finish the First-time configuration
* Go to `Yoast SEO` -> `Search Appearance`
* In the `Knowledge Graph & Schema.org section` verify the value in `Alternate organization name` text field is the same as specified in the First-time configuration
* Modify the value of the `Alternate organization name` text field and save
* Go back to the First-time configuration `Site representation` step and verify the change is present there, too

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [X] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.

Fixes [PC-835](https://yoast.atlassian.net/browse/PC-835)
