### PR TITLE
Estimated_Reading_Time_Conditional_Test: remove unnecessary `@requires` tags

### DIFF
--- a/tests/unit/conditionals/estimated-reading-time-conditional-test.php
+++ b/tests/unit/conditionals/estimated-reading-time-conditional-test.php
@@ -59,8 +59,6 @@ class Estimated_Reading_Time_Conditional_Test extends TestCase {
 	 * Tests that the conditional is met when we are saving for Elementor.
 	 *
 	 * @covers ::is_met
-	 *
-	 * @requires PHP < 8.1
 	 */
 	public function test_ajax_elementor_save() {
 		// We are in an Ajax request.
@@ -80,8 +78,6 @@ class Estimated_Reading_Time_Conditional_Test extends TestCase {
 	 * Tests that the conditional is not met when we are not on a post, and also not in an Elementor save.
 	 *
 	 * @covers ::is_met
-	 *
-	 * @requires PHP < 8.1
 	 */
 	public function test_not_post_not_elementor_save() {
 		// We are in an Ajax request.


### PR DESCRIPTION
## Context

* Test QA

## Summary

This PR can be summarized in the following changelog entry:

* Test QA

## Relevant technical choices:

Remove unnecessary `@requires` tags as the deprecation due to code _within_ the test, which originally made those necessary, will no longer show now the deprecation has been silenced.


## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A- If the build passes, we're good.