### PR TITLE
PC-853 When author archives are disabled we should not store indexables for author pages

### DIFF
--- a/inc/sitemaps/class-author-sitemap-provider.php
+++ b/inc/sitemaps/class-author-sitemap-provider.php
@@ -6,6 +6,8 @@
  */
 
 use Yoast\WP\SEO\Helpers\Author_Archive_Helper;
+use Yoast\WP\SEO\Helpers\Options_Helper;
+use Yoast\WP\SEO\Helpers\User_Helper;
 use Yoast\WP\SEO\Helpers\Wordpress_Helper;
 
 /**
@@ -131,8 +133,7 @@ class WPSEO_Author_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 
 		if ( WPSEO_Options::get( 'noindex-author-noposts-wpseo', true ) ) {
 			unset( $defaults['who'], $defaults['capability'] ); // Otherwise it cancels out next argument.
-			$author_archive                  = new Author_Archive_Helper();
-			$defaults['has_published_posts'] = $author_archive->get_author_archive_post_types();
+			$defaults['has_published_posts'] = \YoastSEO()->helpers->author_archive->get_author_archive_post_types();
 		}
 
 		return get_users( array_merge( $defaults, $arguments ) );

--- a/inc/sitemaps/class-author-sitemap-provider.php
+++ b/inc/sitemaps/class-author-sitemap-provider.php
@@ -5,9 +5,6 @@
  * @package WPSEO\XML_Sitemaps
  */
 
-use Yoast\WP\SEO\Helpers\Author_Archive_Helper;
-use Yoast\WP\SEO\Helpers\Options_Helper;
-use Yoast\WP\SEO\Helpers\User_Helper;
 use Yoast\WP\SEO\Helpers\Wordpress_Helper;
 
 /**
@@ -133,7 +130,7 @@ class WPSEO_Author_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 
 		if ( WPSEO_Options::get( 'noindex-author-noposts-wpseo', true ) ) {
 			unset( $defaults['who'], $defaults['capability'] ); // Otherwise it cancels out next argument.
-			$defaults['has_published_posts'] = \YoastSEO()->helpers->author_archive->get_author_archive_post_types();
+			$defaults['has_published_posts'] = YoastSEO()->helpers->author_archive->get_author_archive_post_types();
 		}
 
 		return get_users( array_merge( $defaults, $arguments ) );

--- a/src/builders/indexable-author-builder.php
+++ b/src/builders/indexable-author-builder.php
@@ -77,12 +77,12 @@ class Indexable_Author_Builder {
 	 * @throws Author_Not_Built_Exception When author is not built.
 	 */
 	public function build( $user_id, Indexable $indexable ) {
-		if ( $this->author_archive->is_disabled_for_user( $user_id ) ) {
-			throw Author_Not_Built_Exception::author_archives_are_disabled_for_user( $user_id );
-		}
-
 		if ( $this->author_archive->are_disabled() ) {
 			throw Author_Not_Built_Exception::author_archives_are_disabled( $user_id );
+		}
+
+		if ( $this->author_archive->is_disabled_for_user( $user_id ) ) {
+			throw Author_Not_Built_Exception::author_archives_are_disabled_for_user( $user_id );
 		}
 
 		if (

--- a/src/builders/indexable-author-builder.php
+++ b/src/builders/indexable-author-builder.php
@@ -81,15 +81,19 @@ class Indexable_Author_Builder {
 			throw Author_Not_Built_Exception::author_archives_are_disabled( $user_id );
 		}
 
+		if ( $this->author_archive->are_not_indexed() ) {
+			throw Author_Not_Built_Exception::author_archives_are_not_indexed( $user_id );
+		}
+
 		if ( $this->author_archive->is_disabled_for_user( $user_id ) ) {
 			throw Author_Not_Built_Exception::author_archives_are_disabled_for_user( $user_id );
 		}
 
 		if (
-			$this->author_archive->are_disabled_for_users_without_posts()
+			$this->author_archive->are_not_indexed_for_users_without_posts()
 			&& $this->author_archive->author_has_public_posts( $user_id ) === false
 		) {
-			throw Author_Not_Built_Exception::author_archives_are_disabled_for_users_without_posts( $user_id );
+			throw Author_Not_Built_Exception::author_archives_are_not_indexed_for_users_without_posts( $user_id );
 		}
 
 		$meta_data = $this->get_meta_data( $user_id );

--- a/src/builders/indexable-author-builder.php
+++ b/src/builders/indexable-author-builder.php
@@ -234,10 +234,7 @@ class Indexable_Author_Builder {
 			return Author_Not_Built_Exception::author_archives_are_disabled_for_user( $user_id );
 		}
 
-		if (
-			$this->author_archive->are_not_indexed_for_users_without_posts()
-			&& $this->author_archive->author_has_public_posts( $user_id ) === false
-		) {
+		if ( $this->author_archive->author_has_public_posts( $user_id ) === false ) {
 			return Author_Not_Built_Exception::author_archives_are_not_indexed_for_users_without_posts( $user_id );
 		}
 

--- a/src/builders/indexable-author-builder.php
+++ b/src/builders/indexable-author-builder.php
@@ -214,7 +214,7 @@ class Indexable_Author_Builder {
 			$exception = Author_Not_Built_Exception::author_archives_are_disabled( $user_id );
 		}
 
-		if ( $this->author_archive->author_has_public_posts_wp( $user_id ) === false ) {
+		if ( $this->author_archive->author_has_public_posts( $user_id ) === false ) {
 			$exception = Author_Not_Built_Exception::author_archives_are_not_indexed_for_users_without_posts( $user_id );
 		}
 

--- a/src/builders/indexable-author-builder.php
+++ b/src/builders/indexable-author-builder.php
@@ -3,6 +3,7 @@
 namespace Yoast\WP\SEO\Builders;
 
 use wpdb;
+use Yoast\WP\SEO\Exceptions\Indexable\Author_Not_Built_Exception;
 use Yoast\WP\SEO\Helpers\Author_Archive_Helper;
 use Yoast\WP\SEO\Helpers\Post_Helper;
 use Yoast\WP\SEO\Models\Indexable;
@@ -72,8 +73,25 @@ class Indexable_Author_Builder {
 	 * @param Indexable $indexable The indexable to format.
 	 *
 	 * @return Indexable The extended indexable.
+	 *
+	 * @throws Author_Not_Built_Exception When author is not built.
 	 */
 	public function build( $user_id, Indexable $indexable ) {
+		if ( $this->author_archive->is_disabled_for_user( $user_id ) ) {
+			throw Author_Not_Built_Exception::author_archives_are_disabled_for_user( $user_id );
+		}
+
+		if ( $this->author_archive->are_disabled() ) {
+			throw Author_Not_Built_Exception::author_archives_are_disabled( $user_id );
+		}
+
+		if (
+			$this->author_archive->are_disabled_for_users_without_posts()
+			&& $this->author_archive->author_has_public_posts( $user_id ) === false
+		) {
+			throw Author_Not_Built_Exception::author_archives_are_disabled_for_users_without_posts( $user_id );
+		}
+
 		$meta_data = $this->get_meta_data( $user_id );
 
 		$indexable->object_id              = $user_id;

--- a/src/builders/indexable-author-builder.php
+++ b/src/builders/indexable-author-builder.php
@@ -230,10 +230,6 @@ class Indexable_Author_Builder {
 			return Author_Not_Built_Exception::author_archives_are_disabled( $user_id );
 		}
 
-		if ( $this->author_archive->is_disabled_for_user( $user_id ) ) {
-			return Author_Not_Built_Exception::author_archives_are_disabled_for_user( $user_id );
-		}
-
 		if ( $this->author_archive->author_has_public_posts( $user_id ) === false ) {
 			return Author_Not_Built_Exception::author_archives_are_not_indexed_for_users_without_posts( $user_id );
 		}

--- a/src/builders/indexable-author-builder.php
+++ b/src/builders/indexable-author-builder.php
@@ -208,6 +208,24 @@ class Indexable_Author_Builder {
 	 * @return Author_Not_Built_Exception|null The exception if it should not be indexed, or `null` if it should.
 	 */
 	protected function check_if_user_should_be_indexed( $user_id ) {
+		/**
+		 * Filter: Include or exclude a user from being build and saved as an indexable.
+		 * Return `true` if the user with the given ID should be included.
+		 * Return `false` if the user with the given ID should be excluded.
+		 * Return `null` if the standard Yoast SEO logic should apply.
+		 *
+		 * @param string $user_id The ID of the user that should or should not be excluded.
+		 */
+		$user_should_be_indexed = \apply_filters( 'wpseo_should_build_and_save_user_indexable', $user_id );
+
+		if ( $user_should_be_indexed === true ) {
+			return null;
+		}
+
+		if ( $user_should_be_indexed === false ) {
+			return Author_Not_Built_Exception::author_not_built_because_of_filter( $user_id );
+		}
+
 		if ( $this->author_archive->are_disabled() ) {
 			return Author_Not_Built_Exception::author_archives_are_disabled( $user_id );
 		}

--- a/src/builders/indexable-author-builder.php
+++ b/src/builders/indexable-author-builder.php
@@ -208,32 +208,24 @@ class Indexable_Author_Builder {
 	 * @return Author_Not_Built_Exception|null The exception if it should not be indexed, or `null` if it should.
 	 */
 	protected function check_if_user_should_be_indexed( $user_id ) {
-		/**
-		 * Filter: Include or exclude a user from being build and saved as an indexable.
-		 * Return `true` if the user with the given ID should be included.
-		 * Return `false` if the user with the given ID should be excluded.
-		 * Return `null` if the standard Yoast SEO logic should apply.
-		 *
-		 * @param string $user_id The ID of the user that should or should not be excluded.
-		 */
-		$user_should_be_indexed = \apply_filters( 'wpseo_should_build_and_save_user_indexable', $user_id );
-
-		if ( $user_should_be_indexed === true ) {
-			return null;
-		}
-
-		if ( $user_should_be_indexed === false ) {
-			return Author_Not_Built_Exception::author_not_built_because_of_filter( $user_id );
-		}
+		$exception = null;
 
 		if ( $this->author_archive->are_disabled() ) {
-			return Author_Not_Built_Exception::author_archives_are_disabled( $user_id );
+			$exception = Author_Not_Built_Exception::author_archives_are_disabled( $user_id );
 		}
 
 		if ( $this->author_archive->author_has_public_posts( $user_id ) === false ) {
-			return Author_Not_Built_Exception::author_archives_are_not_indexed_for_users_without_posts( $user_id );
+			$exception = Author_Not_Built_Exception::author_archives_are_not_indexed_for_users_without_posts( $user_id );
 		}
 
-		return null;
+		/**
+		 * Filter: Include or exclude a user from being build and saved as an indexable.
+		 * Return an `Author_Not_Built_Exception` when the indexable should not be build, with an appropriate message telling why it should not be built.
+		 * Return `null` if the indexable should be build.
+		 *
+		 * @param Author_Not_Built_Exception|null $exception An exception if the indexable is not being built, `null` if the indexable should be built.
+		 * @param string                          $user_id   The ID of the user that should or should not be excluded.
+		 */
+		return \apply_filters( 'wpseo_should_build_and_save_user_indexable', $exception, $user_id );
 	}
 }

--- a/src/builders/indexable-author-builder.php
+++ b/src/builders/indexable-author-builder.php
@@ -230,10 +230,6 @@ class Indexable_Author_Builder {
 			return Author_Not_Built_Exception::author_archives_are_disabled( $user_id );
 		}
 
-		if ( $this->author_archive->are_not_indexed() ) {
-			return Author_Not_Built_Exception::author_archives_are_not_indexed( $user_id );
-		}
-
 		if ( $this->author_archive->is_disabled_for_user( $user_id ) ) {
 			return Author_Not_Built_Exception::author_archives_are_disabled_for_user( $user_id );
 		}

--- a/src/builders/indexable-author-builder.php
+++ b/src/builders/indexable-author-builder.php
@@ -214,7 +214,7 @@ class Indexable_Author_Builder {
 			$exception = Author_Not_Built_Exception::author_archives_are_disabled( $user_id );
 		}
 
-		if ( $this->author_archive->author_has_public_posts( $user_id ) === false ) {
+		if ( $this->author_archive->author_has_public_posts_wp( $user_id ) === false ) {
 			$exception = Author_Not_Built_Exception::author_archives_are_not_indexed_for_users_without_posts( $user_id );
 		}
 

--- a/src/builders/indexable-builder.php
+++ b/src/builders/indexable-builder.php
@@ -338,11 +338,18 @@ class Indexable_Builder {
 						false
 					);
 					if ( ! $author_indexable || $this->version_manager->indexable_needs_upgrade( $author_indexable ) ) {
-						$author_defaults = [
+						// Save indexable, to make sure that it can be queried when determining if an author has public posts.
+						$this->save_indexable( $indexable, $indexable_before );
+						// Try to build the author.
+						$author_defaults  = [
 							'object_type' => 'user',
 							'object_id'   => $indexable->author_id,
 						];
-						$this->build( $author_indexable, $author_defaults );
+						$author_indexable = $this->build( $author_indexable, $author_defaults );
+						if ( $author_indexable ) {
+							// Set author ID.
+							$indexable->author_id = $author_indexable->id;
+						}
 					}
 					break;
 

--- a/src/builders/indexable-builder.php
+++ b/src/builders/indexable-builder.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\WP\SEO\Builders;
 
+use Yoast\WP\SEO\Exceptions\Indexable\Not_Built_Exception;
 use Yoast\WP\SEO\Exceptions\Indexable\Source_Exception;
 use Yoast\WP\SEO\Helpers\Indexable_Helper;
 use Yoast\WP\SEO\Models\Indexable;
@@ -394,6 +395,9 @@ class Indexable_Builder {
 			$indexable = $this->version_manager->set_latest( $indexable );
 
 			return $this->save_indexable( $indexable, $indexable_before );
+		}
+		catch ( Not_Built_Exception $exception ) {
+			return false;
 		}
 	}
 }

--- a/src/exceptions/indexable/author-not-built-exception.php
+++ b/src/exceptions/indexable/author-not-built-exception.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Yoast\WP\SEO\Exceptions\Indexable;
+
+/**
+ * For when an author indexable is not being built.
+ */
+class Author_Not_Built_Exception extends Not_Built_Exception {
+
+	/**
+	 * Named constructor for creating an Author_Not_Built_Exception
+	 * when author archives are disabled for users without posts.
+	 *
+	 * @param string $user_id The user id.
+	 *
+	 * @return Author_Not_Built_Exception The exception.
+	 */
+	public static function author_archives_are_disabled_for_users_without_posts( $user_id ) {
+		return new Author_Not_Built_Exception(
+			'Indexable for author with id ' . $user_id . ' is not being built, since author archives are disabled for users without posts.'
+		);
+	}
+
+	/**
+	 * Named constructor for creating an Author_Not_Built_Exception
+	 * when author archives are disabled.
+	 *
+	 * @param string $user_id The user id.
+	 *
+	 * @return Author_Not_Built_Exception The exception.
+	 */
+	public static function author_archives_are_disabled( $user_id ) {
+		return new Author_Not_Built_Exception(
+			'Indexable for author with id ' . $user_id . ' is not being built, since author archives are disabled.'
+		);
+	}
+
+	/**
+	 * Named constructor for creating an Author_Not_Built_Exception
+	 * when author archives are disabled for the user with the given id.
+	 *
+	 * @param string $user_id The user id.
+	 *
+	 * @return Author_Not_Built_Exception The exception.
+	 */
+	public static function author_archives_are_disabled_for_user( $user_id ) {
+		return new Author_Not_Built_Exception(
+			'Indexable for author with id ' . $user_id . ' is not being built, since author archives are disabled for this user.'
+		);
+	}
+}

--- a/src/exceptions/indexable/author-not-built-exception.php
+++ b/src/exceptions/indexable/author-not-built-exception.php
@@ -15,9 +15,9 @@ class Author_Not_Built_Exception extends Not_Built_Exception {
 	 *
 	 * @return Author_Not_Built_Exception The exception.
 	 */
-	public static function author_archives_are_disabled_for_users_without_posts( $user_id ) {
+	public static function author_archives_are_not_indexed_for_users_without_posts( $user_id ) {
 		return new Author_Not_Built_Exception(
-			'Indexable for author with id ' . $user_id . ' is not being built, since author archives are disabled for users without posts.'
+			'Indexable for author with id ' . $user_id . ' is not being built, since author archives are not indexed for users without posts.'
 		);
 	}
 
@@ -46,6 +46,20 @@ class Author_Not_Built_Exception extends Not_Built_Exception {
 	public static function author_archives_are_disabled_for_user( $user_id ) {
 		return new Author_Not_Built_Exception(
 			'Indexable for author with id ' . $user_id . ' is not being built, since author archives are disabled for this user.'
+		);
+	}
+
+	/**
+	 * Named constructor for creating an Author_Not_Built_Exception
+	 * when author archives are disabled for the user with the given id.
+	 *
+	 * @param string $user_id The user id.
+	 *
+	 * @return Author_Not_Built_Exception The exception.
+	 */
+	public static function author_archives_are_not_indexed( $user_id ) {
+		return new Author_Not_Built_Exception(
+			'Indexable for author with id ' . $user_id . ' is not being built, since author archives are not indexed.'
 		);
 	}
 }

--- a/src/exceptions/indexable/author-not-built-exception.php
+++ b/src/exceptions/indexable/author-not-built-exception.php
@@ -62,4 +62,18 @@ class Author_Not_Built_Exception extends Not_Built_Exception {
 			'Indexable for author with id ' . $user_id . ' is not being built, since author archives are not indexed.'
 		);
 	}
+
+	/**
+	 * Named constructor for creating an Author_Not_Build_Exception
+	 * when an author is excluded because of the `'wpseo_should_build_and_save_user_indexable'` filter.
+	 *
+	 * @param string $user_id The user id.
+	 *
+	 * @return Author_Not_Built_Exception The exception.
+	 */
+	public static function author_not_built_because_of_filter( $user_id ) {
+		return new Author_Not_Built_Exception(
+			'Indexable for author with id ' . $user_id . ' is not being built, since it is excluded because of the \'wpseo_should_build_and_save_user_indexable\' filter.'
+		);
+	}
 }

--- a/src/exceptions/indexable/author-not-built-exception.php
+++ b/src/exceptions/indexable/author-not-built-exception.php
@@ -36,20 +36,6 @@ class Author_Not_Built_Exception extends Not_Built_Exception {
 	}
 
 	/**
-	 * Named constructor for creating an Author_Not_Built_Exception
-	 * when author archives are disabled for the user with the given id.
-	 *
-	 * @param string $user_id The user id.
-	 *
-	 * @return Author_Not_Built_Exception The exception.
-	 */
-	public static function author_archives_are_disabled_for_user( $user_id ) {
-		return new Author_Not_Built_Exception(
-			'Indexable for author with id ' . $user_id . ' is not being built, since author archives are disabled for this user.'
-		);
-	}
-
-	/**
 	 * Named constructor for creating an Author_Not_Build_Exception
 	 * when an author is excluded because of the `'wpseo_should_build_and_save_user_indexable'` filter.
 	 *

--- a/src/exceptions/indexable/author-not-built-exception.php
+++ b/src/exceptions/indexable/author-not-built-exception.php
@@ -50,20 +50,6 @@ class Author_Not_Built_Exception extends Not_Built_Exception {
 	}
 
 	/**
-	 * Named constructor for creating an Author_Not_Built_Exception
-	 * when author archives are disabled for the user with the given id.
-	 *
-	 * @param string $user_id The user id.
-	 *
-	 * @return Author_Not_Built_Exception The exception.
-	 */
-	public static function author_archives_are_not_indexed( $user_id ) {
-		return new Author_Not_Built_Exception(
-			'Indexable for author with id ' . $user_id . ' is not being built, since author archives are not indexed.'
-		);
-	}
-
-	/**
 	 * Named constructor for creating an Author_Not_Build_Exception
 	 * when an author is excluded because of the `'wpseo_should_build_and_save_user_indexable'` filter.
 	 *

--- a/src/exceptions/indexable/not-built-exception.php
+++ b/src/exceptions/indexable/not-built-exception.php
@@ -1,0 +1,11 @@
+<?php
+
+
+namespace Yoast\WP\SEO\Exceptions\Indexable;
+
+/**
+ * Class Not_Built_Exception
+ */
+class Not_Built_Exception extends Indexable_Exception {
+
+}

--- a/src/helpers/author-archive-helper.php
+++ b/src/helpers/author-archive-helper.php
@@ -95,15 +95,6 @@ class Author_Archive_Helper {
 	}
 
 	/**
-	 * Checks whether author archives are disabled for users without posts.
-	 *
-	 * @return bool
-	 */
-	public function are_not_indexed_for_users_without_posts() {
-		return $this->options_helper->get( 'noindex-author-noposts-wpseo' );
-	}
-
-	/**
 	 * Returns whether the author has at least one public post.
 	 *
 	 * @codeCoverageIgnore It looks for the first ID through the ORM and converts it to a boolean.

--- a/src/helpers/author-archive-helper.php
+++ b/src/helpers/author-archive-helper.php
@@ -10,6 +10,33 @@ use Yoast\WP\Lib\Model;
 class Author_Archive_Helper {
 
 	/**
+	 * The options helper.
+	 *
+	 * @var Options_Helper
+	 */
+	private $options_helper;
+
+	/**
+	 * The user helper.
+	 *
+	 * @var User_helper
+	 */
+	private $user_helper;
+
+	/**
+	 * Creates a new author archive helper.
+	 *
+	 * @param Options_Helper $options_helper The options helper.
+	 */
+	public function __construct(
+		Options_Helper $options_helper,
+		User_helper $user_helper
+	) {
+		$this->options_helper = $options_helper;
+		$this->user_helper    = $user_helper;
+	}
+
+	/**
 	 * Gets the array of post types that are shown on an author's archive.
 	 *
 	 * @return array The post types that are shown on an author's archive.
@@ -44,6 +71,35 @@ class Author_Archive_Helper {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Checks if the author archives are disabled for a user with the given id.
+	 *
+	 * @param string $user_id The user id.
+	 *
+	 * @return bool If the user archive is disabled for the given user.
+	 */
+	public function is_disabled_for_user( $user_id ) {
+		return $this->user_helper->get_the_author_meta( 'wpseo_noindex_author', $user_id );
+	}
+
+	/**
+	 * Checks whether author archives are disabled.
+	 *
+	 * @return bool
+	 */
+	public function are_disabled() {
+		return $this->options_helper->get( 'noindex-author-wpseo' );
+	}
+
+	/**
+	 * Checks whether author archives are disabled for users without posts.
+	 *
+	 * @return bool
+	 */
+	public function are_disabled_for_users_without_posts() {
+		return $this->options_helper->get( 'noindex-author-noposts-wpseo' );
 	}
 
 	/**

--- a/src/helpers/author-archive-helper.php
+++ b/src/helpers/author-archive-helper.php
@@ -42,53 +42,6 @@ class Author_Archive_Helper {
 	}
 
 	/**
-	 * Checks whether the user with the given ID has publicly viewable posts.
-	 *
-	 * **Note**: It uses the WordPress tables to determine the number of posts,
-	 * not the indexables table.
-	 *
-	 * @param string $user_id The user ID.
-	 *
-	 * @return bool Whether the author has public posts, according to the WordPress tables.
-	 */
-	public function author_has_public_posts_wp( $user_id ) {
-		$cache_key       = 'author_has_a_public_post_wp_' . $user_id;
-		$has_public_post = \wp_cache_get( $cache_key );
-
-		if ( $has_public_post === false ) {
-			global $wpdb;
-
-			$post_types        = $this->get_author_archive_post_types();
-			$public_post_stati = \array_values( \array_filter( \get_post_stati(), 'is_post_status_viewable' ) );
-
-			$post_type_placeholders         = \implode( ', ', \array_fill( 0, \count( $post_types ), '%s' ) );
-			$public_post_stati_placeholders = \implode( ', ', \array_fill( 0, \count( $public_post_stati ), '%s' ) );
-
-			$sql = "
-				SELECT ID 
-				FROM $wpdb->posts 
-				WHERE post_author = %d 
-				  AND post_type IN ( $post_type_placeholders ) 
-				  AND post_status IN ( $public_post_stati_placeholders )
-				LIMIT 1";
-
-			$replacements = \array_merge( [ $user_id ], $post_types, $public_post_stati );
-
-			// phpcs:disable WordPress.DB -- Query is prepared with placeholders above, query is cached.
-			$single_public_post = $wpdb->query( $wpdb->prepare( $sql, $replacements ) );
-
-			$has_public_post = (bool) $single_public_post;
-
-			if ( $has_public_post === false ) {
-				// Cache no results to prevent extra database query.
-				\wp_cache_set( $cache_key, 0, '', \wp_rand( ( 2 * \HOUR_IN_SECONDS ), ( 4 * \HOUR_IN_SECONDS ) ) );
-			}
-		}
-
-		return (bool) $has_public_post;
-	}
-
-	/**
 	 * Returns whether the author has at least one public post.
 	 *
 	 * @param int $author_id The author ID.

--- a/src/helpers/author-archive-helper.php
+++ b/src/helpers/author-archive-helper.php
@@ -55,20 +55,22 @@ class Author_Archive_Helper {
 		global $wpdb;
 
 		$post_types        = $this->get_author_archive_post_types();
-		$public_post_stati = \array_values ( \array_filter( \get_post_stati(), 'is_post_status_viewable' ) );
+		$public_post_stati = \array_values( \array_filter( \get_post_stati(), 'is_post_status_viewable' ) );
 
 		$post_type_placeholders         = \implode( ', ', \array_fill( 0, \count( $post_types ), '%s' ) );
 		$public_post_stati_placeholders = \implode( ', ', \array_fill( 0, \count( $public_post_stati ), '%s' ) );
 
-		$sql = $wpdb->prepare(
-			'SELECT ID FROM ' . $wpdb->posts . ' WHERE ( post_author = %d AND post_type IN (' . $post_type_placeholders .
-			') AND post_status IN (' . $public_post_stati_placeholders . ') )',
-			$user_id,
-			...$post_types,
-			...$public_post_stati
-		);
+		$sql = "
+			SELECT ID 
+			FROM $wpdb->posts 
+			WHERE post_author = %d 
+			  AND post_type IN ( $post_type_placeholders ) 
+			  AND post_status IN ( $public_post_stati_placeholders )
+		  LIMIT 1";
 
-		$single_public_post = $wpdb->query( $sql );
+		$replacements = \array_merge( [ $user_id ], $post_types, $public_post_stati );
+
+		$single_public_post = $wpdb->query( $wpdb->prepare( $sql, $replacements ) );
 
 		return (bool) $single_public_post;
 	}

--- a/src/helpers/author-archive-helper.php
+++ b/src/helpers/author-archive-helper.php
@@ -88,9 +88,18 @@ class Author_Archive_Helper {
 	/**
 	 * Checks whether author archives are disabled.
 	 *
-	 * @return bool
+	 * @return bool `true` if author archives are disabled, `false` if not.
 	 */
 	public function are_disabled() {
+		return $this->options_helper->get( 'disable-author' );
+	}
+
+	/**
+	 * Checks whether author archives are not indexed.
+	 *
+	 * @return bool `true` if author archives are not indexed, `false` if author archives are indexed.
+	 */
+	public function are_not_indexed() {
 		return $this->options_helper->get( 'noindex-author-wpseo' );
 	}
 
@@ -99,7 +108,7 @@ class Author_Archive_Helper {
 	 *
 	 * @return bool
 	 */
-	public function are_disabled_for_users_without_posts() {
+	public function are_not_indexed_for_users_without_posts() {
 		return $this->options_helper->get( 'noindex-author-noposts-wpseo' );
 	}
 

--- a/src/helpers/author-archive-helper.php
+++ b/src/helpers/author-archive-helper.php
@@ -27,10 +27,11 @@ class Author_Archive_Helper {
 	 * Creates a new author archive helper.
 	 *
 	 * @param Options_Helper $options_helper The options helper.
+	 * @param User_Helper    $user_helper    The user helper.
 	 */
 	public function __construct(
 		Options_Helper $options_helper,
-		User_helper $user_helper
+		User_Helper $user_helper
 	) {
 		$this->options_helper = $options_helper;
 		$this->user_helper    = $user_helper;

--- a/src/helpers/author-archive-helper.php
+++ b/src/helpers/author-archive-helper.php
@@ -95,15 +95,6 @@ class Author_Archive_Helper {
 	}
 
 	/**
-	 * Checks whether author archives are not indexed.
-	 *
-	 * @return bool `true` if author archives are not indexed, `false` if author archives are indexed.
-	 */
-	public function are_not_indexed() {
-		return $this->options_helper->get( 'noindex-author-wpseo' );
-	}
-
-	/**
 	 * Checks whether author archives are disabled for users without posts.
 	 *
 	 * @return bool

--- a/src/helpers/author-archive-helper.php
+++ b/src/helpers/author-archive-helper.php
@@ -17,24 +17,14 @@ class Author_Archive_Helper {
 	private $options_helper;
 
 	/**
-	 * The user helper.
-	 *
-	 * @var User_helper
-	 */
-	private $user_helper;
-
-	/**
 	 * Creates a new author archive helper.
 	 *
 	 * @param Options_Helper $options_helper The options helper.
-	 * @param User_Helper    $user_helper    The user helper.
 	 */
 	public function __construct(
-		Options_Helper $options_helper,
-		User_Helper $user_helper
+		Options_Helper $options_helper
 	) {
 		$this->options_helper = $options_helper;
-		$this->user_helper    = $user_helper;
 	}
 
 	/**
@@ -72,17 +62,6 @@ class Author_Archive_Helper {
 		}
 
 		return false;
-	}
-
-	/**
-	 * Checks if the author archives are disabled for a user with the given id.
-	 *
-	 * @param string $user_id The user id.
-	 *
-	 * @return bool If the user archive is disabled for the given user.
-	 */
-	public function is_disabled_for_user( $user_id ) {
-		return $this->user_helper->get_the_author_meta( 'wpseo_noindex_author', $user_id );
 	}
 
 	/**

--- a/src/helpers/author-archive-helper.php
+++ b/src/helpers/author-archive-helper.php
@@ -52,27 +52,40 @@ class Author_Archive_Helper {
 	 * @return bool Whether the author has public posts, according to the WordPress tables.
 	 */
 	public function author_has_public_posts_wp( $user_id ) {
-		global $wpdb;
+		$cache_key       = 'author_has_a_public_post_wp_' . $user_id;
+		$has_public_post = \wp_cache_get( $cache_key );
 
-		$post_types        = $this->get_author_archive_post_types();
-		$public_post_stati = \array_values( \array_filter( \get_post_stati(), 'is_post_status_viewable' ) );
+		if ( $has_public_post === false ) {
+			global $wpdb;
 
-		$post_type_placeholders         = \implode( ', ', \array_fill( 0, \count( $post_types ), '%s' ) );
-		$public_post_stati_placeholders = \implode( ', ', \array_fill( 0, \count( $public_post_stati ), '%s' ) );
+			$post_types        = $this->get_author_archive_post_types();
+			$public_post_stati = \array_values( \array_filter( \get_post_stati(), 'is_post_status_viewable' ) );
 
-		$sql = "
-			SELECT ID 
-			FROM $wpdb->posts 
-			WHERE post_author = %d 
-			  AND post_type IN ( $post_type_placeholders ) 
-			  AND post_status IN ( $public_post_stati_placeholders )
-		  LIMIT 1";
+			$post_type_placeholders         = \implode( ', ', \array_fill( 0, \count( $post_types ), '%s' ) );
+			$public_post_stati_placeholders = \implode( ', ', \array_fill( 0, \count( $public_post_stati ), '%s' ) );
 
-		$replacements = \array_merge( [ $user_id ], $post_types, $public_post_stati );
+			$sql = "
+				SELECT ID 
+				FROM $wpdb->posts 
+				WHERE post_author = %d 
+				  AND post_type IN ( $post_type_placeholders ) 
+				  AND post_status IN ( $public_post_stati_placeholders )
+				LIMIT 1";
 
-		$single_public_post = $wpdb->query( $wpdb->prepare( $sql, $replacements ) );
+			$replacements = \array_merge( [ $user_id ], $post_types, $public_post_stati );
 
-		return (bool) $single_public_post;
+			// phpcs:disable WordPress.DB -- Query is prepared with placeholders above, query is cached.
+			$single_public_post = $wpdb->query( $wpdb->prepare( $sql, $replacements ) );
+
+			$has_public_post = (bool) $single_public_post;
+
+			if ( $has_public_post === false ) {
+				// Cache no results to prevent extra database query.
+				\wp_cache_set( $cache_key, 0, '', \wp_rand( ( 2 * \HOUR_IN_SECONDS ), ( 4 * \HOUR_IN_SECONDS ) ) );
+			}
+		}
+
+		return (bool) $has_public_post;
 	}
 
 	/**

--- a/src/integrations/watchers/indexable-author-archive-watcher.php
+++ b/src/integrations/watchers/indexable-author-archive-watcher.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Yoast\WP\SEO\Integrations\Watchers;
+
+use Yoast\WP\SEO\Conditionals\Migrations_Conditional;
+use Yoast\WP\SEO\Integrations\Cleanup_Integration;
+use Yoast\WP\SEO\Integrations\Integration_Interface;
+
+/**
+ * Watches the `wpseo_titles` option for changes to the author archive settings.
+ */
+class Indexable_Author_Archive_Watcher implements Integration_Interface {
+
+	/**
+	 * Check if the author archives are disabled whenever the `wpseo_titles` option
+	 * changes.
+	 *
+	 * @return void
+	 */
+	public function register_hooks() {
+		\add_action(
+			'update_option_wpseo_titles',
+			[ $this, 'reschedule_indexable_cleanup_when_author_archives_are_disabled' ],
+			10,
+			2
+		);
+	}
+
+	/**
+	 * This watcher should only be run when the migrations have been run.
+	 * (Otherwise there may not be an indexable table to clean).
+	 *
+	 * @return string[] The conditionals.
+	 */
+	public static function get_conditionals() {
+		return [ Migrations_Conditional::class ];
+	}
+
+	/**
+	 * Reschedule the indexable cleanup routine if the author archives are disabled.
+	 * to make sure that all authors are removed from the indexables table.
+	 *
+	 * When author archives are disabled, they can never be indexed.
+	 *
+	 * @param array $old_value The old `wpseo_titles` option value.
+	 * @param array $new_value The new `wpseo_titles` option value.
+	 *
+	 * @return void
+	 */
+	public function reschedule_indexable_cleanup_when_author_archives_are_disabled( $old_value, $new_value ) {
+		if ( $old_value['disable-author'] !== true && $new_value[ 'disable-author' ] === true ) {
+			$cleanup_not_yet_scheduled = ! \wp_next_scheduled( Cleanup_Integration::START_HOOK );
+			if ( $cleanup_not_yet_scheduled ) {
+				\wp_schedule_single_event( ( time() + ( MINUTE_IN_SECONDS * 5 ) ), Cleanup_Integration::START_HOOK );
+			}
+		}
+	}
+}

--- a/src/integrations/watchers/indexable-author-archive-watcher.php
+++ b/src/integrations/watchers/indexable-author-archive-watcher.php
@@ -48,7 +48,7 @@ class Indexable_Author_Archive_Watcher implements Integration_Interface {
 	 * @return void
 	 */
 	public function reschedule_indexable_cleanup_when_author_archives_are_disabled( $old_value, $new_value ) {
-		if ( $old_value['disable-author'] !== true && $new_value[ 'disable-author' ] === true ) {
+		if ( $old_value['disable-author'] !== true && $new_value['disable-author'] === true ) {
 			$cleanup_not_yet_scheduled = ! \wp_next_scheduled( Cleanup_Integration::START_HOOK );
 			if ( $cleanup_not_yet_scheduled ) {
 				\wp_schedule_single_event( ( time() + ( MINUTE_IN_SECONDS * 5 ) ), Cleanup_Integration::START_HOOK );

--- a/src/integrations/watchers/indexable-post-watcher.php
+++ b/src/integrations/watchers/indexable-post-watcher.php
@@ -212,9 +212,11 @@ class Indexable_Post_Watcher implements Integration_Interface {
 	protected function update_has_public_posts( $indexable ) {
 		// Update the author indexable's has public posts value.
 		try {
-			$author_indexable                   = $this->repository->find_by_id_and_type( $indexable->author_id, 'user' );
-			$author_indexable->has_public_posts = $this->author_archive->author_has_public_posts( $author_indexable->object_id );
-			$author_indexable->save();
+			$author_indexable = $this->repository->find_by_id_and_type( $indexable->author_id, 'user' );
+			if ( $author_indexable ) {
+				$author_indexable->has_public_posts = $this->author_archive->author_has_public_posts( $author_indexable->object_id );
+				$author_indexable->save();
+			}
 		} catch ( Exception $exception ) {
 			$this->logger->log( LogLevel::ERROR, $exception->getMessage() );
 		}

--- a/src/integrations/watchers/indexable-post-watcher.php
+++ b/src/integrations/watchers/indexable-post-watcher.php
@@ -169,7 +169,6 @@ class Indexable_Post_Watcher implements Integration_Interface {
 		}
 
 		$this->update_relations( $post );
-		$this->update_has_public_posts( $indexable );
 
 		$indexable->save();
 	}
@@ -192,6 +191,15 @@ class Indexable_Post_Watcher implements Integration_Interface {
 			$indexable = $this->builder->build_for_id_and_type( $post_id, 'post', $indexable );
 
 			$post = $this->post->get_post( $post_id );
+
+			/*
+			 * Update whether an author has public posts.
+			 * For example this post could be set to Draft or Private,
+			 * which can influence if its author has any public posts at all.
+			 */
+			if ( $indexable ) {
+				$this->update_has_public_posts( $indexable );
+			}
 
 			// Build links for this post.
 			if ( $post && $indexable && \in_array( $post->post_status, $this->post->get_public_post_statuses(), true ) ) {

--- a/tests/unit/builders/indexable-author-builder-test.php
+++ b/tests/unit/builders/indexable-author-builder-test.php
@@ -88,9 +88,9 @@ class Indexable_Author_Builder_Test extends TestCase {
 	}
 
 	/**
-	 * @return Indexable|Mockery\MockInterface
+	 * Mocks an indexable.
 	 *
-	 * @throws Monkey\Expectation\Exception\ExpectationArgsRequired
+	 * @return Indexable|Mockery\MockInterface
 	 */
 	protected function mock_indexable() {
 		$indexable_mock      = Mockery::mock( Indexable::class );
@@ -171,7 +171,10 @@ class Indexable_Author_Builder_Test extends TestCase {
 			->expects( 'are_disabled' )
 			->andReturn( false );
 		$this->author_archive
-			->expects( 'are_disabled_for_users_without_posts' )
+			->expects( 'are_not_indexed' )
+			->andReturn( false );
+		$this->author_archive
+			->expects( 'are_not_indexed_for_users_without_posts' )
 			->andReturn( false );
 
 		$this->wpdb->expects( 'prepare' )->once()->with(
@@ -240,7 +243,10 @@ class Indexable_Author_Builder_Test extends TestCase {
 			->expects( 'are_disabled' )
 			->andReturn( false );
 		$this->author_archive
-			->expects( 'are_disabled_for_users_without_posts' )
+			->expects( 'are_not_indexed' )
+			->andReturn( false );
+		$this->author_archive
+			->expects( 'are_not_indexed_for_users_without_posts' )
 			->andReturn( false );
 
 		$this->wpdb->expects( 'prepare' )->once()->with(
@@ -318,10 +324,13 @@ class Indexable_Author_Builder_Test extends TestCase {
 			->with( 1 )
 			->andReturn( false );
 		$this->author_archive
+			->expects( 'are_not_indexed' )
+			->andReturn( false );
+		$this->author_archive
 			->expects( 'are_disabled' )
 			->andReturn( false );
 		$this->author_archive
-			->expects( 'are_disabled_for_users_without_posts' )
+			->expects( 'are_not_indexed_for_users_without_posts' )
 			->andReturn( false );
 
 		$this->wpdb->expects( 'prepare' )->once()->with(
@@ -371,6 +380,27 @@ class Indexable_Author_Builder_Test extends TestCase {
 
 	/**
 	 * Tests that the building an author throws an exception when author archives
+	 * are not indexed in general.
+	 *
+	 * @covers ::build
+	 */
+	public function test_throws_exception_when_author_archives_are_not_indexed() {
+		$this->author_archive
+			->expects( 'are_disabled' )
+			->andReturn( false );
+		$this->author_archive
+			->expects( 'are_not_indexed' )
+			->andReturn( true );
+
+		$this->expectException( Author_Not_Built_Exception::class );
+
+		$indexable_mock = Mockery::mock( Indexable::class );
+
+		$this->instance->build( 1, $indexable_mock );
+	}
+
+	/**
+	 * Tests that the building an author throws an exception when author archives
 	 * are disabled for the given user.
 	 *
 	 * @covers ::build
@@ -380,6 +410,9 @@ class Indexable_Author_Builder_Test extends TestCase {
 
 		$this->author_archive
 			->expects( 'are_disabled' )
+			->andReturn( false );
+		$this->author_archive
+			->expects( 'are_not_indexed' )
 			->andReturn( false );
 		$this->author_archive
 			->expects( 'is_disabled_for_user' )
@@ -399,11 +432,14 @@ class Indexable_Author_Builder_Test extends TestCase {
 	 *
 	 * @covers ::build
 	 */
-	public function test_throws_exception_when_author_are_disabled_for_users_without_posts_and_user_has_no_posts() {
+	public function test_throws_exception_when_author_archives_are_not_indexed_for_users_without_posts_and_user_has_no_posts() {
 		$user_id = 1;
 
 		$this->author_archive
 			->expects( 'are_disabled' )
+			->andReturn( false );
+		$this->author_archive
+			->expects( 'are_not_indexed' )
 			->andReturn( false );
 		$this->author_archive
 			->expects( 'is_disabled_for_user' )
@@ -414,7 +450,7 @@ class Indexable_Author_Builder_Test extends TestCase {
 			->with( $user_id )
 			->andReturn( false );
 		$this->author_archive
-			->expects( 'are_disabled_for_users_without_posts' )
+			->expects( 'are_not_indexed_for_users_without_posts' )
 			->andReturn( true );
 
 		$this->expectException( Author_Not_Built_Exception::class );

--- a/tests/unit/builders/indexable-author-builder-test.php
+++ b/tests/unit/builders/indexable-author-builder-test.php
@@ -6,6 +6,7 @@ use Brain\Monkey;
 use Mockery;
 use Yoast\WP\Lib\ORM;
 use Yoast\WP\SEO\Builders\Indexable_Author_Builder;
+use Yoast\WP\SEO\Exceptions\Indexable\Author_Not_Built_Exception;
 use Yoast\WP\SEO\Helpers\Author_Archive_Helper;
 use Yoast\WP\SEO\Helpers\Post_Helper;
 use Yoast\WP\SEO\Models\Indexable;
@@ -71,54 +72,59 @@ class Indexable_Author_Builder_Test extends TestCase {
 	protected function set_up() {
 		parent::set_up();
 
-		$this->indexable_mock      = Mockery::mock( Indexable::class );
-		$this->indexable_mock->orm = Mockery::mock( ORM::class );
-
-		Monkey\Functions\expect( 'get_author_posts_url' )->once()->with( 1 )->andReturn( 'https://permalink' );
-
-		$this->indexable_mock->orm->expects( 'set' )->with( 'object_id', 1 );
-		$this->indexable_mock->orm->expects( 'set' )->with( 'object_type', 'user' );
-		$this->indexable_mock->orm->expects( 'set' )->with( 'permalink', 'https://permalink' );
-		$this->indexable_mock->orm->expects( 'set' )->with( 'is_cornerstone', false );
-		$this->indexable_mock->orm->expects( 'set' )->with( 'is_robots_nofollow', null );
-		$this->indexable_mock->orm->expects( 'set' )->with( 'is_robots_noarchive', null );
-		$this->indexable_mock->orm->expects( 'set' )->with( 'is_robots_noimageindex', null );
-		$this->indexable_mock->orm->expects( 'set' )->with( 'is_robots_nosnippet', null );
-
-		// Resetting the image.
-		$this->indexable_mock->orm->expects( 'set' )->with( 'open_graph_image', null );
-		$this->indexable_mock->orm->expects( 'set' )->with( 'open_graph_image_id', null );
-		$this->indexable_mock->orm->expects( 'set' )->with( 'open_graph_image_source', null );
-		$this->indexable_mock->orm->expects( 'set' )->with( 'open_graph_image_meta', null );
-		$this->indexable_mock->orm->expects( 'set' )->with( 'twitter_image', null );
-		$this->indexable_mock->orm->expects( 'set' )->with( 'twitter_image_id', null );
-		$this->indexable_mock->orm->expects( 'set' )->with( 'twitter_image_source', null );
-
-		$this->indexable_mock->orm->expects( 'set' )->with( 'is_public', null );
-		$this->indexable_mock->orm->expects( 'set' )->with( 'has_public_posts', true );
-
-		$this->indexable_mock->orm->expects( 'get' )->with( 'is_robots_noindex' )->andReturn( 0 );
-
-		Monkey\Functions\expect( 'get_current_blog_id' )->once()->andReturn( 1 );
-		$this->indexable_mock->orm->expects( 'set' )->with( 'blog_id', 1 );
-
-		$this->author_archive = Mockery::mock( Author_Archive_Helper::class );
-		$this->author_archive
-			->expects( 'author_has_public_posts' )
-			->with( 1 )
-			->andReturn( true );
-
 		$this->versions = Mockery::mock( Indexable_Builder_Versions::class );
 		$this->versions
-			->expects( 'get_latest_version_for_type' )
+			->shouldReceive( 'get_latest_version_for_type' )
 			->with( 'user' )
 			->andReturn( 2 );
+
+		$this->author_archive = Mockery::mock( Author_Archive_Helper::class );
 
 		$this->post_helper = Mockery::mock( Post_Helper::class );
 		$this->wpdb        = Mockery::mock( 'wpdb' );
 		$this->wpdb->posts = 'wp_posts';
 
 		$this->instance = new Indexable_Author_Builder( $this->author_archive, $this->versions, $this->post_helper, $this->wpdb );
+	}
+
+	/**
+	 * @return Indexable|Mockery\MockInterface
+	 *
+	 * @throws Monkey\Expectation\Exception\ExpectationArgsRequired
+	 */
+	protected function mock_indexable() {
+		$indexable_mock      = Mockery::mock( Indexable::class );
+		$indexable_mock->orm = Mockery::mock( ORM::class );
+
+		Monkey\Functions\expect( 'get_author_posts_url' )->once()->with( 1 )->andReturn( 'https://permalink' );
+
+		$indexable_mock->orm->expects( 'set' )->with( 'object_id', 1 );
+		$indexable_mock->orm->expects( 'set' )->with( 'object_type', 'user' );
+		$indexable_mock->orm->expects( 'set' )->with( 'permalink', 'https://permalink' );
+		$indexable_mock->orm->expects( 'set' )->with( 'is_cornerstone', false );
+		$indexable_mock->orm->expects( 'set' )->with( 'is_robots_nofollow', null );
+		$indexable_mock->orm->expects( 'set' )->with( 'is_robots_noarchive', null );
+		$indexable_mock->orm->expects( 'set' )->with( 'is_robots_noimageindex', null );
+		$indexable_mock->orm->expects( 'set' )->with( 'is_robots_nosnippet', null );
+
+		// Resetting the image.
+		$indexable_mock->orm->expects( 'set' )->with( 'open_graph_image', null );
+		$indexable_mock->orm->expects( 'set' )->with( 'open_graph_image_id', null );
+		$indexable_mock->orm->expects( 'set' )->with( 'open_graph_image_source', null );
+		$indexable_mock->orm->expects( 'set' )->with( 'open_graph_image_meta', null );
+		$indexable_mock->orm->expects( 'set' )->with( 'twitter_image', null );
+		$indexable_mock->orm->expects( 'set' )->with( 'twitter_image_id', null );
+		$indexable_mock->orm->expects( 'set' )->with( 'twitter_image_source', null );
+
+		$indexable_mock->orm->expects( 'set' )->with( 'is_public', null );
+		$indexable_mock->orm->expects( 'set' )->with( 'has_public_posts', true );
+
+		$indexable_mock->orm->expects( 'get' )->with( 'is_robots_noindex' )->andReturn( 0 );
+
+		Monkey\Functions\expect( 'get_current_blog_id' )->once()->andReturn( 1 );
+		$indexable_mock->orm->expects( 'set' )->with( 'blog_id', 1 );
+
+		return $indexable_mock;
 	}
 
 	/**
@@ -131,6 +137,8 @@ class Indexable_Author_Builder_Test extends TestCase {
 		Monkey\Functions\expect( 'get_the_author_meta' )->once()->with( 'wpseo_title', 1 )->andReturn( 'title' );
 		Monkey\Functions\expect( 'get_the_author_meta' )->once()->with( 'wpseo_metadesc', 1 )->andReturn( 'description' );
 		Monkey\Functions\expect( 'get_the_author_meta' )->once()->with( 'wpseo_noindex_author', 1 )->andReturn( 'on' );
+
+		$this->indexable_mock = $this->mock_indexable();
 
 		$this->indexable_mock->orm->expects( 'set' )->with( 'title', 'title' );
 		$this->indexable_mock->orm->expects( 'set' )->with( 'description', 'description' );
@@ -151,6 +159,10 @@ class Indexable_Author_Builder_Test extends TestCase {
 
 		$this->post_helper->expects( 'get_public_post_statuses' )->once()->andReturn( [ 'publish' ] );
 
+		$this->author_archive
+			->expects( 'author_has_public_posts' )
+			->with( 1 )
+			->andReturn( true );
 		$this->author_archive
 			->expects( 'is_disabled_for_user' )
 			->with( 1 )
@@ -199,6 +211,9 @@ class Indexable_Author_Builder_Test extends TestCase {
 		Monkey\Functions\expect( 'get_the_author_meta' )->once()->with( 'wpseo_title', 1 )->andReturn( 'title' );
 		Monkey\Functions\expect( 'get_the_author_meta' )->once()->with( 'wpseo_metadesc', 1 )->andReturn( 'description' );
 		Monkey\Functions\expect( 'get_the_author_meta' )->once()->with( 'wpseo_noindex_author', 1 )->andReturn( 'on' );
+
+		$this->indexable_mock = $this->mock_indexable();
+
 		$this->indexable_mock->orm->expects( 'set' )->with( 'title', 'title' );
 		$this->indexable_mock->orm->expects( 'set' )->with( 'description', 'description' );
 		$this->indexable_mock->orm->expects( 'set' )->with( 'is_robots_noindex', true );
@@ -213,6 +228,10 @@ class Indexable_Author_Builder_Test extends TestCase {
 
 		$this->post_helper->expects( 'get_public_post_statuses' )->once()->andReturn( [ 'publish' ] );
 
+		$this->author_archive
+			->expects( 'author_has_public_posts' )
+			->with( 1 )
+			->andReturn( true );
 		$this->author_archive
 			->expects( 'is_disabled_for_user' )
 			->with( 1 )
@@ -269,6 +288,8 @@ class Indexable_Author_Builder_Test extends TestCase {
 		Monkey\Functions\expect( 'get_the_author_meta' )->once()->with( 'wpseo_metadesc', 1 )->andReturn( '' );
 		Monkey\Functions\expect( 'get_the_author_meta' )->once()->with( 'wpseo_noindex_author', 1 )->andReturn( '' );
 
+		$this->indexable_mock = $this->mock_indexable();
+
 		$this->indexable_mock->orm->expects( 'set' )->with( 'title', null );
 		$this->indexable_mock->orm->expects( 'set' )->with( 'description', null );
 		$this->indexable_mock->orm->expects( 'set' )->with( 'is_robots_noindex', false );
@@ -288,6 +309,10 @@ class Indexable_Author_Builder_Test extends TestCase {
 
 		$this->post_helper->expects( 'get_public_post_statuses' )->once()->andReturn( [ 'publish' ] );
 
+		$this->author_archive
+			->expects( 'author_has_public_posts' )
+			->with( 1 )
+			->andReturn( true );
 		$this->author_archive
 			->expects( 'is_disabled_for_user' )
 			->with( 1 )
@@ -324,5 +349,78 @@ class Indexable_Author_Builder_Test extends TestCase {
 			->andReturn( 'avatar_image.jpg' );
 
 		$this->instance->build( 1, $this->indexable_mock );
+	}
+
+	/**
+	 * Tests that the building an author throws an exception when author archives
+	 * are disabled in general.
+	 *
+	 * @covers ::build
+	 */
+	public function test_throws_exception_when_author_archives_are_disabled() {
+		$this->author_archive
+			->expects( 'are_disabled' )
+			->andReturn( true );
+
+		$this->expectException( Author_Not_Built_Exception::class );
+
+		$indexable_mock = Mockery::mock( Indexable::class );
+
+		$this->instance->build( 1, $indexable_mock );
+	}
+
+	/**
+	 * Tests that the building an author throws an exception when author archives
+	 * are disabled for the given user.
+	 *
+	 * @covers ::build
+	 */
+	public function test_throws_exception_when_author_archives_are_disabled_for_a_user() {
+		$user_id = 1;
+
+		$this->author_archive
+			->expects( 'are_disabled' )
+			->andReturn( false );
+		$this->author_archive
+			->expects( 'is_disabled_for_user' )
+			->with( $user_id )
+			->andReturn( true );
+
+		$this->expectException( Author_Not_Built_Exception::class );
+
+		$indexable_mock = Mockery::mock( Indexable::class );
+
+		$this->instance->build( $user_id, $indexable_mock );
+	}
+
+	/**
+	 * Tests that the building an author throws an exception when author archives
+	 * are disabled for users without posts and the user does not have posts.
+	 *
+	 * @covers ::build
+	 */
+	public function test_throws_exception_when_author_are_disabled_for_users_without_posts_and_user_has_no_posts() {
+		$user_id = 1;
+
+		$this->author_archive
+			->expects( 'are_disabled' )
+			->andReturn( false );
+		$this->author_archive
+			->expects( 'is_disabled_for_user' )
+			->with( $user_id )
+			->andReturn( false );
+		$this->author_archive
+			->expects( 'author_has_public_posts' )
+			->with( $user_id )
+			->andReturn( false );
+		$this->author_archive
+			->expects( 'are_disabled_for_users_without_posts' )
+			->andReturn( true );
+
+		$this->expectException( Author_Not_Built_Exception::class );
+
+		$indexable_mock = Mockery::mock( Indexable::class );
+
+		$this->instance->build( $user_id, $indexable_mock );
 	}
 }

--- a/tests/unit/builders/indexable-author-builder-test.php
+++ b/tests/unit/builders/indexable-author-builder-test.php
@@ -175,9 +175,6 @@ class Indexable_Author_Builder_Test extends TestCase {
 			->expects( 'are_disabled' )
 			->andReturn( false );
 		$this->author_archive
-			->expects( 'are_not_indexed' )
-			->andReturn( false );
-		$this->author_archive
 			->expects( 'are_not_indexed_for_users_without_posts' )
 			->andReturn( false );
 
@@ -248,9 +245,6 @@ class Indexable_Author_Builder_Test extends TestCase {
 			->never();
 		$this->author_archive
 			->expects( 'are_disabled' )
-			->never();
-		$this->author_archive
-			->expects( 'are_not_indexed' )
 			->never();
 		$this->author_archive
 			->expects( 'are_not_indexed_for_users_without_posts' )
@@ -325,9 +319,6 @@ class Indexable_Author_Builder_Test extends TestCase {
 			->andReturn( false );
 		$this->author_archive
 			->expects( 'are_disabled' )
-			->andReturn( false );
-		$this->author_archive
-			->expects( 'are_not_indexed' )
 			->andReturn( false );
 		$this->author_archive
 			->expects( 'are_not_indexed_for_users_without_posts' )
@@ -408,9 +399,6 @@ class Indexable_Author_Builder_Test extends TestCase {
 			->with( 1 )
 			->andReturn( false );
 		$this->author_archive
-			->expects( 'are_not_indexed' )
-			->andReturn( false );
-		$this->author_archive
 			->expects( 'are_disabled' )
 			->andReturn( false );
 		$this->author_archive
@@ -464,27 +452,6 @@ class Indexable_Author_Builder_Test extends TestCase {
 
 	/**
 	 * Tests that the building an author throws an exception when author archives
-	 * are not indexed in general.
-	 *
-	 * @covers ::build
-	 */
-	public function test_throws_exception_when_author_archives_are_not_indexed() {
-		$this->author_archive
-			->expects( 'are_disabled' )
-			->andReturn( false );
-		$this->author_archive
-			->expects( 'are_not_indexed' )
-			->andReturn( true );
-
-		$this->expectException( Author_Not_Built_Exception::class );
-
-		$indexable_mock = Mockery::mock( Indexable::class );
-
-		$this->instance->build( 1, $indexable_mock );
-	}
-
-	/**
-	 * Tests that the building an author throws an exception when author archives
 	 * are disabled for the given user.
 	 *
 	 * @covers ::build
@@ -494,9 +461,6 @@ class Indexable_Author_Builder_Test extends TestCase {
 
 		$this->author_archive
 			->expects( 'are_disabled' )
-			->andReturn( false );
-		$this->author_archive
-			->expects( 'are_not_indexed' )
 			->andReturn( false );
 		$this->author_archive
 			->expects( 'is_disabled_for_user' )
@@ -521,9 +485,6 @@ class Indexable_Author_Builder_Test extends TestCase {
 
 		$this->author_archive
 			->expects( 'are_disabled' )
-			->andReturn( false );
-		$this->author_archive
-			->expects( 'are_not_indexed' )
 			->andReturn( false );
 		$this->author_archive
 			->expects( 'is_disabled_for_user' )

--- a/tests/unit/builders/indexable-author-builder-test.php
+++ b/tests/unit/builders/indexable-author-builder-test.php
@@ -231,16 +231,15 @@ class Indexable_Author_Builder_Test extends TestCase {
 		$this->post_helper->expects( 'get_public_post_statuses' )->once()->andReturn( [ 'publish' ] );
 
 		Monkey\Filters\expectApplied( 'wpseo_should_build_and_save_user_indexable' )
-			->with( 1 )
-			->andReturn( true );
+			->andReturn( null );
 
 		$this->author_archive
 			->expects( 'are_disabled' )
-			->never();
-
+			->andReturn( false );
 		$this->author_archive
 			->expects( 'author_has_public_posts' )
 			->with( 1 )
+			->twice()
 			->andReturn( true );
 
 		$this->wpdb->expects( 'prepare' )->once()->with(
@@ -419,6 +418,11 @@ class Indexable_Author_Builder_Test extends TestCase {
 			->expects( 'are_disabled' )
 			->andReturn( true );
 
+		$this->author_archive
+			->expects( 'author_has_public_posts' )
+			->with( 1 )
+			->andReturn( true );
+
 		$this->expectException( Author_Not_Built_Exception::class );
 
 		$indexable_mock = Mockery::mock( Indexable::class );
@@ -458,9 +462,16 @@ class Indexable_Author_Builder_Test extends TestCase {
 	public function test_throws_an_exception_when_user_is_excluded_in_filter() {
 		$user_id = 1;
 
-		Monkey\Filters\expectApplied( 'wpseo_should_build_and_save_user_indexable' )
+		$this->author_archive
+			->expects( 'are_disabled' )
+			->andReturn( false );
+		$this->author_archive
+			->expects( 'author_has_public_posts' )
 			->with( $user_id )
 			->andReturn( false );
+
+		Monkey\Filters\expectApplied( 'wpseo_should_build_and_save_user_indexable' )
+			->andReturn( new Author_Not_Built_Exception( 'Author should not be build.' ) );
 
 		$this->expectException( Author_Not_Built_Exception::class );
 

--- a/tests/unit/builders/indexable-author-builder-test.php
+++ b/tests/unit/builders/indexable-author-builder-test.php
@@ -166,7 +166,10 @@ class Indexable_Author_Builder_Test extends TestCase {
 		$this->author_archive
 			->expects( 'author_has_public_posts' )
 			->with( 1 )
-			->twice()
+			->andReturn( true );
+		$this->author_archive
+			->expects( 'author_has_public_posts_wp' )
+			->with( 1 )
 			->andReturn( true );
 		$this->author_archive
 			->expects( 'are_disabled' )
@@ -237,9 +240,12 @@ class Indexable_Author_Builder_Test extends TestCase {
 			->expects( 'are_disabled' )
 			->andReturn( false );
 		$this->author_archive
+			->expects( 'author_has_public_posts_wp' )
+			->with( 1 )
+			->andReturn( true );
+		$this->author_archive
 			->expects( 'author_has_public_posts' )
 			->with( 1 )
-			->twice()
 			->andReturn( true );
 
 		$this->wpdb->expects( 'prepare' )->once()->with(
@@ -299,7 +305,10 @@ class Indexable_Author_Builder_Test extends TestCase {
 		$this->author_archive
 			->expects( 'author_has_public_posts' )
 			->with( 1 )
-			->twice()
+			->andReturn( true );
+		$this->author_archive
+			->expects( 'author_has_public_posts_wp' )
+			->with( 1 )
 			->andReturn( true );
 		$this->author_archive
 			->expects( 'are_disabled' )
@@ -374,7 +383,10 @@ class Indexable_Author_Builder_Test extends TestCase {
 		$this->author_archive
 			->expects( 'author_has_public_posts' )
 			->with( 1 )
-			->twice()
+			->andReturn( true );
+		$this->author_archive
+			->expects( 'author_has_public_posts_wp' )
+			->with( 1 )
 			->andReturn( true );
 		$this->author_archive
 			->expects( 'are_disabled' )
@@ -419,7 +431,7 @@ class Indexable_Author_Builder_Test extends TestCase {
 			->andReturn( true );
 
 		$this->author_archive
-			->expects( 'author_has_public_posts' )
+			->expects( 'author_has_public_posts_wp' )
 			->with( 1 )
 			->andReturn( true );
 
@@ -443,7 +455,7 @@ class Indexable_Author_Builder_Test extends TestCase {
 			->expects( 'are_disabled' )
 			->andReturn( false );
 		$this->author_archive
-			->expects( 'author_has_public_posts' )
+			->expects( 'author_has_public_posts_wp' )
 			->with( $user_id )
 			->andReturn( false );
 
@@ -466,7 +478,7 @@ class Indexable_Author_Builder_Test extends TestCase {
 			->expects( 'are_disabled' )
 			->andReturn( false );
 		$this->author_archive
-			->expects( 'author_has_public_posts' )
+			->expects( 'author_has_public_posts_wp' )
 			->with( $user_id )
 			->andReturn( false );
 

--- a/tests/unit/builders/indexable-author-builder-test.php
+++ b/tests/unit/builders/indexable-author-builder-test.php
@@ -159,6 +159,10 @@ class Indexable_Author_Builder_Test extends TestCase {
 
 		$this->post_helper->expects( 'get_public_post_statuses' )->once()->andReturn( [ 'publish' ] );
 
+		Monkey\Filters\expectApplied( 'wpseo_should_build_and_save_user_indexable' )
+			->with( 1 )
+			->andReturn( null );
+
 		$this->author_archive
 			->expects( 'author_has_public_posts' )
 			->with( 1 )
@@ -176,6 +180,86 @@ class Indexable_Author_Builder_Test extends TestCase {
 		$this->author_archive
 			->expects( 'are_not_indexed_for_users_without_posts' )
 			->andReturn( false );
+
+		$this->wpdb->expects( 'prepare' )->once()->with(
+			"
+			SELECT MAX(p.post_modified_gmt) AS last_modified, MIN(p.post_date_gmt) AS published_at
+			FROM {$this->wpdb->posts} AS p
+			WHERE p.post_status IN (%s)
+				AND p.post_password = ''
+				AND p.post_author = %d
+		",
+			[ 'publish', 1 ]
+		)->andReturn( 'PREPARED_QUERY' );
+		$this->wpdb->expects( 'get_row' )->once()->with( 'PREPARED_QUERY' )->andReturn(
+			(object) [
+				'last_modified' => '1234-12-12 00:00:00',
+				'published_at'  => '1234-12-12 00:00:00',
+			]
+		);
+
+		$this->indexable_mock->orm->expects( 'set' )->with( 'object_published_at', '1234-12-12 00:00:00' );
+		$this->indexable_mock->orm->expects( 'set' )->with( 'object_last_modified', '1234-12-12 00:00:00' );
+
+		Monkey\Functions\expect( 'get_avatar_url' )
+			->once()
+			->andReturn( 'avatar_image.jpg' );
+
+		$this->instance->build( 1, $this->indexable_mock );
+	}
+
+	/**
+	 * Tests whether the author is being built when it is explicitly included by the `'wpseo_should_build_and_save_user_indexable'` filter.
+	 *
+	 * @covers ::build
+	 */
+	public function test_build_when_user_is_explicitly_included_by_filter() {
+		Monkey\Functions\expect( 'get_the_author_meta' )->once()->with( 'wpseo_title', 1 )->andReturn( 'title' );
+		Monkey\Functions\expect( 'get_the_author_meta' )->once()->with( 'wpseo_metadesc', 1 )->andReturn( 'description' );
+		Monkey\Functions\expect( 'get_the_author_meta' )->once()->with( 'wpseo_noindex_author', 1 )->andReturn( 'on' );
+
+		$this->indexable_mock = $this->mock_indexable();
+
+		$this->indexable_mock->orm->expects( 'set' )->with( 'title', 'title' );
+		$this->indexable_mock->orm->expects( 'set' )->with( 'description', 'description' );
+		$this->indexable_mock->orm->expects( 'set' )->with( 'is_robots_noindex', true );
+		$this->indexable_mock->orm->expects( 'set' )->with( 'version', 2 );
+
+		$this->indexable_mock->orm->expects( 'get' )->once()->with( 'open_graph_image' );
+		$this->indexable_mock->orm->expects( 'get' )->twice()->with( 'open_graph_image_id' );
+		$this->indexable_mock->orm->expects( 'get' )->twice()->with( 'open_graph_image_source' );
+		$this->indexable_mock->orm->expects( 'get' )->twice()->with( 'twitter_image' );
+		$this->indexable_mock->orm->expects( 'get' )->times( 3 )->with( 'twitter_image_id' );
+		$this->indexable_mock->orm->expects( 'get' )->with( 'object_id' );
+
+		$this->indexable_mock->orm->expects( 'set' )->with( 'open_graph_image', 'avatar_image.jpg' );
+		$this->indexable_mock->orm->expects( 'set' )->with( 'open_graph_image_source', 'gravatar-image' );
+		$this->indexable_mock->orm->expects( 'set' )->with( 'twitter_image', 'avatar_image.jpg' );
+		$this->indexable_mock->orm->expects( 'set' )->with( 'twitter_image_source', 'gravatar-image' );
+
+		$this->post_helper->expects( 'get_public_post_statuses' )->once()->andReturn( [ 'publish' ] );
+
+		Monkey\Filters\expectApplied( 'wpseo_should_build_and_save_user_indexable' )
+			->with( 1 )
+			->andReturn( true );
+
+		$this->author_archive
+			->expects( 'is_disabled_for_user' )
+			->never();
+		$this->author_archive
+			->expects( 'are_disabled' )
+			->never();
+		$this->author_archive
+			->expects( 'are_not_indexed' )
+			->never();
+		$this->author_archive
+			->expects( 'are_not_indexed_for_users_without_posts' )
+			->never();
+
+		$this->author_archive
+			->expects( 'author_has_public_posts' )
+			->with( 1 )
+			->andReturn( true );
 
 		$this->wpdb->expects( 'prepare' )->once()->with(
 			"
@@ -452,6 +536,25 @@ class Indexable_Author_Builder_Test extends TestCase {
 		$this->author_archive
 			->expects( 'are_not_indexed_for_users_without_posts' )
 			->andReturn( true );
+
+		$this->expectException( Author_Not_Built_Exception::class );
+
+		$indexable_mock = Mockery::mock( Indexable::class );
+
+		$this->instance->build( $user_id, $indexable_mock );
+	}
+
+	/**
+	 * Tests that no indexable is built for a user if it is excluded in a filter.
+	 *
+	 * @covers ::build
+	 */
+	public function test_throws_an_exception_when_user_is_excluded_in_filter() {
+		$user_id = 1;
+
+		Monkey\Filters\expectApplied( 'wpseo_should_build_and_save_user_indexable' )
+			->with( $user_id )
+			->andReturn( false );
 
 		$this->expectException( Author_Not_Built_Exception::class );
 

--- a/tests/unit/builders/indexable-author-builder-test.php
+++ b/tests/unit/builders/indexable-author-builder-test.php
@@ -151,6 +151,17 @@ class Indexable_Author_Builder_Test extends TestCase {
 
 		$this->post_helper->expects( 'get_public_post_statuses' )->once()->andReturn( [ 'publish' ] );
 
+		$this->author_archive
+			->expects( 'is_disabled_for_user' )
+			->with( 1 )
+			->andReturn( false );
+		$this->author_archive
+			->expects( 'are_disabled' )
+			->andReturn( false );
+		$this->author_archive
+			->expects( 'are_disabled_for_users_without_posts' )
+			->andReturn( false );
+
 		$this->wpdb->expects( 'prepare' )->once()->with(
 			"
 			SELECT MAX(p.post_modified_gmt) AS last_modified, MIN(p.post_date_gmt) AS published_at
@@ -201,6 +212,17 @@ class Indexable_Author_Builder_Test extends TestCase {
 		$this->indexable_mock->orm->expects( 'get' )->twice()->with( 'object_id' );
 
 		$this->post_helper->expects( 'get_public_post_statuses' )->once()->andReturn( [ 'publish' ] );
+
+		$this->author_archive
+			->expects( 'is_disabled_for_user' )
+			->with( 1 )
+			->andReturn( false );
+		$this->author_archive
+			->expects( 'are_disabled' )
+			->andReturn( false );
+		$this->author_archive
+			->expects( 'are_disabled_for_users_without_posts' )
+			->andReturn( false );
 
 		$this->wpdb->expects( 'prepare' )->once()->with(
 			"
@@ -265,6 +287,17 @@ class Indexable_Author_Builder_Test extends TestCase {
 		$this->indexable_mock->orm->expects( 'set' )->with( 'twitter_image_source', 'gravatar-image' );
 
 		$this->post_helper->expects( 'get_public_post_statuses' )->once()->andReturn( [ 'publish' ] );
+
+		$this->author_archive
+			->expects( 'is_disabled_for_user' )
+			->with( 1 )
+			->andReturn( false );
+		$this->author_archive
+			->expects( 'are_disabled' )
+			->andReturn( false );
+		$this->author_archive
+			->expects( 'are_disabled_for_users_without_posts' )
+			->andReturn( false );
 
 		$this->wpdb->expects( 'prepare' )->once()->with(
 			"

--- a/tests/unit/builders/indexable-author-builder-test.php
+++ b/tests/unit/builders/indexable-author-builder-test.php
@@ -169,10 +169,6 @@ class Indexable_Author_Builder_Test extends TestCase {
 			->twice()
 			->andReturn( true );
 		$this->author_archive
-			->expects( 'is_disabled_for_user' )
-			->with( 1 )
-			->andReturn( false );
-		$this->author_archive
 			->expects( 'are_disabled' )
 			->andReturn( false );
 
@@ -238,9 +234,6 @@ class Indexable_Author_Builder_Test extends TestCase {
 			->with( 1 )
 			->andReturn( true );
 
-		$this->author_archive
-			->expects( 'is_disabled_for_user' )
-			->never();
 		$this->author_archive
 			->expects( 'are_disabled' )
 			->never();
@@ -309,10 +302,6 @@ class Indexable_Author_Builder_Test extends TestCase {
 			->with( 1 )
 			->twice()
 			->andReturn( true );
-		$this->author_archive
-			->expects( 'is_disabled_for_user' )
-			->with( 1 )
-			->andReturn( false );
 		$this->author_archive
 			->expects( 'are_disabled' )
 			->andReturn( false );
@@ -389,10 +378,6 @@ class Indexable_Author_Builder_Test extends TestCase {
 			->twice()
 			->andReturn( true );
 		$this->author_archive
-			->expects( 'is_disabled_for_user' )
-			->with( 1 )
-			->andReturn( false );
-		$this->author_archive
 			->expects( 'are_disabled' )
 			->andReturn( false );
 
@@ -443,30 +428,6 @@ class Indexable_Author_Builder_Test extends TestCase {
 
 	/**
 	 * Tests that the building an author throws an exception when author archives
-	 * are disabled for the given user.
-	 *
-	 * @covers ::build
-	 */
-	public function test_throws_exception_when_author_archives_are_disabled_for_a_user() {
-		$user_id = 1;
-
-		$this->author_archive
-			->expects( 'are_disabled' )
-			->andReturn( false );
-		$this->author_archive
-			->expects( 'is_disabled_for_user' )
-			->with( $user_id )
-			->andReturn( true );
-
-		$this->expectException( Author_Not_Built_Exception::class );
-
-		$indexable_mock = Mockery::mock( Indexable::class );
-
-		$this->instance->build( $user_id, $indexable_mock );
-	}
-
-	/**
-	 * Tests that the building an author throws an exception when author archives
 	 * are disabled for users without posts and the user does not have posts.
 	 *
 	 * @covers ::build
@@ -476,10 +437,6 @@ class Indexable_Author_Builder_Test extends TestCase {
 
 		$this->author_archive
 			->expects( 'are_disabled' )
-			->andReturn( false );
-		$this->author_archive
-			->expects( 'is_disabled_for_user' )
-			->with( $user_id )
 			->andReturn( false );
 		$this->author_archive
 			->expects( 'author_has_public_posts' )

--- a/tests/unit/builders/indexable-author-builder-test.php
+++ b/tests/unit/builders/indexable-author-builder-test.php
@@ -166,6 +166,7 @@ class Indexable_Author_Builder_Test extends TestCase {
 		$this->author_archive
 			->expects( 'author_has_public_posts' )
 			->with( 1 )
+			->twice()
 			->andReturn( true );
 		$this->author_archive
 			->expects( 'is_disabled_for_user' )
@@ -173,9 +174,6 @@ class Indexable_Author_Builder_Test extends TestCase {
 			->andReturn( false );
 		$this->author_archive
 			->expects( 'are_disabled' )
-			->andReturn( false );
-		$this->author_archive
-			->expects( 'are_not_indexed_for_users_without_posts' )
 			->andReturn( false );
 
 		$this->wpdb->expects( 'prepare' )->once()->with(
@@ -246,9 +244,6 @@ class Indexable_Author_Builder_Test extends TestCase {
 		$this->author_archive
 			->expects( 'are_disabled' )
 			->never();
-		$this->author_archive
-			->expects( 'are_not_indexed_for_users_without_posts' )
-			->never();
 
 		$this->author_archive
 			->expects( 'author_has_public_posts' )
@@ -312,6 +307,7 @@ class Indexable_Author_Builder_Test extends TestCase {
 		$this->author_archive
 			->expects( 'author_has_public_posts' )
 			->with( 1 )
+			->twice()
 			->andReturn( true );
 		$this->author_archive
 			->expects( 'is_disabled_for_user' )
@@ -319,9 +315,6 @@ class Indexable_Author_Builder_Test extends TestCase {
 			->andReturn( false );
 		$this->author_archive
 			->expects( 'are_disabled' )
-			->andReturn( false );
-		$this->author_archive
-			->expects( 'are_not_indexed_for_users_without_posts' )
 			->andReturn( false );
 
 		$this->wpdb->expects( 'prepare' )->once()->with(
@@ -393,6 +386,7 @@ class Indexable_Author_Builder_Test extends TestCase {
 		$this->author_archive
 			->expects( 'author_has_public_posts' )
 			->with( 1 )
+			->twice()
 			->andReturn( true );
 		$this->author_archive
 			->expects( 'is_disabled_for_user' )
@@ -400,9 +394,6 @@ class Indexable_Author_Builder_Test extends TestCase {
 			->andReturn( false );
 		$this->author_archive
 			->expects( 'are_disabled' )
-			->andReturn( false );
-		$this->author_archive
-			->expects( 'are_not_indexed_for_users_without_posts' )
 			->andReturn( false );
 
 		$this->wpdb->expects( 'prepare' )->once()->with(
@@ -480,7 +471,7 @@ class Indexable_Author_Builder_Test extends TestCase {
 	 *
 	 * @covers ::build
 	 */
-	public function test_throws_exception_when_author_archives_are_not_indexed_for_users_without_posts_and_user_has_no_posts() {
+	public function test_throws_exception_when_user_has_no_posts() {
 		$user_id = 1;
 
 		$this->author_archive
@@ -494,9 +485,6 @@ class Indexable_Author_Builder_Test extends TestCase {
 			->expects( 'author_has_public_posts' )
 			->with( $user_id )
 			->andReturn( false );
-		$this->author_archive
-			->expects( 'are_not_indexed_for_users_without_posts' )
-			->andReturn( true );
 
 		$this->expectException( Author_Not_Built_Exception::class );
 

--- a/tests/unit/builders/indexable-author-builder-test.php
+++ b/tests/unit/builders/indexable-author-builder-test.php
@@ -166,10 +166,7 @@ class Indexable_Author_Builder_Test extends TestCase {
 		$this->author_archive
 			->expects( 'author_has_public_posts' )
 			->with( 1 )
-			->andReturn( true );
-		$this->author_archive
-			->expects( 'author_has_public_posts_wp' )
-			->with( 1 )
+			->twice()
 			->andReturn( true );
 		$this->author_archive
 			->expects( 'are_disabled' )
@@ -240,12 +237,9 @@ class Indexable_Author_Builder_Test extends TestCase {
 			->expects( 'are_disabled' )
 			->andReturn( false );
 		$this->author_archive
-			->expects( 'author_has_public_posts_wp' )
-			->with( 1 )
-			->andReturn( true );
-		$this->author_archive
 			->expects( 'author_has_public_posts' )
 			->with( 1 )
+			->twice()
 			->andReturn( true );
 
 		$this->wpdb->expects( 'prepare' )->once()->with(
@@ -305,10 +299,7 @@ class Indexable_Author_Builder_Test extends TestCase {
 		$this->author_archive
 			->expects( 'author_has_public_posts' )
 			->with( 1 )
-			->andReturn( true );
-		$this->author_archive
-			->expects( 'author_has_public_posts_wp' )
-			->with( 1 )
+			->twice()
 			->andReturn( true );
 		$this->author_archive
 			->expects( 'are_disabled' )
@@ -383,10 +374,7 @@ class Indexable_Author_Builder_Test extends TestCase {
 		$this->author_archive
 			->expects( 'author_has_public_posts' )
 			->with( 1 )
-			->andReturn( true );
-		$this->author_archive
-			->expects( 'author_has_public_posts_wp' )
-			->with( 1 )
+			->twice()
 			->andReturn( true );
 		$this->author_archive
 			->expects( 'are_disabled' )
@@ -431,7 +419,7 @@ class Indexable_Author_Builder_Test extends TestCase {
 			->andReturn( true );
 
 		$this->author_archive
-			->expects( 'author_has_public_posts_wp' )
+			->expects( 'author_has_public_posts' )
 			->with( 1 )
 			->andReturn( true );
 
@@ -455,7 +443,7 @@ class Indexable_Author_Builder_Test extends TestCase {
 			->expects( 'are_disabled' )
 			->andReturn( false );
 		$this->author_archive
-			->expects( 'author_has_public_posts_wp' )
+			->expects( 'author_has_public_posts' )
 			->with( $user_id )
 			->andReturn( false );
 
@@ -478,7 +466,7 @@ class Indexable_Author_Builder_Test extends TestCase {
 			->expects( 'are_disabled' )
 			->andReturn( false );
 		$this->author_archive
-			->expects( 'author_has_public_posts_wp' )
+			->expects( 'author_has_public_posts' )
 			->with( $user_id )
 			->andReturn( false );
 

--- a/tests/unit/integrations/watchers/indexable-post-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-post-watcher-test.php
@@ -11,6 +11,7 @@ use Yoast\WP\SEO\Builders\Indexable_Link_Builder;
 use Yoast\WP\SEO\Conditionals\Migrations_Conditional;
 use Yoast\WP\SEO\Helpers\Author_Archive_Helper;
 use Yoast\WP\SEO\Helpers\Post_Helper;
+use Yoast\WP\SEO\Integrations\Cleanup_Integration;
 use Yoast\WP\SEO\Integrations\Watchers\Indexable_Post_Watcher;
 use Yoast\WP\SEO\Loggers\Logger;
 use Yoast\WP\SEO\Repositories\Indexable_Hierarchy_Repository;
@@ -428,6 +429,49 @@ class Indexable_Post_Watcher_Test extends TestCase {
 			->once()
 			->with( 33, null )
 			->andReturnTrue();
+
+		$this->instance->update_has_public_posts( $post_indexable );
+	}
+
+	/**
+	 * Checks whether a cleanup is rescheduled when updating a post
+	 * leads to an author not having any public posts anymore.
+	 *
+	 * (When an author does not have any publicly viewable posts, it should
+	 * be removed from the indexable table).
+	 *
+	 * @covers ::reschedule_cleanup_if_author_has_no_posts
+	 */
+	public function test_reschedule_cleanup_when_author_does_not_have_posts() {
+		$post_indexable                  = Mockery::mock();
+		$post_indexable->object_id       = 33;
+		$post_indexable->object_sub_type = 'post';
+		$post_indexable->author_id       = 11;
+		$post_indexable->is_public       = false;
+
+		$author_indexable            = Mockery::mock( Indexable_Mock::class );
+		$author_indexable->object_id = 11;
+
+		$author_indexable->expects( 'save' );
+
+		$this->repository->expects( 'find_by_id_and_type' )
+			->with( 11, 'user' )
+			->once()
+			->andReturn( $author_indexable );
+		$this->author_archive->expects( 'author_has_public_posts' )
+			->with( 11 )
+			->andReturnFalse();
+		$this->post->expects( 'update_has_public_posts_on_attachments' )
+			->once()
+			->with( 33, null )
+			->andReturnTrue();
+
+		Monkey\Functions\expect( 'wp_next_scheduled' )
+			->with( Cleanup_Integration::START_HOOK )
+			->andReturn( false );
+
+		Monkey\Functions\expect( 'wp_schedule_single_event' )
+			->once();
 
 		$this->instance->update_has_public_posts( $post_indexable );
 	}

--- a/tests/unit/integrations/watchers/indexable-post-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-post-watcher-test.php
@@ -407,6 +407,32 @@ class Indexable_Post_Watcher_Test extends TestCase {
 	}
 
 	/**
+	 * Tests that update_has_public_posts does not update the author archive when
+	 * the author can't be retrieved.
+	 *
+	 * @covers ::update_has_public_posts
+	 */
+	public function test_update_has_public_posts_with_finding_user_returning_false() {
+		$post_indexable                  = Mockery::mock();
+		$post_indexable->object_id       = 33;
+		$post_indexable->object_sub_type = 'post';
+		$post_indexable->author_id       = 1;
+		$post_indexable->is_public       = null;
+
+		$this->repository->expects( 'find_by_id_and_type' )
+			->with( 1, 'user' )
+			->once()
+			->andReturn( false );
+		$this->author_archive->expects( 'author_has_public_posts' )->once()->never();
+		$this->post->expects( 'update_has_public_posts_on_attachments' )
+			->once()
+			->with( 33, null )
+			->andReturnTrue();
+
+		$this->instance->update_has_public_posts( $post_indexable );
+	}
+
+	/**
 	 * Tests the routine for updating the relations.
 	 *
 	 * @covers ::update_relations

--- a/tests/unit/integrations/watchers/indexable-post-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-post-watcher-test.php
@@ -240,6 +240,11 @@ class Indexable_Post_Watcher_Test extends TestCase {
 			->once()
 			->with( $indexable_mock, $post_content );
 
+		$this->instance
+			->expects( 'update_has_public_posts' )
+			->with( $indexable_mock )
+			->once();
+
 		$this->instance->build_indexable( $post_id );
 	}
 
@@ -325,6 +330,11 @@ class Indexable_Post_Watcher_Test extends TestCase {
 			->expects( 'get_public_post_statuses' )
 			->once()
 			->andReturn( [ 'publish' ] );
+
+		$this->instance
+			->expects( 'update_has_public_posts' )
+			->with( $indexable_mock )
+			->once();
 
 		$this->instance->build_indexable( $post_id );
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We do not want to create indexables for users when:
   * Author archives are disabled.
   * An author/user does not have public facing posts or pages.
* We want to schedule a cleanup of the indexables table when:
   * Author archives are disabled. (The cleanup should remove the author indexables again).
   * A post gets updated in such a way that its author does not have any public facing posts anymore.
      * E.g. gets set to be a private post or the last post of an author gets deleted. 
   
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where indexables were created for users when author archives were disabled.
* Fixes a bug where indexables were created for users who did not have any publicly viewable posts.
* Fixes a bug where indexables for users did not get removed when author archives were disabled.
* Fixes a bug where indexables for users did not get removed when a user would not have any publicly viewable posts anymore.

## Relevant technical choices:

* See comments by the author below.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

##### Author archives are enabled, user has posts, no filter
* Make sure that author archives are enabled.
  * Go to _Yoast SEO_ > _Search Appearance_ in the WordPress admin area.
  * Click on the _Archives_ tab.
  * Make sure that the toggle labeled _Author archives_, under the _Author archives_ heading, is set to "on".
* Create a user with edit capabilities (e.g. make sure that the user has the _Author_ role).
  * Go to _Users_ > _Add New_.
  * Fill in all required details.
  * Set the new user's role to _Author_. This makes sure that we can log in as the user and create a post as the user.
  * Save the user. 
  * Edit the user again (we need to get their user id).
  * Look at the URL in the browser, it should look something like this: `https://basic.wordpress.test/wp-admin/user-edit.php?user_id=xy`. Note down the user id, we need it later. 
* Log in as the new user. 
* Create a post as the user.
* An indexable should be created for the user.
   * Login to your website's database using the database tool of your choice.
   * Navigate to the `yoast_indexables` table in your database.
   * There SHOULD be an indexable connected to the user id you noted down earlier. 
      * In other words, there SHOULD be an indexable with `object_type` `user` and `object_id` the user id you noted down earlier.

##### Author archives are disabled
* Disable author archives.
  * Go to _Yoast SEO_ > _Search Appearance_ in the WordPress admin area.
  * Click on the _Archives_ tab.
  * Make sure that the toggle labeled _Author archives_, under the _Author archives_ heading, is set to "off". 
* Create a new user.
  * Go to _Users_ > _Add New_.
  * Fill in all required details.
  * Save the user. 
  * Edit the user again (we need to get their user id).
  * Look at the URL in the browser, it should look something like this: `https://basic.wordpress.test/wp-admin/user-edit.php?user_id=xy`. Note down the user id, we need it later. 
  * Create a post as the user.
* No indexable should be created for the user.
   * Login to your website's database using the database tool of your choice.
   * Navigate to the `yoast_indexables` table in your database.
   * There SHOULD NOT be an indexable connected to the user id you noted down earlier. 
     * In other words, there SHOULD NOT be an indexable with `object_type` `user` and `object_id` the user id you noted down earlier.

##### Author is being excluded from indexables based on filter
* Make sure that the toggle labeled _Author archives_, under the _Author archives_ heading, is set to "on". 
* Add a `wpseo_should_build_and_save_user_indexable` filter and let it return a new `Author_Not_Built_Exception`.
  * Add the following code snippet to your activated theme's `functions.php` file:
    ```php
    \add_filter( 'wpseo_should_build_and_save_user_indexable',
	    static function( $exception, $user_id ) {
	 	   return new Author_Not_Built_Exception( 'Author not built because of filter.' );
	    }, 10, 2
    );
    ```
* Create a new user.
* Create a post as the user.
* No indexable should be created for the user.

##### Author is being included from indexables based on filter
* Add a `wpseo_should_build_and_save_user_indexable` filter and let it return `null`.
  * Add the following code snippet to your activated theme's `functions.php` file:
    ```php
    \add_filter( 'wpseo_should_build_and_save_user_indexable',
	    static function( $exception, $user_id ) {
	 	   return null;
	    }, 10, 2
    );
    ```
    * **Note**: remove any code snippets that hook into the same filter from the previous test steps!
* Create a new user.
* Create a post as the user.
* An indexable should be created for the user.

##### Author is not being excluded or included from indexables based on filter
* Add a `wpseo_should_build_and_save_user_indexable` filter and let it return the same exception as it is called with.
   * Add the following code snippet to your activated theme's `functions.php` file:
    ```php
    \add_filter( 'wpseo_should_build_and_save_user_indexable',
	    static function( $exception, $user_id ) {
	 	   return $exception;
	    }, 10, 2
    );
    ```
    * **Note**: remove any code snippets that hook into the same filter from the previous test steps!
* Create a new user (new users do not have posts yet).
* Save the user.
* Create a post as the user.
* An indexable should or should not be created for the user, depending on the logic and settings of your current WordPress environment, as described above.
  * For example, if author archives are disabled in your WordPress environment, no user indexables should be created. 

##### An indexable cleanup gets scheduled when author archives get disabled and no cleanup is already scheduled
###### Preconditions for testing
* To be able to check if an indexable cleanup is scheduled (by means of a WP cronjob), we need to install a plugin first. I use a plugin called [WP Crontrol](https://wordpress.org/plugins/wp-crontrol/).
  * Install WP Crontrol or make sure that it is already installed.
###### Test steps
* Make sure that author archives are enabled.
* Make sure that no indexable cleanup is already scheduled.
  * Go to WP Crontrol (_Tools_ > _Cron Events_).
  * In the search bar in the top-right, search for `wpseo_start_cleanup_indexables`.
  * If you see an entry in the table for a cron job with the hook name `wpseo_start_cleanup_indexables`, delete it.
* Disable author archives.
  * Go to _Yoast SEO_ > _Search Appearance_ in the WordPress admin area.
  * Click on the _Archives_ tab.
  * Make sure that the toggle labeled _Author archives_, under the _Author archives_ heading, is set to "off". 
* Check if a new indexable cleanup is scheduled.
  * Go to WP Crontrol (_Tools_ > _Cron Events_).
  * In the search bar in the top-right, search for `wpseo_start_cleanup_indexables`.
  * You SHOULD see an entry in the table for a cron job with the hook name `wpseo_start_cleanup_indexables`.  

##### An indexable cleanup gets scheduled when an author does not have any publicly viewable posts anymore
* Make sure that author archives are enabled.
* Make sure that no indexable cleanup is already scheduled.
* Create a user.
* Login as that user.
* Create and publish a new public post as the new user.
* Go to the post overview page again.
* Open the post you just created.
* Set the post to be private.
* Check if a new indexable cleanup is scheduled.

##### The author indexable gets deleted when the user gets deleted, and the status of their posts gets set to "trash" when the "Delete all content" option is selected
* Delete a user that has at least one public facing post.
  * Go to the user overview page.
  * Hover over the user you want to delete.
  * Click on the "Delete" link that is shown on hover.
  * Select "Delete all content" under _What should be done with content owned by this user?_
  * Click on "Confirm Deletion". 
* Check the indexable table in the database, 
  * It SHOULD NOT have an indexable for the author you deleted.
  * All the indexables of the posts that have been authored by the removed user should have a `post_status` of `trash`.
     * You can find these indexables by filtering the table on the `author_id` column, where the `author_id` is the indexable id of the author indexable you removed. 

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The SEO optimization routine. It should not create any indexables for users based on the behavior described above:
   * If author archives are disabled: no indexables for users should be created at all.
   * If author archives are enabled: only authors with one or more public facing posts or pages should get an indexable.
* The author sitemap (`/author-sitemap.xml`).
   * This PR refactors a line of code that checks whether an author has no public posts and whether it should be shown in the sitemap or not based on this fact and whether the "Show archives for authors without posts in search results?" is off.
   * Please check if the following still works as expected:
     * Set the "Show archives for authors without posts in search results?" setting (in _Yoast SEO_ > _Search Appearance_ > _Archives_) to "off".
     * Create a new user (which should have 0 posts when newly created).
     * Go to the author sitemap (e.g. `/author-sitemap.xml` on your website).
     * The newly created user should not be shown in the sitemap.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes #
