### PR TITLE
WebPage_Test: remove stray property assignments

### DIFF
--- a/tests/unit/generators/schema/webpage-test.php
+++ b/tests/unit/generators/schema/webpage-test.php
@@ -197,9 +197,6 @@ class WebPage_Test extends TestCase {
 			$this->meta_tags_context->main_image_url = $values_to_test['image_url'];
 		}
 
-		$this->id->primary_image_hash = '#primaryimage';
-		$this->id->breadcrumb_hash    = '#breadcrumb';
-
 		$this->setup_generate_test(
 			false,
 			[ 'WebPage' ],

--- a/tests/unit/generators/schema/webpage-test.php
+++ b/tests/unit/generators/schema/webpage-test.php
@@ -115,8 +115,6 @@ class WebPage_Test extends TestCase {
 			'object_type'     => 'post',
 			'object_sub_type' => 'page',
 		];
-
-		$this->id->website_hash = '#website';
 	}
 
 	/**


### PR DESCRIPTION
## Context

* Improved PHP 8.2 compatibility (tests only)

## Summary

This PR can be summarized in the following changelog entry:

* Improved PHP 8.2 compatibility (tests only)

## Relevant technical choices:

### WebPage_Test: remove stray property setting [1]

The `website_hash` property is set on the `ID_Helper` class at the end of the `WebPage_Test::set_up()` method.

However, in the whole of the YoastSEO code base, no `$website_hash` property exists, nor any references to a `->website_hash` property, only to a class constant by the same name.

I suspect this is a "stray"/copy-paste test-only bug and that the property assignment should just be removed.

### WebPage_Test: remove stray property setting [2]

The `primary_image_hash` and `breadcrumb_hash` properties are set on the `ID_Helper` class from within the `test_generate_with_provider()` test method.

However, in the whole of the YoastSEO code base, no `$primary_image_hash` nor `$breadcrumb_hash` property exists, nor any references to a `->primary_image_hash` or `->breadcrumb_hash` property, only to class constants by the same name.

I suspect this is a "stray"/copy-paste test-only bug and that the property assignments should just be removed.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_ This is a docs/test only change, if the build passes, we're good.