### PR TITLE
PHP 8.2 | Indexables_Page_Helper: declare a missing property

### DIFF
--- a/src/helpers/indexables-page-helper.php
+++ b/src/helpers/indexables-page-helper.php
@@ -36,6 +36,13 @@ class Indexables_Page_Helper {
 	const ANALYSED_POSTS_THRESHOLD = 0.5;
 
 	/**
+	 * The options helper.
+	 *
+	 * @var Options_Helper
+	 */
+	private $options;
+
+	/**
 	 * Indexables_Page_Helper constructor.
 	 *
 	 * @param Options_Helper $options The options helper.


### PR DESCRIPTION
## Context

* Improved PHP 8.2 compatibility

## Summary

This PR can be summarized in the following changelog entry:

* Improved PHP 8.2 compatibility

## Relevant technical choices:

* This property is assigned to from within the class constructor, so is a known property which should be declared.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_