### PR TITLE
Tests: use named mocks for WP_CLI native classes

### DIFF
--- a/tests/unit/commands/index-command-test.php
+++ b/tests/unit/commands/index-command-test.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Commands;
 
 use Brain\Monkey;
 use Mockery;
+use WP_CLI;
 use wpdb;
 use Yoast\WP\SEO\Actions\Indexing\Indexable_General_Indexation_Action;
 use Yoast\WP\SEO\Actions\Indexing\Indexable_Indexing_Complete_Action;
@@ -227,7 +228,7 @@ class Index_Command_Test extends TestCase {
 		$progress_bar_mock->expects( 'tick' )->times( 6 )->with( 5 );
 		$progress_bar_mock->expects( 'finish' )->times( 6 );
 
-		$cli = Mockery::mock( 'overload:WP_CLI' );
+		$cli = Mockery::mock( 'overload:' . WP_CLI::class );
 		$cli
 			->expects( 'confirm' )
 			->with( 'This will clear all previously indexed objects. Are you certain you wish to proceed?' );

--- a/tests/unit/commands/index-command-test.php
+++ b/tests/unit/commands/index-command-test.php
@@ -3,6 +3,7 @@
 namespace Yoast\WP\SEO\Tests\Unit\Commands;
 
 use Brain\Monkey;
+use cli\progress\Bar;
 use Mockery;
 use WP_CLI;
 use wpdb;
@@ -174,7 +175,7 @@ class Index_Command_Test extends TestCase {
 
 		$this->complete_indexation_action->expects( 'complete' )->once();
 
-		$progress_bar_mock = Mockery::mock( 'cli\progress\Bar' );
+		$progress_bar_mock = Mockery::mock( Bar::class );
 		Monkey\Functions\expect( '\WP_CLI\Utils\make_progress_bar' )
 			->times( 6 )
 			->with( Mockery::type( 'string' ), 30 )
@@ -217,7 +218,7 @@ class Index_Command_Test extends TestCase {
 
 		$this->prepare_indexing_action->expects( 'prepare' )->once();
 
-		$progress_bar_mock = Mockery::mock( 'cli\progress\Bar' );
+		$progress_bar_mock = Mockery::mock( Bar::class );
 		Monkey\Functions\expect( '\WP_CLI\Utils\make_progress_bar' )
 			->times( 6 )
 			->with( Mockery::type( 'string' ), 30 )
@@ -330,7 +331,7 @@ class Index_Command_Test extends TestCase {
 		$this->complete_indexation_action->expects( 'complete' )->twice();
 		$this->prepare_indexing_action->expects( 'prepare' )->twice();
 
-		$progress_bar_mock = Mockery::mock( 'cli\progress\Bar' );
+		$progress_bar_mock = Mockery::mock( Bar::class );
 		Monkey\Functions\expect( '\WP_CLI\Utils\make_progress_bar' )
 			->times( 12 )
 			->with( Mockery::type( 'string' ), 30 )


### PR DESCRIPTION
## Context

* Improved PHP 8.2 compatibility (tests only)

## Summary

This PR can be summarized in the following changelog entry:

* Improved PHP 8.2 compatibility (tests only)

## Relevant technical choices:

### Tests: use named mocks for WP_CLI native classes / WP_CLI

* Add class name into the call to Mockery if the name was missing.
* Add import `use` statement if it was missing.
* Use class name resolution via the `::class` constant

Note: no "double" is added as the class uses `Mockery:mock()` with `overload:`.
See: http://docs.mockery.io/en/latest/reference/creating_test_doubles.html#overloading

### Tests: use named mocks for WP_CLI native classes / cli\progress\Bar

* Add class name into the call to Mockery if the name was missing.
* Add import `use` statement if it was missing.
* Use class name resolution via the `::class` constant

Note: no "double" is added as no properties are being set on the class either by the tests or by the code under test.


## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_ This is a docs/test only change, if the build passes, we're good.