### PR TITLE
Change main image ID generation

### DIFF
--- a/src/context/meta-tags-context.php
+++ b/src/context/meta-tags-context.php
@@ -814,14 +814,14 @@ class Meta_Tags_Context extends Abstract_Presentation {
 
 		$monthnum = \get_query_var( 'monthnum' );
 		$day      = \get_query_var( 'day' );
-		$value    = $this->get_image_for_first_post_in_archive(
+
+		return $this->get_image_for_first_post_in_archive(
 			[
 				'year'     => $year,
 				'monthnum' => ( $monthnum !== 0 ) ? $monthnum : null,
 				'day'      => ( $day !== 0 ) ? $day : null,
 			]
 		);
-		return $value;
 	}
 
 	/**
@@ -830,15 +830,9 @@ class Meta_Tags_Context extends Abstract_Presentation {
 	 * @return int|null The ID of the main image of an author archive, null if no image for the archive exists.
 	 */
 	private function get_main_image_for_author_archive() {
-		$author = \get_query_var( 'author' );
-
-		if ( $author === 0 ) {
-			return null;
-		}
-
 		return $this->get_image_for_first_post_in_archive(
 			[
-				'author' => $author,
+				'author' => $this->id,
 			]
 		);
 	}

--- a/tests/unit/context/meta-tags-context-test.php
+++ b/tests/unit/context/meta-tags-context-test.php
@@ -555,7 +555,7 @@ class Meta_Tags_Context_Test extends TestCase {
 		Functions\expect( 'has_post_thumbnail' )->once()->with( 5 )->andReturn( true );
 		Functions\expect( 'get_post_thumbnail_id' )->once()->with( 5 )->andReturn( 23 );
 
-		$this->assertEquals( $this->instance->generate_main_image_id(), 23 );
+		$this->assertEquals( 23, $this->instance->generate_main_image_id() );
 	}
 
 	/**
@@ -584,7 +584,7 @@ class Meta_Tags_Context_Test extends TestCase {
 			]
 		);
 
-		$this->assertEquals( $this->instance->generate_main_image_id(), 4 );
+		$this->assertEquals( 4, $this->instance->generate_main_image_id() );
 	}
 
 	/**
@@ -612,7 +612,7 @@ class Meta_Tags_Context_Test extends TestCase {
 			]
 		);
 
-		$this->assertEquals( $this->instance->generate_main_image_id(), null );
+		$this->assertEquals( null, $this->instance->generate_main_image_id() );
 	}
 
 	/**
@@ -631,7 +631,7 @@ class Meta_Tags_Context_Test extends TestCase {
 		Functions\expect( 'get_post' )->once()->with( 5 )->andReturn( (object) [ 'post_content' => 'bla bla bla' ] );
 		$this->image->expects( 'get_images_from_post_content' )->once()->with( 'bla bla bla' )->andReturn( [] );
 
-		$this->assertEquals( $this->instance->generate_main_image_id(), null );
+		$this->assertEquals( null, $this->instance->generate_main_image_id() );
 	}
 
 	/**
@@ -645,7 +645,7 @@ class Meta_Tags_Context_Test extends TestCase {
 			'object_sub_type' => 'attachment',
 		];
 		$this->instance->id        = 5;
-		$this->assertEquals( $this->instance->generate_main_image_id(), 5 );
+		$this->assertEquals( 5, $this->instance->generate_main_image_id() );
 	}
 
 	/**
@@ -663,7 +663,7 @@ class Meta_Tags_Context_Test extends TestCase {
 		Functions\expect( 'has_post_thumbnail' )->once()->with( 5 )->andReturn( true );
 		Functions\expect( 'get_post_thumbnail_id' )->once()->with( 5 )->andReturn( 23 );
 
-		$this->assertEquals( $this->instance->generate_main_image_id(), 23 );
+		$this->assertEquals( 23, $this->instance->generate_main_image_id() );
 	}
 
 	/**
@@ -676,7 +676,7 @@ class Meta_Tags_Context_Test extends TestCase {
 			'object_type'     => 'system-page',
 			'object_sub_type' => '404',
 		];
-		$this->assertEquals( $this->instance->generate_main_image_id(), null );
+		$this->assertEquals( null, $this->instance->generate_main_image_id() );
 	}
 
 	/**
@@ -689,99 +689,7 @@ class Meta_Tags_Context_Test extends TestCase {
 			'object_type'     => 'system-page',
 			'object_sub_type' => 'search-result',
 		];
-
-		$this->instance->current_page   = 1;
-		$this->instance->posts_per_page = 10;
-
-		Functions\expect( 'get_search_query' )->once()->andReturn( 'bla' );
-
-		Functions\expect( 'get_posts' )->once()->with(
-			[
-				'paged'          => 1,
-				'posts_per_page' => 10,
-				's'              => 'bla',
-			]
-		)->andReturn(
-			[
-				(object) [
-					'ID' => 5,
-				],
-				(object) [
-					'ID' => 6,
-				],
-			]
-		);
-
-		Functions\expect( 'has_post_thumbnail' )->with( 5 )->andReturn( true );
-		Functions\expect( 'get_post_thumbnail_id' )->with( 5 )->andReturn( 23 );
-
-		$this->assertEquals( $this->instance->generate_main_image_id(), 23 );
-	}
-
-	/**
-	 * Test generate_main_image_id for the search page with no results.
-	 *
-	 * @covers ::generate_main_image_id
-	 */
-	public function test_generate_main_image_id_for_search_page_no_results() {
-		$this->instance->indexable = (object) [
-			'object_type'     => 'system-page',
-			'object_sub_type' => 'search-result',
-		];
-
-		$this->instance->current_page   = 1;
-		$this->instance->posts_per_page = 10;
-
-		Functions\expect( 'get_search_query' )->once()->andReturn( 'bla' );
-
-		Functions\expect( 'get_posts' )->once()->with(
-			[
-				'paged'          => 1,
-				'posts_per_page' => 10,
-				's'              => 'bla',
-			]
-		)->andReturn( [] );
-
-		$this->assertEquals( $this->instance->generate_main_image_id(), null );
-	}
-
-	/**
-	 * Test generate_main_image_id for the search page on page 4.
-	 *
-	 * @covers ::generate_main_image_id
-	 */
-	public function test_generate_main_image_id_for_search_page_page_4() {
-		$this->instance->indexable = (object) [
-			'object_type'     => 'system-page',
-			'object_sub_type' => 'search-result',
-		];
-
-		$this->instance->current_page   = 4;
-		$this->instance->posts_per_page = 10;
-
-		Functions\expect( 'get_search_query' )->once()->andReturn( 'bla' );
-
-		Functions\expect( 'get_posts' )->once()->with(
-			[
-				'paged'          => 4,
-				'posts_per_page' => 10,
-				's'              => 'bla',
-			]
-		)->andReturn(
-			[
-				(object) [
-					'ID' => 5,
-				],
-				(object) [
-					'ID' => 6,
-				],
-			]
-		);
-
-		Functions\expect( 'has_post_thumbnail' )->with( 5 )->andReturn( true );
-		Functions\expect( 'get_post_thumbnail_id' )->with( 5 )->andReturn( 23 );
-
-		$this->assertEquals( $this->instance->generate_main_image_id(), 23 );
+		$this->assertEquals( null, $this->instance->generate_main_image_id() );
 	}
 
 	/**
@@ -794,22 +702,16 @@ class Meta_Tags_Context_Test extends TestCase {
 			'object_type' => 'home-page',
 		];
 
-		$this->instance->home_page_id   = 0;
-		$this->instance->current_page   = 1;
-		$this->instance->posts_per_page = 10;
+		$this->instance->home_page_id = 0;
 
 		Functions\expect( 'get_posts' )->once()->with(
 			[
-				'paged'          => 1,
-				'posts_per_page' => 10,
+				'posts_per_page' => 1,
 			]
 		)->andReturn(
 			[
 				(object) [
 					'ID' => 5,
-				],
-				(object) [
-					'ID' => 6,
 				],
 			]
 		);
@@ -817,7 +719,7 @@ class Meta_Tags_Context_Test extends TestCase {
 		Functions\expect( 'has_post_thumbnail' )->with( 5 )->andReturn( true );
 		Functions\expect( 'get_post_thumbnail_id' )->with( 5 )->andReturn( 23 );
 
-		$this->assertEquals( $this->instance->generate_main_image_id(), 23 );
+		$this->assertEquals( 23, $this->instance->generate_main_image_id() );
 	}
 
 	/**
@@ -830,9 +732,7 @@ class Meta_Tags_Context_Test extends TestCase {
 			'object_type' => 'home-page',
 		];
 
-		$this->instance->home_page_id   = 19;
-		$this->instance->current_page   = 1;
-		$this->instance->posts_per_page = 10;
+		$this->instance->home_page_id = 19;
 
 		Functions\expect( 'has_post_thumbnail' )->with( 19 )->andReturn( true );
 		Functions\expect( 'get_post_thumbnail_id' )->with( 19 )->andReturn( 23 );
@@ -851,14 +751,11 @@ class Meta_Tags_Context_Test extends TestCase {
 			'object_sub_type' => 'category',
 		];
 
-		$this->instance->id             = 18;
-		$this->instance->current_page   = 1;
-		$this->instance->posts_per_page = 10;
+		$this->instance->id = 18;
 
 		Functions\expect( 'get_posts' )->once()->with(
 			[
-				'paged'          => 1,
-				'posts_per_page' => 10,
+				'posts_per_page' => 1,
 				'tax_query'      => [
 					[
 						'taxonomy'         => 'category',
@@ -874,16 +771,13 @@ class Meta_Tags_Context_Test extends TestCase {
 				(object) [
 					'ID' => 5,
 				],
-				(object) [
-					'ID' => 6,
-				],
 			]
 		);
 
 		Functions\expect( 'has_post_thumbnail' )->with( 5 )->andReturn( true );
 		Functions\expect( 'get_post_thumbnail_id' )->with( 5 )->andReturn( 23 );
 
-		$this->assertEquals( $this->instance->generate_main_image_id(), 23 );
+		$this->assertEquals( 23, $this->instance->generate_main_image_id() );
 	}
 
 	/**
@@ -897,14 +791,11 @@ class Meta_Tags_Context_Test extends TestCase {
 			'object_sub_type' => 'custom_term',
 		];
 
-		$this->instance->id             = 18;
-		$this->instance->current_page   = 1;
-		$this->instance->posts_per_page = 10;
+		$this->instance->id = 18;
 
 		Functions\expect( 'get_posts' )->once()->with(
 			[
-				'paged'          => 1,
-				'posts_per_page' => 10,
+				'posts_per_page' => 1,
 				'tax_query'      => [
 					[
 						'taxonomy'         => 'custom_term',
@@ -920,16 +811,13 @@ class Meta_Tags_Context_Test extends TestCase {
 				(object) [
 					'ID' => 5,
 				],
-				(object) [
-					'ID' => 6,
-				],
 			]
 		);
 
 		Functions\expect( 'has_post_thumbnail' )->with( 5 )->andReturn( true );
 		Functions\expect( 'get_post_thumbnail_id' )->with( 5 )->andReturn( 23 );
 
-		$this->assertEquals( $this->instance->generate_main_image_id(), 23 );
+		$this->assertEquals( 23, $this->instance->generate_main_image_id() );
 	}
 
 	/**
@@ -943,13 +831,9 @@ class Meta_Tags_Context_Test extends TestCase {
 			'object_sub_type' => 'post',
 		];
 
-		$this->instance->current_page   = 1;
-		$this->instance->posts_per_page = 10;
-
 		Functions\expect( 'get_posts' )->once()->with(
 			[
-				'paged'          => 1,
-				'posts_per_page' => 10,
+				'posts_per_page' => 1,
 				'post_type'      => 'post',
 			]
 		)->andReturn(
@@ -957,16 +841,13 @@ class Meta_Tags_Context_Test extends TestCase {
 				(object) [
 					'ID' => 5,
 				],
-				(object) [
-					'ID' => 6,
-				],
 			]
 		);
 
 		Functions\expect( 'has_post_thumbnail' )->with( 5 )->andReturn( true );
 		Functions\expect( 'get_post_thumbnail_id' )->with( 5 )->andReturn( 23 );
 
-		$this->assertEquals( $this->instance->generate_main_image_id(), 23 );
+		$this->assertEquals( 23, $this->instance->generate_main_image_id() );
 	}
 
 	/**
@@ -980,13 +861,9 @@ class Meta_Tags_Context_Test extends TestCase {
 			'object_sub_type' => 'custom_post_type',
 		];
 
-		$this->instance->current_page   = 1;
-		$this->instance->posts_per_page = 10;
-
 		Functions\expect( 'get_posts' )->once()->with(
 			[
-				'paged'          => 1,
-				'posts_per_page' => 10,
+				'posts_per_page' => 1,
 				'post_type'      => 'custom_post_type',
 			]
 		)->andReturn(
@@ -994,16 +871,13 @@ class Meta_Tags_Context_Test extends TestCase {
 				(object) [
 					'ID' => 5,
 				],
-				(object) [
-					'ID' => 6,
-				],
 			]
 		);
 
 		Functions\expect( 'has_post_thumbnail' )->with( 5 )->andReturn( true );
 		Functions\expect( 'get_post_thumbnail_id' )->with( 5 )->andReturn( 23 );
 
-		$this->assertEquals( $this->instance->generate_main_image_id(), 23 );
+		$this->assertEquals( 23, $this->instance->generate_main_image_id() );
 	}
 
 	/**
@@ -1016,9 +890,6 @@ class Meta_Tags_Context_Test extends TestCase {
 			'object_type' => 'date-archive',
 		];
 
-		$this->instance->current_page   = 1;
-		$this->instance->posts_per_page = 10;
-
 		Functions\expect( 'get_query_var' )->with( 'year' )->once()->andReturn( 2022 );
 		Functions\expect( 'get_query_var' )->with( 'monthnum' )->once()->andReturn( 11 );
 		Functions\expect( 'get_query_var' )->with( 'day' )->once()->andReturn( 2 );
@@ -1026,8 +897,7 @@ class Meta_Tags_Context_Test extends TestCase {
 
 		Functions\expect( 'get_posts' )->once()->with(
 			[
-				'paged'          => 1,
-				'posts_per_page' => 10,
+				'posts_per_page' => 1,
 				'year'           => 2022,
 				'monthnum'       => 11,
 				'day'            => 2,
@@ -1037,16 +907,13 @@ class Meta_Tags_Context_Test extends TestCase {
 				(object) [
 					'ID' => 5,
 				],
-				(object) [
-					'ID' => 6,
-				],
 			]
 		);
 
 		Functions\expect( 'has_post_thumbnail' )->with( 5 )->andReturn( true );
 		Functions\expect( 'get_post_thumbnail_id' )->with( 5 )->andReturn( 23 );
 
-		$this->assertEquals( $this->instance->generate_main_image_id(), 23 );
+		$this->assertEquals( 23, $this->instance->generate_main_image_id() );
 	}
 
 	/**
@@ -1059,14 +926,11 @@ class Meta_Tags_Context_Test extends TestCase {
 			'object_type' => 'user',
 		];
 
-		$this->instance->current_page   = 1;
-		$this->instance->posts_per_page = 10;
-		$this->instance->id             = 12;
+		$this->instance->id = 12;
 
 		Functions\expect( 'get_posts' )->once()->with(
 			[
-				'paged'          => 1,
-				'posts_per_page' => 10,
+				'posts_per_page' => 1,
 				'author'         => 12,
 			]
 		)->andReturn(
@@ -1074,16 +938,13 @@ class Meta_Tags_Context_Test extends TestCase {
 				(object) [
 					'ID' => 5,
 				],
-				(object) [
-					'ID' => 6,
-				],
 			]
 		);
 
 		Functions\expect( 'has_post_thumbnail' )->with( 5 )->andReturn( true );
 		Functions\expect( 'get_post_thumbnail_id' )->with( 5 )->andReturn( 23 );
 
-		$this->assertEquals( $this->instance->generate_main_image_id(), 23 );
+		$this->assertEquals( 23, $this->instance->generate_main_image_id() );
 	}
 
 	/**
@@ -1096,7 +957,7 @@ class Meta_Tags_Context_Test extends TestCase {
 			'object_type' => 'unsupported',
 		];
 
-		$this->assertEquals( $this->instance->generate_main_image_id(), null );
+		$this->assertEquals( null, $this->instance->generate_main_image_id() );
 	}
 
 	/**

--- a/tests/unit/context/meta-tags-context-test.php
+++ b/tests/unit/context/meta-tags-context-test.php
@@ -11,6 +11,7 @@ use Yoast\WP\SEO\Context\Meta_Tags_Context;
 use Yoast\WP\SEO\Helpers\Image_Helper;
 use Yoast\WP\SEO\Helpers\Indexable_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
+use Yoast\WP\SEO\Helpers\Pagination_Helper;
 use Yoast\WP\SEO\Helpers\Permalink_Helper;
 use Yoast\WP\SEO\Helpers\Schema\ID_Helper;
 use Yoast\WP\SEO\Helpers\Site_Helper;
@@ -99,6 +100,13 @@ class Meta_Tags_Context_Test extends TestCase {
 	private $indexable_repository;
 
 	/**
+	 * The pagination helper.
+	 *
+	 * @var Pagination_Helper
+	 */
+	private $pagination_helper;
+
+	/**
 	 * The meta tags context.
 	 *
 	 * @var Meta_Tags_Context
@@ -121,6 +129,7 @@ class Meta_Tags_Context_Test extends TestCase {
 		$this->permalink_helper     = Mockery::mock( Permalink_Helper::class );
 		$this->indexable_helper     = Mockery::mock( Indexable_Helper::class );
 		$this->indexable_repository = Mockery::mock( Indexable_Repository::class );
+		$this->pagination_helper    = Mockery::mock( Pagination_Helper::class );
 
 		$this->instance = new Meta_Tags_Context(
 			$this->options,
@@ -132,7 +141,8 @@ class Meta_Tags_Context_Test extends TestCase {
 			$this->user,
 			$this->permalink_helper,
 			$this->indexable_helper,
-			$this->indexable_repository
+			$this->indexable_repository,
+			$this->pagination_helper
 		);
 	}
 

--- a/tests/unit/context/meta-tags-context-test.php
+++ b/tests/unit/context/meta-tags-context-test.php
@@ -907,7 +907,7 @@ class Meta_Tags_Context_Test extends TestCase {
 				'posts_per_page' => 10,
 				'tax_query'      => [
 					[
-						'taxonomy'         => 'custom_post_type',
+						'taxonomy'         => 'custom_term',
 						'field'            => 'term_id',
 						'terms'            => 18,
 						'include_children' => true,


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

The `thumbnailUrl` is missing in the schema for REST requests and this has to do with the way we generate the image ID for the main image of a page in `meta-tags-context.php`. We are currently using the ID in `meta-tags-context` ambiguously and we are also relying on the global `$wp_query`. This causes the `thumbnailUrl` to not exist for REST requests as `$wp_query` can't be used. This PR refactors `generate_main_image_id` to rely upon the indexable in `meta-tags-context` such that it can also be used for REST requests.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fix a bug where the `thumbnailUrl` was no longer present in Yoast SEO data for REST requests.

## Relevant technical choices:

* The main image of a home page is either the main image of the post if the home page is set to display a certain post OR it is the first main image that can be found for the posts that are being loaded on the home page (if the home page is set to display the most recent posts).
* For all archive pages, the main image of the page is the main image of the first post in that archive.
* The main image for a post is either the thumbnail image (if it exists) or the first image that can be found inside the post content.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

For all the steps below, compare the image that is stated to the image inside the `primaryImageOfPage` property inside the schema data.

*Testing archive pages*
Also for all archive pages, the `primaryImageOfPage` property in the schema should be:

- The main image of the first post in the archive page (on page one).

Test whether the main image is correctly displayed for posts.

* Create a new post and add a thumbnail image. Remember the URL of the image you added.
* Save the post and check the HTML source of the post. Verify that `primaryImageOfPage` is set to the same URL as the thumbnail image.
* Now remove the thumbnail image from the post and add a content image.
* Save the post and check the HTML source of the post. Verify that `primaryImageOfPage` is set to the same URL as the content image.

Also repeat these steps for a custom post type.

Test whether the main image is correctly displayed for a system page.

* Go to a non-existing page.
* Verify that the `primaryImageOfPage` is not set.
* Head on over to a search page (such as `/search/bla`).
* Verify that the `primaryImageOfPage` is not set.

Test whether the main image is correctly displayed for the home page.

* Make sure that the setting under Settings -> Reading -> Your homepage displays is set to `Your latest posts`.
* Go to your home page, verify that the `primaryImageOfPage` attribute is set to the image based on an archive page (see above).
* Now set the setting under Settings -> Reading -> Your homepage displays to `A static page (select below)`.
* Go to your home page and verify that the `primaryImageOfPage` attribute is set to the main image of the page you selected above (so either the thumbnail URL of the page or the first image found in the page's content).

Test whether the main image is correctly displayed for term archives.

* Go to a term archive page (so for example `/category/cats/`).
* Verify that the `primaryImageOfPage` attribute is set to the image based on an archive page (see above).
* Now go to the second page of the term archive (so for example `/category/cats/page/2/`).
* Verify that the `primaryImageOfPage` is the same as before.

Also test this for a custom term.

Test whether the main image is correctly displayed for post type archives.

* Create a custom post type using, for example, Custom Post Type UI.
* Create a custom post type with archive pages enabled.
* Create some posts for the custom post type (at least 11, so that there are two pages). Also add images to these posts.
* Go to the post type archive page (so for example `/[your-post-type-slug]/`).
* Verify that the `primaryImageOfPage` attribute is set to the image based on an archive page (see above).
* Now go to the second page of the term archive (so for example `/[your-post-type-slug]/page/2/`).
* Verify that the `primaryImageOfPage` is the same as before.

Test whether the main image is correctly displayed for date archives.

* Go to a date archive page (so for example `/2022/`).
* Verify that the `primaryImageOfPage` attribute is set to the image based on an archive page (see above).
* Now go to the second page of the term archive (so for example `/2022/page/2/`).
* Verify that the `primaryImageOfPage` is the same as before.

Also test this for month archives (for example `/2022/10/`) and day archives (for example `/2022/10/31/`).

Test whether the main image is correctly displayed for author archives.

* Go to an author archive page (such as `/author/[username]/`).
* Verify that the `primaryImageOfPage` attribute is set to the image based on an archive page (see above).
* Now go to the second page of the author archive (so for example `/author/[username]/page/2/`).
* Verify that the `primaryImageOfPage` is the same as before.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* This PR affects the main image generation part of the plugin. It might be that we use this in other parts of the plugin as well.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes #19049, [IM-2045](https://yoast.atlassian.net/browse/IM-2045)
