### PR TITLE
Change version number in the upgrade routine

### DIFF
--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -966,8 +966,6 @@ class WPSEO_Upgrade {
 		if ( ! \wp_next_scheduled( Cleanup_Integration::START_HOOK ) ) {
 			\wp_schedule_single_event( ( time() + ( MINUTE_IN_SECONDS * 5 ) ), Cleanup_Integration::START_HOOK );
 		}
-		$this->set_last_known_viewable_post_types();
-		$this->set_last_known_viewable_taxonomies();
 	}
 
 	/**
@@ -1629,29 +1627,5 @@ class WPSEO_Upgrade {
 			array_merge( array_values( $object_ids ), array_values( $newest_indexable_ids ), [ $object_type ] )
 		);
 		// phpcs:enable
-	}
-
-	/**
-	 * Sets the last_known_viewable_post_types option for the 19.11 upgrade routine.
-	 *
-	 * @return void
-	 */
-	public function set_last_known_viewable_post_types() {
-		$post_types          = \get_post_types();
-		$viewable_post_types = \array_keys( \array_filter( $post_types, '\is_post_type_viewable' ) );
-
-		WPSEO_Options::set( 'last_known_viewable_post_types', $viewable_post_types );
-	}
-
-	/**
-	 * Sets the last_known_viewable_taxonomies option for the 19.11 upgrade routine.
-	 *
-	 * @return void
-	 */
-	public function set_last_known_viewable_taxonomies() {
-		$taxonomies          = \get_taxonomies();
-		$viewable_taxonomies = \array_keys( \array_filter( $taxonomies, '\is_taxonomy_viewable' ) );
-
-		WPSEO_Options::set( 'last_known_viewable_taxonomies', $viewable_taxonomies );
 	}
 }

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -966,8 +966,8 @@ class WPSEO_Upgrade {
 		if ( ! \wp_next_scheduled( Cleanup_Integration::START_HOOK ) ) {
 			\wp_schedule_single_event( ( time() + ( MINUTE_IN_SECONDS * 5 ) ), Cleanup_Integration::START_HOOK );
 		}
-		$this->set_last_known_public_post_types();
-		$this->set_last_known_public_taxonomies();
+		$this->set_last_known_viewable_post_types();
+		$this->set_last_known_viewable_taxonomies();
 	}
 
 	/**
@@ -1636,10 +1636,11 @@ class WPSEO_Upgrade {
 	 *
 	 * @return void
 	 */
-	public function set_last_known_public_post_types() {
-		$public_post_types = \array_keys( \YoastSEO()->helpers->post_type->get_public_post_types() );
+	public function set_last_known_viewable_post_types() {
+		$post_types          = \get_post_types();
+		$viewable_post_types = \array_keys( \array_filter( $post_types, '\is_post_type_viewable' ) );
 
-		WPSEO_Options::set( 'last_known_public_post_types', $public_post_types );
+		WPSEO_Options::set( 'last_known_viewable_post_types', $viewable_post_types );
 	}
 
 	/**
@@ -1647,9 +1648,10 @@ class WPSEO_Upgrade {
 	 *
 	 * @return void
 	 */
-	public function set_last_known_public_taxonomies() {
-		$public_taxonomies = \array_keys( \YoastSEO()->helpers->taxonomy->get_public_taxonomies() );
+	public function set_last_known_viewable_taxonomies() {
+		$taxonomies          = \get_taxonomies();
+		$viewable_taxonomies = \array_keys( \array_filter( $taxonomies, '\is_taxonomy_viewable' ) );
 
-		WPSEO_Options::set( 'last_known_public_taxonomies', $public_taxonomies );
+		WPSEO_Options::set( 'last_known_viewable_taxonomies', $viewable_taxonomies );
 	}
 }

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -966,8 +966,8 @@ class WPSEO_Upgrade {
 		if ( ! \wp_next_scheduled( Cleanup_Integration::START_HOOK ) ) {
 			\wp_schedule_single_event( ( time() + ( MINUTE_IN_SECONDS * 5 ) ), Cleanup_Integration::START_HOOK );
 		}
-		$this->set_last_known_viewable_post_types();
-		$this->set_last_known_viewable_taxonomies();
+		$this->set_last_known_public_post_types();
+		$this->set_last_known_public_taxonomies();
 	}
 
 	/**
@@ -1636,11 +1636,10 @@ class WPSEO_Upgrade {
 	 *
 	 * @return void
 	 */
-	public function set_last_known_viewable_post_types() {
-		$post_types          = \get_post_types();
-		$viewable_post_types = \array_keys( \array_filter( $post_types, '\is_post_type_viewable' ) );
+	public function set_last_known_public_post_types() {
+		$public_post_types = \array_keys( \YoastSEO()->helpers->post_type->get_public_post_types() );
 
-		WPSEO_Options::set( 'last_known_viewable_post_types', $viewable_post_types );
+		WPSEO_Options::set( 'last_known_public_post_types', $public_post_types );
 	}
 
 	/**
@@ -1648,10 +1647,9 @@ class WPSEO_Upgrade {
 	 *
 	 * @return void
 	 */
-	public function set_last_known_viewable_taxonomies() {
-		$taxonomies          = \get_taxonomies();
-		$viewable_taxonomies = \array_keys( \array_filter( $taxonomies, '\is_taxonomy_viewable' ) );
+	public function set_last_known_public_taxonomies() {
+		$public_taxonomies = \array_keys( \YoastSEO()->helpers->taxonomy->get_public_taxonomies() );
 
-		WPSEO_Options::set( 'last_known_viewable_taxonomies', $viewable_taxonomies );
+		WPSEO_Options::set( 'last_known_public_taxonomies', $public_taxonomies );
 	}
 }

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -88,7 +88,7 @@ class WPSEO_Upgrade {
 			'19.1-RC0'   => 'upgrade_191',
 			'19.3-RC0'   => 'upgrade_193',
 			'19.6-RC0'   => 'upgrade_196',
-			'19.10-RC0'  => 'upgrade_1910',
+			'19.11-RC0'  => 'upgrade_1911',
 		];
 
 		array_walk( $routines, [ $this, 'run_upgrade_routine' ], $version );
@@ -955,9 +955,9 @@ class WPSEO_Upgrade {
 	}
 
 	/**
-	 * Performs the 19.10 upgrade routine.
+	 * Performs the 19.11 upgrade routine.
 	 */
-	private function upgrade_1910() {
+	private function upgrade_1911() {
 		\add_action( 'shutdown', [ $this, 'remove_indexable_rows_for_non_public_post_types' ] );
 		\add_action( 'shutdown', [ $this, 'remove_indexable_rows_for_non_public_taxonomies' ] );
 		$this->deduplicate_unindexed_indexable_rows();
@@ -1632,7 +1632,7 @@ class WPSEO_Upgrade {
 	}
 
 	/**
-	 * Sets the last_known_viewable_post_types option for the 19.10 upgrade routine.
+	 * Sets the last_known_viewable_post_types option for the 19.11 upgrade routine.
 	 *
 	 * @return void
 	 */
@@ -1644,7 +1644,7 @@ class WPSEO_Upgrade {
 	}
 
 	/**
-	 * Sets the last_known_viewable_taxonomies option for the 19.10 upgrade routine.
+	 * Sets the last_known_viewable_taxonomies option for the 19.11 upgrade routine.
 	 *
 	 * @return void
 	 */

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -966,6 +966,8 @@ class WPSEO_Upgrade {
 		if ( ! \wp_next_scheduled( Cleanup_Integration::START_HOOK ) ) {
 			\wp_schedule_single_event( ( time() + ( MINUTE_IN_SECONDS * 5 ) ), Cleanup_Integration::START_HOOK );
 		}
+		$this->set_last_known_viewable_post_types();
+		$this->set_last_known_viewable_taxonomies();
 	}
 
 	/**
@@ -1627,5 +1629,29 @@ class WPSEO_Upgrade {
 			array_merge( array_values( $object_ids ), array_values( $newest_indexable_ids ), [ $object_type ] )
 		);
 		// phpcs:enable
+	}
+
+	/**
+	 * Sets the last_known_viewable_post_types option for the 19.10 upgrade routine.
+	 *
+	 * @return void
+	 */
+	public function set_last_known_viewable_post_types() {
+		$post_types          = \get_post_types();
+		$viewable_post_types = \array_keys( \array_filter( $post_types, '\is_post_type_viewable' ) );
+
+		WPSEO_Options::set( 'last_known_viewable_post_types', $viewable_post_types );
+	}
+
+	/**
+	 * Sets the last_known_viewable_taxonomies option for the 19.10 upgrade routine.
+	 *
+	 * @return void
+	 */
+	public function set_last_known_viewable_taxonomies() {
+		$taxonomies          = \get_taxonomies();
+		$viewable_taxonomies = \array_keys( \array_filter( $taxonomies, '\is_taxonomy_viewable' ) );
+
+		WPSEO_Options::set( 'last_known_viewable_taxonomies', $viewable_taxonomies );
 	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to change the version number from `19.10` to `19.11` for this upgrade routine.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

*  Change the version number from `19.10` to `19.11`.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Please follow the test instructions here: https://github.com/Yoast/wordpress-seo/pull/19087 

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.

Fixes [PC-875](https://yoast.atassian.net/browse/PC-875)
