### PR TITLE
Pc 910 internal linking upsell help article link should not be disabled

### DIFF
--- a/admin/class-expose-shortlinks.php
+++ b/admin/class-expose-shortlinks.php
@@ -39,6 +39,7 @@ class WPSEO_Expose_Shortlinks implements WPSEO_WordPress_Integration {
 		'shortlinks.upsell.sidebar.additional_button'               => 'https://yoa.st/add-keywords-sidebar',
 		'shortlinks.upsell.sidebar.keyphrase_distribution'          => 'https://yoa.st/keyphrase-distribution-sidebar',
 		'shortlinks.upsell.sidebar.word_complexity'                 => 'https://yoa.st/word-complexity-sidebar',
+		'shortlinks.upsell.sidebar.site_structure'                  => 'https://yoa.st/site-structure-sidebar-upsell',
 		'shortlinks.upsell.metabox.news'                            => 'https://yoa.st/get-news-metabox',
 		'shortlinks.upsell.metabox.go_premium'                      => 'https://yoa.st/pe-premium-page',
 		'shortlinks.upsell.metabox.focus_keyword_synonyms_link'     => 'https://yoa.st/textlink-synonyms-popup-metabox',
@@ -50,6 +51,8 @@ class WPSEO_Expose_Shortlinks implements WPSEO_WordPress_Integration {
 		'shortlinks.upsell.metabox.additional_button'               => 'https://yoa.st/add-keywords-metabox',
 		'shortlinks.upsell.metabox.keyphrase_distribution'          => 'https://yoa.st/keyphrase-distribution-metabox',
 		'shortlinks.upsell.metabox.word_complexity'                 => 'https://yoa.st/word-complexity-metabox',
+		'shortlinks.upsell.metabox.site_structure'                  => 'https://yoa.st/site-structure-metabox-upsell',
+		'shortlinks.upsell.elementor.site_structure'                => 'https://yoa.st/site-structure-elementor-upsell',
 		'shortlinks.upsell.gsc.create_redirect_button'              => 'https://yoa.st/redirects',
 		'shortlinks.readability_analysis_info'                      => 'https://yoa.st/readability-analysis',
 		'shortlinks.activate_premium_info'                          => 'https://yoa.st/activate-subscription',
@@ -77,6 +80,7 @@ class WPSEO_Expose_Shortlinks implements WPSEO_WordPress_Integration {
 		'shortlinks-insights-upsell-elementor-text_formality'       => 'https://yoa.st/formality-upsell-elementor',
 		'shortlinks-insights-text_formality_info_free'              => 'https://yoa.st/formality-free',
 		'shortlinks-insights-text_formality_info_premium'           => 'https://yoa.st/formality',
+
 	];
 
 	/**

--- a/packages/js/src/components/link-suggestions.js
+++ b/packages/js/src/components/link-suggestions.js
@@ -1,3 +1,4 @@
+/* global wpseoAdminL10n */
 import PropTypes from "prop-types";
 
 import styled from "styled-components";
@@ -6,22 +7,6 @@ import { createInterpolateElement } from "@wordpress/element";
 import { makeOutboundLink } from "@yoast/helpers";
 
 import LinkSuggestion from "./link-suggestion";
-
-const introMessage =  createInterpolateElement(
-	sprintf(
-		/**
-		 * translators: %1$s expands to an opening anchor tag.
-		 * %2$s expands to a closing anchor tag.
-		 */
-		__( "To improve your site structure, consider linking to other relevant posts or pages on your website. %1$sRead our guide on internal linking for SEO%2$s to learn more.", "wordpress-seo" ),
-		"<a>",
-		"</a>"
-	),
-	{
-		// eslint-disable-next-line jsx-a11y/anchor-has-content, jsx-a11y/anchor-is-valid
-		a: <a href="#" target="_blank" rel="noreferrer" style={ { cursor: "default", pointerEvents: "none" } } />,
-	}
-);
 
 const OutboundLink = makeOutboundLink();
 const upsellLink = "https://yoa.st/link-suggestions-upsell";
@@ -43,6 +28,23 @@ const suggestions = [
  * @returns {void}
  */
 const LinkSuggestions = ( { location } ) => {
+	const shortlinkKey = `shortlinks.upsell.${location}.site_structure`;
+	const introMessage =  createInterpolateElement(
+		sprintf(
+			/**
+			 * translators: %1$s expands to an opening anchor tag.
+			 * %2$s expands to a closing anchor tag.
+			 */
+			__( "To improve your site structure, consider linking to other relevant posts or pages on your website. %1$sRead our guide on internal linking for SEO%2$s to learn more.", "wordpress-seo" ),
+			"<a>",
+			"</a>"
+		),
+		{
+			// eslint-disable-next-line jsx-a11y/anchor-has-content, jsx-a11y/anchor-is-valid
+			a: <a href={ wpseoAdminL10n[ shortlinkKey ] } target="_blank" rel="noreferrer" />,
+		}
+	);
+
 	const additionalStyle = { minHeight: "revert", maxHeight: "30px" };
 	if ( location === "metabox" ) {
 		additionalStyle.marginTop = "8px";
@@ -57,11 +59,9 @@ const LinkSuggestions = ( { location } ) => {
 				) }
 				<span aria-hidden="true" className="yoast-button-upsell__caret" />
 			</OutboundLink>
+			<p style={ { marginTop: 10 } }>{ introMessage }</p>
 			<div style={ { opacity: 0.5 } }>
-				<p style={ { marginTop: 10 } }>{ introMessage }</p>
-				<div>
-					{ suggestions.map( ( suggestion, key ) => <LinkSuggestion key={ key } { ...suggestion } /> ) }
-				</div>
+				{ suggestions.map( ( suggestion, key ) => <LinkSuggestion key={ key } { ...suggestion } /> ) }
 			</div>
 		</LinkSuggestionsWrapper>
 	);

--- a/packages/js/src/elementor/components/fills/ElementorFill.js
+++ b/packages/js/src/elementor/components/fills/ElementorFill.js
@@ -72,7 +72,7 @@ export default function ElementorFill( { isLoading, onLoad, settings } ) {
 					<SidebarCollapsible
 						title={ __( "Internal linking suggestions", "wordpress-seo" ) }
 					>
-						<LinkSuggestions />
+						<LinkSuggestions location="elementor" />
 					</SidebarCollapsible>
 				</SidebarItem> }
 				<SidebarItem renderPriority={ 25 }>


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to make the link related to the site structure guide in the `Internal linking suggestion` upsell clickable.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Makes the link to to the site structure guide in the `Internal linking suggestion` upsell clickable.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Make sure you don't have Yoast Seo Premium activated
* Go to a post, in the sidebar click on `Internal linking suggestions` and verify that:
  * The introductory paragraph is displayed with full opacity
  * The link is clickable
  * The link points to https://yoa.st/site-structure-sidebar-upsell
  * The link has tracking parameters
<img width="306" alt="Screenshot 2022-10-31 at 16 52 45" src="https://user-images.githubusercontent.com/68744851/199052440-f838927e-6cbf-48ca-9776-11c09636df02.png">

* Now perform the same checks in the metabox:
  * The link here should point to https://yoa.st/site-structure-metabox-upsell
<img width="653" alt="Screenshot 2022-10-31 at 16 57 53" src="https://user-images.githubusercontent.com/68744851/199052539-265ed039-5689-4a74-bc7b-e56eee26e4d2.png">

* Make sure you have Elementor activated
* Go to a post and edit it with Elementor
* In the Yoast section of the sidebar click on `Internal linking suggestions` and verify that:
  * The introductory paragraph is displayed with full opacity
  * The link is clickable
  * The link points to https://yoa.st/site-structure-elementor-upsell
  * The link has tracking parameters
<img width="415" alt="Screenshot 2022-10-31 at 16 58 30" src="https://user-images.githubusercontent.com/68744851/199052723-8b25dca0-cd87-4bac-a5cf-d503cb59f6f6.png">

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [X] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [X] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.

Fixes [PC-910](https://yoast.atlassian.net/browse/PC-910)
