### PR TITLE
PHP 8.2 | Tests: improve Indexable_Mock & use in more places

### DIFF
--- a/tests/unit/builders/indexable-post-builder-test.php
+++ b/tests/unit/builders/indexable-post-builder-test.php
@@ -17,6 +17,7 @@ use Yoast\WP\SEO\Helpers\Twitter\Image_Helper as Twitter_Image_Helper;
 use Yoast\WP\SEO\Models\Indexable;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
 use Yoast\WP\SEO\Tests\Unit\Doubles\Builders\Indexable_Post_Builder_Double;
+use Yoast\WP\SEO\Tests\Unit\Doubles\Models\Indexable_Mock;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 use Yoast\WP\SEO\Values\Indexables\Indexable_Builder_Versions;
 
@@ -95,7 +96,7 @@ class Indexable_Post_Builder_Test extends TestCase {
 
 		$this->stubTranslationFunctions();
 
-		$this->indexable            = Mockery::mock();
+		$this->indexable            = Mockery::mock( Indexable_Mock::class );
 		$this->indexable_repository = Mockery::mock( Indexable_Repository::class );
 		$this->image                = Mockery::mock( Image_Helper::class );
 		$this->open_graph_image     = Mockery::mock( Open_Graph_Image_Helper::class );
@@ -888,7 +889,7 @@ class Indexable_Post_Builder_Test extends TestCase {
 		$this->indexable->post_parent     = 1;
 		$this->indexable->post_status     = 'inherit';
 
-		$post_parent_indexable            = Mockery::mock();
+		$post_parent_indexable            = Mockery::mock( Indexable_Mock::class );
 		$post_parent_indexable->is_public = true;
 
 		$this->indexable_repository->expects( 'find_by_id_and_type' )
@@ -909,7 +910,7 @@ class Indexable_Post_Builder_Test extends TestCase {
 		$this->indexable->post_parent     = 1;
 		$this->indexable->post_status     = 'inherit';
 
-		$post_parent_indexable            = Mockery::mock();
+		$post_parent_indexable            = Mockery::mock( Indexable_Mock::class );
 		$post_parent_indexable->is_public = true;
 
 		$this->indexable_repository->expects( 'find_by_id_and_type' )

--- a/tests/unit/doubles/models/indexable-mock.php
+++ b/tests/unit/doubles/models/indexable-mock.php
@@ -21,6 +21,8 @@ class Indexable_Mock extends Indexable {
 
 	public $author_id;
 
+	public $post_parent;
+
 	public $created_at;
 
 	public $updated_at;
@@ -30,8 +32,6 @@ class Indexable_Mock extends Indexable {
 	public $permalink_hash;
 
 	public $canonical;
-
-	public $content_score;
 
 	public $is_robots_noindex;
 
@@ -97,15 +97,23 @@ class Indexable_Mock extends Indexable {
 
 	public $has_public_posts;
 
-	public $has_ancestors;
+	public $blog_id;
+
+	public $language;
+
+	public $region;
 
 	public $schema_page_type;
 
 	public $schema_article_type;
 
-	public $language;
+	public $has_ancestors;
 
-	public $region;
+	public $estimated_reading_time_minutes;
+
+	public $object_last_modified;
+
+	public $object_published_at;
 
 	public $version;
 }

--- a/tests/unit/integrations/watchers/indexable-post-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-post-watcher-test.php
@@ -153,7 +153,7 @@ class Indexable_Post_Watcher_Test extends TestCase {
 			'ID'          => 0,
 		];
 
-		$indexable              = Mockery::mock();
+		$indexable              = Mockery::mock( Indexable_Mock::class );
 		$indexable->id          = 1;
 		$indexable->is_public   = true;
 		$indexable->object_type = 'post';
@@ -361,7 +361,7 @@ class Indexable_Post_Watcher_Test extends TestCase {
 	 * @covers ::update_has_public_posts
 	 */
 	public function test_update_has_public_posts_with_post() {
-		$post_indexable                  = Mockery::mock();
+		$post_indexable                  = Mockery::mock( Indexable_Mock::class );
 		$post_indexable->object_id       = 33;
 		$post_indexable->object_sub_type = 'post';
 		$post_indexable->author_id       = 1;
@@ -396,7 +396,7 @@ class Indexable_Post_Watcher_Test extends TestCase {
 	 * @covers ::update_has_public_posts
 	 */
 	public function test_update_has_public_posts_with_post_throwing_exceptions() {
-		$post_indexable                  = Mockery::mock();
+		$post_indexable                  = Mockery::mock( Indexable_Mock::class );
 		$post_indexable->object_id       = 33;
 		$post_indexable->object_sub_type = 'post';
 		$post_indexable->author_id       = 1;
@@ -423,7 +423,7 @@ class Indexable_Post_Watcher_Test extends TestCase {
 	 * @covers ::update_has_public_posts
 	 */
 	public function test_update_has_public_posts_with_finding_user_returning_false() {
-		$post_indexable                  = Mockery::mock();
+		$post_indexable                  = Mockery::mock( Indexable_Mock::class );
 		$post_indexable->object_id       = 33;
 		$post_indexable->object_sub_type = 'post';
 		$post_indexable->author_id       = 1;
@@ -452,7 +452,7 @@ class Indexable_Post_Watcher_Test extends TestCase {
 	 * @covers ::reschedule_cleanup_if_author_has_no_posts
 	 */
 	public function test_reschedule_cleanup_when_author_does_not_have_posts() {
-		$post_indexable                  = Mockery::mock();
+		$post_indexable                  = Mockery::mock( Indexable_Mock::class );
 		$post_indexable->object_id       = 33;
 		$post_indexable->object_sub_type = 'post';
 		$post_indexable->author_id       = 11;

--- a/tests/unit/integrations/watchers/indexable-post-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-post-watcher-test.php
@@ -5,7 +5,6 @@ namespace Yoast\WP\SEO\Tests\Unit\Integrations\Watchers;
 use Brain\Monkey;
 use Exception;
 use Mockery;
-use Yoast\WP\Lib\ORM;
 use Yoast\WP\SEO\Builders\Indexable_Builder;
 use Yoast\WP\SEO\Builders\Indexable_Link_Builder;
 use Yoast\WP\SEO\Conditionals\Migrations_Conditional;
@@ -499,10 +498,8 @@ class Indexable_Post_Watcher_Test extends TestCase {
 			'post_modified_gmt' => '1234-12-12 12:12:12',
 		];
 
-		$indexable      = Mockery::mock( Indexable_Mock::class );
-		$indexable->orm = Mockery::mock( ORM::class );
-		$indexable->orm->expects( 'get' )->with( 'object_last_modified' )->andReturn( '1234-12-12 00:00:00' );
-		$indexable->orm->expects( 'set' )->with( 'object_last_modified', '1234-12-12 12:12:12' );
+		$indexable                       = Mockery::mock( Indexable_Mock::class );
+		$indexable->object_last_modified = '1234-12-12 00:00:00';
 		$indexable->expects( 'save' )->once();
 
 		$this->instance
@@ -512,6 +509,8 @@ class Indexable_Post_Watcher_Test extends TestCase {
 			->andReturn( [ $indexable ] );
 
 		$this->instance->update_relations( $post );
+
+		$this->assertSame( '1234-12-12 12:12:12', $indexable->object_last_modified );
 	}
 
 	/**


### PR DESCRIPTION
## Context

* Improved PHP 8.2 compatibility (tests only)

## Summary

This PR can be summarized in the following changelog entry:

* Improved PHP 8.2 compatibility (tests only)

## Relevant technical choices:

### Tests/Indexable_Mock: sync the list of declared properties

... with the properties listed in the class docblock of the `Yoast\WP\SEO\Models\Indexable` class.

Includes a minor fix to one tests to prevent having to _also_ mock the ORM class, while still making sure the test tests what it should be testing.

### PHP 8.2 | Indexable_Mock: implement in more test classes

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_ This is a test only change, if the build passes, we're good.