### PR TITLE
Don't overwrite author_id with indexable id

### DIFF
--- a/src/builders/indexable-builder.php
+++ b/src/builders/indexable-builder.php
@@ -363,12 +363,8 @@ class Indexable_Builder {
 					// Save indexable, to make sure that it can be queried when determining if an author has public posts.
 					$indexable = $this->save_indexable( $indexable, $indexable_before );
 
-					$author_indexable = $this->maybe_build_author_indexable( $indexable->author_id );
+					$this->maybe_build_author_indexable( $indexable->author_id );
 
-					if ( $author_indexable ) {
-						// Set author ID.
-						$indexable->author_id = $author_indexable->id;
-					}
 					break;
 
 				case 'user':


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* After a recent change the author_id was overwitten with the indexable_id of the author. This is incorrect

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes and unreleased bug where post indexables would get the incorrect author_id when the author has an archive.

## Relevant technical choices:

* n/a

## Reproduction steps
1. have a publicly viewable posttype (posts will do just fine).
2. Have author archives enabled.
3. Create a new user and give them the admin role (or something else that can publish posts, but it doesn't matter)
4. While still logged in with your user, create a new post, and before publishing, change the author of the post to your new user.
5. Publish the post
6. Check the database: the indexable record for the new post now has an author_id of the wrong user (it equals the id of the _indexable_ of the author instead of their WP user id).
7. Visit the author archive of the new user. (/author/author-name)
8. On trunk or release/19.11, without this PR, this page has `no-index, follow`.
9. If you now change the post's indexable's author_id back to the WordPress user id, the author archive is no longer no-indexed. (could take a couple of hard-refreshes before it updates)
## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Publish a two publicly viewable posts with the same author.
* Check in the database that both posts' indexables have your user id in the `author_id` column.
* With previous RC, if the author archives are enabled, the posts' indexables would not have the user id in the `author_id` column, but rather the id of the author indexable.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes PC-950
