### PR TITLE
DUPP-670 Deprecate `WPSEO_HelpScout`

### DIFF
--- a/admin/class-helpscout.php
+++ b/admin/class-helpscout.php
@@ -46,7 +46,7 @@ class WPSEO_HelpScout implements WPSEO_WordPress_Integration {
 			return;
 		}
 
-		_deprecated_function( __METHOD__, 'WPSEO 20.3' );
+		_deprecated_function( __METHOD__, 'WPSEO 20.3', 'HelpScout_Beacon::register_hooks' );
 	}
 
 	/**
@@ -56,7 +56,7 @@ class WPSEO_HelpScout implements WPSEO_WordPress_Integration {
 	 * @deprecated 20.3
 	 */
 	public function enqueue_help_scout_script() {
-		_deprecated_function( __METHOD__, 'WPSEO 20.3' );
+		_deprecated_function( __METHOD__, 'WPSEO 20.3', 'HelpScout_Beacon::enqueue_help_scout_script' );
 	}
 
 	/**
@@ -66,6 +66,6 @@ class WPSEO_HelpScout implements WPSEO_WordPress_Integration {
 	 * @deprecated 20.3
 	 */
 	public function output_beacon_js() {
-		_deprecated_function( __METHOD__, 'WPSEO 20.3' );
+		_deprecated_function( __METHOD__, 'WPSEO 20.3', 'HelpScout_Beacon::output_beacon_js' );
 	}
 }

--- a/admin/class-helpscout.php
+++ b/admin/class-helpscout.php
@@ -7,29 +7,11 @@
 
 /**
  * Class WPSEO_HelpScout
+ *
+ * @codeCoverageIgnore
+ * @deprecated 20.3
  */
 class WPSEO_HelpScout implements WPSEO_WordPress_Integration {
-
-	/**
-	 * The id for the beacon.
-	 *
-	 * @var string
-	 */
-	protected $beacon_id;
-
-	/**
-	 * The pages where the beacon is loaded.
-	 *
-	 * @var array
-	 */
-	protected $pages;
-
-	/**
-	 * The products the beacon is loaded for.
-	 *
-	 * @var array
-	 */
-	protected $products;
 
 	/**
 	 * Whether to asks the user's consent before loading in HelpScout.
@@ -41,225 +23,49 @@ class WPSEO_HelpScout implements WPSEO_WordPress_Integration {
 	/**
 	 * WPSEO_HelpScout constructor.
 	 *
+	 * @codeCoverageIgnore
+	 * @deprecated 20.3
+	 *
 	 * @param string $beacon_id   The beacon id.
 	 * @param array  $pages       The pages where the beacon is loaded.
 	 * @param array  $products    The products the beacon is loaded for.
 	 * @param bool   $ask_consent Optional. Whether to ask for consent before loading in HelpScout.
 	 */
 	public function __construct( $beacon_id, array $pages, array $products, $ask_consent = false ) {
-		$this->beacon_id   = $beacon_id;
-		$this->pages       = $pages;
-		$this->products    = $products;
-		$this->ask_consent = $ask_consent;
+		_deprecated_function( __METHOD__, 'WPSEO 20.3' );
 	}
 
 	/**
 	 * {@inheritDoc}
+	 *
+	 * @codeCoverageIgnore
+	 * @deprecated 20.3
 	 */
 	public function register_hooks() {
 		if ( ! $this->is_beacon_page() ) {
 			return;
 		}
 
-		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_help_scout_script' ] );
-		add_action( 'admin_footer', [ $this, 'output_beacon_js' ] );
+		_deprecated_function( __METHOD__, 'WPSEO 20.3' );
 	}
 
 	/**
 	 * Enqueues the HelpScout script.
+	 *
+	 * @codeCoverageIgnore
+	 * @deprecated 20.3
 	 */
 	public function enqueue_help_scout_script() {
-		$asset_manager = new WPSEO_Admin_Asset_Manager();
-		$asset_manager->enqueue_script( 'help-scout-beacon' );
+		_deprecated_function( __METHOD__, 'WPSEO 20.3' );
 	}
 
 	/**
 	 * Outputs a small piece of javascript for the beacon.
+	 *
+	 * @codeCoverageIgnore
+	 * @deprecated 20.3
 	 */
 	public function output_beacon_js() {
-		printf(
-			'<script type="text/javascript">window.%1$s(\'%2$s\', %3$s)</script>',
-			( $this->ask_consent ) ? 'wpseoHelpScoutBeaconConsent' : 'wpseoHelpScoutBeacon',
-			esc_html( $this->beacon_id ),
-			WPSEO_Utils::format_json_encode( $this->get_session_data() )
-		);
-	}
-
-	/**
-	 * Checks if the current page is a page containing the beacon.
-	 *
-	 * @return bool
-	 */
-	private function is_beacon_page() {
-		return in_array( $this->get_current_page(), $this->pages, true );
-	}
-
-	/**
-	 * Retrieves the value of the current page.
-	 *
-	 * @return string The current page.
-	 */
-	private function get_current_page() {
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Reason: We are not processing form information.
-		if ( isset( $_GET['page'] ) && is_string( $_GET['page'] ) ) {
-			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Reason: We are still not processing form information.
-			return sanitize_text_field( wp_unslash( $_GET['page'] ) );
-		}
-		return '';
-	}
-
-	/**
-	 * Retrieves the identifying data.
-	 *
-	 * @return string The data to pass as identifying data.
-	 */
-	protected function get_session_data() {
-		/** @noinspection PhpUnusedLocalVariableInspection */
-		// Do not make these strings translatable! They are for our support agents, the user won't see them!
-		$current_user = wp_get_current_user();
-
-		$data = [
-			'name'                                                  => trim( $current_user->user_firstname . ' ' . $current_user->user_lastname ),
-			'email'                                                 => $current_user->user_email,
-			'WordPress Version'                                     => $this->get_wordpress_version(),
-			'Server'                                                => $this->get_server_info(),
-			'<a href="' . admin_url( 'themes.php' ) . '">Theme</a>' => $this->get_theme_info(),
-			'<a href="' . admin_url( 'plugins.php' ) . '">Plugins</a>' => $this->get_active_plugins(),
-		];
-
-		if ( ! empty( $this->products ) ) {
-			$addon_manager = new WPSEO_Addon_Manager();
-			foreach ( $this->products as $product ) {
-				$subscription = $addon_manager->get_subscription( $product );
-
-				if ( ! $subscription ) {
-					continue;
-				}
-
-				$data[ $subscription->product->name ] = $this->get_product_info( $subscription );
-			}
-		}
-
-		return WPSEO_Utils::format_json_encode( $data );
-	}
-
-	/**
-	 * Returns basic info about the server software.
-	 *
-	 * @return string
-	 */
-	private function get_server_info() {
-		$server_tracking_data = new WPSEO_Tracking_Server_Data();
-		$server_data          = $server_tracking_data->get();
-		$server_data          = $server_data['server'];
-
-		$fields_to_use = [
-			'IP'       => 'ip',
-			'Hostname' => 'Hostname',
-			'OS'       => 'os',
-			'PHP'      => 'PhpVersion',
-			'CURL'     => 'CurlVersion',
-		];
-
-		$server_data['CurlVersion'] = $server_data['CurlVersion']['version'] . '(SSL Support' . $server_data['CurlVersion']['sslSupport'] . ')';
-
-		$server_info = '<table>';
-
-		foreach ( $fields_to_use as $label => $field_to_use ) {
-			if ( isset( $server_data[ $field_to_use ] ) ) {
-				$server_info .= sprintf( '<tr><td>%1$s</td><td>%2$s</td></tr>', esc_html( $label ), esc_html( $server_data[ $field_to_use ] ) );
-			}
-		}
-
-		$server_info .= '</table>';
-
-		return $server_info;
-	}
-
-	/**
-	 * Returns info about the Yoast SEO plugin version and license.
-	 *
-	 * @param object $plugin The plugin.
-	 *
-	 * @return string The product info.
-	 */
-	private function get_product_info( $plugin ) {
-		if ( empty( $plugin ) ) {
-			return '';
-		}
-
-		$product_info  = '<table>';
-		$product_info .= '<tr><td>Version</td><td>' . $plugin->product->version . '</td></tr>';
-		$product_info .= '<tr><td>Expiration date</td><td>' . $plugin->expiry_date . '</td></tr>';
-		$product_info .= '</table>';
-
-		return $product_info;
-	}
-
-	/**
-	 * Returns the WordPress version + a suffix if current WP is multi site.
-	 *
-	 * @return string The WordPress version string.
-	 */
-	private function get_wordpress_version() {
-		global $wp_version;
-
-		$wordpress_version = $wp_version;
-		if ( is_multisite() ) {
-			$wordpress_version .= ' MULTI-SITE';
-		}
-
-		return $wordpress_version;
-	}
-
-	/**
-	 * Returns a formatted HTML string for the current theme.
-	 *
-	 * @return string The theme info as string.
-	 */
-	private function get_theme_info() {
-		$theme = wp_get_theme();
-
-		$theme_info = sprintf(
-			'<a href="%1$s">%2$s</a> v%3$s by %4$s',
-			esc_attr( $theme->display( 'ThemeURI' ) ),
-			esc_html( $theme->display( 'Name' ) ),
-			esc_html( $theme->display( 'Version' ) ),
-			esc_html( $theme->display( 'Author' ) )
-		);
-
-		if ( is_child_theme() ) {
-			$theme_info .= sprintf( '<br />Child theme of: %1$s', esc_html( $theme->display( 'Template' ) ) );
-		}
-
-		return $theme_info;
-	}
-
-	/**
-	 * Returns a formatted HTML list of all active plugins.
-	 *
-	 * @return string The active plugins.
-	 */
-	private function get_active_plugins() {
-		$updates_available = get_site_transient( 'update_plugins' );
-
-		$active_plugins = '';
-		foreach ( wp_get_active_and_valid_plugins() as $plugin ) {
-			$plugin_data = get_plugin_data( $plugin );
-			$plugin_file = str_replace( trailingslashit( WP_PLUGIN_DIR ), '', $plugin );
-
-			if ( isset( $updates_available->response[ $plugin_file ] ) ) {
-				$active_plugins .= '<i class="icon-close1"></i> ';
-			}
-
-			$active_plugins .= sprintf(
-				'<a href="%1$s">%2$s</a> v%3$s',
-				esc_attr( $plugin_data['PluginURI'] ),
-				esc_html( $plugin_data['Name'] ),
-				esc_html( $plugin_data['Version'] )
-			);
-		}
-
-		return $active_plugins;
+		_deprecated_function( __METHOD__, 'WPSEO 20.3' );
 	}
 }

--- a/admin/class-helpscout.php
+++ b/admin/class-helpscout.php
@@ -100,11 +100,11 @@ class WPSEO_HelpScout implements WPSEO_WordPress_Integration {
 	 * @return string The current page.
 	 */
 	private function get_current_page() {
-		$page = filter_input( INPUT_GET, 'page' );
-		if ( isset( $page ) && $page !== false ) {
-			return $page;
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Reason: We are not processing form information.
+		if ( isset( $_GET['page'] ) && is_string( $_GET['page'] ) ) {
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Reason: We are still not processing form information.
+			return sanitize_text_field( wp_unslash( $_GET['page'] ) );
 		}
-
 		return '';
 	}
 

--- a/composer.json
+++ b/composer.json
@@ -83,7 +83,7 @@
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_coding_standards"
 		],
 		"check-cs-thresholds": [
-			"@putenv YOASTCS_THRESHOLD_ERRORS=135",
+			"@putenv YOASTCS_THRESHOLD_ERRORS=133",
 			"@putenv YOASTCS_THRESHOLD_WARNINGS=204",
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_cs_thresholds"
 		],


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to deprecate the unused `WPSEO_HelpScout` class

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Deprecates the `WPSEO_HelpScout` class.

## Relevant technical choices:

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* NA

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
