### PR TITLE
Cleanup indexables when updating the plugin

### DIFF
--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -11,6 +11,7 @@ use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Post_Type_Helper;
 use Yoast\WP\SEO\Helpers\String_Helper;
 use Yoast\WP\SEO\Helpers\Taxonomy_Helper;
+use Yoast\WP\SEO\Integrations\Cleanup_Integration;
 
 /**
  * This code handles the option upgrades.
@@ -852,8 +853,8 @@ class WPSEO_Upgrade {
 		\wp_unschedule_hook( 'wpseo_cleanup_orphaned_indexables' );
 		\wp_unschedule_hook( 'wpseo_cleanup_indexables' );
 
-		if ( ! \wp_next_scheduled( \Yoast\WP\SEO\Integrations\Cleanup_Integration::START_HOOK ) ) {
-			\wp_schedule_single_event( ( time() + ( MINUTE_IN_SECONDS * 5 ) ), \Yoast\WP\SEO\Integrations\Cleanup_Integration::START_HOOK );
+		if ( ! \wp_next_scheduled( Cleanup_Integration::START_HOOK ) ) {
+			\wp_schedule_single_event( ( time() + ( MINUTE_IN_SECONDS * 5 ) ), Cleanup_Integration::START_HOOK );
 		}
 	}
 
@@ -962,6 +963,9 @@ class WPSEO_Upgrade {
 		$this->deduplicate_unindexed_indexable_rows();
 		$this->remove_indexable_rows_for_disabled_authors_archive();
 		$this->remove_indexable_rows_for_authors_without_archive();
+		if ( ! \wp_next_scheduled( Cleanup_Integration::START_HOOK ) ) {
+			\wp_schedule_single_event( ( time() + ( MINUTE_IN_SECONDS * 5 ) ), Cleanup_Integration::START_HOOK );
+		}
 	}
 
 	/**

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -1522,13 +1522,13 @@ class WPSEO_Upgrade {
 	private function remove_indexable_rows_for_disabled_authors_archive() {
 		global $wpdb;
 
-		// If migrations haven't been completed successfully the following may give false errors. So suppress them.
-		$show_errors       = $wpdb->show_errors;
-		$wpdb->show_errors = false;
-
 		if ( ! \YoastSEO()->helpers->author_archive->are_disabled() ) {
 			return;
 		}
+
+		// If migrations haven't been completed successfully the following may give false errors. So suppress them.
+		$show_errors       = $wpdb->show_errors;
+		$wpdb->show_errors = false;
 
 		$indexable_table = Model::get_table_name( 'Indexable' );
 

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -958,8 +958,8 @@ class WPSEO_Upgrade {
 	 * Performs the 19.10 upgrade routine.
 	 */
 	private function upgrade_1910() {
-		add_action( 'shutdown', [ $this, 'remove_indexable_rows_for_non_public_post_types' ] );
-		add_action( 'shutdown', [ $this, 'remove_indexable_rows_for_non_public_taxonomies' ] );
+		\add_action( 'shutdown', [ $this, 'remove_indexable_rows_for_non_public_post_types' ] );
+		\add_action( 'shutdown', [ $this, 'remove_indexable_rows_for_non_public_taxonomies' ] );
 		$this->deduplicate_unindexed_indexable_rows();
 		$this->remove_indexable_rows_for_disabled_authors_archive();
 		$this->remove_indexable_rows_for_authors_without_archive();
@@ -1379,7 +1379,7 @@ class WPSEO_Upgrade {
 
 		$post_type_helper = \YoastSEO()->helpers->post_type;
 
-		$included_post_types = array_diff( $post_type_helper->get_accessible_post_types(), $post_type_helper->get_excluded_post_types_for_indexables() );
+		$included_post_types = \array_diff( $post_type_helper->get_accessible_post_types(), $post_type_helper->get_excluded_post_types_for_indexables() );
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Reason: Too hard to fix.
 		if ( empty( $included_post_types ) ) {
@@ -1563,7 +1563,7 @@ class WPSEO_Upgrade {
 
 		$indexable_table           = Model::get_table_name( 'Indexable' );
 		$author_archive_post_types = \YoastSEO()->helpers->author_archive->get_author_archive_post_types();
-		$viewable_post_stati       = array_filter( get_post_stati(), 'is_post_status_viewable' );
+		$viewable_post_stati       = \array_filter( get_post_stati(), 'is_post_status_viewable' );
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Reason: Too hard to fix.
 		// phpcs:disable WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber -- Reason: we're passing an array instead.
@@ -1576,7 +1576,7 @@ class WPSEO_Upgrade {
 					WHERE post_type IN ( " . \implode( ', ', \array_fill( 0, \count( $author_archive_post_types ), '%s' ) ) . ' )
 					AND post_status IN ( ' . \implode( ', ', \array_fill( 0, \count( $viewable_post_stati ), '%s' ) ) . ' )
 				)',
-			array_merge( $author_archive_post_types, $viewable_post_stati )
+			\array_merge( $author_archive_post_types, $viewable_post_stati )
 		);
 		// phpcs:enable
 
@@ -1601,7 +1601,7 @@ class WPSEO_Upgrade {
 	private function get_indexable_deduplication_query_for_type( $object_type, $duplicates, $wpdb ) {
 		$indexable_table = Model::get_table_name( 'Indexable' );
 
-		$filtered_duplicates = array_filter(
+		$filtered_duplicates = \array_filter(
 			$duplicates,
 			static function ( $duplicate ) use ( $object_type ) {
 				return $duplicate['object_type'] === $object_type;

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -6,6 +6,7 @@
  */
 
 use Yoast\WP\Lib\Model;
+use Yoast\WP\SEO\Helpers\Author_Archive_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Post_Type_Helper;
 use Yoast\WP\SEO\Helpers\String_Helper;
@@ -959,6 +960,8 @@ class WPSEO_Upgrade {
 		add_action( 'shutdown', [ $this, 'remove_indexable_rows_for_non_public_post_types' ] );
 		add_action( 'shutdown', [ $this, 'remove_indexable_rows_for_non_public_taxonomies' ] );
 		$this->deduplicate_unindexed_indexable_rows();
+		$this->remove_indexable_rows_for_disabled_authors_archive();
+		$this->remove_indexable_rows_for_authors_without_archive();
 	}
 
 	/**
@@ -1501,9 +1504,82 @@ class WPSEO_Upgrade {
 
 		foreach ( $delete_queries as $delete_query ) {
 			if ( ! empty( $delete_query ) ) {
+				// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery -- Reason: Most performant way.
+				// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching -- Reason: No relevant caches.
+				// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Reason: Is it prepared already.
 				$wpdb->query( $delete_query );
 			}
 		}
+
+		$wpdb->show_errors = $show_errors;
+	}
+
+	/**
+	 * Removes all user indexable rows when the author archive is disabled.
+	 *
+	 * @return void
+	 */
+	private function remove_indexable_rows_for_disabled_authors_archive() {
+		global $wpdb;
+
+		// If migrations haven't been completed successfully the following may give false errors. So suppress them.
+		$show_errors       = $wpdb->show_errors;
+		$wpdb->show_errors = false;
+
+		if ( ! ( new Author_Archive_Helper() )->are_disabled() ) {
+			return;
+		}
+
+		$indexable_table = Model::get_table_name( 'Indexable' );
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Reason: Too hard to fix.
+		$delete_query = $wpdb->prepare( "DELETE FROM $indexable_table WHERE object_type = 'user'" );
+		// phpcs:enable
+
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching -- Reason: No relevant caches.
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery -- Reason: Most performant way.
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Reason: Is it prepared already.
+		$wpdb->query( $delete_query );
+		// phpcs:enable
+
+		$wpdb->show_errors = $show_errors;
+	}
+
+	/**
+	 * Removes all user indexables rows for users without a publicly viewable author archive.
+	 *
+	 * @return void
+	 */
+	private function remove_indexable_rows_for_authors_without_archive() {
+		global $wpdb;
+
+		// If migrations haven't been completed successfully the following may give false errors. So suppress them.
+		$show_errors       = $wpdb->show_errors;
+		$wpdb->show_errors = false;
+
+		$indexable_table           = Model::get_table_name( 'Indexable' );
+		$author_archive_post_types = ( new Author_Archive_Helper() )->get_author_archive_post_types();
+		$viewable_post_stati       = array_filter( get_post_stati(), 'is_post_status_viewable' );
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Reason: Too hard to fix.
+		$delete_query = $wpdb->prepare(
+			"DELETE FROM $indexable_table
+				WHERE object_type = 'user'
+				AND object_id NOT IN (
+					SELECT DISTINCT post_author
+					FROM $wpdb->posts
+					WHERE post_type IN ( " . \implode( ', ', \array_fill( 0, \count( $author_archive_post_types ), '%s' ) ) . ' )
+					AND post_status IN ( ' . \implode( ', ', \array_fill( 0, \count( $viewable_post_stati ), '%s' ) ) . ' )
+				)',
+			array_merge( $author_archive_post_types, $viewable_post_stati )
+		);
+		// phpcs:enable
+
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching -- Reason: No relevant caches.
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery -- Reason: Most performant way.
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Reason: Is it prepared already.
+		$wpdb->query( $delete_query );
+		// phpcs:enable
 
 		$wpdb->show_errors = $show_errors;
 	}

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -1373,7 +1373,7 @@ class WPSEO_Upgrade {
 
 		$indexable_table = Model::get_table_name( 'Indexable' );
 
-		$post_type_helper = ( new Post_Type_Helper( new Options_Helper() ) );
+		$post_type_helper = \YoastSEO()->helpers->post_type;
 
 		$included_post_types = array_diff( $post_type_helper->get_accessible_post_types(), $post_type_helper->get_excluded_post_types_for_indexables() );
 
@@ -1420,7 +1420,7 @@ class WPSEO_Upgrade {
 
 		$indexable_table = Model::get_table_name( 'Indexable' );
 
-		$included_taxonomies = ( new Taxonomy_Helper( new Options_Helper(), new String_Helper() ) )->get_public_taxonomies();
+		$included_taxonomies = \YoastSEO()->helpers->taxonomy->get_public_taxonomies();
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Reason: Too hard to fix.
 		if ( empty( $included_taxonomies ) ) {
@@ -1526,7 +1526,7 @@ class WPSEO_Upgrade {
 		$show_errors       = $wpdb->show_errors;
 		$wpdb->show_errors = false;
 
-		if ( ! ( new Author_Archive_Helper() )->are_disabled() ) {
+		if ( ! \YoastSEO()->helpers->author_archive->are_disabled() ) {
 			return;
 		}
 
@@ -1558,10 +1558,11 @@ class WPSEO_Upgrade {
 		$wpdb->show_errors = false;
 
 		$indexable_table           = Model::get_table_name( 'Indexable' );
-		$author_archive_post_types = ( new Author_Archive_Helper() )->get_author_archive_post_types();
+		$author_archive_post_types = \YoastSEO()->helpers->author_archive->get_author_archive_post_types();
 		$viewable_post_stati       = array_filter( get_post_stati(), 'is_post_status_viewable' );
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Reason: Too hard to fix.
+		// phpcs:disable WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber -- Reason: we're passing an array instead.
 		$delete_query = $wpdb->prepare(
 			"DELETE FROM $indexable_table
 				WHERE object_type = 'user'
@@ -1610,7 +1611,6 @@ class WPSEO_Upgrade {
 		$object_ids           = wp_list_pluck( $filtered_duplicates, 'object_id' );
 		$newest_indexable_ids = wp_list_pluck( $filtered_duplicates, 'newest_id' );
 
-		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching -- Reason: No relevant caches.
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Reason: Too hard to fix.
 		// phpcs:disable WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber -- Reason: we're passing an array instead.
 		return $wpdb->prepare(

--- a/src/helpers/author-archive-helper.php
+++ b/src/helpers/author-archive-helper.php
@@ -47,6 +47,16 @@ class Author_Archive_Helper {
 	}
 
 	/**
+	 * Checks whether author archives are disabled.
+	 *
+	 * @return bool `true` if author archives are disabled, `false` if not.
+	 */
+	public function are_disabled() {
+		// TODO Use implementation of the PC-853-when-author-archives-are-disabled-we-should-not-store-indexables-for-author-pages branch.
+		return \YoastSeo()->helpers->options->get( 'disable-author' );
+	}
+
+	/**
 	 * Returns whether the author has at least one public post.
 	 *
 	 * @codeCoverageIgnore It looks for the first ID through the ORM and converts it to a boolean.

--- a/src/helpers/post-type-helper.php
+++ b/src/helpers/post-type-helper.php
@@ -74,6 +74,9 @@ class Post_Type_Helper {
 	 * @return array Array with all the accessible post_types.
 	 */
 	public function get_accessible_post_types() {
+		if ( ! \did_action( 'init' ) ) {
+			\_doing_it_wrong( __METHOD__, 'is not reliable before the init hook', 'YoastSEO v19.10' );
+		}
 		$post_types = \get_post_types( [ 'public' => true ] );
 		$post_types = \array_filter( $post_types, 'is_post_type_viewable' );
 

--- a/src/integrations/cleanup-integration.php
+++ b/src/integrations/cleanup-integration.php
@@ -456,17 +456,17 @@ class Cleanup_Integration implements Integration_Interface {
 
 		$indexable_table           = Model::get_table_name( 'Indexable' );
 		$author_archive_post_types = $this->author_archive->get_author_archive_post_types();
-		$viewable_post_stati       = array_filter( get_post_stati(), 'is_post_status_viewable' );
+		$viewable_post_stati       = array_filter( \get_post_stati(), 'is_post_status_viewable' );
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Reason: Too hard to fix.
 		// phpcs:disable WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber -- Reason: we're passing an array instead.
 		$delete_query = $wpdb->prepare(
 			"DELETE FROM $indexable_table
 				WHERE object_type = 'user'
-				AND object_id NOT IN(
+				AND object_id NOT IN (
 					SELECT DISTINCT post_author
 					FROM $wpdb->posts
-					WHERE post_type IN ( " . \implode( ', ', \array_fill( 0, \count( $author_archive_post_types ), '%s' ) ) . ')
+					WHERE post_type IN ( " . \implode( ', ', \array_fill( 0, \count( $author_archive_post_types ), '%s' ) ) . ' )
 					AND post_status IN ( ' . \implode( ', ', \array_fill( 0, \count( $viewable_post_stati ), '%s' ) ) . ' )
 				) LIMIT %d',
 			array_merge( $author_archive_post_types, $viewable_post_stati, [ $limit ] )

--- a/src/integrations/cleanup-integration.php
+++ b/src/integrations/cleanup-integration.php
@@ -342,7 +342,7 @@ class Cleanup_Integration implements Integration_Interface {
 		global $wpdb;
 		$indexable_table = Model::get_table_name( 'Indexable' );
 
-		$included_post_types = array_diff( $this->post_type->get_accessible_post_types(), $this->post_type->get_excluded_post_types_for_indexables() );
+		$included_post_types = \array_diff( $this->post_type->get_accessible_post_types(), $this->post_type->get_excluded_post_types_for_indexables() );
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Reason: Too hard to fix.
 		if ( empty( $included_post_types ) ) {
@@ -362,7 +362,7 @@ class Cleanup_Integration implements Integration_Interface {
 				AND object_sub_type IS NOT NULL
 				AND object_sub_type NOT IN ( " . \implode( ', ', \array_fill( 0, \count( $included_post_types ), '%s' ) ) . ' )
 				LIMIT %d',
-				array_merge( $included_post_types, [ $limit ] )
+				\array_merge( $included_post_types, [ $limit ] )
 			);
 		}
 		// phpcs:enable
@@ -405,7 +405,7 @@ class Cleanup_Integration implements Integration_Interface {
 				AND object_sub_type IS NOT NULL
 				AND object_sub_type NOT IN ( " . \implode( ', ', \array_fill( 0, \count( $included_taxonomies ), '%s' ) ) . ' )
 				LIMIT %d',
-				array_merge( $included_taxonomies, [ $limit ] )
+				\array_merge( $included_taxonomies, [ $limit ] )
 			);
 		}
 		// phpcs:enable
@@ -456,7 +456,7 @@ class Cleanup_Integration implements Integration_Interface {
 
 		$indexable_table           = Model::get_table_name( 'Indexable' );
 		$author_archive_post_types = $this->author_archive->get_author_archive_post_types();
-		$viewable_post_stati       = array_filter( \get_post_stati(), 'is_post_status_viewable' );
+		$viewable_post_stati       = \array_filter( \get_post_stati(), 'is_post_status_viewable' );
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Reason: Too hard to fix.
 		// phpcs:disable WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber -- Reason: we're passing an array instead.
@@ -469,7 +469,7 @@ class Cleanup_Integration implements Integration_Interface {
 					WHERE post_type IN ( " . \implode( ', ', \array_fill( 0, \count( $author_archive_post_types ), '%s' ) ) . ' )
 					AND post_status IN ( ' . \implode( ', ', \array_fill( 0, \count( $viewable_post_stati ), '%s' ) ) . ' )
 				) LIMIT %d',
-			array_merge( $author_archive_post_types, $viewable_post_stati, [ $limit ] )
+			\array_merge( $author_archive_post_types, $viewable_post_stati, [ $limit ] )
 		);
 		// phpcs:enable
 

--- a/tests/unit/integrations/cleanup-integration-test.php
+++ b/tests/unit/integrations/cleanup-integration-test.php
@@ -6,6 +6,9 @@ use Brain\Monkey;
 use Mockery;
 use wpdb;
 use Yoast\WP\Lib\Model;
+use Yoast\WP\SEO\Helpers\Author_Archive_Helper;
+use Yoast\WP\SEO\Helpers\Post_Type_Helper;
+use Yoast\WP\SEO\Helpers\Taxonomy_Helper;
 use Yoast\WP\SEO\Integrations\Cleanup_Integration;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
@@ -26,6 +29,27 @@ class Cleanup_Integration_Test extends TestCase {
 	private $instance;
 
 	/**
+	 * A helper for taxonomies.
+	 *
+	 * @var Mockery\MockInterface|Taxonomy_Helper
+	 */
+	private $taxonomy;
+
+	/**
+	 * A helper for post types.
+	 *
+	 * @var Mockery\MockInterface|Post_Type_Helper
+	 */
+	private $post_type;
+
+	/**
+	 * A helper for author archives.
+	 *
+	 * @var Mockery\MockInterface|Author_Archive_Helper
+	 */
+	private $author_archive;
+
+	/**
 	 * The WPDB mock.
 	 *
 	 * @var Mockery\MockInterface|wpdb
@@ -38,7 +62,15 @@ class Cleanup_Integration_Test extends TestCase {
 	protected function set_up() {
 		parent::set_up();
 
-		$this->instance = new Cleanup_Integration();
+		$this->taxonomy       = Mockery::mock( Taxonomy_Helper::class );
+		$this->post_type      = Mockery::mock( Post_Type_Helper::class );
+		$this->author_archive = Mockery::mock( Author_Archive_Helper::class );
+
+		$this->instance = new Cleanup_Integration(
+			$this->taxonomy,
+			$this->post_type,
+			$this->author_archive
+		);
 
 		global $wpdb;
 
@@ -55,7 +87,6 @@ class Cleanup_Integration_Test extends TestCase {
 	 */
 	public function test_register_hooks() {
 		$this->instance->register_hooks();
-
 		$this->assertNotFalse( Monkey\Actions\has( 'wpseo_start_cleanup_indexables', [ $this->instance, 'run_cleanup' ] ), 'Does not have expected wpseo_cleanup filter' );
 		$this->assertNotFalse( Monkey\Actions\has( 'wpseo_cleanup_cron', [ $this->instance, 'run_cleanup_cron' ] ), 'Does not have expected run_cleanup_cron filter' );
 		$this->assertNotFalse( Monkey\Actions\has( 'wpseo_deactivate', [ $this->instance, 'reset_cleanup' ] ), 'Does not have expected reset_cleanup filter' );
@@ -100,6 +131,18 @@ class Cleanup_Integration_Test extends TestCase {
 
 		/* Clean up of indexables with post_status auto-draft */
 		$this->setup_clean_indexables_with_post_status_mocks( 50, 'auto-draft', $query_limit );
+
+		/* Clean up of indexables where post type is not publicly viewable */
+		$this->setup_clean_indexables_for_non_publicly_viewable_post( 50, $query_limit );
+
+		/* Clean up of indexables where taxonomy is not publicly viewable */
+		$this->setup_clean_indexables_for_non_publicly_viewable_taxonomies( 50, $query_limit );
+
+		/* Clean up of indexables that belong to users while the author archives are disabled */
+		$this->setup_clean_indexables_for_authors_archive_disabled( 50, $query_limit );
+
+		/* Clean up of indexables of users without an author archive */
+		$this->setup_clean_indexables_for_authors_without_archive( 50, $query_limit );
 
 		/* Clean up of indexable hierarchy for deleted indexables */
 		$this->setup_cleanup_orphaned_from_table_mocks( 50, 'Indexable_Hierarchy', 'indexable_id', $query_limit );
@@ -450,5 +493,125 @@ class Cleanup_Integration_Test extends TestCase {
 			->once()
 			->with( "DELETE FROM {$table} WHERE {$column} IN( " . \implode( ',', $ids ) . ' )' )
 			->andReturn( 50 );
+	}
+
+	/**
+	 * Sets up expectations for the clean_indexables_for_non_publicly_viewable_post cleanup task.
+	 *
+	 * @param int $return_value The number of deleted items to return.
+	 * @param int $limit        The query limit.
+	 *
+	 * @return void
+	 */
+	private function setup_clean_indexables_for_non_publicly_viewable_post( $return_value, $limit ) {
+		$this->post_type->expects( 'get_accessible_post_types' )->once()->andReturns( [ 'my_cpt', 'post', 'page', 'attachment' ] );
+		$this->post_type->expects( 'get_excluded_post_types_for_indexables' )->once()->andReturns( [ 'page', 'something else' ] );
+		$this->wpdb->shouldReceive( 'prepare' )
+			->once()
+			->with(
+				'DELETE FROM wp_yoast_indexable
+				WHERE object_type = \'post\'
+				AND object_sub_type IS NOT NULL
+				AND object_sub_type NOT IN ( %s, %s, %s )
+				LIMIT %d',
+				[ 'my_cpt', 'post', 'attachment', $limit ]
+			)
+			->andReturn( 'prepared_clean_query' );
+
+		$this->wpdb->expects( 'query' )
+			->once()
+			->with( 'prepared_clean_query' )
+			->andReturn( $return_value );
+	}
+
+	/**
+	 * Sets up expectations for the clean_indexables_for_non_publicly_viewable_taxonomies cleanup task.
+	 *
+	 * @param int $return_value The number of deleted items to return.
+	 * @param int $limit        The query limit.
+	 *
+	 * @return void
+	 */
+	private function setup_clean_indexables_for_non_publicly_viewable_taxonomies( $return_value, $limit ) {
+		$this->taxonomy->expects( 'get_public_taxonomies' )->once()->andReturns( [ 'category', 'post_tag', 'my_custom_tax' ] );
+
+		$this->wpdb->shouldReceive( 'prepare' )
+			->once()
+			->with(
+				'DELETE FROM wp_yoast_indexable
+				WHERE object_type = \'term\'
+				AND object_sub_type IS NOT NULL
+				AND object_sub_type NOT IN ( %s, %s, %s )
+				LIMIT %d',
+				[ 'category', 'post_tag', 'my_custom_tax', $limit ]
+			)
+			->andReturn( 'prepared_clean_query' );
+
+		$this->wpdb->expects( 'query' )
+			->once()
+			->with( 'prepared_clean_query' )
+			->andReturn( $return_value );
+	}
+
+	/**
+	 * Sets up expectations for the clean_indexables_for_authors_archive_disabled cleanup task.
+	 *
+	 * @param int $return_value The number of deleted items to return.
+	 * @param int $limit        The query limit.
+	 *
+	 * @return void
+	 */
+	private function setup_clean_indexables_for_authors_archive_disabled( $return_value, $limit ) {
+		$this->author_archive->expects( 'are_disabled' )->once()->andReturnTrue();
+
+		$this->wpdb->shouldReceive( 'prepare' )
+			->once()
+			->with( 'DELETE FROM wp_yoast_indexable WHERE object_type = \'user\' LIMIT %d', $limit )
+			->andReturn( 'prepared_clean_query' );
+
+		$this->wpdb->expects( 'query' )
+			->once()
+			->with( 'prepared_clean_query' )
+			->andReturn( $return_value );
+	}
+
+	/**
+	 * Sets up expectations for the clean_indexables_for_authors_without_archive cleanup task.
+	 *
+	 * @param int $return_value The number of deleted items to return.
+	 * @param int $limit        The query limit.
+	 *
+	 * @return void
+	 */
+	private function setup_clean_indexables_for_authors_without_archive( $return_value, $limit ) {
+		$this->author_archive->expects( 'get_author_archive_post_types' )->once()->andReturns( [ 'post' ] );
+
+		Monkey\Functions\expect( 'get_post_stati' )->once()->andReturns( [ 'publish', 'draft' ] );
+		Monkey\Functions\expect( 'is_post_status_viewable' )->twice()->andReturnUsing(
+			static function ( $value ) {
+				return $value === 'publish';
+			}
+		);
+		$this->wpdb->posts = 'wp_posts';
+
+		$this->wpdb->shouldReceive( 'prepare' )
+			->once()
+			->with(
+				'DELETE FROM wp_yoast_indexable
+				WHERE object_type = \'user\'
+				AND object_id NOT IN (
+					SELECT DISTINCT post_author
+					FROM wp_posts
+					WHERE post_type IN ( %s )
+					AND post_status IN ( %s )
+				) LIMIT %d',
+				[ 'post', 'publish', $limit ]
+			)
+			->andReturn( 'prepared_clean_query' );
+
+		$this->wpdb->expects( 'query' )
+			->once()
+			->with( 'prepared_clean_query' )
+			->andReturn( $return_value );
 	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

The indexable table has grown a lot since it was introduced. We're reducing the size by limiting what objects end up in the indexables table. We remove indexables for:
* Posts and taxonomy objects that are not publicly viewable
* Users that do not have an archive. Either because the archives are disabled, or the user doesn't have any publicly viewable posts that would end up in their archives.
* Duplicated indexable rows for the same object with the "unindexed status".

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Reduces the amount of data that is stored in the yoast_indexables table.

## Relevant technical choices:

* I chose to do part of the upgrade routine on shutdown. post_types and taxonomies are to be registered on or after the `init` hook. Especially since not all post types may be available at the end of init, I chose for shutdown. 
* I saw @hansjovis was still working on a `Author_Archive_Helper::are_disabled`, so I copied part of it to be replaced with @hansjovis's final implementation on merge (this will definitely cause a merge conflict).

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

👉 _Start testing without having this branch checkedout yet_

#### 1. Removing user indexables
##### 1.1. Upgrade routine
1. In the search appearance settings, make sure author archives are _enabled_.
1. Perform a full reindex on the latest release (`wp yoast index --reindex --skip-confirmation`).
1. Create a new user that has the subscriber role.
1. In the database, verify that the wp_yoast_indexables table has indexables for all users, including your new subscriber user.
1. checkout this branch.
1. Refresh any page. This runs the upgrade routines (if you have already ran the upgrade routines for 19.10 once, you might need to reset the plugin version number with the Yoast test helper plugin).
1. Check the database again.
	* The user indexable for your new user should be gone.
	* Visiting the permalink for any of the user indexables should show their author archive. No user should be left in the database table _without_ and author archive.

##### 1.2. Cron cleanup
1. Switch back to the latest release.
1. Perform a full reindex on the latest release (`wp yoast index --reindex --skip-confirmation`).
1. Find your new subscriber user, update their profile once to trigger indexable creation.
1. In the database, verify that the wp_yoast_indexables table has indexables for all users, including your new subscriber user.
1. Checkout this branch.
1. The upgrade routines _should not_ run this time.
1. execute this script on the server: ` wp cron event schedule wpseo_start_cleanup_indexables; sleep 1; wp cron event run wpseo_start_cleanup_indexables;  while wp cron event run wpseo_cleanup_cron; do sleep 2; done`. This will start and speed up the background cleanup process so it completed in a matter of seconds (instead of hours/days).
1. Check the database again.
	* The user indexable for your new user should be gone.
	* Visiting the permalink for any of the user indexables should show their author archive. No user should be left in the database table _without_ and author archive.

##### 1.3 Removing all user indexables when author archives are disabled
1. Repeat all steps from 1.1 and 1.2. But this time, make sure the author archives are _disabled_.
1. In both cases, _all_ user indexables should be removed from the database.


#### 2. Removing duplicates
##### 2.1. Upgrade routine
1. Switch back to the latest release. (or at least a version without https://github.com/Yoast/wordpress-seo/pull/19079)
1. We need to simulate a failing indexable build. Add the following line of code before [src/builders/indexable-builder.php:321:](https://github.com/Yoast/wordpress-seo/blob/60871b9bbe6861f1768e17ec3990672cd7efc4b3/src/builders/indexable-builder.php#L321) `throw new \Yoast\WP\SEO\Exceptions\Indexable\Post_Not_Found_Exception();
1. Find any post in the WP admin and click update. Do this 4 times.
1. Check the database: this should have spawned at least 4 indexables with the 'unindexed' status for your post.
1. Switch to this branch.
1. Refresh any page. This runs the upgrade routines (if you have already ran the upgrade routines for 19.10 once, you might need to reset the plugin version number with the Yoast test helper plugin).
1. Check the database again. Only one indexable should remain for your post.

##### 2.2. Cleanup
1. Revert the code changes you made.

#### 3. Removing objects that are not publicly viewable
##### 3.1. Upgrade routine
1. Switch back to the latest release. (or at least a version without https://github.com/Yoast/wordpress-seo/pull/19077)
1. Install a plugin to manage custom post types and taxonomies.
1.  Create a post type and a taxonomy that are publicly viewable. Create multiple and play around with their settings.
1. Create at least one post of each post type/taxonomy.
1. Check the database: all your posts and terms should be present in the wp_yoast_indexables table.
1. Checkout this branch.
1. Refresh any page. This runs the upgrade routines (if you have already ran the upgrade routines for 19.10 once, you might need to reset the plugin version number with the Yoast test helper plugin).
1. Check the database again: there should only be indexable rows for posts and terms that are publicly viewable. The posts/terms that are not should be removed.

##### 3.2. Cron cleanup
1. Switch back to the latest release. (or at least a version without https://github.com/Yoast/wordpress-seo/pull/19077)
1. Perform a full reindex (`wp yoast index --reindex --skip-confirmation`).
1. Switch to this branch.
1. The upgrade routines _should not_ run this time.
1. execute this script on the server: ` wp cron event schedule wpseo_start_cleanup_indexables; sleep 1; wp cron event run wpseo_start_cleanup_indexables;  while wp cron event run wpseo_cleanup_cron; do sleep 2; done`. This will start and speed up the background cleanup process so it completed in a matter of seconds (instead of hours/days).
1. Check the database again. The result should be the same as 3.1.8.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes PC-869
