### PR TITLE
Adds community patch PHP 8.1 improvements and adds unit tests

### DIFF
--- a/src/integrations/admin/installation-success-integration.php
+++ b/src/integrations/admin/installation-success-integration.php
@@ -100,9 +100,9 @@ class Installation_Success_Integration implements Integration_Interface {
 	 */
 	public function add_submenu_page( $submenu_pages ) {
 		\add_submenu_page(
-			null,
+			'',
 			\__( 'Installation Successful', 'wordpress-seo' ),
-			null,
+			'',
 			'manage_options',
 			'wpseo_installation_successful_free',
 			[ $this, 'render_page' ]

--- a/src/integrations/admin/old-configuration-integration.php
+++ b/src/integrations/admin/old-configuration-integration.php
@@ -34,9 +34,9 @@ class Old_Configuration_Integration implements Integration_Interface {
 	 */
 	public function add_submenu_page( $submenu_pages ) {
 		\add_submenu_page(
-			null,
+			'',
 			\__( 'Old Configuration Wizard', 'wordpress-seo' ),
-			null,
+			'',
 			'manage_options',
 			'wpseo_configurator',
 			[ $this, 'render_page' ]

--- a/src/integrations/settings-integration.php
+++ b/src/integrations/settings-integration.php
@@ -282,9 +282,9 @@ class Settings_Integration implements Integration_Interface {
 	 */
 	public function add_settings_saved_page( $pages ) {
 		\add_submenu_page(
-			null,
 			'',
-			null,
+			'',
+			'',
 			'wpseo_manage_options',
 			self::PAGE . '_saved',
 			static function () {

--- a/tests/unit/integrations/admin/installation-success-integration-test.php
+++ b/tests/unit/integrations/admin/installation-success-integration-test.php
@@ -92,9 +92,36 @@ class Installation_Success_Integration_Test extends TestCase {
 	 */
 	public function test_register_hooks() {
 		$this->instance->register_hooks();
-		$this->assertNotFalse( Monkey\Filters\has( 'admin_menu', [ $this->instance, 'add_submenu_page' ] ), 'Does not have expected admin_menu filter' );
-		$this->assertNotFalse( Monkey\Actions\has( 'admin_enqueue_scripts', [ $this->instance, 'enqueue_assets' ] ), 'Does not have expected admin_enqueue_scripts action' );
-		$this->assertNotFalse( Monkey\Actions\has( 'admin_init', [ $this->instance, 'maybe_redirect' ] ), 'Does not have expected admin_init action' );
+		$this->assertNotFalse(
+			Monkey\Filters\has(
+				'admin_menu',
+				[
+					$this->instance,
+					'add_submenu_page',
+				]
+			),
+			'Does not have expected admin_menu filter'
+		);
+		$this->assertNotFalse(
+			Monkey\Actions\has(
+				'admin_enqueue_scripts',
+				[
+					$this->instance,
+					'enqueue_assets',
+				]
+			),
+			'Does not have expected admin_enqueue_scripts action'
+		);
+		$this->assertNotFalse(
+			Monkey\Actions\has(
+				'admin_init',
+				[
+					$this->instance,
+					'maybe_redirect',
+				]
+			),
+			'Does not have expected admin_init action'
+		);
 	}
 
 	/**
@@ -346,7 +373,18 @@ class Installation_Success_Integration_Test extends TestCase {
 		Monkey\Functions\expect( '__' )
 			->andReturnFirstArg();
 
-		Monkey\Functions\expect( 'add_submenu_page' );
+		Monkey\Functions\expect( 'add_submenu_page' )
+			->with(
+				'',
+				'Installation Successful',
+				'',
+				'manage_options',
+				'wpseo_installation_successful_free',
+				[
+					$this->instance,
+					'render_page',
+				]
+			);
 
 		$submenu_pages = [
 			'array',

--- a/tests/unit/integrations/admin/old-configuration-integration-test.php
+++ b/tests/unit/integrations/admin/old-configuration-integration-test.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Integrations\Admin;
+
+use Brain\Monkey;
+use Mockery;
+use Yoast\WP\SEO\Conditionals\Admin_Conditional;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+use Yoast\WP\SEO\Integrations\Admin\Old_Configuration_Integration;
+
+/**
+ * Class Old_Configuration_Integration
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Integrations\Admin\Old_Configuration_Integration
+ *
+ * @group integrations
+ */
+class Old_Configuration_Integration_Test extends TestCase {
+
+	/**
+	 * Represents the instance to test.
+	 *
+	 * @var Old_Configuration_Integration|Mockery\Mock
+	 */
+	protected $instance;
+
+	/**
+	 * Set up the fixtures for the tests.
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->instance = new Old_Configuration_Integration();
+	}
+
+	/**
+	 * Tests the retrieval of the conditionals.
+	 *
+	 * @covers ::get_conditionals
+	 */
+	public function test_get_conditionals() {
+		static::assertEquals(
+			[
+				Admin_Conditional::class,
+			],
+			Old_Configuration_Integration::get_conditionals()
+		);
+	}
+
+	/**
+	 * Tests the registration of the hooks.
+	 *
+	 * @covers ::register_hooks
+	 */
+	public function test_register_hooks() {
+		$this->instance->register_hooks();
+		$this->assertNotFalse(
+			Monkey\Filters\has(
+				'admin_menu',
+				[
+					$this->instance,
+					'add_submenu_page',
+				]
+			),
+			'Does not have expected admin_menu filter'
+		);
+		$this->assertNotFalse(
+			Monkey\Actions\has(
+				'admin_init',
+				[
+					$this->instance,
+					'redirect_to_new_configuration',
+				]
+			),
+			'Does not have expected admin_init action'
+		);
+	}
+
+	/**
+	 * Tests the addition of a submenu page.
+	 *
+	 * @covers ::add_submenu_page
+	 */
+	public function test_add_submenu_page() {
+		Monkey\Functions\expect( '__' )
+			->andReturnFirstArg();
+
+		Monkey\Functions\expect( 'add_submenu_page' )
+			->with(
+				'',
+				'Old Configuration Wizard',
+				'',
+				'manage_options',
+				'wpseo_configurator',
+				[
+					$this->instance,
+					'render_page',
+				]
+			);
+
+		$submenu_pages = [
+			'array',
+			'that',
+			'should',
+			'remain',
+			'untouched',
+		];
+
+		$this->assertSame( $submenu_pages, $this->instance->add_submenu_page( $submenu_pages ) );
+	}
+}

--- a/tests/unit/integrations/settings-integration-test.php
+++ b/tests/unit/integrations/settings-integration-test.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Integrations;
+
+use Brain\Monkey;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+use Yoast\WP\SEO\Integrations\Settings_Integration;
+use Mockery;
+use Yoast\WP\SEO\Config\Schema_Types;
+use Yoast\WP\SEO\Helpers\Current_Page_Helper;
+use Yoast\WP\SEO\Helpers\Post_Type_Helper;
+use Yoast\WP\SEO\Helpers\Taxonomy_Helper;
+use Yoast\WP\SEO\Helpers\Product_Helper;
+use Yoast\WP\SEO\Helpers\Woocommerce_Helper;
+use Yoast\WP\SEO\Helpers\Schema\Article_Helper;
+use Yoast\WP\SEO\Integrations\Admin\Social_Profiles_Helper;
+use WPSEO_Admin_Asset_Manager;
+use WPSEO_Replace_Vars;
+use Yoast\WP\SEO\Conditionals\Settings_Conditional;
+
+/**
+ * Class Settings_Integration_Test.
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Integrations\Settings_Integration
+ *
+ * @group integrations
+ */
+class Settings_Integration_Test extends TestCase {
+
+	/**
+	 * The class under test.
+	 *
+	 * @var Settings_Integration
+	 */
+	protected $instance;
+
+	/**
+	 * Runs the setup to prepare the needed instance
+	 */
+	public function set_up() {
+		$asset_manager          = Mockery::mock( WPSEO_Admin_Asset_Manager::class );
+		$replace_vars           = Mockery::mock( WPSEO_Replace_Vars::class );
+		$schema_types           = Mockery::mock( Schema_Types::class );
+		$current_page_helper    = Mockery::mock( Current_Page_Helper::class );
+		$post_type_helper       = Mockery::mock( Post_Type_Helper::class );
+		$taxonomy_helper        = Mockery::mock( Taxonomy_Helper::class );
+		$product_helper         = Mockery::mock( Product_Helper::class );
+		$woocommerce_helper     = Mockery::mock( Woocommerce_Helper::class );
+		$article_helper         = Mockery::mock( Article_Helper::class );
+		$social_profiles_helper = Mockery::mock( Social_Profiles_Helper::class );
+
+		$this->instance = new Settings_Integration(
+			$asset_manager,
+			$replace_vars,
+			$schema_types,
+			$current_page_helper,
+			$post_type_helper,
+			$taxonomy_helper,
+			$product_helper,
+			$woocommerce_helper,
+			$article_helper,
+			$social_profiles_helper
+		);
+	}
+
+	/**
+	 * Tests the retrieval of the conditionals.
+	 *
+	 * @covers ::get_conditionals
+	 */
+	public function test_get_conditionals() {
+		static::assertEquals(
+			[
+				Settings_Conditional::class,
+			],
+			Settings_Integration::get_conditionals()
+		);
+	}
+
+	/**
+	 * Tests the addition of a submenu page.
+	 *
+	 * @covers ::add_submenu_page
+	 */
+	public function test_add_submenu_page() {
+
+		Monkey\Functions\expect( 'add_submenu_page' )
+			->with( '', '', '', 'wpseo_manage_options', 'wpseo_settings_saved', Mockery::type( 'Closure' ) );
+
+		$submenu_pages = [
+			'array',
+			'that',
+			'should',
+			'remain',
+			'untouched',
+		];
+
+		$this->assertSame( $submenu_pages, $this->instance->add_settings_saved_page( $submenu_pages ) );
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* This PR continues on the work made in https://github.com/Yoast/wordpress-seo/pull/19125

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes deprecated warning generation when executing under PHP 8.1. Props to [@davefx](https://github.com/davefx).

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* To test the `old-configuration-integration` go to https://basic.wordpress.test/wp-admin/admin.php?page=wpseo_configurator and make sure you get redirected to https://basic.wordpress.test/wp-admin/admin.php?page=wpseo_dashboard#top#first-time-configuration

* To test the `settings-integration` open https://basic.wordpress.test/wp-admin/admin.php?page=wpseo_settings#/site-basics and change a setting. Save the setting and make sure you get the `Great! Your settings were saved successfully.`
  * note that you need to enable the new Settings UI for this. 

* To test the `installation-success-integration` open https://basic.wordpress.test/wp-admin/admin.php?page=wpseo_installation_successful_free and make sure you see the thank you page.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
