### PR TITLE
DUPP-670 Refactor filter_input usage in ajax_get_keyword_usage function

### DIFF
--- a/admin/ajax.php
+++ b/admin/ajax.php
@@ -276,9 +276,21 @@ add_action( 'wp_ajax_get_focus_keyword_usage', 'ajax_get_keyword_usage' );
  * Retrieves the keyword for the keyword doubles of the termpages.
  */
 function ajax_get_term_keyword_usage() {
-	$post_id       = filter_input( INPUT_POST, 'post_id' );
-	$keyword       = filter_input( INPUT_POST, 'keyword' );
-	$taxonomy_name = filter_input( INPUT_POST, 'taxonomy' );
+	check_ajax_referer( 'wpseo-keyword-usage', 'nonce' );
+
+	if ( ! isset( $_POST['post_id'], $_POST['keyword'], $_POST['taxonomy'] ) || ! is_string( $_POST['keyword'] ) || ! is_string( $_POST['taxonomy'] ) ) {
+		wp_die( -1 );
+	}
+
+	// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Reason: We are casting the unsafe input to an integer.
+	$post_id = (int) wp_unslash( $_POST['post_id'] );
+
+	if ( $post_id === 0 ) {
+		wp_die( -1 );
+	}
+
+	$keyword       = sanitize_text_field( wp_unslash( $_POST['keyword'] ) );
+	$taxonomy_name = sanitize_text_field( wp_unslash( $_POST['taxonomy'] ) );
 
 	$taxonomy = get_taxonomy( $taxonomy_name );
 
@@ -292,7 +304,7 @@ function ajax_get_term_keyword_usage() {
 
 	$usage = WPSEO_Taxonomy_Meta::get_keyword_usage( $keyword, $post_id, $taxonomy_name );
 
-	// Normalize the result so it it the same as the post keyword usage AJAX request.
+	// Normalize the result so it is the same as the post keyword usage AJAX request.
 	$usage = $usage[ $keyword ];
 
 	wp_die(

--- a/admin/ajax.php
+++ b/admin/ajax.php
@@ -249,12 +249,20 @@ function wpseo_upsert_new( $what, $post_id, $new_value, $original ) {
  * Retrieves the keyword for the keyword doubles.
  */
 function ajax_get_keyword_usage() {
-	$post_id = filter_input( INPUT_POST, 'post_id' );
-	$keyword = filter_input( INPUT_POST, 'keyword' );
+	check_ajax_referer( 'wpseo-keyword-usage', 'nonce' );
 
-	if ( ! current_user_can( 'edit_post', $post_id ) ) {
+	if ( ! isset( $_POST['post_id'], $_POST['keyword'] ) || ! is_string( $_POST['keyword'] ) ) {
 		die( '-1' );
 	}
+
+	// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- We are casting to an integer.
+	$post_id = (int) wp_unslash( $_POST['post_id'] );
+
+	if ( $post_id === 0 || ! current_user_can( 'edit_post', $post_id ) ) {
+		die( '-1' );
+	}
+
+	$keyword = sanitize_text_field( wp_unslash( $_POST['keyword'] ) );
 
 	wp_die(
 		// phpcs:ignore WordPress.Security.EscapeOutput -- Reason: WPSEO_Utils::format_json_encode is safe.

--- a/admin/taxonomy/class-taxonomy.php
+++ b/admin/taxonomy/class-taxonomy.php
@@ -145,7 +145,7 @@ class WPSEO_Taxonomy {
 			$asset_manager->localize_script( 'term-edit', 'wpseoAdminL10n', WPSEO_Utils::get_admin_l10n() );
 
 			$script_data = [
-				'analysis'         => [
+				'analysis'          => [
 					'plugins' => [
 						'replaceVars' => [
 							'no_parent_text'           => __( '(no parent)', 'wordpress-seo' ),
@@ -161,14 +161,15 @@ class WPSEO_Taxonomy {
 						'log_level'               => WPSEO_Utils::get_analysis_worker_log_level(),
 					],
 				],
-				'media'            => [
+				'media'             => [
 					// @todo replace this translation with JavaScript translations.
 					'choose_image' => __( 'Use Image', 'wordpress-seo' ),
 				],
-				'metabox'          => $this->localize_term_scraper_script(),
-				'userLanguageCode' => WPSEO_Language_Utils::get_language( \get_user_locale() ),
-				'isTerm'           => true,
-				'postId'           => $tag_id,
+				'metabox'           => $this->localize_term_scraper_script(),
+				'userLanguageCode'  => WPSEO_Language_Utils::get_language( \get_user_locale() ),
+				'isTerm'            => true,
+				'postId'            => $tag_id,
+				'usedKeywordsNonce' => \wp_create_nonce( 'wpseo-keyword-usage' ),
 			];
 			$asset_manager->localize_script( 'term-edit', 'wpseoScriptData', $script_data );
 			$asset_manager->enqueue_user_language_script();

--- a/packages/js/src/analysis/usedKeywords.js
+++ b/packages/js/src/analysis/usedKeywords.js
@@ -19,10 +19,11 @@ var $ = jQuery;
  * @param {Object}   options.post_edit_url The URL to link the user to if the keyword has been used a single time.
  * @param {Function} refreshAnalysis       Function that triggers a refresh of the analysis.
  * @param {string}   scriptUrl             The URL to the used keywords assessment script.
+ * @param {string}   nonce                 The nonce to use for the POST request to get the used keywords.
  *
  * @returns {void}
  */
-export default function UsedKeywords( ajaxAction, options, refreshAnalysis, scriptUrl ) {
+export default function UsedKeywords( ajaxAction, options, refreshAnalysis, scriptUrl, nonce ) {
 	this._scriptUrl = scriptUrl;
 	this._options = {
 		usedKeywords: options.keyword_usage,
@@ -32,6 +33,7 @@ export default function UsedKeywords( ajaxAction, options, refreshAnalysis, scri
 	this._keywordUsage = options.keyword_usage;
 	this._postID = $( "#post_ID, [name=tag_ID]" ).val();
 	this._taxonomy = $( "[name=taxonomy]" ).val() || "";
+	this._nonce = nonce;
 	this._ajaxAction = ajaxAction;
 	this._refreshAnalysis = refreshAnalysis;
 	this._initialized = false;
@@ -92,6 +94,7 @@ UsedKeywords.prototype.requestKeywordUsage = function( keyword ) {
 		post_id: this._postID,
 		keyword: keyword,
 		taxonomy: this._taxonomy,
+		nonce: this._nonce,
 	}, this.updateKeywordUsage.bind( this, keyword ), "json" );
 };
 

--- a/packages/js/src/elementor/initializers/used-keywords-assessment.js
+++ b/packages/js/src/elementor/initializers/used-keywords-assessment.js
@@ -17,11 +17,18 @@ export default function initializeUsedKeywords() {
 		"used-keywords-assessment.js"
 	);
 
+	const nonce = get(
+		window,
+		[ "wpseoScriptData", "usedKeywordsNonce" ],
+		""
+	);
+
 	const usedKeywords = new UsedKeywords(
 		"get_focus_keyword_usage",
 		localizedData,
 		dispatch( "yoast-seo/editor" ).runAnalysis,
-		scriptUrl
+		scriptUrl,
+		nonce
 	);
 	usedKeywords.init();
 

--- a/packages/js/src/initializers/used-keywords-assessment.js
+++ b/packages/js/src/initializers/used-keywords-assessment.js
@@ -25,11 +25,18 @@ export default function initializeUsedKeywords( refreshAnalysis, ajaxAction, sto
 		"used-keywords-assessment.js"
 	);
 
+	const nonce = get(
+		window,
+		[ "wpseoScriptData", "usedKeywordsNonce" ],
+		""
+	);
+
 	const usedKeywords = new UsedKeywords(
 		ajaxAction,
 		localizedData,
 		refreshAnalysis,
-		scriptUrl
+		scriptUrl,
+		nonce
 	);
 	usedKeywords.init();
 

--- a/src/integrations/third-party/elementor.php
+++ b/src/integrations/third-party/elementor.php
@@ -434,6 +434,7 @@ class Elementor implements Integration_Interface {
 			],
 			'dismissedAlerts'          => $dismissed_alerts,
 			'webinarIntroElementorUrl' => WPSEO_Shortlinker::get( 'https://yoa.st/webinar-intro-elementor' ),
+			'usedKeywordsNonce'        => \wp_create_nonce( 'wpseo-keyword-usage' ),
 		];
 
 		if ( \post_type_supports( $this->get_metabox_post()->post_type, 'thumbnail' ) ) {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to replace all `filter_input` calls in our codebase.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Refactor `filter_input` calls in `ajax_get_keyword_usage` and `ajax_get_term_keyword_usage` functions.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Activate Yoast SEO and go to a post editor.
* Enter a focus keyphrase and verify that the right assessments show up (e.g. that your focus keyphrase is not in post title and not in the beginning of the post content).
* Now add your focus keyphrase to the post title or the beginning of the post content and verify that the assessments disappear.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [x] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

Fixes #
