### PR TITLE
PC-989 Add a safeguard to check if wpseoAdminL10n is defined in the worker

### DIFF
--- a/packages/yoastseo/src/worker/createWorker.js
+++ b/packages/yoastseo/src/worker/createWorker.js
@@ -90,7 +90,7 @@ function createWorkerFallback( url ) {
  */
 function createWorker( url ) {
 	// If we are not on the same domain, or we are editing a post in the Web Stories plug-in integration, we require a fallback worker.
-	if ( ! isSameOrigin( window.location, url ) || window.wpseoAdminL10n.isWebStoriesIntegrationActive === "1" ) {
+	if ( ! isSameOrigin( window.location, url ) || ( window.wpseoAdminL10n && window.wpseoAdminL10n.isWebStoriesIntegrationActive === "1" ) ) {
 		return createWorkerFallback( url );
 	}
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* In this PR #19170 we made it possible to load the worker in a web story, by creating a worker blob when editing in a web story in `createWorker.js`
* This requires us to check `wpseoAdminL10n` whether the post type is indeed a web story:

````
if ( ! isSameOrigin( window.location, url ) || window.wpseoAdminL10n.isWebStoriesIntegrationActive === "1" ) {
		return createWorkerFallback( url );
	}
```` 

* However, when `createWorker` is used `shopify-seo`, we don't have access to `wpseoAdminL10n`. This will return undefined and trying to access a key of an undefined object will cause an error (in this case, it was a silent error without warning at all)
* As a result, in Shopify, we cannot load the worker since we failed to create one.
* In this PR, we add a safeguard to check if `wpseoAdminL10n` is defined before trying to access it's key.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds a safeguard to check if `wpseoAdminL10n` is defined in the `createWorker.js`.
* [yoastseo] Adds a safeguard to check if `wpseoAdminL10n` is defined in the `createWorker.js`.
* [shopify-seo] Fixes an unreleased bug where the worker was not loaded in the app when visiting `Optimize`.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### WordPress
* Follow the testing instruction in this PR: https://github.com/Yoast/wordpress-seo/pull/19170
* Confirm that you still get the same results

#### Shopify
* Install and activate Yoast SEO for Shopify
   * If building the app:
      * Build the app from `main`
      * Don't forget to link `wordpress-seo` before building the app
* Visit `Optimize`
* Confirm that there is no error and `Optimize` can be accessed
* Inspect the page
* Go to Network tab
* Search for `analysis-worker.js`   and confirm that it's loaded properly

<img width="537" alt="Screenshot 2022-11-18 at 12 10 00" src="https://user-images.githubusercontent.com/48715883/202692051-da1e9461-6ab5-4d2c-a64c-6215189bf3cb.png">

* Smoke test the analysis and confirm that it works fine

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [x] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes https://yoast.atlassian.net/browse/PC-989
