### PR TITLE
DUPP-755 - PHP 8.1 compat: Use array to pass parameters to schedule a cron job to send tracking data after core update

### DIFF
--- a/admin/tracking/class-tracking.php
+++ b/admin/tracking/class-tracking.php
@@ -93,12 +93,12 @@ class WPSEO_Tracking implements WPSEO_WordPress_Integration {
 		 * needs to receive the same arguments as those used when originally
 		 * scheduling the event otherwise it will always return false.
 		 */
-		if ( ! wp_next_scheduled( 'wpseo_send_tracking_data_after_core_update', true ) ) {
+		if ( ! wp_next_scheduled( 'wpseo_send_tracking_data_after_core_update', [ true ] ) ) {
 			/*
 			 * Schedule sending of data tracking 6 hours after a WordPress core
 			 * update. Pass a `true` parameter for the callback `$force` argument.
 			 */
-			wp_schedule_single_event( ( time() + ( HOUR_IN_SECONDS * 6 ) ), 'wpseo_send_tracking_data_after_core_update', true );
+			wp_schedule_single_event( ( time() + ( HOUR_IN_SECONDS * 6 ) ), 'wpseo_send_tracking_data_after_core_update', [ true ] );
 		}
 	}
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to fix a compatibility problem with PHP 8.1 when we schedule a job to send tracking data after a core upgrade.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug that would affect users managing the cron jobs with a plugin on PHP 8.1 after they have performed a core upgrade.

## Relevant technical choices:

* The problem has been reported with PHP 8.0, but it gives just a warning in that case that can be easily suppressed. In PHP 8.1 the problem triggers a fatal error, that's why we are treating it as a PHP 8.1 compatibility issue.
* if the cron job is scheduled in the wrong way as it happens currently, it will stay this way until it runs. For the sake of simplicity, **we're not introducing an upgrade routine** to remove the offending cron job, because it will run anyway and will thus be removed after max 6h. While running it could possibly fail, but the tracking will be refreshed in max 2 weeks anyway.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:


#### Reproduce the bug

* Switch to PHP 8.1
* checkout `trunk` or `main`
* Go to `Yoast SEO` -> `General` -> `Features` tab and and set `Usage tracking` to `Yes`
* install the Advanced Cron Manager plugin
* Update WP or reinstall the same version (Dashboard > Updates)
* visit Tools > Cron manager
* see that you get a Fatal Error in Query Monitor and the page renders only in part, up to the `wpseo_send_tracking_data_after_core_update` job

#### Test the fix
* if you have done the above, make sure that you remove the job first with `wp cron event delete wpseo_send_tracking_data_after_core_update`, otherwise it will remain broken (see "Relevant technical choices")
* checkout this branch
* install the Advanced Cron Manager plugin
* Update WP or reinstall the same version (Dashboard > Updates)
* visit Tools > Cron manager
* see that you **don't get** a Fatal Error in Query Monitor and the page renders fully

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes [DUPP-755]


[DUPP-755]: https://yoast.atlassian.net/browse/DUPP-755?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ