### PR TITLE
Add a CLI command to run a cleanup of our custom tables

### DIFF
--- a/src/commands/cleanup-command.php
+++ b/src/commands/cleanup-command.php
@@ -110,7 +110,7 @@ final class Cleanup_Command implements Command_Interface {
 	 *
 	 * @param array|null $assoc_args The associative arguments.
 	 *
-	 * @return int
+	 * @return int The number of cleaned up records.
 	 */
 	private function cleanup_network( $assoc_args ) {
 		$criteria      = [
@@ -135,17 +135,25 @@ final class Cleanup_Command implements Command_Interface {
 	 *
 	 * @param array|null $assoc_args The associative arguments.
 	 *
-	 * @return int
+	 * @return int The number of cleaned up records.
 	 */
 	private function cleanup_current_site( $assoc_args ) {
+		$site_url      = \site_url();
+		$total_removed = 0;
+
+		if ( ! is_plugin_active( WPSEO_BASENAME ) ) {
+			/* translators: %1$s is the site url of the site that is skipped. %2$s is Yoast SEO. */
+			\WP_CLI::warning( sprintf( __( 'Skipping %1$s. %2$s is not active on this site.', 'wordpress-seo' ), $site_url, 'Yoast SEO' ) );
+
+			return $total_removed;
+		}
+
 		// Make sure the DB is up to date first.
 		\do_action( '_yoast_run_migrations' );
 
-		$total_removed = 0;
-		$site_url      = \site_url();
-		$tasks         = $this->cleanup_integration->get_cleanup_tasks();
-		$limit         = (int) $assoc_args['batch-size'];
-		$interval      = (int) $assoc_args['interval'];
+		$tasks    = $this->cleanup_integration->get_cleanup_tasks();
+		$limit    = (int) $assoc_args['batch-size'];
+		$interval = (int) $assoc_args['interval'];
 
 		/* translators: %1$s is the site url of the site that is cleaned up. %2$s is the name of the cleanup task that is currently running. */
 		$progress_bar_title_format = __( 'Cleaning up %1$s [%2$s]', 'wordpress-seo' );

--- a/src/commands/cleanup-command.php
+++ b/src/commands/cleanup-command.php
@@ -1,0 +1,188 @@
+<?php
+
+namespace Yoast\WP\SEO\Commands;
+
+use WP_CLI\ExitException;
+use Yoast\WP\SEO\Integrations\Cleanup_Integration;
+use Yoast\WP\SEO\Main;
+use function get_sites;
+use function WP_CLI\Utils\make_progress_bar;
+
+/**
+ * A WP CLI command that helps with cleaning up unwanted records from our custom tables.
+ */
+final class Cleanup_Command implements Command_Interface {
+
+	/**
+	 * The integration that cleans up on cron.
+	 *
+	 * @var Cleanup_Integration
+	 */
+	private $cleanup_integration;
+
+	/**
+	 * The constructor.
+	 *
+	 * @param Cleanup_Integration $cleanup_integration The integration that cleans up on cron.
+	 */
+	public function __construct( Cleanup_Integration $cleanup_integration ) {
+		$this->cleanup_integration = $cleanup_integration;
+	}
+
+	/**
+	 * Returns the namespace of this command.
+	 *
+	 * @return string
+	 */
+	public static function get_namespace() {
+		return Main::WP_CLI_NAMESPACE;
+	}
+
+	/**
+	 * Performs a cleanup of custom Yoast tables.
+	 *
+	 * This removes unused, unwanted or orphaned database records, which ensures the best performance. Including:
+	 * - Indexables
+	 * - Indexable hierarchy
+	 * - SEO links
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--batch-size=<batch-size>]
+	 * : The number of database records to clean up in a single sql query.
+	 * ---
+	 * default: 1000
+	 * ---
+	 *
+	 * [--interval=<interval>]
+	 * : The number of microseconds (millionths of a second) to wait between cleanup batches.
+	 * ---
+	 * default: 500000
+	 * ---
+	 *
+	 * [--network]
+	 * : Performs the cleanup on all sites within the network.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp yoast cleanup
+	 *
+	 * @when after_wp_load
+	 *
+	 * @param array|null $args       The arguments.
+	 * @param array|null $assoc_args The associative arguments.
+	 *
+	 * @return void
+	 *
+	 * @throws ExitException When the input args are invalid.
+	 */
+	public function cleanup( $args = null, $assoc_args = null ) {
+		if ( isset( $assoc_args['interval'] ) && (int) $assoc_args['interval'] < 0 ) {
+			\WP_CLI::error( __( 'The value for \'interval\' must be a positive integer.', 'wordpress-seo' ) );
+		}
+		if ( isset( $assoc_args['batch-size'] ) && (int) $assoc_args['batch-size'] < 1 ) {
+			\WP_CLI::error( __( 'The value for \'batch-size\' must be a positive integer higher than equal to 1.', 'wordpress-seo' ) );
+		}
+
+		if ( isset( $assoc_args['network'] ) && \is_multisite() ) {
+			$total_removed = $this->cleanup_network( $assoc_args );
+		}
+		else {
+			$total_removed = $this->cleanup_current_site( $assoc_args );
+		}
+
+		\WP_CLI::success(
+			sprintf(
+			/* translators: %1$d is the number of records that are removed. */
+				_n(
+					'Cleaned up %1$d record.',
+					'Cleaned up %1$d records.',
+					$total_removed,
+					'wordpress-seo'
+				),
+				$total_removed
+			)
+		);
+	}
+
+	/**
+	 * Performs the cleanup for the entire network.
+	 *
+	 * @param array|null $assoc_args The associative arguments.
+	 *
+	 * @return int
+	 */
+	private function cleanup_network( $assoc_args ) {
+		$criteria      = [
+			'fields'   => 'ids',
+			'spam'     => 0,
+			'deleted'  => 0,
+			'archived' => 0,
+		];
+		$blog_ids      = get_sites( $criteria );
+		$total_removed = 0;
+		foreach ( $blog_ids as $blog_id ) {
+			\switch_to_blog( $blog_id );
+			$total_removed += $this->cleanup_current_site( $assoc_args );
+			\restore_current_blog();
+		}
+
+		return $total_removed;
+	}
+
+	/**
+	 * Performs the cleanup for a single site.
+	 *
+	 * @param array|null $assoc_args The associative arguments.
+	 *
+	 * @return int
+	 */
+	private function cleanup_current_site( $assoc_args ) {
+		// Make sure the DB is up to date first.
+		\do_action( '_yoast_run_migrations' );
+
+		$total_removed = 0;
+		$site_url      = \site_url();
+		$tasks         = $this->cleanup_integration->get_cleanup_tasks();
+		$limit         = (int) $assoc_args['batch-size'];
+		$interval      = (int) $assoc_args['interval'];
+
+		/* translators: %1$s is the site url of the site that is cleaned up. %2$s is the name of the cleanup task that is currently running. */
+		$progress_bar_title_format = __( 'Cleaning up %1$s [%2$s]', 'wordpress-seo' );
+		$progress                  = make_progress_bar( sprintf( $progress_bar_title_format, $site_url, \key( $tasks ) ), count( $tasks ) );
+
+		foreach ( $tasks as $task_name => $task ) {
+			// Update the progressbar title with the current task name.
+			$progress->tick( 0, sprintf( $progress_bar_title_format, $site_url, $task_name ) );
+			do {
+				$items_cleaned = $task( $limit );
+				if ( is_int( $items_cleaned ) ) {
+					$total_removed += $items_cleaned;
+				}
+				\usleep( $interval );
+
+				// Update the timer.
+				$progress->tick( 0 );
+			} while ( $items_cleaned !== false && $items_cleaned > 0 );
+			$progress->tick();
+		}
+		$progress->finish();
+
+		$this->cleanup_integration->reset_cleanup();
+		\WP_CLI::log(
+			sprintf(
+			/* translators: %1$d is the number of records that were removed. %2$s is the site url. */
+				_n(
+					'Cleaned up %1$d record from %2$s.',
+					'Cleaned up %1$d records from %2$s.',
+					$total_removed,
+					'wordpress-seo'
+				),
+				$total_removed,
+				$site_url
+			)
+		);
+
+		return $total_removed;
+	}
+}

--- a/src/commands/cleanup-command.php
+++ b/src/commands/cleanup-command.php
@@ -92,9 +92,9 @@ final class Cleanup_Command implements Command_Interface {
 		}
 
 		\WP_CLI::success(
-			sprintf(
+			\sprintf(
 			/* translators: %1$d is the number of records that are removed. */
-				_n(
+				\_n(
 					'Cleaned up %1$d record.',
 					'Cleaned up %1$d records.',
 					$total_removed,
@@ -119,7 +119,7 @@ final class Cleanup_Command implements Command_Interface {
 			'deleted'  => 0,
 			'archived' => 0,
 		];
-		$blog_ids      = get_sites( $criteria );
+		$blog_ids      = \get_sites( $criteria );
 		$total_removed = 0;
 		foreach ( $blog_ids as $blog_id ) {
 			\switch_to_blog( $blog_id );
@@ -141,9 +141,9 @@ final class Cleanup_Command implements Command_Interface {
 		$site_url      = \site_url();
 		$total_removed = 0;
 
-		if ( ! is_plugin_active( WPSEO_BASENAME ) ) {
+		if ( ! \is_plugin_active( WPSEO_BASENAME ) ) {
 			/* translators: %1$s is the site url of the site that is skipped. %2$s is Yoast SEO. */
-			\WP_CLI::warning( sprintf( __( 'Skipping %1$s. %2$s is not active on this site.', 'wordpress-seo' ), $site_url, 'Yoast SEO' ) );
+			\WP_CLI::warning( \sprintf( \__( 'Skipping %1$s. %2$s is not active on this site.', 'wordpress-seo' ), $site_url, 'Yoast SEO' ) );
 
 			return $total_removed;
 		}
@@ -156,15 +156,15 @@ final class Cleanup_Command implements Command_Interface {
 		$interval = (int) $assoc_args['interval'];
 
 		/* translators: %1$s is the site url of the site that is cleaned up. %2$s is the name of the cleanup task that is currently running. */
-		$progress_bar_title_format = __( 'Cleaning up %1$s [%2$s]', 'wordpress-seo' );
-		$progress                  = make_progress_bar( sprintf( $progress_bar_title_format, $site_url, \key( $tasks ) ), count( $tasks ) );
+		$progress_bar_title_format = \__( 'Cleaning up %1$s [%2$s]', 'wordpress-seo' );
+		$progress                  = make_progress_bar( \sprintf( $progress_bar_title_format, $site_url, \key( $tasks ) ), count( $tasks ) );
 
 		foreach ( $tasks as $task_name => $task ) {
 			// Update the progressbar title with the current task name.
-			$progress->tick( 0, sprintf( $progress_bar_title_format, $site_url, $task_name ) );
+			$progress->tick( 0, \sprintf( $progress_bar_title_format, $site_url, $task_name ) );
 			do {
 				$items_cleaned = $task( $limit );
-				if ( is_int( $items_cleaned ) ) {
+				if ( \is_int( $items_cleaned ) ) {
 					$total_removed += $items_cleaned;
 				}
 				\usleep( $interval );
@@ -178,9 +178,9 @@ final class Cleanup_Command implements Command_Interface {
 
 		$this->cleanup_integration->reset_cleanup();
 		\WP_CLI::log(
-			sprintf(
+			\sprintf(
 			/* translators: %1$d is the number of records that were removed. %2$s is the site url. */
-				_n(
+				\_n(
 					'Cleaned up %1$d record from %2$s.',
 					'Cleaned up %1$d records from %2$s.',
 					$total_removed,

--- a/src/integrations/cleanup-integration.php
+++ b/src/integrations/cleanup-integration.php
@@ -118,7 +118,7 @@ class Cleanup_Integration implements Integration_Interface {
 	 *
 	 * @return Closure[] The cleanup tasks.
 	 */
-	protected function get_cleanup_tasks() {
+	public function get_cleanup_tasks() {
 		return \array_merge(
 			[
 				'clean_indexables_with_object_type_and_object_sub_type_shop_order' => function( $limit ) {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Not all sites can rely on WP-CRON for the cleanup or want the cleanup to be done faster and want more control over it.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds a WP-CLI command to cleanup unused data from our custom database tables:`wp yoast cleanup`

## Relevant technical choices:

* To reduce the impact of this change, I directly depend on the Cleanup_Integration. This is a bit nasty. I would've split up the responsibilities of cleaning up the tables from the Cron-specific implementation if test-scope wasn't a concern.
* When the cleanup is done for a site, I unschedule the CRON, because that wouldn't have anything left to cleanup.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Use a plugin like _Custom Post Type UI_ to register a new post type that has `public` = `true`.
* Generate 5000 posts for this posttype.
	* You can do this with WP-CLI: ` wp post generate --post_type=your-public-post-type --count=5000`
	* You can also do this with a plugin like _FakerPress_.
* Check the indexables table in the database. It should have records for the 5000 posts.
* Using the  _Custom Post Type UI_ plugin, change the post type to private.
* Run the new cleanup command `wp yoast cleanup`
	* You can also use `wp yoast cleanup --help` to see which options are available. Try (to break) them all.
	* Check that the `--network` flag skips any sites in the multisite setup that don't have Yoast SEO active.
* When it's finished, it should state that (at least) your 5000 posts were cleaned up.
* Verify this by checking that the 5000 indexables are gone.
* Verify that the cleanup cron is not scheduled anymore.
	* run `wp cron event list` and see that there is no `wpseo_cleanup_cron` item in the list.


#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [x] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.


## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The impact is limited to this WP CLI command. There's no additional impact compared to https://github.com/Yoast/wordpress-seo/pull/19087.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

