### PR TITLE
Change prepare to query to mitigate wp notices.

### DIFF
--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -1380,7 +1380,7 @@ class WPSEO_Upgrade {
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Reason: Too hard to fix.
 		if ( empty( $included_post_types ) ) {
-			$delete_query = $wpdb->prepare(
+			$delete_query = $wpdb->query(
 				"DELETE FROM $indexable_table
 				WHERE object_type = 'post'
 				AND object_sub_type IS NOT NULL"
@@ -1425,7 +1425,7 @@ class WPSEO_Upgrade {
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Reason: Too hard to fix.
 		if ( empty( $included_taxonomies ) ) {
-			$delete_query = $wpdb->prepare(
+			$delete_query = $wpdb->query(
 				"DELETE FROM $indexable_table
 				WHERE object_type = 'term'
 				AND object_sub_type IS NOT NULL"
@@ -1466,7 +1466,7 @@ class WPSEO_Upgrade {
 		$indexable_table = Model::get_table_name( 'Indexable' );
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Reason: Too hard to fix.
-		$query = $wpdb->prepare(
+		$query = $wpdb->query(
 			"SELECT
 				MAX(id) as newest_id,
 				object_id,
@@ -1534,7 +1534,7 @@ class WPSEO_Upgrade {
 		$indexable_table = Model::get_table_name( 'Indexable' );
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Reason: Too hard to fix.
-		$delete_query = $wpdb->prepare( "DELETE FROM $indexable_table WHERE object_type = 'user'" );
+		$delete_query = $wpdb->query( "DELETE FROM $indexable_table WHERE object_type = 'user'" );
 		// phpcs:enable
 
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching -- Reason: No relevant caches.

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -518,6 +518,7 @@ class WPSEO_Upgrade {
 		global $wpdb;
 		// We've moved the cornerstone checkbox to our proper namespace.
 		$wpdb->query( "UPDATE $wpdb->postmeta SET meta_key = '_yoast_wpseo_is_cornerstone' WHERE meta_key = '_yst_is_cornerstone'" );
+
 		// Remove the previous Whip dismissed message, as this is a new one regarding PHP 5.2.
 		delete_option( 'whip_dismiss_timestamp' );
 	}
@@ -587,6 +588,7 @@ class WPSEO_Upgrade {
 
 		// Removes all scheduled tasks for hitting the sitemap index.
 		wp_clear_scheduled_hook( 'wpseo_hit_sitemap_index' );
+
 		$wpdb->query( 'DELETE FROM ' . $wpdb->options . ' WHERE option_name LIKE "wpseo_sitemap_%"' );
 	}
 
@@ -658,7 +660,6 @@ class WPSEO_Upgrade {
 		}
 
 		global $wpdb;
-
 		$wpdb->query( "DELETE FROM $wpdb->usermeta WHERE meta_key = 'wp_yoast_promo_hide_premium_upsell_admin_block'" );
 
 		// Removes the WordPress update notification, because it is no longer necessary when WordPress 5.3 is released.

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -287,7 +287,12 @@ class WPSEO_Upgrade {
 		global $wpdb;
 
 		// Between 3.2 and 3.4 the sitemap options were saved with autoloading enabled.
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery -- Reason: Most performant way.
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching -- Reason: No relevant caches.
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Reason: Too hard to fix.
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Reason: Is it prepared already.
 		$wpdb->query( 'DELETE FROM ' . $wpdb->options . ' WHERE option_name LIKE "wpseo_sitemap_%" AND autoload = "yes"' );
+		// phpcs:enable
 	}
 
 	/**
@@ -318,12 +323,16 @@ class WPSEO_Upgrade {
 		global $wpdb;
 
 		// The meta key has to be private, so prefix it.
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery -- Reason: Most performant way.
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching -- Reason: No relevant caches.
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Reason: Is it prepared already.
 		$wpdb->query(
 			$wpdb->prepare(
 				'UPDATE ' . $wpdb->postmeta . ' SET meta_key = %s WHERE meta_key = "yst_is_cornerstone"',
 				WPSEO_Cornerstone_Filter::META_NAME
 			)
 		);
+		//phpcs:enable
 	}
 
 	/**
@@ -395,8 +404,12 @@ class WPSEO_Upgrade {
 	private function upgrade_50() {
 		global $wpdb;
 
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery -- Reason: Most performant way.
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching -- Reason: No relevant caches.
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Reason: Is it prepared already.
 		// Deletes the post meta value, which might created in the RC.
 		$wpdb->query( 'DELETE FROM ' . $wpdb->postmeta . ' WHERE meta_key = "_yst_content_links_processed"' );
+		//phpcs:enable
 	}
 
 	/**
@@ -488,7 +501,11 @@ class WPSEO_Upgrade {
 
 		// Moves the user meta for excluding from the XML sitemap to a noindex.
 		global $wpdb;
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery -- Reason: Most performant way.
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching -- Reason: No relevant caches.
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Reason: Is it prepared already.
 		$wpdb->query( "UPDATE $wpdb->usermeta SET meta_key = 'wpseo_noindex_author' WHERE meta_key = 'wpseo_excludeauthorsitemap'" );
+		//phpcs:enable
 	}
 
 	/**
@@ -517,8 +534,11 @@ class WPSEO_Upgrade {
 	private function upgrade_73() {
 		global $wpdb;
 		// We've moved the cornerstone checkbox to our proper namespace.
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery -- Reason: Most performant way.
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching -- Reason: No relevant caches.
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Reason: Is it prepared already.
 		$wpdb->query( "UPDATE $wpdb->postmeta SET meta_key = '_yoast_wpseo_is_cornerstone' WHERE meta_key = '_yst_is_cornerstone'" );
-
+		// phpcs:enable
 		// Remove the previous Whip dismissed message, as this is a new one regarding PHP 5.2.
 		delete_option( 'whip_dismiss_timestamp' );
 	}
@@ -588,8 +608,11 @@ class WPSEO_Upgrade {
 
 		// Removes all scheduled tasks for hitting the sitemap index.
 		wp_clear_scheduled_hook( 'wpseo_hit_sitemap_index' );
-
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery -- Reason: Most performant way.
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching -- Reason: No relevant caches.
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Reason: Is it prepared already.
 		$wpdb->query( 'DELETE FROM ' . $wpdb->options . ' WHERE option_name LIKE "wpseo_sitemap_%"' );
+		// phpcs:enable
 	}
 
 	/**
@@ -660,8 +683,11 @@ class WPSEO_Upgrade {
 		}
 
 		global $wpdb;
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery -- Reason: Most performant way.
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching -- Reason: No relevant caches.
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Reason: Is it prepared already.
 		$wpdb->query( "DELETE FROM $wpdb->usermeta WHERE meta_key = 'wp_yoast_promo_hide_premium_upsell_admin_block'" );
-
+		// phpcs:enable
 		// Removes the WordPress update notification, because it is no longer necessary when WordPress 5.3 is released.
 		$center = Yoast_Notification_Center::get();
 		$center->remove_notification_by_id( 'wpseo-dismiss-wordpress-upgrade' );
@@ -1380,6 +1406,9 @@ class WPSEO_Upgrade {
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Reason: Too hard to fix.
 		if ( empty( $included_post_types ) ) {
+			// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery -- Reason: Most performant way.
+			// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching -- Reason: No relevant caches.
+			// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Reason: Is it prepared already.
 			$delete_query = $wpdb->query(
 				"DELETE FROM $indexable_table
 				WHERE object_type = 'post'
@@ -1425,6 +1454,9 @@ class WPSEO_Upgrade {
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Reason: Too hard to fix.
 		if ( empty( $included_taxonomies ) ) {
+			// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery -- Reason: Most performant way.
+			// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching -- Reason: No relevant caches.
+			// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Reason: Is it prepared already.
 			$delete_query = $wpdb->query(
 				"DELETE FROM $indexable_table
 				WHERE object_type = 'term'
@@ -1465,7 +1497,10 @@ class WPSEO_Upgrade {
 
 		$indexable_table = Model::get_table_name( 'Indexable' );
 
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery -- Reason: Most performant way.
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching -- Reason: No relevant caches.
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Reason: Too hard to fix.
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Reason: Is it prepared already.
 		$query = $wpdb->query(
 			"SELECT
 				MAX(id) as newest_id,
@@ -1509,6 +1544,7 @@ class WPSEO_Upgrade {
 				// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching -- Reason: No relevant caches.
 				// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Reason: Is it prepared already.
 				$wpdb->query( $delete_query );
+				// phpcs:enable
 			}
 		}
 
@@ -1533,6 +1569,9 @@ class WPSEO_Upgrade {
 
 		$indexable_table = Model::get_table_name( 'Indexable' );
 
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery -- Reason: Most performant way.
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching -- Reason: No relevant caches.
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Reason: Is it prepared already.
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Reason: Too hard to fix.
 		$delete_query = $wpdb->query( "DELETE FROM $indexable_table WHERE object_type = 'user'" );
 		// phpcs:enable

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -1379,14 +1379,10 @@ class WPSEO_Upgrade {
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Reason: Too hard to fix.
 		if ( empty( $included_post_types ) ) {
-			// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery -- Reason: Most performant way.
-			// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching -- Reason: No relevant caches.
-			// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Reason: Is it prepared already.
-			$delete_query = $wpdb->query(
+			$delete_query =
 				"DELETE FROM $indexable_table
 				WHERE object_type = 'post'
-				AND object_sub_type IS NOT NULL"
-			);
+				AND object_sub_type IS NOT NULL";
 		}
 		else {
 			$delete_query = $wpdb->prepare(
@@ -1427,14 +1423,9 @@ class WPSEO_Upgrade {
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Reason: Too hard to fix.
 		if ( empty( $included_taxonomies ) ) {
-			// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery -- Reason: Most performant way.
-			// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching -- Reason: No relevant caches.
-			// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Reason: Is it prepared already.
-			$delete_query = $wpdb->query(
-				"DELETE FROM $indexable_table
+			$delete_query = "DELETE FROM $indexable_table
 				WHERE object_type = 'term'
-				AND object_sub_type IS NOT NULL"
-			);
+				AND object_sub_type IS NOT NULL";
 		}
 		else {
 			$delete_query = $wpdb->prepare(
@@ -1536,11 +1527,7 @@ class WPSEO_Upgrade {
 
 		$indexable_table = Model::get_table_name( 'Indexable' );
 
-		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery -- Reason: Most performant way.
-		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching -- Reason: No relevant caches.
-		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Reason: Is it prepared already.
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Reason: Too hard to fix.
-		$delete_query = $wpdb->query( "DELETE FROM $indexable_table WHERE object_type = 'user'" );
+		$delete_query = "DELETE FROM $indexable_table WHERE object_type = 'user'";
 		// phpcs:enable
 
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching -- Reason: No relevant caches.

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -1497,11 +1497,7 @@ class WPSEO_Upgrade {
 
 		$indexable_table = Model::get_table_name( 'Indexable' );
 
-		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery -- Reason: Most performant way.
-		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching -- Reason: No relevant caches.
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Reason: Too hard to fix.
-		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Reason: Is it prepared already.
-		$query = $wpdb->query(
+		$query =
 			"SELECT
 				MAX(id) as newest_id,
 				object_id,
@@ -1515,9 +1511,7 @@ class WPSEO_Upgrade {
 				object_id,
 				object_type
 			HAVING
-				count(*) > 1"
-		);
-		// phpcs:enable
+				count(*) > 1";
 
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery -- Reason: Most performant way.
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching -- Reason: No relevant caches.

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -287,12 +287,7 @@ class WPSEO_Upgrade {
 		global $wpdb;
 
 		// Between 3.2 and 3.4 the sitemap options were saved with autoloading enabled.
-		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery -- Reason: Most performant way.
-		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching -- Reason: No relevant caches.
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Reason: Too hard to fix.
-		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Reason: Is it prepared already.
 		$wpdb->query( 'DELETE FROM ' . $wpdb->options . ' WHERE option_name LIKE "wpseo_sitemap_%" AND autoload = "yes"' );
-		// phpcs:enable
 	}
 
 	/**
@@ -323,16 +318,12 @@ class WPSEO_Upgrade {
 		global $wpdb;
 
 		// The meta key has to be private, so prefix it.
-		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery -- Reason: Most performant way.
-		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching -- Reason: No relevant caches.
-		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Reason: Is it prepared already.
 		$wpdb->query(
 			$wpdb->prepare(
 				'UPDATE ' . $wpdb->postmeta . ' SET meta_key = %s WHERE meta_key = "yst_is_cornerstone"',
 				WPSEO_Cornerstone_Filter::META_NAME
 			)
 		);
-		//phpcs:enable
 	}
 
 	/**
@@ -404,12 +395,8 @@ class WPSEO_Upgrade {
 	private function upgrade_50() {
 		global $wpdb;
 
-		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery -- Reason: Most performant way.
-		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching -- Reason: No relevant caches.
-		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Reason: Is it prepared already.
 		// Deletes the post meta value, which might created in the RC.
 		$wpdb->query( 'DELETE FROM ' . $wpdb->postmeta . ' WHERE meta_key = "_yst_content_links_processed"' );
-		//phpcs:enable
 	}
 
 	/**
@@ -501,11 +488,7 @@ class WPSEO_Upgrade {
 
 		// Moves the user meta for excluding from the XML sitemap to a noindex.
 		global $wpdb;
-		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery -- Reason: Most performant way.
-		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching -- Reason: No relevant caches.
-		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Reason: Is it prepared already.
 		$wpdb->query( "UPDATE $wpdb->usermeta SET meta_key = 'wpseo_noindex_author' WHERE meta_key = 'wpseo_excludeauthorsitemap'" );
-		//phpcs:enable
 	}
 
 	/**
@@ -534,11 +517,7 @@ class WPSEO_Upgrade {
 	private function upgrade_73() {
 		global $wpdb;
 		// We've moved the cornerstone checkbox to our proper namespace.
-		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery -- Reason: Most performant way.
-		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching -- Reason: No relevant caches.
-		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Reason: Is it prepared already.
 		$wpdb->query( "UPDATE $wpdb->postmeta SET meta_key = '_yoast_wpseo_is_cornerstone' WHERE meta_key = '_yst_is_cornerstone'" );
-		// phpcs:enable
 		// Remove the previous Whip dismissed message, as this is a new one regarding PHP 5.2.
 		delete_option( 'whip_dismiss_timestamp' );
 	}
@@ -608,11 +587,7 @@ class WPSEO_Upgrade {
 
 		// Removes all scheduled tasks for hitting the sitemap index.
 		wp_clear_scheduled_hook( 'wpseo_hit_sitemap_index' );
-		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery -- Reason: Most performant way.
-		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching -- Reason: No relevant caches.
-		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Reason: Is it prepared already.
 		$wpdb->query( 'DELETE FROM ' . $wpdb->options . ' WHERE option_name LIKE "wpseo_sitemap_%"' );
-		// phpcs:enable
 	}
 
 	/**
@@ -683,11 +658,9 @@ class WPSEO_Upgrade {
 		}
 
 		global $wpdb;
-		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery -- Reason: Most performant way.
-		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching -- Reason: No relevant caches.
-		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Reason: Is it prepared already.
+
 		$wpdb->query( "DELETE FROM $wpdb->usermeta WHERE meta_key = 'wp_yoast_promo_hide_premium_upsell_admin_block'" );
-		// phpcs:enable
+
 		// Removes the WordPress update notification, because it is no longer necessary when WordPress 5.3 is released.
 		$center = Yoast_Notification_Center::get();
 		$center->remove_notification_by_id( 'wpseo-dismiss-wordpress-upgrade' );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Changes a couple of queries to make sure they don't create a notice.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the upgrade routine would throw a notice when certain queries were executed.

## Relevant technical choices:

* None.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Run the upgrade routine and confirm that there are no PHP notices in the debug.log file afterwards.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

Taken from [the original cleanup PR](https://github.com/Yoast/wordpress-seo/pull/19087):

👉 _Start testing with our production version installed_

#### 1. Removing user indexables

1. In the search appearance settings, make sure author archives are _enabled_.
1. Perform a full reindex on the latest release (`wp yoast index --reindex --skip-confirmation`).
1. Create a new user that has the subscriber role.
1. In the database, verify that the wp_yoast_indexables table has indexables for all users, including your new subscriber user.
1. checkout this branch.
1. Refresh any page. This runs the upgrade routines (if you have already ran the upgrade routines for 19.10 once, you might need to reset the plugin version number with the Yoast test helper plugin).
2. Now run the `wpseo_start_cleanup_indexables` cron job
1. Check the database again.
	* The user indexable for your new user should be gone.
	* Visiting the permalink for any of the user indexables should show their author archive. No user should be left in the database table _without_ and author archive.


##### 1.3 Removing all user indexables when author archives are disabled
1. Repeat all steps from 1.1 and 1.2. But this time, make sure the author archives are _disabled_. (no need to run the `wpseo_start_cleanup_indexables` cron job)
1. In both cases, _all_ user indexables should be removed from the database.


#### 2. Removing duplicates

1. Switch back to the latest release. (or at least a version without https://github.com/Yoast/wordpress-seo/pull/19079)
1. We need to simulate a failing indexable build. Add the following line of code before [src/builders/indexable-builder.php:321:](https://github.com/Yoast/wordpress-seo/blob/60871b9bbe6861f1768e17ec3990672cd7efc4b3/src/builders/indexable-builder.php#L321) `throw new \Yoast\WP\SEO\Exceptions\Indexable\Post_Not_Found_Exception();`
1. Find any post in the WP admin and click update. Do this 4 times.
1. Check the database: this should have spawned at least 4 indexables with the 'unindexed' status for your post.
1. Switch to this branch.
1. Refresh any page. This runs the upgrade routines (if you have already ran the upgrade routines for 19.10 once, you might need to reset the plugin version number with the Yoast test helper plugin).
1. Check the database again. Only one indexable should remain for your post.

##### 2.2. Cleanup
1. Revert the code changes you made.

#### 3. Removing objects that are not publicly viewable

1. Switch back to the latest release. (or at least a version without https://github.com/Yoast/wordpress-seo/pull/19077)
1. Install a plugin to manage custom post types and taxonomies.
1.  Create a post type and a taxonomy that are publicly viewable. Create multiple and play around with their settings.
1. Create at least one post of each post type/taxonomy.
1. Check the database: all your posts and terms should be present in the wp_yoast_indexables table.
1. Checkout this branch.
1. Refresh any page. This runs the upgrade routines (if you have already ran the upgrade routines for 19.10 once, you might need to reset the plugin version number with the Yoast test helper plugin).
1. Check the database again: there should only be indexable rows for posts and terms that are publicly viewable. The posts/terms that are not should be removed.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes #
DUPP-669