### PR TITLE
Don't store indexables for non-public post/tax types

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -84,7 +84,7 @@
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_coding_standards"
 		],
 		"check-cs-thresholds": [
-			"@putenv YOASTCS_THRESHOLD_ERRORS=145",
+			"@putenv YOASTCS_THRESHOLD_ERRORS=144",
 			"@putenv YOASTCS_THRESHOLD_WARNINGS=208",
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_cs_thresholds"
 		],

--- a/composer.json
+++ b/composer.json
@@ -84,7 +84,7 @@
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_coding_standards"
 		],
 		"check-cs-thresholds": [
-			"@putenv YOASTCS_THRESHOLD_ERRORS=144",
+			"@putenv YOASTCS_THRESHOLD_ERRORS=145",
 			"@putenv YOASTCS_THRESHOLD_WARNINGS=208",
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_cs_thresholds"
 		],

--- a/src/actions/indexing/indexable-post-indexation-action.php
+++ b/src/actions/indexing/indexable-post-indexation-action.php
@@ -139,7 +139,7 @@ class Indexable_Post_Indexation_Action extends Abstract_Indexing_Action {
 	protected function get_count_query() {
 		$indexable_table = Model::get_table_name( 'Indexable' );
 
-		$post_types             = $this->get_post_types();
+		$post_types             = $this->post_type_helper->get_indexable_post_types();
 		$excluded_post_statuses = $this->post_helper->get_excluded_post_statuses();
 		$replacements           = \array_merge(
 			$post_types,
@@ -174,7 +174,7 @@ class Indexable_Post_Indexation_Action extends Abstract_Indexing_Action {
 	protected function get_select_query( $limit = false ) {
 		$indexable_table = Model::get_table_name( 'Indexable' );
 
-		$post_types             = $this->get_post_types();
+		$post_types             = $this->post_type_helper->get_indexable_post_types();
 		$excluded_post_statuses = $this->post_helper->get_excluded_post_statuses();
 		$replacements           = \array_merge(
 			$post_types,
@@ -203,18 +203,5 @@ class Indexable_Post_Indexation_Action extends Abstract_Indexing_Action {
 			$limit_query",
 			$replacements
 		);
-	}
-
-	/**
-	 * Returns the post types that should be indexed.
-	 *
-	 * @return array The post types that should be indexed.
-	 */
-	protected function get_post_types() {
-		$public_post_types   = $this->post_type_helper->get_public_post_types();
-		$excluded_post_types = $this->post_type_helper->get_excluded_post_types_for_indexables();
-
-		// `array_values`, to make sure that the keys are reset.
-		return \array_values( \array_diff( $public_post_types, $excluded_post_types ) );
 	}
 }

--- a/src/actions/indexing/indexable-term-indexation-action.php
+++ b/src/actions/indexing/indexable-term-indexation-action.php
@@ -126,7 +126,7 @@ class Indexable_Term_Indexation_Action extends Abstract_Indexing_Action {
 	protected function get_count_query() {
 		$indexable_table   = Model::get_table_name( 'Indexable' );
 		$taxonomy_table    = $this->wpdb->term_taxonomy;
-		$public_taxonomies = $this->get_taxonomies();
+		$public_taxonomies = $this->taxonomy->get_indexable_taxonomies();
 
 		$taxonomies_placeholders = \implode( ', ', \array_fill( 0, \count( $public_taxonomies ), '%s' ) );
 
@@ -158,7 +158,7 @@ class Indexable_Term_Indexation_Action extends Abstract_Indexing_Action {
 	protected function get_select_query( $limit = false ) {
 		$indexable_table   = Model::get_table_name( 'Indexable' );
 		$taxonomy_table    = $this->wpdb->term_taxonomy;
-		$public_taxonomies = $this->get_taxonomies();
+		$public_taxonomies = $this->taxonomy->get_indexable_taxonomies();
 		$placeholders      = \implode( ', ', \array_fill( 0, \count( $public_taxonomies ), '%s' ) );
 
 		$replacements = [ $this->version ];
@@ -184,18 +184,5 @@ class Indexable_Term_Indexation_Action extends Abstract_Indexing_Action {
 			$limit_query",
 			$replacements
 		);
-	}
-
-	/**
-	 * Returns the taxonomies that should be indexed.
-	 *
-	 * @return array The taxonomies that should be indexed.
-	 */
-	protected function get_taxonomies() {
-		$public_taxonomies   = \array_keys( $this->taxonomy->get_public_taxonomies() );
-		$excluded_taxonomies = $this->taxonomy->get_excluded_taxonomies_for_indexables();
-
-		// `array_values`, to make sure that the keys are reset.
-		return \array_values( \array_diff( $public_taxonomies, $excluded_taxonomies ) );
 	}
 }

--- a/src/actions/indexing/indexable-term-indexation-action.php
+++ b/src/actions/indexing/indexable-term-indexation-action.php
@@ -124,9 +124,10 @@ class Indexable_Term_Indexation_Action extends Abstract_Indexing_Action {
 	 * @return string The prepared query string.
 	 */
 	protected function get_count_query() {
-		$indexable_table         = Model::get_table_name( 'Indexable' );
-		$taxonomy_table          = $this->wpdb->term_taxonomy;
-		$public_taxonomies       = \array_keys( $this->taxonomy->get_public_taxonomies() );
+		$indexable_table   = Model::get_table_name( 'Indexable' );
+		$taxonomy_table    = $this->wpdb->term_taxonomy;
+		$public_taxonomies = $this->get_taxonomies();
+
 		$taxonomies_placeholders = \implode( ', ', \array_fill( 0, \count( $public_taxonomies ), '%s' ) );
 
 		$replacements = [ $this->version ];
@@ -157,7 +158,7 @@ class Indexable_Term_Indexation_Action extends Abstract_Indexing_Action {
 	protected function get_select_query( $limit = false ) {
 		$indexable_table   = Model::get_table_name( 'Indexable' );
 		$taxonomy_table    = $this->wpdb->term_taxonomy;
-		$public_taxonomies = \array_keys( $this->taxonomy->get_public_taxonomies() );
+		$public_taxonomies = $this->get_taxonomies();
 		$placeholders      = \implode( ', ', \array_fill( 0, \count( $public_taxonomies ), '%s' ) );
 
 		$replacements = [ $this->version ];
@@ -183,5 +184,18 @@ class Indexable_Term_Indexation_Action extends Abstract_Indexing_Action {
 			$limit_query",
 			$replacements
 		);
+	}
+
+	/**
+	 * Returns the taxonomies that should be indexed.
+	 *
+	 * @return array The taxonomies that should be indexed.
+	 */
+	protected function get_taxonomies() {
+		$public_taxonomies   = \array_keys( $this->taxonomy->get_public_taxonomies() );
+		$excluded_taxonomies = $this->taxonomy->get_excluded_taxonomies_for_indexables();
+
+		// `array_values`, to make sure that the keys are reset.
+		return \array_values( \array_diff( $public_taxonomies, $excluded_taxonomies ) );
 	}
 }

--- a/src/actions/indexing/post-link-indexing-action.php
+++ b/src/actions/indexing/post-link-indexing-action.php
@@ -73,7 +73,7 @@ class Post_Link_Indexing_Action extends Abstract_Link_Indexing_Action {
 	 * @return string The prepared query string.
 	 */
 	protected function get_count_query() {
-		$public_post_types = $this->get_post_types();
+		$public_post_types = $this->post_type_helper->get_indexable_post_types();
 		$indexable_table   = Model::get_table_name( 'Indexable' );
 		$links_table       = Model::get_table_name( 'SEO_Links' );
 
@@ -106,7 +106,7 @@ class Post_Link_Indexing_Action extends Abstract_Link_Indexing_Action {
 	 * @return string The prepared query string.
 	 */
 	protected function get_select_query( $limit = false ) {
-		$public_post_types = $this->get_post_types();
+		$public_post_types = $this->post_type_helper->get_indexable_post_types();
 		$indexable_table   = Model::get_table_name( 'Indexable' );
 		$links_table       = Model::get_table_name( 'SEO_Links' );
 		$replacements      = $public_post_types;
@@ -138,18 +138,5 @@ class Post_Link_Indexing_Action extends Abstract_Link_Indexing_Action {
 			$limit_query",
 			$replacements
 		);
-	}
-
-	/**
-	 * Returns the post types that should be indexed.
-	 *
-	 * @return array The post types that should be indexed.
-	 */
-	protected function get_post_types() {
-		$public_post_types   = $this->post_type_helper->get_accessible_post_types();
-		$excluded_post_types = $this->post_type_helper->get_excluded_post_types_for_indexables();
-
-		// `array_values`, to make sure that the keys are reset.
-		return \array_values( \array_diff( $public_post_types, $excluded_post_types ) );
 	}
 }

--- a/src/actions/indexing/term-link-indexing-action.php
+++ b/src/actions/indexing/term-link-indexing-action.php
@@ -73,7 +73,7 @@ class Term_Link_Indexing_Action extends Abstract_Link_Indexing_Action {
 	 * @return string The prepared query string.
 	 */
 	protected function get_count_query() {
-		$public_taxonomies = $this->taxonomy_helper->get_public_taxonomies();
+		$public_taxonomies = $this->taxonomy_helper->get_indexable_taxonomies();
 		$placeholders      = \implode( ', ', \array_fill( 0, \count( $public_taxonomies ), '%s' ) );
 		$indexable_table   = Model::get_table_name( 'Indexable' );
 
@@ -100,9 +100,10 @@ class Term_Link_Indexing_Action extends Abstract_Link_Indexing_Action {
 	 * @return string The prepared query string.
 	 */
 	protected function get_select_query( $limit = false ) {
-		$public_taxonomies = $this->taxonomy_helper->get_public_taxonomies();
-		$indexable_table   = Model::get_table_name( 'Indexable' );
-		$replacements      = $public_taxonomies;
+		$public_taxonomies = $this->taxonomy_helper->get_indexable_taxonomies();
+
+		$indexable_table = Model::get_table_name( 'Indexable' );
+		$replacements    = $public_taxonomies;
 
 		$limit_query = '';
 		if ( $limit ) {

--- a/src/builders/indexable-builder.php
+++ b/src/builders/indexable-builder.php
@@ -353,11 +353,6 @@ class Indexable_Builder {
 				case 'term':
 					$indexable = $this->term_builder->build( $indexable->object_id, $indexable );
 
-					if ( ! $indexable ) {
-						// Indexable for this term was not built for a reason; e.g. if its post type is excluded.
-						return $indexable;
-					}
-
 					$this->hierarchy_builder->build( $indexable );
 					break;
 

--- a/src/builders/indexable-builder.php
+++ b/src/builders/indexable-builder.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\WP\SEO\Builders;
 
+use Yoast\WP\SEO\Exceptions\Indexable\Not_Built_Exception;
 use Yoast\WP\SEO\Exceptions\Indexable\Source_Exception;
 use Yoast\WP\SEO\Helpers\Indexable_Helper;
 use Yoast\WP\SEO\Models\Indexable;
@@ -351,6 +352,12 @@ class Indexable_Builder {
 
 				case 'term':
 					$indexable = $this->term_builder->build( $indexable->object_id, $indexable );
+
+					if ( ! $indexable ) {
+						// Indexable for this term was not built for a reason; e.g. if its post type is excluded.
+						return $indexable;
+					}
+
 					$this->hierarchy_builder->build( $indexable );
 					break;
 
@@ -395,6 +402,9 @@ class Indexable_Builder {
 			$indexable = $this->version_manager->set_latest( $indexable );
 
 			return $this->save_indexable( $indexable, $indexable_before );
+		}
+		catch ( Not_Built_Exception $exception ) {
+			return false;
 		}
 	}
 }

--- a/src/builders/indexable-post-builder.php
+++ b/src/builders/indexable-post-builder.php
@@ -11,6 +11,7 @@ use Yoast\WP\SEO\Helpers\Post_Type_Helper;
 use Yoast\WP\SEO\Models\Indexable;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
 use Yoast\WP\SEO\Values\Indexables\Indexable_Builder_Versions;
+use Yoast\WP\SEO\Exceptions\Indexable\Post_Not_Built_Exception;
 
 /**
  * Post Builder for the indexables.
@@ -96,10 +97,11 @@ class Indexable_Post_Builder {
 	 * @return bool|Indexable The extended indexable. False when unable to build.
 	 *
 	 * @throws Post_Not_Found_Exception When the post could not be found.
+	 * @throws Post_Not_Built_Exception When the post should not be indexed.
 	 */
 	public function build( $post_id, $indexable ) {
 		if ( ! $this->post_helper->is_post_indexable( $post_id ) ) {
-			return false;
+			throw Post_Not_Built_Exception::because_not_viewable( $post_id );
 		}
 
 		$post = $this->post_helper->get_post( $post_id );
@@ -109,7 +111,7 @@ class Indexable_Post_Builder {
 		}
 
 		if ( $this->should_exclude_post( $post ) ) {
-			return false;
+			throw Post_Not_Built_Exception::because_not_viewable( $post_id );
 		}
 
 		$indexable->object_id       = $post_id;

--- a/src/builders/indexable-post-builder.php
+++ b/src/builders/indexable-post-builder.php
@@ -101,7 +101,7 @@ class Indexable_Post_Builder {
 	 */
 	public function build( $post_id, $indexable ) {
 		if ( ! $this->post_helper->is_post_indexable( $post_id ) ) {
-			throw Post_Not_Built_Exception::because_not_viewable( $post_id );
+			throw Post_Not_Built_Exception::because_not_indexable( $post_id );
 		}
 
 		$post = $this->post_helper->get_post( $post_id );
@@ -111,7 +111,7 @@ class Indexable_Post_Builder {
 		}
 
 		if ( $this->should_exclude_post( $post ) ) {
-			throw Post_Not_Built_Exception::because_not_viewable( $post_id );
+			throw Post_Not_Built_Exception::because_post_type_excluded( $post_id );
 		}
 
 		$indexable->object_id       = $post_id;

--- a/src/builders/indexable-term-builder.php
+++ b/src/builders/indexable-term-builder.php
@@ -86,11 +86,11 @@ class Indexable_Term_Builder {
 		if ( $term === null ) {
 			throw new Term_Not_Found_Exception();
 		}
-		
+
 		if ( \is_wp_error( $term ) ) {
 			throw new Invalid_Term_Exception( $term->get_error_message() );
 		}
-		
+
 		if ( ! is_taxonomy_viewable( $term->taxonomy ) ) {
 			throw Term_Not_Built_Exception::because_not_viewable( $term_id );
 		}

--- a/src/builders/indexable-term-builder.php
+++ b/src/builders/indexable-term-builder.php
@@ -92,7 +92,7 @@ class Indexable_Term_Builder {
 		}
 
 		$indexable_taxonomies = $this->taxonomy_helper->get_indexable_taxonomies();
-		if ( ! in_array( $term->taxonomy, $indexable_taxonomies, true ) ) {
+		if ( ! \in_array( $term->taxonomy, $indexable_taxonomies, true ) ) {
 			throw Term_Not_Built_Exception::because_not_indexable( $term_id );
 		}
 

--- a/src/builders/indexable-term-builder.php
+++ b/src/builders/indexable-term-builder.php
@@ -91,12 +91,9 @@ class Indexable_Term_Builder {
 			throw new Invalid_Term_Exception( $term->get_error_message() );
 		}
 
-		if ( ! is_taxonomy_viewable( $term->taxonomy ) ) {
-			throw Term_Not_Built_Exception::because_not_viewable( $term_id );
-		}
-
-		if ( $this->taxonomy_helper->is_excluded( $term->taxonomy ) ) {
-			throw Term_Not_Built_Exception::because_excluded( $term_id );
+		$indexable_taxonomies = $this->taxonomy_helper->get_indexable_taxonomies();
+		if ( ! in_array( $term->taxonomy, $indexable_taxonomies, true ) ) {
+			throw Term_Not_Built_Exception::because_not_indexable( $term_id );
 		}
 
 		$term_link = \get_term_link( $term, $term->taxonomy );

--- a/src/builders/indexable-term-builder.php
+++ b/src/builders/indexable-term-builder.php
@@ -5,6 +5,7 @@ namespace Yoast\WP\SEO\Builders;
 use wpdb;
 use Yoast\WP\SEO\Exceptions\Indexable\Invalid_Term_Exception;
 use Yoast\WP\SEO\Exceptions\Indexable\Term_Not_Found_Exception;
+use Yoast\WP\SEO\Exceptions\Indexable\Term_Not_Built_Exception;
 use Yoast\WP\SEO\Helpers\Post_Helper;
 use Yoast\WP\SEO\Helpers\Taxonomy_Helper;
 use Yoast\WP\SEO\Models\Indexable;
@@ -75,7 +76,8 @@ class Indexable_Term_Builder {
 	 *
 	 * @return bool|Indexable The extended indexable. False when unable to build.
 	 *
-	 * @throws Invalid_Term_Exception When the term is invalid.
+	 * @throws Invalid_Term_Exception   When the term is invalid.
+	 * @throws Term_Not_Built_Exception When the term is not viewable.
 	 * @throws Term_Not_Found_Exception When the term is not found.
 	 */
 	public function build( $term_id, $indexable ) {
@@ -84,9 +86,13 @@ class Indexable_Term_Builder {
 		if ( $term === null ) {
 			throw new Term_Not_Found_Exception();
 		}
-
+		
 		if ( \is_wp_error( $term ) ) {
 			throw new Invalid_Term_Exception( $term->get_error_message() );
+		}
+		
+		if ( ! is_taxonomy_viewable( $term->taxonomy ) ) {
+			throw Term_Not_Built_Exception::because_not_viewable( $term_id );
 		}
 
 		$term_link = \get_term_link( $term, $term->taxonomy );

--- a/src/builders/indexable-term-builder.php
+++ b/src/builders/indexable-term-builder.php
@@ -95,6 +95,10 @@ class Indexable_Term_Builder {
 			throw Term_Not_Built_Exception::because_not_viewable( $term_id );
 		}
 
+		if ( $this->taxonomy_helper->is_excluded( $term->taxonomy ) ) {
+			throw Term_Not_Built_Exception::because_excluded( $term_id );
+		}
+
 		$term_link = \get_term_link( $term, $term->taxonomy );
 
 		if ( \is_wp_error( $term_link ) ) {

--- a/src/exceptions/indexable/not-built-exception.php
+++ b/src/exceptions/indexable/not-built-exception.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Yoast\WP\SEO\Exceptions\Indexable;
+
+/**
+ * Class Not_Built_Exception
+ */
+class Not_Built_Exception extends Indexable_Exception {
+
+}

--- a/src/exceptions/indexable/post-not-built-exception.php
+++ b/src/exceptions/indexable/post-not-built-exception.php
@@ -11,12 +11,12 @@ class Post_Not_Built_Exception extends Not_Built_Exception {
 	/**
 	 * Throws an exception if the post is not viewable.
 	 *
-	 * @param int $post_id ID of the term.
+	 * @param int $post_id ID of the post.
 	 *
 	 * @throws Post_Not_Built_Exception When the post is not found.
 	 */
 	public static function because_not_viewable( $post_id ) {
-		/* translators: %s: expands to the term id */
+		/* translators: %s: expands to the post id */
 		return new Post_Not_Built_Exception( sprintf( __( 'The post %s could not be built because it\'s not viewable.', 'wordpress-seo' ), $post_id ) );
 	}
 }

--- a/src/exceptions/indexable/post-not-built-exception.php
+++ b/src/exceptions/indexable/post-not-built-exception.php
@@ -9,14 +9,26 @@ namespace Yoast\WP\SEO\Exceptions\Indexable;
 class Post_Not_Built_Exception extends Not_Built_Exception {
 
 	/**
-	 * Throws an exception if the post is not viewable.
+	 * Throws an exception if the post is not indexable.
 	 *
 	 * @param int $post_id ID of the post.
 	 *
-	 * @throws Post_Not_Built_Exception When the post is not found.
+	 * @throws Post_Not_Built_Exception When the post is not indexable.
 	 */
-	public static function because_not_viewable( $post_id ) {
+	public static function because_not_indexable( $post_id ) {
 		/* translators: %s: expands to the post id */
-		return new Post_Not_Built_Exception( sprintf( __( 'The post %s could not be built because it\'s not viewable.', 'wordpress-seo' ), $post_id ) );
+		return new Post_Not_Built_Exception( sprintf( __( 'The post %s could not be indexed because it does not meet indexing requirments.', 'wordpress-seo' ), $post_id ) );
+	}
+
+	/**
+	 * Throws an exception if the post type is excluded from indexing.
+	 *
+	 * @param int $post_id ID of the post.
+	 *
+	 * @throws Post_Not_Built_Exception When the post type is excluded.
+	 */
+	public static function because_post_type_excluded( $post_id ) {
+		/* translators: %s: expands to the post id */
+		return new Post_Not_Built_Exception( sprintf( __( 'The post %s could not be indexed because it\'s post type is excluded from indexing.', 'wordpress-seo' ), $post_id ) );
 	}
 }

--- a/src/exceptions/indexable/post-not-built-exception.php
+++ b/src/exceptions/indexable/post-not-built-exception.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Yoast\WP\SEO\Exceptions\Indexable;
+
+/**
+ * Exception that is thrown whenever a post could not be built
+ * in the context of the indexables.
+ */
+class Post_Not_Built_Exception extends Not_Built_Exception {
+
+	/**
+	 * Throws an exception if the post is not viewable.
+	 *
+	 * @param int $post_id ID of the term.
+	 *
+	 * @throws Post_Not_Built_Exception When the post is not found.
+	 */
+	public static function because_not_viewable( $post_id ) {
+		/* translators: %s: expands to the term id */
+		return new Post_Not_Built_Exception( sprintf( __( 'The post %s could not be built because it\'s not viewable.', 'wordpress-seo' ), $post_id ) );
+	}
+}

--- a/src/exceptions/indexable/post-not-built-exception.php
+++ b/src/exceptions/indexable/post-not-built-exception.php
@@ -17,7 +17,7 @@ class Post_Not_Built_Exception extends Not_Built_Exception {
 	 */
 	public static function because_not_indexable( $post_id ) {
 		/* translators: %s: expands to the post id */
-		return new Post_Not_Built_Exception( sprintf( __( 'The post %s could not be indexed because it does not meet indexing requirments.', 'wordpress-seo' ), $post_id ) );
+		return new Post_Not_Built_Exception( sprintf( __( 'The post %s could not be indexed because it does not meet indexing requirements.', 'wordpress-seo' ), $post_id ) );
 	}
 
 	/**

--- a/src/exceptions/indexable/term-not-built-exception.php
+++ b/src/exceptions/indexable/term-not-built-exception.php
@@ -19,4 +19,16 @@ class Term_Not_Built_Exception extends Not_Built_Exception {
 		/* translators: %s: expands to the term id */
 		return new Term_Not_Built_Exception( sprintf( __( 'The term %s could not be built because it\'s not viewable.', 'wordpress-seo' ), $term_id ) );
 	}
+
+	/**
+	 * Throws an exception if the term is excluded.
+	 *
+	 * @param int $term_id ID of the term.
+	 *
+	 * @throws Term_Not_Built_Exception When the term is not built.
+	 */
+	public static function because_excluded( $term_id ) {
+		/* translators: %s: expands to the term id */
+		return new Term_Not_Built_Exception( sprintf( __( 'The term %s could not be built because it\'s excluded by a filter.', 'wordpress-seo' ), $term_id ) );
+	}
 }

--- a/src/exceptions/indexable/term-not-built-exception.php
+++ b/src/exceptions/indexable/term-not-built-exception.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Yoast\WP\SEO\Exceptions\Indexable;
+
+/**
+ * Exception that is thrown whenever a term could not be built
+ * in the context of the indexables.
+ */
+class Term_Not_Built_Exception extends Not_Built_Exception {
+
+	/**
+	 * Throws an exception if the term is not viewable.
+	 *
+	 * @param int $term_id ID of the term.
+	 *
+	 * @throws Term_Not_Built_Exception When the term is not built.
+	 */
+	public static function because_not_viewable( $term_id ) {
+		/* translators: %s: expands to the term id */
+		return new Term_Not_Built_Exception( sprintf( __( 'The term %s could not be built because it\'s not viewable.', 'wordpress-seo' ), $term_id ) );
+	}
+}

--- a/src/exceptions/indexable/term-not-built-exception.php
+++ b/src/exceptions/indexable/term-not-built-exception.php
@@ -9,26 +9,14 @@ namespace Yoast\WP\SEO\Exceptions\Indexable;
 class Term_Not_Built_Exception extends Not_Built_Exception {
 
 	/**
-	 * Throws an exception if the term is not viewable.
+	 * Throws an exception if the term is not indexable.
 	 *
 	 * @param int $term_id ID of the term.
 	 *
 	 * @throws Term_Not_Built_Exception When the term is not built.
 	 */
-	public static function because_not_viewable( $term_id ) {
+	public static function because_not_indexable( $term_id ) {
 		/* translators: %s: expands to the term id */
-		return new Term_Not_Built_Exception( sprintf( __( 'The term %s could not be built because it\'s not viewable.', 'wordpress-seo' ), $term_id ) );
-	}
-
-	/**
-	 * Throws an exception if the term is excluded.
-	 *
-	 * @param int $term_id ID of the term.
-	 *
-	 * @throws Term_Not_Built_Exception When the term is not built.
-	 */
-	public static function because_excluded( $term_id ) {
-		/* translators: %s: expands to the term id */
-		return new Term_Not_Built_Exception( sprintf( __( 'The term %s could not be built because it\'s excluded by a filter.', 'wordpress-seo' ), $term_id ) );
+		return new Term_Not_Built_Exception( sprintf( __( 'The term %s could not be built because it\'s not indexable.', 'wordpress-seo' ), $term_id ) );
 	}
 }

--- a/src/generators/schema/breadcrumb.php
+++ b/src/generators/schema/breadcrumb.php
@@ -15,6 +15,10 @@ class Breadcrumb extends Abstract_Schema_Piece {
 	 * @return bool
 	 */
 	public function is_needed() {
+		if ( $this->context->indexable->object_type === 'unknown' ) {
+			return false;
+		}
+
 		if ( $this->context->indexable->object_type === 'system-page' && $this->context->indexable->object_sub_type === '404' ) {
 			return false;
 		}

--- a/src/generators/schema/webpage.php
+++ b/src/generators/schema/webpage.php
@@ -16,6 +16,9 @@ class WebPage extends Abstract_Schema_Piece {
 	 * @return bool
 	 */
 	public function is_needed() {
+		if ( $this->context->indexable->object_type === 'unknown' ) {
+			return false;
+		}
 		return ! ( $this->context->indexable->object_type === 'system-page' && $this->context->indexable->object_sub_type === '404' );
 	}
 

--- a/src/helpers/post-helper.php
+++ b/src/helpers/post-helper.php
@@ -164,6 +164,11 @@ class Post_Helper {
 	 * @return bool True if the post can be indexed.
 	 */
 	public function is_post_indexable( $post_id ) {
+		// Don't index posts which are not public (i.e. viewable).
+		if( ! \is_post_type_viewable( \get_post_type( $post_id ) ) ) {
+			return false;
+		}
+
 		// Don't index excluded post statuses.
 		if ( \in_array( \get_post_status( $post_id ), $this->get_excluded_post_statuses(), true ) ) {
 			return false;

--- a/src/helpers/post-helper.php
+++ b/src/helpers/post-helper.php
@@ -179,7 +179,7 @@ class Post_Helper {
 		// Don't index posts which are not public (i.e. viewable).
 		$post_type    = \get_post_type( $post_id );
 		$public_types = $this->post_type->get_indexable_post_types();
-		if ( ! in_array( $post_type, $public_types, true ) ) {
+		if ( ! \in_array( $post_type, $public_types, true ) ) {
 			return false;
 		}
 

--- a/src/helpers/post-helper.php
+++ b/src/helpers/post-helper.php
@@ -18,6 +18,13 @@ class Post_Helper {
 	private $string;
 
 	/**
+	 * Holds the Post_Type_Helper instance.
+	 *
+	 * @var Post_Type_Helper
+	 */
+	private $post_type;
+
+	/**
 	 * Represents the indexables repository.
 	 *
 	 * @var Indexable_Repository
@@ -29,10 +36,15 @@ class Post_Helper {
 	 *
 	 * @codeCoverageIgnore It only sets dependencies.
 	 *
-	 * @param String_Helper $string_helper The string helper.
+	 * @param String_Helper    $string_helper The string helper.
+	 * @param Post_Type_Helper $post_type_helper The string helper.
 	 */
-	public function __construct( String_Helper $string_helper ) {
-		$this->string = $string_helper;
+	public function __construct(
+		String_Helper $string_helper,
+		Post_Type_Helper $post_type_helper
+	) {
+		$this->string    = $string_helper;
+		$this->post_type = $post_type_helper;
 	}
 
 	/**
@@ -165,7 +177,9 @@ class Post_Helper {
 	 */
 	public function is_post_indexable( $post_id ) {
 		// Don't index posts which are not public (i.e. viewable).
-		if ( ! \is_post_type_viewable( \get_post_type( $post_id ) ) ) {
+		$post_type               = \get_post_type( $post_id );
+		$publicly_viewable_types = $this->post_type->get_public_post_types();
+		if ( ! in_array( $post_type, $publicly_viewable_types, true ) ) {
 			return false;
 		}
 

--- a/src/helpers/post-helper.php
+++ b/src/helpers/post-helper.php
@@ -165,7 +165,7 @@ class Post_Helper {
 	 */
 	public function is_post_indexable( $post_id ) {
 		// Don't index posts which are not public (i.e. viewable).
-		if( ! \is_post_type_viewable( \get_post_type( $post_id ) ) ) {
+		if ( ! \is_post_type_viewable( \get_post_type( $post_id ) ) ) {
 			return false;
 		}
 

--- a/src/helpers/post-helper.php
+++ b/src/helpers/post-helper.php
@@ -177,9 +177,9 @@ class Post_Helper {
 	 */
 	public function is_post_indexable( $post_id ) {
 		// Don't index posts which are not public (i.e. viewable).
-		$post_type               = \get_post_type( $post_id );
-		$publicly_viewable_types = $this->post_type->get_public_post_types();
-		if ( ! in_array( $post_type, $publicly_viewable_types, true ) ) {
+		$post_type    = \get_post_type( $post_id );
+		$public_types = $this->post_type->get_indexable_post_types();
+		if ( ! in_array( $post_type, $public_types, true ) ) {
 			return false;
 		}
 

--- a/src/helpers/post-type-helper.php
+++ b/src/helpers/post-type-helper.php
@@ -58,19 +58,12 @@ class Post_Type_Helper {
 	 *
 	 * @codeCoverageIgnore It only wraps a WordPress function.
 	 *
-	 * @param string $output               The output type to use.
-	 * @param bool   $exclude_non_viewable Whether to exclude non viewable post types.
+	 * @param string $output The output type to use.
 	 *
 	 * @return array Array with all the public post_types.
 	 */
-	public function get_public_post_types( $output = 'names', $exclude_non_viewable = true ) {
-		$post_types = \get_post_types( [ 'public' => true ], $output );
-
-		if ( $exclude_non_viewable ) {
-			$post_types = \array_filter( $post_types, 'is_post_type_viewable' );
-		}
-
-		return $post_types;
+	public function get_public_post_types( $output = 'names' ) {
+		return \get_post_types( [ 'public' => true ], $output );
 	}
 
 	/**

--- a/src/helpers/post-type-helper.php
+++ b/src/helpers/post-type-helper.php
@@ -147,4 +147,17 @@ class Post_Type_Helper {
 
 		return ( ! empty( $post_type->has_archive ) );
 	}
+
+	/**
+	 * Returns the post types that should be indexed.
+	 *
+	 * @return array The post types that should be indexed.
+	 */
+	public function get_indexable_post_types() {
+		$public_post_types   = $this->get_public_post_types();
+		$excluded_post_types = $this->get_excluded_post_types_for_indexables();
+
+		// `array_values`, to make sure that the keys are reset.
+		return \array_values( \array_diff( $public_post_types, $excluded_post_types ) );
+	}
 }

--- a/src/helpers/post-type-helper.php
+++ b/src/helpers/post-type-helper.php
@@ -63,7 +63,9 @@ class Post_Type_Helper {
 	 * @return array Array with all the public post_types.
 	 */
 	public function get_public_post_types( $output = 'names' ) {
-		return \get_post_types( [ 'public' => true ], $output );
+		$post_types = \get_post_types( [ 'public' => true ], $output );
+
+		return \array_filter( $post_types, 'is_post_type_viewable' );
 	}
 
 	/**

--- a/src/helpers/post-type-helper.php
+++ b/src/helpers/post-type-helper.php
@@ -58,14 +58,19 @@ class Post_Type_Helper {
 	 *
 	 * @codeCoverageIgnore It only wraps a WordPress function.
 	 *
-	 * @param string $output The output type to use.
+	 * @param string $output               The output type to use.
+	 * @param bool   $exclude_non_viewable Whether to exclude non viewable post types.
 	 *
 	 * @return array Array with all the public post_types.
 	 */
-	public function get_public_post_types( $output = 'names' ) {
+	public function get_public_post_types( $output = 'names', $exclude_non_viewable = true ) {
 		$post_types = \get_post_types( [ 'public' => true ], $output );
 
-		return \array_filter( $post_types, 'is_post_type_viewable' );
+		if ( $exclude_non_viewable ) {
+			$post_types = \array_filter( $post_types, 'is_post_type_viewable' );
+		}
+
+		return $post_types;
 	}
 
 	/**

--- a/src/helpers/taxonomy-helper.php
+++ b/src/helpers/taxonomy-helper.php
@@ -52,15 +52,20 @@ class Taxonomy_Helper {
 	/**
 	 * Returns an array with the public taxonomies.
 	 *
-	 * @param string $output The output type to use.
+	 * @param string $output               The output type to use.
+	 * @param bool   $exclude_non_viewable Whether to exclude non viewable taxonomies.
 	 *
 	 * @return string[]|WP_Taxonomy[] Array with all the public taxonomies.
 	 *                                The type depends on the specified output variable.
 	 */
-	public function get_public_taxonomies( $output = 'names' ) {
-		$taxonomies = \get_taxonomies( [ 'public' => true ], $output );
+	public function get_public_taxonomies( $output = 'names', $exclude_non_viewable = true ) {
+		$public_taxonomies = \get_taxonomies( [ 'public' => true ], $output );
 
-		return \array_filter( $taxonomies, 'is_taxonomy_viewable' );
+		if ( $exclude_non_viewable ) {
+			$public_taxonomies = \array_filter( $public_taxonomies, 'is_taxonomy_viewable' );
+		}
+
+		return $public_taxonomies;
 	}
 
 	/**

--- a/src/helpers/taxonomy-helper.php
+++ b/src/helpers/taxonomy-helper.php
@@ -52,20 +52,13 @@ class Taxonomy_Helper {
 	/**
 	 * Returns an array with the public taxonomies.
 	 *
-	 * @param string $output               The output type to use.
-	 * @param bool   $exclude_non_viewable Whether to exclude non viewable taxonomies.
+	 * @param string $output The output type to use.
 	 *
 	 * @return string[]|WP_Taxonomy[] Array with all the public taxonomies.
 	 *                                The type depends on the specified output variable.
 	 */
-	public function get_public_taxonomies( $output = 'names', $exclude_non_viewable = true ) {
-		$public_taxonomies = \get_taxonomies( [ 'public' => true ], $output );
-
-		if ( $exclude_non_viewable ) {
-			$public_taxonomies = \array_filter( $public_taxonomies, 'is_taxonomy_viewable' );
-		}
-
-		return $public_taxonomies;
+	public function get_public_taxonomies( $output = 'names' ) {
+		return \get_taxonomies( [ 'public' => true ], $output );
 	}
 
 	/**

--- a/src/helpers/taxonomy-helper.php
+++ b/src/helpers/taxonomy-helper.php
@@ -62,6 +62,19 @@ class Taxonomy_Helper {
 	}
 
 	/**
+	 * Returns an array with the accessible taxonomies.
+	 *
+	 * An accessible taxonomies is public and viewable.
+	 *
+	 * @return array Array with all the accessible taxonomies.
+	 */
+	public function get_accessible_taxonomies() {
+		$post_types = \get_taxonomies( [ 'public' => true ] );
+
+		return \array_filter( $post_types, 'is_taxonomy_viewable' );
+	}
+
+	/**
 	 * Retrieves the term description (without tags).
 	 *
 	 * @param int $term_id Term ID.
@@ -147,5 +160,18 @@ class Taxonomy_Helper {
 	 */
 	public function is_excluded( $taxonomy ) {
 		return \in_array( $taxonomy, $this->get_excluded_taxonomies_for_indexables(), true );
+	}
+
+	/**
+	 * This builds a list of indexable taxonomies.
+	 *
+	 * @return array The indexable taxnomies.
+	 */
+	public function get_indexable_taxonomies() {
+		$public_taxonomies   = $this->get_accessible_taxonomies();
+		$excluded_taxonomies = $this->get_excluded_taxonomies_for_indexables();
+
+		// `array_values`, to make sure that the keys are reset.
+		return \array_values( \array_diff( $public_taxonomies, $excluded_taxonomies ) );
 	}
 }

--- a/src/helpers/taxonomy-helper.php
+++ b/src/helpers/taxonomy-helper.php
@@ -114,4 +114,27 @@ class Taxonomy_Helper {
 	public function get_custom_taxonomies( $output = 'names' ) {
 		return \get_taxonomies( [ '_builtin' => false ], $output );
 	}
+
+	/**
+	 * Returns an array of taxonomies that are excluded from being indexed for the
+	 * indexables.
+	 *
+	 * @return array The excluded taxonomies.
+	 */
+	public function get_excluded_taxonomies_for_indexables() {
+		/**
+		 * Filter: 'wpseo_indexable_excluded_taxonomies' - Allow developers to prevent a certain taxonomy
+		 * from being saved to the indexable table.
+		 *
+		 * @param array $excluded_taxonomies The currently excluded taxonomies.
+		 */
+		$excluded_taxonomies = \apply_filters( 'wpseo_indexable_excluded_taxonomies', [] );
+
+		// Failsafe, to always make sure that `excluded_taxonomies` is an array.
+		if ( ! \is_array( $excluded_taxonomies ) ) {
+			return [];
+		}
+
+		return $excluded_taxonomies;
+	}
 }

--- a/src/helpers/taxonomy-helper.php
+++ b/src/helpers/taxonomy-helper.php
@@ -58,20 +58,9 @@ class Taxonomy_Helper {
 	 *                                The type depends on the specified output variable.
 	 */
 	public function get_public_taxonomies( $output = 'names' ) {
-		return \get_taxonomies( [ 'public' => true ], $output );
-	}
+		$taxonomies = \get_taxonomies( [ 'public' => true ], $output );
 
-	/**
-	 * Returns an array with the accessible taxonomies.
-	 *
-	 * An accessible taxonomies is public and viewable.
-	 *
-	 * @return array Array with all the accessible taxonomies.
-	 */
-	public function get_accessible_taxonomies() {
-		$post_types = \get_taxonomies( [ 'public' => true ] );
-
-		return \array_filter( $post_types, 'is_taxonomy_viewable' );
+		return \array_filter( $taxonomies, 'is_taxonomy_viewable' );
 	}
 
 	/**
@@ -165,10 +154,10 @@ class Taxonomy_Helper {
 	/**
 	 * This builds a list of indexable taxonomies.
 	 *
-	 * @return array The indexable taxnomies.
+	 * @return array The indexable taxonomies.
 	 */
 	public function get_indexable_taxonomies() {
-		$public_taxonomies   = $this->get_accessible_taxonomies();
+		$public_taxonomies   = $this->get_public_taxonomies();
 		$excluded_taxonomies = $this->get_excluded_taxonomies_for_indexables();
 
 		// `array_values`, to make sure that the keys are reset.

--- a/src/helpers/taxonomy-helper.php
+++ b/src/helpers/taxonomy-helper.php
@@ -137,4 +137,15 @@ class Taxonomy_Helper {
 
 		return $excluded_taxonomies;
 	}
+
+	/**
+	 * Checks if the taxonomy is excluded.
+	 *
+	 * @param string $taxonomy The taxonomy to check.
+	 *
+	 * @return bool If the taxonomy is excluded.
+	 */
+	public function is_excluded( $taxonomy ) {
+		return \in_array( $taxonomy, $this->get_excluded_taxonomies_for_indexables(), true );
+	}
 }

--- a/src/integrations/admin/indexables-exclude-taxonomy-integration.php
+++ b/src/integrations/admin/indexables-exclude-taxonomy-integration.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Yoast\WP\SEO\Integrations\Admin;
+
+use Yoast\WP\SEO\Conditionals\Admin_Conditional;
+use Yoast\WP\SEO\Helpers\Options_Helper;
+use Yoast\WP\SEO\Integrations\Integration_Interface;
+
+/**
+ * Indexables_Exclude_Post_Type_Integration class
+ */
+class Indexables_Exclude_Post_Type_Integration implements Integration_Interface {
+
+	/**
+	 * The options helper.
+	 *
+	 * @var Options_Helper
+	 */
+	private $options_helper;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_conditionals() {
+		return [
+			Admin_Conditional::class,
+		];
+	}
+
+	/**
+	 * Indexables_Page_Integration constructor.
+	 *
+	 * @param Options_Helper $options_helper The options helper.
+	 */
+	public function __construct( Options_Helper $options_helper ) {
+		$this->options_helper = $options_helper;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function register_hooks() {
+		\add_filter( 'wpseo_indexable_excluded_taxonomies', [ $this, 'exclude_taxonomies_for_indexation' ] );
+	}
+
+	/**
+	 * Exclude the taxonomy from the indexable table.
+	 *
+	 * @param array $excluded_taxonomies The excluded taxonomies.
+	 *
+	 * @return array The excluded post types, including the specific post type.
+	 */
+	public function exclude_taxonomies_for_indexation( $excluded_taxonomies ) {
+		if ( $this->options_helper->get( 'disable-post_format', false ) ) {
+			return \array_merge( $excluded_taxonomies, [ 'post_format' ] );
+		}
+
+		return $excluded_taxonomies;
+	}
+}

--- a/src/integrations/admin/indexables-exclude-taxonomy-integration.php
+++ b/src/integrations/admin/indexables-exclude-taxonomy-integration.php
@@ -2,14 +2,16 @@
 
 namespace Yoast\WP\SEO\Integrations\Admin;
 
-use Yoast\WP\SEO\Conditionals\Admin_Conditional;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
+use Yoast\WP\SEO\Conditionals\No_Conditionals;
 
 /**
  * Indexables_Exclude_Taxonomy_Integration class
  */
 class Indexables_Exclude_Taxonomy_Integration implements Integration_Interface {
+
+	use No_Conditionals;
 
 	/**
 	 * The options helper.
@@ -17,15 +19,6 @@ class Indexables_Exclude_Taxonomy_Integration implements Integration_Interface {
 	 * @var Options_Helper
 	 */
 	private $options_helper;
-
-	/**
-	 * {@inheritDoc}
-	 */
-	public static function get_conditionals() {
-		return [
-			Admin_Conditional::class,
-		];
-	}
 
 	/**
 	 * Indexables_Exclude_Taxonomy_Integration constructor.

--- a/src/integrations/admin/indexables-exclude-taxonomy-integration.php
+++ b/src/integrations/admin/indexables-exclude-taxonomy-integration.php
@@ -7,9 +7,9 @@ use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
 
 /**
- * Indexables_Exclude_Post_Type_Integration class
+ * Indexables_Exclude_Taxonomy_Integration class
  */
-class Indexables_Exclude_Post_Type_Integration implements Integration_Interface {
+class Indexables_Exclude_Taxonomy_Integration implements Integration_Interface {
 
 	/**
 	 * The options helper.
@@ -28,7 +28,7 @@ class Indexables_Exclude_Post_Type_Integration implements Integration_Interface 
 	}
 
 	/**
-	 * Indexables_Page_Integration constructor.
+	 * Indexables_Exclude_Taxonomy_Integration constructor.
 	 *
 	 * @param Options_Helper $options_helper The options helper.
 	 */

--- a/src/presentations/indexable-term-archive-presentation.php
+++ b/src/presentations/indexable-term-archive-presentation.php
@@ -100,7 +100,11 @@ class Indexable_Term_Archive_Presentation extends Indexable_Presentation {
 	 * @return array The source.
 	 */
 	public function generate_source() {
-		return \get_term( $this->model->object_id, $this->model->object_sub_type );
+		if ( ! empty( $this->model->object_id ) ) {
+			return \get_term( $this->model->object_id, $this->model->object_sub_type );
+		}
+
+		return \get_term( \get_queried_object()->term_id, \get_queried_object()->taxonomy );
 	}
 
 	/**

--- a/src/routes/yoast-head-rest-field.php
+++ b/src/routes/yoast-head-rest-field.php
@@ -93,13 +93,13 @@ class Yoast_Head_REST_Field implements Route_Interface {
 	 * @return void
 	 */
 	public function register_routes() {
-		$public_post_types = $this->post_type_helper->get_public_post_types();
+		$public_post_types = $this->post_type_helper->get_public_post_types( 'names', false );
 
 		foreach ( $public_post_types as $post_type ) {
 			$this->register_rest_fields( $post_type, 'for_post' );
 		}
 
-		$public_taxonomies = $this->taxonomy_helper->get_public_taxonomies();
+		$public_taxonomies = $this->taxonomy_helper->get_public_taxonomies( 'names', false );
 
 		foreach ( $public_taxonomies as $taxonomy ) {
 			if ( $taxonomy === 'post_tag' ) {

--- a/src/routes/yoast-head-rest-field.php
+++ b/src/routes/yoast-head-rest-field.php
@@ -126,10 +126,7 @@ class Yoast_Head_REST_Field implements Route_Interface {
 		}
 
 		if ( ! $this->post_helper->is_post_indexable( $params['id'] ) ) {
-			if ( $format === self::YOAST_JSON_HEAD_ATTRIBUTE_NAME ) {
-				return (object) [];
-			}
-			return '';
+			return null;
 		}
 		$obj = $this->head_action->for_post( $params['id'] );
 

--- a/src/routes/yoast-head-rest-field.php
+++ b/src/routes/yoast-head-rest-field.php
@@ -122,11 +122,11 @@ class Yoast_Head_REST_Field implements Route_Interface {
 	 */
 	public function for_post( $params, $format = self::YOAST_HEAD_ATTRIBUTE_NAME ) {
 		if ( ! isset( $params['id'] ) ) {
-			return null;
+			return "";
 		}
 
 		if ( ! $this->post_helper->is_post_indexable( $params['id'] ) ) {
-			return null;
+			return "";
 		}
 		$obj = $this->head_action->for_post( $params['id'] );
 
@@ -174,7 +174,7 @@ class Yoast_Head_REST_Field implements Route_Interface {
 			$obj = $this->head_action->for_posts_page();
 		}
 		elseif ( ! $this->post_type_helper->has_archive( $params['slug'] ) ) {
-			return null;
+			return "";
 		}
 		else {
 			$obj = $this->head_action->for_post_type_archive( $params['slug'] );

--- a/src/routes/yoast-head-rest-field.php
+++ b/src/routes/yoast-head-rest-field.php
@@ -126,6 +126,9 @@ class Yoast_Head_REST_Field implements Route_Interface {
 		}
 
 		if ( ! $this->post_helper->is_post_indexable( $params['id'] ) ) {
+			if ( $format === self::YOAST_JSON_HEAD_ATTRIBUTE_NAME ) {
+				return (object) [];
+			}
 			return '';
 		}
 		$obj = $this->head_action->for_post( $params['id'] );

--- a/src/routes/yoast-head-rest-field.php
+++ b/src/routes/yoast-head-rest-field.php
@@ -93,13 +93,13 @@ class Yoast_Head_REST_Field implements Route_Interface {
 	 * @return void
 	 */
 	public function register_routes() {
-		$public_post_types = $this->post_type_helper->get_public_post_types( 'names', false );
+		$public_post_types = $this->post_type_helper->get_indexable_post_types();
 
 		foreach ( $public_post_types as $post_type ) {
 			$this->register_rest_fields( $post_type, 'for_post' );
 		}
 
-		$public_taxonomies = $this->taxonomy_helper->get_public_taxonomies( 'names', false );
+		$public_taxonomies = $this->taxonomy_helper->get_indexable_taxonomies();
 
 		foreach ( $public_taxonomies as $taxonomy ) {
 			if ( $taxonomy === 'post_tag' ) {

--- a/src/routes/yoast-head-rest-field.php
+++ b/src/routes/yoast-head-rest-field.php
@@ -122,11 +122,11 @@ class Yoast_Head_REST_Field implements Route_Interface {
 	 */
 	public function for_post( $params, $format = self::YOAST_HEAD_ATTRIBUTE_NAME ) {
 		if ( ! isset( $params['id'] ) ) {
-			return "";
+			return '';
 		}
 
 		if ( ! $this->post_helper->is_post_indexable( $params['id'] ) ) {
-			return "";
+			return '';
 		}
 		$obj = $this->head_action->for_post( $params['id'] );
 
@@ -174,7 +174,7 @@ class Yoast_Head_REST_Field implements Route_Interface {
 			$obj = $this->head_action->for_posts_page();
 		}
 		elseif ( ! $this->post_type_helper->has_archive( $params['slug'] ) ) {
-			return "";
+			return '';
 		}
 		else {
 			$obj = $this->head_action->for_post_type_archive( $params['slug'] );

--- a/src/routes/yoast-head-rest-field.php
+++ b/src/routes/yoast-head-rest-field.php
@@ -122,7 +122,7 @@ class Yoast_Head_REST_Field implements Route_Interface {
 	 */
 	public function for_post( $params, $format = self::YOAST_HEAD_ATTRIBUTE_NAME ) {
 		if ( ! isset( $params['id'] ) ) {
-			return '';
+			return null;
 		}
 
 		if ( ! $this->post_helper->is_post_indexable( $params['id'] ) ) {
@@ -174,7 +174,7 @@ class Yoast_Head_REST_Field implements Route_Interface {
 			$obj = $this->head_action->for_posts_page();
 		}
 		elseif ( ! $this->post_type_helper->has_archive( $params['slug'] ) ) {
-			return '';
+			return null;
 		}
 		else {
 			$obj = $this->head_action->for_post_type_archive( $params['slug'] );

--- a/tests/unit/actions/indexing/indexable-post-indexation-action-test.php
+++ b/tests/unit/actions/indexing/indexable-post-indexation-action-test.php
@@ -123,8 +123,7 @@ class Indexable_Post_Indexation_Action_Test extends TestCase {
 			->andReturn( 'query' );
 		$this->wpdb->expects( 'get_var' )->once()->with( 'query' )->andReturn( '10' );
 
-		$this->post_type_helper->expects( 'get_public_post_types' )->once()->andReturn( [ 'public_post_type' ] );
-		$this->post_type_helper->expects( 'get_excluded_post_types_for_indexables' )->once()->andReturn( [] );
+		$this->post_type_helper->expects( 'get_indexable_post_types' )->once()->andReturn( [ 'public_post_type' ] );
 		$this->post_helper->expects( 'get_excluded_post_statuses' )->once()->andReturn( [ 'auto-draft' ] );
 
 		$this->assertEquals( 10, $this->instance->get_total_unindexed() );
@@ -165,8 +164,7 @@ class Indexable_Post_Indexation_Action_Test extends TestCase {
 			->andReturn( 'query' );
 		$this->wpdb->expects( 'get_col' )->once()->with( 'query' )->andReturn( $query_result );
 
-		$this->post_type_helper->expects( 'get_public_post_types' )->once()->andReturn( [ 'public_post_type' ] );
-		$this->post_type_helper->expects( 'get_excluded_post_types_for_indexables' )->once()->andReturn( [] );
+		$this->post_type_helper->expects( 'get_indexable_post_types' )->once()->andReturn( [ 'public_post_type' ] );
 		$this->post_helper->expects( 'get_excluded_post_statuses' )->once()->andReturn( [ 'auto-draft' ] );
 
 		$this->assertEquals( \count( $query_result ), $this->instance->get_limited_unindexed_count( $limit ) );
@@ -198,8 +196,7 @@ class Indexable_Post_Indexation_Action_Test extends TestCase {
 			->with( 'wpseo_total_unindexed_posts', 0, ( \MINUTE_IN_SECONDS * 15 ) )
 			->andReturnFalse();
 
-		$this->post_type_helper->expects( 'get_public_post_types' )->once()->andReturn( [ 'public_post_type' ] );
-		$this->post_type_helper->expects( 'get_excluded_post_types_for_indexables' )->once()->andReturn( [] );
+		$this->post_type_helper->expects( 'get_indexable_post_types' )->once()->andReturn( [ 'public_post_type' ] );
 		$this->post_helper->expects( 'get_excluded_post_statuses' )->once()->andReturn( [ 'auto-draft' ] );
 
 		$this->wpdb->expects( 'prepare' )->once()->andReturn( 'query' );
@@ -217,8 +214,7 @@ class Indexable_Post_Indexation_Action_Test extends TestCase {
 	 * @covers ::get_post_types
 	 */
 	public function test_get_total_unindexed_with_excluded_post_types() {
-		$public_post_types   = [ 'public_post_type', 'excluded_post_type' ];
-		$excluded_post_types = [ 'excluded_post_type' ];
+		$public_post_types   = [ 'public_post_type'];
 		$query_params        = [ 'public_post_type', 'auto-draft', 2 ];
 
 		$expected_query = "
@@ -234,8 +230,7 @@ class Indexable_Post_Indexation_Action_Test extends TestCase {
 		Functions\expect( 'get_transient' )->once()->with( 'wpseo_total_unindexed_posts' )->andReturnFalse();
 		Functions\expect( 'set_transient' )->once()->with( 'wpseo_total_unindexed_posts', '10', \DAY_IN_SECONDS )->andReturnTrue();
 
-		$this->post_type_helper->expects( 'get_public_post_types' )->once()->andReturn( $public_post_types );
-		$this->post_type_helper->expects( 'get_excluded_post_types_for_indexables' )->once()->andReturn( $excluded_post_types );
+		$this->post_type_helper->expects( 'get_indexable_post_types' )->once()->andReturn( $public_post_types );
 		$this->post_helper->expects( 'get_excluded_post_statuses' )->once()->andReturn( [ 'auto-draft' ] );
 
 		$this->wpdb->expects( 'prepare' )
@@ -270,13 +265,10 @@ class Indexable_Post_Indexation_Action_Test extends TestCase {
 		Filters\expectApplied( 'wpseo_post_indexation_limit' )->andReturn( 25 );
 
 		$this->post_type_helper
-			->expects( 'get_public_post_types' )
+			->expects( 'get_indexable_post_types' )
 			->once()
 			->andReturn( [ 'public_post_type' ] );
-		$this->post_type_helper
-			->expects( 'get_excluded_post_types_for_indexables' )
-			->once()
-			->andReturn( [] );
+
 		$this->post_helper->expects( 'get_excluded_post_statuses' )
 			->once()
 			->andReturn( [ 'auto-draft' ] );
@@ -314,8 +306,7 @@ class Indexable_Post_Indexation_Action_Test extends TestCase {
 	public function test_index_with_limit_filter_no_int() {
 		Filters\expectApplied( 'wpseo_post_indexation_limit' )->andReturn( 'not an integer' );
 
-		$this->post_type_helper->expects( 'get_public_post_types' )->once()->andReturn( [ 'public_post_type' ] );
-		$this->post_type_helper->expects( 'get_excluded_post_types_for_indexables' )->once()->andReturn( [] );
+		$this->post_type_helper->expects( 'get_indexable_post_types' )->once()->andReturn( [ 'public_post_type' ] );
 		$this->post_helper->expects( 'get_excluded_post_statuses' )->once()->andReturn( [ 'auto-draft' ] );
 
 		$this->wpdb->expects( 'prepare' )->once()->andReturn( 'query' );
@@ -340,8 +331,7 @@ class Indexable_Post_Indexation_Action_Test extends TestCase {
 	 * @covers ::get_post_types
 	 */
 	public function test_index_with_excluded_post_types() {
-		$public_post_types   = [ 'public_post_type', 'excluded_post_type' ];
-		$excluded_post_types = [ 'excluded_post_type' ];
+		$public_post_types   = [ 'public_post_type' ];
 
 		$expected_query = "
 			SELECT P.ID
@@ -357,13 +347,9 @@ class Indexable_Post_Indexation_Action_Test extends TestCase {
 		Filters\expectApplied( 'wpseo_post_indexation_limit' )->andReturn( 25 );
 
 		$this->post_type_helper
-			->expects( 'get_public_post_types' )
+			->expects( 'get_indexable_post_types' )
 			->once()
 			->andReturn( $public_post_types );
-		$this->post_type_helper
-			->expects( 'get_excluded_post_types_for_indexables' )
-			->once()
-			->andReturn( $excluded_post_types );
 		$this->post_helper
 			->expects( 'get_excluded_post_statuses' )
 			->once()
@@ -415,13 +401,9 @@ class Indexable_Post_Indexation_Action_Test extends TestCase {
 		Filters\expectApplied( 'wpseo_post_indexation_limit' )->andReturn( 25 );
 
 		$this->post_type_helper
-			->expects( 'get_public_post_types' )
+			->expects( 'get_indexable_post_types' )
 			->once()
 			->andReturn( [ 'public_post_type' ] );
-		$this->post_type_helper
-			->expects( 'get_excluded_post_types_for_indexables' )
-			->once()
-			->andReturn( [] );
 		$this->post_helper
 			->expects( 'get_excluded_post_statuses' )
 			->once()

--- a/tests/unit/actions/indexing/indexable-term-indexation-action-test.php
+++ b/tests/unit/actions/indexing/indexable-term-indexation-action-test.php
@@ -111,6 +111,7 @@ class Indexable_Term_Indexation_Action_Test extends TestCase {
 				'other_taxonomy'  => 'other_taxonomy',
 			]
 		);
+		$this->taxonomy->expects( 'get_excluded_taxonomies_for_indexables' )->once()->andReturn( [] );
 		$this->wpdb->expects( 'prepare' )
 			->once()
 			->with( $expected_query, [ 2, 'public_taxonomy', 'other_taxonomy' ] )
@@ -154,6 +155,8 @@ class Indexable_Term_Indexation_Action_Test extends TestCase {
 				'other_taxonomy'  => 'other_taxonomy',
 			]
 		);
+		$this->taxonomy->expects( 'get_excluded_taxonomies_for_indexables' )->once()->andReturn( [] );
+
 		$this->wpdb->expects( 'prepare' )
 			->once()
 			->with( $expected_query, [ 2, 'public_taxonomy', 'other_taxonomy', $limit ] )
@@ -196,7 +199,7 @@ class Indexable_Term_Indexation_Action_Test extends TestCase {
 			->expects( 'get_public_taxonomies' )
 			->once()
 			->andReturn( [ 'public_taxonomy' => 'public_taxonomy' ] );
-
+		$this->taxonomy->expects( 'get_excluded_taxonomies_for_indexables' )->once()->andReturn( [] );
 		$this->wpdb
 			->expects( 'prepare' )
 			->once()
@@ -237,6 +240,7 @@ class Indexable_Term_Indexation_Action_Test extends TestCase {
 				'other_taxonomy'  => 'other_taxonomy',
 			]
 		);
+		$this->taxonomy->expects( 'get_excluded_taxonomies_for_indexables' )->once()->andReturn( [] );
 		$this->wpdb->expects( 'prepare' )
 			->once()
 			->with( $expected_query, [ 2, 'public_taxonomy', 'other_taxonomy', 25 ] )
@@ -263,6 +267,7 @@ class Indexable_Term_Indexation_Action_Test extends TestCase {
 		Filters\expectApplied( 'wpseo_term_indexation_limit' )->andReturn( 'not an integer' );
 
 		$this->taxonomy->expects( 'get_public_taxonomies' )->once()->andReturn( [ 'public_taxonomy' => 'public_taxonomy' ] );
+		$this->taxonomy->expects( 'get_excluded_taxonomies_for_indexables' )->once()->andReturn( [] );
 		$this->wpdb->expects( 'prepare' )->once()->andReturn( 'query' );
 		$this->wpdb->expects( 'get_col' )->once()->with( 'query' )->andReturn( [ '1', '3', '8' ] );
 
@@ -303,6 +308,7 @@ class Indexable_Term_Indexation_Action_Test extends TestCase {
 				'other_taxonomy'  => 'other_taxonomy',
 			]
 		);
+		$this->taxonomy->expects( 'get_excluded_taxonomies_for_indexables' )->once()->andReturn( [] );
 		$this->wpdb->expects( 'prepare' )
 			->once()
 			->with( $expected_query, [ 2, 'public_taxonomy', 'other_taxonomy', 25 ] )

--- a/tests/unit/actions/indexing/indexable-term-indexation-action-test.php
+++ b/tests/unit/actions/indexing/indexable-term-indexation-action-test.php
@@ -105,13 +105,12 @@ class Indexable_Term_Indexation_Action_Test extends TestCase {
 
 		Functions\expect( 'get_transient' )->once()->with( 'wpseo_total_unindexed_terms' )->andReturnFalse();
 		Functions\expect( 'set_transient' )->once()->with( 'wpseo_total_unindexed_terms', '10', \DAY_IN_SECONDS )->andReturnTrue();
-		$this->taxonomy->expects( 'get_public_taxonomies' )->once()->andReturn(
+		$this->taxonomy->expects( 'get_indexable_taxonomies' )->once()->andReturn(
 			[
-				'public_taxonomy' => 'public_taxonomy',
-				'other_taxonomy'  => 'other_taxonomy',
+				'public_taxonomy',
+				'other_taxonomy',
 			]
 		);
-		$this->taxonomy->expects( 'get_excluded_taxonomies_for_indexables' )->once()->andReturn( [] );
 		$this->wpdb->expects( 'prepare' )
 			->once()
 			->with( $expected_query, [ 2, 'public_taxonomy', 'other_taxonomy' ] )
@@ -149,13 +148,12 @@ class Indexable_Term_Indexation_Action_Test extends TestCase {
 
 		Functions\expect( 'get_transient' )->once()->with( 'wpseo_total_unindexed_terms_limited' )->andReturnFalse();
 		Functions\expect( 'set_transient' )->once()->with( 'wpseo_total_unindexed_terms_limited', \count( $query_result ), ( \MINUTE_IN_SECONDS * 15 ) )->andReturnTrue();
-		$this->taxonomy->expects( 'get_public_taxonomies' )->once()->andReturn(
+		$this->taxonomy->expects( 'get_indexable_taxonomies' )->once()->andReturn(
 			[
-				'public_taxonomy' => 'public_taxonomy',
-				'other_taxonomy'  => 'other_taxonomy',
+				'public_taxonomy',
+				'other_taxonomy',
 			]
 		);
-		$this->taxonomy->expects( 'get_excluded_taxonomies_for_indexables' )->once()->andReturn( [] );
 
 		$this->wpdb->expects( 'prepare' )
 			->once()
@@ -196,10 +194,9 @@ class Indexable_Term_Indexation_Action_Test extends TestCase {
 			->andReturn( true );
 
 		$this->taxonomy
-			->expects( 'get_public_taxonomies' )
+			->expects( 'get_indexable_taxonomies' )
 			->once()
-			->andReturn( [ 'public_taxonomy' => 'public_taxonomy' ] );
-		$this->taxonomy->expects( 'get_excluded_taxonomies_for_indexables' )->once()->andReturn( [] );
+			->andReturn( [ 'public_taxonomy' ] );
 		$this->wpdb
 			->expects( 'prepare' )
 			->once()
@@ -234,13 +231,12 @@ class Indexable_Term_Indexation_Action_Test extends TestCase {
 
 		Filters\expectApplied( 'wpseo_term_indexation_limit' )->andReturn( 25 );
 
-		$this->taxonomy->expects( 'get_public_taxonomies' )->once()->andReturn(
+		$this->taxonomy->expects( 'get_indexable_taxonomies' )->once()->andReturn(
 			[
-				'public_taxonomy' => 'public_taxonomy',
-				'other_taxonomy'  => 'other_taxonomy',
+				'public_taxonomy',
+				'other_taxonomy',
 			]
 		);
-		$this->taxonomy->expects( 'get_excluded_taxonomies_for_indexables' )->once()->andReturn( [] );
 		$this->wpdb->expects( 'prepare' )
 			->once()
 			->with( $expected_query, [ 2, 'public_taxonomy', 'other_taxonomy', 25 ] )
@@ -266,8 +262,7 @@ class Indexable_Term_Indexation_Action_Test extends TestCase {
 	public function test_index_with_limit_filter_no_int() {
 		Filters\expectApplied( 'wpseo_term_indexation_limit' )->andReturn( 'not an integer' );
 
-		$this->taxonomy->expects( 'get_public_taxonomies' )->once()->andReturn( [ 'public_taxonomy' => 'public_taxonomy' ] );
-		$this->taxonomy->expects( 'get_excluded_taxonomies_for_indexables' )->once()->andReturn( [] );
+		$this->taxonomy->expects( 'get_indexable_taxonomies' )->once()->andReturn( [ 'public_taxonomy' ] );
 		$this->wpdb->expects( 'prepare' )->once()->andReturn( 'query' );
 		$this->wpdb->expects( 'get_col' )->once()->with( 'query' )->andReturn( [ '1', '3', '8' ] );
 
@@ -302,13 +297,12 @@ class Indexable_Term_Indexation_Action_Test extends TestCase {
 
 		Filters\expectApplied( 'wpseo_term_indexation_limit' )->andReturn( 25 );
 
-		$this->taxonomy->expects( 'get_public_taxonomies' )->once()->andReturn(
+		$this->taxonomy->expects( 'get_indexable_taxonomies' )->once()->andReturn(
 			[
-				'public_taxonomy' => 'public_taxonomy',
-				'other_taxonomy'  => 'other_taxonomy',
+				'public_taxonomy',
+				'other_taxonomy',
 			]
 		);
-		$this->taxonomy->expects( 'get_excluded_taxonomies_for_indexables' )->once()->andReturn( [] );
 		$this->wpdb->expects( 'prepare' )
 			->once()
 			->with( $expected_query, [ 2, 'public_taxonomy', 'other_taxonomy', 25 ] )

--- a/tests/unit/actions/indexing/post-link-indexing-action-test.php
+++ b/tests/unit/actions/indexing/post-link-indexing-action-test.php
@@ -114,14 +114,10 @@ class Post_Link_Indexing_Action_Test extends TestCase {
 			->andReturn( true );
 
 		$this->post_type_helper
-			->expects( 'get_accessible_post_types' )
+			->expects( 'get_indexable_post_types' )
 			->once()
 			->andReturn( [ 'post', 'page' ] );
 
-		$this->post_type_helper
-			->expects( 'get_excluded_post_types_for_indexables' )
-			->once()
-			->andReturn( [] );
 
 		$expected_query = "SELECT COUNT(P.ID)
 			FROM wp_posts AS P
@@ -174,14 +170,10 @@ class Post_Link_Indexing_Action_Test extends TestCase {
 			->andReturn( true );
 
 		$this->post_type_helper
-			->expects( 'get_accessible_post_types' )
+			->expects( 'get_indexable_post_types' )
 			->once()
 			->andReturn( [ 'post', 'page' ] );
 
-		$this->post_type_helper
-			->expects( 'get_excluded_post_types_for_indexables' )
-			->once()
-			->andReturn( [] );
 
 		$expected_query = "SELECT COUNT(P.ID)
 			FROM wp_posts AS P
@@ -238,14 +230,9 @@ class Post_Link_Indexing_Action_Test extends TestCase {
 		];
 
 		$this->post_type_helper
-			->expects( 'get_accessible_post_types' )
+			->expects( 'get_indexable_post_types' )
 			->once()
 			->andReturn( [ 'post', 'page' ] );
-
-		$this->post_type_helper
-			->expects( 'get_excluded_post_types_for_indexables' )
-			->once()
-			->andReturn( [] );
 
 		$expected_query = "
 			SELECT P.ID, P.post_content
@@ -302,14 +289,10 @@ class Post_Link_Indexing_Action_Test extends TestCase {
 		Filters\expectApplied( 'wpseo_link_indexing_limit' );
 
 		$this->post_type_helper
-			->expects( 'get_accessible_post_types' )
+			->expects( 'get_indexable_post_types' )
 			->once()
 			->andReturn( [ 'post', 'page' ] );
 
-		$this->post_type_helper
-			->expects( 'get_excluded_post_types_for_indexables' )
-			->once()
-			->andReturn( [] );
 		$expected_query = "
 			SELECT P.ID, P.post_content
 			FROM wp_posts AS P
@@ -378,14 +361,9 @@ class Post_Link_Indexing_Action_Test extends TestCase {
 		Filters\expectApplied( 'wpseo_link_indexing_limit' );
 
 		$this->post_type_helper
-			->expects( 'get_accessible_post_types' )
+			->expects( 'get_indexable_post_types' )
 			->once()
 			->andReturn( [ 'post', 'page' ] );
-
-		$this->post_type_helper
-			->expects( 'get_excluded_post_types_for_indexables' )
-			->once()
-			->andReturn( [] );
 
 		$expected_query = "
 			SELECT P.ID, P.post_content

--- a/tests/unit/actions/indexing/term-link-indexing-action-test.php
+++ b/tests/unit/actions/indexing/term-link-indexing-action-test.php
@@ -119,7 +119,7 @@ class Term_Link_Indexing_Action_Test extends TestCase {
 			->andReturn( false );
 
 		$this->taxonomy_helper
-			->expects( 'get_public_taxonomies' )
+			->expects( 'get_indexable_taxonomies' )
 			->once()
 			->andReturn( [ 'category', 'tag' ] );
 
@@ -167,9 +167,10 @@ class Term_Link_Indexing_Action_Test extends TestCase {
 			->andReturn( false );
 
 		$this->taxonomy_helper
-			->expects( 'get_public_taxonomies' )
+			->expects( 'get_indexable_taxonomies' )
 			->once()
 			->andReturn( [ 'category', 'tag' ] );
+
 
 		$this->wpdb
 			->expects( 'prepare' )
@@ -222,7 +223,7 @@ class Term_Link_Indexing_Action_Test extends TestCase {
 			->andReturn( true );
 
 		$this->taxonomy_helper
-			->expects( 'get_public_taxonomies' )
+			->expects( 'get_indexable_taxonomies' )
 			->once()
 			->andReturn( [ 'category', 'tag' ] );
 
@@ -276,7 +277,7 @@ class Term_Link_Indexing_Action_Test extends TestCase {
 		];
 
 		$this->taxonomy_helper
-			->expects( 'get_public_taxonomies' )
+			->expects( 'get_indexable_taxonomies' )
 			->once()
 			->andReturn( [ 'category', 'tag' ] );
 
@@ -328,10 +329,9 @@ class Term_Link_Indexing_Action_Test extends TestCase {
 		Filters\expectApplied( 'wpseo_link_indexing_limit' );
 
 		$this->taxonomy_helper
-			->expects( 'get_public_taxonomies' )
+			->expects( 'get_indexable_taxonomies' )
 			->once()
 			->andReturn( [ 'category', 'tag' ] );
-
 		$expected_query = "
 			SELECT T.term_id, T.description
 			FROM wp_term_taxonomy AS T
@@ -393,10 +393,9 @@ class Term_Link_Indexing_Action_Test extends TestCase {
 		Filters\expectApplied( 'wpseo_link_indexing_limit' );
 
 		$this->taxonomy_helper
-			->expects( 'get_public_taxonomies' )
+			->expects( 'get_indexable_taxonomies' )
 			->once()
 			->andReturn( [ 'category', 'tag' ] );
-
 		$expected_query = "
 			SELECT T.term_id, T.description
 			FROM wp_term_taxonomy AS T

--- a/tests/unit/builders/indexable-term-builder-test.php
+++ b/tests/unit/builders/indexable-term-builder-test.php
@@ -249,7 +249,7 @@ class Indexable_Term_Builder_Test extends TestCase {
 					'wpseo_twitter-description'   => 'twitter_description',
 				]
 			);
-
+		$this->taxonomy->expects( 'is_excluded' )->andReturnFalse();
 		$this->post_helper->expects( 'get_public_post_statuses' )->once()->andReturn( [ 'publish' ] );
 
 		$this->wpdb->expects( 'prepare' )->once()->with(
@@ -409,6 +409,7 @@ class Indexable_Term_Builder_Test extends TestCase {
 	public function test_build_term_link_error() {
 		$term = (object) [ 'taxonomy' => 'tax' ];
 
+		$this->taxonomy->expects( 'is_excluded' )->andReturnFalse();
 		$error = Mockery::mock( '\WP_Error' );
 		$error
 			->expects( 'get_error_message' )

--- a/tests/unit/builders/indexable-term-builder-test.php
+++ b/tests/unit/builders/indexable-term-builder-test.php
@@ -223,7 +223,7 @@ class Indexable_Term_Builder_Test extends TestCase {
 			->with( $term, 'category' )
 			->andReturn( 'https://example.org/category/1' );
 		Monkey\Functions\expect( 'is_wp_error' )->twice()->andReturn( false );
-		Monkey\Functions\expect( 'is_taxonomy_viewable' )->once()->andReturn( true );
+		$this->taxonomy->expects( 'get_indexable_taxonomies' )->andReturn(['category']);
 
 		$this->taxonomy->expects( 'get_term_meta' )
 			->once()
@@ -249,7 +249,6 @@ class Indexable_Term_Builder_Test extends TestCase {
 					'wpseo_twitter-description'   => 'twitter_description',
 				]
 			);
-		$this->taxonomy->expects( 'is_excluded' )->andReturnFalse();
 		$this->post_helper->expects( 'get_public_post_statuses' )->once()->andReturn( [ 'publish' ] );
 
 		$this->wpdb->expects( 'prepare' )->once()->with(
@@ -409,7 +408,7 @@ class Indexable_Term_Builder_Test extends TestCase {
 	public function test_build_term_link_error() {
 		$term = (object) [ 'taxonomy' => 'tax' ];
 
-		$this->taxonomy->expects( 'is_excluded' )->andReturnFalse();
+		$this->taxonomy->expects( 'get_indexable_taxonomies' )->andReturn(['tax']);
 		$error = Mockery::mock( '\WP_Error' );
 		$error
 			->expects( 'get_error_message' )
@@ -423,9 +422,6 @@ class Indexable_Term_Builder_Test extends TestCase {
 			->once()
 			->with( $term, 'tax' )
 			->andReturn( $error );
-		Monkey\Functions\expect( 'is_taxonomy_viewable' )
-			->once()
-			->andReturn( true );
 
 		$this->expectException( Invalid_Term_Exception::class );
 

--- a/tests/unit/builders/indexable-term-builder-test.php
+++ b/tests/unit/builders/indexable-term-builder-test.php
@@ -21,8 +21,8 @@ use Yoast\WP\SEO\Values\Indexables\Indexable_Builder_Versions;
 /**
  * Class Indexable_Term_Builder_Test.
  *
- * @group indexables
- * @group builders
+ * @group  indexables
+ * @group  builders
  *
  * @coversDefaultClass \Yoast\WP\SEO\Builders\Indexable_Term_Builder
  * @covers \Yoast\WP\SEO\Builders\Indexable_Term_Builder
@@ -218,8 +218,12 @@ class Indexable_Term_Builder_Test extends TestCase {
 		];
 
 		Monkey\Functions\expect( 'get_term' )->once()->with( 1 )->andReturn( $term );
-		Monkey\Functions\expect( 'get_term_link' )->once()->with( $term, 'category' )->andReturn( 'https://example.org/category/1' );
+		Monkey\Functions\expect( 'get_term_link' )
+			->once()
+			->with( $term, 'category' )
+			->andReturn( 'https://example.org/category/1' );
 		Monkey\Functions\expect( 'is_wp_error' )->twice()->andReturn( false );
+		Monkey\Functions\expect( 'is_taxonomy_viewable' )->once()->andReturn( true );
 
 		$this->taxonomy->expects( 'get_term_meta' )
 			->once()
@@ -418,6 +422,9 @@ class Indexable_Term_Builder_Test extends TestCase {
 			->once()
 			->with( $term, 'tax' )
 			->andReturn( $error );
+		Monkey\Functions\expect( 'is_taxonomy_viewable' )
+			->once()
+			->andReturn( true );
 
 		$this->expectException( Invalid_Term_Exception::class );
 

--- a/tests/unit/helpers/post-helper-test.php
+++ b/tests/unit/helpers/post-helper-test.php
@@ -7,6 +7,7 @@ use Mockery;
 use Yoast\WP\SEO\Helpers\Post_Helper;
 use Yoast\WP\SEO\Helpers\String_Helper;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
+use Yoast\WP\SEO\Helpers\Post_Type_Helper;
 
 /**
  * Class Post_Helper_Test
@@ -32,6 +33,13 @@ class Post_Helper_Test extends TestCase {
 	private $string;
 
 	/**
+	 * The post type helper.
+	 *
+	 * @var Mockery\MockInterface|Post_Type_Helper
+	 */
+	private $post_type_helper;
+
+	/**
 	 * Sets up the test class.
 	 */
 	protected function set_up() {
@@ -39,8 +47,9 @@ class Post_Helper_Test extends TestCase {
 
 		$this->stubTranslationFunctions();
 
-		$this->string   = Mockery::mock( String_Helper::class );
-		$this->instance = new Post_Helper( $this->string );
+		$this->string           = Mockery::mock( String_Helper::class );
+		$this->post_type_helper = Mockery::mock( Post_Type_Helper::class );
+		$this->instance         = new Post_Helper( $this->string, $this->post_type_helper );
 	}
 
 	/**

--- a/tests/unit/routes/yoast-head-rest-field-test.php
+++ b/tests/unit/routes/yoast-head-rest-field-test.php
@@ -222,7 +222,7 @@ class Yoast_Head_REST_Field_Test extends TestCase {
 	public function test_adding_yoast_head_to_post_type_without_archive() {
 		$this->post_type_helper->expects( 'has_archive' )->with( 'no-archive' )->andReturnFalse();
 
-		$this->assertEquals('', $this->instance->for_post_type_archive( [ 'slug' => 'no-archive' ] ) );
+		$this->assertEquals( '', $this->instance->for_post_type_archive( [ 'slug' => 'no-archive' ] ) );
 	}
 
 	/**

--- a/tests/unit/routes/yoast-head-rest-field-test.php
+++ b/tests/unit/routes/yoast-head-rest-field-test.php
@@ -222,7 +222,7 @@ class Yoast_Head_REST_Field_Test extends TestCase {
 	public function test_adding_yoast_head_to_post_type_without_archive() {
 		$this->post_type_helper->expects( 'has_archive' )->with( 'no-archive' )->andReturnFalse();
 
-		$this->assertNull( $this->instance->for_post_type_archive( [ 'slug' => 'no-archive' ] ) );
+		$this->assertEquals('', $this->instance->for_post_type_archive( [ 'slug' => 'no-archive' ] ) );
 	}
 
 	/**

--- a/tests/unit/routes/yoast-head-rest-field-test.php
+++ b/tests/unit/routes/yoast-head-rest-field-test.php
@@ -112,12 +112,12 @@ class Yoast_Head_REST_Field_Test extends TestCase {
 	 */
 	public function test_register_routes() {
 		$this->post_type_helper
-			->expects( 'get_public_post_types' )
+			->expects( 'get_indexable_post_types' )
 			->once()
 			->andReturn( [ 'post_type' ] );
 
 		$this->taxonomy_helper
-			->expects( 'get_public_taxonomies' )
+			->expects( 'get_indexable_taxonomies' )
 			->once()
 			->andReturn( [ 'taxonomy', 'post_tag' ] );
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We don't want to store indexables for non public pages/tax types

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where an entry to the indexable DB table would be added when saving, or updating or accessing a post (or term) for a non-public post type (or taxonomy).
* Introduces the `wpseo_indexable_excluded_taxonomies` filter, to allow manually excluding taxonomies from being indexed. 

## Relevant technical choices:

* None.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

**_Note: Pay special attention to Query Monitor for PHP errors_**

**Post type both non-public AND non-publicly queryable - Create/Update (not included in our production version)**
* Enable a custom post type creator
* Add a custom post type with the properties `public` and `Publicly Queryable` set to false.
* Add a new post in the custom post type. and copy the post ID
* Open a MySQL client and connect to the local database.
* Browse to the _yoast_indexable table. Sort the table by `object_id` and confirm that the ID is `not` present.
* Repeat the same with a custom taxonomy, to ensure you get the same result (although our production version already doesnt create indexables for those)

**Post type (or taxonomy) both non-public AND non-publicly queryable - SEO optimization (already included in our production version)**
* Continuing the above instructions.
* Clean out all indexables.
* Run SEO optimization
* Browse to the _yoast_indexable table. Sort the table by `object_id` and again confirm that the ID is `not` present.

**Regression testing the public and publicly queryable post types (or taxonomies)**
* Enable a custom post type creator
* Add a custom post type (and a taxonomy) with the properties `public` set to true and `Publicly Queryable` set to true.
* Add a new post (or term) in the custom post type. and copy the post ID
* Open a MySQL client and connect to the local database.
* Browse to the _yoast_indexable table. Sort the table by `object_id` and confirm that the ID `is` present.
* Clean out all indexables.
* Run SEO optimization
* Browse to the _yoast_indexable table. Sort the table by `object_id` and again confirm that the ID `is` present.

---

Make sure these post types are not present in the indexable table: "custom_css", "acf-field"
To achieve this do the following:
* Check out trunk
* for ACF -> activate ACF and create a 'field group' you should have 2 new records in the indexables with `object_sub_type` `acf-field` and `acf-field-group`
* for `custom_css` go to the customizer open `additional CSS` and save some content
* Checkout this branch 
* Empty the indexable table with the test helper and run the SEO optimization.
* The `object_sub_type` mentioned above should not be in there.
* Also, repeat the above (create a 'field group' in ACF and also go to the customizer open `additional CSS` and save some content)
* Confirm again that the object_sub_type` mentioned above should not be in there

---

To check if `post_format` is gone do the following:

* browse to wp-admin/admin.php?page=wpseo_titles#top#taxonomies and in the `post_format` tab make sure `Format-based archives` is ON. (you should see the option `Show Formats in search results` if that is the case the selector is correct.
* Make sure the following lines are in your `functions.php`
```
add_theme_support( 'post-formats', array( 'aside', 'gallery', 'link' ) );
add_post_type_support( 'post', 'post-formats' );
```
* create a new post and select a different post format in the top right of the editor

<img width="290" alt="image" src="https://user-images.githubusercontent.com/6975345/197521488-377dbd98-f42c-4466-97cf-dbc7a3292d34.png">

* reset your indexables and run the SEO optimization again.
* Open a MySQL client and connect to the local database.
* Browse to the _yoast_indexable table. Sort the table by `object_sub_type` and make sure that `post_format` is present.
* browse to /wp-admin/admin.php?page=wpseo_titles#top#taxonomies make sure that for the `post_format` is OFF the option `Show Formats in search results` should be gone.
* Run the SEO optimization and the indexable record should be gone!

---
- create a new public post type or make sure one of your existing CPT is public
- Add

```
add_filter( 'wpseo_indexable_excluded_post_types', 'yoast_exclude_some_custom_post_types' );
function yoast_exclude_some_custom_post_types( $excluded_post_types ) {
	$excluded_post_types[] = 'your-cpt';

	return $excluded_post_types;
}
```

- Edit a post in your CPT and hit update. (save the ID for later)
- Go view the post in the front-end
- Open a MySQL client and connect to the local database.
- Browse to the _yoast_indexable table. Sort the table by `object_sub_type` and make sure that no posts for your CPT are present. (this is already happening with our production versions, it's a regression test)

- create a new public taxonomy or make sure one of your existing taxonomies is public
- Add

```
add_filter( 'wpseo_indexable_excluded_taxonomies', 'yoast_exclude_some_custom_taxonomies' );
function yoast_exclude_some_custom_taxonomies( $excluded_taxonomies ) {
	$excluded_taxonomies[] = 'your-tax';

	return $excluded_taxonomies;
}
```

- Edit a taxonomy in your CPT and hit update. (save the ID for later)
- Go view the post in the front-end
- Open a MySQL client and connect to the local database.
- Browse to the _yoast_indexable table. Sort the table by `object_sub_type` and make sure that no posts for your CPT are present.

---

- Edit one of your CPT's to be `public` false `publicly queriable` true 
- Create a post and add in its content 2 links, one to a post and one to a page
- Clear your indexables with the test helper.
- Run the SEO optimization from wp-admin/admin.php?page=wpseo_tools
- Make sure you get NO error while running the optimization

- Edit one of your CPT's to be `public` true `publicly queriable` false 
- Clear your indexables with the test helper.
- Run the SEO optimization from wp-admin/admin.php?page=wpseo_tools
- Make sure you get NO error while running the optimization

- Edit one of your custom taxonomies to be `public` false `publicly queriable` true 
- Add the taxonomy to a public post type
- Create a post and add in its content 2 links, one to a post and one to a page. 
- Clear your indexables with the test helper.
- Run the SEO optimization from wp-admin/admin.php?page=wpseo_tools
- Make sure you get NO error while running the optimization

- Edit one of your custom taxonomies to be `public` true `publicly queriable` false 
- Add the taxonomy to a public post type
- Create a post and add in its content 2 links, one to a post and one to a page. 
- Clear your indexables with the test helper.
- Run the SEO optimization from wp-admin/admin.php?page=wpseo_tools
- Make sure you get NO error while running the optimization

---
* Exclude a taxonomy via the above mentioned filter (`wpseo_indexable_excluded_taxonomies`)
* Visit the frontend of a term of that taxonomy
* Confirm that you don't get PHP errors
* Confirm that the meta tags that are shown are the same as what we get with our production version (aside from the Canonical URL that we currently dont output (expected as per [this](https://yoast.slack.com/archives/C03KU0EHCNQ/p1667222738068089?thread_ts=1667208840.186639&cid=C03KU0EHCNQ)))
* Check the schema, confirm that it doesnt have a `WebPage` node and a `Breadcrumb` node (expected as per [this](https://yoast.slack.com/archives/C03KU0EHCNQ/p1667222738068089?thread_ts=1667208840.186639&cid=C03KU0EHCNQ))
* Repeat the test for excluded posttype as well (`wpseo_indexable_excluded_post_types`)
* Repeat the test for `public` true `publicly queriable` false taxonomy
* Repeat the test for `public` true `publicly queriable` false posttype

---


**REST API testing**

* Enable a custom post type creator
* Create a custom post type and set the properties `public` set to true.
* Open /wp-json/wp/v2/{your-post-type-slug} and make sure `yoast_head` and `yoast_head_json` are filled (same with our production version)
* Open the custom post type editor and set `public` to false. `yoast_head` and `yoast_head_json` should now not exist (same with our production version) 
* Also visit the /wp-json/yoast/v1/get_head?url=http://basic.wordpress.test/your-posttype/test/ URL (replace the last part with a URL of a post of the non-public post type) and you will get a 404 (same as with our production version)

* Create a custom taxonomy and set the properties `public` set to true.
* Open /wp-json/wp/v2/{your-taxonomy-slug} and make sure `yoast_head` and `yoast_head_json` are filled (same with our production version)
* Open the custom post type editor and set `public` to false. `yoast_head` and `yoast_head_json` should now not exist (same with our production version) 
* Also visit the /wp-json/yoast/v1/get_head?url=http://basic.wordpress.test/taxonomy/term/ URL (replace the last part with a URL of a term of the non-public taxonomy) and you will get a 404 (same as with our production version)

* Now set the `public` property of both the post type and the taxonomy to true.
* Exclude the post type and the taxonomy with the filters (described above)
* Open /wp-json/wp/v2/{your-posttype/taxonomy-slug} and the `yoast_head` and `yoast_head_json` should now not exist (as opposed to our production version, and this breaking change is described in [this dev blog post](https://yoast.com/developer-blog/breaking-changes-to-our-rest-api-integration/))
* Also visit the /wp-json/yoast/v1/get_head?url=http://basic.wordpress.test/your-posttype/test/ URL (replace the last part with a URL of a post of the excluded post type) and confirm that you now get a 404 (we used to get a 200 but we're fine with this change, as per [this convo](https://yoast.slack.com/archives/C03KU0EHCNQ/p1666774605798219?thread_ts=1666707679.533119&cid=C03KU0EHCNQ)). Do the same for the /wp-json/yoast/v1/get_head?url=http://basic.wordpress.test/taxonomy/term URL


#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes #
PC-857