### PR TITLE
PC-868 Declare compatibility with the HPOS feature (WooCommerce 7.1+)

### DIFF
--- a/src/initializers/woocommerce.php
+++ b/src/initializers/woocommerce.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Yoast\WP\SEO\Initializers;
+
+use Yoast\WP\SEO\Conditionals\No_Conditionals;
+
+/**
+ * Declares compatibility with the WooCommerce HPOS feature.
+ */
+class Woocommerce implements Initializer_Interface {
+
+	use No_Conditionals;
+
+	/**
+	 * Hooks into WooCommerce.
+	 */
+	public function initialize() {
+			\add_action( 'before_woocommerce_init', [ $this, 'declare_custom_order_tables_compatibility' ] );
+	}
+
+	/**
+	 * Declares compatibility with the WooCommerce HPOS feature.
+	 */
+	public function declare_custom_order_tables_compatibility() {
+		if ( class_exists( '\Automattic\WooCommerce\Utilities\FeaturesUtil' ) ) {
+			\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', WPSEO_FILE, true );
+		}
+	}
+}

--- a/tests/unit/initializers/woocommerce-test.php
+++ b/tests/unit/initializers/woocommerce-test.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Initializers;
+
+use Yoast\WP\SEO\Initializers\Woocommerce;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Class Woocommerce_Test.
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Initializers\Woocommerce
+ *
+ * @group integrations
+ */
+class Woocommerce_Test extends TestCase {
+
+	/**
+	 * Represents the instance we are testing.
+	 *
+	 * @var Woocommerce
+	 */
+	private $instance;
+
+	/**
+	 * Sets up the tests.
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->instance = new Woocommerce();
+	}
+
+	/**
+	 * Tests the initialization.
+	 *
+	 * @covers ::__construct
+	 * @covers ::initialize
+	 */
+	public function test_initialize() {
+		$this->instance->initialize();
+
+		$this->assertNotFalse( \has_action( 'before_woocommerce_init', [ $this->instance, 'declare_custom_order_tables_compatibility' ] ), 'Does not have expected before_woocommerce_init action' );
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to declare compatibility with High Performance Order Storage feature in WooCommerce 7.1+. Yoast SEO doesn't perform any operation on WC orders, so it's not affected by the switch to custom tables.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Ensures compatibility with the High Performance Order Storage feature in WooCommerce 7.1+.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install the WooCommerce zip from the [HPOS feature release page](https://github.com/woocommerce/woocommerce/releases/tag/feature-custom-order-table) and install it.
* make sure you have only Free with this branch active (no other addons)
* create one or more orders under WooCommerce > Orders
* visit WooCommerce > Settings > Advanced > Features
* under Experimental features, at the "High-Performance order storage (COT)" section
  * the checkbox "Enable the high performance order storage feature." should **not** be greyed out and disabled
  * you should **not** see "⚠ This feature shouldn't be enabled, the Yoast SEO plugin is active and isn't compatible with it." below it


#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes [PC-868]


[PC-868]: https://yoast.atlassian.net/browse/PC-868?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ