### PR TITLE
Description_Presenter_Test: declare known property

### DIFF
--- a/tests/unit/presenters/open-graph/description-presenter-test.php
+++ b/tests/unit/presenters/open-graph/description-presenter-test.php
@@ -42,6 +42,13 @@ class Description_Presenter_Test extends TestCase {
 	protected $replace_vars;
 
 	/**
+	 * The string helper mock.
+	 *
+	 * @var Mockery\MockInterface|String_Helper
+	 */
+	protected $string;
+
+	/**
 	 * Sets up the test class.
 	 */
 	protected function set_up() {


### PR DESCRIPTION
## Context

* Improved PHP 8.2 compatibility (tests only)

## Summary

This PR can be summarized in the following changelog entry:

* Improved PHP 8.2 compatibility (tests only)

## Relevant technical choices:

### Description_Presenter_Test: declare known property

This property is being set in the test `set_up()` and should be declared.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_ This is a docs/test only change, if the build passes, we're good.