### PR TITLE
Schema_Generator/Abstract_Schema_Piece: improve handling of optional identifiers

### DIFF
--- a/src/generators/schema-generator.php
+++ b/src/generators/schema-generator.php
@@ -95,7 +95,7 @@ class Schema_Generator implements Generator_Interface {
 		$pieces_to_generate = [];
 		foreach ( $graph_pieces as $piece ) {
 			$identifier = \strtolower( \str_replace( 'Yoast\WP\SEO\Generators\Schema\\', '', \get_class( $piece ) ) );
-			if ( \property_exists( $piece, 'identifier' ) ) {
+			if ( isset( $piece->identifier ) ) {
 				$identifier = $piece->identifier;
 			}
 

--- a/src/generators/schema/abstract-schema-piece.php
+++ b/src/generators/schema/abstract-schema-piece.php
@@ -25,6 +25,15 @@ abstract class Abstract_Schema_Piece {
 	public $helpers;
 
 	/**
+	 * Optional identifier for this schema piece.
+	 *
+	 * Used in the `Schema_Generator::filter_graph_pieces_to_generate()` method.
+	 *
+	 * @var string
+	 */
+	public $identifier;
+
+	/**
 	 * Generates the schema piece.
 	 *
 	 * @return mixed


### PR DESCRIPTION
# Context

* Improved PHP 8.2 compatibility

## Summary

This PR can be summarized in the following changelog entry:

* Improved PHP 8.2 compatibility

## Relevant technical choices:

### Schema_Generator/Abstract_Schema_Piece: improve handling of optional identifiers

The `Schema_Generator::filter_graph_pieces_to_generate()` method would previously check using `property_exists()` whether a non-declared, dynamic property `$identifier` has been added to the graph piece.

As dynamic properties are deprecated and this is a "known" (non-variable name) property, we may as well declare the `$identifier` property on the `Abstract_Schema_Piece` class, which all schema pieces extend.

By changing the function call in the `Schema_Generator::filter_graph_pieces_to_generate()` method from `property_exists()` to `isset()`, we maintain the same behaviour, but the code is now compatible with PHP 8.2.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

The deprecation notice should be visible when running on PHP 8.2, but probably hidden in the HTML source code...

#### Regression test of the touched code
1. View a post on the frontend view the page source. There should be a `"@type": "WebPage",` schema piece in there.
2. Add `add_filter( 'wpseo_schema_needs_my-identifier', '__return_false' );` to your wp-config.php or functions.php file. (I used the last line of wordpress-seo/src/functions.php, which works fine)
3. Refresh the page, inspect the page source again and see that the WebPage schema is still there.
4. Modify the wordpress-seo/src/generators/schema/webpage.php. Near the top, you can find this line `class WebPage extends Abstract_Schema_Piece {`. On the next line, add this: `public $identifier = 'my-identifier';`
	- On PHP >= 8.2, you will start to see a deprecation warning in Query Monitor on every page load on `trunk`, but not on this branch.
5. Refresh the page, inspect the page source again and see that the WebPage schema is now gone.
6. Change the code you added in step 2 to this: `add_filter( 'wpseo_schema_needs_my-identifier', '__return_true' );`
7. Refresh the page, inspect the page source again and see that the WebPage schema is restored.
8. Remove your code from step 2.
9. Refresh the page, inspect the page source again and see that the WebPage schema is still there.
10. (To cleanup) undo the change you made in step 4.