### PR TITLE
Check for real ID before updating the database

### DIFF
--- a/inc/class-wpseo-image-utils.php
+++ b/inc/class-wpseo-image-utils.php
@@ -456,14 +456,20 @@ class WPSEO_Image_Utils {
 	 */
 	public static function get_attachment_id_from_settings( $setting ) {
 		$image_id = WPSEO_Options::get( $setting . '_id', false );
-		if ( ! $image_id ) {
-			$image = WPSEO_Options::get( $setting, false );
-			if ( $image ) {
-				// There is not an option to put a URL in an image field in the settings anymore, only to upload it through the media manager.
-				// This means an attachment always exists, so doing this is only needed once.
-				$image_id = self::get_attachment_by_url( $image );
-				WPSEO_Options::set( $setting . '_id', $image_id );
-			}
+		if ( $image_id ) {
+            return $image_id;
+        }
+
+        $image = WPSEO_Options::get( $setting, false );
+        if ( $image ) {
+            // There is not an option to put a URL in an image field in the settings anymore, only to upload it through the media manager.
+            // This means an attachment always exists, so doing this is only needed once.
+            $image_id = self::get_attachment_by_url( $image );
+        }
+        
+        // Only store a new ID if it is not 0, to prevent an update loop.
+        if ( $image_id ) {
+            WPSEO_Options::set( $setting . '_id', $image_id );
 		}
 
 		return $image_id;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Thanks to https://github.com/Yoast/wordpress-seo/issues/13586#issuecomment-1317406365 for the details!
* We use attachment IDs for our general representation settings (person / company logo). When these do not exist, they are saved as ID 0 and in that case, we see if the attachment URL exists. If so, we grab the ID of that URL and save it, even if it does not exist and returns 0. This causes a loop where we keep updating these options on every page request, since the ID is always 0 and a URL that leads to a 0 ID always exists.
* It is unknown how this situation may arise. We used to allow for external URLs to be saved but this removed quite a while ago. It might also be caused by plugins that offload media to external services.
* This problem might also cause unnecessary cache flushes, completely neutralizing caching functionality of some plugins that flush on option updates.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Prevent database update requests on page loads when the site representation settings contain conflicting data. Props to [jboonstra](https://github.com/jboonstra)

## Relevant technical choices:

* Instead of always saving the ID when it's grabbed from the attachment URL, we only save it if an ID that is not 0 was retrieved.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

Without this PR:
* Make sure you have Query Monitor running
* Set a company logo under Search Appearance -> Knowledge Graph & Schema.org
* Go into the database in your `{prefix}_options` table. 
* Under the `wpseo_titles` option: 
  * search for `company_logo_id`. Change that value to `0`. 
  * search for `company_logo`. Change that url by replacing one character.
* Go to your frontpage and check the database queries in query monitor. Notice an UPDATE of the options table cause by the caller `update_option('wpseo_titles')`
* Refresh the page, and notice that every refresh this UPDATE returns.

With this PR, the UPDATES should not happen.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

Repeat the following steps for both `company` and `person` representation
* Set a logo under Search Appearance -> Knowledge Graph & Schema.org
* Visit a few frontpages and make sure the logo is correctly represented in the schema 

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Representation settings: Company and Person logo.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
