### PR TITLE
Enforce displaying title tags for web stories

### DIFF
--- a/src/integrations/third-party/web-stories.php
+++ b/src/integrations/third-party/web-stories.php
@@ -3,10 +3,12 @@
 namespace Yoast\WP\SEO\Integrations\Third_Party;
 
 use Yoast\WP\SEO\Conditionals\Web_Stories_Conditional;
+use Yoast\WP\SEO\Context\Meta_Tags_Context;
 use Yoast\WP\SEO\Integrations\Front_End_Integration;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
 use Yoast\WP\SEO\Models\Indexable;
 use Yoast\WP\SEO\Presentations\Indexable_Presentation;
+use Yoast\WP\SEO\Presenters\Title_Presenter;
 
 /**
  * Web Stories integration.
@@ -46,10 +48,12 @@ class Web_Stories implements Integration_Interface {
 	 * @return void
 	 */
 	public function register_hooks() {
-		// If the title presenter was not removed, we will disable the web stories metadata because Yoast SEO will output the title already.
-		if ( ! $this->front_end->should_title_presenter_be_removed() ) {
-			\add_action( 'web_stories_enable_metadata', '__return_false' );
-		}
+		// Disable default title and meta description output in the Web Stories plugin,
+		// and force-add title & meta description presenter, regardless of theme support.
+		\add_filter( 'web_stories_enable_document_title', '__return_false' );
+		\add_filter( 'web_stories_enable_metadata', '__return_false' );
+		\add_filter( 'wpseo_frontend_presenters', [ $this, 'filter_frontend_presenters' ], 10, 2 );
+
 		\add_action( 'web_stories_enable_schemaorg_metadata', '__return_false' );
 		\add_action( 'web_stories_enable_open_graph_metadata', '__return_false' );
 		\add_action( 'web_stories_enable_twitter_metadata', '__return_false' );
@@ -57,6 +61,33 @@ class Web_Stories implements Integration_Interface {
 		\add_action( 'web_stories_story_head', [ $this, 'web_stories_story_head' ], 1 );
 		\add_filter( 'wpseo_schema_article_type', [ $this, 'filter_schema_article_type' ], 10, 2 );
 		\add_filter( 'wpseo_metadesc', [ $this, 'filter_meta_description' ], 10, 2 );
+	}
+
+	/**
+	 * Filter 'wpseo_frontend_presenters' - Allow filtering the presenter instances in or out of the request.
+	 *
+	 * @param array             $presenters The presenters.
+	 * @param Meta_Tags_Context $context    The meta tags context for the current page.
+	 * @return array Filtered presenters.
+	 */
+	public function filter_frontend_presenters( $presenters, $context ) {
+		if ( $context->indexable->object_sub_type !== 'web-story' ) {
+			return $presenters;
+		}
+
+		$has_title_presenter = false;
+
+		foreach ( $presenters as $presenter ) {
+			if ( $presenter instanceof Title_Presenter ) {
+				$has_title_presenter = true;
+			}
+		}
+
+		if ( ! $has_title_presenter ) {
+			$presenters[] = new Title_Presenter();
+		}
+
+		return $presenters;
 	}
 
 	/**

--- a/tests/unit/integrations/third-party/web-stories-test.php
+++ b/tests/unit/integrations/third-party/web-stories-test.php
@@ -64,10 +64,6 @@ class Web_Stories_Test extends TestCase {
 	 * @covers ::register_hooks
 	 */
 	public function test_register_hooks() {
-		$this->front_end
-			->expects( 'should_title_presenter_be_removed' )
-			->andReturn( false );
-
 		$this->instance->register_hooks();
 
 		$this->assertNotFalse( \has_filter( 'web_stories_enable_document_title', '__return_false' ), 'The enable document title filter is registered.' );

--- a/tests/unit/integrations/third-party/web-stories-test.php
+++ b/tests/unit/integrations/third-party/web-stories-test.php
@@ -10,6 +10,10 @@ use Yoast\WP\SEO\Integrations\Front_End_Integration;
 use Yoast\WP\SEO\Integrations\Third_Party\Web_Stories;
 use Yoast\WP\SEO\Models\Indexable;
 use Yoast\WP\SEO\Presentations\Indexable_Presentation;
+use Yoast\WP\SEO\Presenters\Meta_Description_Presenter;
+use Yoast\WP\SEO\Presenters\Title_Presenter;
+use Yoast\WP\SEO\Tests\Unit\Doubles\Context\Meta_Tags_Context_Mock;
+use Yoast\WP\SEO\Tests\Unit\Doubles\Models\Indexable_Mock;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
@@ -59,6 +63,18 @@ class Web_Stories_Test extends TestCase {
 	}
 
 	/**
+	 * Tests constructor.
+	 *
+	 * @covers ::__construct
+	 */
+	public function test_constructor() {
+		$this->assertInstanceOf(
+			Front_End_Integration::class,
+			$this->getPropertyValue( $this->instance, 'front_end' )
+		);
+	}
+
+	/**
 	 * Tests register hooks.
 	 *
 	 * @covers ::register_hooks
@@ -74,6 +90,79 @@ class Web_Stories_Test extends TestCase {
 		$this->assertNotFalse( \has_action( 'web_stories_story_head', [ $this->instance, 'web_stories_story_head' ] ), 'The web-story head action is not registered' );
 		$this->assertNotFalse( \has_filter( 'wpseo_schema_article_type', [ $this->instance, 'filter_schema_article_type' ] ), 'The filter schema article type function is registered.' );
 		$this->assertNotFalse( \has_filter( 'wpseo_metadesc', [ $this->instance, 'filter_meta_description' ] ), 'The metadesc action is registered.' );
+	}
+
+	/**
+	 * Tests filter_frontend_presenters method for stories.
+	 *
+	 * @covers ::filter_frontend_presenters
+	 */
+	public function test_filter_frontend_presenters_stories() {
+		$context                             = new Meta_Tags_Context_Mock();
+		$context->indexable                  = new Indexable_Mock();
+		$context->indexable->object_sub_type = 'web-story';
+
+		$title_presenter = Mockery::mock( Title_Presenter::class );
+		$other_presenter = Mockery::mock( Meta_Description_Presenter::class );
+
+
+		// First case: a title presenter is already there.
+		$presenters = [
+			$title_presenter,
+			$other_presenter,
+		];
+
+		$return_presenters = $this->instance->filter_frontend_presenters( $presenters, $context );
+
+		$title_presenter_found = false;
+
+		foreach ( $return_presenters as $item ) {
+			if ( $item instanceof Title_Presenter ) {
+				$title_presenter_found = true;
+				$this->assertInstanceOf( Title_Presenter::class, $item );
+			}
+		}
+
+		$this->assertTrue( $title_presenter_found );
+
+		// Second case: a title presenter is not there yet, will be added.
+		$presenters_no_title = [
+			$other_presenter,
+		];
+
+		$return_presenters = $this->instance->filter_frontend_presenters( $presenters_no_title, $context );
+
+		$title_presenter_found = false;
+
+		foreach ( $return_presenters as $item ) {
+			if ( $item instanceof Title_Presenter ) {
+				$title_presenter_found = true;
+				$this->assertInstanceOf( Title_Presenter::class, $item );
+			}
+		}
+
+		$this->assertTrue( $title_presenter_found );
+	}
+
+	/**
+	 * Tests filter_frontend_presenters method for other types.
+	 *
+	 * @covers ::filter_frontend_presenters
+	 */
+	public function test_filter_frontend_presenters_other() {
+		$context                             = new Meta_Tags_Context_Mock();
+		$context->indexable                  = new Indexable_Mock();
+		$context->indexable->object_sub_type = 'post';
+
+		$title_presenter = Mockery::mock( Title_Presenter::class );
+		$other_presenter = Mockery::mock( Meta_Description_Presenter::class );
+
+		$presenters = [
+			$title_presenter,
+			$other_presenter,
+		];
+
+		$this->assertSame( $presenters, $this->instance->filter_frontend_presenters( $presenters, $context ) );
 	}
 
 	/**

--- a/tests/unit/integrations/third-party/web-stories-test.php
+++ b/tests/unit/integrations/third-party/web-stories-test.php
@@ -70,7 +70,8 @@ class Web_Stories_Test extends TestCase {
 
 		$this->instance->register_hooks();
 
-		$this->assertNotFalse( \has_action( 'web_stories_enable_metadata', '__return_false' ), 'The enable metadata filter is registered.' );
+		$this->assertNotFalse( \has_filter( 'web_stories_enable_document_title', '__return_false' ), 'The enable document title filter is registered.' );
+		$this->assertNotFalse( \has_filter( 'web_stories_enable_metadata', '__return_false' ), 'The enable metadata filter is registered.' );
 		$this->assertNotFalse( \has_action( 'web_stories_enable_schemaorg_metadata', '__return_false' ), 'The enable metadata filter is registered.' );
 		$this->assertNotFalse( \has_action( 'web_stories_enable_open_graph_metadata', '__return_false' ), 'The enable metadata filter is registered.' );
 		$this->assertNotFalse( \has_action( 'web_stories_enable_twitter_metadata', '__return_false' ), 'The enable metadata filter is registered.' );

--- a/tests/unit/integrations/third-party/web-stories-test.php
+++ b/tests/unit/integrations/third-party/web-stories-test.php
@@ -84,6 +84,7 @@ class Web_Stories_Test extends TestCase {
 
 		$this->assertNotFalse( \has_filter( 'web_stories_enable_document_title', '__return_false' ), 'The enable document title filter is registered.' );
 		$this->assertNotFalse( \has_filter( 'web_stories_enable_metadata', '__return_false' ), 'The enable metadata filter is registered.' );
+		$this->assertNotFalse( \has_filter( 'wpseo_frontend_presenters', [ $this->instance, 'filter_frontend_presenters' ] ), 'The frontend presenters filter is registered.' );
 		$this->assertNotFalse( \has_action( 'web_stories_enable_schemaorg_metadata', '__return_false' ), 'The enable metadata filter is registered.' );
 		$this->assertNotFalse( \has_action( 'web_stories_enable_open_graph_metadata', '__return_false' ), 'The enable metadata filter is registered.' );
 		$this->assertNotFalse( \has_action( 'web_stories_enable_twitter_metadata', '__return_false' ), 'The enable metadata filter is registered.' );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* #18977

The above PR is not really correct. It disables the wrong filter in the Web Stories plugin (the correct one would be `web_stories_enable_document_title`) and it also wrongly depends on the type of theme being used (block theme vs classic).

Yoast SEO should always override the Web Stories plugin's default behavior and use its own presenters to add things like title tags and meta descriptions, regardless of theme support.

Please note that at the same time we're also making some changes to the Web Stories plugin itself to ensure there are never duplicate title tags, and never missing title tags.

I would appreciate being contacted before making changes to the Web Stories integration class in the future so that we can better coordinate such fixes.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->

This PR can be summarized in the following changelog entry:

* Fixes a bug where the `<title>` tag could be missing when publishing a story with the Web Stories plugin. Props to [@swissspidy](https://github.com/swissspidy). 

## Relevant technical choices:

* Please note that I was unable to add proper unit tests for this new `filter_frontend_presenters` because I was unable to get the development environment running locally on PHP 8.1.

There's tons of issues with PHP-Scoper and not finding the (private?) `yoast/php-development-environment` dependency.

If this could be made easier somehow, I'd be happy to contribute tests. But right now it's not really possible for me to do so.


## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

1. Install and activate both Yoast SEO and Web stories.
2. Activate the Twenty Twenty-Two theme.
3. Go to the Web Stories -> Add New and publish a new story.
6. View the published story on the frontend
7. View the page source and search for `<title>`, verify that there is only one match.
8. Repeat with an older theme like Twenty Ten

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
