### PR TITLE
DUPP-670 Refactor filter_input call in class-bulk-editor-list-table class

### DIFF
--- a/admin/class-bulk-editor-list-table.php
+++ b/admin/class-bulk-editor-list-table.php
@@ -188,12 +188,17 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 	}
 
 	/**
-	 * Will show the navigation for the table like pagenavigation and pagefilter.
+	 * Will show the navigation for the table like page navigation and page filter.
 	 *
 	 * @param string $which Table nav location (such as top).
 	 */
 	public function display_tablenav( $which ) {
-		$post_status = sanitize_text_field( filter_input( INPUT_GET, 'post_status' ) );
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended -- Reason: We are not processing form information.
+		$post_status      = isset( $_GET['post_status'] ) && is_string( $_GET['post_status'] ) ? sanitize_text_field( wp_unslash( $_GET['post_status'] ) ) : '';
+		$order_by         = isset( $_GET['orderby'] ) && is_string( $_GET['orderby'] ) ? sanitize_text_field( wp_unslash( $_GET['orderby'] ) ) : '';
+		$order            = isset( $_GET['order'] ) && is_string( $_GET['order'] ) ? sanitize_text_field( wp_unslash( $_GET['order'] ) ) : '';
+		$post_type_filter = isset( $_GET['post_type_filter'] ) && is_string( $_GET['post_type_filter'] ) ? sanitize_text_field( wp_unslash( $_GET['post_type_filter'] ) ) : '';
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended;
 		?>
 		<div class="tablenav <?php echo esc_attr( $which ); ?>">
 
@@ -204,11 +209,11 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 				<input type="hidden" name="tool" value="bulk-editor"/>
 				<input type="hidden" name="type" value="<?php echo esc_attr( $this->page_type ); ?>"/>
 				<input type="hidden" name="orderby"
-					value="<?php echo esc_attr( filter_input( INPUT_GET, 'orderby' ) ); ?>"/>
+					value="<?php echo esc_attr( $order_by ); ?>"/>
 				<input type="hidden" name="order"
-					value="<?php echo esc_attr( filter_input( INPUT_GET, 'order' ) ); ?>"/>
+					value="<?php echo esc_attr( $order ); ?>"/>
 				<input type="hidden" name="post_type_filter"
-					value="<?php echo esc_attr( filter_input( INPUT_GET, 'post_type_filter' ) ); ?>"/>
+					value="<?php echo esc_attr( $post_type_filter ); ?>"/>
 				<?php if ( ! empty( $post_status ) ) { ?>
 					<input type="hidden" name="post_status" value="<?php echo esc_attr( $post_status ); ?>"/>
 				<?php } ?>
@@ -281,7 +286,7 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 			)
 		);
 
-		$post_status             = filter_input( INPUT_GET, 'post_status' );
+		$post_status             = isset( $_GET['post_status'] ) && is_string( $_GET['post_status'] ) ? sanitize_text_field( wp_unslash( $_GET['post_status'] ) ) : '';
 		$current_link_attributes = empty( $post_status ) ? ' class="current" aria-current="page"' : '';
 		$localized_text          = sprintf(
 			/* translators: %s expands to the number of posts in localized format. */
@@ -383,8 +388,8 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 					)
 				);
 
-				$post_type_filter = filter_input( INPUT_GET, 'post_type_filter' );
-				$selected         = ( ! empty( $post_type_filter ) ) ? sanitize_text_field( $post_type_filter ) : '-1';
+				$post_type_filter = isset( $_GET['post_type_filter'] ) && is_string( $_GET['post_type_filter'] ) ? sanitize_text_field( wp_unslash( $_GET['post_type_filter'] ) ) : '';
+				$selected         = ( ! empty( $post_type_filter ) ) ? $post_type_filter : '-1';
 
 				$options = '<option value="-1">' . esc_html__( 'Show All Content Types', 'wordpress-seo' ) . '</option>';
 
@@ -547,12 +552,11 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 	 */
 	protected function get_post_type_clause() {
 		// Filter Block.
-		$post_types       = null;
 		$post_type_clause = '';
-		$post_type_filter = filter_input( INPUT_GET, 'post_type_filter' );
+		$post_type_filter = isset( $_GET['post_type_filter'] ) && is_string( $_GET['post_type_filter'] ) ? sanitize_text_field( wp_unslash( $_GET['post_type_filter'] ) ) : '';
 
-		if ( ! empty( $post_type_filter ) && get_post_type_object( sanitize_text_field( $post_type_filter ) ) ) {
-			$post_types       = esc_sql( sanitize_text_field( $post_type_filter ) );
+		if ( ! empty( $post_type_filter ) && get_post_type_object( $post_type_filter ) ) {
+			$post_types       = esc_sql( $post_type_filter );
 			$post_type_clause = "AND post_type IN ('{$post_types}')";
 		}
 
@@ -567,12 +571,18 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 	 * @param int $total_items Total items counts.
 	 */
 	protected function set_pagination( $total_items ) {
-
 		// Calculate items per page.
 		$per_page = $this->get_items_per_page( 'wpseo_posts_per_page', 10 );
-		$paged    = esc_sql( sanitize_text_field( filter_input( INPUT_GET, 'paged' ) ) );
+		$paged    = isset( $_GET['paged'] ) && is_string( $_GET['paged'] ) ? esc_sql( sanitize_text_field( wp_unslash( $_GET['paged'] ) ) ) : '';
 
-		if ( empty( $paged ) || ! is_numeric( $paged ) || $paged <= 0 ) {
+		if ( empty( $paged ) || ! is_numeric( $paged ) ) {
+			$paged = 1;
+		}
+		else {
+			$paged = (int) $paged;
+		}
+
+		if ( $paged <= 0 ) {
 			$paged = 1;
 		}
 
@@ -604,14 +614,14 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 	 */
 	protected function parse_item_query( $subquery, $all_states, $post_type_clause ) {
 		// Order By block.
-		$orderby = filter_input( INPUT_GET, 'orderby' );
+		$orderby = isset( $_GET['orderby'] ) && is_string( $_GET['orderby'] ) ? sanitize_text_field( wp_unslash( $_GET['orderby'] ) ) : '';
 
-		$orderby = ! empty( $orderby ) ? esc_sql( sanitize_text_field( $orderby ) ) : 'post_title';
+		$orderby = ! empty( $orderby ) ? esc_sql( $orderby ) : 'post_title';
 		$orderby = $this->sanitize_orderby( $orderby );
 
 		// Order clause.
-		$order = filter_input( INPUT_GET, 'order' );
-		$order = ! empty( $order ) ? esc_sql( strtoupper( sanitize_text_field( $order ) ) ) : 'ASC';
+		$order = isset( $_GET['order'] ) && is_string( $_GET['order'] ) ? sanitize_text_field( wp_unslash( $_GET['order'] ) ) : '';
+		$order = ! empty( $order ) ? esc_sql( strtoupper( $order ) ) : 'ASC';
 		$order = $this->sanitize_order( $order );
 
 		// Get all needed results.


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to replace all `filter_input` calls in our codebase.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Refactor all calls to `filter_input` in `class-bulk-editor-list-table` class.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install and activate Yoast SEO.
* Head on over to the administration screen and open the bulk editor by going to Yoast SEO -> Tools and clicking on Bulk editor.
* Verify that all the filters and sorting options on the page still work, so test the content type filter, all the sorting options and go to page 2 and verify that all of that works as expected.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
