### PR TITLE
Add a transition when a route changes

### DIFF
--- a/packages/js/src/settings/app.js
+++ b/packages/js/src/settings/app.js
@@ -1,3 +1,4 @@
+import { Transition } from "@headlessui/react";
 import {
 	AdjustmentsIcon,
 	ArrowNarrowRightIcon,
@@ -240,40 +241,49 @@ const App = () => {
 						<div className="yst-grow yst-space-y-6 yst-mb-6 xl:yst-mb-0">
 							<main className="yst-relative yst-rounded-lg yst-bg-white yst-shadow">
 								<ErrorBoundary FallbackComponent={ ErrorFallback }>
-									<Routes>
-										<Route path="author-archives" element={ <AuthorArchives /> } />
-										<Route path="breadcrumbs" element={ <Breadcrumbs /> } />
-										<Route path="crawl-optimization" element={ <CrawlSettings /> } />
-										<Route path="date-archives" element={ <DateArchives /> } />
-										<Route path="homepage" element={ <Homepage /> } />
-										<Route path="format-archives" element={ <FormatArchives /> } />
-										<Route path="media" element={ <Media /> } />
-										<Route path="rss" element={ <Rss /> } />
-										<Route path="site-basics" element={ <SiteBasics /> } />
-										<Route path="site-connections" element={ <SiteConnections /> } />
-										<Route path="site-representation" element={ <SiteRepresentation /> } />
-										<Route path="site-features" element={ <SiteFeatures /> } />
-										<Route path="special-pages" element={ <SpecialPages /> } />
-										<Route path="post-type">
-											{ map( postTypes, postType => (
-												<Route
-													key={ `route-post-type-${ postType.name }` }
-													path={ postType.route }
-													element={ <PostType { ...postType } /> }
-												/>
-											) ) }
-										</Route>
-										<Route path="taxonomy">
-											{ map( taxonomies, taxonomy => (
-												<Route
-													key={ `route-taxonomy-${ taxonomy.name }` }
-													path={ taxonomy.route }
-													element={ <Taxonomy { ...taxonomy } /> }
-												/>
-											) ) }
-										</Route>
-										<Route path="*" element={ <Navigate to="/site-features" replace={ true } /> } />
-									</Routes>
+									<Transition
+										key={ pathname }
+										appear={ true }
+										show={ true }
+										enter="yst-transition-opacity yst-delay-100 yst-duration-300"
+										enterFrom="yst-opacity-0"
+										enterTo="yst-opacity-100"
+									>
+										<Routes>
+											<Route path="author-archives" element={ <AuthorArchives /> } />
+											<Route path="breadcrumbs" element={ <Breadcrumbs /> } />
+											<Route path="crawl-optimization" element={ <CrawlSettings /> } />
+											<Route path="date-archives" element={ <DateArchives /> } />
+											<Route path="homepage" element={ <Homepage /> } />
+											<Route path="format-archives" element={ <FormatArchives /> } />
+											<Route path="media" element={ <Media /> } />
+											<Route path="rss" element={ <Rss /> } />
+											<Route path="site-basics" element={ <SiteBasics /> } />
+											<Route path="site-connections" element={ <SiteConnections /> } />
+											<Route path="site-representation" element={ <SiteRepresentation /> } />
+											<Route path="site-features" element={ <SiteFeatures /> } />
+											<Route path="special-pages" element={ <SpecialPages /> } />
+											<Route path="post-type">
+												{ map( postTypes, postType => (
+													<Route
+														key={ `route-post-type-${ postType.name }` }
+														path={ postType.route }
+														element={ <PostType { ...postType } /> }
+													/>
+												) ) }
+											</Route>
+											<Route path="taxonomy">
+												{ map( taxonomies, taxonomy => (
+													<Route
+														key={ `route-taxonomy-${ taxonomy.name }` }
+														path={ taxonomy.route }
+														element={ <Taxonomy { ...taxonomy } /> }
+													/>
+												) ) }
+											</Route>
+											<Route path="*" element={ <Navigate to="/site-features" replace={ true } /> } />
+										</Routes>
+									</Transition>
 								</ErrorBoundary>
 							</main>
 							{ ! isPremium && <PremiumUpsellList /> }

--- a/packages/js/src/settings/app.js
+++ b/packages/js/src/settings/app.js
@@ -1,3 +1,4 @@
+import { Transition } from "@headlessui/react";
 import {
 	AdjustmentsIcon,
 	ArrowNarrowRightIcon,
@@ -7,9 +8,9 @@ import {
 	DesktopComputerIcon,
 	NewspaperIcon,
 } from "@heroicons/react/outline";
-import { useCallback, useMemo } from "@wordpress/element";
+import { Fragment, useCallback, useEffect, useMemo } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
-import { Badge, Button, ChildrenLimiter, ErrorBoundary, Title, useBeforeUnload, useSvgAria } from "@yoast/ui-library";
+import { Badge, Button, ChildrenLimiter, ErrorBoundary, Title, useBeforeUnload, usePrevious, useSvgAria, useToggleState } from "@yoast/ui-library";
 import classNames from "classnames";
 import { useFormikContext } from "formik";
 import { map } from "lodash";
@@ -204,6 +205,37 @@ const PremiumUpsellList = () => {
 };
 
 /**
+ * @returns {JSX.Element} The Route Transition Effect.
+ */
+const RouteTransitionEffect = () => {
+	const { pathname } = useLocation();
+	const previousPathname = usePrevious( pathname );
+	const [ hasRouteChanged, , , setHasRouteChangedTrue, setHasRouteChangedFalse ] = useToggleState( false );
+
+	useEffect( () => {
+		if ( pathname !== previousPathname ) {
+			setHasRouteChangedTrue();
+		}
+	}, [ pathname, previousPathname, setHasRouteChangedTrue ] );
+
+	return (
+		<Transition
+			as={ Fragment }
+			show={ hasRouteChanged }
+			afterEnter={ setHasRouteChangedFalse }
+			enter="yst-transition-opacity yst-duration-150"
+			enterFrom="yst-opacity-0"
+			enterTo="yst-opacity-50"
+			leave="yst-transition-opacity yst-duration-150"
+			leaveFrom="yst-opacity-50"
+			leaveTo="yst-opacity-0"
+		>
+			<div className="yst-absolute yst-inset-0 yst-bg-white yst-select-none yst-rounded-lg" />
+		</Transition>
+	);
+};
+
+/**
  * @returns {JSX.Element} The app component.
  */
 const App = () => {
@@ -238,7 +270,7 @@ const App = () => {
 					</aside>
 					<div className={ classNames( "yst-flex yst-grow yst-flex-wrap", ! isPremium && "xl:yst-pr-[20.5rem]" ) }>
 						<div className="yst-grow yst-space-y-6 yst-mb-6 xl:yst-mb-0">
-							<main className="yst-rounded-lg yst-bg-white yst-shadow">
+							<main className="yst-relative yst-rounded-lg yst-bg-white yst-shadow">
 								<ErrorBoundary FallbackComponent={ ErrorFallback }>
 									<Routes>
 										<Route path="author-archives" element={ <AuthorArchives /> } />
@@ -274,6 +306,7 @@ const App = () => {
 										</Route>
 										<Route path="*" element={ <Navigate to="/site-features" replace={ true } /> } />
 									</Routes>
+									<RouteTransitionEffect />
 								</ErrorBoundary>
 							</main>
 							{ ! isPremium && <PremiumUpsellList /> }

--- a/packages/js/src/settings/app.js
+++ b/packages/js/src/settings/app.js
@@ -249,6 +249,7 @@ const App = () => {
 										enterFrom="yst-opacity-0"
 										enterTo="yst-opacity-100"
 									>
+										{ /* eslint-disable react/jsx-max-depth */ }
 										<Routes>
 											<Route path="author-archives" element={ <AuthorArchives /> } />
 											<Route path="breadcrumbs" element={ <Breadcrumbs /> } />
@@ -283,6 +284,7 @@ const App = () => {
 											</Route>
 											<Route path="*" element={ <Navigate to="/site-features" replace={ true } /> } />
 										</Routes>
+										{ /* eslint-enable react/jsx-max-depth */ }
 									</Transition>
 								</ErrorBoundary>
 							</main>

--- a/packages/js/src/settings/app.js
+++ b/packages/js/src/settings/app.js
@@ -1,4 +1,3 @@
-import { Transition } from "@headlessui/react";
 import {
 	AdjustmentsIcon,
 	ArrowNarrowRightIcon,
@@ -8,9 +7,9 @@ import {
 	DesktopComputerIcon,
 	NewspaperIcon,
 } from "@heroicons/react/outline";
-import { Fragment, useCallback, useEffect, useMemo } from "@wordpress/element";
+import { useCallback, useMemo } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
-import { Badge, Button, ChildrenLimiter, ErrorBoundary, Title, useBeforeUnload, usePrevious, useSvgAria, useToggleState } from "@yoast/ui-library";
+import { Badge, Button, ChildrenLimiter, ErrorBoundary, Title, useBeforeUnload, useSvgAria } from "@yoast/ui-library";
 import classNames from "classnames";
 import { useFormikContext } from "formik";
 import { map } from "lodash";
@@ -205,37 +204,6 @@ const PremiumUpsellList = () => {
 };
 
 /**
- * @returns {JSX.Element} The Route Transition Effect.
- */
-const RouteTransitionEffect = () => {
-	const { pathname } = useLocation();
-	const previousPathname = usePrevious( pathname );
-	const [ hasRouteChanged, , , setHasRouteChangedTrue, setHasRouteChangedFalse ] = useToggleState( false );
-
-	useEffect( () => {
-		if ( pathname !== previousPathname ) {
-			setHasRouteChangedTrue();
-		}
-	}, [ pathname, previousPathname, setHasRouteChangedTrue ] );
-
-	return (
-		<Transition
-			as={ Fragment }
-			show={ hasRouteChanged }
-			afterEnter={ setHasRouteChangedFalse }
-			enter="yst-transition-opacity yst-duration-150"
-			enterFrom="yst-opacity-0"
-			enterTo="yst-opacity-50"
-			leave="yst-transition-opacity yst-duration-150"
-			leaveFrom="yst-opacity-50"
-			leaveTo="yst-opacity-0"
-		>
-			<div className="yst-absolute yst-inset-0 yst-bg-white yst-select-none yst-rounded-lg" />
-		</Transition>
-	);
-};
-
-/**
  * @returns {JSX.Element} The app component.
  */
 const App = () => {
@@ -306,7 +274,6 @@ const App = () => {
 										</Route>
 										<Route path="*" element={ <Navigate to="/site-features" replace={ true } /> } />
 									</Routes>
-									<RouteTransitionEffect />
 								</ErrorBoundary>
 							</main>
 							{ ! isPremium && <PremiumUpsellList /> }

--- a/packages/js/src/settings/app.js
+++ b/packages/js/src/settings/app.js
@@ -239,7 +239,7 @@ const App = () => {
 					</aside>
 					<div className={ classNames( "yst-flex yst-grow yst-flex-wrap", ! isPremium && "xl:yst-pr-[20.5rem]" ) }>
 						<div className="yst-grow yst-space-y-6 yst-mb-6 xl:yst-mb-0">
-							<main className="yst-relative yst-rounded-lg yst-bg-white yst-shadow">
+							<main className="yst-rounded-lg yst-bg-white yst-shadow">
 								<ErrorBoundary FallbackComponent={ ErrorFallback }>
 									<Transition
 										key={ pathname }

--- a/packages/js/src/settings/components/route-layout.js
+++ b/packages/js/src/settings/components/route-layout.js
@@ -1,42 +1,7 @@
-import { Transition } from "@headlessui/react";
-import { Fragment, useEffect } from "@wordpress/element";
-import { Title, usePrevious, useToggleState } from "@yoast/ui-library";
+import { Title } from "@yoast/ui-library";
 import PropTypes from "prop-types";
 import { Helmet } from "react-helmet";
-import { useLocation } from "react-router-dom";
 import { useDocumentTitle } from "../hooks";
-
-/**
- * @returns {JSX.Element} The Route Transition Effect.
- */
-const RouteTransitionEffect = () => {
-	const { pathname } = useLocation();
-	const previousPathname = usePrevious( pathname );
-	const [ hasRouteChanged, , , setHasRouteChangedTrue, setHasRouteChangedFalse ] = useToggleState( false );
-
-	useEffect( () => {
-		if ( pathname !== previousPathname ) {
-			setHasRouteChangedTrue();
-		}
-	}, [ pathname, previousPathname, setHasRouteChangedTrue ] );
-
-	return (
-		<Transition
-			as={ Fragment }
-			appear={ true }
-			show={ hasRouteChanged }
-			afterEnter={ setHasRouteChangedFalse }
-			enter="yst-transition-opacity yst-duration-150"
-			enterFrom="yst-opacity-0"
-			enterTo="yst-opacity-50"
-			leave="yst-transition-opacity yst-duration-150"
-			leaveFrom="yst-opacity-50"
-			leaveTo="yst-opacity-0"
-		>
-			<div className="yst-absolute yst-inset-0 yst-bg-white yst-select-none yst-rounded-lg" />
-		</Transition>
-	);
-};
 
 /**
  * @param {Object} props The properties.
@@ -51,6 +16,7 @@ const RouteLayout = ( {
 	description,
 } ) => {
 	const documentTitle = useDocumentTitle( { prefix: `${ title } ‹ ` } );
+
 	return (
 		<>
 			<Helmet>
@@ -63,7 +29,6 @@ const RouteLayout = ( {
 				</div>
 			</header>
 			{ children }
-			<RouteTransitionEffect />
 		</>
 	);
 };

--- a/packages/js/src/settings/components/route-layout.js
+++ b/packages/js/src/settings/components/route-layout.js
@@ -1,7 +1,42 @@
+import { Transition } from "@headlessui/react";
+import { Fragment, useEffect } from "@wordpress/element";
+import { Title, usePrevious, useToggleState } from "@yoast/ui-library";
 import PropTypes from "prop-types";
 import { Helmet } from "react-helmet";
-import { Title } from "@yoast/ui-library";
+import { useLocation } from "react-router-dom";
 import { useDocumentTitle } from "../hooks";
+
+/**
+ * @returns {JSX.Element} The Route Transition Effect.
+ */
+const RouteTransitionEffect = () => {
+	const { pathname } = useLocation();
+	const previousPathname = usePrevious( pathname );
+	const [ hasRouteChanged, , , setHasRouteChangedTrue, setHasRouteChangedFalse ] = useToggleState( false );
+
+	useEffect( () => {
+		if ( pathname !== previousPathname ) {
+			setHasRouteChangedTrue();
+		}
+	}, [ pathname, previousPathname, setHasRouteChangedTrue ] );
+
+	return (
+		<Transition
+			as={ Fragment }
+			appear={ true }
+			show={ hasRouteChanged }
+			afterEnter={ setHasRouteChangedFalse }
+			enter="yst-transition-opacity yst-duration-150"
+			enterFrom="yst-opacity-0"
+			enterTo="yst-opacity-50"
+			leave="yst-transition-opacity yst-duration-150"
+			leaveFrom="yst-opacity-50"
+			leaveTo="yst-opacity-0"
+		>
+			<div className="yst-absolute yst-inset-0 yst-bg-white yst-select-none yst-rounded-lg" />
+		</Transition>
+	);
+};
 
 /**
  * @param {Object} props The properties.
@@ -28,6 +63,7 @@ const RouteLayout = ( {
 				</div>
 			</header>
 			{ children }
+			<RouteTransitionEffect />
 		</>
 	);
 };


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* ⚠️ This PR is branched of from `feature/new-settings-ui-phase-6` and requested to be merged in there ⚠️ -- this seems like the best solution until that is merged
* UX has not looked at this in detail yet.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds a transition around the `routes` to make it more obvious when you switch pages.

## Relevant technical choices:

* Nice `key` prop to force React to rerender whenever the route changes. Which makes it always appear.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Go to the Settings UI
* Switch routes.
* Notice the effect.
* Specifically when switching between Posts and Pages for example. There was not to notify the page did in fact change before this PR.
* Ensure there is no effect on initial page load.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [x] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes https://yoast.atlassian.net/browse/DUPP-686
