### PR TITLE
Hackaton/di improvements

### DIFF
--- a/config/dependency-injection/loader-pass.php
+++ b/config/dependency-injection/loader-pass.php
@@ -12,7 +12,7 @@ use Yoast\WP\SEO\Initializers\Initializer_Interface;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
 use Yoast\WP\SEO\Loader;
 use Yoast\WP\SEO\Routes\Route_Interface;
-
+use Yoast\WP\SEO\Conditionals\Conditional;
 /**
  * A pass is a step in the compilation process of the container.
  *
@@ -53,20 +53,51 @@ class Loader_Pass implements CompilerPassInterface {
 	private function process_definition( Definition $definition, Definition $loader_definition ) {
 		$class = $definition->getClass();
 
+		$reflect = new ReflectionClass( $class );
+		$path    = $reflect->getFileName();
+		if( strpos($path, 'wordpress-seo/src/helpers') ||
+			strpos($path, 'wordpress-seo/src/surfaces') ||
+			strpos($path, 'wordpress-seo/src/actions') ||
+			strpos($path, 'wordpress-seo/src/builders') ||
+			strpos($path, 'wordpress-seo/src/config') ||
+			strpos($path, 'wordpress-seo/src/generators') ||
+			strpos($path, 'wordpress-seo/src/integrations') ||
+			strpos($path, 'wordpress-seo/src/logger') ||
+			strpos($path, 'wordpress-seo/src/loader') ||
+			strpos($path, 'wordpress-seo/src/memoizers') ||
+			strpos($path, 'wordpress-seo/src/presentations') ||
+			strpos($path, 'wordpress-seo/src/repositories') ||
+			strpos($path, 'wordpress-seo/src/services') ||
+			strpos($path, 'wordpress-seo/src/schema-templates') ||
+			strpos($path, 'wordpress-seo/src/wrappers') ||
+			strpos($path, 'wordpress-seo/src/context') ||
+			strpos($path, 'wordpress-seo/src/values')
+			) {
+			$definition->setPublic( true );
+		}
+
+		if ( is_subclass_of( $class, Conditional::class ) ) {
+			$definition->setPublic( true );
+		}
+
 		if ( \is_subclass_of( $class, Initializer_Interface::class ) ) {
 			$loader_definition->addMethodCall( 'register_initializer', [ $class ] );
+			$definition->setPublic( true );
 		}
 
 		if ( \is_subclass_of( $class, Integration_Interface::class ) ) {
 			$loader_definition->addMethodCall( 'register_integration', [ $class ] );
+			$definition->setPublic( true );
 		}
 
 		if ( \is_subclass_of( $class, Route_Interface::class ) ) {
 			$loader_definition->addMethodCall( 'register_route', [ $class ] );
+			$definition->setPublic( true );
 		}
 
 		if ( \is_subclass_of( $class, Command_Interface::class ) ) {
 			$loader_definition->addMethodCall( 'register_command', [ $class ] );
+			$definition->setPublic( true );
 		}
 
 		if ( \is_subclass_of( $class, Migration::class ) ) {
@@ -76,6 +107,7 @@ class Loader_Pass implements CompilerPassInterface {
 			$version = \explode( '_', $file )[0];
 			$plugin  = $class::$plugin;
 			$loader_definition->addMethodCall( 'register_migration', [ $plugin, $version, $class ] );
+			$definition->setPublic( true );
 		}
 	}
 }

--- a/config/dependency-injection/loader-pass.php
+++ b/config/dependency-injection/loader-pass.php
@@ -53,27 +53,31 @@ class Loader_Pass implements CompilerPassInterface {
 	private function process_definition( Definition $definition, Definition $loader_definition ) {
 		$class = $definition->getClass();
 
-		$reflect = new ReflectionClass( $class );
-		$path    = $reflect->getFileName();
-		if( strpos($path, 'wordpress-seo/src/helpers') ||
-			strpos($path, 'wordpress-seo/src/surfaces') ||
-			strpos($path, 'wordpress-seo/src/actions') ||
-			strpos($path, 'wordpress-seo/src/builders') ||
-			strpos($path, 'wordpress-seo/src/config') ||
-			strpos($path, 'wordpress-seo/src/generators') ||
-			strpos($path, 'wordpress-seo/src/integrations') ||
-			strpos($path, 'wordpress-seo/src/logger') ||
-			strpos($path, 'wordpress-seo/src/loader') ||
-			strpos($path, 'wordpress-seo/src/memoizers') ||
-			strpos($path, 'wordpress-seo/src/presentations') ||
-			strpos($path, 'wordpress-seo/src/repositories') ||
-			strpos($path, 'wordpress-seo/src/services') ||
-			strpos($path, 'wordpress-seo/src/schema-templates') ||
-			strpos($path, 'wordpress-seo/src/wrappers') ||
-			strpos($path, 'wordpress-seo/src/context') ||
-			strpos($path, 'wordpress-seo/src/values')
-			) {
-			$definition->setPublic( true );
+		try {
+			$reflect = new ReflectionClass( $class );
+			$path    = $reflect->getFileName();
+			if( strpos($path, 'wordpress-seo/src/helpers') ||
+				strpos($path, 'wordpress-seo/src/surfaces') ||
+				strpos($path, 'wordpress-seo/src/actions') ||
+				strpos($path, 'wordpress-seo/src/builders') ||
+				strpos($path, 'wordpress-seo/src/config') ||
+				strpos($path, 'wordpress-seo/src/generators') ||
+				strpos($path, 'wordpress-seo/src/integrations') ||
+				strpos($path, 'wordpress-seo/src/logger') ||
+				strpos($path, 'wordpress-seo/src/loader') ||
+				strpos($path, 'wordpress-seo/src/memoizers') ||
+				strpos($path, 'wordpress-seo/src/presentations') ||
+				strpos($path, 'wordpress-seo/src/repositories') ||
+				strpos($path, 'wordpress-seo/src/services') ||
+				strpos($path, 'wordpress-seo/src/schema-templates') ||
+				strpos($path, 'wordpress-seo/src/wrappers') ||
+				strpos($path, 'wordpress-seo/src/context') ||
+				strpos($path, 'wordpress-seo/src/values')
+				) {
+				$definition->setPublic( true );
+			}
+		} catch ( \Exception $e){
+			
 		}
 
 		if ( is_subclass_of( $class, Conditional::class ) ) {

--- a/config/dependency-injection/services.php
+++ b/config/dependency-injection/services.php
@@ -73,7 +73,7 @@ $yoast_seo_base_definition = new Definition();
 $yoast_seo_base_definition
 	->setAutowired( true )
 	->setAutoconfigured( true )
-	->setPublic( true );
+	->setPublic( false );
 
 /**
  * Holds the dependency injection loader.

--- a/src/schema/application/generate-search-result-schema-piece-handler.php
+++ b/src/schema/application/generate-search-result-schema-piece-handler.php
@@ -1,0 +1,13 @@
+<?php
+namespace Yoast\WP\SEO\Schema\Application;
+
+use Yoast\WP\SEO\Schema\Application\Generate_Search_Result_Schema_Piece;
+use Yoast\WP\SEO\Schema\Domain\Search_Result_Schema_Piece;
+
+class Generate_Search_Result_Schema_Piece_Handler {
+
+	public function __invoke( Generate_Search_Result_Schema_Piece $command ) {
+		 return new Search_Result_Schema_Piece( $command->get_search_term() );
+	}
+
+}

--- a/src/schema/application/generate-search-result-schema-piece.php
+++ b/src/schema/application/generate-search-result-schema-piece.php
@@ -1,0 +1,20 @@
+<?php
+namespace Yoast\WP\SEO\Schema\Application;
+
+use Yoast\WP\SEO\Schema\Domain\Search_Term;
+
+class Generate_Search_Result_Schema_Piece {
+
+	private $search_term;
+	/**
+	 * @param string $query The query.
+	 */
+	public function __construct( $search_term ) {
+		$this->search_term = new Search_Term( $search_term );
+	}
+
+	public function get_search_term() {
+		return $this->search_term;
+	}
+
+}

--- a/src/schema/domain/search-result-schema-piece.php
+++ b/src/schema/domain/search-result-schema-piece.php
@@ -1,0 +1,29 @@
+<?php
+namespace Yoast\WP\SEO\Schema\Domain;
+
+use Yoast\WP\SEO\Generators\Schema\Abstract_Schema_Piece;
+use Yoast\WP\SEO\Schema\Domain\Search_Term;
+
+class Search_Result_Schema_Piece extends Abstract_Schema_Piece {
+
+	private $search_term;
+
+	public function __construct( Search_Term $search_term ) {
+		$this->search_term = $search_term;
+	}
+	public function generate() {
+		$data   = [
+			'@type'            => "SearchAction",
+			'actionStatus'     => "https://schema.org/CompletedActionStatus",
+			'query'            => $this->search_term->get_query(),
+			'result'           => [ '@id' => $this->context->main_schema_id ]
+		];
+
+		return $data;
+	}
+
+	public function is_needed()
+	{
+		return true;
+	}
+}

--- a/src/schema/domain/search-term.php
+++ b/src/schema/domain/search-term.php
@@ -1,0 +1,17 @@
+<?php
+namespace Yoast\WP\SEO\Schema\Domain;
+
+class Search_Term {
+	private $query;
+
+	/**
+	 * @param string $query The query.
+	 */
+	public function __construct( $query ) {
+		$this->query = $query;
+	}
+
+	public function get_query() {
+		return $this->query;
+	}
+}

--- a/src/schema/framework/search-result-integration.php
+++ b/src/schema/framework/search-result-integration.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Yoast\WP\SEO\Schema\Framework;
+
+use Yoast\WP\SEO\Schema\Domain\Search_Result_Schema_Piece;
+use Yoast\WP\SEO\Schema\Application\Generate_Search_Result_Schema_Piece_Handler;
+use Yoast\WP\SEO\Schema\Application\Generate_Search_Result_Schema_Piece;
+use Yoast\WP\SEO\Integrations\Integration_Interface;
+use Yoast\WP\SEO\Helpers\Current_Page_Helper;
+use Yoast\WP\SEO\Conditionals\Front_End_Conditional;
+
+class Search_Result_Integration implements Integration_Interface {
+
+
+	/**
+	 * The current page helper.
+	 *
+	 * @var Current_Page_Helper
+	 */
+	private $current_page_helper;
+
+	private $handler;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_conditionals() {
+		return [ Front_End_Conditional::class ];
+	}
+
+	public function __construct ( Current_Page_Helper $current_page_helper, 
+		Generate_Search_Result_Schema_Piece_Handler $handler ) {
+		$this->current_page_helper = $current_page_helper;
+		$this->handler = $handler;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function register_hooks() {
+		\add_filter( 'wpseo_schema_graph_pieces', [ $this, 'add_search_result_schema_piece' ], 10, 2 );
+	}
+
+	public function add_search_result_schema_piece( $graph, $context ) {
+		if ( $this->current_page_helper->is_search_result() ) {
+			$graph[] = ( $this->handler )( new Generate_Search_Result_Schema_Piece( \get_search_query() ) );
+		}
+
+		return $graph;
+	}
+}
+


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to add a `searchAction` piece to the schema graph upon a successfully performed search action

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds an integration to generate a `searchAction` schema piece for search results pages.

## Relevant technical choices:

* The DI container has been updated to allow for objects that should not be autwired
* A completely new directory structure has been implemented following the DDD paradigm 
* In the DI container all the classes are now registered as non-public and made public later, to ensure backward compatibility

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Perform a search in the frontend of your site
* View the source code of the page and verify in the schema you have the `searchAction` schema piece, e.g.:
```
{
	            "@type": "SearchAction",
	            "actionStatus": "https://schema.org/CompletedActionStatus",
	            "query": "hello",
	            "result": {
	                "@id": "https://basic.wordpress.test/?s=hello"
	            }
	        }
```

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes #
