### PR TITLE
PC-343 Fixes loading of the webworker while editing posts with the Web Stories plug-in

### DIFF
--- a/packages/yoastseo/spec/worker/createWorkerSpec.js
+++ b/packages/yoastseo/spec/worker/createWorkerSpec.js
@@ -7,6 +7,8 @@ import { createExceptionHandler, isSameOrigin, createBlobURL, createWorkerFallba
  */
 import "blob-polyfill";
 
+global.window.wpseoAdminL10n = [];
+
 describe( "The createWorker module", () => {
 	let originalWorker, originalURL;
 
@@ -32,18 +34,21 @@ describe( "The createWorker module", () => {
 
 	describe( "checks isSameOrigin function", () => {
 		it( "checks if two different URLS from different sites have the same origin (hostname, port, protocol)", () => {
-			const sameURL = isSameOrigin( "https://jestjs.io/docs/mock-functions", "https://developer.mozilla.org/en-US/docs/Web/API/Location/origin" );
+			const sameURL = isSameOrigin( "https://jestjs.io/docs/mock-functions",
+				"https://developer.mozilla.org/en-US/docs/Web/API/Location/origin" );
 			expect( sameURL ).toBeFalsy();
 		} );
 
 		it( "checks if two URLS of different posts on the same site have the same origin (hostname, port, protocol)", () => {
 			// eslint-disable-next-line max-len
-			const sameURL = isSameOrigin( "https://stackoverflow.com/questions/52968969/jest-url-createobjecturl-is-not-a-function", "https://stackoverflow.com/questions/41885841/how-can-i-mock-the-javascript-window-object-using-jest" );
+			const sameURL = isSameOrigin( "https://stackoverflow.com/questions/52968969/jest-url-createobjecturl-is-not-a-function",
+				"https://stackoverflow.com/questions/41885841/how-can-i-mock-the-javascript-window-object-using-jest" );
 			expect( sameURL ).toBeTruthy();
 		} );
 
 		it( "checks if two URLS with different scheme (http vs https) have the same origin (hostname, port, protocol/ scheme)", () => {
-			const sameURL = isSameOrigin( "http://jestjs.io/docs/mock-functions", "https://jestjs.io/docs/mock-functions" );
+			const sameURL = isSameOrigin( "http://jestjs.io/docs/mock-functions",
+				"https://jestjs.io/docs/mock-functions" );
 			expect( sameURL ).toBeFalsy();
 		} );
 	} );
@@ -127,6 +132,15 @@ describe( "The createWorker module", () => {
 		it( "creates a worker using the fallback when the worker script does not have the same origin", () => {
 			const worker = createWorker( "http://example.org/some/code.js" );
 			expect( worker ).toBeInstanceOf( global.Worker );
+		} );
+
+		it( "creates a worker using the fallback when we are editing a post with the Google Web Stories integration active", () => {
+			window.wpseoAdminL10n = { isWebStoriesIntegrationActive: 1 };
+
+			const worker = createWorker( "http://example.org/some/code.js" );
+			expect( worker ).toBeInstanceOf( global.Worker );
+
+			window.wpseoAdminL10n = { isWebStoriesIntegrationActive: 0 };
 		} );
 
 		it( "creates a worker using the fallback when the worker script cannot be created", () => {

--- a/packages/yoastseo/src/worker/createWorker.js
+++ b/packages/yoastseo/src/worker/createWorker.js
@@ -90,7 +90,7 @@ function createWorkerFallback( url ) {
  */
 function createWorker( url ) {
 	// If we are not on the same domain, or we are editing a post in the Web Stories plug-in integration, we require a fallback worker.
-	if ( ! isSameOrigin( window.location, url ) || !! window.wpseoAdminL10n.isWebStoriesIntegrationActive ) {
+	if ( ! isSameOrigin( window.location, url ) || window.wpseoAdminL10n.isWebStoriesIntegrationActive === 1 ) {
 		return createWorkerFallback( url );
 	}
 

--- a/packages/yoastseo/src/worker/createWorker.js
+++ b/packages/yoastseo/src/worker/createWorker.js
@@ -90,7 +90,7 @@ function createWorkerFallback( url ) {
  */
 function createWorker( url ) {
 	// If we are not on the same domain, or we are editing a post in the Web Stories plug-in integration, we require a fallback worker.
-	if ( ! isSameOrigin( window.location, url ) || window.wpseoAdminL10n.isWebStoriesIntegrationActive === 1 ) {
+	if ( ! isSameOrigin( window.location, url ) || window.wpseoAdminL10n.isWebStoriesIntegrationActive === "1" ) {
 		return createWorkerFallback( url );
 	}
 

--- a/packages/yoastseo/src/worker/createWorker.js
+++ b/packages/yoastseo/src/worker/createWorker.js
@@ -37,12 +37,12 @@ function createBlobScript( url ) {
  * @returns {boolean} Whether the URLs have the same origin.
  */
 function isSameOrigin( urlA, urlB ) {
-	urlA = new URL( urlA, window.location.origin );
-	urlB = new URL( urlB, window.location.origin );
+	const url1 = new URL( urlA, window.location.origin );
+	const url2 = new URL( urlB, window.location.origin );
 
-	return urlA.hostname === urlB.hostname &&
-		urlA.port === urlB.port &&
-		urlA.protocol === urlB.protocol;
+	return url1.hostname === url2.hostname &&
+		url1.port === url2.port &&
+		url1.protocol === url2.protocol;
 }
 
 /**

--- a/packages/yoastseo/src/worker/createWorker.js
+++ b/packages/yoastseo/src/worker/createWorker.js
@@ -89,8 +89,8 @@ function createWorkerFallback( url ) {
  * @returns 	{Worker} 					The worker.
  */
 function createWorker( url ) {
-	// If we are not on the same domain, we require a fallback worker.
-	if ( ! isSameOrigin( window.location, url ) ) {
+	// If we are not on the same domain, or we are editing a post in the Web Stories plug-in integration, we require a fallback worker.
+	if ( ! isSameOrigin( window.location, url ) || !! window.wpseoAdminL10n.isWebStoriesIntegrationActive ) {
 		return createWorkerFallback( url );
 	}
 

--- a/src/integrations/third-party/web-stories-post-edit.php
+++ b/src/integrations/third-party/web-stories-post-edit.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Yoast\WP\SEO\Integrations\Third_Party;
+
+use Yoast\WP\SEO\Conditionals\Admin\Post_Conditional;
+use Yoast\WP\SEO\Conditionals\Web_Stories_Conditional;
+use Yoast\WP\SEO\Integrations\Integration_Interface;
+
+/**
+ * Web Stories integration.
+ */
+class Web_Stories_Post_Edit implements Integration_Interface {
+
+	/**
+	 * Returns the conditionals based in which this loadable should be active.
+	 *
+	 * @return array
+	 */
+	public static function get_conditionals() {
+		return [ Web_Stories_Conditional::class, Post_Conditional::class ];
+	}
+
+	/**
+	 * Initializes the integration.
+	 *
+	 * This is the place to register hooks and filters.
+	 *
+	 * @return void
+	 */
+	public function register_hooks() {
+		\add_filter( 'wpseo_admin_l10n', [ $this, 'add_admin_l10n' ] );
+	}
+
+	/**
+	 * Adds a isWebStoriesIntegrationActive variable to the Adminl10n array.
+	 *
+	 * @param array $input The array to add the isWebStoriesIntegrationActive to.
+	 *
+	 * @return array The passed array with the additional isWebStoriesIntegrationActive variable set to 1 if we are editing a web story.
+	 */
+	public function add_admin_l10n( $input ) {
+		if ( get_post_type() === 'web-story' ) {
+			$input['isWebStoriesIntegrationActive'] = 1;
+		}
+		return $input;
+	}
+}

--- a/src/integrations/third-party/web-stories-post-edit.php
+++ b/src/integrations/third-party/web-stories-post-edit.php
@@ -39,7 +39,7 @@ class Web_Stories_Post_Edit implements Integration_Interface {
 	 * @return array The passed array with the additional isWebStoriesIntegrationActive variable set to 1 if we are editing a web story.
 	 */
 	public function add_admin_l10n( $input ) {
-		if ( get_post_type() === 'web-story' ) {
+		if ( \get_post_type() === 'web-story' ) {
 			$input['isWebStoriesIntegrationActive'] = 1;
 		}
 		return $input;

--- a/tests/unit/integrations/third-party/web-stories-post-edit-test.php
+++ b/tests/unit/integrations/third-party/web-stories-post-edit-test.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Integrations\Third_Party;
+
+use Brain\Monkey;
+use Yoast\WP\SEO\Conditionals\Admin\Post_Conditional;
+use Yoast\WP\SEO\Conditionals\Web_Stories_Conditional;
+use Yoast\WP\SEO\Integrations\Third_Party\Web_Stories_Post_Edit;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Web Stories integration test.
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Integrations\Third_Party\Web_Stories_Post_Edit
+ *
+ * @group integrations
+ * @group third-party
+ */
+class Web_Stories_Post_Edit_Test extends TestCase {
+
+	/**
+	 * The Web Stories integration.
+	 *
+	 * @var Web_Stories_Post_Edit
+	 */
+	protected $instance;
+
+	/**
+	 * Sets an instance for test purposes.
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->instance = new Web_Stories_Post_Edit();
+	}
+
+	/**
+	 * Tests if the expected conditionals are in place.
+	 *
+	 * @covers ::get_conditionals
+	 */
+	public function test_get_conditionals() {
+		$this->assertEquals(
+			[ Web_Stories_Conditional::class, Post_Conditional::class ],
+			Web_Stories_Post_Edit::get_conditionals()
+		);
+	}
+
+	/**
+	 * Tests register hooks.
+	 *
+	 * @covers ::register_hooks
+	 */
+	public function test_register_hooks() {
+		$this->instance->register_hooks();
+
+		$this->assertNotFalse( \has_filter( 'wpseo_admin_l10n', [ $this->instance, 'add_admin_l10n' ] ), 'The add_admin_l10n filter is registered.' );
+	}
+
+	/**
+	 * Tests add_admin_l10n integration.
+	 *
+	 * @covers ::add_admin_l10n
+	 */
+	public function test_add_admin_l10n() {
+		Monkey\Functions\expect( 'get_post_type' )
+			->once()
+			->andReturn( 'page' );
+
+		$additional_entries = $this->instance->add_admin_l10n( [] );
+		$this->assertEmpty( $additional_entries );
+
+		Monkey\Functions\expect( 'get_post_type' )
+			->once()
+			->andReturn( 'web-story' );
+		$additional_entries = $this->instance->add_admin_l10n( [] );
+		$this->assertEquals( [ 'isWebStoriesIntegrationActive' => 1 ], $additional_entries );
+	}
+}
+


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Our `analysis-worker.js` file was not being loaded when creating a Web Story through the Google Web Stories plug-in, breaking the Yoast metabox, and not allowing analysis. 
* After some research, we found that this was due to strict CORS headers from the Web Stories plug-in. With the introduction of the "Video Optimization" setting in the Web Stories plug-in, these strict headers were introduced, and as a result, the analysis broke. 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the content analysis would not load when editing web stories in the Web Stories plug-in. 

## Relevant technical choices:

* With this PR, we add an integration that is only loaded when the Web Stories plug-in is activated and we are creating/editing a post. 
* When this post is of the `web-story` type, we add an additional setting to our `window.wpseoAdminL10n` global variable.
* When loading the webworker, we check whether this setting is set to true (i.e., if we are editing a Web Story). If so, we use the fallback creation of the `Worker` through a `Blob`, instead of the default creation by calling `Worker` directly with the script. This prevents the blocking of loading the script by the strict CORS headers.
* In the code, we do not check the value of the "Video Optimization" setting in the Web Stories plug-in. In principle, the analysis is only not loaded when "Video Optimization" is set to true. However, this would (1) complicate the code and (2) this setting is set to true by default.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Activate both the Yoast SEO and the Google Web Stories plug-in. 
* In the Google Web Stories plug-in, on the Settings page, make sure the checkbox "Video Optimization" is activated.
* Create a new post with the Google Web Stories plug-in.
* Make sure that `analysis-worker.js` is loaded properly (i.e., not blocked) in the Network tab of the Chrome DevTools Panel (right-click anywhere on the page and click Inspect to open this panel, and refresh the Network tab to show all requests). The line should look like this: 
  * <img width="412" alt="Screenshot 2022-11-15 at 08 57 00" src="https://user-images.githubusercontent.com/7521233/201861904-ae2c6567-3a80-4168-8973-b9dfa62d3466.png">
* Open the Yoast metabox (click the "M" on the bottom right). 
* Make sure the content analysis works by adding a keyphrase (e.g., `blog`) and confirming that the SEO analysis is updated.
  * For example, note that the feedback for the _keyphrase length_ assessment now reads "Good job!".
* Also add a meta description (e.g., `Open source software which you can use to easily create a beautiful website, blog, or app.` and confirm that the SEO analysis is updated. 
  * For example, note that the feedback for the _keyphrase in meta description_ assessment now reads "Keyphrase or synonym appear in the meta description. Well done!".
* Save the post.
* Edit this post, and confirm the content analysis still returns the same feedback, and confirm that it changes if you e.g. extend the meta description with `WordPress is just great.`.
  * For example, note that the feedback for the _meta description length_ assessment now reads "Well done!".
* Note that it is not possible to do readability analysis on Web Stories (that seems to have never been implemented), but with the PR in place, at least the readability analysis traffic light does not spin. 

#### Regression test

* Follow the above steps, but while creating a post with all editors (Block, Classic, Elementor).
* Also, smoke test the analysis when working on pages and custom post types.
* Do note that the screenshot in the Network tab should now looks like this: 
  * <img width="409" alt="Screenshot 2022-11-15 at 09 09 23" src="https://user-images.githubusercontent.com/7521233/201864625-ca60e7c4-0adc-4fc7-a150-0308e42cc171.png"> 
  * ... which is because we load the analysis directly via the script (as we used too), and not by first turning it into a `Blob`. 

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [x] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Only posts created through the Web Stories plug-in should be affected by this change.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes https://yoast.atlassian.net/browse/PC-343
