### PR TITLE
PC-962 Remove beta badge from word complexity assessment

### DIFF
--- a/packages/yoastseo/spec/scoring/assessments/readability/WordComplexityAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/readability/WordComplexityAssessmentSpec.js
@@ -29,7 +29,7 @@ describe( "a test for an assessment that checks complex words in a text", functi
 							"an amalgamation of Calico and Tabby." },
 			} ]
 		);
-		expect( result.hasBetaBadge() ).toBe( true );
+		expect( result.hasBetaBadge() ).toBe( false );
 	} );
 
 	let runningPaper = new Paper( "Also called torties for short, tortoiseshell cats combine two colors other than white, " +

--- a/packages/yoastseo/src/scoring/assessments/readability/WordComplexityAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/readability/WordComplexityAssessment.js
@@ -56,7 +56,7 @@ export default class WordComplexityAssessment extends Assessment {
 		assessmentResult.setScore( calculatedScore.score );
 		assessmentResult.setText( calculatedScore.resultText );
 		assessmentResult.setHasMarks( calculatedScore.hasMarks );
-		assessmentResult.setHasBetaBadge( true );
+
 		return assessmentResult;
 	}
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [wordpress-seo-premium] Removes the beta badge from the _word complexity_ assessment.
* [wpseo-woocommerce] Removes the beta badge from the _word complexity_ assessment.
* [shopify-seo] Removes the beta badge from the _word complexity_ assessment.
* [yoastseo] Removes the beta badge from the result of the WordComplexityAssessment.


## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Upgrade routine in WordPress
* Install and activate the previous version of Yoast SEO (19.10)
* Install and activate the previous version of Yoast SEO Premium (19.5)
* Create a new post.
* Add at least 50 characters of content.
* Confirm that in front of the word complexity assessment, a beta badge is shown.
* Install and activate Yoast SEO with the badge removed
* Install and activate Yoast SEO Premium with the badge removed
* Confirm that in front of the word complexity assessment, a beta badge is NOT shown.

#### Test in WordPress
##### Without Premium activated
* Install and activate Yoast SEO
* Set the site language to English
* Create or open a post
* Go to Readability analysis
* Confirm that the word complexity upsell appears and that there is no beta badge attached to it
<img width="257" alt="Screenshot 2022-11-08 at 10 46 12" src="https://user-images.githubusercontent.com/48715883/200531681-b5afddb8-1c59-4ccb-9394-9913f04689c0.png">


##### With Premium activated
* Install and activate Yoast SEO
* Install and activate Yoast SEO Premium
   * If building the plugin, run `composer require yoast/wordpress-seo:dev-PC-962-remove-beta-badge-from-word-complexity-assessment@dev` before building the plugin
* Set the site language to English
* Create or open a post with at least 50 characters
* Go to Readability analysis
* Confirm that there is no beta badge attached to the Word complexity assessment feedback
* Change the site language to one of these: German, Spanish, French
* Create or open a post with at least 50 characters
* Go to Readability analysis
* Confirm that there is no beta badge attached to the Word complexity assessment feedback

#### Test in Woocommerce
* Install and activate Yoast SEO
* Install and activate Yoast SEO Premium
* Install and activate Woocommerce
* Install and activate Yoast SEO for Woocommerce
   * If building the plugin, run `composer require yoast/wordpress-seo:dev-PC-962-remove-beta-badge-from-word-complexity-assessment@dev --dev` before building the plugin 
* Set the site language to English
* Create or open a product with at least 50 characters
* Go to Readability analysis
* Confirm that there is no beta badge attached to the Word complexity assessment feedback
* Change the site language to one of these: German, Spanish, French
* Create or open a product with at least 50 characters
* Go to Readability analysis
* Confirm that there is no beta badge attached to the Word complexity assessment feedback

#### Test in Shopify
* Install and activate Yoast SEO for Shopify
   * When building the app, don't forget to link the `wordpress-seo` branch
* Set the store language to English
* Create or open a product with at least 50 characters
* Go to Readability analysis
* Confirm that there is no beta badge attached to the Word complexity assessment feedback
* Change the store language to one of these: German, Spanish, French
* Create or open a product with at least 50 characters
* Go to Readability analysis
* Confirm that there is no beta badge attached to the Word complexity assessment feedback
* Repeat the steps in other content types in Shopify, except Blogs (Blogs content type doesn't have Readability analysis)

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [x] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [x] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes https://yoast.atlassian.net/browse/PC-962
