### PR TITLE
Remove Flesch reading ease move notice

### DIFF
--- a/packages/analysis-report/src/AnalysisResult.js
+++ b/packages/analysis-report/src/AnalysisResult.js
@@ -44,7 +44,7 @@ export const AnalysisResult = ( props ) => {
 	return (
 		<AnalysisResultBase>
 			<ScoreIcon
-				icon={ props.icon }
+				icon="circle"
 				color={ props.bulletColor }
 				size="13px"
 			/>
@@ -79,7 +79,6 @@ export const AnalysisResult = ( props ) => {
 };
 
 AnalysisResult.propTypes = {
-	icon: PropTypes.string,
 	text: PropTypes.string.isRequired,
 	suppressedText: PropTypes.bool,
 	bulletColor: PropTypes.string.isRequired,
@@ -100,7 +99,6 @@ AnalysisResult.propTypes = {
 };
 
 AnalysisResult.defaultProps = {
-	icon: "circle",
 	suppressedText: false,
 	marksButtonStatus: "enabled",
 	marksButtonClassName: "",

--- a/packages/components/src/insights-card/InsightsCard.js
+++ b/packages/components/src/insights-card/InsightsCard.js
@@ -31,16 +31,14 @@ class InsightsCard extends React.Component {
 	 */
 	render() {
 		return (
-			<div id={ this.props.id }>
-				<FieldGroup
-					label={ this.props.title }
-					linkTo={ this.props.linkTo }
-					linkText={ this.props.linkText }
-					wrapperClassName={ "yoast-insights-card" }
-				>
-					{ this.getInsightsCardContent() }
-				</FieldGroup>
-			</div>
+			<FieldGroup
+				label={ this.props.title }
+				linkTo={ this.props.linkTo }
+				linkText={ this.props.linkText }
+				wrapperClassName={ "yoast-insights-card" }
+			>
+				{ this.getInsightsCardContent() }
+			</FieldGroup>
 		);
 	}
 }
@@ -48,7 +46,6 @@ class InsightsCard extends React.Component {
 export default InsightsCard;
 
 InsightsCard.propTypes = {
-	id: PropTypes.string.isRequired,
 	title: PropTypes.string,
 	amount: PropTypes.oneOfType( [ PropTypes.number, PropTypes.oneOf( [ "?" ] ) ] ).isRequired,
 	description: PropTypes.element,

--- a/packages/js/src/components/contentAnalysis/ReadabilityAnalysis.js
+++ b/packages/js/src/components/contentAnalysis/ReadabilityAnalysis.js
@@ -176,7 +176,6 @@ ReadabilityAnalysis.propTypes = {
 	isYoastSEOWooActive: PropTypes.bool,
 	isInsightsEnabled: PropTypes.bool,
 	isElementorEditor: PropTypes.bool,
-	isFleschReadingEaseAvailable: PropTypes.bool,
 };
 
 ReadabilityAnalysis.defaultProps = {
@@ -185,7 +184,6 @@ ReadabilityAnalysis.defaultProps = {
 	isYoastSEOWooActive: false,
 	isInsightsEnabled: false,
 	isElementorEditor: false,
-	isFleschReadingEaseAvailable: false,
 };
 
 export default withSelect( select => {
@@ -194,7 +192,6 @@ export default withSelect( select => {
 		getMarkButtonStatus,
 		getPreference,
 		getIsElementorEditor,
-		isFleschReadingEaseAvailable,
 	} = select( "yoast-seo/editor" );
 
 	const isInsightsEnabled = getPreference( "isInsightsEnabled", false );
@@ -204,6 +201,5 @@ export default withSelect( select => {
 		marksButtonStatus: getMarkButtonStatus(),
 		isInsightsEnabled,
 		isElementorEditor: getIsElementorEditor(),
-		isFleschReadingEaseAvailable: isFleschReadingEaseAvailable(),
 	};
 } )( ReadabilityAnalysis );

--- a/packages/js/src/components/contentAnalysis/ReadabilityAnalysis.js
+++ b/packages/js/src/components/contentAnalysis/ReadabilityAnalysis.js
@@ -5,7 +5,7 @@ import { withSelect } from "@wordpress/data";
 import PropTypes from "prop-types";
 import styled from "styled-components";
 import { __, sprintf } from "@wordpress/i18n";
-import { isNil, noop } from "lodash-es";
+import { isNil } from "lodash-es";
 
 /* Internal components */
 import ScoreIconPortal from "../portals/ScoreIconPortal";
@@ -16,8 +16,6 @@ import { getIconForScore } from "./mapResults";
 import { LocationConsumer } from "@yoast/externals/contexts";
 import HelpLink from "../HelpLink";
 import ReadabilityResultsPortal from "../portals/ReadabilityResultsPortal";
-import { AnalysisResult } from "@yoast/analysis-report";
-import { icons } from "@yoast/components";
 import { isWordComplexitySupported } from "../../helpers/assessmentUpsellHelpers";
 
 const AnalysisHeader = styled.span`
@@ -119,96 +117,6 @@ class ReadabilityAnalysis extends Component {
 	}
 
 	/**
-	 * Returns a note letting the user know that the Flesch reading ease score has moved to
-	 * the insights section.
-	 *
-	 * @param {string} location The location of the readability analysis (e.g. "metabox" or "sidebar" ).
-	 *
-	 * @returns {JSX.Element} The Flesch reading ease note.
-	 */
-	renderFleschReadingEaseNote( location ) {
-		const icon = `<svg
-			style="vertical-align: middle; margin-left: 2px"
-			width="14px"
-			height="14px"
-			aria-hidden="true"
-			role="img"
-			focusable="false"
-			class="yoast-svg-icon yoast-svg-icon-pencil-square"
-			viewBox="0 0 1792 1792"
-			fill="currentColor">
-				<path d="${ icons[ "pencil-square" ].path }"></path>
-		</svg>`;
-
-		const linkToYoastCom = location === "sidebar"
-			? wpseoAdminL10n[ "shortlinks-insights-flesch_reading_ease_sidebar" ]
-			: wpseoAdminL10n[ "shortlinks-insights-flesch_reading_ease_metabox" ];
-
-		let text = "";
-		if ( this.props.isInsightsEnabled ) {
-			const onClick = `
-			const location = "${ location }";
-			const isElementor = ${ this.props.isElementorEditor };
-			
-			if ( isElementor ) {
-				document.getElementById( "yoast-insights-modal-elementor-open-button" ).click();
-			} else {
-				const metaTab = document.getElementById( "wpseo-meta-tab-content" );
-				if ( metaTab && location === "metabox" ) {
-					metaTab.click();
-					setTimeout( () => {
-						const collapsible = document.getElementById( "yoast-insights-collapsible-metabox" );
-						if( collapsible.getAttribute( "aria-expanded" ) === "false" ) {
-							collapsible.click();
-						}
-						document.getElementById( "yoastseo-flesch-reading-ease-insights" ).scrollIntoView();
-					}, 300 );
-				} else if ( location === "sidebar" ) {
-					document.getElementById( "yoast-insights-modal-sidebar-open-button" ).click();
-				}
-			}
-			`.replaceAll( /(\n|\s)+/g, " " );
-
-			text = sprintf(
-				/* Translators:
-					%1$s is an anchor opening tag with a link leading to an article on yoast.com;
-					%2$s is an anchor closing tag;
-					%3$s is an anchor opening tag with a link to our insights section;
-					%4$s is an icon. */
-				__( "Curious to see the %1$sFlesch reading ease%2$s score of your text? We've moved the score to our %3$sInsights%4$s%2$s section.", "wordpress-seo" ),
-				`<a href='${ linkToYoastCom }' target='_blank'>`,
-				"</a>",
-				`<a href='#' onclick='${ onClick }'>`,
-				icon
-			);
-		} else {
-			text = sprintf(
-				/* Translators:
-					%1$s is an anchor opening tag with a link leading to an article on yoast.com;
-					%2$s is an anchor closing tag; */
-				__( "Curious to see the %1$sFlesch reading ease%2$s score of your text? " +
-					"We've moved the score to our Insights section. " +
-					"Enable the Insights feature in General > Features, or ask your admin to enable it for you.", "wordpress-seo" ),
-				`<a href='${ linkToYoastCom }' target='_blank'>`,
-				"</a>"
-			);
-		}
-
-		return <ul>
-			<AnalysisResult
-				icon="alert-info"
-				pressed={ false }
-				onButtonClickMarks={ noop }
-				bulletColor="gray"
-				buttonIdMarks={ "" }
-				text={ text }
-				hasMarksButton={ false }
-				ariaLabelMarks={ "" }
-			/>
-		</ul>;
-	}
-
-	/**
 	 * Renders the Readability Analysis component.
 	 *
 	 * @returns {wp.Element} The Readability Analysis component.
@@ -237,7 +145,6 @@ class ReadabilityAnalysis extends Component {
 								id={ `yoast-readability-analysis-collapsible-${ location }` }
 							>
 								{ this.renderResults( upsellResults ) }
-								{ this.props.isFleschReadingEaseAvailable && this.renderFleschReadingEaseNote( location ) }
 							</Collapsible>
 						);
 					}
@@ -251,7 +158,6 @@ class ReadabilityAnalysis extends Component {
 										scoreIndicator={ score.className }
 									/>
 									{ this.renderResults( upsellResults ) }
-									{ this.props.isFleschReadingEaseAvailable && this.renderFleschReadingEaseNote( location ) }
 								</ReadabilityResultsTabContainer>
 							</ReadabilityResultsPortal>
 						);

--- a/packages/js/src/components/contentAnalysis/ReadabilityAnalysis.js
+++ b/packages/js/src/components/contentAnalysis/ReadabilityAnalysis.js
@@ -174,32 +174,22 @@ ReadabilityAnalysis.propTypes = {
 	overallScore: PropTypes.number,
 	shouldUpsell: PropTypes.bool,
 	isYoastSEOWooActive: PropTypes.bool,
-	isInsightsEnabled: PropTypes.bool,
-	isElementorEditor: PropTypes.bool,
 };
 
 ReadabilityAnalysis.defaultProps = {
 	overallScore: null,
 	shouldUpsell: false,
 	isYoastSEOWooActive: false,
-	isInsightsEnabled: false,
-	isElementorEditor: false,
 };
 
 export default withSelect( select => {
 	const {
 		getReadabilityResults,
 		getMarkButtonStatus,
-		getPreference,
-		getIsElementorEditor,
 	} = select( "yoast-seo/editor" );
-
-	const isInsightsEnabled = getPreference( "isInsightsEnabled", false );
 
 	return {
 		...getReadabilityResults(),
 		marksButtonStatus: getMarkButtonStatus(),
-		isInsightsEnabled,
-		isElementorEditor: getIsElementorEditor(),
 	};
 } )( ReadabilityAnalysis );

--- a/packages/js/src/insights/components/estimated-reading-time.js
+++ b/packages/js/src/insights/components/estimated-reading-time.js
@@ -14,7 +14,6 @@ const EstimatedReadingTime = () => {
 
 	return (
 		<InsightsCard
-			id={ "yoastseo-estimated-reading-time-insights" }
 			amount={ estimatedReadingTime }
 			unit={ _n( "minute", "minutes", estimatedReadingTime, "wordpress-seo" ) }
 			title={ __( "Reading time", "wordpress-seo" ) }

--- a/packages/js/src/insights/components/flesch-reading-ease.js
+++ b/packages/js/src/insights/components/flesch-reading-ease.js
@@ -131,7 +131,6 @@ const FleschReadingEase = () => {
 
 	return (
 		<InsightsCard
-			id={ "yoastseo-flesch-reading-ease-insights" }
 			amount={ score }
 			unit={ __( "out of 100", "wordpress-seo" ) }
 			title={ __( "Flesch reading ease", "wordpress-seo" ) }

--- a/packages/js/src/insights/components/text-length.js
+++ b/packages/js/src/insights/components/text-length.js
@@ -23,7 +23,6 @@ const TextLength = () => {
 
 	return (
 		<InsightsCard
-			id={ "yoastseo-text-length-insights" }
 			amount={ textLength.count }
 			unit={ unitString }
 			title={ titleString }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* After moving the Flesch reading ease assessment to Insights, we [added a notice in the Readability analysis metabox](https://github.com/Yoast/wordpress-seo/pull/18677) to inform the users. This notice can now be removed.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Removes the note in the readability analysis results that tells users that the Flesch reading ease score has moved to the insights section.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Block / Gutenberg editor.
* Create a new post.
* Open the readability analysis in the metabox.
* Confirm that below the assessments no notice on the Flesch reading ease assessment is shown.
* Repeat the above steps for the readability analysis in the sidebar.

#### Shopify
* Repeat the above steps, but given that there is no sidebar, you only have to test the metabox.

#### Classic editor
* Repeat the above steps, but given that there is no sidebar, you only have to test the metabox.

#### Elementor
* Create a new post.
* Edit the post using Elementor.
* Open the readability analysis in the Yoast SEO section.
* * Confirm that below the assessments no notice on the Flesch reading ease assessment is shown.

#### Upgrade from previous release
* Install a previous version of the plugin.
* Create a new post.
* Install the latest version of the plugin (that includes this change).
* Open the post inside of the block editor.
* Open the readability analysis in the metabox.
* Confirm that below the assessments no paragraph about the Flesh reading ease is shown
* Repeat the above steps for the readability analysis in the sidebar.

**Do a quick check on post/page/taxonomies/CPT/custom taxonomy.
**Test with Premium activated/deactivated

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [x] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

Fixes #https://yoast.atlassian.net/jira/software/c/projects/PC/boards/138?modal=detail&selectedIssue=PC-964
