### PR TITLE
DUPP-670 Fix filter_var call for dismiss_notice

### DIFF
--- a/admin/ajax/class-yoast-plugin-conflict-ajax.php
+++ b/admin/ajax/class-yoast-plugin-conflict-ajax.php
@@ -38,9 +38,11 @@ class Yoast_Plugin_Conflict_Ajax {
 		\check_ajax_referer( 'dismiss-plugin-conflict' );
 
 		if ( ! isset( $_POST['data'] ) || ! is_array( $_POST['data'] ) ) {
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Reason: WPSEO_Utils::format_json_encode is considered safe.
 			\wp_die( WPSEO_Utils::format_json_encode( [] ) );
 		}
 
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Reason: $conflict_data is getting sanitized later.
 		$conflict_data = \wp_unslash( $_POST['data'] );
 
 		$conflict_data = [

--- a/admin/ajax/class-yoast-plugin-conflict-ajax.php
+++ b/admin/ajax/class-yoast-plugin-conflict-ajax.php
@@ -35,9 +35,18 @@ class Yoast_Plugin_Conflict_Ajax {
 	 * Handles the dismiss notice request.
 	 */
 	public function dismiss_notice() {
-		check_ajax_referer( 'dismiss-plugin-conflict' );
+		\check_ajax_referer( 'dismiss-plugin-conflict' );
 
-		$conflict_data = filter_input( INPUT_POST, 'data', FILTER_DEFAULT, FILTER_REQUIRE_ARRAY );
+		if ( ! isset( $_POST['data']) || ! is_array( $_POST['data'] ) ) {
+			\wp_die( WPSEO_Utils::format_json_encode( [] ) );
+		}
+
+		$conflict_data = \wp_unslash( $_POST[ 'data' ] );
+
+		$conflict_data = [
+			'section' => \sanitize_text_field( $conflict_data[ 'section' ] ),
+			'plugins' => \sanitize_text_field( $conflict_data['plugins' ] ),
+		];
 
 		$this->dismissed_conflicts = $this->get_dismissed_conflicts( $conflict_data['section'] );
 
@@ -45,7 +54,7 @@ class Yoast_Plugin_Conflict_Ajax {
 
 		$this->save_dismissed_conflicts( $conflict_data['section'] );
 
-		wp_die( 'true' );
+		\wp_die( 'true' );
 	}
 
 	/**

--- a/admin/ajax/class-yoast-plugin-conflict-ajax.php
+++ b/admin/ajax/class-yoast-plugin-conflict-ajax.php
@@ -37,15 +37,15 @@ class Yoast_Plugin_Conflict_Ajax {
 	public function dismiss_notice() {
 		\check_ajax_referer( 'dismiss-plugin-conflict' );
 
-		if ( ! isset( $_POST['data']) || ! is_array( $_POST['data'] ) ) {
+		if ( ! isset( $_POST['data'] ) || ! is_array( $_POST['data'] ) ) {
 			\wp_die( WPSEO_Utils::format_json_encode( [] ) );
 		}
 
-		$conflict_data = \wp_unslash( $_POST[ 'data' ] );
+		$conflict_data = \wp_unslash( $_POST['data'] );
 
 		$conflict_data = [
-			'section' => \sanitize_text_field( $conflict_data[ 'section' ] ),
-			'plugins' => \sanitize_text_field( $conflict_data['plugins' ] ),
+			'section' => \sanitize_text_field( $conflict_data['section'] ),
+			'plugins' => \sanitize_text_field( $conflict_data['plugins'] ),
 		];
 
 		$this->dismissed_conflicts = $this->get_dismissed_conflicts( $conflict_data['section'] );

--- a/admin/ajax/class-yoast-plugin-conflict-ajax.php
+++ b/admin/ajax/class-yoast-plugin-conflict-ajax.php
@@ -35,19 +35,19 @@ class Yoast_Plugin_Conflict_Ajax {
 	 * Handles the dismiss notice request.
 	 */
 	public function dismiss_notice() {
-		\check_ajax_referer( 'dismiss-plugin-conflict' );
+		check_ajax_referer( 'dismiss-plugin-conflict' );
 
 		if ( ! isset( $_POST['data'] ) || ! is_array( $_POST['data'] ) ) {
 			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Reason: WPSEO_Utils::format_json_encode is considered safe.
-			\wp_die( WPSEO_Utils::format_json_encode( [] ) );
+			wp_die( WPSEO_Utils::format_json_encode( [] ) );
 		}
 
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Reason: $conflict_data is getting sanitized later.
-		$conflict_data = \wp_unslash( $_POST['data'] );
+		$conflict_data = wp_unslash( $_POST['data'] );
 
 		$conflict_data = [
-			'section' => \sanitize_text_field( $conflict_data['section'] ),
-			'plugins' => \sanitize_text_field( $conflict_data['plugins'] ),
+			'section' => sanitize_text_field( $conflict_data['section'] ),
+			'plugins' => sanitize_text_field( $conflict_data['plugins'] ),
 		];
 
 		$this->dismissed_conflicts = $this->get_dismissed_conflicts( $conflict_data['section'] );
@@ -56,7 +56,7 @@ class Yoast_Plugin_Conflict_Ajax {
 
 		$this->save_dismissed_conflicts( $conflict_data['section'] );
 
-		\wp_die( 'true' );
+		wp_die( 'true' );
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to be compatible with PHP 8.1.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improve PHP 8.1 compatibility for `dismiss_notice` function.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* The class seems to be not used so there are no test instructions for this PR.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes #
