### PR TITLE
Calculate posts of authors via the WP way

### DIFF
--- a/src/builders/indexable-author-builder.php
+++ b/src/builders/indexable-author-builder.php
@@ -214,7 +214,8 @@ class Indexable_Author_Builder {
 			$exception = Author_Not_Built_Exception::author_archives_are_disabled( $user_id );
 		}
 
-		if ( $this->author_archive->author_has_public_posts( $user_id ) === false ) {
+		// We will check if the author has public posts the WP way, instead of the indexable way, to make sure we get proper results even if SEO optimization is not run.
+		if ( $this->author_archive->author_has_public_posts_wp( $user_id ) === false ) {
 			$exception = Author_Not_Built_Exception::author_archives_are_not_indexed_for_users_without_posts( $user_id );
 		}
 

--- a/src/helpers/author-archive-helper.php
+++ b/src/helpers/author-archive-helper.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\WP\SEO\Helpers;
 
+use WP_Query;
 use Yoast\WP\Lib\Model;
 
 /**
@@ -17,14 +18,24 @@ class Author_Archive_Helper {
 	private $options_helper;
 
 	/**
+	 * The post type helper.
+	 *
+	 * @var Post_Type_Helper
+	 */
+	private $post_type_helper;
+
+	/**
 	 * Creates a new author archive helper.
 	 *
-	 * @param Options_Helper $options_helper The options helper.
+	 * @param Options_Helper   $options_helper   The options helper.
+	 * @param Post_Type_Helper $post_type_helper The post type helper.
 	 */
 	public function __construct(
-		Options_Helper $options_helper
+		Options_Helper $options_helper,
+		Post_Type_Helper $post_type_helper
 	) {
-		$this->options_helper = $options_helper;
+		$this->options_helper   = $options_helper;
+		$this->post_type_helper = $post_type_helper;
 	}
 
 	/**
@@ -59,6 +70,34 @@ class Author_Archive_Helper {
 		$has_public_post_depending_on_the_global_setting = $this->author_has_a_post_with_is_public_null( $author_id );
 		if ( $has_public_post_depending_on_the_global_setting ) {
 			return null;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Checks whether the user with the given ID has publicly viewable posts.
+	 *
+	 * **Note**: It uses WP_Query to determine the number of posts,
+	 * not the indexables table.
+	 *
+	 * @param string $user_id The user ID.
+	 *
+	 * @return bool Whether the author has public posts, according to the WordPress tables.
+	 */
+	public function author_has_public_posts_wp( $user_id ) {
+		$post_types        = \array_intersect( $this->get_author_archive_post_types(), $this->post_type_helper->get_indexable_post_types() );
+		$public_post_stati = \array_values( \array_filter( \get_post_stati(), 'is_post_status_viewable' ) );
+
+		$args  = [
+			'post_type'   => $post_types,
+			'post_status' => $public_post_stati,
+			'author'      => $user_id,
+		];
+		$query = new WP_Query( $args );
+
+		if ( ! empty( $query->posts ) ) {
+			return true;
 		}
 
 		return false;

--- a/src/helpers/author-archive-helper.php
+++ b/src/helpers/author-archive-helper.php
@@ -76,14 +76,14 @@ class Author_Archive_Helper {
 	}
 
 	/**
-	 * Checks whether the user with the given ID has publicly viewable posts.
+	 * Returns whether the author has at least one public post.
 	 *
 	 * **Note**: It uses WP_Query to determine the number of posts,
 	 * not the indexables table.
 	 *
 	 * @param string $user_id The user ID.
 	 *
-	 * @return bool Whether the author has public posts, according to the WordPress tables.
+	 * @return bool Whether the author has at least one public post.
 	 */
 	public function author_has_public_posts_wp( $user_id ) {
 		$post_types        = \array_intersect( $this->get_author_archive_post_types(), $this->post_type_helper->get_indexable_post_types() );

--- a/tests/unit/builders/indexable-author-builder-test.php
+++ b/tests/unit/builders/indexable-author-builder-test.php
@@ -134,6 +134,12 @@ class Indexable_Author_Builder_Test extends TestCase {
 	 * @covers ::build
 	 */
 	public function test_build() {
+		$this->author_archive
+			->expects( 'author_has_public_posts_wp' )
+			->with( 1 )
+			->once()
+			->andReturn( true );
+
 		Monkey\Functions\expect( 'get_the_author_meta' )->once()->with( 'wpseo_title', 1 )->andReturn( 'title' );
 		Monkey\Functions\expect( 'get_the_author_meta' )->once()->with( 'wpseo_metadesc', 1 )->andReturn( 'description' );
 		Monkey\Functions\expect( 'get_the_author_meta' )->once()->with( 'wpseo_noindex_author', 1 )->andReturn( 'on' );
@@ -166,7 +172,7 @@ class Indexable_Author_Builder_Test extends TestCase {
 		$this->author_archive
 			->expects( 'author_has_public_posts' )
 			->with( 1 )
-			->twice()
+			->once()
 			->andReturn( true );
 		$this->author_archive
 			->expects( 'are_disabled' )
@@ -205,6 +211,12 @@ class Indexable_Author_Builder_Test extends TestCase {
 	 * @covers ::build
 	 */
 	public function test_build_when_user_is_explicitly_included_by_filter() {
+		$this->author_archive
+			->expects( 'author_has_public_posts_wp' )
+			->with( 1 )
+			->once()
+			->andReturn( true );
+
 		Monkey\Functions\expect( 'get_the_author_meta' )->once()->with( 'wpseo_title', 1 )->andReturn( 'title' );
 		Monkey\Functions\expect( 'get_the_author_meta' )->once()->with( 'wpseo_metadesc', 1 )->andReturn( 'description' );
 		Monkey\Functions\expect( 'get_the_author_meta' )->once()->with( 'wpseo_noindex_author', 1 )->andReturn( 'on' );
@@ -239,7 +251,7 @@ class Indexable_Author_Builder_Test extends TestCase {
 		$this->author_archive
 			->expects( 'author_has_public_posts' )
 			->with( 1 )
-			->twice()
+			->once()
 			->andReturn( true );
 
 		$this->wpdb->expects( 'prepare' )->once()->with(
@@ -276,6 +288,12 @@ class Indexable_Author_Builder_Test extends TestCase {
 	 * @covers ::build
 	 */
 	public function test_build_without_alternative_image() {
+		$this->author_archive
+			->expects( 'author_has_public_posts_wp' )
+			->with( 1 )
+			->once()
+			->andReturn( true );
+
 		Monkey\Functions\expect( 'get_the_author_meta' )->once()->with( 'wpseo_title', 1 )->andReturn( 'title' );
 		Monkey\Functions\expect( 'get_the_author_meta' )->once()->with( 'wpseo_metadesc', 1 )->andReturn( 'description' );
 		Monkey\Functions\expect( 'get_the_author_meta' )->once()->with( 'wpseo_noindex_author', 1 )->andReturn( 'on' );
@@ -299,7 +317,7 @@ class Indexable_Author_Builder_Test extends TestCase {
 		$this->author_archive
 			->expects( 'author_has_public_posts' )
 			->with( 1 )
-			->twice()
+			->once()
 			->andReturn( true );
 		$this->author_archive
 			->expects( 'are_disabled' )
@@ -346,6 +364,12 @@ class Indexable_Author_Builder_Test extends TestCase {
 	 * @covers ::build
 	 */
 	public function test_build_with_undefined_author_meta() {
+		$this->author_archive
+			->expects( 'author_has_public_posts_wp' )
+			->with( 1 )
+			->once()
+			->andReturn( true );
+
 		Monkey\Functions\expect( 'get_the_author_meta' )->once()->with( 'wpseo_title', 1 )->andReturn( '' );
 		Monkey\Functions\expect( 'get_the_author_meta' )->once()->with( 'wpseo_metadesc', 1 )->andReturn( '' );
 		Monkey\Functions\expect( 'get_the_author_meta' )->once()->with( 'wpseo_noindex_author', 1 )->andReturn( '' );
@@ -374,7 +398,7 @@ class Indexable_Author_Builder_Test extends TestCase {
 		$this->author_archive
 			->expects( 'author_has_public_posts' )
 			->with( 1 )
-			->twice()
+			->once()
 			->andReturn( true );
 		$this->author_archive
 			->expects( 'are_disabled' )
@@ -419,7 +443,7 @@ class Indexable_Author_Builder_Test extends TestCase {
 			->andReturn( true );
 
 		$this->author_archive
-			->expects( 'author_has_public_posts' )
+			->expects( 'author_has_public_posts_wp' )
 			->with( 1 )
 			->andReturn( true );
 
@@ -443,7 +467,7 @@ class Indexable_Author_Builder_Test extends TestCase {
 			->expects( 'are_disabled' )
 			->andReturn( false );
 		$this->author_archive
-			->expects( 'author_has_public_posts' )
+			->expects( 'author_has_public_posts_wp' )
 			->with( $user_id )
 			->andReturn( false );
 
@@ -466,7 +490,7 @@ class Indexable_Author_Builder_Test extends TestCase {
 			->expects( 'are_disabled' )
 			->andReturn( false );
 		$this->author_archive
-			->expects( 'author_has_public_posts' )
+			->expects( 'author_has_public_posts_wp' )
 			->with( $user_id )
 			->andReturn( false );
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* When SEO optimization is not run, querying the indexables table to figure out whether an author has authored public posts will fail.
* As a result, author archives will be no-indexed when SEO optimization is not run 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where author archives would get no-indexed if SEO optimization hasn't been ran.

## Relevant technical choices:

* We no longer query indexables when assessing whether an author has authored public posts, upon page load of author archives. We now use `WP_Query` instead.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* NOT have Yoast SEO active
* create xyz author
* create a post with the xyz author
* THEN activate Yoast SEO
* Visit `/author/xyz` archive page and confirm it's no-indexed with the previous RC (or with the release/19.11 checked out if you're a developer)
* Install this RC (or checkout this PR)
* Reload the  `/author/xyz` archive page and confirm that it's no longer no-indexed.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* https://github.com/Yoast/wordpress-seo/pull/19078

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes [#DUPP-667](https://yoast.atlassian.net/browse/DUPP-667)
