### PR TITLE
PC-961 inclusive language analysis is not loaded when premium is activated

### DIFF
--- a/admin/metabox/class-metabox-analysis-inclusive-language.php
+++ b/admin/metabox/class-metabox-analysis-inclusive-language.php
@@ -45,13 +45,13 @@ class WPSEO_Metabox_Analysis_Inclusive_Language implements WPSEO_Metabox_Analysi
 	 * versions also have inclusive language code (when it was still a Premium only feature) which would result in rendering
 	 * the analysis twice. In those cases, the analysis should be only loaded from the Premium side.
 	 *
-	 * @return bool Whether or not the inclusive language analysis should be loaded
+	 * @return bool Whether or not the inclusive language analysis should be loaded.
 	 */
 	private function is_current_version_supported() {
 		$is_premium      = YoastSEO()->helpers->product->is_premium();
 		$premium_version = YoastSEO()->helpers->product->get_premium_version();
 
-		return ! $is_premium || \version_compare( $premium_version, '19.5-RC0', '>=' ) ||
+		return ! $is_premium || \version_compare( $premium_version, '19.6-RC0', '>=' ) ||
 			\version_compare( $premium_version, '19.2', '==' );
 	}
 }

--- a/admin/metabox/class-metabox-analysis-inclusive-language.php
+++ b/admin/metabox/class-metabox-analysis-inclusive-language.php
@@ -51,7 +51,7 @@ class WPSEO_Metabox_Analysis_Inclusive_Language implements WPSEO_Metabox_Analysi
 		$is_premium      = YoastSEO()->helpers->product->is_premium();
 		$premium_version = YoastSEO()->helpers->product->get_premium_version();
 
-		return ! $is_premium || \version_compare( $premium_version, '19.7', '>=' ) ||
+		return ! $is_premium || \version_compare( $premium_version, '19.5-RC0', '>=' ) ||
 			\version_compare( $premium_version, '19.2', '==' );
 	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Previously, in [this PR](https://github.com/Yoast/wordpress-seo/pull/19115), we decided on the following:
  * With Premium 19.2, we use the inclusive language as defined in Free.
  * With Premium 19.2.1 - 19.6 activated, we use the inclusive language analysis as defined in Premium.
  * With Premium >= 19.7 activated, we use the inclusive language analysis as defined in Free.
* However, in the upcoming Free 19.11 release cycle, we will **not** release Premium. Therefore, we need our to change our approach to the following:
  * With Premium 19.2, we use the inclusive language as defined in Free.
  * With Premium 19.2.1 - 19.5 activated, we use the inclusive language analysis as defined in Premium.
  * With Premium >= 19.6 activated, we use the inclusive language analysis as defined in Free.
* Moreover, the current version check does not allow us to check against RC versions. So, we need to target Premium >=19.6-RC0. 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Changes the minimum version check for the inclusive language analysis to Premium 19.6-RC0 after skipping a Premium release.

## Relevant technical choices:

* None

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Follow the test instructions from [this PR](https://github.com/Yoast/wordpress-seo/pull/19115).
  * Change the requiring code to `composer require yoast/wordpress-seo:dev-PC-961-inclusive-language-analysis-is-not-loaded-when-premium-is-activated@dev`.
  * No need to test multisite again.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes https://yoast.atlassian.net/browse/PC-961
