### PR TITLE
Settings UI: change site representation user rights notifications

### DIFF
--- a/packages/js/src/settings/routes/site-representation.js
+++ b/packages/js/src/settings/routes/site-representation.js
@@ -21,7 +21,6 @@ const PersonSocialProfiles = () => {
 	const { values, status, setStatus, setFieldValue } = useFormikContext();
 	const { company_or_person_user_id: companyOrPersonId } = values.wpseo_titles;
 	const previousUserId = usePrevious( companyOrPersonId );
-	const personUser = useSelectSettings( "selectUserById", [ companyOrPersonId ], companyOrPersonId );
 	const canEditUser = useSelectSettings( "selectCanEditUser", [], companyOrPersonId );
 	const socialProfileFieldLabels = useMemo( () => ( {
 		facebook: __( "Facebook URL", "wordpress-seo" ),
@@ -65,20 +64,6 @@ const PersonSocialProfiles = () => {
 			title={ __( "Other profiles", "wordpress-seo" ) }
 			description={ __( "Tell us about the other profiles on the web that belong to the person.", "wordpress-seo" ) }
 		>
-			{ ! canEditUser && <Alert variant="info">
-				{ ! isEmpty( personUser ) && createInterpolateElement(
-					sprintf(
-						// translators: %1$s and %2$s are replaced by opening and closing <span> tags.
-						// %3$s is replaced by the selected user display name.
-						__( "We're sorry, you're not allowed to edit the other profiles of %1$s%3$s%2$s.", "wordpress-seo" ),
-						"<strong>",
-						"</strong>",
-						personUser?.name
-					), {
-						strong: <strong className="yst-font-medium" />,
-					} ) }
-				{ isEmpty( personUser ) && __( "We're sorry, you're not allowed to edit the other profiles of the selected user.", "wordpress-seo" ) }
-			</Alert> }
 			{ map( personSocialProfiles, socialProfile => (
 				<FormikWithErrorField
 					key={ socialProfile }
@@ -324,7 +309,7 @@ const SiteRepresentation = () => {
 											sprintf(
 												// translators: %1$s and %2$s are replaced by opening and closing <span> tags.
 												// %3$s is replaced by the selected user display name.
-												__( "You have selected the user %1$s%3$s%2$s as the person this site represents. Their user profile information will now be used in search results. We're sorry, you're not allowed to edit this user's profile.", "wordpress-seo" ),
+												__( "You have selected the user %1$s%3$s%2$s as the person this site represents. Their user profile information will now be used in search results. We're sorry, you're not allowed to edit this user's profile. Please contact your admin or %1$s%3$s%2$s to check and/or update the information below.", "wordpress-seo" ),
 												"<strong>",
 												"</strong>",
 												personUser?.name


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Implemented the suggested quick win from Luc (in the issue comments)

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Finetunes the site representation user profile alerts in the Settings UI for when a user does not have the capabilities to alter the profiles.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Log in as a user with the SEO manager role (or something else that does not allowed editing of random users?)
* Open the Settings UI
* Go to site representation
* Switch to represent a user and change the user to someone that is not your current user
* Verify the alert changes:
  * Removed the alert at the top of the other profiles section
  * Added a sentance at the end of the alert under the user select:
![image](https://user-images.githubusercontent.com/35524806/202451545-aa1fa497-1f62-411a-bebc-b86e639bce16.png)


#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [x] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes https://yoast.atlassian.net/browse/DUPP-691
