### PR TITLE
PHP 8.2 | Tests: improve Primary_Term_Mock & use in more places

### DIFF
--- a/tests/unit/doubles/models/primary-term-mock.php
+++ b/tests/unit/doubles/models/primary-term-mock.php
@@ -20,4 +20,8 @@ class Primary_Term_Mock extends Primary_Term {
 	public $taxonomy;
 
 	public $blog_id;
+
+	public $created_at;
+
+	public $updated_at;
 }

--- a/tests/unit/integrations/watchers/primary-category-quick-edit-watcher-test.php
+++ b/tests/unit/integrations/watchers/primary-category-quick-edit-watcher-test.php
@@ -14,6 +14,7 @@ use Yoast\WP\SEO\Integrations\Watchers\Primary_Category_Quick_Edit_Watcher;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
 use Yoast\WP\SEO\Repositories\Primary_Term_Repository;
 use Yoast\WP\SEO\Tests\Unit\Doubles\Models\Indexable_Mock;
+use Yoast\WP\SEO\Tests\Unit\Doubles\Models\Primary_Term_Mock;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
@@ -316,7 +317,7 @@ class Primary_Category_Quick_Edit_Watcher_Test extends TestCase {
 			->never()
 			->with( 1337, WPSEO_Meta::$meta_prefix . 'primary_category', true );
 
-		$primary_term          = Mockery::mock();
+		$primary_term          = Mockery::mock( Primary_Term_Mock::class );
 		$primary_term->term_id = 2;
 
 		$this->primary_term_repository
@@ -354,7 +355,7 @@ class Primary_Category_Quick_Edit_Watcher_Test extends TestCase {
 			->never()
 			->with( 1337, WPSEO_Meta::$meta_prefix . 'primary_category', true );
 
-		$primary_term          = Mockery::mock();
+		$primary_term          = Mockery::mock( Primary_Term_Mock::class );
 		$primary_term->term_id = 3;
 
 		$this->primary_term_repository


### PR DESCRIPTION
## Context

* Improved PHP 8.2 compatibility (tests only)

## Summary

This PR can be summarized in the following changelog entry:

* Improved PHP 8.2 compatibility (tests only)

## Relevant technical choices:

### Tests/Primary_Term_Mock: sync the list of declared properties

... with the properties listed in the class docblock of the `Yoast\WP\SEO\Models\Primary_Term` class.

### PHP 8.2 | Primary_Term_Mock: implement in more test classes

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_ This is a test only change, if the build passes, we're good.