### PR TITLE
Unit tests for the viewability watchers

### DIFF
--- a/src/integrations/watchers/indexable-post-type-change-watcher.php
+++ b/src/integrations/watchers/indexable-post-type-change-watcher.php
@@ -54,7 +54,11 @@ class Indexable_Post_Type_Change_Watcher implements Integration_Interface {
 	 * @return array
 	 */
 	public static function get_conditionals() {
-		return [ Not_Admin_Ajax_Conditional::class, Admin_Conditional::class, Migrations_Conditional::class ];
+		return [
+			Not_Admin_Ajax_Conditional::class,
+			Admin_Conditional::class,
+			Migrations_Conditional::class
+		];
 	}
 
 	/**

--- a/src/integrations/watchers/indexable-post-type-change-watcher.php
+++ b/src/integrations/watchers/indexable-post-type-change-watcher.php
@@ -57,7 +57,7 @@ class Indexable_Post_Type_Change_Watcher implements Integration_Interface {
 		return [
 			Not_Admin_Ajax_Conditional::class,
 			Admin_Conditional::class,
-			Migrations_Conditional::class
+			Migrations_Conditional::class,
 		];
 	}
 

--- a/src/integrations/watchers/indexable-post-type-change-watcher.php
+++ b/src/integrations/watchers/indexable-post-type-change-watcher.php
@@ -54,11 +54,7 @@ class Indexable_Post_Type_Change_Watcher implements Integration_Interface {
 	 * @return array
 	 */
 	public static function get_conditionals() {
-		return [
-			Not_Admin_Ajax_Conditional::class,
-			Admin_Conditional::class,
-			Migrations_Conditional::class,
-		];
+		return [ Not_Admin_Ajax_Conditional::class, Admin_Conditional::class, Migrations_Conditional::class ];
 	}
 
 	/**

--- a/tests/unit/integrations/watchers/indexable-post-type-change-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-post-type-change-watcher-test.php
@@ -4,7 +4,6 @@ namespace Yoast\WP\SEO\Tests\Unit\Integrations\Watchers;
 
 use Brain\Monkey\Functions;
 use Mockery;
-use Yoast_Notification_Center;
 use Yoast\WP\SEO\Actions\Indexing\Indexable_Post_Indexation_Action;
 use Yoast\WP\SEO\Conditionals\Admin_Conditional;
 use Yoast\WP\SEO\Conditionals\Migrations_Conditional;
@@ -16,6 +15,7 @@ use Yoast\WP\SEO\Helpers\Post_Type_Helper;
 use Yoast\WP\SEO\Integrations\Cleanup_Integration;
 use Yoast\WP\SEO\Integrations\Watchers\Indexable_Post_Type_Change_Watcher;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
+use Yoast_Notification_Center;
 
 /**
  * Class Indexable_Post_Type_Change_Watcher_Test.

--- a/tests/unit/integrations/watchers/indexable-post-type-change-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-post-type-change-watcher-test.php
@@ -1,0 +1,230 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Integrations\Watchers;
+
+use Brain\Monkey\Functions;
+use Mockery;
+use Yoast_Notification;
+use Yoast_Notification_Center;
+use Yoast\WP\SEO\Actions\Indexing\Indexable_Post_Indexation_Action;
+use Yoast\WP\SEO\Conditionals\Admin_Conditional;
+use Yoast\WP\SEO\Conditionals\Migrations_Conditional;
+use Yoast\WP\SEO\Conditionals\Not_Admin_Ajax_Conditional;
+use Yoast\WP\SEO\Config\Indexing_Reasons;
+use Yoast\WP\SEO\Helpers\Indexing_Helper;
+use Yoast\WP\SEO\Helpers\Options_Helper;
+use Yoast\WP\SEO\Helpers\Post_Type_Helper;
+use Yoast\WP\SEO\Integrations\Cleanup_Integration;
+use Yoast\WP\SEO\Integrations\Watchers\Indexable_Post_Type_Change_Watcher;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Class Indexable_Post_Type_Change_Watcher_Test.
+ *
+ * @group indexables
+ * @group integrations
+ * @group watchers
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Integrations\Watchers\Indexable_Post_Type_Change_Watcher
+ * @covers \Yoast\WP\SEO\Integrations\Watchers\Indexable_Post_Type_Change_Watcher
+ *
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
+ */
+class Indexable_Post_Type_Change_Watcher_Test extends TestCase {
+
+	/**
+	 * Holds the Options_Helper instance.
+	 *
+	 * @var Mockery\MockInterface|Options_Helper
+	 */
+	private $options;
+
+	/**
+	 * The indexing helper.
+	 *
+	 * @var Mockery\MockInterface|Indexing_Helper
+	 */
+	protected $indexing_helper;
+
+	/**
+	 * Holds the Post_Type_Helper instance.
+	 *
+	 * @var Mockery\MockInterface|Post_Type_Helper
+	 */
+	private $post_type_helper;
+
+	/**
+	 * The notifications center.
+	 *
+	 * @var Mockery\MockInterface|Yoast_Notification_Center
+	 */
+	private $notification_center;
+
+	/**
+	 * Represents the instance to test.
+	 *
+	 * @var Indexablec_Post_Type_Change_Watcher
+	 */
+	private $instance;
+
+	/**
+	 * Sets up the test fixtures.
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->stubEscapeFunctions();
+		$this->stubTranslationFunctions();
+
+		$this->options             = Mockery::mock( Options_Helper::class );
+		$this->indexing_helper     = Mockery::mock( Indexing_Helper::class );
+		$this->post_type_helper    = Mockery::mock( Post_Type_Helper::class );
+		$this->notification_center = Mockery::mock( Yoast_Notification_Center::class );
+
+		$this->instance = new Indexable_Post_Type_Change_Watcher(
+			$this->options,
+			$this->indexing_helper,
+			$this->post_type_helper,
+			$this->notification_center
+		);
+	}
+
+	/**
+	 * Tests if the expected conditionals are in place.
+	 *
+	 * @covers ::get_conditionals
+	 */
+	public function test_get_conditionals() {
+		$this->assertEquals(
+			[
+				Not_Admin_Ajax_Conditional::class,
+				Admin_Conditional::class,
+				Migrations_Conditional::class,
+			],
+			Indexable_Post_Type_Change_Watcher::get_conditionals()
+		);
+	}
+
+	/**
+	 * Tests if the expected hooks are registered.
+	 *
+	 * @covers ::__construct
+	 * @covers ::register_hooks
+	 */
+	public function test_register_hooks() {
+		$this->instance->register_hooks();
+		$this->assertNotFalse( \has_action( 'admin_init', [ $this->instance, 'check_post_types_public_availability' ] ) );
+	}
+
+	/**
+	 * Tests check option with false given as old_value. This happens when the value is updated
+	 * the first time.
+	 *
+	 * @dataProvider provider_check_post_types_public_availability
+	 *
+	 * @covers ::check_post_types_public_availability
+	 * @covers ::maybe_add_notification
+	 * @covers ::add_notification
+	 *
+	 * @param bool                    $is_json_request              Whether it's a JSON request.
+	 * @param array                   $public_post_types            The public post types.
+	 * @param int                     $get_public_post_types_times  The times we get the public post types.
+	 * @param array                   $last_known_public_post_types The last known public post types.
+	 * @param int                     $set_public_post_types_times  The times we get the last known public post types.
+	 * @param int                     $delete_transient_times       The times we delete the transients.
+	 * @param Yoast_Notification|null $notification                 A Yoast_Notification if valid id.
+	 * @param int                     $add_notification_times       The times we add notification.
+	 * @param int                     $schedule_cleanup_times       The times we schedule cleanup.
+	 */
+	public function test_check_post_types_public_availability(
+		$is_json_request, $public_post_types, $get_public_post_types_times, $last_known_public_post_types, $set_public_post_types_times, $delete_transient_times, $notification, $add_notification_times, $schedule_cleanup_times
+	) {
+		Functions\expect( 'wp_is_json_request' )
+			->once()
+			->andReturn( $is_json_request );
+
+		$this->post_type_helper
+			->expects( 'get_public_post_types' )
+			->times( $get_public_post_types_times )
+			->andReturn( $public_post_types );
+
+		$this->options
+			->expects( 'get' )
+			->times( $get_public_post_types_times )
+			->with( 'last_known_public_post_types', [] )
+			->andReturn( $last_known_public_post_types );
+
+		$this->options
+			->expects( 'set' )
+			->times( $set_public_post_types_times )
+			->with( $public_post_types );
+
+		Functions\expect( 'delete_transient' )
+			->times( $delete_transient_times )
+			->with( Indexable_Post_Indexation_Action::UNINDEXED_COUNT_TRANSIENT );
+
+		Functions\expect( 'delete_transient' )
+			->times( $delete_transient_times )
+			->andReturn( Indexable_Post_Indexation_Action::UNINDEXED_LIMITED_COUNT_TRANSIENT );
+
+		$this->indexing_helper
+			->expects( 'set_reason' )
+			->times( $delete_transient_times )
+			->with( Indexing_Reasons::REASON_POST_TYPE_MADE_PUBLIC );
+
+		$this->notification_center
+			->expects( 'get_notification_by_id' )
+			->times( $delete_transient_times )
+			->with( 'post-types-made-public' )
+			->andReturn( $notification );
+
+		Functions\expect( 'admin_url' )
+			->times( $add_notification_times )
+			->with( 'admin.php?page=wpseo_titles#top#post-types' )
+			->andReturn( 'https://example.com/admin.php?page=wpseo_titles#top#post-types' );
+
+		if ( $add_notification_times > 0 ) {
+			$new_notification = new Yoast_Notification(
+				'It looks like you\'ve added a new type of content to your website. We recommend that you review your <a href="https://example.com/admin.php?page=wpseo_titles#top#post-types">Search appearance settings</a>.',
+				[
+					'type'         => Yoast_Notification::WARNING,
+					'id'           => 'post-types-made-public',
+					'capabilities' => 'wpseo_manage_options',
+					'priority'     => 0.8,
+				]
+			);
+		}
+
+		Functions\expect( 'wp_get_current_user' )
+			->times( $add_notification_times )
+			->andReturn( 1 );
+
+		$this->notification_center
+			->expects( 'add_notification' )
+			->times( $add_notification_times )
+			->with( 'post-types-made-public' );
+
+		Functions\expect( 'wp_next_scheduled' )
+			->times( $schedule_cleanup_times * 2 )
+			->with( Cleanup_Integration::START_HOOK )
+			->andReturn( false );
+
+		Functions\expect( 'wp_schedule_single_event' )
+			->times( $schedule_cleanup_times * 2 );
+
+		$this->instance->check_post_types_public_availability();
+	}
+
+	/**
+	 * Data provider for test_check_post_types_public_availability().
+	 *
+	 * @return array
+	 */
+	public function provider_check_post_types_public_availability() {
+
+		return [
+			[ true, ['irrelevant'], 0, ['irrelevant'], 0, 0, null, 0, 0 ],
+			[ false, [], 1, ['irrelevant'], 1, 0, null, 0, 0 ],
+		];
+	}
+}

--- a/tests/unit/integrations/watchers/indexable-post-type-change-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-post-type-change-watcher-test.php
@@ -72,9 +72,6 @@ class Indexable_Post_Type_Change_Watcher_Test extends TestCase {
 	protected function set_up() {
 		parent::set_up();
 
-		$this->stubEscapeFunctions();
-		$this->stubTranslationFunctions();
-
 		$this->options             = Mockery::mock( Options_Helper::class );
 		$this->indexing_helper     = Mockery::mock( Indexing_Helper::class );
 		$this->post_type_helper    = Mockery::mock( Post_Type_Helper::class );

--- a/tests/unit/integrations/watchers/indexable-post-type-change-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-post-type-change-watcher-test.php
@@ -4,7 +4,6 @@ namespace Yoast\WP\SEO\Tests\Unit\Integrations\Watchers;
 
 use Brain\Monkey\Functions;
 use Mockery;
-use Yoast_Notification;
 use Yoast_Notification_Center;
 use Yoast\WP\SEO\Actions\Indexing\Indexable_Post_Indexation_Action;
 use Yoast\WP\SEO\Conditionals\Admin_Conditional;
@@ -117,27 +116,22 @@ class Indexable_Post_Type_Change_Watcher_Test extends TestCase {
 	}
 
 	/**
-	 * Tests check option with false given as old_value. This happens when the value is updated
-	 * the first time.
+	 * Tests checking if one or more post types change visibility.
 	 *
 	 * @dataProvider provider_check_post_types_public_availability
 	 *
 	 * @covers ::check_post_types_public_availability
-	 * @covers ::maybe_add_notification
-	 * @covers ::add_notification
 	 *
-	 * @param bool                    $is_json_request              Whether it's a JSON request.
-	 * @param array                   $public_post_types            The public post types.
-	 * @param int                     $get_public_post_types_times  The times we get the public post types.
-	 * @param array                   $last_known_public_post_types The last known public post types.
-	 * @param int                     $set_public_post_types_times  The times we get the last known public post types.
-	 * @param int                     $delete_transient_times       The times we delete the transients.
-	 * @param Yoast_Notification|null $notification                 A Yoast_Notification if valid id.
-	 * @param int                     $add_notification_times       The times we add notification.
-	 * @param int                     $schedule_cleanup_times       The times we schedule cleanup.
+	 * @param bool  $is_json_request              Whether it's a JSON request.
+	 * @param array $public_post_types            The public post types.
+	 * @param int   $get_public_post_types_times  The times we get the public post types.
+	 * @param array $last_known_public_post_types The last known public post types.
+	 * @param int   $set_public_post_types_times  The times we get the last known public post types.
+	 * @param int   $delete_transient_times       The times we delete the transients.
+	 * @param int   $schedule_cleanup_times       The times we schedule cleanup.
 	 */
 	public function test_check_post_types_public_availability(
-		$is_json_request, $public_post_types, $get_public_post_types_times, $last_known_public_post_types, $set_public_post_types_times, $delete_transient_times, $notification, $add_notification_times, $schedule_cleanup_times
+		$is_json_request, $public_post_types, $get_public_post_types_times, $last_known_public_post_types, $set_public_post_types_times, $delete_transient_times, $schedule_cleanup_times
 	) {
 		Functions\expect( 'wp_is_json_request' )
 			->once()
@@ -157,7 +151,7 @@ class Indexable_Post_Type_Change_Watcher_Test extends TestCase {
 		$this->options
 			->expects( 'set' )
 			->times( $set_public_post_types_times )
-			->with( $public_post_types );
+			->with( 'last_known_public_post_types', \array_keys( $public_post_types ) );
 
 		Functions\expect( 'delete_transient' )
 			->times( $delete_transient_times )
@@ -176,33 +170,7 @@ class Indexable_Post_Type_Change_Watcher_Test extends TestCase {
 			->expects( 'get_notification_by_id' )
 			->times( $delete_transient_times )
 			->with( 'post-types-made-public' )
-			->andReturn( $notification );
-
-		Functions\expect( 'admin_url' )
-			->times( $add_notification_times )
-			->with( 'admin.php?page=wpseo_titles#top#post-types' )
-			->andReturn( 'https://example.com/admin.php?page=wpseo_titles#top#post-types' );
-
-		if ( $add_notification_times > 0 ) {
-			$new_notification = new Yoast_Notification(
-				'It looks like you\'ve added a new type of content to your website. We recommend that you review your <a href="https://example.com/admin.php?page=wpseo_titles#top#post-types">Search appearance settings</a>.',
-				[
-					'type'         => Yoast_Notification::WARNING,
-					'id'           => 'post-types-made-public',
-					'capabilities' => 'wpseo_manage_options',
-					'priority'     => 0.8,
-				]
-			);
-		}
-
-		Functions\expect( 'wp_get_current_user' )
-			->times( $add_notification_times )
-			->andReturn( 1 );
-
-		$this->notification_center
-			->expects( 'add_notification' )
-			->times( $add_notification_times )
-			->with( 'post-types-made-public' );
+			->andReturn( 'not_null' );
 
 		Functions\expect( 'wp_next_scheduled' )
 			->times( $schedule_cleanup_times * 2 )
@@ -223,8 +191,51 @@ class Indexable_Post_Type_Change_Watcher_Test extends TestCase {
 	public function provider_check_post_types_public_availability() {
 
 		return [
-			[ true, ['irrelevant'], 0, ['irrelevant'], 0, 0, null, 0, 0 ],
-			[ false, [], 1, ['irrelevant'], 1, 0, null, 0, 0 ],
+			[ true, [ 'irrelevant' ], 0, [ 'irrelevant' ], 0, 0, 0 ],
+			[ false, [], 1, [], 1, 0, 0 ],
+			[
+				false,
+				[
+					'post' => 'post',
+					'page' => 'page',
+				],
+				1,
+				[
+					'post' => 'post',
+					'page' => 'page',
+				],
+				0,
+				0,
+				0,
+			],
+			[
+				false,
+				[
+					'post' => 'post',
+					'page' => 'page',
+				],
+				1,
+				[
+					'post' => 'post',
+				],
+				1,
+				1,
+				0,
+			],
+			[
+				false,
+				[
+					'post' => 'post',
+				],
+				1,
+				[
+					'post' => 'post',
+					'page' => 'page',
+				],
+				1,
+				0,
+				1,
+			],
 		];
 	}
 }

--- a/tests/unit/integrations/watchers/indexable-post-type-change-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-post-type-change-watcher-test.php
@@ -173,12 +173,12 @@ class Indexable_Post_Type_Change_Watcher_Test extends TestCase {
 			->andReturn( 'not_null' );
 
 		Functions\expect( 'wp_next_scheduled' )
-			->times( $schedule_cleanup_times * 2 )
+			->times( $schedule_cleanup_times )
 			->with( Cleanup_Integration::START_HOOK )
 			->andReturn( false );
 
 		Functions\expect( 'wp_schedule_single_event' )
-			->times( $schedule_cleanup_times * 2 );
+			->times( $schedule_cleanup_times );
 
 		$this->instance->check_post_types_public_availability();
 	}

--- a/tests/unit/integrations/watchers/indexable-taxonomy-change-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-taxonomy-change-watcher-test.php
@@ -5,31 +5,31 @@ namespace Yoast\WP\SEO\Tests\Unit\Integrations\Watchers;
 use Brain\Monkey\Functions;
 use Mockery;
 use Yoast_Notification_Center;
-use Yoast\WP\SEO\Actions\Indexing\Indexable_Post_Indexation_Action;
+use Yoast\WP\SEO\Actions\Indexing\Indexable_Term_Indexation_Action;
 use Yoast\WP\SEO\Conditionals\Admin_Conditional;
 use Yoast\WP\SEO\Conditionals\Migrations_Conditional;
 use Yoast\WP\SEO\Conditionals\Not_Admin_Ajax_Conditional;
 use Yoast\WP\SEO\Config\Indexing_Reasons;
 use Yoast\WP\SEO\Helpers\Indexing_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
-use Yoast\WP\SEO\Helpers\Post_Type_Helper;
+use Yoast\WP\SEO\Helpers\Taxonomy_Helper;
 use Yoast\WP\SEO\Integrations\Cleanup_Integration;
-use Yoast\WP\SEO\Integrations\Watchers\Indexable_Post_Type_Change_Watcher;
+use Yoast\WP\SEO\Integrations\Watchers\Indexable_Taxonomy_Change_Watcher;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
- * Class Indexable_Post_Type_Change_Watcher_Test.
+ * Class Indexable_Taxonomy_Change_Watcher_Test.
  *
  * @group indexables
  * @group integrations
  * @group watchers
  *
- * @coversDefaultClass \Yoast\WP\SEO\Integrations\Watchers\Indexable_Post_Type_Change_Watcher
- * @covers \Yoast\WP\SEO\Integrations\Watchers\Indexable_Post_Type_Change_Watcher
+ * @coversDefaultClass \Yoast\WP\SEO\Integrations\Watchers\Indexable_Taxonomy_Change_Watcher
+ * @covers \Yoast\WP\SEO\Integrations\Watchers\Indexable_Taxonomy_Change_Watcher
  *
  * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
-class Indexable_Post_Type_Change_Watcher_Test extends TestCase {
+class Indexable_Taxonomy_Change_Watcher_Test extends TestCase {
 
 	/**
 	 * Holds the Options_Helper instance.
@@ -46,11 +46,11 @@ class Indexable_Post_Type_Change_Watcher_Test extends TestCase {
 	protected $indexing_helper;
 
 	/**
-	 * Holds the Post_Type_Helper instance.
+	 * Holds the Taxonomy_Helper instance.
 	 *
-	 * @var Mockery\MockInterface|Post_Type_Helper
+	 * @var Mockery\MockInterface|Taxonomy_Helper
 	 */
-	private $post_type_helper;
+	private $taxonomy_helper;
 
 	/**
 	 * The notifications center.
@@ -62,7 +62,7 @@ class Indexable_Post_Type_Change_Watcher_Test extends TestCase {
 	/**
 	 * Represents the instance to test.
 	 *
-	 * @var Indexable_Post_Type_Change_Watcher
+	 * @var Indexable_Taxonomy_Change_Watcher
 	 */
 	private $instance;
 
@@ -75,15 +75,15 @@ class Indexable_Post_Type_Change_Watcher_Test extends TestCase {
 		$this->stubEscapeFunctions();
 		$this->stubTranslationFunctions();
 
-		$this->options             = Mockery::mock( Options_Helper::class );
 		$this->indexing_helper     = Mockery::mock( Indexing_Helper::class );
-		$this->post_type_helper    = Mockery::mock( Post_Type_Helper::class );
+		$this->options             = Mockery::mock( Options_Helper::class );
+		$this->taxonomy_helper     = Mockery::mock( Taxonomy_Helper::class );
 		$this->notification_center = Mockery::mock( Yoast_Notification_Center::class );
 
-		$this->instance = new Indexable_Post_Type_Change_Watcher(
-			$this->options,
+		$this->instance = new Indexable_Taxonomy_Change_Watcher(
 			$this->indexing_helper,
-			$this->post_type_helper,
+			$this->options,
+			$this->taxonomy_helper,
 			$this->notification_center
 		);
 	}
@@ -100,7 +100,7 @@ class Indexable_Post_Type_Change_Watcher_Test extends TestCase {
 				Admin_Conditional::class,
 				Migrations_Conditional::class,
 			],
-			Indexable_Post_Type_Change_Watcher::get_conditionals()
+			Indexable_Taxonomy_Change_Watcher::get_conditionals()
 		);
 	}
 
@@ -112,64 +112,64 @@ class Indexable_Post_Type_Change_Watcher_Test extends TestCase {
 	 */
 	public function test_register_hooks() {
 		$this->instance->register_hooks();
-		$this->assertNotFalse( \has_action( 'admin_init', [ $this->instance, 'check_post_types_public_availability' ] ) );
+		$this->assertNotFalse( \has_action( 'admin_init', [ $this->instance, 'check_taxonomy_public_availability' ] ) );
 	}
 
 	/**
-	 * Tests checking if one or more post types change visibility.
+	 * Tests checking if one or more taxonomies change visibility.
 	 *
-	 * @dataProvider provider_check_post_types_public_availability
+	 * @dataProvider provider_check_taxonomy_public_availability
 	 *
-	 * @covers ::check_post_types_public_availability
+	 * @covers ::check_taxonomy_public_availability
 	 *
 	 * @param bool  $is_json_request              Whether it's a JSON request.
-	 * @param array $public_post_types            The public post types.
-	 * @param int   $get_public_post_types_times  The times we get the public post types.
-	 * @param array $last_known_public_post_types The last known public post types.
-	 * @param int   $set_public_post_types_times  The times we get the last known public post types.
+	 * @param array $public_taxonomies            The public taxonomies.
+	 * @param int   $get_public_taxonomies_times  The times we get the public taxonomies.
+	 * @param array $last_known_public_taxonomies The last known public taxonomies.
+	 * @param int   $set_public_taxonomies_times  The times we get the last known public taxonomies.
 	 * @param int   $delete_transient_times       The times we delete the transients.
 	 * @param int   $schedule_cleanup_times       The times we schedule cleanup.
 	 */
-	public function test_check_post_types_public_availability(
-		$is_json_request, $public_post_types, $get_public_post_types_times, $last_known_public_post_types, $set_public_post_types_times, $delete_transient_times, $schedule_cleanup_times
+	public function test_check_taxonomy_public_availability(
+		$is_json_request, $public_taxonomies, $get_public_taxonomies_times, $last_known_public_taxonomies, $set_public_taxonomies_times, $delete_transient_times, $schedule_cleanup_times
 	) {
 		Functions\expect( 'wp_is_json_request' )
 			->once()
 			->andReturn( $is_json_request );
 
-		$this->post_type_helper
-			->expects( 'get_public_post_types' )
-			->times( $get_public_post_types_times )
-			->andReturn( $public_post_types );
+		$this->taxonomy_helper
+			->expects( 'get_public_taxonomies' )
+			->times( $get_public_taxonomies_times )
+			->andReturn( $public_taxonomies );
 
 		$this->options
 			->expects( 'get' )
-			->times( $get_public_post_types_times )
-			->with( 'last_known_public_post_types', [] )
-			->andReturn( $last_known_public_post_types );
+			->times( $get_public_taxonomies_times )
+			->with( 'last_known_public_taxonomies', [] )
+			->andReturn( $last_known_public_taxonomies );
 
 		$this->options
 			->expects( 'set' )
-			->times( $set_public_post_types_times )
-			->with( 'last_known_public_post_types', \array_keys( $public_post_types ) );
+			->times( $set_public_taxonomies_times )
+			->with( 'last_known_public_taxonomies', \array_keys( $public_taxonomies ) );
 
 		Functions\expect( 'delete_transient' )
 			->times( $delete_transient_times )
-			->with( Indexable_Post_Indexation_Action::UNINDEXED_COUNT_TRANSIENT );
+			->with( Indexable_Term_Indexation_Action::UNINDEXED_COUNT_TRANSIENT );
 
 		Functions\expect( 'delete_transient' )
 			->times( $delete_transient_times )
-			->andReturn( Indexable_Post_Indexation_Action::UNINDEXED_LIMITED_COUNT_TRANSIENT );
+			->andReturn( Indexable_Term_Indexation_Action::UNINDEXED_LIMITED_COUNT_TRANSIENT );
 
 		$this->indexing_helper
 			->expects( 'set_reason' )
 			->times( $delete_transient_times )
-			->with( Indexing_Reasons::REASON_POST_TYPE_MADE_PUBLIC );
+			->with( Indexing_Reasons::REASON_TAXONOMY_MADE_PUBLIC );
 
 		$this->notification_center
 			->expects( 'get_notification_by_id' )
 			->times( $delete_transient_times )
-			->with( 'post-types-made-public' )
+			->with( 'taxonomies-made-public' )
 			->andReturn( 'not_null' );
 
 		Functions\expect( 'wp_next_scheduled' )
@@ -180,15 +180,15 @@ class Indexable_Post_Type_Change_Watcher_Test extends TestCase {
 		Functions\expect( 'wp_schedule_single_event' )
 			->times( $schedule_cleanup_times * 2 );
 
-		$this->instance->check_post_types_public_availability();
+		$this->instance->check_taxonomy_public_availability();
 	}
 
 	/**
-	 * Data provider for test_check_post_types_public_availability().
+	 * Data provider for test_check_taxonomy_public_availability().
 	 *
 	 * @return array
 	 */
-	public function provider_check_post_types_public_availability() {
+	public function provider_check_taxonomy_public_availability() {
 
 		return [
 			[ true, [ 'irrelevant' ], 0, [ 'irrelevant' ], 0, 0, 0 ],
@@ -196,13 +196,13 @@ class Indexable_Post_Type_Change_Watcher_Test extends TestCase {
 			[
 				false,
 				[
-					'post' => 'post',
-					'page' => 'page',
+					'category' => 'category',
+					'post_tag' => 'post_tag',
 				],
 				1,
 				[
-					'post' => 'post',
-					'page' => 'page',
+					'category' => 'category',
+					'post_tag' => 'post_tag',
 				],
 				0,
 				0,
@@ -211,12 +211,12 @@ class Indexable_Post_Type_Change_Watcher_Test extends TestCase {
 			[
 				false,
 				[
-					'post' => 'post',
-					'page' => 'page',
+					'category' => 'category',
+					'post_tag' => 'post_tag',
 				],
 				1,
 				[
-					'post' => 'post',
+					'category' => 'category',
 				],
 				1,
 				1,
@@ -225,12 +225,12 @@ class Indexable_Post_Type_Change_Watcher_Test extends TestCase {
 			[
 				false,
 				[
-					'post' => 'post',
+					'category' => 'category',
 				],
 				1,
 				[
-					'post' => 'post',
-					'page' => 'page',
+					'category' => 'category',
+					'post_tag' => 'post_tag',
 				],
 				1,
 				0,

--- a/tests/unit/integrations/watchers/indexable-taxonomy-change-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-taxonomy-change-watcher-test.php
@@ -72,9 +72,6 @@ class Indexable_Taxonomy_Change_Watcher_Test extends TestCase {
 	protected function set_up() {
 		parent::set_up();
 
-		$this->stubEscapeFunctions();
-		$this->stubTranslationFunctions();
-
 		$this->indexing_helper     = Mockery::mock( Indexing_Helper::class );
 		$this->options             = Mockery::mock( Options_Helper::class );
 		$this->taxonomy_helper     = Mockery::mock( Taxonomy_Helper::class );

--- a/tests/unit/integrations/watchers/indexable-taxonomy-change-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-taxonomy-change-watcher-test.php
@@ -173,12 +173,12 @@ class Indexable_Taxonomy_Change_Watcher_Test extends TestCase {
 			->andReturn( 'not_null' );
 
 		Functions\expect( 'wp_next_scheduled' )
-			->times( $schedule_cleanup_times * 2 )
+			->times( $schedule_cleanup_times )
 			->with( Cleanup_Integration::START_HOOK )
 			->andReturn( false );
 
 		Functions\expect( 'wp_schedule_single_event' )
-			->times( $schedule_cleanup_times * 2 );
+			->times( $schedule_cleanup_times );
 
 		$this->instance->check_taxonomy_public_availability();
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* In https://github.com/Yoast/wordpress-seo/pull/19095 we added two watchers to detect when post types or taxonomies switch from being public to private and vice-versa. With this PR we add unit tests for those watchers.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds unit tests for the post type/taxonomy viewability watchers

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* N/A (no changes in public code)

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* No impact check

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [x] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
