### PR TITLE
Update to use new V2 TEC functions

### DIFF
--- a/src/generators/schema/third-party/events-calendar-schema.php
+++ b/src/generators/schema/third-party/events-calendar-schema.php
@@ -228,8 +228,8 @@ class Events_Calendar_Schema extends Abstract_Schema_Piece {
 
 		$args = [
 			'eventDisplay'   => 'custom',
-			'start_date'     => Tribe__Events__Template__Month::calculate_first_cell_date( $month ),
-			'end_date'       => Tribe__Events__Template__Month::calculate_final_cell_date( $month ),
+			'start_date'     => \Tribe\Events\Views\V2\Views\Month_View::calculate_first_cell_date( $event_date ),
+			'end_date'       => \Tribe\Events\Views\V2\Views\Month_View::calculate_final_cell_date( $event_date ),
 			'posts_per_page' => -1,
 			'hide_upcoming'  => true,
 		];


### PR DESCRIPTION


## Context

Fixes https://wordpress.org/support/topic/the-events-calendar-6-0-conflict/#post-16142388

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->

**calculate_first_cell_date** and **calculate_final_cell_date from** class **Tribe__Events__Template__Month** are both deprecated since TEC 6.0. Change the calls to \Tribe\Events\Views\V2\Views\Month_View::calculate_first_cell_date and \Tribe\Events\Views\V2\Views\Month_View::calculate_final_cell_date

## Quality assurance

* [x] I have tested this code to the best of my abilities

