### PR TITLE
Remove unneeded repetitions

### DIFF
--- a/src/integrations/watchers/indexable-post-type-change-watcher.php
+++ b/src/integrations/watchers/indexable-post-type-change-watcher.php
@@ -137,11 +137,9 @@ class Indexable_Post_Type_Change_Watcher implements Integration_Interface {
 		// There are post types that have been made private.
 		if ( ! empty( $newly_made_non_public_post_types ) ) {
 			// Schedule a cron job to remove all the posts whose post type has been made private.
-			if ( ! \wp_next_scheduled( \Yoast\WP\SEO\Integrations\Cleanup_Integration::START_HOOK ) ) {
-				if ( ! \wp_next_scheduled( Cleanup_Integration::START_HOOK ) ) {
-					\wp_schedule_single_event( ( time() + 5 ), \Yoast\WP\SEO\Integrations\Cleanup_Integration::START_HOOK );
-					\wp_schedule_single_event( ( time() + 5 ), Cleanup_Integration::START_HOOK );
-				}
+			$cleanup_not_yet_scheduled = ! \wp_next_scheduled( Cleanup_Integration::START_HOOK );
+			if ( $cleanup_not_yet_scheduled ) {
+				\wp_schedule_single_event( ( \time() + ( \MINUTE_IN_SECONDS * 5 ) ), Cleanup_Integration::START_HOOK );
 			}
 		}
 	}

--- a/src/integrations/watchers/indexable-taxonomy-change-watcher.php
+++ b/src/integrations/watchers/indexable-taxonomy-change-watcher.php
@@ -139,11 +139,9 @@ class Indexable_Taxonomy_Change_Watcher implements Integration_Interface {
 		// There are taxonomies that have been made private.
 		if ( ! empty( $newly_made_non_public_taxonomies ) ) {
 			// Schedule a cron job to remove all the terms whose taxonomy has been made private.
-			if ( ! \wp_next_scheduled( \Yoast\WP\SEO\Integrations\Cleanup_Integration::START_HOOK ) ) {
-				if ( ! \wp_next_scheduled( Cleanup_Integration::START_HOOK ) ) {
-					\wp_schedule_single_event( ( time() + ( MINUTE_IN_SECONDS * 5 ) ), \Yoast\WP\SEO\Integrations\Cleanup_Integration::START_HOOK );
-					\wp_schedule_single_event( ( time() + ( MINUTE_IN_SECONDS * 5 ) ), Cleanup_Integration::START_HOOK );
-				}
+			$cleanup_not_yet_scheduled = ! \wp_next_scheduled( Cleanup_Integration::START_HOOK );
+			if ( $cleanup_not_yet_scheduled ) {
+				\wp_schedule_single_event( ( \time() + ( \MINUTE_IN_SECONDS * 5 ) ), Cleanup_Integration::START_HOOK );
 			}
 		}
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Both the check for a cleanup cron job already scheduled and the actual scheduling of a new cron job were wrongly doubled. 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Removes unnecessary duplicated checks
* Sets correct delay in seconds for post types watcher

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

**Note:** these are basically part of the instructions of the [original PR](https://yoast.atlassian.net/browse/DUPP-618) except for some temp things that were there while other PRs were in the process

**Prerequisite**
* install and activate [CPT UI](https://wordpress.org/plugins/custom-post-type-ui/)
* install and activate [WP Crontrol](https://wordpress.org/plugins/wp-crontrol/)
* Add the following code to your WordPress theme:
```
add_filter( 'wpseo_shutdown_indexation_limit', 'custom_limit', 1 );
function custom_limit() {
  return 2;
}
```
**Testing post types**
* Go to `Tools` -> `Cron Events`
* Click on `Custom events` and verify `wpseo_start_cleanup_indexables` is not in the list of the scheduled hooks; if it is, delete it
* Go to `CPT UI` -> `Add/Edit Post Type` -> `Add New Post Type` tab
* Add the `Post Type Slug`, `Plural Label` and `Singular Label`
* Save the post type
* In the sidebar, select your newly-created post type -> `Add new`
* Add a post of your new post type and publish it
* Run the `SEO Data Optimization`
* With a MySQL client (e.g. TablePlus), go to `[PREFIX]_yoast_indexable` table 
* Check that an indexable has been created for your new post with `object_sub_type` equal to the new post type
* Go to `CPT UI` -> `Add/Edit Post Type` -> `Edit Post Types` tab
* Select your post type from the upper drop-down menu
* Scroll down to the `Settings` section and set `Public` to `False`
* Go to `Tools` -> `Cron Events`
* Click on `Custom events` and verify `wpseo_start_cleanup_indexables` is in the list of the scheduled hooks
---
**Testing taxonomies**
* Go to `Tools` -> `Cron Events`
* Click on `Custom events` and verify `wpseo_start_cleanup_indexables` is not in the list of the scheduled hooks; if it is, delete it
* Go to `CPT UI` -> `Add/Edit Taxonomies` -> `Add New Taxonomy` tab
* Add the `Taxonomy Slug`, `Plural Label` and `Singular Label`
* In `Attach to Post Type` select `Posts (WP Core)`
* Save the taxonomy
* In the sidebar, go to `Posts` -> your new taxonomy
* Add a term to your taxonomy
* Run the `SEO Data Optimization`
* With a MySQL client (e.g. TablePlus), go to `[PREFIX]_yoast_indexable` table 
* Check that an indexable has been created for your new term
* Go to `CPT UI` -> `Add/Edit Taxonomies` -> `Edit Taxonomies` tab
* Select your taxonomy from the upper drop-down menu
* Scroll down to the `Settings` section and set `Public` to `False`
* Go to `Tools` -> `Cron Events`
* Click on `Custom events` and verify `wpseo_start_cleanup_indexables` is in the list of the scheduled hooks

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [X] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes [DUPP-706](https://yoast.atlassian.net/browse/DUPP-706)
