### PR TITLE
CS/QA: silence a few deprecations

### DIFF
--- a/admin/class-my-yoast-proxy.php
+++ b/admin/class-my-yoast-proxy.php
@@ -174,7 +174,8 @@ class WPSEO_MyYoast_Proxy implements WPSEO_WordPress_Integration {
 	 * @return string The sanitized file request parameter.
 	 */
 	protected function get_proxy_file() {
-		return filter_input( INPUT_GET, 'file', FILTER_SANITIZE_STRING );
+		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- This deprecation will be addressed later.
+		return filter_input( INPUT_GET, 'file', @FILTER_SANITIZE_STRING );
 	}
 
 	/**
@@ -185,7 +186,8 @@ class WPSEO_MyYoast_Proxy implements WPSEO_WordPress_Integration {
 	 * @return string The sanitized plugin_version request parameter.
 	 */
 	protected function get_plugin_version() {
-		$plugin_version = filter_input( INPUT_GET, 'plugin_version', FILTER_SANITIZE_STRING );
+		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- This deprecation will be addressed later.
+		$plugin_version = filter_input( INPUT_GET, 'plugin_version', @FILTER_SANITIZE_STRING );
 		// Replace slashes to secure against requiring a file from another path.
 		$plugin_version = str_replace( [ '/', '\\' ], '_', $plugin_version );
 

--- a/admin/class-yoast-network-admin.php
+++ b/admin/class-yoast-network-admin.php
@@ -100,7 +100,8 @@ class Yoast_Network_Admin implements WPSEO_WordPress_AJAX_Integration, WPSEO_Wor
 	 * @return void
 	 */
 	public function handle_update_options_request() {
-		$option_group = filter_input( INPUT_POST, 'network_option_group', FILTER_SANITIZE_STRING );
+		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- This deprecation will be addressed later.
+		$option_group = filter_input( INPUT_POST, 'network_option_group', @FILTER_SANITIZE_STRING );
 
 		$this->verify_request( "{$option_group}-network-options" );
 

--- a/src/conditionals/admin/estimated-reading-time-conditional.php
+++ b/src/conditionals/admin/estimated-reading-time-conditional.php
@@ -43,7 +43,8 @@ class Estimated_Reading_Time_Conditional implements Conditional {
 	public function is_met() {
 		// Check if we are in our Elementor ajax request (for saving).
 		if ( \wp_doing_ajax() ) {
-			$post_action = $this->input_helper->filter( \INPUT_POST, 'action', \FILTER_SANITIZE_STRING );
+			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- This deprecation will be addressed later.
+			$post_action = $this->input_helper->filter( \INPUT_POST, 'action', @\FILTER_SANITIZE_STRING );
 			if ( $post_action === 'wpseo_elementor_save' ) {
 				return true;
 			}

--- a/src/conditionals/third-party/elementor-edit-conditional.php
+++ b/src/conditionals/third-party/elementor-edit-conditional.php
@@ -19,13 +19,15 @@ class Elementor_Edit_Conditional implements Conditional {
 		global $pagenow;
 
 		// Check if we are on an Elementor edit page.
-		$get_action = \filter_input( \INPUT_GET, 'action', \FILTER_SANITIZE_STRING );
+		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- This deprecation will be addressed later.
+		$get_action = \filter_input( \INPUT_GET, 'action', @\FILTER_SANITIZE_STRING );
 		if ( $pagenow === 'post.php' && $get_action === 'elementor' ) {
 			return true;
 		}
 
 		// Check if we are in our Elementor ajax request.
-		$post_action = \filter_input( \INPUT_POST, 'action', \FILTER_SANITIZE_STRING );
+		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- This deprecation will be addressed later.
+		$post_action = \filter_input( \INPUT_POST, 'action', @\FILTER_SANITIZE_STRING );
 		return \wp_doing_ajax() && $post_action === 'wpseo_elementor_save';
 	}
 }

--- a/src/integrations/admin/helpscout-beacon.php
+++ b/src/integrations/admin/helpscout-beacon.php
@@ -104,10 +104,11 @@ class HelpScout_Beacon implements Integration_Interface {
 	 * @param Migration_Status          $migration_status The migrations status.
 	 */
 	public function __construct( Options_Helper $options, WPSEO_Admin_Asset_Manager $asset_manager, Migration_Status $migration_status ) {
-		$this->options          = $options;
-		$this->asset_manager    = $asset_manager;
-		$this->ask_consent      = ! $this->options->get( 'tracking' );
-		$this->page             = \filter_input( \INPUT_GET, 'page', \FILTER_SANITIZE_STRING );
+		$this->options       = $options;
+		$this->asset_manager = $asset_manager;
+		$this->ask_consent   = ! $this->options->get( 'tracking' );
+		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- This deprecation will be addressed later.
+		$this->page             = \filter_input( \INPUT_GET, 'page', @\FILTER_SANITIZE_STRING );
 		$this->migration_status = $migration_status;
 
 		foreach ( $this->base_pages as $page ) {

--- a/src/integrations/settings-integration.php
+++ b/src/integrations/settings-integration.php
@@ -204,8 +204,10 @@ class Settings_Integration implements Integration_Interface {
 
 		// Are we saving the settings?
 		if ( $this->current_page_helper->get_current_admin_page() === 'options.php' ) {
-			$post_action = \filter_input( \INPUT_POST, 'action', \FILTER_SANITIZE_STRING );
-			$option_page = \filter_input( \INPUT_POST, 'option_page', \FILTER_SANITIZE_STRING );
+			// phpcs:disable WordPress.PHP.NoSilencedErrors.Discouraged -- This deprecation will be addressed later.
+			$post_action = \filter_input( \INPUT_POST, 'action', @\FILTER_SANITIZE_STRING );
+			$option_page = \filter_input( \INPUT_POST, 'option_page', @\FILTER_SANITIZE_STRING );
+			// phpcs:enable
 
 			if ( $post_action === 'update' && $option_page === self::PAGE ) {
 				\add_action( 'admin_init', [ $this, 'register_setting' ] );

--- a/src/integrations/third-party/elementor.php
+++ b/src/integrations/third-party/elementor.php
@@ -319,7 +319,8 @@ class Elementor implements Integration_Interface {
 		}
 
 		// Saving the WP post to save the slug.
-		$slug = \filter_input( \INPUT_POST, WPSEO_Meta::$form_prefix . 'slug', \FILTER_SANITIZE_STRING );
+		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- This deprecation will be addressed later.
+		$slug = \filter_input( \INPUT_POST, WPSEO_Meta::$form_prefix . 'slug', @\FILTER_SANITIZE_STRING );
 		if ( $post->post_name !== $slug ) {
 			$post_array              = $post->to_array();
 			$post_array['post_name'] = $slug;

--- a/tests/integration/admin/test-class-yoast-network-admin.php
+++ b/tests/integration/admin/test-class-yoast-network-admin.php
@@ -130,21 +130,14 @@ class Yoast_Network_Admin_Test extends WPSEO_UnitTestCase {
 			->setMethods( [ 'verify_request', 'terminate_request' ] )
 			->getMock();
 
-		// These two expectations should be removed once the underlying issue has been resolved.
-		if ( PHP_VERSION_ID >= 80100 ) {
-			$this->expectDeprecation();
-			$this->expectDeprecationMessage( 'Constant FILTER_SANITIZE_STRING is deprecated' );
-		}
-		else {
-			$admin
-				->expects( $this->once() )
-				->method( 'verify_request' )
-				->with( '-network-options' );
+		$admin
+			->expects( $this->once() )
+			->method( 'verify_request' )
+			->with( '-network-options' );
 
-			$admin
-				->expects( $this->once() )
-				->method( 'terminate_request' );
-		}
+		$admin
+			->expects( $this->once() )
+			->method( 'terminate_request' );
 
 		$admin->handle_update_options_request();
 	}

--- a/tests/unit/conditionals/estimated-reading-time-conditional-test.php
+++ b/tests/unit/conditionals/estimated-reading-time-conditional-test.php
@@ -69,7 +69,8 @@ class Estimated_Reading_Time_Conditional_Test extends TestCase {
 		// We are saving in Elementor with Ajax.
 		$this->input_helper
 			->expects( 'filter' )
-			->with( \INPUT_POST, 'action', \FILTER_SANITIZE_STRING )
+			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- This whole expectation will probably be removed/changed when the underlying deprecation is fixed..
+			->with( \INPUT_POST, 'action', @\FILTER_SANITIZE_STRING )
 			->andReturn( 'wpseo_elementor_save' );
 
 		$this->assertEquals( true, $this->instance->is_met() );
@@ -89,7 +90,8 @@ class Estimated_Reading_Time_Conditional_Test extends TestCase {
 		// The Ajax action is not for saving Elementor.
 		$this->input_helper
 			->expects( 'filter' )
-			->with( \INPUT_POST, 'action', \FILTER_SANITIZE_STRING )
+			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- This whole expectation will probably be removed/changed when the underlying deprecation is fixed..
+			->with( \INPUT_POST, 'action', @\FILTER_SANITIZE_STRING )
 			->andReturn( 'some_other_value' );
 
 		// We are not on a post according to the post conditional.

--- a/tests/unit/main-test.php
+++ b/tests/unit/main-test.php
@@ -62,12 +62,6 @@ class Main_Test extends TestCase {
 	 * @covers ::get_container
 	 */
 	public function test_surfaces() {
-		// These two expectations should be removed once the underlying issue has been resolved.
-		if ( \PHP_VERSION_ID >= 80100 ) {
-			$this->expectDeprecation();
-			$this->expectDeprecationMessage( 'Constant FILTER_SANITIZE_STRING is deprecated' );
-		}
-
 		// Deprecated classes call _deprecated_function in the constructor, so stub the function to do nothing.
 		Monkey\Functions\stubs( [ '_deprecated_function' => '__return_null' ] );
 


### PR DESCRIPTION
## Context

* Reduce noise from PHP 8.1 deprecations

## Summary

This PR can be summarized in the following changelog entry:

* Reduce noise from PHP 8.1 deprecations

## Relevant technical choices:

The deprecation of the `FILTER_SANITIZE_STRING` constant will be addressed at a later point, but is causing undue confusion for users, so for now, we'll be silencing the deprecation notices.

Includes updating a few test expectations to no longer expect the deprecation notice.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_ This just works - see: https://3v4l.org/9QiUq