### PR TITLE
Prevent duplicate indexable records for the same object

### DIFF
--- a/src/builders/indexable-builder.php
+++ b/src/builders/indexable-builder.php
@@ -380,16 +380,17 @@ class Indexable_Builder {
 			 *
 			 * @var Indexable $indexable
 			 */
-			$indexable = $this->indexable_repository
-				->query()
-				->create(
-					[
-						'object_id'   => $indexable->object_id,
-						'object_type' => $indexable->object_type,
-						'post_status' => 'unindexed',
-						'version'     => 0,
-					]
-				);
+			$indexable = $this->ensure_indexable(
+				$indexable,
+				[
+					'object_id'   => $indexable->object_id,
+					'object_type' => $indexable->object_type,
+					'post_status' => 'unindexed',
+					'version'     => 0,
+				]
+			);
+			// If we already had an existing indexable, mark it as unindexed. We cannot rely on its validity anymore.
+			$indexable->post_status = 'unindexed';
 			// Make sure that the indexing process doesn't get stuck in a loop on this broken indexable.
 			$indexable = $this->version_manager->set_latest( $indexable );
 

--- a/tests/unit/builders/indexable-builder-test.php
+++ b/tests/unit/builders/indexable-builder-test.php
@@ -489,16 +489,20 @@ class Indexable_Builder_Test extends TestCase {
 		$this->indexable_repository
 			->expects( 'create' )
 			->once()
-			->with( [
-				'object_type' => 'post',
-				'object_id'   => 1337,
-			] )
-			->andReturnUsing( static function () use ( $empty_indexable ) {
-				$empty_indexable->object_type = 'post';
-				$empty_indexable->object_id = '1337';
+			->with(
+				[
+					'object_type' => 'post',
+					'object_id'   => 1337,
+				]
+			)
+			->andReturnUsing(
+				static function () use ( $empty_indexable ) {
+					$empty_indexable->object_type = 'post';
+					$empty_indexable->object_id   = '1337';
 
-				return $empty_indexable;
-			} );
+					return $empty_indexable;
+				}
+			);
 
 		// Force an exception during the build process.
 		$this->post_builder

--- a/tests/unit/builders/indexable-builder-test.php
+++ b/tests/unit/builders/indexable-builder-test.php
@@ -407,14 +407,14 @@ class Indexable_Builder_Test extends TestCase {
 	}
 
 	/**
-	 * Tests building an indexable for a post when the post builder throws an exception.
+	 * Tests building an indexable for a post when the post builder throws an exception because the post does not exist anymore.
 	 *
 	 * @covers ::__construct
 	 * @covers ::set_indexable_repository
 	 * @covers ::build_for_id_and_type
 	 * @covers ::ensure_indexable
 	 */
-	public function test_build_for_id_and_type_with_post_given_and_no_indexable_build() {
+	public function test_build_for_id_and_type_with_post_and_indexable_given_and_no_indexable_build() {
 		$this->indexable
 			->expects( 'as_array' )
 			->once()
@@ -422,7 +422,7 @@ class Indexable_Builder_Test extends TestCase {
 
 		$this->indexable_repository
 			->expects( 'query' )
-			->times( 2 )
+			->once()
 			->andReturnSelf();
 
 		$this->indexable_repository
@@ -443,29 +443,15 @@ class Indexable_Builder_Test extends TestCase {
 			->expects( 'build' )
 			->never();
 
-		// Verify that the exception is caught and a placeholder indexable is created.
-		$fake_indexable              = Mockery::mock( Indexable_Mock::class );
-		$fake_indexable->post_status = 'unindexed';
-		$this->indexable_repository
-			->expects( 'create' )
-			->once()
-			->with(
-				[
-					'object_id'   => 1337,
-					'object_type' => 'post',
-					'post_status' => 'unindexed',
-					'version'     => 0,
-				]
-			)
-			->andReturn( $fake_indexable );
-
+		// Verify that the exception is caught and a placeholder indexable is saved instead.
 		$this->version_manager
 			->expects( 'set_latest' )
 			->once()
-			->with( $fake_indexable )
+			->with( $this->indexable )
 			->andReturnUsing(
 				static function ( $indexable ) {
 					$indexable->version = 2;
+
 					return $indexable;
 				}
 			);
@@ -479,7 +465,78 @@ class Indexable_Builder_Test extends TestCase {
 
 		$result = $this->instance->build_for_id_and_type( 1337, 'post', $this->indexable );
 
-		$this->assertEquals( $fake_indexable, $result );
+		$expected_indexable              = clone $this->indexable;
+		$expected_indexable->post_status = 'unindexed';
+		$this->assertEquals( $expected_indexable, $result );
+	}
+
+	/**
+	 * Tests building an indexable for a post when the post builder throws an exception because the post does not exist.
+	 *
+	 * @covers ::__construct
+	 * @covers ::set_indexable_repository
+	 * @covers ::build_for_id_and_type
+	 * @covers ::ensure_indexable
+	 */
+	public function test_build_for_id_and_type_with_post_given_and_no_indexable_build() {
+		$empty_indexable = Mockery::mock( Indexable_Mock::class );
+
+		$this->indexable_repository
+			->expects( 'query' )
+			->times( 1 )
+			->andReturnSelf();
+
+		$this->indexable_repository
+			->expects( 'create' )
+			->once()
+			->with( [
+				'object_type' => 'post',
+				'object_id'   => 1337,
+			] )
+			->andReturnUsing( static function () use ( $empty_indexable ) {
+				$empty_indexable->object_type = 'post';
+				$empty_indexable->object_id = '1337';
+
+				return $empty_indexable;
+			} );
+
+		// Force an exception during the build process.
+		$this->post_builder
+			->expects( 'build' )
+			->once()
+			->with( 1337, $empty_indexable )
+			->andThrows( Post_Not_Found_Exception::class );
+
+		// Verify the code after exception is not run.
+		$this->primary_term_builder
+			->expects( 'build' )
+			->never();
+
+		// Verify that the exception is caught and a placeholder indexable is created.
+		$this->version_manager
+			->expects( 'set_latest' )
+			->once()
+			->with( $empty_indexable )
+			->andReturnUsing(
+				static function ( $indexable ) {
+					$indexable->version = 2;
+
+					return $indexable;
+				}
+			);
+
+		// Actually saving is outside the scope of this test.
+		$this->indexable_helper
+			->expects( 'should_index_indexables' )
+			->once()
+			->withNoArgs()
+			->andReturnFalse();
+
+		$result = $this->instance->build_for_id_and_type( 1337, 'post' );
+
+		$expected_indexable              = clone $empty_indexable;
+		$expected_indexable->post_status = 'unindexed';
+		$this->assertEquals( $empty_indexable, $result );
 	}
 
 	/**
@@ -513,8 +570,9 @@ class Indexable_Builder_Test extends TestCase {
 			->once()
 			->with( 1337, $this->indexable )
 			->andReturnUsing(
-				static function( $id, Indexable $indexable ) {
+				static function ( $id, Indexable $indexable ) {
 					$indexable->version = 2;
+
 					return $indexable;
 				}
 			);
@@ -789,7 +847,7 @@ class Indexable_Builder_Test extends TestCase {
 
 		$this->indexable_repository
 			->expects( 'query' )
-			->twice()
+			->once()
 			->andReturnSelf();
 
 		$this->indexable
@@ -808,30 +866,17 @@ class Indexable_Builder_Test extends TestCase {
 			->with( 1337, $this->indexable )
 			->andThrows( Invalid_Term_Exception::class );
 
-		$fake_indexable              = Mockery::mock( Indexable_Mock::class );
-		$fake_indexable->object_type = 'term';
-		$fake_indexable->object_id   = 1337;
-		$fake_indexable->object_type = 'term';
-		$fake_indexable->post_status = 'unindexed';
-		$fake_indexable->version     = 0;
-
-		$this->indexable_repository
-			->expects( 'create' )
-			->once()
-			->with(
-				[
-					'object_id'   => 1337,
-					'object_type' => 'term',
-					'post_status' => 'unindexed',
-					'version'     => 0,
-				]
-			)->andReturn( $fake_indexable );
-
 		$this->version_manager
 			->expects( 'set_latest' )
 			->once()
-			->with( $fake_indexable )
-			->andReturn( $fake_indexable );
+			->with( $this->indexable )
+			->andReturnUsing(
+				static function ( $indexable ) {
+					$indexable->version = 2;
+
+					return $indexable;
+				}
+			);
 
 		$this->indexable_helper
 			->expects( 'should_index_indexables' )
@@ -841,7 +886,9 @@ class Indexable_Builder_Test extends TestCase {
 
 		$result = $this->instance->build_for_id_and_type( 1337, 'term', $this->indexable );
 
-		$this->assertEquals( $fake_indexable, $result );
+		$expected_indexable              = clone $this->indexable;
+		$expected_indexable->post_status = 'unindexed';
+		$this->assertEquals( $expected_indexable, $result );
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* When building an indexable fails, we insert a new indexable record with the "unindexed" status. This, however, doens't take into account any existing records for that object. Saving an object for which the building step fails over and over results in multiple records of the same indexable object in the database.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Prevent duplicate indexable records for the same object

## Relevant technical choices:

* Instead of querying the db for any existing indexables, I rely on the caller to provide the existing indexable, as we already do.
* If the indexable already exists, but rebuilding the indexable fails, I mark it as "unindexed". The indexable should have changed, but that failed, so we cannot reliably determine the validity of the indexable contents.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

**With this PR/RC:**
* In the src\builders\indexable-builder.php file, add a `throw new Post_Not_Found_Exception();` line in the `build()` function, inside the `case 'post':`. So like this:
```
case 'post':
	throw new Source_Exception(); // This is the new line that we are adding.
	$indexable = $this->post_builder->build( $indexable->object_id, $indexable );
```
* Clean out indexables
* Go to a post's edit page and Update (or Create) it (take a note of the post's ID, eg. 123).
* Run a query in your DB to find the indexables of that post: `SELECT * FROM wordpress.wp2_yoast_indexable where object_id=18542;`
* Confirm that there is one row and that is has `post_status` = `unindexed`
* Update that post again
* Run a query in your DB to find the indexables of that post: `SELECT * FROM wordpress.wp2_yoast_indexable where object_id=18542;`
* Confirm that there again there is ONLY ONE row and that is has `post_status` = `unindexed`
* Also confirm that once you have removed that custom code line and hit Update, the query will again return one row, this time with `post_status` = `publish`

**With the current version:**
* The above test would result with one more indexable row every time you did the update, which would bloat the db table

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Building indexables and hierarchies
* Breadcrumb generators (maybe with parents that are `unindexed`) 

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [x] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

PC-867