### PR TITLE
Filter admin tracking data for Local SEO

### DIFF
--- a/admin/tracking/class-tracking-addon-data.php
+++ b/admin/tracking/class-tracking-addon-data.php
@@ -54,7 +54,7 @@ class WPSEO_Tracking_Addon_Data implements WPSEO_Collection {
 		$addon_manager  = new WPSEO_Addon_Manager();
 
 		if ( $addon_manager->is_installed( WPSEO_Addon_Manager::LOCAL_SLUG ) ) {
-			$addon_settings = $this->get_addon_settings( $addon_settings, 'wpseo_local', WPSEO_Addon_Manager::LOCAL_SLUG, $this->local_include_list );
+			$addon_settings = $this->get_local_addon_settings( $addon_settings, 'wpseo_local', WPSEO_Addon_Manager::LOCAL_SLUG, $this->local_include_list );
 		}
 
 		if ( $addon_manager->is_installed( WPSEO_Addon_Manager::WOOCOMMERCE_SLUG ) ) {
@@ -83,8 +83,31 @@ class WPSEO_Tracking_Addon_Data implements WPSEO_Collection {
 	 * @return array
 	 */
 	public function get_addon_settings( array $addon_settings, $source_name, $slug, $option_include_list ) {
-		$source_options          = get_option( $source_name );
-		$addon_settings[ $slug ] = array_intersect_key( $source_options, array_flip( $option_include_list ) );
+		$source_options          = \get_option( $source_name );
+		$addon_settings[ $slug ] = \array_intersect_key( $source_options, \array_flip( $option_include_list ) );
+
+		return $addon_settings;
+	}
+
+	/**
+	 * Filter business_type in local addon settings.
+	 *
+	 * Remove the business_type setting when 'multiple_locations_shared_business_info' setting is turned off.
+	 *
+	 * @param array  $addon_settings      The current list of addon settings.
+	 * @param string $source_name         The option key of the addon.
+	 * @param string $slug                The addon slug.
+	 * @param array  $option_include_list All the options to be included in tracking.
+	 *
+	 * @return array
+	 */
+	public function get_local_addon_settings( array $addon_settings, $source_name, $slug, $option_include_list ) {
+		$source_options          = \get_option( $source_name );
+		$addon_settings[ $slug ] = \array_intersect_key( $source_options, \array_flip( $option_include_list ) );
+
+		if ( \key_exists( 'multiple_locations_shared_business_info', $source_options ) && \key_exists( 'business_type', $addon_settings[ $slug ] ) && $source_options['multiple_locations_shared_business_info'] === 'off' ) {
+			unset( $addon_settings[ $slug ]['business_type'] );
+		}
 
 		return $addon_settings;
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* When `Locations inherit shared business info` is set to `off` in Local SEO, the `business_type` should not get added to the addon data but it is.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Remove `business_type` from addon tracking data when `Locations inherit shared business info` is turned off.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Activate Yoast SEO and Yoast Local SEO.
* Go to Yoast SEO -> Local SEO
* Set `My business has multiple locations` to `on`.
* Set `All locations are part of the same business` to `on`.
* Set `Locations inherit shared business info` to `on`
* Set `Business type` to `Preschool` (for example).
* Add the following piece of code to `admin/class-admin.php` in Yoast SEO at the end of the constructor:
```
if ( filter_input( INPUT_GET, 'action' ) === 'test' ) {
	$collector = new WPSEO_Collector();
	$collector->add_collection( new WPSEO_Tracking_Addon_Data() );
	echo '<pre>';
	print_r( $collector->collect() );
	echo '</pre>';
        die;
}
```
* Head over to `/wp-admin/admin.php?page=wpseo_dashboard&action=test` and verity that `business_type` is set to `Preschool`.
* Now set `Locations inherit shared business info` to `off`.
* Reload `/wp-admin/admin.php?page=wpseo_dashboard&action=test` and verify that `business_type` does not exist in the array.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes [PC-918](https://yoast.atlassian.net/browse/PC-918)
