### PR TITLE
PHP 8.2 | Tests: improve Meta_Tags_Context_Mock & use in more places

### DIFF
--- a/src/context/meta-tags-context.php
+++ b/src/context/meta-tags-context.php
@@ -25,35 +25,36 @@ use Yoast\WP\SEO\Repositories\Indexable_Repository;
  *
  * Class that contains all relevant data for rendering the meta tags.
  *
- * @property string       $canonical
- * @property string       $permalink
- * @property string       $title
- * @property string       $description
- * @property string       $id
- * @property string       $site_name
- * @property string       $alternate_site_name
- * @property string       $wordpress_site_name
- * @property string       $site_url
- * @property string       $company_name
- * @property string       $company_alternate_name
- * @property int          $company_logo_id
- * @property array        $company_logo_meta
- * @property int          $person_logo_id
- * @property array        $person_logo_meta
- * @property int          $site_user_id
- * @property string       $site_represents
- * @property array|false  $site_represents_reference
- * @property string       schema_page_type
- * @property string       $main_schema_id
- * @property string|array $main_entity_of_page
- * @property bool         $open_graph_enabled
- * @property string       $open_graph_publisher
- * @property string       $twitter_card
- * @property string       $page_type
- * @property bool         $has_article
- * @property bool         $has_image
- * @property int          $main_image_id
- * @property string       $main_image_url
+ * @property string          $canonical
+ * @property string          $permalink
+ * @property string          $title
+ * @property string          $description
+ * @property string          $id
+ * @property string          $site_name
+ * @property string          $alternate_site_name
+ * @property string          $wordpress_site_name
+ * @property string          $site_url
+ * @property string          $company_name
+ * @property string          $company_alternate_name
+ * @property int             $company_logo_id
+ * @property array           $company_logo_meta
+ * @property int             $person_logo_id
+ * @property array           $person_logo_meta
+ * @property int             $site_user_id
+ * @property string          $site_represents
+ * @property array|false     $site_represents_reference
+ * @property string          $schema_page_type
+ * @property string|string[] $schema_article_type      Represents the type of article.
+ * @property string          $main_schema_id
+ * @property string|array    $main_entity_of_page
+ * @property bool            $open_graph_enabled
+ * @property string          $open_graph_publisher
+ * @property string          $twitter_card
+ * @property string          $page_type
+ * @property bool            $has_article
+ * @property bool            $has_image
+ * @property int             $main_image_id
+ * @property string          $main_image_url
  */
 class Meta_Tags_Context extends Abstract_Presentation {
 

--- a/tests/unit/doubles/context/meta-tags-context-mock.php
+++ b/tests/unit/doubles/context/meta-tags-context-mock.php
@@ -9,137 +9,64 @@ use Yoast\WP\SEO\Context\Meta_Tags_Context;
  */
 class Meta_Tags_Context_Mock extends Meta_Tags_Context {
 
-	/**
-	 * Represents the canonical.
-	 *
-	 * @var string
-	 */
 	public $canonical;
 
-	/**
-	 * Represents the permalink.
-	 *
-	 * @var string
-	 */
 	public $permalink;
 
-	/**
-	 * Represents the title.
-	 *
-	 * @var string
-	 */
 	public $title;
 
-	/**
-	 * Represents the meta description.
-	 *
-	 * @var string
-	 */
 	public $description;
 
-	/**
-	 * Represents the id.
-	 *
-	 * @var string
-	 */
 	public $id;
 
-	/**
-	 * Represents the site name.
-	 *
-	 * @var string
-	 */
 	public $site_name;
 
-	/**
-	 * Represents the site name set in WordPress.
-	 *
-	 * @var string
-	 */
+	public $alternate_site_name;
+
 	public $wordpress_site_name;
 
-	/**
-	 * Represents the site url.
-	 *
-	 * @var string
-	 */
 	public $site_url;
 
-	/**
-	 * Represents the company name.
-	 *
-	 * @var string
-	 */
 	public $company_name;
 
-	/**
-	 * Represents the id of the company logo
-	 *
-	 * @var int
-	 */
+	public $company_alternate_name;
+
 	public $company_logo_id;
 
-	/**
-	 * Represents the site user id.
-	 *
-	 * @var int
-	 */
+	public $company_logo_meta;
+
+	public $person_logo_id;
+
+	public $person_logo_meta;
+
 	public $site_user_id;
 
-	/**
-	 * Representation of the site.
-	 *
-	 * @var string
-	 */
 	public $site_represents;
 
-	/**
-	 * Represents the one that is represented by the site.
-	 *
-	 * @var array|false
-	 */
 	public $site_represents_reference;
 
-	/**
-	 * Represents the page type in schema output.
-	 *
-	 * @var string|string[]
-	 */
 	public $schema_page_type;
 
-	/**
-	 * Represents the type of article.
-	 *
-	 * @var string|string[]
-	 */
 	public $schema_article_type;
 
-	/**
-	 * Represents the main schema id.
-	 *
-	 * @var string
-	 */
 	public $main_schema_id;
 
-	/**
-	 * Represents the enabled state of open-graph.
-	 *
-	 * @var bool
-	 */
+	public $main_entity_of_page;
+
 	public $open_graph_enabled = true;
 
-	/**
-	 * Represents the meta image ID.
-	 *
-	 * @var int
-	 */
+	public $open_graph_publisher;
+
+	public $twitter_card;
+
+	public $page_type;
+
+	public $has_article;
+
+	public $has_image;
+
 	public $main_image_id;
 
-	/**
-	 * Represents the meta image URL.
-	 *
-	 * @var string
-	 */
 	public $main_image_url;
 
 	/**

--- a/tests/unit/helpers/schema/id-helper-test.php
+++ b/tests/unit/helpers/schema/id-helper-test.php
@@ -5,6 +5,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Helpers\Schema;
 use Brain\Monkey;
 use Mockery;
 use Yoast\WP\SEO\Helpers\Schema\ID_Helper;
+use Yoast\WP\SEO\Tests\Unit\Doubles\Context\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
@@ -42,7 +43,7 @@ class ID_Helper_Test extends TestCase {
 		$user             = Mockery::mock( 'WP_User' );
 		$user->user_login = 'dingdong';
 
-		$context           = Mockery::mock();
+		$context           = Mockery::mock( Meta_Tags_Context_Mock::class );
 		$context->site_url = 'https://example.org/';
 
 		Monkey\Functions\expect( 'get_userdata' )
@@ -67,7 +68,7 @@ class ID_Helper_Test extends TestCase {
 	 * @covers ::get_user_schema_id
 	 */
 	public function test_get_user_schema_id_no_user_found() {
-		$context           = Mockery::mock();
+		$context           = Mockery::mock( Meta_Tags_Context_Mock::class );
 		$context->site_url = 'https://example.org/';
 
 		Monkey\Functions\expect( 'get_userdata' )

--- a/tests/unit/integrations/front-end-integration-test.php
+++ b/tests/unit/integrations/front-end-integration-test.php
@@ -6,7 +6,6 @@ use Brain\Monkey;
 use Mockery;
 use WPSEO_Replace_Vars;
 use Yoast\WP\SEO\Conditionals\Front_End_Conditional;
-use Yoast\WP\SEO\Context\Meta_Tags_Context;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Request_Helper;
 use Yoast\WP\SEO\Integrations\Front_End_Integration;
@@ -14,6 +13,7 @@ use Yoast\WP\SEO\Memoizers\Meta_Tags_Context_Memoizer;
 use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 use Yoast\WP\SEO\Presenters\Abstract_Indexable_Presenter;
 use Yoast\WP\SEO\Surfaces\Helpers_Surface;
+use Yoast\WP\SEO\Tests\Unit\Doubles\Context\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 use YoastSEO_Vendor\Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -106,7 +106,7 @@ class Front_End_Integration_Test extends TestCase {
 		)->makePartial();
 
 		// Set up mocks for classes which which are used in multiple tests.
-		$this->context   = Mockery::mock( Meta_Tags_Context::class );
+		$this->context   = Mockery::mock( Meta_Tags_Context_Mock::class );
 		$this->presenter = Mockery::mock( Abstract_Indexable_Presenter::class );
 
 		$this->context->page_type    = 'page_type';


### PR DESCRIPTION
## Context

* Improved PHP 8.2 compatibility (tests only)

## Summary

This PR can be summarized in the following changelog entry:

* Improved PHP 8.2 compatibility (tests only)

## Relevant technical choices:

### Meta_Tags_Context[_Mock]: sync the declared properties

Take note of the addition of `$schema_article_type` to the properties list.
This property is referenced in the `Yoast\WP\SEO\Generators\Schema\Person::site_represents_current_author()` method on line 274.

### PHP 8.2 | PHP 8.2 | Meta_Tags_Context_Mock: implement in more test classes

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_ This is a docs/test only change, if the build passes, we're good.