### PR TITLE
PHP 8.2 | Indexable_Presentation: work around dynamic properties

### DIFF
--- a/src/presentations/indexable-presentation.php
+++ b/src/presentations/indexable-presentation.php
@@ -33,6 +33,8 @@ use Yoast\WP\SEO\Models\Indexable;
  * @property string       $open_graph_title
  * @property string       $open_graph_description
  * @property array        $open_graph_images
+ * @property int          $open_graph_image_id
+ * @property string       $open_graph_image
  * @property string       $open_graph_url
  * @property string       $open_graph_site_name
  * @property string       $open_graph_article_publisher
@@ -52,6 +54,8 @@ use Yoast\WP\SEO\Models\Indexable;
  * @property object|array $source
  * @property array        $breadcrumbs
  * @property int          $estimated_reading_time_minutes
+ * @property array        $googlebot
+ * @property array        $bingbot
  */
 class Indexable_Presentation extends Abstract_Presentation {
 

--- a/tests/unit/doubles/presentations/indexable-presentation-mock.php
+++ b/tests/unit/doubles/presentations/indexable-presentation-mock.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Doubles\Presentations;
+
+use Yoast\WP\SEO\Presentations\Indexable_Presentation;
+
+/**
+ * Indexable_Presentation mock class.
+ */
+class Indexable_Presentation_Mock extends Indexable_Presentation {
+
+	public $title;
+
+	public $meta_description;
+
+	public $robots;
+
+	public $canonical;
+
+	public $rel_next;
+
+	public $rel_prev;
+
+	public $open_graph_type;
+
+	public $open_graph_title;
+
+	public $open_graph_description;
+
+	public $open_graph_images;
+
+	public $open_graph_image_id;
+
+	public $open_graph_image;
+
+	public $open_graph_url;
+
+	public $open_graph_site_name;
+
+	public $open_graph_article_publisher;
+
+	public $open_graph_article_author;
+
+	public $open_graph_article_published_time;
+
+	public $open_graph_article_modified_time;
+
+	public $open_graph_locale;
+
+	public $open_graph_fb_app_id;
+
+	public $permalink;
+
+	public $schema;
+
+	public $twitter_card;
+
+	public $twitter_title;
+
+	public $twitter_description;
+
+	public $twitter_image;
+
+	public $twitter_creator;
+
+	public $twitter_site;
+
+	public $source;
+
+	public $breadcrumbs;
+
+	public $estimated_reading_time_minutes;
+
+	public $googlebot;
+
+	public $bingbot;
+}

--- a/tests/unit/generators/schema-generator-test.php
+++ b/tests/unit/generators/schema-generator-test.php
@@ -20,10 +20,10 @@ use Yoast\WP\SEO\Helpers\Schema\Replace_Vars_Helper;
 use Yoast\WP\SEO\Helpers\Site_Helper;
 use Yoast\WP\SEO\Helpers\Url_Helper;
 use Yoast\WP\SEO\Helpers\User_Helper;
-use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 use Yoast\WP\SEO\Surfaces\Helpers_Surface;
 use Yoast\WP\SEO\Tests\Unit\Doubles\Context\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\Unit\Doubles\Models\Indexable_Mock;
+use Yoast\WP\SEO\Tests\Unit\Doubles\Presentations\Indexable_Presentation_Mock;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
@@ -178,7 +178,7 @@ class Schema_Generator_Test extends TestCase {
 
 		$this->context->main_schema_id            = 'https://example.com/the-post/';
 		$this->context->indexable                 = Mockery::mock( Indexable_Mock::class );
-		$this->context->presentation              = Mockery::mock( Indexable_Presentation::class );
+		$this->context->presentation              = Mockery::mock( Indexable_Presentation_Mock::class );
 		$this->context->presentation->source      = Mockery::mock();
 		$this->context->presentation->breadcrumbs = [
 			'item' => [

--- a/tests/unit/generators/schema/breadcrumb-test.php
+++ b/tests/unit/generators/schema/breadcrumb-test.php
@@ -7,9 +7,9 @@ use Yoast\WP\SEO\Generators\Schema\Breadcrumb;
 use Yoast\WP\SEO\Helpers\Current_Page_Helper;
 use Yoast\WP\SEO\Helpers\Schema\HTML_Helper;
 use Yoast\WP\SEO\Helpers\Schema\ID_Helper;
-use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 use Yoast\WP\SEO\Tests\Unit\Doubles\Context\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\Unit\Doubles\Models\Indexable_Mock;
+use Yoast\WP\SEO\Tests\Unit\Doubles\Presentations\Indexable_Presentation_Mock;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
@@ -69,7 +69,7 @@ class Breadcrumb_Test extends TestCase {
 		$this->html         = Mockery::mock( HTML_Helper::class );
 
 		$this->meta_tags_context               = Mockery::mock( Meta_Tags_Context_Mock::class );
-		$this->meta_tags_context->presentation = Mockery::mock( Indexable_Presentation::class );
+		$this->meta_tags_context->presentation = Mockery::mock( Indexable_Presentation_Mock::class );
 		$this->meta_tags_context->indexable    = Mockery::mock( Indexable_Mock::class );
 		$this->meta_tags_context->canonical    = 'https://wordpress.example.com/canonical';
 

--- a/tests/unit/helpers/schema/replace-vars-helper-test.php
+++ b/tests/unit/helpers/schema/replace-vars-helper-test.php
@@ -9,10 +9,10 @@ use Yoast\WP\SEO\Helpers\Date_Helper;
 use Yoast\WP\SEO\Helpers\Schema\ID_Helper;
 use Yoast\WP\SEO\Helpers\Schema\Replace_Vars_Helper;
 use Yoast\WP\SEO\Memoizers\Meta_Tags_Context_Memoizer;
-use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 use Yoast\WP\SEO\Tests\Unit\Doubles\Context\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\Unit\Doubles\Helpers\Schema\Replace_Vars_Helper_Double;
 use Yoast\WP\SEO\Tests\Unit\Doubles\Models\Indexable_Mock;
+use Yoast\WP\SEO\Tests\Unit\Doubles\Presentations\Indexable_Presentation_Mock;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
@@ -253,7 +253,7 @@ class Replace_Vars_Helper_Test extends TestCase {
 			],
 		];
 
-		$presentation         = Mockery::mock( Indexable_Presentation::class );
+		$presentation         = Mockery::mock( Indexable_Presentation_Mock::class );
 		$presentation->source = [ 'post_content' => 'some text' ];
 
 		$values = $this->array_values_recursively( $schema_data );

--- a/tests/unit/integrations/breadcrumbs-integration-test.php
+++ b/tests/unit/integrations/breadcrumbs-integration-test.php
@@ -6,9 +6,9 @@ use Mockery;
 use WPSEO_Replace_Vars;
 use Yoast\WP\SEO\Integrations\Breadcrumbs_Integration;
 use Yoast\WP\SEO\Memoizers\Meta_Tags_Context_Memoizer;
-use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 use Yoast\WP\SEO\Presenters\Breadcrumbs_Presenter;
 use Yoast\WP\SEO\Surfaces\Helpers_Surface;
+use Yoast\WP\SEO\Tests\Unit\Doubles\Presentations\Indexable_Presentation_Mock;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
@@ -70,7 +70,7 @@ class Breadcrumbs_Integration_Test extends TestCase {
 	 * @covers ::render
 	 */
 	public function test_render() {
-		$indexable_presentation              = Mockery::mock( Indexable_Presentation::class );
+		$indexable_presentation              = Mockery::mock( Indexable_Presentation_Mock::class );
 		$indexable_presentation->breadcrumbs = [];
 
 		$this->context_memoizer

--- a/tests/unit/integrations/third-party/woocommerce-test.php
+++ b/tests/unit/integrations/third-party/woocommerce-test.php
@@ -15,6 +15,7 @@ use Yoast\WP\SEO\Memoizers\Meta_Tags_Context_Memoizer;
 use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
 use Yoast\WP\SEO\Tests\Unit\Doubles\Models\Indexable_Mock;
+use Yoast\WP\SEO\Tests\Unit\Doubles\Presentations\Indexable_Presentation_Mock;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
@@ -52,7 +53,7 @@ class WooCommerce_Test extends TestCase {
 	/**
 	 * The presentation.
 	 *
-	 * @var Indexable_Presentation
+	 * @var Indexable_Presentation|Indexable_Presentation_Mock|Mockery\MockInterface
 	 */
 	private $presentation;
 
@@ -462,7 +463,7 @@ class WooCommerce_Test extends TestCase {
 	 * @covers ::canonical
 	 */
 	public function test_canonical_on_paginated_shop_page() {
-		$presentation = Mockery::mock( Indexable_Presentation::class );
+		$presentation = Mockery::mock( Indexable_Presentation_Mock::class );
 
 		$presentation->permalink = 'https://example.com/permalink/';
 
@@ -489,7 +490,7 @@ class WooCommerce_Test extends TestCase {
 	 * @covers ::canonical
 	 */
 	public function test_canonical_on_non_paginated_shop_page() {
-		$presentation = Mockery::mock( Indexable_Presentation::class );
+		$presentation = Mockery::mock( Indexable_Presentation_Mock::class );
 
 		$presentation->permalink = 'https://example.com/permalink/';
 
@@ -512,7 +513,7 @@ class WooCommerce_Test extends TestCase {
 	 * @covers ::canonical
 	 */
 	public function test_canonical_on_non_shop_page() {
-		$presentation = Mockery::mock( Indexable_Presentation::class );
+		$presentation = Mockery::mock( Indexable_Presentation_Mock::class );
 
 		$this->woocommerce_helper->expects( 'is_shop_page' )
 			->once()
@@ -529,7 +530,7 @@ class WooCommerce_Test extends TestCase {
 	 * @covers ::canonical
 	 */
 	public function test_canonical_on_invalid_permalink() {
-		$presentation = Mockery::mock( Indexable_Presentation::class );
+		$presentation = Mockery::mock( Indexable_Presentation_Mock::class );
 
 		$this->woocommerce_helper->expects( 'is_shop_page' )
 			->once()


### PR DESCRIPTION
## Context

* Improved PHP 8.2 compatibility (tests only)

## Summary

This PR can be summarized in the following changelog entry:

* Improved PHP 8.2 compatibility (tests only)

## Relevant technical choices:

### PHP 8.2 | Indexable_Presentation: work around dynamic properties via a Mock with all properties declared

... and implement the use of this new `Indexable_Presentation_Mock` class in select test classes.

Includes adding some missing properties to the docs for the `Indexable_Presentation` class.


## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_ This is a docs/test only change, if the build passes, we're good.