### PR TITLE
Performance issues happen due to whitespace blocks with NULL value as blockName

### DIFF
--- a/src/helpers/blocks-helper.php
+++ b/src/helpers/blocks-helper.php
@@ -84,7 +84,7 @@ class Blocks_Helper {
 			if ( \is_null( $block['blockName'] ) ) {
 				continue;
 			}
-			
+
 			if ( ! isset( $collection[ $block['blockName'] ] ) || ! \is_array( $collection[ $block['blockName'] ] ) ) {
 				$collection[ $block['blockName'] ] = [];
 			}

--- a/src/helpers/blocks-helper.php
+++ b/src/helpers/blocks-helper.php
@@ -81,7 +81,7 @@ class Blocks_Helper {
 	 */
 	private function collect_blocks( $blocks, $collection ) {
 		foreach ( $blocks as $block ) {
-			if ( is_null( $block['blockName'] ) ) {
+			if ( \is_null( $block['blockName'] ) ) {
 				continue;
 			}
 			

--- a/src/helpers/blocks-helper.php
+++ b/src/helpers/blocks-helper.php
@@ -81,6 +81,10 @@ class Blocks_Helper {
 	 */
 	private function collect_blocks( $blocks, $collection ) {
 		foreach ( $blocks as $block ) {
+			if ( is_null( $block['blockName'] ) ) {
+				continue;
+			}
+			
 			if ( ! isset( $collection[ $block['blockName'] ] ) || ! \is_array( $collection[ $block['blockName'] ] ) ) {
 				$collection[ $block['blockName'] ] = [];
 			}

--- a/src/helpers/blocks-helper.php
+++ b/src/helpers/blocks-helper.php
@@ -81,7 +81,7 @@ class Blocks_Helper {
 	 */
 	private function collect_blocks( $blocks, $collection ) {
 		foreach ( $blocks as $block ) {
-			if ( \is_null( $block['blockName'] ) ) {
+			if ( empty( $block['blockName'] ) ) {
 				continue;
 			}
 


### PR DESCRIPTION
Fixes Issue #19173 where performance issues happen due to whitespace blocks with a NULL value as the blockName

## Context
* Fix performance issues as outlined in Issue #19173


## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where blocks with a NULL `blockName` would trigger deprecation errors with PHP 8.1 and cause performance issues. Props to [@dustyf](https://github.com/dustyf).

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Set up an environment on PHP 8.1
* make sure you have WP_DEBUG set to `true`, Debug Bar and Query Monitor installed and active
* create and publish a post with several blocks (they can just be multiple paragraphs)
* visit the Frontend and check the PHP Errors in Query Monitor:
  * without this patch: you should get a "Deprecated" error with `strtolower(): Passing null to parameter #1 ($string) of type string is deprecated` pointing to `plugins/wordpress-seo/src/generators/schema-generator.php:186`
  * with this patch: you should NOT get such error.

**Note**: reproducing the perfomance issue can be hard, but the test above already shows that the underlying issue is fixed.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [X] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
Could affect any post type using the block editor, so testing should be done on different post types.

<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes [DUPP-801]
Fixes #19173


[DUPP-801]: https://yoast.atlassian.net/browse/DUPP-801?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ