### PR TITLE
Remove notification from free

### DIFF
--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -160,7 +160,6 @@ class WPSEO_Admin_Init {
 			$page = filter_input( INPUT_GET, 'page' );
 			// Only register the yoast i18n when the page is a Yoast SEO page.
 			if ( WPSEO_Utils::is_yoast_seo_free_page( $page ) ) {
-				$this->register_i18n_promo_class();
 				if ( $page !== 'wpseo_titles' ) {
 					$this->register_premium_upsell_admin_block();
 				}
@@ -186,47 +185,6 @@ class WPSEO_Admin_Init {
 			$upsell_block = new WPSEO_Premium_Upsell_Admin_Block( 'wpseo_admin_promo_footer' );
 			$upsell_block->register_hooks();
 		}
-	}
-
-	/**
-	 * Registers the promotion class for our GlotPress instance, then creates a notification with the i18n promo.
-	 *
-	 * @link https://github.com/Yoast/i18n-module
-	 */
-	private function register_i18n_promo_class() {
-		// BC, because an older version of the i18n-module didn't have this class.
-		$i18n_module = new Yoast_I18n_WordPressOrg_v3(
-			[
-				'textdomain'  => 'wordpress-seo',
-				'plugin_name' => 'Yoast SEO',
-				'hook'        => 'wpseo_admin_promo_footer',
-			],
-			false
-		);
-
-		$message = $i18n_module->get_promo_message();
-
-		if ( $message !== '' ) {
-			$message .= $i18n_module->get_dismiss_i18n_message_button();
-		}
-
-		$notification_center = Yoast_Notification_Center::get();
-
-		$notification = new Yoast_Notification(
-			$message,
-			[
-				'type' => Yoast_Notification::WARNING,
-				'id'   => 'i18nModuleTranslationAssistance',
-			]
-		);
-
-		if ( $message ) {
-			$notification_center->add_notification( $notification );
-
-			return;
-		}
-
-		$notification_center->remove_notification( $notification );
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to have fewer notifications

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Removes a notification that prompts users to help with translating the plugin in the language of the site.

## Relevant technical choices:

* None.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Disable premium
* Switch to a different language then english for example dutch. Go to https://basic.wordpress.test/wp-admin/admin.php?page=wpseo_dashboard and make sure there is no notification with the text
`You're using WordPress in Dutch. While Yoast SEO has been translated to Dutch for 94%, it's not been shipped with the plugin yet. You can help! Register at [Translating WordPress](https://translate.wordpress.org/projects/wp-plugins/wordpress-seo/) to help complete the translation to Dutch!`

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes #
