### PR TITLE
PC-848-add-support-for-website-name-to-first-time-configuration

### DIFF
--- a/packages/js/src/first-time-configuration/first-time-configuration-steps.js
+++ b/packages/js/src/first-time-configuration/first-time-configuration-steps.js
@@ -45,6 +45,7 @@ async function updateSiteRepresentation( state ) {
 		company_name: state.companyName,
 		company_logo: state.companyLogo,
 		company_logo_id: state.companyLogoId ? state.companyLogoId : 0,
+		website_name: state.websiteName,
 		person_logo: state.personLogo,
 		person_logo_id: state.personLogoId ? state.personLogoId : 0,
 		company_or_person_user_id: state.personId,

--- a/packages/js/src/first-time-configuration/tailwind-components/helpers/index.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/helpers/index.js
@@ -145,6 +145,10 @@ export function configurationReducer( state, action ) {
 			newState.companyLogo = "";
 			newState.companyLogoId = "";
 			return newState;
+		case "CHANGE_WEBSITE_NAME":
+			newState = handleStepEdit( newState, 2 );
+			newState.websiteName = action.payload;
+			return newState;
 		case "SET_PERSON_LOGO":
 			newState = handleStepEdit( newState, 2 );
 			newState.personLogo = action.payload.url;

--- a/packages/js/src/first-time-configuration/tailwind-components/steps/site-representation/site-representation-step.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/steps/site-representation/site-representation-step.js
@@ -7,6 +7,7 @@ import classNames from "classnames";
 import { addLinkToString } from "../../../../helpers/stringHelpers.js";
 import Alert, { FadeInAlert } from "../../base/alert";
 import SingleSelect from "../../base/single-select";
+import TextInput from "../../base/text-input";
 import { OrganizationSection } from "./organization-section";
 import { PersonSection } from "./person-section";
 
@@ -26,6 +27,10 @@ export default function SiteRepresentationStep( { onOrganizationOrPersonChange, 
 	const [ sectionOpacity, setSectionOpacity ] = useState( state.companyOrPerson === "emptyChoice" ? "yst-opacity-0" : "yst-opacity-100" );
 	const startOpacityTransition = useCallback( () => {
 		setSectionOpacity( "yst-opacity-100" );
+	} );
+
+	const handleWebsiteNameChange = useCallback( ( event ) => {
+		dispatch( { type: "CHANGE_WEBSITE_NAME", payload: event.target.value } );
 	} );
 
 	const richResultsMessage = addLinkToString(
@@ -78,6 +83,7 @@ export default function SiteRepresentationStep( { onOrganizationOrPersonChange, 
 					</Fragment>
 			}
 		</p>
+
 		<SingleSelect
 			id="organization-person-select"
 			htmlFor="organization-person-select"
@@ -92,6 +98,20 @@ export default function SiteRepresentationStep( { onOrganizationOrPersonChange, 
 		{ shouldDisplayDefaultValuesNotice() && <Alert type="info" className="yst-mt-6">
 			{ __( "We took the liberty of using your site title and logo for the organization name and logo. Feel free to change them below.", "wordpress-seo" ) }
 		</Alert> }
+
+		<TextInput
+			className="yst-my-6"
+			id="website-name-input"
+			name="website-name"
+			label={ __( "Website name", "wordpress-seo" ) }
+			value={ ( state.websiteName === "" ) ? state.fallbackWebsiteName : state.websiteName }
+			onChange={ handleWebsiteNameChange }
+			feedback={ {
+				isVisible: state.errorFields.includes( "website_name" ),
+				message: [ __( "We could not save the website name. Please check the value.", "wordpress-seo" ) ],
+				type: "error",
+			} }
+		/>
 
 		<ReactAnimateHeight
 			height={ [ "company", "person" ].includes( state.companyOrPerson ) ? "auto" : 0 }

--- a/src/actions/configuration/first-time-configuration-action.php
+++ b/src/actions/configuration/first-time-configuration-action.php
@@ -16,6 +16,7 @@ class First_Time_Configuration_Action {
 	const SITE_REPRESENTATION_FIELDS = [
 		'company_or_person',
 		'company_name',
+		'website_name',
 		'company_logo',
 		'company_logo_id',
 		'person_logo',

--- a/src/integrations/admin/first-time-configuration-integration.php
+++ b/src/integrations/admin/first-time-configuration-integration.php
@@ -193,6 +193,8 @@ class First_Time_Configuration_Integration implements Integration_Interface {
 					"companyOrPersonLabel": "%s",
 					"companyName": "%s",
 					"fallbackCompanyName": "%s",
+					"websiteName": "%s",
+					"fallbackWebsiteName": "%s",
 					"companyLogo": "%s",
 					"companyLogoFallback": "%s",
 					"companyLogoId": %d,
@@ -226,6 +228,8 @@ class First_Time_Configuration_Integration implements Integration_Interface {
 				$selected_option_label,
 				$this->get_company_name(),
 				$this->get_fallback_company_name( $this->get_company_name() ),
+				$this->get_website_name(),
+				$this->get_fallback_website_name( $this->get_website_name() ),
 				$this->get_company_logo(),
 				$this->get_company_fallback_logo( $this->get_company_logo() ),
 				$this->get_company_logo_id(),
@@ -316,6 +320,30 @@ class First_Time_Configuration_Integration implements Integration_Interface {
 	 */
 	private function get_fallback_company_name( $company_name ) {
 		if ( $company_name ) {
+			return false;
+		}
+
+		return \get_bloginfo( 'name' );
+	}
+
+	/**
+	 * Gets the website name from the option in the database.
+	 *
+	 * @return string The website name.
+	 */
+	private function get_website_name() {
+		return $this->options_helper->get( 'website_name', '' );
+	}
+
+	/**
+	 * Gets the fallback website name from the option in the database if there is no website name.
+	 *
+	 * @param string $company_name The given website name by the user, default empty string.
+	 *
+	 * @return string|false The website name.
+	 */
+	private function get_fallback_website_name( $website_name ) {
+		if ( $website_name ) {
 			return false;
 		}
 

--- a/src/integrations/admin/first-time-configuration-integration.php
+++ b/src/integrations/admin/first-time-configuration-integration.php
@@ -338,7 +338,7 @@ class First_Time_Configuration_Integration implements Integration_Interface {
 	/**
 	 * Gets the fallback website name from the option in the database if there is no website name.
 	 *
-	 * @param string $company_name The given website name by the user, default empty string.
+	 * @param string $website_name The given website name by the user, default empty string.
 	 *
 	 * @return string|false The website name.
 	 */


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to add a new `Website name` text field in the `Site Representation` step of the `First-time configuration`

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds a new `Website name` text field in the `Site Representation` step of the `First-time configuration`.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Go to `Yoast SEO` -> `General` -> `First-time Configuration` tab
* Advance to the `Site Representation step`
* Notice the `Website name` text field is pre-filled with your blog's name
* Change the value in `Website name` and click `Save and continue`
---
* Go to `Yoast SEO` -> `Search Appearance`
* Under `Knowledge Graph & Schema.org` you'll find the `Website name` text field with the value you have specified previously
* Change it and press `Save Changes`
* Go back to `Yoast SEO` -> `General` -> `First-time Configuration` tab
* In the `Site Representation` step you should see the `Website name` value changed, coherently with what you specified in the `Search Appearance` section
---
* Now visit a post in the front-end, and inspect the page source code
* In the page schema look for the `WebSite` schema piece: the `name` property should have the value you have specified as the `Website name`
---
* Go back to `Yoast SEO` -> `General` -> `First-time Configuration` tab
* In the `Site Representation` step change the value in the drop-down `Does your site represent an Organization or Person?` to `Person`
* Notice the `Website name` value remains the same
* Select a user in the `Name` drop-down and an image in the `Personal logo or avatar` image selector
* Visit a post in the front-end, inspect the page source code and make sure  the `name` property of the `WebSite` schema piece has the same value as before

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [X] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.

Fixes [PC-848](https://yoast.atlassian.net/browse/PC-848)
