### PR TITLE
Robots_Txt_[Helper|Integration]: fix line ending handling robots.txt

### DIFF
--- a/config/dependency-injection/services.php
+++ b/config/dependency-injection/services.php
@@ -14,6 +14,7 @@ use Yoast\WP\Lib\Migrations\Adapter;
 use Yoast\WP\SEO\WordPress\Wrapper;
 use Yoast_Notification_Center;
 use YoastSEO_Vendor\Symfony\Component\DependencyInjection\ContainerInterface;
+use Yoast\WP\SEO\Presenters\Robots_Txt_Presenter;
 
 /**
  * Holds the dependency injection container.
@@ -36,6 +37,9 @@ $container->register( WPSEO_Utils::class, WPSEO_Utils::class )->setFactory( [ Wr
 // Backwards-compatibility classes in the global namespace.
 $container->register( WPSEO_Breadcrumbs::class, WPSEO_Breadcrumbs::class )->setAutowired( true )->setPublic( true );
 $container->register( WPSEO_Frontend::class, WPSEO_Frontend::class )->setAutowired( true )->setPublic( true );
+
+// Non-excluded from excluded directories.
+$container->register( Robots_Txt_Presenter::class, Robots_Txt_Presenter::class )->setAutowired( true )->setPublic( false );
 
 // The container itself.
 $container->setAlias( ContainerInterface::class, 'service_container' );

--- a/src/integrations/front-end/robots-txt-integration.php
+++ b/src/integrations/front-end/robots-txt-integration.php
@@ -108,8 +108,8 @@ class Robots_Txt_Integration implements Integration_Interface {
 	 * @return string
 	 */
 	protected function remove_default_robots( $robots_txt ) {
-		return \str_replace(
-			"User-agent: *\nDisallow: /wp-admin/\nAllow: /wp-admin/admin-ajax.php\n",
+		return \preg_replace(
+			'`User-agent: \*[\r\n]+Disallow: /wp-admin/[\r\n]+Allow: /wp-admin/admin-ajax\.php[\r\n]+`',
 			'',
 			$robots_txt
 		);

--- a/src/integrations/front-end/robots-txt-integration.php
+++ b/src/integrations/front-end/robots-txt-integration.php
@@ -38,13 +38,14 @@ class Robots_Txt_Integration implements Integration_Interface {
 	/**
 	 * Sets the helpers.
 	 *
-	 * @param Options_Helper    $options_helper    Options helper.
-	 * @param Robots_Txt_Helper $robots_txt_helper Robots txt helper.
+	 * @param Options_Helper       $options_helper       Options helper.
+	 * @param Robots_Txt_Helper    $robots_txt_helper    Robots txt helper.
+	 * @param Robots_Txt_Presenter $robots_txt_presenter Robots txt presenter.
 	 */
-	public function __construct( Options_Helper $options_helper, Robots_Txt_Helper $robots_txt_helper ) {
+	public function __construct( Options_Helper $options_helper, Robots_Txt_Helper $robots_txt_helper, Robots_Txt_Presenter $robots_txt_presenter ) {
 		$this->options_helper       = $options_helper;
 		$this->robots_txt_helper    = $robots_txt_helper;
-		$this->robots_txt_presenter = new Robots_Txt_Presenter( $robots_txt_helper );
+		$this->robots_txt_presenter = $robots_txt_presenter;
 	}
 
 	/**

--- a/src/presenters/robots-txt-presenter.php
+++ b/src/presenters/robots-txt-presenter.php
@@ -9,9 +9,9 @@ use Yoast\WP\SEO\Helpers\Robots_Txt_Helper;
  */
 class Robots_Txt_Presenter extends Abstract_Presenter {
 
-	const YOAST_OUTPUT_BEFORE_COMMENT = "# START YOAST BLOCK\n# ---------------------------\n";
+	const YOAST_OUTPUT_BEFORE_COMMENT = '# START YOAST BLOCK' . \PHP_EOL . '# ---------------------------' . \PHP_EOL;
 
-	const YOAST_OUTPUT_AFTER_COMMENT = "# ---------------------------\n# END YOAST BLOCK";
+	const YOAST_OUTPUT_AFTER_COMMENT = '# ---------------------------' . \PHP_EOL . '# END YOAST BLOCK';
 
 	/**
 	 * Text to be outputted for the allow directive.
@@ -125,8 +125,8 @@ class Robots_Txt_Presenter extends Abstract_Presenter {
 			$robots_txt_content = $this->add_user_agent_directives( $user_agents, $robots_txt_content );
 		}
 		else {
-			$robots_txt_content .= "User-agent: *\n";
-			$robots_txt_content .= "Disallow:\n\n";
+			$robots_txt_content .= 'User-agent: *' . \PHP_EOL;
+			$robots_txt_content .= 'Disallow:' . \PHP_EOL . \PHP_EOL;
 		}
 
 		return $robots_txt_content;

--- a/tests/unit/integrations/front-end/robots-txt-integration-test.php
+++ b/tests/unit/integrations/front-end/robots-txt-integration-test.php
@@ -246,6 +246,42 @@ Sitemap: http://basic.wordpress.test/sitemap_index.xml
 	}
 
 	/**
+	 * Provides the test with multisite data.
+	 *
+	 * @return array The multisite to test.
+	 */
+	public function multisite_provider() {
+		return [
+			'Multisite subdomain' => [
+				'multisite' => [
+					'is_subdirectory' => false,
+					'sites'           => [
+						1 => 'https://example.com/',
+					],
+				],
+			],
+			'Multisite subdirectory' => [
+				'multisite' => [
+					'is_subdirectory' => true,
+					'sites'           => [
+						1 => 'https://example.com/',
+						2 => 'https://example.com/test/',
+					],
+				],
+			],
+			'Multisite subdirectory with only 1 active' => [
+				'multisite' => [
+					'is_subdirectory' => true,
+					'sites'           => [
+						1 => 'https://example.com/',
+						2 => false,
+					],
+				],
+			],
+		];
+	}
+
+	/**
 	 * Tests the robots filter for multisite installations, other site without Yoast SEO activated.
 	 *
 	 * @covers ::filter_robots
@@ -442,44 +478,5 @@ Disallow:
 # END YOAST BLOCK',
 			$this->instance->filter_robots( '' )
 		);
-	}
-
-	/**
-	 * Provides the test with multisite data.
-	 *
-	 * @return array The multisite to test.
-	 */
-	public function multisite_provider() {
-		return [
-			'Multisite subdomain' => [
-				'data' => [
-					'is_subdirectory' => false,
-					'sitemap'         => "Input\n",
-					'sites'           => [
-						1 => 'https://example.com/',
-					],
-				],
-			],
-			'Multisite subdirectory' => [
-				'data' => [
-					'is_subdirectory' => true,
-					'sitemap'         => "Input\n",
-					'sites'           => [
-						1 => 'https://example.com/',
-						2 => 'https://example.com/test/',
-					],
-				],
-			],
-			'Multisite subdirectory with only 1 active' => [
-				'data' => [
-					'is_subdirectory' => true,
-					'sitemap'         => "Input\n",
-					'sites'           => [
-						1 => 'https://example.com/',
-						2 => false,
-					],
-				],
-			],
-		];
 	}
 }

--- a/tests/unit/integrations/front-end/robots-txt-integration-test.php
+++ b/tests/unit/integrations/front-end/robots-txt-integration-test.php
@@ -139,17 +139,16 @@ class Robots_Txt_Integration_Test extends TestCase {
 			->expects( 'get_sitemap_rules' )
 			->andReturn( [ 'http://basic.wordpress.test/sitemap_index.xml' ] );
 
-		$this->assertSame(
-			'# START YOAST BLOCK
-# ---------------------------
-User-agent: *
-Disallow:
+		$expected = '# START YOAST BLOCK' . \PHP_EOL
+			. '# ---------------------------' . \PHP_EOL
+			. 'User-agent: *' . \PHP_EOL
+			. 'Disallow:' . \PHP_EOL
+			. \PHP_EOL
+			. 'Sitemap: http://basic.wordpress.test/sitemap_index.xml' . \PHP_EOL
+			. '# ---------------------------' . \PHP_EOL
+			. '# END YOAST BLOCK';
 
-Sitemap: http://basic.wordpress.test/sitemap_index.xml
-# ---------------------------
-# END YOAST BLOCK',
-			$this->instance->filter_robots( '' )
-		);
+		$this->assertSame( $expected, $this->instance->filter_robots( '' ) );
 	}
 
 	/**
@@ -232,17 +231,16 @@ Sitemap: http://basic.wordpress.test/sitemap_index.xml
 			->expects( 'get_sitemap_rules' )
 			->andReturn( [ 'http://basic.wordpress.test/sitemap_index.xml' ] );
 
-		$this->assertSame(
-			'# START YOAST BLOCK
-# ---------------------------
-User-agent: *
-Disallow:
+		$expected = '# START YOAST BLOCK' . \PHP_EOL
+			. '# ---------------------------' . \PHP_EOL
+			. 'User-agent: *' . \PHP_EOL
+			. 'Disallow:' . \PHP_EOL
+			. \PHP_EOL
+			. 'Sitemap: http://basic.wordpress.test/sitemap_index.xml' . \PHP_EOL
+			. '# ---------------------------' . \PHP_EOL
+			. '# END YOAST BLOCK';
 
-Sitemap: http://basic.wordpress.test/sitemap_index.xml
-# ---------------------------
-# END YOAST BLOCK',
-			$this->instance->filter_robots( '' )
-		);
+		$this->assertSame( $expected, $this->instance->filter_robots( '' ) );
 	}
 
 	/**
@@ -351,17 +349,16 @@ Sitemap: http://basic.wordpress.test/sitemap_index.xml
 			->expects( 'get_sitemap_rules' )
 			->andReturn( [ 'http://basic.wordpress.test/sitemap_index.xml' ] );
 
-		$this->assertSame(
-			'# START YOAST BLOCK
-# ---------------------------
-User-agent: *
-Disallow:
+		$expected = '# START YOAST BLOCK' . \PHP_EOL
+			. '# ---------------------------' . \PHP_EOL
+			. 'User-agent: *' . \PHP_EOL
+			. 'Disallow:' . \PHP_EOL
+			. \PHP_EOL
+			. 'Sitemap: http://basic.wordpress.test/sitemap_index.xml' . \PHP_EOL
+			. '# ---------------------------' . \PHP_EOL
+			. '# END YOAST BLOCK';
 
-Sitemap: http://basic.wordpress.test/sitemap_index.xml
-# ---------------------------
-# END YOAST BLOCK',
-			$this->instance->filter_robots( '' )
-		);
+		$this->assertSame( $expected, $this->instance->filter_robots( '' ) );
 	}
 
 	/**
@@ -433,17 +430,16 @@ Sitemap: http://basic.wordpress.test/sitemap_index.xml
 			->expects( 'get_sitemap_rules' )
 			->andReturn( [ 'http://basic.wordpress.test/sitemap_index.xml' ] );
 
-		$this->assertSame(
-			'# START YOAST BLOCK
-# ---------------------------
-User-agent: *
-Disallow:
+		$expected = '# START YOAST BLOCK' . \PHP_EOL
+			. '# ---------------------------' . \PHP_EOL
+			. 'User-agent: *' . \PHP_EOL
+			. 'Disallow:' . \PHP_EOL
+			. \PHP_EOL
+			. 'Sitemap: http://basic.wordpress.test/sitemap_index.xml' . \PHP_EOL
+			. '# ---------------------------' . \PHP_EOL
+			. '# END YOAST BLOCK';
 
-Sitemap: http://basic.wordpress.test/sitemap_index.xml
-# ---------------------------
-# END YOAST BLOCK',
-			$this->instance->filter_robots( '' )
-		);
+		$this->assertSame( $expected, $this->instance->filter_robots( '' ) );
 	}
 
 	/**
@@ -468,15 +464,14 @@ Sitemap: http://basic.wordpress.test/sitemap_index.xml
 			->expects( 'get_sitemap_rules' )
 			->andReturn( [] );
 
-		$this->assertSame(
-			'# START YOAST BLOCK
-# ---------------------------
-User-agent: *
-Disallow:
+		$expected = '# START YOAST BLOCK' . \PHP_EOL
+			. '# ---------------------------' . \PHP_EOL
+			. 'User-agent: *' . \PHP_EOL
+			. 'Disallow:' . \PHP_EOL
+			. \PHP_EOL
+			. '# ---------------------------' . \PHP_EOL
+			. '# END YOAST BLOCK';
 
-# ---------------------------
-# END YOAST BLOCK',
-			$this->instance->filter_robots( '' )
-		);
+		$this->assertSame( $expected, $this->instance->filter_robots( '' ) );
 	}
 }

--- a/tests/unit/integrations/front-end/robots-txt-integration-test.php
+++ b/tests/unit/integrations/front-end/robots-txt-integration-test.php
@@ -36,6 +36,13 @@ class Robots_Txt_Integration_Test extends TestCase {
 	protected $robots_txt_helper;
 
 	/**
+	 * Holds the robots txt presenter.
+	 *
+	 * @var Mockery\MockInterface|Robots_Txt_Presenter
+	 */
+	protected $robots_txt_presenter;
+
+	/**
 	 * Represents the instance to test.
 	 *
 	 * @var Robots_Txt_Integration
@@ -49,9 +56,10 @@ class Robots_Txt_Integration_Test extends TestCase {
 		parent::set_up();
 		$this->stubEscapeFunctions();
 
-		$this->options_helper    = Mockery::mock( Options_Helper::class );
-		$this->robots_txt_helper = Mockery::mock( Robots_Txt_Helper::class );
-		$this->instance          = new Robots_Txt_Integration( $this->options_helper, $this->robots_txt_helper );
+		$this->options_helper       = Mockery::mock( Options_Helper::class );
+		$this->robots_txt_helper    = Mockery::mock( Robots_Txt_Helper::class );
+		$this->robots_txt_presenter = Mockery::mock( Robots_Txt_Presenter::class, [ $this->robots_txt_helper ] )->makePartial();
+		$this->instance             = new Robots_Txt_Integration( $this->options_helper, $this->robots_txt_helper, $this->robots_txt_presenter );
 	}
 
 	/**

--- a/tests/unit/presenters/robots-txt-presenter-test.php
+++ b/tests/unit/presenters/robots-txt-presenter-test.php
@@ -62,7 +62,7 @@ class Robots_Txt_Presenter_Test extends TestCase {
 			->expects( 'get_sitemap_rules' )
 			->andReturn( $sitemaps );
 
-		$this->assertEquals(
+		$this->assertSame(
 			$expected,
 			$this->instance->present()
 		);
@@ -79,7 +79,14 @@ class Robots_Txt_Presenter_Test extends TestCase {
 			'sitemaps'               => [
 				'http://example.com/sitemap_index.html',
 			],
-			'expected'               => "# START YOAST BLOCK\n# ---------------------------\nUser-agent: *\nDisallow:\n\nSitemap: http://example.com/sitemap_index.html\n# ---------------------------\n# END YOAST BLOCK",
+			'expected'               => '# START YOAST BLOCK' . \PHP_EOL
+				. '# ---------------------------' . \PHP_EOL
+				. 'User-agent: *' . \PHP_EOL
+				. 'Disallow:' . \PHP_EOL
+				. \PHP_EOL
+				. 'Sitemap: http://example.com/sitemap_index.html' . \PHP_EOL
+				. '# ---------------------------' . \PHP_EOL
+				. '# END YOAST BLOCK',
 		];
 		$user_agent_list                         = new User_Agent_List();
 		$user_agent                              = $user_agent_list->get_user_agent( '*' );
@@ -90,7 +97,14 @@ class Robots_Txt_Presenter_Test extends TestCase {
 			'sitemaps'               => [
 				'http://example.com/sitemap_index.html',
 			],
-			'expected'               => "# START YOAST BLOCK\n# ---------------------------\nUser-agent: *\nDisallow: /wp-json/\n\nSitemap: http://example.com/sitemap_index.html\n# ---------------------------\n# END YOAST BLOCK",
+			'expected'               => '# START YOAST BLOCK' . \PHP_EOL
+				. '# ---------------------------' . \PHP_EOL
+				. 'User-agent: *' . \PHP_EOL
+				. 'Disallow: /wp-json/' . \PHP_EOL
+				. \PHP_EOL
+				. 'Sitemap: http://example.com/sitemap_index.html' . \PHP_EOL
+				. '# ---------------------------' . \PHP_EOL
+				. '# END YOAST BLOCK',
 		];
 
 		$user_agent_list = new User_Agent_List();
@@ -105,7 +119,18 @@ class Robots_Txt_Presenter_Test extends TestCase {
 			'sitemaps'               => [
 				'http://example.com/sitemap_index.html',
 			],
-			'expected'               => "# START YOAST BLOCK\n# ---------------------------\nUser-agent: *\nDisallow: /wp-json/\nDisallow: /search/\n\nUser-agent: Googlebot\nDisallow: /disallowed/for/googlebot\n\nSitemap: http://example.com/sitemap_index.html\n# ---------------------------\n# END YOAST BLOCK",
+			'expected'               => '# START YOAST BLOCK' . \PHP_EOL
+				. '# ---------------------------' . \PHP_EOL
+				. 'User-agent: *' . \PHP_EOL
+				. 'Disallow: /wp-json/' . \PHP_EOL
+				. 'Disallow: /search/' . \PHP_EOL
+				. \PHP_EOL
+				. 'User-agent: Googlebot' . \PHP_EOL
+				. 'Disallow: /disallowed/for/googlebot' . \PHP_EOL
+				. \PHP_EOL
+				. 'Sitemap: http://example.com/sitemap_index.html' . \PHP_EOL
+				. '# ---------------------------' . \PHP_EOL
+				. '# END YOAST BLOCK',
 		];
 		$user_agent_list              = new User_Agent_List();
 		$user_agent                   = $user_agent_list->get_user_agent( '*' );
@@ -117,7 +142,15 @@ class Robots_Txt_Presenter_Test extends TestCase {
 			'sitemaps'               => [
 				'http://example.com/sitemap_index.html',
 			],
-			'expected'               => "# START YOAST BLOCK\n# ---------------------------\nUser-agent: *\nDisallow: /wp-json/\nAllow: /search/\n\nSitemap: http://example.com/sitemap_index.html\n# ---------------------------\n# END YOAST BLOCK",
+			'expected'               => '# START YOAST BLOCK' . \PHP_EOL
+				. '# ---------------------------' . \PHP_EOL
+				. 'User-agent: *' . \PHP_EOL
+				. 'Disallow: /wp-json/' . \PHP_EOL
+				. 'Allow: /search/' . \PHP_EOL
+				. \PHP_EOL
+				. 'Sitemap: http://example.com/sitemap_index.html' . \PHP_EOL
+				. '# ---------------------------' . \PHP_EOL
+				. '# END YOAST BLOCK',
 		];
 
 		$user_agent_list = new User_Agent_List();
@@ -136,7 +169,22 @@ class Robots_Txt_Presenter_Test extends TestCase {
 			'sitemaps'               => [
 				'http://example.com/sitemap_index.html',
 			],
-			'expected'               => "# START YOAST BLOCK\n# ---------------------------\nUser-agent: *\nDisallow: /wp-json/\nAllow: /search/\n\nUser-agent: Googlebot\nDisallow: /disallowed/for/googlebot\nDisallow: /wp-admin\n\nUser-agent: Yahoobot\nAllow: /allowed/for/yahoo\n\nSitemap: http://example.com/sitemap_index.html\n# ---------------------------\n# END YOAST BLOCK",
+			'expected'               => '# START YOAST BLOCK' . \PHP_EOL
+				. '# ---------------------------' . \PHP_EOL
+				. 'User-agent: *' . \PHP_EOL
+				. 'Disallow: /wp-json/' . \PHP_EOL
+				. 'Allow: /search/' . \PHP_EOL
+				. \PHP_EOL
+				. 'User-agent: Googlebot' . \PHP_EOL
+				. 'Disallow: /disallowed/for/googlebot' . \PHP_EOL
+				. 'Disallow: /wp-admin' . \PHP_EOL
+				. \PHP_EOL
+				. 'User-agent: Yahoobot' . \PHP_EOL
+				. 'Allow: /allowed/for/yahoo' . \PHP_EOL
+				. \PHP_EOL
+				. 'Sitemap: http://example.com/sitemap_index.html' . \PHP_EOL
+				. '# ---------------------------' . \PHP_EOL
+				. '# END YOAST BLOCK',
 		];
 
 		$user_agent_list = new User_Agent_List();
@@ -148,7 +196,14 @@ class Robots_Txt_Presenter_Test extends TestCase {
 			'sitemaps'               => [
 				'http://example.com/sitemap_index.html',
 			],
-			'expected'               => "# START YOAST BLOCK\n# ---------------------------\nUser-agent: *\nAllow: /search/\n\nSitemap: http://example.com/sitemap_index.html\n# ---------------------------\n# END YOAST BLOCK",
+			'expected'               => '# START YOAST BLOCK' . \PHP_EOL
+				. '# ---------------------------' . \PHP_EOL
+				. 'User-agent: *' . \PHP_EOL
+				. 'Allow: /search/' . \PHP_EOL
+				. \PHP_EOL
+				. 'Sitemap: http://example.com/sitemap_index.html' . \PHP_EOL
+				. '# ---------------------------' . \PHP_EOL
+				. '# END YOAST BLOCK',
 		];
 		$multiple_sitemaps      = [
 			'robots_txt_user_agents' => ( new User_Agent_List() )->get_user_agents(),
@@ -156,7 +211,15 @@ class Robots_Txt_Presenter_Test extends TestCase {
 				'http://example.com/sitemap_index.html',
 				'http://example.com/subsite/sitemap_index.html',
 			],
-			'expected'               => "# START YOAST BLOCK\n# ---------------------------\nUser-agent: *\nDisallow:\n\nSitemap: http://example.com/sitemap_index.html\nSitemap: http://example.com/subsite/sitemap_index.html\n# ---------------------------\n# END YOAST BLOCK",
+			'expected'               => '# START YOAST BLOCK' . \PHP_EOL
+				. '# ---------------------------' . \PHP_EOL
+				. 'User-agent: *' . \PHP_EOL
+				. 'Disallow:' . \PHP_EOL
+				. \PHP_EOL
+				. 'Sitemap: http://example.com/sitemap_index.html' . \PHP_EOL
+				. 'Sitemap: http://example.com/subsite/sitemap_index.html' . \PHP_EOL
+				. '# ---------------------------' . \PHP_EOL
+				. '# END YOAST BLOCK',
 		];
 
 		return [


### PR DESCRIPTION
## Context

* Improved line ending handling for robots.txt contents.

## Summary

This PR can be summarized in the following changelog entry:

* Improved line ending handling for robots.txt contents.

## Relevant technical choices:

### Robots_Txt_Integration_Test: minor fixes for data provider

* Move the data provider up to be directly below the test using it.
* Rename the index key for the parameter in the datasets to match the parameter name as used by the test method (to prevent issues with PHP 8.0 named parameters).
* Remove the unused `'sitemap'` sub array key.

### Robots_Txt_Helper: use OS-based new lines

As things were, the `Robots_Txt_Helper` was mixing the use of `"\n"` (Linux new lines) and `PHP_EOL` (OS-based new lines).

This could (on non-Linux machines) result in the text string being generated for `robots.txt` having mixed line endings, which is never a good idea.

The [RFC regarding `robots.txt`](https://datatracker.ietf.org/doc/rfc9309/) specifies the _use_ of `EOL` characters in specific places, but doesn't specify whether those should be OS-based or `\n`.

As the `robots.txt` file is, in rare cases, also being called up by humans, using `PHP_EOL` or `"\r\n"` should probably be the preferred choice of line ending to keep the file human readable.

With this in mind, this PR proposes to standardize on `PHP_EOL`, which was already used in a number of places.

**_Note_**: the OS on which `PHP_EOL` is based will be the OS of the machine on which the code is being run, i.e. the machine _serving_ the "page", not the OS of the user potentially _reading_ the file.

Includes updating the text expectations to use `PHP_EOL` as well (and making those test expectations a little more human readable as well when needed).

### Robots_Txt_Integration: allow for injecting the Robots_Txt_Presenter

This allows for mocking the `Robots_Txt_Presenter` in unit tests.

### Robots_Txt_Integration: allow for different line endings

Along the same lines as the changes to `Robots_Txt_Helper`, it should be recognized that the `robots.txt` _input_ could be:
* Auto-generated by WP (non-file based).
* File based with unknown line endings.
* Pre-filtered by other plugins which may or may not affect the line endings.

So, this changes the code in the `Robots_Txt_Integration::remove_default_robots()` method to allow for all potential line endings.

Includes a new set of dedicated tests, specifically for the `Robots_Txt_Integration::remove_default_robots()` method, to verify and safeguard the change.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

**_I suspect this will be hard to test manually_** as it would require:
- The ability in a browser source view to distinguish between different type of line endings;
- A "windows server" (or windows machine to test act as server during testing;
- Manually creating a `robots.txt` file with mixed or Windows line endings for a subset of the tests.

I have added unit tests for the more pertinent changes (regex change) and have verified that the other changes are covered by pre-existing tests.

Without this change, the unit tests would previously pass on Linux, but not when run on Windows.
With this change, the unit tests will pass on both Linux as well as Windows.


#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check

This PR affects the following parts of the plugin, which may require extra testing:

* Robots.txt

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [x] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## WBSO

* [ ] No WBSO project is applicable for this PR.
* [ ] This PR falls under a WBSO project. I have attached the `innovation` label and noted the work hours.

Fixes #
DUPP-701