### PR TITLE
Improve consistency with indexable builders

### DIFF
--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -1377,9 +1377,7 @@ class WPSEO_Upgrade {
 
 		$indexable_table = Model::get_table_name( 'Indexable' );
 
-		$post_type_helper = \YoastSEO()->helpers->post_type;
-
-		$included_post_types = \array_diff( $post_type_helper->get_accessible_post_types(), $post_type_helper->get_excluded_post_types_for_indexables() );
+		$included_post_types = \YoastSEO()->helpers->post_type->get_indexable_post_types();
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Reason: Too hard to fix.
 		if ( empty( $included_post_types ) ) {
@@ -1424,7 +1422,7 @@ class WPSEO_Upgrade {
 
 		$indexable_table = Model::get_table_name( 'Indexable' );
 
-		$included_taxonomies = \YoastSEO()->helpers->taxonomy->get_public_taxonomies();
+		$included_taxonomies = \YoastSEO()->helpers->taxonomy->get_indexable_taxonomies();
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Reason: Too hard to fix.
 		if ( empty( $included_taxonomies ) ) {

--- a/src/integrations/cleanup-integration.php
+++ b/src/integrations/cleanup-integration.php
@@ -342,7 +342,7 @@ class Cleanup_Integration implements Integration_Interface {
 		global $wpdb;
 		$indexable_table = Model::get_table_name( 'Indexable' );
 
-		$included_post_types = \array_diff( $this->post_type->get_accessible_post_types(), $this->post_type->get_excluded_post_types_for_indexables() );
+		$included_post_types = $this->post_type->get_indexable_post_types();
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Reason: Too hard to fix.
 		if ( empty( $included_post_types ) ) {
@@ -385,7 +385,7 @@ class Cleanup_Integration implements Integration_Interface {
 		global $wpdb;
 		$indexable_table = Model::get_table_name( 'Indexable' );
 
-		$included_taxonomies = $this->taxonomy->get_public_taxonomies();
+		$included_taxonomies = $this->taxonomy->get_indexable_taxonomies();
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Reason: Too hard to fix.
 		if ( empty( $included_taxonomies ) ) {

--- a/tests/unit/integrations/cleanup-integration-test.php
+++ b/tests/unit/integrations/cleanup-integration-test.php
@@ -504,8 +504,7 @@ class Cleanup_Integration_Test extends TestCase {
 	 * @return void
 	 */
 	private function setup_clean_indexables_for_non_publicly_viewable_post( $return_value, $limit ) {
-		$this->post_type->expects( 'get_accessible_post_types' )->once()->andReturns( [ 'my_cpt', 'post', 'page', 'attachment' ] );
-		$this->post_type->expects( 'get_excluded_post_types_for_indexables' )->once()->andReturns( [ 'page', 'something else' ] );
+		$this->post_type->expects( 'get_indexable_post_types' )->once()->andReturns( [ 'my_cpt', 'post', 'attachment' ] );
 		$this->wpdb->shouldReceive( 'prepare' )
 			->once()
 			->with(
@@ -533,7 +532,7 @@ class Cleanup_Integration_Test extends TestCase {
 	 * @return void
 	 */
 	private function setup_clean_indexables_for_non_publicly_viewable_taxonomies( $return_value, $limit ) {
-		$this->taxonomy->expects( 'get_public_taxonomies' )->once()->andReturns( [ 'category', 'post_tag', 'my_custom_tax' ] );
+		$this->taxonomy->expects( 'get_indexable_taxonomies' )->once()->andReturns( [ 'category', 'post_tag', 'my_custom_tax' ] );
 
 		$this->wpdb->shouldReceive( 'prepare' )
 			->once()


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Since the cleanup and upgrade routine have been introduced, a new helper functions were added. They are a better fit for what we're trying to do.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where the post_format indexable would not be removed when updating the plugin while post_format archives are disabled. 

## Relevant technical choices:

* n/a

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

👉 Start testing without having this branch checkedout yet

1. In the search appearance settings, make sure post_format archives are disabled.
2. Perform a full reindex on the latest release (wp yoast index --reindex --skip-confirmation).
3. Verify that there are post_format indexables in the indexables table the database `*`.
4. checkout this branch.
5. Refresh any page. This runs the upgrade routines (if you have already ran the upgrade routines for 19.10 once, you might need to reset the plugin version number with the Yoast test helper plugin).
6. Verify that there are no more post_format indexables left in the indexables table the database.

`*` To make sure you get those indexables, make sure the following lines are in your `functions.php`
```
add_theme_support( 'post-formats', array( 'aside', 'gallery', 'link' ) );
add_post_type_support( 'post', 'post-formats' );
```
#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* 

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The removal of indexables of non-public objects should be retested. (see https://github.com/Yoast/wordpress-seo/pull/19077 for examples).

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes PC-930
