### PR TITLE
PC-871 fixes fatal error call when running seo optimization

### DIFF
--- a/src/actions/indexing/post-link-indexing-action.php
+++ b/src/actions/indexing/post-link-indexing-action.php
@@ -73,7 +73,7 @@ class Post_Link_Indexing_Action extends Abstract_Link_Indexing_Action {
 	 * @return string The prepared query string.
 	 */
 	protected function get_count_query() {
-		$public_post_types = $this->post_type_helper->get_accessible_post_types();
+		$public_post_types = $this->get_post_types();
 		$indexable_table   = Model::get_table_name( 'Indexable' );
 		$links_table       = Model::get_table_name( 'SEO_Links' );
 
@@ -106,7 +106,7 @@ class Post_Link_Indexing_Action extends Abstract_Link_Indexing_Action {
 	 * @return string The prepared query string.
 	 */
 	protected function get_select_query( $limit = false ) {
-		$public_post_types = $this->post_type_helper->get_accessible_post_types();
+		$public_post_types = $this->get_post_types();
 		$indexable_table   = Model::get_table_name( 'Indexable' );
 		$links_table       = Model::get_table_name( 'SEO_Links' );
 		$replacements      = $public_post_types;
@@ -138,5 +138,18 @@ class Post_Link_Indexing_Action extends Abstract_Link_Indexing_Action {
 			$limit_query",
 			$replacements
 		);
+	}
+
+	/**
+	 * Returns the post types that should be indexed.
+	 *
+	 * @return array The post types that should be indexed.
+	 */
+	protected function get_post_types() {
+		$public_post_types   = $this->post_type_helper->get_accessible_post_types();
+		$excluded_post_types = $this->post_type_helper->get_excluded_post_types_for_indexables();
+
+		// `array_values`, to make sure that the keys are reset.
+		return \array_values( \array_diff( $public_post_types, $excluded_post_types ) );
 	}
 }

--- a/tests/unit/actions/indexing/post-link-indexing-action-test.php
+++ b/tests/unit/actions/indexing/post-link-indexing-action-test.php
@@ -118,6 +118,11 @@ class Post_Link_Indexing_Action_Test extends TestCase {
 			->once()
 			->andReturn( [ 'post', 'page' ] );
 
+		$this->post_type_helper
+			->expects( 'get_excluded_post_types_for_indexables' )
+			->once()
+			->andReturn( [] );
+
 		$expected_query = "SELECT COUNT(P.ID)
 			FROM wp_posts AS P
 			LEFT JOIN wp_yoast_indexable AS I
@@ -172,6 +177,11 @@ class Post_Link_Indexing_Action_Test extends TestCase {
 			->expects( 'get_accessible_post_types' )
 			->once()
 			->andReturn( [ 'post', 'page' ] );
+
+		$this->post_type_helper
+			->expects( 'get_excluded_post_types_for_indexables' )
+			->once()
+			->andReturn( [] );
 
 		$expected_query = "SELECT COUNT(P.ID)
 			FROM wp_posts AS P
@@ -232,6 +242,11 @@ class Post_Link_Indexing_Action_Test extends TestCase {
 			->once()
 			->andReturn( [ 'post', 'page' ] );
 
+		$this->post_type_helper
+			->expects( 'get_excluded_post_types_for_indexables' )
+			->once()
+			->andReturn( [] );
+
 		$expected_query = "
 			SELECT P.ID, P.post_content
 			FROM wp_posts AS P
@@ -291,6 +306,10 @@ class Post_Link_Indexing_Action_Test extends TestCase {
 			->once()
 			->andReturn( [ 'post', 'page' ] );
 
+		$this->post_type_helper
+			->expects( 'get_excluded_post_types_for_indexables' )
+			->once()
+			->andReturn( [] );
 		$expected_query = "
 			SELECT P.ID, P.post_content
 			FROM wp_posts AS P
@@ -362,6 +381,11 @@ class Post_Link_Indexing_Action_Test extends TestCase {
 			->expects( 'get_accessible_post_types' )
 			->once()
 			->andReturn( [ 'post', 'page' ] );
+
+		$this->post_type_helper
+			->expects( 'get_excluded_post_types_for_indexables' )
+			->once()
+			->andReturn( [] );
 
 		$expected_query = "
 			SELECT P.ID, P.post_content


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* When the `wpseo_indexable_excluded_post_types` filter is used to exclude a post type from indexables, a fatal error occurs when the SEO data optimization is run. 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the SEO optimization would error out when a post type is manually excluded via a filter.

## Relevant technical choices:

* None.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

Do the following in trunk or the previous RC
* Add the following code snippet to run on every page
```
add_filter( 'wpseo_indexable_excluded_post_types', 'yoast_exclude_some_custom_post_types' );
function yoast_exclude_some_custom_post_types( $excluded_post_types ) {
	$excluded_post_types[] = 'page';

	return $excluded_post_types;
}
```
* Make sure you have published pages.
* Clear your indexables with the test helper.
* Run the SEO optimization from wp-admin/admin.php?page=wpseo_tools 
* Make sure you get an error while running the optimization


* Check out this branch
* Run it again it should now go through all the steps, without an error
* Reset the indexables and do it again to make sure it goes through in one go.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

**The internal linking count**
* With the filter above, create a post and add in its content 2 links, one to a post and one to a page
* Clean out indexables and run SEO optimization 
* Check **the indexable table** in the DB, for the row of that post and confirm that it has `link_count` as 2, as expected.
* You can also check the `link_count` of the row of that post, if you add or remove any other links in its content

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes #
PC-871