### PR TITLE
Settings UI: crawl cleanup robots txt modification rules should be disabled on multisite

### DIFF
--- a/packages/js/src/settings/hocs/with-disabled-message-support.js
+++ b/packages/js/src/settings/hocs/with-disabled-message-support.js
@@ -1,7 +1,7 @@
 import { useMemo } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
 import { Badge } from "@yoast/ui-library";
-import { get } from "lodash";
+import { get, isEmpty } from "lodash";
 import PropTypes from "prop-types";
 import { useSelectSettings } from "../hooks";
 
@@ -19,17 +19,30 @@ const withDisabledMessageSupport = ( Component ) => {
 	const WithDisabledMessageSupport = ( { name, ...props } ) => {
 		const isNetworkAdmin = useSelectSettings( "selectPreference", [], "isNetworkAdmin" );
 		const isMainSite = useSelectSettings( "selectPreference", [], "isMainSite" );
-		const isDisabledSetting = useMemo( () => get( window, `wpseoScriptData.disabledSettings.${ name }`, false ), [] );
-		const isDisabledTracking = useMemo( () => name === "wpseo.tracking" && ! isNetworkAdmin && ! isMainSite, [ name, isNetworkAdmin, isMainSite ] );
+		const disabledSetting = useMemo( () => get( window, `wpseoScriptData.disabledSettings.${ name }`, "" ), [] );
+		const isDisabledTracking = useMemo(
+			() => name === "wpseo.tracking" && ! isNetworkAdmin && ! isMainSite,
+			[ name, isNetworkAdmin, isMainSite ]
+		);
 		const text = useMemo( () => {
 			if ( isDisabledTracking ) {
 				return __( "Unavailable for sub-sites", "wordpress-seo" );
 			}
-			return __( "Network disabled", "wordpress-seo" );
-		}, [ isDisabledTracking ] );
+			switch ( disabledSetting ) {
+				case "multisite":
+					return __( "Unavailable for multi-sites", "wordpress-seo" );
+				default:
+					return __( "Network disabled", "wordpress-seo" );
+			}
+		}, [ disabledSetting, isDisabledTracking ] );
 
-		if ( isDisabledSetting || isDisabledTracking ) {
-			return <Component name={ name } { ...props } disabled={ true } labelSuffix={ <Badge variant="plain" size="small" className="yst-ml-1.5">{ text }</Badge> } />;
+		if ( ! isEmpty( disabledSetting ) || isDisabledTracking ) {
+			return <Component
+				name={ name }
+				{ ...props }
+				disabled={ true }
+				labelSuffix={ <Badge variant="plain" size="small" className="yst-ml-1.5">{ text }</Badge> }
+			/>;
 		}
 		return <Component name={ name } { ...props } />;
 	};

--- a/packages/js/src/settings/routes/crawl-optimization.js
+++ b/packages/js/src/settings/routes/crawl-optimization.js
@@ -5,12 +5,12 @@ import { Alert, Button, Code, FeatureUpsell, TextField, ToggleField, useSvgAria 
 import { Field, useFormikContext } from "formik";
 import { addLinkToString } from "../../helpers/stringHelpers";
 import { FieldsetLayout, FormikTagField, FormikValueChangeField, FormLayout, RouteLayout } from "../components";
-import { withFormikDummyField } from "../hocs";
+import { withDisabledMessageSupport, withFormikDummyField } from "../hocs";
 import { useSelectSettings } from "../hooks";
 
 const FormikFieldWithDummy = withFormikDummyField( Field );
 const FormikTagFieldWithDummy = withFormikDummyField( FormikTagField );
-const FormikValueChangeFieldWithDummy = withFormikDummyField( FormikValueChangeField );
+const FormikValueChangeFieldWithDummy = withFormikDummyField( withDisabledMessageSupport( FormikValueChangeField ) );
 
 /**
  * @returns {JSX.Element} The crawl optimization route.

--- a/packages/js/src/settings/routes/crawl-optimization.js
+++ b/packages/js/src/settings/routes/crawl-optimization.js
@@ -262,7 +262,7 @@ const CrawlOptimization = () => {
 					<Button as="a" className="yst-gap-2" variant="upsell" href={ premiumLink } target="_blank" rel="noopener">
 						<LockOpenIcon className="yst-w-5 yst-h-5 yst--ml-1 yst-shrink-0" { ...svgAriaProps } />
 						{ sprintf(
-						/* translators: %1$s expands to Premium. */
+							/* translators: %1$s expands to Premium. */
 							__( "Unlock with %1$s", "wordpress-seo" ),
 							"Premium"
 						) }
@@ -286,7 +286,7 @@ const CrawlOptimization = () => {
 								isDummy={ ! isPremium }
 							>
 								{ __( "Remove links to WordPress' internal 'shortlink' URLs for your posts.", "wordpress-seo" ) }
-							&nbsp;
+								&nbsp;
 								{ descriptions.removeShortlinks }
 							</FormikValueChangeFieldWithDummy>
 							<FormikValueChangeFieldWithDummy
@@ -298,7 +298,7 @@ const CrawlOptimization = () => {
 								isDummy={ ! isPremium }
 							>
 								{ __( "Remove links to the location of your site’s REST API endpoints.", "wordpress-seo" ) }
-							&nbsp;
+								&nbsp;
 								{ descriptions.removeRestApiLinks }
 							</FormikValueChangeFieldWithDummy>
 							<FormikValueChangeFieldWithDummy
@@ -310,7 +310,7 @@ const CrawlOptimization = () => {
 								isDummy={ ! isPremium }
 							>
 								{ __( "Remove links used by external systems for publishing content to your blog.", "wordpress-seo" ) }
-							&nbsp;
+								&nbsp;
 								{ descriptions.removeRsdWlwLinks }
 							</FormikValueChangeFieldWithDummy>
 							<FormikValueChangeFieldWithDummy
@@ -322,7 +322,7 @@ const CrawlOptimization = () => {
 								isDummy={ ! isPremium }
 							>
 								{ __( "Remove links used for embedding your content on other sites.", "wordpress-seo" ) }
-							&nbsp;
+								&nbsp;
 								{ descriptions.removeOembedLinks }
 							</FormikValueChangeFieldWithDummy>
 							<FormikValueChangeFieldWithDummy
@@ -334,7 +334,7 @@ const CrawlOptimization = () => {
 								isDummy={ ! isPremium }
 							>
 								{ __( "Remove information about the plugins and software used by your site.", "wordpress-seo" ) }
-							&nbsp;
+								&nbsp;
 								{ descriptions.removeGenerator }
 							</FormikValueChangeFieldWithDummy>
 							<FormikValueChangeFieldWithDummy
@@ -346,7 +346,7 @@ const CrawlOptimization = () => {
 								isDummy={ ! isPremium }
 							>
 								{ __( "Remove links which allow others sites to ‘ping’ yours when they link to you.", "wordpress-seo" ) }
-							&nbsp;
+								&nbsp;
 								{ descriptions.removePingbackHeader }
 							</FormikValueChangeFieldWithDummy>
 							<FormikValueChangeFieldWithDummy
@@ -358,7 +358,7 @@ const CrawlOptimization = () => {
 								isDummy={ ! isPremium }
 							>
 								{ __( "Remove information about the plugins and software used by your site.", "wordpress-seo" ) }
-							&nbsp;
+								&nbsp;
 								{ descriptions.removePoweredByHeader }
 							</FormikValueChangeFieldWithDummy>
 						</FieldsetLayout>
@@ -376,7 +376,7 @@ const CrawlOptimization = () => {
 								isDummy={ ! isPremium }
 							>
 								{ __( "Remove URLs which provide an overview of your recent posts.", "wordpress-seo" ) }
-							&nbsp;
+								&nbsp;
 								{ descriptions.removeFeedGlobal }
 							</FormikValueChangeFieldWithDummy>
 							<FormikValueChangeFieldWithDummy
@@ -388,7 +388,7 @@ const CrawlOptimization = () => {
 								isDummy={ ! isPremium }
 							>
 								{ __( "Remove URLs which provide an overview of recent comments on your site.", "wordpress-seo" ) }
-							&nbsp;
+								&nbsp;
 								{ descriptions.removeFeedGlobalComments }
 								{ __( "Also disables Post comment feeds.", "wordpress-seo" ) }
 							</FormikValueChangeFieldWithDummy>
@@ -403,7 +403,7 @@ const CrawlOptimization = () => {
 								isDummy={ ! isPremium }
 							>
 								{ __( "Remove URLs which provide information about recent comments on each post.", "wordpress-seo" ) }
-							&nbsp;
+								&nbsp;
 								{ descriptions.removeFeedPostComments }
 							</FormikValueChangeFieldWithDummy>
 							<FormikValueChangeFieldWithDummy
@@ -415,7 +415,7 @@ const CrawlOptimization = () => {
 								isDummy={ ! isPremium }
 							>
 								{ __( "Remove URLs which provide information about recent posts by specific authors.", "wordpress-seo" ) }
-							&nbsp;
+								&nbsp;
 								{ descriptions.removeFeedAuthors }
 							</FormikValueChangeFieldWithDummy>
 							<FormikValueChangeFieldWithDummy
@@ -427,7 +427,7 @@ const CrawlOptimization = () => {
 								isDummy={ ! isPremium }
 							>
 								{ __( "Remove URLs which provide information about your recent posts, for each post type.", "wordpress-seo" ) }
-							&nbsp;
+								&nbsp;
 								{ descriptions.removeFeedPostTypes }
 							</FormikValueChangeFieldWithDummy>
 							<FormikValueChangeFieldWithDummy
@@ -439,7 +439,7 @@ const CrawlOptimization = () => {
 								isDummy={ ! isPremium }
 							>
 								{ __( "Remove URLs which provide information about your recent posts, for each category.", "wordpress-seo" ) }
-							&nbsp;
+								&nbsp;
 								{ descriptions.removeFeedCategories }
 							</FormikValueChangeFieldWithDummy>
 							<FormikValueChangeFieldWithDummy
@@ -451,7 +451,7 @@ const CrawlOptimization = () => {
 								isDummy={ ! isPremium }
 							>
 								{ __( "Remove URLs which provide information about your recent posts, for each tag.", "wordpress-seo" ) }
-							&nbsp;
+								&nbsp;
 								{ descriptions.removeFeedTags }
 							</FormikValueChangeFieldWithDummy>
 							<FormikValueChangeFieldWithDummy
@@ -463,7 +463,7 @@ const CrawlOptimization = () => {
 								isDummy={ ! isPremium }
 							>
 								{ __( "Remove URLs which provide information about your recent posts, for each custom taxonomy.", "wordpress-seo" ) }
-							&nbsp;
+								&nbsp;
 								{ descriptions.removeFeedCustomTaxonomies }
 							</FormikValueChangeFieldWithDummy>
 							<FormikValueChangeFieldWithDummy
@@ -475,7 +475,7 @@ const CrawlOptimization = () => {
 								isDummy={ ! isPremium }
 							>
 								{ __( "Remove URLs which provide information about your search results.", "wordpress-seo" ) }
-							&nbsp;
+								&nbsp;
 								{ descriptions.removeFeedSearch }
 							</FormikValueChangeFieldWithDummy>
 							<FormikValueChangeFieldWithDummy
@@ -487,7 +487,7 @@ const CrawlOptimization = () => {
 								isDummy={ ! isPremium }
 							>
 								{ __( "Remove URLs which provide alternative (legacy) formats of all of the above.", "wordpress-seo" ) }
-							&nbsp;
+								&nbsp;
 								{ descriptions.removeAtomRdfFeeds }
 							</FormikValueChangeFieldWithDummy>
 						</FieldsetLayout>
@@ -514,7 +514,7 @@ const CrawlOptimization = () => {
 								isDummy={ ! isPremium }
 							>
 								{ __( "Add a ‘disallow’ rule to your robots.txt file to prevent crawling of WordPress' JSON API endpoints.", "wordpress-seo" ) }
-							&nbsp;
+								&nbsp;
 								{ descriptions.denyWpJsonCrawling }
 							</FormikValueChangeFieldWithDummy>
 						</FieldsetLayout>
@@ -580,7 +580,7 @@ const CrawlOptimization = () => {
 							<Alert id="alert-permalink-cleanup-settings" variant="warning">
 								{ addLinkToString(
 									sprintf(
-									// translators: %1$s and %2$s are replaced by opening and closing <a> tags.
+										// translators: %1$s and %2$s are replaced by opening and closing <a> tags.
 										__( "These are expert features, so make sure you know what you're doing before removing the parameters. %1$sRead more about how your site can be affected%2$s.", "wordpress-seo" ),
 										"<a>",
 										"</a>"

--- a/src/integrations/settings-integration.php
+++ b/src/integrations/settings-integration.php
@@ -46,8 +46,6 @@ class Settings_Integration implements Integration_Interface {
 	/**
 	 * Holds the disallowed settings, per option group.
 	 *
-	 * Note: these are the settings that hold Objects.
-	 *
 	 * @var array
 	 */
 	const DISALLOWED_SETTINGS = [

--- a/src/integrations/settings-integration.php
+++ b/src/integrations/settings-integration.php
@@ -74,6 +74,18 @@ class Settings_Integration implements Integration_Interface {
 	];
 
 	/**
+	 * Holds the disabled on multisite settings, per option group.
+	 *
+	 * @var array
+	 */
+	const DISABLED_ON_MULTISITE_SETTINGS = [
+		'wpseo' => [
+			'deny_search_crawling',
+			'deny_wp_json_crawling',
+		],
+	];
+
+	/**
 	 * Holds the WPSEO_Admin_Asset_Manager.
 	 *
 	 * @var WPSEO_Admin_Asset_Manager
@@ -527,7 +539,16 @@ class Settings_Integration implements Integration_Interface {
 			}
 			foreach ( $settings[ $option_name ] as $setting_name => $setting_value ) {
 				if ( $option_instance->is_disabled( $setting_name ) ) {
-					$disabled_settings[ $option_name ][ $setting_name ] = true;
+					$disabled_settings[ $option_name ][ $setting_name ] = 'network';
+				}
+			}
+		}
+
+		// Remove disabled on multisite settings.
+		foreach ( self::DISABLED_ON_MULTISITE_SETTINGS as $option_name => $disabled_ms_settings ) {
+			if ( \array_key_exists( $option_name, $disabled_settings ) ) {
+				foreach ( $disabled_ms_settings as $disabled_ms_setting ) {
+					$disabled_settings[ $option_name ][ $disabled_ms_setting ] = 'multisite';
 				}
 			}
 		}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes the Crawl optimization page' support for disabled options. Both disallowed by the network admin and unavailable on multisite.

## Relevant technical choices:

* In the current/old options UI, the disabling of the multisite is determined in the specific views. Here I created a list in the settings integration instead. We should keep this in mind for the cleanup. The "normal" disabled is controlled via the options framework. Not sure why this is not, but out of scope for now I think.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Switch to a multisite environment.
* Disable some crawl optimization settings in the network admin.
* Go to a sub site and verify in the Settings UI' Crawl optimization that those options are disabled with the right label "Network disabled" (as opposed to "Unavailable for multi-sites")

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [x] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [x] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes https://yoast.atlassian.net/browse/DUPP-708
