### PR TITLE
PC-870 Fix highlight issue

### DIFF
--- a/packages/analysis-report/src/AnalysisList.js
+++ b/packages/analysis-report/src/AnalysisList.js
@@ -131,4 +131,5 @@ AnalysisList.defaultProps = {
 	onMarksButtonClick: noop,
 	onEditButtonClick: noop,
 	isPremium: false,
+	onResultChange: noop,
 };

--- a/packages/analysis-report/src/AnalysisList.js
+++ b/packages/analysis-report/src/AnalysisList.js
@@ -84,7 +84,8 @@ export default function AnalysisList( props ) {
 					   slug or SEO title). */
 					__( "Edit your %1$s", "wordpress-seo" ), editFieldName );
 
-			props.onResultChange( result );
+			// On result change, we also update the status of the marker.
+			props.onResultChange( result.id, result.marker, result.hasMarks );
 
 			return <AnalysisResult
 				key={ result.id }

--- a/packages/analysis-report/src/AnalysisList.js
+++ b/packages/analysis-report/src/AnalysisList.js
@@ -84,12 +84,11 @@ export default function AnalysisList( props ) {
 					   slug or SEO title). */
 					__( "Edit your %1$s", "wordpress-seo" ), editFieldName );
 
-			// On result change, we also update the status of the marker.
-			props.onResultChange( result.id, result.marker, result.hasMarks );
-
 			return <AnalysisResult
 				key={ result.id }
+				id={ result.id }
 				text={ result.text }
+				marker={ result.marker }
 				bulletColor={ color }
 				hasMarksButton={ result.hasMarks }
 				hasEditButton={ result.hasJumps }
@@ -106,6 +105,7 @@ export default function AnalysisList( props ) {
 				marksButtonStatus={ props.marksButtonStatus }
 				hasBetaBadgeLabel={ result.hasBetaBadge }
 				isPremium={ props.isPremium }
+				onResultChange={ props.onResultChange }
 			/>;
 		} ) }
 	</AnalysisListBase>;

--- a/packages/analysis-report/src/AnalysisList.js
+++ b/packages/analysis-report/src/AnalysisList.js
@@ -84,6 +84,8 @@ export default function AnalysisList( props ) {
 					   slug or SEO title). */
 					__( "Edit your %1$s", "wordpress-seo" ), editFieldName );
 
+			props.onResultChange( result );
+
 			return <AnalysisResult
 				key={ result.id }
 				text={ result.text }
@@ -117,6 +119,7 @@ AnalysisList.propTypes = {
 	onMarksButtonClick: PropTypes.func,
 	onEditButtonClick: PropTypes.func,
 	isPremium: PropTypes.bool,
+	onResultChange: PropTypes.func,
 };
 
 AnalysisList.defaultProps = {

--- a/packages/analysis-report/src/AnalysisResult.js
+++ b/packages/analysis-report/src/AnalysisResult.js
@@ -44,6 +44,12 @@ const areButtonsHidden = function( props ) {
 export const AnalysisResult = ( props ) => {
 	const { id, marker, hasMarksButton } = props;
 
+	/*
+	 * Update the marker status when there is a change in the following:
+	 * a) the result's id, or
+	 * b) the objects that need to be marked for the current result, or
+	 * c) the information whether there is an object to be marked for the current result.
+	 */
 	useEffect( () => {
 		props.onResultChange( id, marker, hasMarksButton );
 	}, [ id, marker, hasMarksButton ] );

--- a/packages/analysis-report/src/AnalysisResult.js
+++ b/packages/analysis-report/src/AnalysisResult.js
@@ -1,3 +1,4 @@
+import { useEffect } from "@wordpress/element";
 import React from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
@@ -41,6 +42,12 @@ const areButtonsHidden = function( props ) {
  * @returns {ReactElement} The rendered AnalysisResult component.
  */
 export const AnalysisResult = ( props ) => {
+	const { id, marker, hasMarksButton } = props;
+
+	useEffect( () => {
+		props.onResultChange( id, marker, hasMarksButton );
+	}, [ id, marker, hasMarksButton ] );
+
 	return (
 		<AnalysisResultBase>
 			<ScoreIcon
@@ -97,6 +104,9 @@ AnalysisResult.propTypes = {
 	editButtonClassName: PropTypes.string,
 	hasBetaBadgeLabel: PropTypes.bool,
 	isPremium: PropTypes.bool,
+	onResultChange: PropTypes.func,
+	id: PropTypes.string,
+	marker: PropTypes.array,
 };
 
 AnalysisResult.defaultProps = {
@@ -111,6 +121,9 @@ AnalysisResult.defaultProps = {
 	ariaLabelEdit: "",
 	onButtonClickEdit: noop,
 	isPremium: false,
+	onResultChange: noop,
+	id: "",
+	marker: [],
 };
 
 export default AnalysisResult;

--- a/packages/analysis-report/src/ContentAnalysis.js
+++ b/packages/analysis-report/src/ContentAnalysis.js
@@ -65,6 +65,7 @@ class ContentAnalysis extends React.Component {
 					onMarksButtonClick={ this.props.onMarkButtonClick }
 					onEditButtonClick={ this.props.onEditButtonClick }
 					isPremium={ this.props.isPremium }
+					onResultChange={ this.props.onResultChange }
 				/>
 			</StyledCollapsible>
 		);
@@ -148,6 +149,7 @@ ContentAnalysis.propTypes = {
 		considerations: PropTypes.string,
 		goodResults: PropTypes.string,
 	} ),
+	onResultChange: PropTypes.func,
 };
 
 ContentAnalysis.defaultProps = {
@@ -166,6 +168,7 @@ ContentAnalysis.defaultProps = {
 	activeMarker: "",
 	isPremium: false,
 	resultCategoryLabels: {},
+	onResultChange: () => {},
 };
 
 export default ContentAnalysis;

--- a/packages/js/src/components/contentAnalysis/Results.js
+++ b/packages/js/src/components/contentAnalysis/Results.js
@@ -2,6 +2,7 @@ import { __ } from "@wordpress/i18n";
 import PropTypes from "prop-types";
 import { ContentAnalysis } from "@yoast/analysis-report";
 import { Component, Fragment } from "@wordpress/element";
+import { isUndefined } from "lodash-es";
 import { Paper } from "yoastseo";
 
 import mapResults from "./mapResults";
@@ -34,6 +35,7 @@ class Results extends Component {
 
 		this.handleMarkButtonClick = this.handleMarkButtonClick.bind( this );
 		this.handleEditButtonClick = this.handleEditButtonClick.bind( this );
+		this.handleResultsChange   = this.handleResultsChange.bind( this );
 	}
 
 	/**
@@ -98,6 +100,43 @@ class Results extends Component {
 			block: "center",
 			inline: "center",
 		} );
+	}
+
+	handleResultsChange( result ) {
+		// const { mappedResults } = this.state;
+		//
+		// const hasmarksList = [];
+		// for ( const resultListKey in mappedResults ) {
+		// 	const resultlist = mappedResults[ resultListKey ];
+		// 	for ( const resultKey in resultlist ) {
+		// 		const result = resultlist[ resultKey ];
+		// 		const whatwewant = result.hasMarks;
+		// 		hasmarksList.push( whatwewant );
+		// 	}
+		// }
+		// console.log( hasmarksList );
+		//
+		// if ( ! hasmarksList.includes( true ) ) {
+		// 	console.log( "TEST" );
+		// 	this.props.setActiveMarker( null );
+		// 	this.props.setMarkerPauseStatus( false );
+		// 	this.removeMarkers();
+		// }
+
+		if ( ! isUndefined( result ) && result.id === this.props.activeMarker && ! result.hasMarks ) {
+			console.log( "TEST" );
+			this.props.setActiveMarker( null );
+			this.props.setMarkerPauseStatus( false );
+			this.removeMarkers();
+		}
+		//
+		// goodResults.forEach( result => {
+		// 	if ( result.id === this.props.activeMarker ) {
+		// 		this.props.setActiveMarker( null );
+		// 		this.props.setMarkerPauseStatus( false );
+		// 		this.removeMarkers();
+		// 	}
+		// } );
 	}
 
 	/**
@@ -192,6 +231,8 @@ class Results extends Component {
 			problemsResults,
 		} = mappedResults;
 
+		console.log( mappedResults, "mappedResult" );
+
 		const { upsellResults, resultCategoryLabels } = this.props;
 
 		const defaultLabels = {
@@ -223,6 +264,7 @@ class Results extends Component {
 					keywordKey={ this.props.keywordKey }
 					isPremium={ this.props.isPremium }
 					resultCategoryLabels={ labels }
+					onResultChange={ this.handleResultsChange }
 				/>
 			</Fragment>
 		);

--- a/packages/js/src/components/contentAnalysis/Results.js
+++ b/packages/js/src/components/contentAnalysis/Results.js
@@ -108,10 +108,13 @@ class Results extends Component {
 	 * @returns {void}
 	 */
 	handleResultsChange( id, marker, hasMarks ) {
-		if ( id === this.props.activeMarker && ! hasMarks ) {
+		// To see a difference between keyphrases: Prepend the keyword key when applicable.
+		const markerId = this.props.keywordKey.length > 0 ? `${this.props.keywordKey}:${id}` : id;
+
+		if ( markerId === this.props.activeMarker && ! hasMarks ) {
 			this.deactivateMarker();
-		} else if ( ! isUndefined( marker ) && hasMarks && id === this.props.activeMarker ) {
-			this.activateMarker( id, marker );
+		} else if ( ! isUndefined( marker ) && hasMarks && markerId === this.props.activeMarker ) {
+			this.activateMarker( markerId, marker );
 		}
 	}
 

--- a/packages/js/src/components/contentAnalysis/Results.js
+++ b/packages/js/src/components/contentAnalysis/Results.js
@@ -111,10 +111,12 @@ class Results extends Component {
 		// To see a difference between keyphrases: Prepend the keyword key when applicable.
 		const markerId = this.props.keywordKey.length > 0 ? `${this.props.keywordKey}:${id}` : id;
 
-		if ( markerId === this.props.activeMarker && ! hasMarks ) {
-			this.deactivateMarker();
-		} else if ( ! isUndefined( marker ) && hasMarks && markerId === this.props.activeMarker ) {
-			this.activateMarker( markerId, marker );
+		if ( markerId === this.props.activeMarker  ) {
+			if ( ! hasMarks ) {
+				this.deactivateMarker();
+			} else if ( ! isUndefined( marker ) ) {
+				this.activateMarker( markerId, marker );
+			}
 		}
 	}
 

--- a/packages/js/src/components/contentAnalysis/Results.js
+++ b/packages/js/src/components/contentAnalysis/Results.js
@@ -57,6 +57,28 @@ class Results extends Component {
 	}
 
 	/**
+	 * Deactivates the marker from the page.
+	 * @returns {void}
+	 */
+	deactivateMarker() {
+		this.props.setActiveMarker( null );
+		this.props.setMarkerPauseStatus( false );
+		this.removeMarkers();
+	}
+
+	/**
+	 * Activates the marker from the page.
+	 *
+	 * @param {string}      id         A unique string representing the result.
+	 * @param {Function}    marker     The marker function, which returns the marks for the current paper.
+	 * @returns {void}
+	 */
+	activateMarker( id, marker ) {
+		this.props.setActiveMarker( id );
+		marker();
+	}
+
+	/**
 	 * Handles a click on a marker button, to mark the text in the editor.
 	 *
 	 * @param {string}   id     Result id, empty if a marker is deselected.
@@ -70,12 +92,26 @@ class Results extends Component {
 
 		// If marker button is clicked while active, disable markers.
 		if ( markerId === this.props.activeMarker ) {
-			this.props.setActiveMarker( null );
-			this.props.setMarkerPauseStatus( false );
-			this.removeMarkers();
+			this.deactivateMarker();
 		} else {
-			this.props.setActiveMarker( markerId );
-			marker();
+			this.activateMarker( markerId, marker );
+		}
+	}
+
+	/**
+	 * Updates or resets the marking on result change.
+	 *
+	 * @param {string}      id         A unique string representing the result, which is the same as the assessment id the result is coming from.
+	 * @param {Function}    marker     The marker function, which returns the marks for the current paper.
+	 * @param {boolean}     hasMarks   Whether the result has marks or not.
+	 *
+	 * @returns {void}
+	 */
+	handleResultsChange( id, marker, hasMarks ) {
+		if ( id === this.props.activeMarker && ! hasMarks ) {
+			this.deactivateMarker();
+		} else if ( ! isUndefined( marker ) && hasMarks && id === this.props.activeMarker ) {
+			this.activateMarker( id, marker );
 		}
 	}
 
@@ -100,43 +136,6 @@ class Results extends Component {
 			block: "center",
 			inline: "center",
 		} );
-	}
-
-	handleResultsChange( result ) {
-		// const { mappedResults } = this.state;
-		//
-		// const hasmarksList = [];
-		// for ( const resultListKey in mappedResults ) {
-		// 	const resultlist = mappedResults[ resultListKey ];
-		// 	for ( const resultKey in resultlist ) {
-		// 		const result = resultlist[ resultKey ];
-		// 		const whatwewant = result.hasMarks;
-		// 		hasmarksList.push( whatwewant );
-		// 	}
-		// }
-		// console.log( hasmarksList );
-		//
-		// if ( ! hasmarksList.includes( true ) ) {
-		// 	console.log( "TEST" );
-		// 	this.props.setActiveMarker( null );
-		// 	this.props.setMarkerPauseStatus( false );
-		// 	this.removeMarkers();
-		// }
-
-		if ( ! isUndefined( result ) && result.id === this.props.activeMarker && ! result.hasMarks ) {
-			console.log( "TEST" );
-			this.props.setActiveMarker( null );
-			this.props.setMarkerPauseStatus( false );
-			this.removeMarkers();
-		}
-		//
-		// goodResults.forEach( result => {
-		// 	if ( result.id === this.props.activeMarker ) {
-		// 		this.props.setActiveMarker( null );
-		// 		this.props.setMarkerPauseStatus( false );
-		// 		this.removeMarkers();
-		// 	}
-		// } );
 	}
 
 	/**
@@ -230,8 +229,6 @@ class Results extends Component {
 			considerationsResults,
 			problemsResults,
 		} = mappedResults;
-
-		console.log( mappedResults, "mappedResult" );
 
 		const { upsellResults, resultCategoryLabels } = this.props;
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* This bug affects the assessments that:
   * have highlighting functionality, AND
   * it's possible to update the assessment feedback without making any changes in the highlighted text area. For example:
      * Keyphrase distribution assessment
      * Subheading distribution assessment
      * Keyword density assessment

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where highlighting would not be removed from the text after the analysis is updated and the present highlighting has become irrelevant.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### SEO Analysis
##### Keyphrase distribution
NOTE: This assessment is not available for related keyphrase. It is only available for focus keyphrase.
* Install and activate Yoast SEO
* Install and activate Yoast SEO Premium
   * If building the plugin: run  `composer require yoast/wordpress-seo:dev-fix-highlight-issue@dev` in `wordpress-seo-premium` `trunk`
* Create a post with at least 300 words and at least 15 sentences
* Set a focus keyphrase, for example "cats"
* Add your focus keyphrase in the text
* Checkout the Keyphrase distribution assessment
* Click on the eye icon
* Confirm that all the keyphrase occurrences in the text are highlighted
* Change the keyphrase to "cat"
* Confirm that the previously highlighted keyphrase occurrences in the text are still highlighted
* Change the focus keyphrase to "tortoiseshell cats"
* Confirm that the previously highlighted keyphrase occurrences in the text are NOT highlighted anymore

##### Keyword density
* Install and activate Yoast SEO
* Create a post with at least 300 words
* Set a focus keyphrase, for example "cats"
* Add your focus keyphrase in the text
* Checkout the Keyword density assessment
* Click on the eye icon
* Confirm that all the keyphrase occurrences in the text are highlighted
* Change the focus keyphrase to "tortoiseshell cats"
* Confirm that the previously highlighted keyphrase occurrences in the text are NOT highlighted anymore

##### Test with related keyphrase
* Repeat the steps in **Keyword density**, but fill in the related keyphrase instead of the focus keyphrase
* Confirm that you receive the same results

#### Readability analysis
##### Subheading distribution
* Create a post with this scenario
   ````
   short text of fewer than 300 words +
   Subheading 1 +
   long text between 300-350 words + 
   Subheading 2 +
   long text between 300-350 words 
   ````
* Confirm that Subehading distribution assessment returns with:
   * Bullet: orange
   * Feedback: **Subheading distribution**: 2 sections of your text is longer than 300 words and are not separated by any subheadings. Add subheadings to improve readability.
* Click on the eye icon
* Confirm that `Subheading 1` and `Subheading 2` are highlighted
* Make the text after `Subheading 2` less than 300 words
* Confirm that `Subheading 2` is not highlighted anymore
* Confirm that `Subheading 1` is still highlighted
* Make the text after `Subheading 1` less than 300 words
* Confirm that `Subheading 1` is also not highlighted anymore
 
#### Test in Shopify
* Test together with this PR: https://github.com/Yoast/shopify-seo/pull/882
    * The `shopify-seo` branch is `PC-870-fix-highlight-bug`
    * Don't forget to link the `wordpress-seo` branch to the Shopify branch. See [this doc](https://github.com/Yoast/shopify-seo/blob/main/doc/run-the-app.md#embedded-development-of-admin-ui--wordpress-seo-packages) on how to do it. 
* Repeat the test instructions in **SEO Analysis** and in **Readability Analysis**
* Repeat the steps fully in all content types (Product, Collections, Blog posts, Pages)
* Note: Keyphrase distribution is not available for Collections and Blogs don’t have the relevant assessments so it’s not necessary to test them there.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/custom post types
   * Testing in taxonomies and custom taxonomies is not necessary since we don't support highlighting functionality there 
* [x] Changes should be tested on different editors (Block/Classic)
   * Elementor is not necessary since we don't support highlighting functionality there 
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Make sure that the highlight function for other assessments still works:
   *  Passive voice
   * Transition words
   * Word complexity
   * Consecutive sentences (not available in Shopify)
   * Inclusive language (not available in Shopify)

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes https://yoast.atlassian.net/browse/PC-870
