### PR TITLE
Tests: use named mocks for YoastSEO native classes

### DIFF
--- a/tests/unit/actions/indexables/indexable-head-action-test.php
+++ b/tests/unit/actions/indexables/indexable-head-action-test.php
@@ -5,6 +5,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Actions\Indexables;
 use Mockery;
 use Yoast\WP\SEO\Actions\Indexables\Indexable_Head_Action;
 use Yoast\WP\SEO\Surfaces\Meta_Surface;
+use Yoast\WP\SEO\Surfaces\Values\Meta;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
@@ -68,7 +69,7 @@ class Indexable_Head_Action_Test extends TestCase {
 	 * @param string|int $input  The data to pass.
 	 */
 	public function test_retrieving_meta( $method, $input ) {
-		$meta = Mockery::mock();
+		$meta = Mockery::mock( Meta::class );
 		$meta
 			->expects( 'get_head' )
 			->andReturn( $this->get_head() );
@@ -96,7 +97,7 @@ class Indexable_Head_Action_Test extends TestCase {
 	 * @covers ::for_posts_page
 	 */
 	public function test_retrieving_meta_for_posts_page() {
-		$meta = Mockery::mock();
+		$meta = Mockery::mock( Meta::class );
 		$meta
 			->expects( 'get_head' )
 			->andReturn( $this->get_head() );
@@ -131,7 +132,7 @@ class Indexable_Head_Action_Test extends TestCase {
 	 * @param string|int $input  The data to pass.
 	 */
 	public function test_retrieving_meta_with_meta_not_found( $method, $input ) {
-		$meta = Mockery::mock();
+		$meta = Mockery::mock( Meta::class );
 		$meta
 			->expects( 'get_head' )
 			->andReturn(
@@ -166,7 +167,7 @@ class Indexable_Head_Action_Test extends TestCase {
 	 * @covers ::for_posts_page
 	 */
 	public function test_retrieving_meta_for_posts_page_with_meta_not_found() {
-		$meta = Mockery::mock();
+		$meta = Mockery::mock( Meta::class );
 		$meta
 			->expects( 'get_head' )
 			->andReturn(

--- a/tests/unit/admin/admin-gutenberg-compatibility-notification-test.php
+++ b/tests/unit/admin/admin-gutenberg-compatibility-notification-test.php
@@ -4,8 +4,12 @@ namespace Yoast\WP\SEO\Tests\Unit\Admin;
 
 use Brain\Monkey;
 use Mockery;
+use WPSEO_Admin_Gutenberg_Compatibility_Notification;
+use WPSEO_Gutenberg_Compatibility;
 use Yoast\WP\SEO\Tests\Unit\Doubles\Admin\WPSEO_Admin_Gutenberg_Compatibility_Notification_Double;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
+use Yoast_Notification;
+use Yoast_Notification_Center;
 
 /**
  * Unit test class
@@ -45,8 +49,8 @@ class WPSEO_Admin_Gutenberg_Compatibility_Notification_Test extends TestCase {
 	public function set_up() {
 		parent::set_up();
 
-		$this->gutenberg_compatibility_mock = Mockery::mock( 'WPSEO_Gutenberg_Compatibility' )->makePartial();
-		$this->notification_center_mock     = Mockery::mock( 'Yoast_Notification_Center' );
+		$this->gutenberg_compatibility_mock = Mockery::mock( WPSEO_Gutenberg_Compatibility::class )->makePartial();
+		$this->notification_center_mock     = Mockery::mock( Yoast_Notification_Center::class );
 
 		$this->gutenberg_notification = new WPSEO_Admin_Gutenberg_Compatibility_Notification_Double();
 		$this->gutenberg_notification->set_dependencies( $this->gutenberg_compatibility_mock, $this->notification_center_mock );
@@ -135,7 +139,7 @@ class WPSEO_Admin_Gutenberg_Compatibility_Notification_Test extends TestCase {
 		$this->notification_center_mock->expects( 'add_notification' )->once()->withArgs(
 			static function ( $arg ) {
 				// Verify that the added notification is a Yoast_Notification object and has the correct id.
-				return ( \is_a( $arg, 'Yoast_Notification' ) && $arg->get_id() === 'wpseo-outdated-gutenberg-plugin' );
+				return ( \is_a( $arg, Yoast_Notification::class ) && $arg->get_id() === 'wpseo-outdated-gutenberg-plugin' );
 			}
 		);
 

--- a/tests/unit/builders/indexable-link-builder-test.php
+++ b/tests/unit/builders/indexable-link-builder-test.php
@@ -5,6 +5,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Builders;
 use Brain\Monkey\Filters;
 use Brain\Monkey\Functions;
 use Mockery;
+use Yoast\WP\Lib\ORM;
 use Yoast\WP\SEO\Builders\Indexable_Link_Builder;
 use Yoast\WP\SEO\Helpers\Image_Helper;
 use Yoast\WP\SEO\Helpers\Post_Helper;
@@ -154,7 +155,7 @@ class Indexable_Link_Builder_Test extends TestCase {
 		$this->url_helper->expects( 'get_link_type' )->with( $parsed_new_link_url, $parsed_home_url, $is_image )->andReturn( $link_type );
 		$this->url_helper->expects( 'get_link_type' )->with( $parsed_existing_link_url, $parsed_home_url, $is_image )->andReturn( $link_type );
 
-		$query_mock                 = Mockery::mock();
+		$query_mock                 = Mockery::mock( ORM::class );
 		$new_seo_link               = Mockery::mock( SEO_Links_Mock::class );
 		$new_seo_link->type         = $link_type;
 		$new_seo_link->url          = 'https://link.com/newly-added-in-post';
@@ -269,7 +270,7 @@ class Indexable_Link_Builder_Test extends TestCase {
 		$this->url_helper->expects( 'get_link_type' )->with( $parsed_link_url, $parsed_home_url, false )->andReturn( $link_type );
 		$this->url_helper->expects( 'is_relative' )->with( $target_permalink )->andReturnFalse();
 
-		$query_mock                    = Mockery::mock();
+		$query_mock                    = Mockery::mock( ORM::class );
 		$seo_link                      = Mockery::mock( SEO_Links_Mock::class );
 		$seo_link->type                = $link_type;
 		$seo_link->url                 = $target_indexable->permalink;

--- a/tests/unit/builders/primary-term-builder-test.php
+++ b/tests/unit/builders/primary-term-builder-test.php
@@ -7,6 +7,7 @@ use Mockery;
 use Yoast\WP\SEO\Builders\Primary_Term_Builder;
 use Yoast\WP\SEO\Helpers\Meta_Helper;
 use Yoast\WP\SEO\Helpers\Primary_Term_Helper;
+use Yoast\WP\SEO\Models\Primary_Term;
 use Yoast\WP\SEO\Repositories\Primary_Term_Repository;
 use Yoast\WP\SEO\Tests\Unit\Doubles\Builders\Primary_Term_Builder_Double;
 use Yoast\WP\SEO\Tests\Unit\Doubles\Models\Primary_Term_Mock;
@@ -221,7 +222,7 @@ class Primary_Term_Builder_Test extends TestCase {
 			->with( 'primary_category', 1 )
 			->andReturn( false );
 
-		$primary_term = Mockery::mock();
+		$primary_term = Mockery::mock( Primary_Term::class );
 		$primary_term->expects( 'delete' )->once();
 		$primary_term->expects( 'save' )->never();
 

--- a/tests/unit/dependency-injection/schema-templates-pass-test.php
+++ b/tests/unit/dependency-injection/schema-templates-pass-test.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Dependency_Injection;
 
 use Mockery;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
 use Yoast\WP\SEO\Dependency_Injection\Schema_Templates_Loader;
 use Yoast\WP\SEO\Dependency_Injection\Schema_Templates_Pass;
 use Yoast\WP\SEO\Integrations\Schema_Blocks;
@@ -56,7 +57,7 @@ class Schema_Templates_Pass_Test extends TestCase {
 	 * @covers ::process
 	 */
 	public function test_process() {
-		$schema_blocks_definition = Mockery::mock();
+		$schema_blocks_definition = Mockery::mock( Definition::class );
 
 		$this->container_builder
 			->expects( 'hasDefinition' )

--- a/tests/unit/integrations/watchers/primary-category-quick-edit-watcher-test.php
+++ b/tests/unit/integrations/watchers/primary-category-quick-edit-watcher-test.php
@@ -11,6 +11,7 @@ use Yoast\WP\SEO\Conditionals\Migrations_Conditional;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Post_Type_Helper;
 use Yoast\WP\SEO\Integrations\Watchers\Primary_Category_Quick_Edit_Watcher;
+use Yoast\WP\SEO\Models\Primary_Term;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
 use Yoast\WP\SEO\Repositories\Primary_Term_Repository;
 use Yoast\WP\SEO\Tests\Unit\Doubles\Models\Indexable_Mock;

--- a/tests/unit/integrations/watchers/primary-term-watcher-test.php
+++ b/tests/unit/integrations/watchers/primary-term-watcher-test.php
@@ -9,6 +9,7 @@ use Yoast\WP\SEO\Conditionals\Migrations_Conditional;
 use Yoast\WP\SEO\Helpers\Primary_Term_Helper;
 use Yoast\WP\SEO\Helpers\Site_Helper;
 use Yoast\WP\SEO\Integrations\Watchers\Primary_Term_Watcher;
+use Yoast\WP\SEO\Models\Primary_Term;
 use Yoast\WP\SEO\Repositories\Primary_Term_Repository;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
@@ -116,7 +117,7 @@ class Primary_Term_Watcher_Test extends TestCase {
 			->with( 1 )
 			->andReturn( [ (object) [ 'name' => 'category' ] ] );
 
-		$primary_term = Mockery::mock();
+		$primary_term = Mockery::mock( Primary_Term::class );
 		$primary_term->expects( 'delete' )->once();
 
 		$this->repository

--- a/tests/unit/models/indexable-test.php
+++ b/tests/unit/models/indexable-test.php
@@ -153,7 +153,7 @@ class Indexable_Test extends TestCase {
 	 * @covers ::get_extension
 	 */
 	public function test_get_extension_has_one() {
-		$this->instance->mock_has_one = Mockery::mock();
+		$this->instance->mock_has_one = Mockery::mock( ORM::class );
 		$this->instance->mock_has_one->expects( 'find_one' )->once()->andReturn( 'found one' );
 
 		$this->assertSame( 'found one', $this->instance->get_extension( 'has_one' ) );

--- a/tests/unit/repositories/indexable-hierarchy-repository-test.php
+++ b/tests/unit/repositories/indexable-hierarchy-repository-test.php
@@ -6,6 +6,7 @@ use Brain\Monkey\Functions;
 use Mockery;
 use Yoast\WP\Lib\ORM;
 use Yoast\WP\SEO\Builders\Indexable_Hierarchy_Builder;
+use Yoast\WP\SEO\Models\Indexable_Hierarchy;
 use Yoast\WP\SEO\Repositories\Indexable_Hierarchy_Repository;
 use Yoast\WP\SEO\Tests\Unit\Doubles\Models\Indexable_Hierarchy_Mock;
 use Yoast\WP\SEO\Tests\Unit\Doubles\Models\Indexable_Mock;
@@ -70,7 +71,7 @@ class Indexable_Hierarchy_Repository_Test extends TestCase {
 
 		$ancestors = [ 2 ];
 
-		$orm_object = Mockery::mock();
+		$orm_object = Mockery::mock( ORM::class );
 
 		$orm_object
 			->expects( 'select' )
@@ -119,7 +120,7 @@ class Indexable_Hierarchy_Repository_Test extends TestCase {
 
 		$ancestors = [ 2 ];
 
-		$orm_object = Mockery::mock();
+		$orm_object = Mockery::mock( ORM::class );
 
 		$orm_object
 			->expects( 'select' )
@@ -168,7 +169,7 @@ class Indexable_Hierarchy_Repository_Test extends TestCase {
 	 * @covers ::clear_ancestors
 	 */
 	public function test_clear_ancestors() {
-		$orm_object = Mockery::mock()->makePartial();
+		$orm_object = Mockery::mock( ORM::class )->makePartial();
 		$this->instance->expects( 'query' )->andReturn( $orm_object );
 
 		$orm_object
@@ -200,7 +201,7 @@ class Indexable_Hierarchy_Repository_Test extends TestCase {
 
 		$hierarchy->expects( 'save' )->once()->andReturn( true );
 
-		$orm_object = Mockery::mock()->makePartial();
+		$orm_object = Mockery::mock( ORM::class )->makePartial();
 
 		$orm_object
 			->expects( 'create' )
@@ -245,7 +246,7 @@ class Indexable_Hierarchy_Repository_Test extends TestCase {
 		$indexable     = Mockery::mock( Indexable_Mock::class );
 		$indexable->id = 1;
 
-		$orm_object = Mockery::mock();
+		$orm_object = Mockery::mock( ORM::class );
 
 		$orm_object
 			->expects( 'select' )
@@ -292,7 +293,7 @@ class Indexable_Hierarchy_Repository_Test extends TestCase {
 		$indexable     = Mockery::mock( Indexable_Mock::class );
 		$indexable->id = 1;
 
-		$orm_object = Mockery::mock();
+		$orm_object = Mockery::mock( ORM::class );
 
 		$orm_object
 			->expects( 'select' )

--- a/tests/unit/repositories/indexable-repository-test.php
+++ b/tests/unit/repositories/indexable-repository-test.php
@@ -285,7 +285,7 @@ class Indexable_Repository_Test extends TestCase {
 	 * @return Mockery\Mock The mocked ORM object.
 	 */
 	private function mock_orm( $indexable_ids, $indexables ) {
-		$orm_object = Mockery::mock()->makePartial();
+		$orm_object = Mockery::mock( ORM::class )->makePartial();
 		$orm_object
 			->expects( 'where_in' )
 			->with( 'id', $indexable_ids )
@@ -329,7 +329,7 @@ class Indexable_Repository_Test extends TestCase {
 		$indexable              = Mockery::mock( Indexable_Mock::class );
 		$indexable->object_type = 'post';
 
-		$orm_object = Mockery::mock();
+		$orm_object = Mockery::mock( ORM::class );
 
 		$this->instance
 			->expects( 'query' )
@@ -359,7 +359,7 @@ class Indexable_Repository_Test extends TestCase {
 	 * @covers ::reset_permalink
 	 */
 	public function test_reset_permalink() {
-		$orm_object = Mockery::mock();
+		$orm_object = Mockery::mock( ORM::class );
 
 		$this->instance
 			->expects( 'query' )
@@ -391,7 +391,7 @@ class Indexable_Repository_Test extends TestCase {
 	 * @covers ::reset_permalink
 	 */
 	public function test_reset_permalink_with_args() {
-		$orm_object = Mockery::mock();
+		$orm_object = Mockery::mock( ORM::class );
 
 		$this->instance
 			->expects( 'query' )
@@ -433,7 +433,7 @@ class Indexable_Repository_Test extends TestCase {
 	 * @covers ::reset_permalink
 	 */
 	public function test_reset_permalink_with_invalid_args() {
-		$orm_object = Mockery::mock();
+		$orm_object = Mockery::mock( ORM::class );
 
 		$this->instance
 			->expects( 'query' )


### PR DESCRIPTION
## Context

* Improved PHP 8.2 compatibility (tests only)

## Summary

This PR can be summarized in the following changelog entry:

* Improved PHP 8.2 compatibility (tests only)

## Relevant technical choices:

### Tests: use named mocks for YoastSEO native classes

Including for YoastSEO native dependency classes.


## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_ This is a docs/test only change, if the build passes, we're good.