### PR TITLE
DUPP-670 Fix PHP 8.1 compatibility for class-my-yoast-proxy class

### DIFF
--- a/admin/class-my-yoast-proxy.php
+++ b/admin/class-my-yoast-proxy.php
@@ -163,7 +163,9 @@ class WPSEO_MyYoast_Proxy implements WPSEO_WordPress_Integration {
 	 * @return bool True when the page request parameter equals the proxy page.
 	 */
 	protected function is_proxy_page() {
-		return filter_input( INPUT_GET, 'page' ) === self::PAGE_IDENTIFIER;
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Reason: We are not processing form information.
+		$page = isset( $_GET['page'] ) && is_string( $_GET['page'] ) ? sanitize_text_field( wp_unslash( $_GET['page'] ) ) : '';
+		return $page === self::PAGE_IDENTIFIER;
 	}
 
 	/**
@@ -171,11 +173,15 @@ class WPSEO_MyYoast_Proxy implements WPSEO_WordPress_Integration {
 	 *
 	 * @codeCoverageIgnore
 	 *
-	 * @return string The sanitized file request parameter.
+	 * @return string The sanitized file request parameter or an empty string if it does not exist.
 	 */
 	protected function get_proxy_file() {
-		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- This deprecation will be addressed later.
-		return filter_input( INPUT_GET, 'file', @FILTER_SANITIZE_STRING );
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Reason: We are not processing form information.
+		if ( isset( $_GET['file'] ) && is_string( $_GET['file'] ) ) {
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Reason: We are not processing form information.
+			return sanitize_text_field( wp_unslash( $_GET['file'] ) );
+		}
+		return '';
 	}
 
 	/**
@@ -183,15 +189,17 @@ class WPSEO_MyYoast_Proxy implements WPSEO_WordPress_Integration {
 	 *
 	 * @codeCoverageIgnore
 	 *
-	 * @return string The sanitized plugin_version request parameter.
+	 * @return string The sanitized plugin_version request parameter or an empty string if it does not exist.
 	 */
 	protected function get_plugin_version() {
-		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- This deprecation will be addressed later.
-		$plugin_version = filter_input( INPUT_GET, 'plugin_version', @FILTER_SANITIZE_STRING );
-		// Replace slashes to secure against requiring a file from another path.
-		$plugin_version = str_replace( [ '/', '\\' ], '_', $plugin_version );
-
-		return $plugin_version;
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Reason: We are not processing form information.
+		if ( isset( $_GET['plugin_version'] ) && is_string( $_GET['plugin_version'] ) ) {
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Reason: We are not processing form information.
+			$plugin_version = sanitize_text_field( wp_unslash( $_GET['plugin_version'] ) );
+			// Replace slashes to secure against requiring a file from another path.
+			return str_replace( [ '/', '\\' ], '_', $plugin_version );
+		}
+		return '';
 	}
 
 	/**

--- a/tests/unit/admin/myyoast-proxy-test.php
+++ b/tests/unit/admin/myyoast-proxy-test.php
@@ -49,6 +49,94 @@ class MyYoast_Proxy_Test extends TestCase {
 	}
 
 	/**
+	 * Test get_plugin_version.
+	 *
+	 * @covers ::get_plugin_version
+	 */
+	public function test_get_plugin_version() {
+		$instance               = new MyYoast_Proxy_Double();
+		$_GET['plugin_version'] = '19.11';
+		$this->assertEquals( '19.11', $instance->get_plugin_version() );
+	}
+
+	/**
+	 * Test get_plugin_version when plugin_version is not set.
+	 *
+	 * @covers ::get_plugin_version
+	 */
+	public function test_get_plugin_version_not_set() {
+		$instance               = new MyYoast_Proxy_Double();
+		$_GET['plugin_version'] = null;
+		$this->assertEquals( '', $instance->get_plugin_version() );
+	}
+
+	/**
+	 * Test get_plugin_version when plugin_version includes slashes.
+	 *
+	 * @covers ::get_plugin_version
+	 */
+	public function test_get_plugin_version_with_slashes() {
+		$instance               = new MyYoast_Proxy_Double();
+		$_GET['plugin_version'] = '19/11';
+		$this->assertEquals( '19_11', $instance->get_plugin_version() );
+	}
+
+	/**
+	 * Test get_proxy_file.
+	 *
+	 * @covers ::get_proxy_file
+	 */
+	public function test_get_proxy_file() {
+		$instance     = new MyYoast_Proxy_Double();
+		$_GET['file'] = 'this_is_a_file';
+		$this->assertEquals( 'this_is_a_file', $instance->get_proxy_file() );
+	}
+
+	/**
+	 * Test get_proxy_file when file is not set.
+	 *
+	 * @covers ::get_proxy_file
+	 */
+	public function test_get_proxy_file_not_set() {
+		$instance     = new MyYoast_Proxy_Double();
+		$_GET['file'] = null;
+		$this->assertEquals( '', $instance->get_proxy_file() );
+	}
+
+	/**
+	 * Test is_proxy_page.
+	 *
+	 * @covers ::is_proxy_page
+	 */
+	public function test_is_proxy_page() {
+		$instance     = new MyYoast_Proxy_Double();
+		$_GET['page'] = 'wpseo_myyoast_proxy';
+		$this->assertEquals( true, $instance->is_proxy_page() );
+	}
+
+	/**
+	 * Test is_proxy_page when page is not set.
+	 *
+	 * @covers ::is_proxy_page
+	 */
+	public function test_is_proxy_page_not_set() {
+		$instance     = new MyYoast_Proxy_Double();
+		$_GET['page'] = null;
+		$this->assertEquals( false, $instance->is_proxy_page() );
+	}
+
+	/**
+	 * Test is_proxy_page when page is not equal to the proxy page.
+	 *
+	 * @covers ::is_proxy_page
+	 */
+	public function test_is_proxy_page_wrong_page() {
+		$instance     = new MyYoast_Proxy_Double();
+		$_GET['page'] = 'wpseo_some_other_page';
+		$this->assertEquals( false, $instance->is_proxy_page() );
+	}
+
+	/**
 	 * Tests the rendering of the proxy page for an unknown file.
 	 *
 	 * @covers ::render_proxy_page

--- a/tests/unit/doubles/admin/myyoast-proxy-double.php
+++ b/tests/unit/doubles/admin/myyoast-proxy-double.php
@@ -25,4 +25,31 @@ class MyYoast_Proxy_Double extends WPSEO_MyYoast_Proxy {
 	public function determine_proxy_options() {
 		return parent::determine_proxy_options();
 	}
+
+	/**
+	 * Test double for is_proxy_page.
+	 *
+	 * @return bool
+	 */
+	public function is_proxy_page() {
+		return parent::is_proxy_page();
+	}
+
+	/**
+	 * Test double for get_proxy_file.
+	 *
+	 * @return string
+	 */
+	public function get_proxy_file() {
+		return parent::get_proxy_file();
+	}
+
+	/**
+	 * Test double for get_plugin_version.
+	 *
+	 * @return string
+	 */
+	public function get_plugin_version() {
+		return parent::get_plugin_version();
+	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to be compatible with PHP 8.1

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Refactor all calls to `filter_input` in `class-my-yoast-proxy` class.
* Prevents deprecation warnings in PHP 8.1 to be triggered when a file was requested with the MyYoast proxy.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install and activate Yoast SEO.
* Go to `/wp-admin/admin.php?page=wpseo_myyoast_proxy&file=research-webworker&plugin_version=19.11` and verify whether you see javascript code.
* Change the `plugin_version` parameter to something else and verify whether the page shows a 501 error.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
