### PR TITLE
Tests: use named mocks for WP native classes

### DIFF
--- a/tests/unit/actions/importing/aioseo-cleanup-action-test.php
+++ b/tests/unit/actions/importing/aioseo-cleanup-action-test.php
@@ -53,7 +53,7 @@ class Aioseo_Cleanup_Action_Test extends TestCase {
 	protected function set_up() {
 		parent::set_up();
 
-		$this->wpdb          = Mockery::mock( 'wpdb' );
+		$this->wpdb          = Mockery::mock( wpdb::class );
 		$this->options       = Mockery::mock( Options_Helper::class );
 		$this->aioseo_helper = Mockery::mock( Aioseo_Helper::class );
 

--- a/tests/unit/actions/importing/aioseo-posts-importing-action-test.php
+++ b/tests/unit/actions/importing/aioseo-posts-importing-action-test.php
@@ -153,7 +153,7 @@ class Aioseo_Posts_Importing_Action_Test extends TestCase {
 		parent::set_up();
 
 		$this->indexable_repository   = Mockery::mock( Indexable_Repository::class );
-		$this->wpdb                   = Mockery::mock( 'wpdb' );
+		$this->wpdb                   = Mockery::mock( wpdb::class );
 		$this->meta                   = Mockery::mock( Meta_Helper::class );
 		$this->import_cursor          = Mockery::mock( Import_Cursor_Helper::class );
 		$this->indexable_helper       = Mockery::mock( Indexable_Helper::class );

--- a/tests/unit/actions/importing/aioseo-validate-data-action-test.php
+++ b/tests/unit/actions/importing/aioseo-validate-data-action-test.php
@@ -110,7 +110,7 @@ class Aioseo_Validate_Data_Action_Test extends TestCase {
 	protected function set_up() {
 		parent::set_up();
 
-		$this->wpdb                  = Mockery::mock( 'wpdb' );
+		$this->wpdb                  = Mockery::mock( wpdb::class );
 		$this->options               = Mockery::mock( Options_Helper::class );
 		$this->aioseo_helper         = Mockery::mock( Aioseo_Helper::class );
 		$this->post_importing_action = Mockery::mock( Aioseo_Posts_Importing_Action::class );

--- a/tests/unit/actions/indexing/abstract-link-indexing-action-test.php
+++ b/tests/unit/actions/indexing/abstract-link-indexing-action-test.php
@@ -68,7 +68,7 @@ class Abstract_Link_Indexing_Action_Test extends TestCase {
 
 		$this->link_builder        = Mockery::mock( Indexable_Link_Builder::class );
 		$this->repository          = Mockery::mock( Indexable_Repository::class );
-		$this->wpdb                = Mockery::mock( 'wpdb' );
+		$this->wpdb                = Mockery::mock( wpdb::class );
 		$this->wpdb->term_taxonomy = 'wp_term_taxonomy';
 
 		$this->instance = Mockery::mock(

--- a/tests/unit/actions/indexing/indexable-post-indexation-action-test.php
+++ b/tests/unit/actions/indexing/indexable-post-indexation-action-test.php
@@ -77,7 +77,7 @@ class Indexable_Post_Indexation_Action_Test extends TestCase {
 		$this->post_type_helper = Mockery::mock( Post_Type_Helper::class );
 		$this->post_helper      = Mockery::mock( Post_Helper::class );
 		$this->repository       = Mockery::mock( Indexable_Repository::class );
-		$this->wpdb             = Mockery::mock( 'wpdb' );
+		$this->wpdb             = Mockery::mock( wpdb::class );
 		$this->wpdb->posts      = 'wp_posts';
 		$this->builder_versions = Mockery::mock( Indexable_Builder_Versions::class );
 

--- a/tests/unit/actions/indexing/indexable-term-indexation-action-test.php
+++ b/tests/unit/actions/indexing/indexable-term-indexation-action-test.php
@@ -68,7 +68,7 @@ class Indexable_Term_Indexation_Action_Test extends TestCase {
 
 		$this->taxonomy            = Mockery::mock( Taxonomy_Helper::class );
 		$this->repository          = Mockery::mock( Indexable_Repository::class );
-		$this->wpdb                = Mockery::mock( 'wpdb' );
+		$this->wpdb                = Mockery::mock( wpdb::class );
 		$this->wpdb->term_taxonomy = 'wp_term_taxonomy';
 		$this->versions            = Mockery::mock( Indexable_Builder_Versions::class );
 

--- a/tests/unit/actions/indexing/post-link-indexing-action-test.php
+++ b/tests/unit/actions/indexing/post-link-indexing-action-test.php
@@ -71,7 +71,7 @@ class Post_Link_Indexing_Action_Test extends TestCase {
 		$this->link_builder     = Mockery::mock( Indexable_Link_Builder::class );
 		$this->post_type_helper = Mockery::mock( Post_Type_Helper::class );
 		$this->repository       = Mockery::mock( Indexable_Repository::class );
-		$this->wpdb             = Mockery::mock( 'wpdb' );
+		$this->wpdb             = Mockery::mock( wpdb::class );
 		$this->wpdb->posts      = 'wp_posts';
 
 		$this->instance = new Post_Link_Indexing_Action(

--- a/tests/unit/actions/indexing/term-link-indexing-action-test.php
+++ b/tests/unit/actions/indexing/term-link-indexing-action-test.php
@@ -71,7 +71,7 @@ class Term_Link_Indexing_Action_Test extends TestCase {
 		$this->link_builder        = Mockery::mock( Indexable_Link_Builder::class );
 		$this->taxonomy_helper     = Mockery::mock( Taxonomy_Helper::class );
 		$this->repository          = Mockery::mock( Indexable_Repository::class );
-		$this->wpdb                = Mockery::mock( 'wpdb' );
+		$this->wpdb                = Mockery::mock( wpdb::class );
 		$this->wpdb->term_taxonomy = 'wp_term_taxonomy';
 
 		$this->instance = new Term_Link_Indexing_Action(

--- a/tests/unit/admin/capabilities/capabilities-utils-test.php
+++ b/tests/unit/admin/capabilities/capabilities-utils-test.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Admin\Capabilities;
 
 use Brain\Monkey;
 use Mockery;
+use WP_Roles;
 use WPSEO_Capability_Utils;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
@@ -29,7 +30,7 @@ final class Capabilities_Utils_Test extends TestCase {
 	protected function set_up() {
 		parent::set_up();
 
-		$this->roles = Mockery::mock();
+		$this->roles = Mockery::mock( WP_Roles::class );
 
 		$this->roles
 			->expects( 'get_names' )

--- a/tests/unit/admin/formatter/post-metabox-formatter-test.php
+++ b/tests/unit/admin/formatter/post-metabox-formatter-test.php
@@ -37,7 +37,7 @@ class Post_Metabox_Formatter_Test extends TestCase {
 	protected function set_up() {
 		parent::set_up();
 
-		$this->mock_post               = Mockery::mock( '\WP_Post' )->makePartial();
+		$this->mock_post               = Mockery::mock( WP_Post::class )->makePartial();
 		$this->mock_post->ID           = 1;
 		$this->mock_post->post_content = '';
 

--- a/tests/unit/admin/formatter/term-metabox-formatter-test.php
+++ b/tests/unit/admin/formatter/term-metabox-formatter-test.php
@@ -46,7 +46,7 @@ class Term_Metabox_Formatter_Test extends TestCase {
 		parent::set_up();
 
 		$this->taxonomy           = (object) [];
-		$this->mock_term          = Mockery::mock( '\WP_Term' )->makePartial();
+		$this->mock_term          = Mockery::mock( WP_Term::class )->makePartial();
 		$this->mock_term->term_id = 1;
 
 		$this->instance = new Term_Metabox_Formatter_Double( $this->taxonomy, $this->mock_term );

--- a/tests/unit/admin/import/plugins/import-aioseo-v4-test.php
+++ b/tests/unit/admin/import/plugins/import-aioseo-v4-test.php
@@ -41,7 +41,7 @@ class WPSEO_Import_AIOSEO_V4_Test extends TestCase {
 	public function test_meta_key_clone_replace() {
 		global $wpdb;
 
-		$wpdb         = Mockery::mock( 'wpdb' );
+		$wpdb         = Mockery::mock( wpdb::class );
 		$wpdb->prefix = 'test';
 
 		$wpdb->shouldReceive( 'query' );
@@ -142,7 +142,7 @@ class WPSEO_Import_AIOSEO_V4_Test extends TestCase {
 	public function test_meta_key_clone_replace_no_custom_field_replace_vars() {
 		global $wpdb;
 
-		$wpdb         = Mockery::mock( 'wpdb' );
+		$wpdb         = Mockery::mock( wpdb::class );
 		$wpdb->prefix = 'test';
 
 		$wpdb->shouldReceive( 'query' );

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -54,6 +54,7 @@ if ( is_dir( WPSEO_PATH . YOAST_VENDOR_PREFIX_DIRECTORY ) ) {
 // Create the necessary test doubles for WP native classes on which properties are being set (PHP 8.2 compat).
 Yoast\WPTestUtils\BrainMonkey\makeDoublesForUnavailableClasses(
 	[
+		'WP_Post',
 		'WP_Query',
 		'WP_User',
 	]

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -55,6 +55,7 @@ if ( is_dir( WPSEO_PATH . YOAST_VENDOR_PREFIX_DIRECTORY ) ) {
 Yoast\WPTestUtils\BrainMonkey\makeDoublesForUnavailableClasses(
 	[
 		'WP_Query',
+		'WP_User',
 	]
 );
 

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -57,6 +57,7 @@ Yoast\WPTestUtils\BrainMonkey\makeDoublesForUnavailableClasses(
 		'WP_Post',
 		'WP_Query',
 		'WP_Roles',
+		'WP_Term',
 		'WP_User',
 		'wpdb',
 	]

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -49,6 +49,15 @@ if ( is_dir( WPSEO_PATH . YOAST_VENDOR_PREFIX_DIRECTORY ) ) {
 	require_once WPSEO_PATH . YOAST_VENDOR_PREFIX_DIRECTORY . '/guzzlehttp/promises/src/functions_include.php';
 }
 
+/* ********************* LOAD TEST DOUBLES FOR WP NATIVE CLASSES ********************* */
+
+// Create the necessary test doubles for WP native classes on which properties are being set (PHP 8.2 compat).
+Yoast\WPTestUtils\BrainMonkey\makeDoublesForUnavailableClasses(
+	[
+		'WP_Query',
+	]
+);
+
 /* ********************* DEFINES DEPENDING ON AUTOLOADED CODE ********************* */
 
 /**

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -56,6 +56,7 @@ Yoast\WPTestUtils\BrainMonkey\makeDoublesForUnavailableClasses(
 	[
 		'WP_Post',
 		'WP_Query',
+		'WP_Rewrite',
 		'WP_Roles',
 		'WP_Term',
 		'WP_User',

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -57,6 +57,7 @@ Yoast\WPTestUtils\BrainMonkey\makeDoublesForUnavailableClasses(
 		'WP_Post',
 		'WP_Query',
 		'WP_User',
+		'wpdb',
 	]
 );
 

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -56,6 +56,7 @@ Yoast\WPTestUtils\BrainMonkey\makeDoublesForUnavailableClasses(
 	[
 		'WP_Post',
 		'WP_Query',
+		'WP_Roles',
 		'WP_User',
 		'wpdb',
 	]

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -54,6 +54,7 @@ if ( is_dir( WPSEO_PATH . YOAST_VENDOR_PREFIX_DIRECTORY ) ) {
 // Create the necessary test doubles for WP native classes on which properties are being set (PHP 8.2 compat).
 Yoast\WPTestUtils\BrainMonkey\makeDoublesForUnavailableClasses(
 	[
+		'WP',
 		'WP_Post',
 		'WP_Query',
 		'WP_Rewrite',

--- a/tests/unit/builders/indexable-author-builder-test.php
+++ b/tests/unit/builders/indexable-author-builder-test.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Builders;
 
 use Brain\Monkey;
 use Mockery;
+use wpdb;
 use Yoast\WP\Lib\ORM;
 use Yoast\WP\SEO\Builders\Indexable_Author_Builder;
 use Yoast\WP\SEO\Exceptions\Indexable\Author_Not_Built_Exception;
@@ -81,7 +82,7 @@ class Indexable_Author_Builder_Test extends TestCase {
 		$this->author_archive = Mockery::mock( Author_Archive_Helper::class );
 
 		$this->post_helper = Mockery::mock( Post_Helper::class );
-		$this->wpdb        = Mockery::mock( 'wpdb' );
+		$this->wpdb        = Mockery::mock( wpdb::class );
 		$this->wpdb->posts = 'wp_posts';
 
 		$this->instance = new Indexable_Author_Builder( $this->author_archive, $this->versions, $this->post_helper, $this->wpdb );

--- a/tests/unit/builders/indexable-home-page-builder-test.php
+++ b/tests/unit/builders/indexable-home-page-builder-test.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Builders;
 
 use Brain\Monkey;
 use Mockery;
+use wpdb;
 use WPSEO_Utils;
 use Yoast\WP\Lib\ORM;
 use Yoast\WP\SEO\Builders\Indexable_Home_Page_Builder;
@@ -178,7 +179,7 @@ class Indexable_Home_Page_Builder_Test extends TestCase {
 			->andReturn( 2 );
 
 		$this->post_helper = Mockery::mock( Post_Helper::class );
-		$this->wpdb        = Mockery::mock( 'wpdb' );
+		$this->wpdb        = Mockery::mock( wpdb::class );
 		$this->wpdb->posts = 'wp_posts';
 
 		$this->instance = new Indexable_Home_Page_Builder(

--- a/tests/unit/builders/indexable-post-type-archive-builder-test.php
+++ b/tests/unit/builders/indexable-post-type-archive-builder-test.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Builders;
 
 use Brain\Monkey;
 use Mockery;
+use wpdb;
 use Yoast\WP\Lib\ORM;
 use Yoast\WP\SEO\Builders\Indexable_Post_Type_Archive_Builder;
 use Yoast\WP\SEO\Helpers\Options_Helper;
@@ -47,7 +48,7 @@ class Indexable_Post_Type_Archive_Builder_Test extends TestCase {
 		$post_helper = Mockery::mock( Post_Helper::class );
 		$post_helper->expects( 'get_public_post_statuses' )->once()->andReturn( [ 'publish' ] );
 
-		$wpdb        = Mockery::mock( 'wpdb' );
+		$wpdb        = Mockery::mock( wpdb::class );
 		$wpdb->posts = 'wp_posts';
 		$wpdb->expects( 'prepare' )->once()->with(
 			"

--- a/tests/unit/builders/indexable-term-builder-test.php
+++ b/tests/unit/builders/indexable-term-builder-test.php
@@ -5,6 +5,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Builders;
 use Brain\Monkey;
 use Mockery;
 use wpdb;
+use WP_Error;
 use Yoast\WP\Lib\ORM;
 use Yoast\WP\SEO\Builders\Indexable_Term_Builder;
 use Yoast\WP\SEO\Exceptions\Indexable\Invalid_Term_Exception;
@@ -386,7 +387,7 @@ class Indexable_Term_Builder_Test extends TestCase {
 	 * @covers ::build
 	 */
 	public function test_build_term_error() {
-		$error = Mockery::mock( '\WP_Error' );
+		$error = Mockery::mock( WP_Error::class );
 		$error
 			->expects( 'get_error_message' )
 			->andReturn( 'An error message' );
@@ -410,7 +411,7 @@ class Indexable_Term_Builder_Test extends TestCase {
 		$term = (object) [ 'taxonomy' => 'tax' ];
 
 		$this->taxonomy->expects( 'get_indexable_taxonomies' )->andReturn( [ 'tax' ] );
-		$error = Mockery::mock( '\WP_Error' );
+		$error = Mockery::mock( WP_Error::class );
 		$error
 			->expects( 'get_error_message' )
 			->andReturn( 'An error message' );

--- a/tests/unit/builders/indexable-term-builder-test.php
+++ b/tests/unit/builders/indexable-term-builder-test.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Builders;
 
 use Brain\Monkey;
 use Mockery;
+use wpdb;
 use Yoast\WP\Lib\ORM;
 use Yoast\WP\SEO\Builders\Indexable_Term_Builder;
 use Yoast\WP\SEO\Exceptions\Indexable\Invalid_Term_Exception;
@@ -103,7 +104,7 @@ class Indexable_Term_Builder_Test extends TestCase {
 		$this->taxonomy                 = Mockery::mock( Taxonomy_Helper::class );
 		$this->versions                 = Mockery::mock( Indexable_Builder_Versions::class );
 		$this->post_helper              = Mockery::mock( Post_Helper::class );
-		$this->wpdb                     = Mockery::mock( 'wpdb' );
+		$this->wpdb                     = Mockery::mock( wpdb::class );
 		$this->wpdb->posts              = 'wp_posts';
 		$this->wpdb->term_relationships = 'wp_term_relationships';
 		$this->wpdb->term_taxonomy      = 'wp_term_taxonomy';

--- a/tests/unit/commands/index-command-test.php
+++ b/tests/unit/commands/index-command-test.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Commands;
 
 use Brain\Monkey;
 use Mockery;
+use wpdb;
 use Yoast\WP\SEO\Actions\Indexing\Indexable_General_Indexation_Action;
 use Yoast\WP\SEO\Actions\Indexing\Indexable_Indexing_Complete_Action;
 use Yoast\WP\SEO\Actions\Indexing\Indexable_Post_Indexation_Action;
@@ -231,7 +232,7 @@ class Index_Command_Test extends TestCase {
 			->expects( 'confirm' )
 			->with( 'This will clear all previously indexed objects. Are you certain you wish to proceed?' );
 
-		$wpdb            = Mockery::mock();
+		$wpdb            = Mockery::mock( wpdb::class );
 		$wpdb->prefix    = 'wp_';
 		$GLOBALS['wpdb'] = $wpdb; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Intended override for test purpose.
 

--- a/tests/unit/database/migration-runner-test.php
+++ b/tests/unit/database/migration-runner-test.php
@@ -179,7 +179,7 @@ class Migration_Runner_Test extends TestCase {
 	 * @return wpdb The wpdb mock.
 	 */
 	protected function get_wpdb_mock() {
-		$wpdb         = Mockery::mock( 'wpdb' );
+		$wpdb         = Mockery::mock( wpdb::class );
 		$wpdb->prefix = 'test';
 
 		return $wpdb;

--- a/tests/unit/helpers/aioseo-helper-test.php
+++ b/tests/unit/helpers/aioseo-helper-test.php
@@ -46,7 +46,7 @@ class Aioseo_Helper_Test extends TestCase {
 	public function set_up() {
 		parent::set_up();
 
-		$this->wpdb        = Mockery::mock( 'wpdb' );
+		$this->wpdb        = Mockery::mock( wpdb::class );
 		$this->wpdb_helper = Mockery::mock( Wpdb_Helper::class );
 		$this->instance    = new Aioseo_Helper(
 			$this->wpdb,

--- a/tests/unit/helpers/current-page-helper-test.php
+++ b/tests/unit/helpers/current-page-helper-test.php
@@ -5,6 +5,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Helpers;
 use Brain\Monkey;
 use Mockery;
 use WP_Post;
+use WP_Query;
 use Yoast\WP\SEO\Helpers\Current_Page_Helper;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 use Yoast\WP\SEO\Wrappers\WP_Query_Wrapper;
@@ -46,7 +47,7 @@ class Current_Page_Helper_Test extends TestCase {
 		parent::set_up();
 
 		$this->wp_query_wrapper = Mockery::mock( WP_Query_Wrapper::class );
-		$this->wp_query         = Mockery::mock();
+		$this->wp_query         = Mockery::mock( WP_Query::class );
 
 		$this->instance = Mockery::mock( Current_Page_Helper::class, [ $this->wp_query_wrapper ] )
 			->makePartial()

--- a/tests/unit/helpers/pagination-helper-test.php
+++ b/tests/unit/helpers/pagination-helper-test.php
@@ -5,6 +5,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Helpers;
 use Brain\Monkey;
 use Mockery;
 use WP_Query;
+use WP_Rewrite;
 use Yoast\WP\SEO\Helpers\Pagination_Helper;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 use Yoast\WP\SEO\Wrappers\WP_Query_Wrapper;
@@ -254,7 +255,7 @@ class Pagination_Helper_Test extends TestCase {
 	 * @param bool $using_permalinks Returns value of $wp_rewrite->using_permalinks.
 	 */
 	private function using_permalinks( $using_permalinks ) {
-		$wp_rewrite_mock                  = Mockery::mock( 'WP_Rewrite' );
+		$wp_rewrite_mock                  = Mockery::mock( WP_Rewrite::class );
 		$wp_rewrite_mock->pagination_base = 'page';
 
 		$wp_rewrite_mock

--- a/tests/unit/helpers/pagination-helper-test.php
+++ b/tests/unit/helpers/pagination-helper-test.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Helpers;
 
 use Brain\Monkey;
 use Mockery;
+use WP_Query;
 use Yoast\WP\SEO\Helpers\Pagination_Helper;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 use Yoast\WP\SEO\Wrappers\WP_Query_Wrapper;
@@ -168,7 +169,7 @@ class Pagination_Helper_Test extends TestCase {
 	 * @covers ::get_number_of_archive_pages
 	 */
 	public function test_get_number_of_archive_pages() {
-		$wp_query                = Mockery::mock( 'WP_Query' );
+		$wp_query                = Mockery::mock( WP_Query::class );
 		$wp_query->max_num_pages = '6';
 
 		$this->wp_query_wrapper
@@ -185,7 +186,7 @@ class Pagination_Helper_Test extends TestCase {
 	 * @covers ::get_current_archive_page_number
 	 */
 	public function test_get_current_archive_page() {
-		$wp_query = Mockery::mock( 'WP_Query' );
+		$wp_query = Mockery::mock( WP_Query::class );
 		$wp_query->expects( 'get' )->with( 'paged' )->once()->andReturn( '2' );
 
 		$this->wp_query_wrapper
@@ -202,7 +203,7 @@ class Pagination_Helper_Test extends TestCase {
 	 * @covers ::get_current_post_page_number
 	 */
 	public function test_get_current_post_page() {
-		$wp_query = Mockery::mock( 'WP_Query' );
+		$wp_query = Mockery::mock( WP_Query::class );
 		$wp_query->expects( 'get' )->with( 'page' )->once()->andReturn( '2' );
 
 		$this->wp_query_wrapper

--- a/tests/unit/helpers/schema/id-helper-test.php
+++ b/tests/unit/helpers/schema/id-helper-test.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Helpers\Schema;
 
 use Brain\Monkey;
 use Mockery;
+use WP_User;
 use Yoast\WP\SEO\Helpers\Schema\ID_Helper;
 use Yoast\WP\SEO\Tests\Unit\Doubles\Context\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
@@ -40,7 +41,7 @@ class ID_Helper_Test extends TestCase {
 	 * @covers ::get_user_schema_id
 	 */
 	public function test_get_user_schema_id() {
-		$user             = Mockery::mock( 'WP_User' );
+		$user             = Mockery::mock( WP_User::class );
 		$user->user_login = 'dingdong';
 
 		$context           = Mockery::mock( Meta_Tags_Context_Mock::class );

--- a/tests/unit/inc/sitemaps/sitemaps-admin-test.php
+++ b/tests/unit/inc/sitemaps/sitemaps-admin-test.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Inc\Sitemaps;
 
 use Brain\Monkey;
 use Mockery;
+use WP_Post;
 use WPSEO_Options;
 use WPSEO_Sitemaps_Admin;
 use Yoast\WP\SEO\Helpers\Environment_Helper;
@@ -49,7 +50,7 @@ class WPSEO_Sitemaps_Admin_Test extends TestCase {
 
 		$this->instance             = new WPSEO_Sitemaps_Admin();
 		$this->options_mock         = Mockery::mock( WPSEO_Options::class )->shouldAllowMockingProtectedMethods();
-		$this->mock_post            = Mockery::mock( '\WP_Post' )->makePartial();
+		$this->mock_post            = Mockery::mock( WP_Post::class )->makePartial();
 		$this->mock_post->post_type = 'post';
 	}
 

--- a/tests/unit/inc/sitemaps/sitemaps-admin-test.php
+++ b/tests/unit/inc/sitemaps/sitemaps-admin-test.php
@@ -5,6 +5,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Inc\Sitemaps;
 use Brain\Monkey;
 use Mockery;
 use WP_Post;
+use WP_Rewrite;
 use WPSEO_Options;
 use WPSEO_Sitemaps_Admin;
 use Yoast\WP\SEO\Helpers\Environment_Helper;
@@ -100,7 +101,7 @@ class WPSEO_Sitemaps_Admin_Test extends TestCase {
 	public function test_status_transition_on_production() {
 		global $wp_rewrite;
 
-		$wp_rewrite = Mockery::mock();
+		$wp_rewrite = Mockery::mock( WP_Rewrite::class );
 		$wp_rewrite->expects( 'using_index_permalinks' )->andReturnFalse();
 
 		Monkey\Functions\stubs(

--- a/tests/unit/integrations/cleanup-integration-test.php
+++ b/tests/unit/integrations/cleanup-integration-test.php
@@ -74,7 +74,7 @@ class Cleanup_Integration_Test extends TestCase {
 
 		global $wpdb;
 
-		$wpdb         = Mockery::mock( 'wpdb' );
+		$wpdb         = Mockery::mock( wpdb::class );
 		$wpdb->prefix = 'wp_';
 
 		$this->wpdb = $wpdb;

--- a/tests/unit/integrations/front-end-integration-test.php
+++ b/tests/unit/integrations/front-end-integration-test.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Integrations;
 
 use Brain\Monkey;
 use Mockery;
+use WP_Query;
 use WPSEO_Replace_Vars;
 use Yoast\WP\SEO\Conditionals\Front_End_Conditional;
 use Yoast\WP\SEO\Helpers\Options_Helper;
@@ -147,7 +148,7 @@ class Front_End_Integration_Test extends TestCase {
 	public function test_call_wpseo_head() {
 		global $wp_query;
 
-		$initial_wp_query = Mockery::mock( 'WP_Query' );
+		$initial_wp_query = Mockery::mock( WP_Query::class );
 		$wp_query         = $initial_wp_query;
 		Monkey\Functions\expect( 'wp_reset_query' )->once();
 

--- a/tests/unit/integrations/front-end/handle-404-test.php
+++ b/tests/unit/integrations/front-end/handle-404-test.php
@@ -5,6 +5,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Integrations\Front_End;
 use Brain\Monkey;
 use Mockery;
 use stdClass;
+use WP_Query;
 use Yoast\WP\SEO\Conditionals\Front_End_Conditional;
 use Yoast\WP\SEO\Integrations\Front_End\Handle_404;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
@@ -114,7 +115,7 @@ class Handle_404_Test extends TestCase {
 			->once()
 			->andReturn( true );
 
-		$wp_query        = Mockery::mock();
+		$wp_query        = Mockery::mock( WP_Query::class );
 		$wp_query->posts = false;
 		$wp_query->expects( 'get_queried_object' )->once()->andReturnTrue();
 
@@ -137,7 +138,7 @@ class Handle_404_Test extends TestCase {
 			->once()
 			->andReturn( true );
 
-		$wp_query        = Mockery::mock();
+		$wp_query        = Mockery::mock( WP_Query::class );
 		$wp_query->posts = false;
 		$wp_query->expects( 'get_queried_object' )->once()->andReturnFalse();
 		$wp_query->expects( 'is_archive' )->once()->andReturnFalse();
@@ -162,7 +163,7 @@ class Handle_404_Test extends TestCase {
 			->once()
 			->andReturn( true );
 
-		$wp_query        = Mockery::mock();
+		$wp_query        = Mockery::mock( WP_Query::class );
 		$wp_query->posts = false;
 		$wp_query->expects( 'get_queried_object' )->once()->andReturnFalse();
 		$wp_query->expects( 'is_archive' )->once()->andReturnTrue();
@@ -197,7 +198,7 @@ class Handle_404_Test extends TestCase {
 			->once()
 			->andReturn( true );
 
-		$wp_query        = Mockery::mock();
+		$wp_query        = Mockery::mock( WP_Query::class );
 		$wp_query->posts = false;
 		$wp_query->expects( 'get_queried_object' )->once()->andReturnFalse();
 		$wp_query->expects( 'is_archive' )->once()->andReturnFalse();
@@ -228,7 +229,7 @@ class Handle_404_Test extends TestCase {
 	 * @covers ::set_404
 	 */
 	public function test_404_when_page_is_404() {
-		$wp_query = Mockery::mock( 'WP_Query' );
+		$wp_query = Mockery::mock( WP_Query::class );
 		$wp_query->expects( 'set_404' )->once()->andReturnNull();
 
 		$this->query_wrapper

--- a/tests/unit/integrations/front-end/robots-txt-integration-test.php
+++ b/tests/unit/integrations/front-end/robots-txt-integration-test.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Integrations\Front_End;
 
 use Brain\Monkey;
 use Mockery;
+use WP_Rewrite;
 use Yoast\WP\SEO\Conditionals\Robots_Txt_Conditional;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Robots_Txt_Helper;
@@ -116,7 +117,7 @@ class Robots_Txt_Integration_Test extends TestCase {
 	public function test_public_site_with_sitemaps() {
 		global $wp_rewrite;
 
-		$wp_rewrite = Mockery::mock();
+		$wp_rewrite = Mockery::mock( WP_Rewrite::class );
 		$wp_rewrite->expects( 'using_index_permalinks' )->andReturnFalse();
 
 		Monkey\Functions\expect( 'home_url' )
@@ -186,7 +187,7 @@ class Robots_Txt_Integration_Test extends TestCase {
 
 		global $wp_rewrite;
 
-		$wp_rewrite = Mockery::mock();
+		$wp_rewrite = Mockery::mock( WP_Rewrite::class );
 		$wp_rewrite->expects( 'using_index_permalinks' )->andReturnFalse();
 
 		Monkey\Functions\expect( 'home_url' )
@@ -304,7 +305,7 @@ class Robots_Txt_Integration_Test extends TestCase {
 	public function test_multisite_sitemaps_without_yoast_seo_active() {
 		global $wp_rewrite;
 
-		$wp_rewrite = Mockery::mock();
+		$wp_rewrite = Mockery::mock( WP_Rewrite::class );
 		$wp_rewrite->expects( 'using_index_permalinks' )->andReturnFalse();
 
 		Monkey\Functions\expect( 'home_url' )
@@ -386,7 +387,7 @@ class Robots_Txt_Integration_Test extends TestCase {
 	public function test_multisite_sitemaps_option_not_found() {
 		global $wp_rewrite;
 
-		$wp_rewrite = Mockery::mock();
+		$wp_rewrite = Mockery::mock( WP_Rewrite::class );
 		$wp_rewrite->expects( 'using_index_permalinks' )->andReturnFalse();
 
 		Monkey\Functions\expect( 'home_url' )

--- a/tests/unit/integrations/third-party/woocommerce-post-edit-test.php
+++ b/tests/unit/integrations/third-party/woocommerce-post-edit-test.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Integrations\Third_Party;
 
 use Brain\Monkey;
 use Mockery;
+use WP_Post;
 use Yoast\WP\SEO\Conditionals\Admin\Post_Conditional;
 use Yoast\WP\SEO\Conditionals\WooCommerce_Conditional;
 use Yoast\WP\SEO\Integrations\Third_Party\WooCommerce_Post_Edit;
@@ -82,7 +83,7 @@ class WooCommerce_Post_Edit_Test extends TestCase {
 			'author_name'         => 'Yoasie',
 		];
 
-		$post            = Mockery::mock( '\WP_Post' )->makePartial();
+		$post            = Mockery::mock( WP_Post::class )->makePartial();
 		$post->post_type = 'product';
 
 		$new_values = $this->instance->remove_meta_description_date( $original_values, $post );
@@ -101,7 +102,7 @@ class WooCommerce_Post_Edit_Test extends TestCase {
 			'author_name'         => 'Yoasie',
 		];
 
-		$post            = Mockery::mock( '\WP_Post' )->makePartial();
+		$post            = Mockery::mock( WP_Post::class )->makePartial();
 		$post->post_type = 'post';
 
 		$new_values = $this->instance->remove_meta_description_date( $original_values, $post );

--- a/tests/unit/integrations/watchers/indexable-post-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-post-watcher-test.php
@@ -5,6 +5,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Integrations\Watchers;
 use Brain\Monkey;
 use Exception;
 use Mockery;
+use WP_Post;
 use Yoast\WP\SEO\Builders\Indexable_Builder;
 use Yoast\WP\SEO\Builders\Indexable_Link_Builder;
 use Yoast\WP\SEO\Conditionals\Migrations_Conditional;
@@ -348,7 +349,7 @@ class Indexable_Post_Watcher_Test extends TestCase {
 			->expects( 'update_relations' )
 			->never();
 
-		$post                   = Mockery::mock( 'WP_Post' );
+		$post                   = Mockery::mock( WP_Post::class );
 		$indexable              = Mockery::mock( Indexable_Mock::class );
 		$indexable->object_type = 'term';
 

--- a/tests/unit/integrations/watchers/option-titles-watcher-test.php
+++ b/tests/unit/integrations/watchers/option-titles-watcher-test.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Integrations\Watchers;
 
 use Brain\Monkey;
 use Mockery;
+use wpdb;
 use Yoast\WP\SEO\Conditionals\Migrations_Conditional;
 use Yoast\WP\SEO\Integrations\Watchers\Option_Titles_Watcher;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
@@ -123,7 +124,7 @@ class Option_Titles_Watcher_Test extends TestCase {
 	 * @covers ::delete_ancestors
 	 */
 	public function test_check_option_with_ancestors_being_removed() {
-		$wpdb         = Mockery::mock();
+		$wpdb         = Mockery::mock( wpdb::class );
 		$wpdb->prefix = 'wp_';
 
 		$wpdb
@@ -194,7 +195,7 @@ class Option_Titles_Watcher_Test extends TestCase {
 	 * @covers ::delete_ancestors
 	 */
 	public function test_check_option_with_ancestors_not_being_removed() {
-		$wpdb         = Mockery::mock();
+		$wpdb         = Mockery::mock( wpdb::class );
 		$wpdb->prefix = 'wp_';
 
 		$wpdb

--- a/tests/unit/main-test.php
+++ b/tests/unit/main-test.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\SEO\Tests\Unit;
 
 use Brain\Monkey;
 use Mockery;
+use wpdb;
 use Yoast\WP\SEO\Integrations\Third_Party\Elementor;
 use Yoast\WP\SEO\Integrations\Watchers\Indexable_Category_Permalink_Watcher;
 use Yoast\WP\SEO\Integrations\Watchers\Indexable_Permalink_Watcher;
@@ -53,7 +54,7 @@ class Main_Test extends TestCase {
 		$this->instance->load();
 
 		global $wpdb;
-		$wpdb = Mockery::mock( '\wpdb' );
+		$wpdb = Mockery::mock( wpdb::class );
 	}
 
 	/**

--- a/tests/unit/presentations/indexable-presentation/canonical-test.php
+++ b/tests/unit/presentations/indexable-presentation/canonical-test.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Presentations\Indexable_Presentation;
 
 use Brain\Monkey;
 use Mockery;
+use WP;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
@@ -136,7 +137,7 @@ class Canonical_Test extends TestCase {
 	 * @covers ::generate_canonical
 	 */
 	public function test_with_permalink_on_attachment_page() {
-		$wp          = Mockery::mock();
+		$wp          = Mockery::mock( WP::class );
 		$wp->request = 'https://example.com/image';
 
 		$GLOBALS['wp'] = $wp;

--- a/tests/unit/presentations/indexable-term-archive-presentation/canonical-test.php
+++ b/tests/unit/presentations/indexable-term-archive-presentation/canonical-test.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Presentations\Indexable_Term_Archive_Presentat
 
 use Brain\Monkey;
 use Mockery;
+use WP_Query;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
@@ -227,7 +228,7 @@ class Canonical_Test extends TestCase {
 			$terms = [ 'term1', 'term2', 'term3' ];
 		}
 
-		$wp_query            = Mockery::mock( 'WP_Query' );
+		$wp_query            = Mockery::mock( WP_Query::class );
 		$wp_query->tax_query = (object) [
 			'queried_terms' => [
 				'my-taxonomy' => [

--- a/tests/unit/presentations/indexable-term-archive-presentation/robots-test.php
+++ b/tests/unit/presentations/indexable-term-archive-presentation/robots-test.php
@@ -3,6 +3,7 @@
 namespace Yoast\WP\SEO\Tests\Unit\Presentations\Indexable_Term_Archive_Presentation;
 
 use Mockery;
+use WP_Query;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
@@ -186,7 +187,7 @@ class Robots_Test extends TestCase {
 	 * Setup default WP_Query_Wrapper.
 	 */
 	private function setup_wp_query_wrapper() {
-		$wp_query = Mockery::mock( '\WP_Query' );
+		$wp_query = Mockery::mock( WP_Query::class );
 		$wp_query
 			->expects( 'get_queried_object' )
 			->zeroOrMoreTimes()

--- a/tests/unit/presenters/open-graph/image-presenter-test.php
+++ b/tests/unit/presenters/open-graph/image-presenter-test.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Presenters\Open_Graph;
 
 use Brain\Monkey;
 use Mockery;
+use WP;
 use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 use Yoast\WP\SEO\Presenters\Open_Graph\Image_Presenter;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
@@ -179,7 +180,7 @@ class Image_Presenter_Test extends TestCase {
 	 */
 	public function test_present_with_attachment_page() {
 		$this->stubEscapeFunctions();
-		$wp          = Mockery::mock();
+		$wp          = Mockery::mock( WP::class );
 		$wp->request = 'https://example.com/image';
 
 		$GLOBALS['wp'] = $wp;

--- a/tests/unit/repositories/indexable-hierarchy-repository-test.php
+++ b/tests/unit/repositories/indexable-hierarchy-repository-test.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Repositories;
 
 use Brain\Monkey\Functions;
 use Mockery;
+use wpdb;
 use Yoast\WP\Lib\ORM;
 use Yoast\WP\SEO\Builders\Indexable_Hierarchy_Builder;
 use Yoast\WP\SEO\Models\Indexable_Hierarchy;
@@ -226,7 +227,7 @@ class Indexable_Hierarchy_Repository_Test extends TestCase {
 	 * @covers ::query
 	 */
 	public function test_query() {
-		$wpdb         = Mockery::mock();
+		$wpdb         = Mockery::mock( wpdb::class );
 		$wpdb->prefix = 'wp_';
 
 		$GLOBALS['wpdb'] = $wpdb;

--- a/tests/unit/repositories/indexable-repository-test.php
+++ b/tests/unit/repositories/indexable-repository-test.php
@@ -309,7 +309,7 @@ class Indexable_Repository_Test extends TestCase {
 	 * @covers ::query
 	 */
 	public function test_query() {
-		$wpdb         = Mockery::mock();
+		$wpdb         = Mockery::mock( wpdb::class );
 		$wpdb->prefix = 'wp_';
 
 		$GLOBALS['wpdb'] = $wpdb;

--- a/tests/unit/routes/abstract-indexation-route-test.php
+++ b/tests/unit/routes/abstract-indexation-route-test.php
@@ -3,6 +3,7 @@
 namespace Yoast\WP\SEO\Tests\Unit\Routes;
 
 use Mockery;
+use WP_REST_Response;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Tests\Unit\Doubles\Routes\Abstract_Indexation_Route_Mock;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
@@ -26,8 +27,8 @@ class Abstract_Indexation_Route_Test extends TestCase {
 		$options_helper = Mockery::mock( Options_Helper::class );
 		$instance       = new Abstract_Indexation_Route_Mock( $options_helper );
 
-		Mockery::mock( 'overload:WP_REST_Response' );
+		Mockery::mock( 'overload:' . WP_REST_Response::class );
 
-		$this->assertInstanceOf( 'WP_Rest_Response', $instance->respond_with( [], 'https://example.org/next/url' ) );
+		$this->assertInstanceOf( WP_REST_Response::class, $instance->respond_with( [], 'https://example.org/next/url' ) );
 	}
 }

--- a/tests/unit/routes/alert-dismissal-route-test.php
+++ b/tests/unit/routes/alert-dismissal-route-test.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Routes;
 
 use Brain\Monkey;
 use Mockery;
+use WP_REST_Request;
 use Yoast\WP\SEO\Actions\Alert_Dismissal_Action;
 use Yoast\WP\SEO\Routes\Alert_Dismissal_Route;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
@@ -100,7 +101,7 @@ class Alert_Dismissal_Route_Test extends TestCase {
 	 * @covers ::dismiss
 	 */
 	public function test_dismiss() {
-		$request = Mockery::mock( 'WP_REST_Request', 'ArrayAccess' );
+		$request = Mockery::mock( WP_REST_Request::class, 'ArrayAccess' );
 		$request
 			->expects( 'offsetGet' )
 			->with( 'key' )

--- a/tests/unit/routes/alert-dismissal-route-test.php
+++ b/tests/unit/routes/alert-dismissal-route-test.php
@@ -5,6 +5,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Routes;
 use Brain\Monkey;
 use Mockery;
 use WP_REST_Request;
+use WP_REST_Response;
 use Yoast\WP\SEO\Actions\Alert_Dismissal_Action;
 use Yoast\WP\SEO\Routes\Alert_Dismissal_Route;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
@@ -112,11 +113,11 @@ class Alert_Dismissal_Route_Test extends TestCase {
 			->with( 'alert_key' )
 			->andReturn( true );
 
-		Mockery::mock( 'overload:WP_REST_Response' );
+		Mockery::mock( 'overload:' . WP_REST_Response::class );
 
 		$response = $this->instance->dismiss( $request );
 
-		$this->assertInstanceOf( 'WP_REST_Response', $response );
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
 	}
 
 	/**

--- a/tests/unit/routes/first-time-configuration-route-test.php
+++ b/tests/unit/routes/first-time-configuration-route-test.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Routes;
 
 use Brain\Monkey;
 use Mockery;
+use WP_REST_Request;
 use Yoast\WP\SEO\Actions\Configuration\First_Time_Configuration_Action;
 use Yoast\WP\SEO\Routes\First_Time_Configuration_Route;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
@@ -273,7 +274,7 @@ class First_Time_Configuration_Route_Test extends TestCase {
 	 * @param object $expected The expected result object.
 	 */
 	public function test_can_edit_user( $can_edit, $expected ) {
-		$request = Mockery::mock( 'WP_Rest_Request' );
+		$request = Mockery::mock( WP_REST_Request::class );
 		$request
 			->shouldReceive( 'get_param' )
 			->with( 'user_id' )

--- a/tests/unit/routes/importing-route-test.php
+++ b/tests/unit/routes/importing-route-test.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Routes;
 
 use Brain\Monkey;
 use Mockery;
+use WP_Error;
 use Yoast\WP\SEO\Actions\Importing\Aioseo\Aioseo_Posts_Importing_Action;
 use Yoast\WP\SEO\Actions\Importing\Importing_Action_Interface;
 use Yoast\WP\SEO\Routes\Importing_Route;
@@ -47,7 +48,7 @@ class Importing_Route_Test extends TestCase {
 	protected function set_up() {
 		parent::set_up();
 
-		Mockery::mock( '\WP_Error' );
+		Mockery::mock( WP_Error::class );
 
 		$this->importable_detector = Mockery::mock( Importable_Detector_Service::class );
 		$this->importers           = [

--- a/tests/unit/routes/importing-route-test.php
+++ b/tests/unit/routes/importing-route-test.php
@@ -5,6 +5,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Routes;
 use Brain\Monkey;
 use Mockery;
 use WP_Error;
+use WP_REST_Response;
 use Yoast\WP\SEO\Actions\Importing\Aioseo\Aioseo_Posts_Importing_Action;
 use Yoast\WP\SEO\Actions\Importing\Importing_Action_Interface;
 use Yoast\WP\SEO\Routes\Importing_Route;
@@ -114,7 +115,7 @@ class Importing_Route_Test extends TestCase {
 	 * @param string $expected_response The class of the expected response.
 	 */
 	public function test_execute_import_aioseo_posts( $plugin, $type, $is_enabled, $index_times, $expected_response ) {
-		Mockery::mock( 'overload:WP_REST_Response' );
+		Mockery::mock( 'overload:' . WP_REST_Response::class );
 
 
 		$this->importable_detector->expects( 'filter_actions' )

--- a/tests/unit/routes/indexables-head-route-test.php
+++ b/tests/unit/routes/indexables-head-route-test.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Routes;
 
 use Brain\Monkey;
 use Mockery;
+use WP_REST_Request;
 use Yoast\WP\SEO\Actions\Indexables\Indexable_Head_Action;
 use Yoast\WP\SEO\Conditionals\Headless_Rest_Endpoints_Enabled_Conditional;
 use Yoast\WP\SEO\Routes\Indexables_Head_Route;
@@ -103,7 +104,7 @@ class Indexables_Head_Route_Test extends TestCase {
 	public function test_get_head() {
 		$this->stubEscapeFunctions();
 
-		$request = Mockery::mock( 'WP_REST_Request', 'ArrayAccess' );
+		$request = Mockery::mock( WP_REST_Request::class, 'ArrayAccess' );
 		$request
 			->expects( 'offsetGet' )
 			->with( 'url' )

--- a/tests/unit/routes/indexables-head-route-test.php
+++ b/tests/unit/routes/indexables-head-route-test.php
@@ -5,6 +5,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Routes;
 use Brain\Monkey;
 use Mockery;
 use WP_REST_Request;
+use WP_REST_Response;
 use Yoast\WP\SEO\Actions\Indexables\Indexable_Head_Action;
 use Yoast\WP\SEO\Conditionals\Headless_Rest_Endpoints_Enabled_Conditional;
 use Yoast\WP\SEO\Routes\Indexables_Head_Route;
@@ -115,7 +116,7 @@ class Indexables_Head_Route_Test extends TestCase {
 			->with( 'https://example.org' )
 			->andReturn( (object) [ 'status' => 'yes' ] );
 
-		Mockery::mock( 'overload:WP_REST_Response' );
+		Mockery::mock( 'overload:' . WP_REST_Response::class );
 
 		Monkey\Functions\expect( 'utf8_uri_encode' )
 			->with( 'https://example.org' )

--- a/tests/unit/routes/indexables-page-route-test.php
+++ b/tests/unit/routes/indexables-page-route-test.php
@@ -6,6 +6,7 @@ use Brain\Monkey;
 use Mockery;
 use WP_Error;
 use WP_REST_Request;
+use WP_REST_Response;
 use Yoast\WP\SEO\Actions\Indexables_Page_Action;
 use Yoast\WP\SEO\Helpers\Indexables_Page_Helper;
 use Yoast\WP\SEO\Models\Indexable;
@@ -290,7 +291,7 @@ class Indexables_Page_Route_Test extends TestCase {
 			->once()
 			->andReturn( 20 );
 
-		$wp_rest_response_mock = Mockery::mock( 'overload:WP_REST_Response' );
+		$wp_rest_response_mock = Mockery::mock( 'overload:' . WP_REST_Response::class );
 		$wp_rest_response_mock
 			->expects( '__construct' )
 			->with(
@@ -330,7 +331,7 @@ class Indexables_Page_Route_Test extends TestCase {
 			->once()
 			->andReturn( 20 );
 
-		$wp_rest_response_mock = Mockery::mock( 'overload:WP_REST_Response' );
+		$wp_rest_response_mock = Mockery::mock( 'overload:' . WP_REST_Response::class );
 		$wp_rest_response_mock
 			->expects( '__construct' )
 			->with(
@@ -370,7 +371,7 @@ class Indexables_Page_Route_Test extends TestCase {
 			->once()
 			->andReturn( 20 );
 
-		$wp_rest_response_mock = Mockery::mock( 'overload:WP_REST_Response' );
+		$wp_rest_response_mock = Mockery::mock( 'overload:' . WP_REST_Response::class );
 		$wp_rest_response_mock
 			->expects( '__construct' )
 			->with(
@@ -410,7 +411,7 @@ class Indexables_Page_Route_Test extends TestCase {
 			->once()
 			->andReturn( 20 );
 
-		$wp_rest_response_mock = Mockery::mock( 'overload:WP_REST_Response' );
+		$wp_rest_response_mock = Mockery::mock( 'overload:' . WP_REST_Response::class );
 		$wp_rest_response_mock
 			->expects( '__construct' )
 			->with(
@@ -458,7 +459,7 @@ class Indexables_Page_Route_Test extends TestCase {
 			);
 
 		if ( $rest_response_type === 'WP_REST_Response' ) {
-			$wp_rest_response_mock = Mockery::mock( 'overload:WP_REST_Response' );
+			$wp_rest_response_mock = Mockery::mock( 'overload:' . WP_REST_Response::class );
 			$wp_rest_response_mock
 				->expects( '__construct' )
 				->with(
@@ -550,7 +551,7 @@ class Indexables_Page_Route_Test extends TestCase {
 			);
 
 		if ( $rest_response_type === 'WP_REST_Response' ) {
-			$wp_rest_response_mock = Mockery::mock( 'overload:WP_REST_Response' );
+			$wp_rest_response_mock = Mockery::mock( 'overload:' . WP_REST_Response::class );
 			$wp_rest_response_mock
 				->expects( '__construct' )
 				->with(

--- a/tests/unit/routes/indexables-page-route-test.php
+++ b/tests/unit/routes/indexables-page-route-test.php
@@ -5,6 +5,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Routes;
 use Brain\Monkey;
 use Mockery;
 use WP_Error;
+use WP_REST_Request;
 use Yoast\WP\SEO\Actions\Indexables_Page_Action;
 use Yoast\WP\SEO\Helpers\Indexables_Page_Helper;
 use Yoast\WP\SEO\Models\Indexable;
@@ -442,7 +443,7 @@ class Indexables_Page_Route_Test extends TestCase {
 	 * @param string $rest_response_type            The type of the response object, WP_REST_Response or WP_Error.
 	 */
 	public function test_ignore_indexables( $request_params, $indexable_action_params, $indexable_action_return_value, $params_rest_response, $rest_response_type ) {
-		$wp_rest_request = Mockery::mock( 'WP_REST_Request' );
+		$wp_rest_request = Mockery::mock( WP_REST_Request::class );
 		$wp_rest_request
 			->expects( 'get_json_params' )
 			->once()
@@ -534,7 +535,7 @@ class Indexables_Page_Route_Test extends TestCase {
 	 * @param string $rest_response_type            The type of the response object, WP_REST_Response or WP_Error.
 	 */
 	public function test_restore_indexables( $request_params, $indexable_action_params, $indexable_action_return_value, $params_rest_response, $rest_response_type ) {
-		$wp_rest_request = Mockery::mock( 'WP_REST_Request' );
+		$wp_rest_request = Mockery::mock( WP_REST_Request::class );
 		$wp_rest_request
 			->expects( 'get_json_params' )
 			->once()

--- a/tests/unit/routes/indexables-page-route-test.php
+++ b/tests/unit/routes/indexables-page-route-test.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Routes;
 
 use Brain\Monkey;
 use Mockery;
+use WP_Error;
 use Yoast\WP\SEO\Actions\Indexables_Page_Action;
 use Yoast\WP\SEO\Helpers\Indexables_Page_Helper;
 use Yoast\WP\SEO\Models\Indexable;
@@ -47,7 +48,7 @@ class Indexables_Page_Route_Test extends TestCase {
 	protected function set_up() {
 		parent::set_up();
 
-		Mockery::mock( '\WP_Error' );
+		Mockery::mock( WP_Error::class );
 
 		$this->indexable_action       = Mockery::mock( Indexables_Page_Action::class );
 		$this->indexables_page_helper = Mockery::mock( Indexables_Page_Helper::class );

--- a/tests/unit/routes/indexing-route-test.php
+++ b/tests/unit/routes/indexing-route-test.php
@@ -6,6 +6,7 @@ use Brain\Monkey;
 use Exception;
 use Mockery;
 use WP_Error;
+use WP_REST_Response;
 use Yoast\WP\SEO\Actions\Indexing\Indexable_General_Indexation_Action;
 use Yoast\WP\SEO\Actions\Indexing\Indexable_Indexing_Complete_Action;
 use Yoast\WP\SEO\Actions\Indexing\Indexable_Post_Indexation_Action;
@@ -330,9 +331,9 @@ class Indexing_Route_Test extends TestCase {
 			->with( 'yoast/v1/indexing/posts' )
 			->andReturnFirstArg();
 
-		Mockery::mock( 'overload:WP_REST_Response' );
+		Mockery::mock( 'overload:' . WP_REST_Response::class );
 
-		$this->assertInstanceOf( 'WP_Rest_Response', $this->instance->index_posts() );
+		$this->assertInstanceOf( WP_REST_Response::class, $this->instance->index_posts() );
 	}
 
 	/**
@@ -355,9 +356,9 @@ class Indexing_Route_Test extends TestCase {
 			->with( 'yoast/v1/indexing/terms' )
 			->andReturnFirstArg();
 
-		Mockery::mock( 'overload:WP_REST_Response' );
+		Mockery::mock( 'overload:' . WP_REST_Response::class );
 
-		$this->assertInstanceOf( 'WP_Rest_Response', $this->instance->index_terms() );
+		$this->assertInstanceOf( WP_REST_Response::class, $this->instance->index_terms() );
 	}
 
 	/**
@@ -380,9 +381,9 @@ class Indexing_Route_Test extends TestCase {
 			->with( 'yoast/v1/indexing/post-type-archives' )
 			->andReturnFirstArg();
 
-		Mockery::mock( 'overload:WP_REST_Response' );
+		Mockery::mock( 'overload:' . WP_REST_Response::class );
 
-		$this->assertInstanceOf( 'WP_Rest_Response', $this->instance->index_post_type_archives() );
+		$this->assertInstanceOf( WP_REST_Response::class, $this->instance->index_post_type_archives() );
 	}
 
 	/**
@@ -406,9 +407,9 @@ class Indexing_Route_Test extends TestCase {
 			->with( 'yoast/v1/indexing/general' )
 			->andReturnFirstArg();
 
-		Mockery::mock( 'overload:WP_REST_Response' );
+		Mockery::mock( 'overload:' . WP_REST_Response::class );
 
-		$this->assertInstanceOf( 'WP_Rest_Response', $this->instance->index_general() );
+		$this->assertInstanceOf( WP_REST_Response::class, $this->instance->index_general() );
 	}
 
 	/**
@@ -432,9 +433,9 @@ class Indexing_Route_Test extends TestCase {
 			->with( 'yoast/v1/link-indexing/posts' )
 			->andReturnFirstArg();
 
-		Mockery::mock( 'overload:WP_REST_Response' );
+		Mockery::mock( 'overload:' . WP_REST_Response::class );
 
-		$this->assertInstanceOf( 'WP_Rest_Response', $this->instance->index_post_links() );
+		$this->assertInstanceOf( WP_REST_Response::class, $this->instance->index_post_links() );
 	}
 
 	/**
@@ -458,9 +459,9 @@ class Indexing_Route_Test extends TestCase {
 			->with( 'yoast/v1/link-indexing/terms' )
 			->andReturnFirstArg();
 
-		Mockery::mock( 'overload:WP_REST_Response' );
+		Mockery::mock( 'overload:' . WP_REST_Response::class );
 
-		$this->assertInstanceOf( 'WP_Rest_Response', $this->instance->index_term_links() );
+		$this->assertInstanceOf( WP_REST_Response::class, $this->instance->index_term_links() );
 	}
 
 	/**

--- a/tests/unit/routes/indexing-route-test.php
+++ b/tests/unit/routes/indexing-route-test.php
@@ -5,6 +5,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Routes;
 use Brain\Monkey;
 use Exception;
 use Mockery;
+use WP_Error;
 use Yoast\WP\SEO\Actions\Indexing\Indexable_General_Indexation_Action;
 use Yoast\WP\SEO\Actions\Indexing\Indexable_Indexing_Complete_Action;
 use Yoast\WP\SEO\Actions\Indexing\Indexable_Post_Indexation_Action;
@@ -486,7 +487,7 @@ class Indexing_Route_Test extends TestCase {
 
 		$this->indexing_helper->expects( 'indexing_failed' )->withNoArgs();
 
-		Mockery::mock( '\WP_Error' );
+		Mockery::mock( WP_Error::class );
 
 		$this->instance->index_general();
 	}

--- a/tests/unit/routes/semrush-route-test.php
+++ b/tests/unit/routes/semrush-route-test.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Routes;
 
 use Brain\Monkey;
 use Mockery;
+use WP_REST_Request;
 use Yoast\WP\SEO\Actions\SEMrush\SEMrush_Login_Action;
 use Yoast\WP\SEO\Actions\SEMrush\SEMrush_Options_Action;
 use Yoast\WP\SEO\Actions\SEMrush\SEMrush_Phrases_Action;
@@ -219,7 +220,7 @@ class SEMrush_Route_Test extends TestCase {
 	 * @covers ::authenticate
 	 */
 	public function test_authenticate() {
-		$request = Mockery::mock( 'WP_REST_Request', 'ArrayAccess' );
+		$request = Mockery::mock( WP_REST_Request::class, 'ArrayAccess' );
 		$request
 			->expects( 'offsetGet' )
 			->with( 'code' )
@@ -241,7 +242,7 @@ class SEMrush_Route_Test extends TestCase {
 	 * @covers ::set_country_code_option
 	 */
 	public function test_country_code() {
-		$request = Mockery::mock( 'WP_REST_Request', 'ArrayAccess' );
+		$request = Mockery::mock( WP_REST_Request::class, 'ArrayAccess' );
 		$request
 			->expects( 'offsetGet' )
 			->with( 'country_code' )
@@ -263,7 +264,7 @@ class SEMrush_Route_Test extends TestCase {
 	 * @covers ::get_related_keyphrases
 	 */
 	public function test_get_related_keyphrases() {
-		$request = Mockery::mock( 'WP_REST_Request', 'ArrayAccess' );
+		$request = Mockery::mock( WP_REST_Request::class, 'ArrayAccess' );
 		$request
 			->expects( 'offsetGet' )
 			->with( 'keyphrase' )

--- a/tests/unit/routes/semrush-route-test.php
+++ b/tests/unit/routes/semrush-route-test.php
@@ -5,6 +5,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Routes;
 use Brain\Monkey;
 use Mockery;
 use WP_REST_Request;
+use WP_REST_Response;
 use Yoast\WP\SEO\Actions\SEMrush\SEMrush_Login_Action;
 use Yoast\WP\SEO\Actions\SEMrush\SEMrush_Options_Action;
 use Yoast\WP\SEO\Actions\SEMrush\SEMrush_Phrases_Action;
@@ -231,9 +232,9 @@ class SEMrush_Route_Test extends TestCase {
 			->with( '123456' )
 			->andReturn( (object) [ 'status' => '200' ] );
 
-		Mockery::mock( 'overload:WP_REST_Response' );
+		Mockery::mock( 'overload:' . WP_REST_Response::class );
 
-		$this->assertInstanceOf( 'WP_REST_Response', $this->instance->authenticate( $request ) );
+		$this->assertInstanceOf( WP_REST_Response::class, $this->instance->authenticate( $request ) );
 	}
 
 	/**
@@ -253,9 +254,9 @@ class SEMrush_Route_Test extends TestCase {
 			->with( 'nl' )
 			->andReturn( (object) [ 'status' => '200' ] );
 
-		Mockery::mock( 'overload:WP_REST_Response' );
+		Mockery::mock( 'overload:' . WP_REST_Response::class );
 
-		$this->assertInstanceOf( 'WP_REST_Response', $this->instance->set_country_code_option( $request ) );
+		$this->assertInstanceOf( WP_REST_Response::class, $this->instance->set_country_code_option( $request ) );
 	}
 
 	/**
@@ -280,8 +281,8 @@ class SEMrush_Route_Test extends TestCase {
 			->with( 'seo', 'us' )
 			->andReturn( (object) [ 'status' => '200' ] );
 
-		Mockery::mock( 'overload:WP_REST_Response' );
+		Mockery::mock( 'overload:' . WP_REST_Response::class );
 
-		$this->assertInstanceOf( 'WP_REST_Response', $this->instance->get_related_keyphrases( $request ) );
+		$this->assertInstanceOf( WP_REST_Response::class, $this->instance->get_related_keyphrases( $request ) );
 	}
 }

--- a/tests/unit/routes/supported-features-route-test.php
+++ b/tests/unit/routes/supported-features-route-test.php
@@ -72,7 +72,7 @@ class Supported_Features_Route_Test extends TestCase {
 	 * @covers ::get_supported_features
 	 */
 	public function test_get_supported_features() {
-		Mockery::mock( 'overload:WP_REST_Response' );
+		Mockery::mock( 'overload:' . WP_REST_Response::class );
 		$actual = $this->instance->get_supported_features();
 
 		$expected = new WP_REST_Response(
@@ -81,7 +81,7 @@ class Supported_Features_Route_Test extends TestCase {
 			]
 		);
 
-		$this->assertInstanceOf( 'WP_REST_Response', $actual );
+		$this->assertInstanceOf( WP_REST_Response::class, $actual );
 		$this->assertEquals( $expected, $actual );
 	}
 }

--- a/tests/unit/routes/wincher-route-test.php
+++ b/tests/unit/routes/wincher-route-test.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Routes;
 
 use Brain\Monkey;
 use Mockery;
+use WP_REST_Request;
 use Yoast\WP\SEO\Actions\Wincher\Wincher_Account_Action;
 use Yoast\WP\SEO\Actions\Wincher\Wincher_Keyphrases_Action;
 use Yoast\WP\SEO\Actions\Wincher\Wincher_Login_Action;
@@ -259,7 +260,7 @@ class Wincher_Route_Test extends TestCase {
 	 * @covers ::authenticate
 	 */
 	public function test_authenticate() {
-		$request = Mockery::mock( 'WP_REST_Request', 'ArrayAccess' );
+		$request = Mockery::mock( WP_REST_Request::class, 'ArrayAccess' );
 		$request
 			->expects( 'offsetGet' )
 			->with( 'code' )
@@ -293,7 +294,7 @@ class Wincher_Route_Test extends TestCase {
 			'status'    => 200,
 		];
 
-		$request = Mockery::mock( 'WP_REST_Request', 'ArrayAccess' );
+		$request = Mockery::mock( WP_REST_Request::class, 'ArrayAccess' );
 		$request
 			->expects( 'offsetGet' )
 			->with( 'keyphrases' )
@@ -322,7 +323,7 @@ class Wincher_Route_Test extends TestCase {
 	 * @covers ::get_tracked_keyphrases
 	 */
 	public function test_get_tracked_keyphrases() {
-		$request = Mockery::mock( 'WP_REST_Request', 'ArrayAccess' );
+		$request = Mockery::mock( WP_REST_Request::class, 'ArrayAccess' );
 		$request
 			->expects( 'offsetGet' )
 			->with( 'permalink' )
@@ -352,7 +353,7 @@ class Wincher_Route_Test extends TestCase {
 	 * @covers ::get_tracked_keyphrases
 	 */
 	public function test_get_tracked_keyphrases_without_permalink() {
-		$request = Mockery::mock( 'WP_REST_Request', 'ArrayAccess' );
+		$request = Mockery::mock( WP_REST_Request::class, 'ArrayAccess' );
 		$request
 			->expects( 'offsetGet' )
 			->with( 'permalink' )
@@ -382,7 +383,7 @@ class Wincher_Route_Test extends TestCase {
 	 * @covers ::untrack_keyphrase
 	 */
 	public function test_untrack_keyphrase() {
-		$request = Mockery::mock( 'WP_REST_Request', 'ArrayAccess' );
+		$request = Mockery::mock( WP_REST_Request::class, 'ArrayAccess' );
 		$request
 			->expects( 'offsetGet' )
 			->with( 'keyphraseID' )

--- a/tests/unit/routes/wincher-route-test.php
+++ b/tests/unit/routes/wincher-route-test.php
@@ -5,6 +5,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Routes;
 use Brain\Monkey;
 use Mockery;
 use WP_REST_Request;
+use WP_REST_Response;
 use Yoast\WP\SEO\Actions\Wincher\Wincher_Account_Action;
 use Yoast\WP\SEO\Actions\Wincher\Wincher_Keyphrases_Action;
 use Yoast\WP\SEO\Actions\Wincher\Wincher_Login_Action;
@@ -276,9 +277,9 @@ class Wincher_Route_Test extends TestCase {
 			->with( '123456', '123456' )
 			->andReturn( (object) [ 'status' => '200' ] );
 
-		Mockery::mock( 'overload:WP_REST_Response' );
+		Mockery::mock( 'overload:' . WP_REST_Response::class );
 
-		$this->assertInstanceOf( 'WP_REST_Response', $this->instance->authenticate( $request ) );
+		$this->assertInstanceOf( WP_REST_Response::class, $this->instance->authenticate( $request ) );
 	}
 
 	/**
@@ -312,9 +313,9 @@ class Wincher_Route_Test extends TestCase {
 			)
 			->andReturn( (object) [ 'status' => '200' ] );
 
-		Mockery::mock( 'overload:WP_REST_Response' );
+		Mockery::mock( 'overload:' . WP_REST_Response::class );
 
-		$this->assertInstanceOf( 'WP_REST_Response', $this->instance->track_keyphrases( $request ) );
+		$this->assertInstanceOf( WP_REST_Response::class, $this->instance->track_keyphrases( $request ) );
 	}
 
 	/**
@@ -342,9 +343,9 @@ class Wincher_Route_Test extends TestCase {
 			)
 			->andReturn( (object) [ 'status' => '200' ] );
 
-		Mockery::mock( 'overload:WP_REST_Response' );
+		Mockery::mock( 'overload:' . WP_REST_Response::class );
 
-		$this->assertInstanceOf( 'WP_REST_Response', $this->instance->get_tracked_keyphrases( $request ) );
+		$this->assertInstanceOf( WP_REST_Response::class, $this->instance->get_tracked_keyphrases( $request ) );
 	}
 
 	/**
@@ -372,9 +373,9 @@ class Wincher_Route_Test extends TestCase {
 			)
 			->andReturn( (object) [ 'status' => '200' ] );
 
-		Mockery::mock( 'overload:WP_REST_Response' );
+		Mockery::mock( 'overload:' . WP_REST_Response::class );
 
-		$this->assertInstanceOf( 'WP_REST_Response', $this->instance->get_tracked_keyphrases( $request ) );
+		$this->assertInstanceOf( WP_REST_Response::class, $this->instance->get_tracked_keyphrases( $request ) );
 	}
 
 	/**
@@ -399,7 +400,7 @@ class Wincher_Route_Test extends TestCase {
 				]
 			);
 
-		Mockery::mock( 'overload:WP_REST_Response' );
+		Mockery::mock( 'overload:' . WP_REST_Response::class );
 
 		$this->assertIsObject( $this->instance->untrack_keyphrase( $request ) );
 	}

--- a/tests/unit/services/importing/importable-detector-service-test.php
+++ b/tests/unit/services/importing/importable-detector-service-test.php
@@ -174,7 +174,7 @@ class Importable_Detector_Service_Test extends TestCase {
 		parent::set_up();
 
 		$this->indexable_repository   = Mockery::mock( Indexable_Repository::class );
-		$this->wpdb                   = Mockery::mock( 'wpdb' );
+		$this->wpdb                   = Mockery::mock( wpdb::class );
 		$this->import_cursor          = Mockery::mock( Import_Cursor_Helper::class );
 		$this->aioseo_helper          = Mockery::mock( Aioseo_Helper::class );
 		$this->meta                   = Mockery::mock( Meta_Helper::class );

--- a/tests/unit/surfaces/meta-surface-test.php
+++ b/tests/unit/surfaces/meta-surface-test.php
@@ -5,6 +5,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Surfaces;
 use Brain\Monkey;
 use Brain\Monkey\Filters;
 use Mockery;
+use WP_Rewrite;
 use Yoast\WP\SEO\Helpers\Indexable_Helper;
 use Yoast\WP\SEO\Memoizers\Meta_Tags_Context_Memoizer;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
@@ -437,7 +438,7 @@ class Meta_Surface_Test extends TestCase {
 	 * @param bool   $is_date_archive Optional. Whether the page is a date archive. Defaults to false.
 	 */
 	public function test_for_url( $object_type, $object_sub_type, $object_id, $page_type, $is_date_archive = false ) {
-		$wp_rewrite = Mockery::mock( 'WP_Rewrite' );
+		$wp_rewrite = Mockery::mock( WP_Rewrite::class );
 
 		Monkey\Functions\expect( 'wp_parse_url' )
 			->times( 3 )


### PR DESCRIPTION
## Context

* Improved PHP 8.2 compatibility (tests only)

## Summary

This PR can be summarized in the following changelog entry:

* Improved PHP 8.2 compatibility (tests only)

## Relevant technical choices:

### Tests: use named mocks for WP native classes / WP_Query

* Add class name into the call to Mockery if the name was missing.
* Add import `use` statement if it was missing.
* Use class name resolution via the `::class` constant.
* Create test double from within the test bootstrap.

### Tests: use named mocks for WP native classes / WP_User

* Add class name into the call to Mockery if the name was missing.
* Add import `use` statement if it was missing.
* Use class name resolution via the `::class` constant.
* Create test double from within the test bootstrap.

### Tests: use named mocks for WP native classes / WP_Post

* Add class name into the call to Mockery if the name was missing.
* Add import `use` statement if it was missing.
* Use class name resolution via the `::class` constant.
* Create test double from within the test bootstrap.

### Tests: use named mocks for WP native classes / wpdb

* Add class name into the call to Mockery if the name was missing.
* Add import `use` statement if it was missing.
* Use class name resolution via the `::class` constant.
* Create test double from within the test bootstrap.

### Tests: use named mocks for WP native classes / WP_Roles

* Add class name into the call to Mockery if the name was missing.
* Add import `use` statement if it was missing.
* Use class name resolution via the `::class` constant.
* Create test double from within the test bootstrap.

### Tests: use named mocks for WP native classes / WP_Term

* Add class name into the call to Mockery if the name was missing.
* Add import `use` statement if it was missing.
* Use class name resolution via the `::class` constant.
* Create test double from within the test bootstrap.

### Tests: use named mocks for WP native classes / WP_Error

* Add class name into the call to Mockery if the name was missing.
* Add import `use` statement if it was missing.
* Use class name resolution via the `::class` constant.

Note: no "double" is added as no properties are being set on the class either by the tests or by the code under test.

### Tests: use named mocks for WP native classes / WP_Rewrite

* Add class name into the call to Mockery if the name was missing.
* Add import `use` statement if it was missing.
* Use class name resolution via the `::class` constant.
* Create test double from within the test bootstrap.

### Tests: use named mocks for WP native classes / WP

* Add class name into the call to Mockery if the name was missing.
* Add import `use` statement if it was missing.
* Use class name resolution via the `::class` constant.
* Create test double from within the test bootstrap.

### Tests: use named mocks for WP native classes / WP_REST_Request

* Add class name into the call to Mockery if the name was missing.
* Add import `use` statement if it was missing.
* Use class name resolution via the `::class` constant.

Note: no "double" is added as no properties are being set on the class either by the tests or by the code under test.

### Tests: use named mocks for WP native classes / WP_REST_Response

* Add class name into the call to Mockery if the name was missing.
* Add import `use` statement if it was missing.
* Use class name resolution via the `::class` constant.

Note: no "double" is added as the class uses `Mockery:mock()` with `overload:`.
See: http://docs.mockery.io/en/latest/reference/creating_test_doubles.html#overloading


## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_ This is a docs/test only change, if the build passes, we're good.