### PR TITLE
Co Authors Plus integration: Add support to Guest Authors

### DIFF
--- a/src/generators/schema/third-party/coauthor.php
+++ b/src/generators/schema/third-party/coauthor.php
@@ -116,7 +116,7 @@ class CoAuthor extends Author {
 		$data = $this->set_image_from_avatar( $data, $guest_author, $schema_id, $add_hash );
 
 		// If local avatar is present, override.
-		$avatar_meta = \wp_get_attachment_image_src( get_post_thumbnail_id( $guest_author->ID ) );
+		$avatar_meta = \wp_get_attachment_image_src( \get_post_thumbnail_id( $guest_author->ID ) );
 		if ( $avatar_meta ) {
 			$avatar_meta   = [
 				'url'    => $avatar_meta[0],

--- a/src/generators/schema/third-party/coauthor.php
+++ b/src/generators/schema/third-party/coauthor.php
@@ -2,7 +2,9 @@
 
 namespace Yoast\WP\SEO\Generators\Schema\Third_Party;
 
+use Yoast\WP\SEO\Config\Schema_IDs;
 use Yoast\WP\SEO\Generators\Schema\Author;
+
 
 /**
  * Returns schema Author data for the CoAuthor Plus assigned user on a post.
@@ -12,7 +14,7 @@ class CoAuthor extends Author {
 	/**
 	 * The user ID of the author we're generating data for.
 	 *
-	 * @var int
+	 * @var int $user_id
 	 */
 	private $user_id;
 
@@ -63,11 +65,70 @@ class CoAuthor extends Author {
 	}
 
 	/**
+	 * Generate the Person data given a user ID.
+	 *
+	 * @param int $user_id User ID.
+	 *
+	 * @return array|bool
+	 */
+	public function generate_from_guest_author( $guest_author ) {
+		$this->user_id = $user_id;
+
+		$data = $this->build_person_data_for_guest_author( $guest_author, true );
+
+		$data['@type'] = 'Person';
+		unset( $data['logo'] );
+
+		// If this is a post and the author archives are enabled, set the author archive url as the author url.
+		// if ( $this->helpers->options->get( 'disable-author' ) !== true ) {
+		// 	$data['url'] = $this->helpers->user->get_the_author_posts_url( $user_id );
+		// }
+
+		return $data;
+
+		//return $this->generate();
+	}
+
+	/**
 	 * Determines a User ID for the Person data.
 	 *
 	 * @return bool|int User ID or false upon return.
 	 */
 	protected function determine_user_id() {
 		return $this->user_id;
+	}
+
+	/**
+	 * Builds our array of Schema Person data for a given user ID.
+	 *
+	 * @param int  $user_id  The user ID to use.
+	 * @param bool $add_hash Wether or not the person's image url hash should be added to the image id.
+	 *
+	 * @return array An array of Schema Person data.
+	 */
+	protected function build_person_data_for_guest_author( $guest_author, $add_hash = false ) {
+		$data      = [
+			'@type' => $this->type,
+			'@id'   => $this->context->site_url . Schema_IDs::PERSON_HASH . \wp_hash( $guest_author->user_login . $guest_author->ID . 'guest' ),
+		];
+
+		$data['name'] = $this->helpers->schema->html->smart_strip_tags( $guest_author->display_name );
+		//$data         = $this->add_image( $data, $guest_author, $add_hash );
+
+		if ( ! empty( $guest_author->description ) ) {
+			$data['description'] = $this->helpers->schema->html->smart_strip_tags( $guest_author->description );
+		}
+
+		//$data = $this->add_same_as_urls( $data, $guest_author, $user_id );
+
+		/**
+		 * Filter: 'wpseo_schema_person_data' - Allows filtering of schema data per user.
+		 *
+		 * @param array $data    The schema data we have for this person.
+		 * @param int   $user_id The current user we're collecting schema data for.
+		 */
+		//$data = \apply_filters( 'wpseo_schema_person_data', $data, $user_id );generate_from_guest_author
+
+		return $data;
 	}
 }

--- a/src/integrations/third-party/coauthors-plus.php
+++ b/src/integrations/third-party/coauthors-plus.php
@@ -74,7 +74,7 @@ class CoAuthors_Plus implements Integration_Interface {
 			return $data;
 		}
 
-		$user = get_queried_object();
+		$user = \get_queried_object();
 
 		if ( empty( $user->type ) || $user->type !== 'guest-author' ) {
 			return $data;

--- a/src/integrations/third-party/coauthors-plus.php
+++ b/src/integrations/third-party/coauthors-plus.php
@@ -183,7 +183,7 @@ class CoAuthors_Plus implements Integration_Interface {
 
 			if ( ! empty( $author_data ) ) {
 				if ( $context->site_represents !== 'person' || $author->ID !== $context->site_user_id ) {
-					$data = array_merge( $data, $authors );
+					$data = \array_merge( $data, $authors );
 				}
 			}
 		}

--- a/src/integrations/third-party/coauthors-plus.php
+++ b/src/integrations/third-party/coauthors-plus.php
@@ -81,7 +81,7 @@ class CoAuthors_Plus implements Integration_Interface {
 		}
 
 		// Fix author URL.
-		$author_url                                     = \get_author_posts_url( $user->ID );
+		$author_url                                     = \get_author_posts_url( $user->ID, $user->user_nicename );
 		$graph_piece_generator->context->canonical      = $author_url;
 		$graph_piece_generator->context->main_schema_id = $author_url;
 

--- a/src/integrations/third-party/coauthors-plus.php
+++ b/src/integrations/third-party/coauthors-plus.php
@@ -174,7 +174,7 @@ class CoAuthors_Plus implements Integration_Interface {
 
 		if ( $add_to_graph ) {
 			// Clean all Persons from the schema, as the user stored as post owner might be incorrectly added if the post post has only guest authors as authors.
-			$data = array_filter(
+			$data = \array_filter(
 				$data,
 				function( $piece ) {
 					return empty( $piece['@type'] ) || $piece['@type'] !== 'Person';

--- a/src/integrations/third-party/coauthors-plus.php
+++ b/src/integrations/third-party/coauthors-plus.php
@@ -81,7 +81,7 @@ class CoAuthors_Plus implements Integration_Interface {
 		}
 
 		// Fix author URL.
-		$author_url                                     = get_author_posts_url( $user->ID );
+		$author_url                                     = \get_author_posts_url( $user->ID );
 		$graph_piece_generator->context->canonical      = $author_url;
 		$graph_piece_generator->context->main_schema_id = $author_url;
 

--- a/src/integrations/third-party/coauthors-plus.php
+++ b/src/integrations/third-party/coauthors-plus.php
@@ -31,6 +31,7 @@ class CoAuthors_Plus implements Integration_Interface {
 	public function register_hooks() {
 		\add_filter( 'wpseo_schema_graph', [ $this, 'filter_graph' ], 11, 2 );
 		\add_filter( 'wpseo_schema_author', [ $this, 'filter_author_graph' ], 11, 4 );
+		\add_filter( 'wpseo_meta_author', [ $this, 'filter_author_meta' ], 11, 2 );
 	}
 
 	/**
@@ -157,5 +158,30 @@ class CoAuthors_Plus implements Integration_Interface {
 		}
 
 		return $data;
+	}
+
+	/**
+	 * Filters the author meta tag
+	 *
+	 * @param string                 $author_name  The article author's display name. Return empty to disable the tag.
+	 * @param Indexable_Presentation $presentation The presentation of an indexable.
+	 * @return string
+	 */
+	public function filter_author_meta( $author_name, $presentation ) {
+		$author_objects = \get_coauthors( $presentation->context->post->id );
+
+		// Fallback in case of error.
+		if ( empty( $author_objects ) ) {
+			return $author_name;
+		}
+
+		$output = '';
+		foreach ( $author_objects as $i => $author ) {
+			$output .= $author->display_name;
+			if ( $i <= ( count( $author_objects ) - 2 ) ) {
+				$output .= ', ';
+			}
+		}
+		return $output;
 	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Improve the CoAuthors Plus integration adding support to guest authors

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improve the CoAuthors Plus integration adding support to guest authors

## Relevant technical choices:

* Until now, the integration would only act if a post had more than one author. It would not touch the first author added and it would simply add additional authors
* This PR changes it and replaces all authors from the post schema. That's because the real post author can be different than the post_author column in the database. Also, the author can be an guest author, which means it's not a real user. 
* By overriding the list of authors we assure we get all the cases right

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Enable Yoast and CoAuthors Plus plugin
* Create a post
* Enable the integration by adding `define('YOAST_SEO_COAUTHORS_PLUS', true);` to your wp-config.php

Now try different authorship states and check the resulting schema:

* Visit the post you created and look at the source code
* We want to look at the schema that is inserted in the `<script type="application/ld+json" class="yoast-schema-graph">` tag
* Make sure the "author" key has a list of IDs and they match the authors you have set up for the post:

```
"@graph": [
	        {
	            "@type": "Article",
	            "@id": "https://leogermani.jurassic.tube/2022/09/15/venenatis-dapibus-odio-sollicitudin-ultricies-magna-sem-hac-hendrerit-cursus-faucibus/#article",
	            "isPartOf": {
	                "@id": "https://leogermani.jurassic.tube/2022/09/15/venenatis-dapibus-odio-sollicitudin-ultricies-magna-sem-hac-hendrerit-cursus-faucibus/"
	            },
	            "author": [
	                {
	                    "@id": "https://leogermani.jurassic.tube/#/schema/person/743c49680386c3bcf517e1753cd46a25"
	                }
	            ],
 ...
```
* The example above shows a post with only one author
* At the end of the schema, look for the `Person` sections. There should be one section for each author you added to the post. Example:
```
	        {
	            "@type": "Person",
	            "@id": "https://leogermani.jurassic.tube/#/schema/person/743c49680386c3bcf517e1753cd46a25",
	            "name": "leo",
	            "image": {
	                "@type": "ImageObject",
	                "inLanguage": "en-US",
	                "@id": "https://leogermani.jurassic.tube/#/schema/person/image/00d99ee8603d99603d8c6be4dbc57016",
	                "url": "https://secure.gravatar.com/avatar/ea8b076b398ee48b71cfaecf898c582b?s=96&d=mm&r=g",
	                "contentUrl": "https://secure.gravatar.com/avatar/ea8b076b398ee48b71cfaecf898c582b?s=96&d=mm&r=g",
	                "caption": "leo"
	            },
	            "sameAs": [
	                "http://localhost"
	            ],
	            "mainEntityOfPage": {
	                "@id": "https://leogermani.jurassic.tube/author/leo/"
	            }
	        }
```
* The persons in the list must match the IDs in the author key we saw above. 
* Confirm that the `<meta name="author" ..` tag correctly displays the name of all authors
* Repeat the above steps changing the post authorship with different combinations:
  * only one regular author
  * 2 or more authors who are regular users
  * mix of regular users and guest authors as authors of the post
  * only one guest author as the post author
  * multiple guest authors as post authors
  * Also test guest authors with and without avatars, and with and without emails with gravatars. Check that the image tag is properly added in all cases.
 * Visit an author archive page for both a regular author and a guest author and make sure the schema for `profilePage` has the right links

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [x] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* This PR only affects the CoAuthors Plus integration

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
