### PR TITLE
PHP 8.2 | Abstract_Main and surface helpers: Fix use of dynamic properties 

### DIFF
--- a/lib/abstract-main.php
+++ b/lib/abstract-main.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\Lib;
 
 use Exception;
 use Yoast\WP\Lib\Dependency_Injection\Container_Registry;
+use Yoast\WP\SEO\Exceptions\Forbidden_Property_Mutation_Exception;
 use Yoast\WP\SEO\Loader;
 use YoastSEO_Vendor\Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -18,6 +19,13 @@ abstract class Abstract_Main {
 	 * @var ContainerInterface|null
 	 */
 	protected $container;
+
+	/**
+	 * A cache for previously requested and constructed surfaces.
+	 *
+	 * @var mixed[]
+	 */
+	private $cached_surfaces = [];
 
 	/**
 	 * Loads the plugin.
@@ -50,23 +58,27 @@ abstract class Abstract_Main {
 	}
 
 	/**
-	 * Magic getter for retrieving a property.
+	 * Magic getter for retrieving a property from a surface.
 	 *
 	 * @param string $property The property to retrieve.
 	 *
-	 * @return string The value of the property.
+	 * @return mixed The value of the property.
 	 *
 	 * @throws Exception When the property doesn't exist.
 	 */
 	public function __get( $property ) {
+		if ( \array_key_exists( $property, $this->cached_surfaces ) ) {
+			return $this->cached_surfaces[ $property ];
+		}
+
 		$surfaces = $this->get_surfaces();
 
 		if ( isset( $surfaces[ $property ] ) ) {
-			$this->{$property} = $this->container->get( $surfaces[ $property ] );
+			$this->cached_surfaces[ $property ] = $this->container->get( $surfaces[ $property ] );
 
-			return $this->{$property};
+			return $this->cached_surfaces[ $property ];
 		}
-		throw new Exception( "Property $property does not exist." );
+		throw new Exception( sprintf( 'Property $%s does not exist.', $property ) );
 	}
 
 	/**
@@ -77,7 +89,46 @@ abstract class Abstract_Main {
 	 * @return bool True when property is set.
 	 */
 	public function __isset( $property ) {
-		return isset( $this->surfaces[ $property ] );
+		if ( \array_key_exists( $property, $this->cached_surfaces ) ) {
+			return true;
+		}
+
+		$surfaces = $this->get_surfaces();
+
+		if ( ! isset( $surfaces[ $property ] ) ) {
+			return false;
+		}
+
+		return $this->container->has( $surfaces[ $property ] );
+	}
+
+	/**
+	 * Prevents setting dynamic properties and unsetting declared properties
+	 * from an inaccessible context.
+	 *
+	 * @param string $name  The property name.
+	 * @param mixed  $value The property value.
+	 *
+	 * @return void
+	 *
+	 * @throws Forbidden_Property_Mutation_Exception Set is never meant to be called.
+	 */
+	public function __set( $name, $value ) { // @phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- __set must have a name and value.
+		throw Forbidden_Property_Mutation_Exception::cannot_set_because_property_is_immutable( $name );
+	}
+
+	/**
+	 * Prevents unsetting dynamic properties and unsetting declared properties
+	 * from an inaccessible context.
+	 *
+	 * @param string $name The property name.
+	 *
+	 * @return void
+	 *
+	 * @throws Forbidden_Property_Mutation_Exception Unset is never meant to be called.
+	 */
+	public function __unset( $name ) {
+		throw Forbidden_Property_Mutation_Exception::cannot_unset_because_property_is_immutable( $name );
 	}
 
 	/**

--- a/src/exceptions/forbidden-property-mutation-exception.php
+++ b/src/exceptions/forbidden-property-mutation-exception.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Yoast\WP\SEO\Exceptions;
+
+use RuntimeException;
+
+/**
+ * Exception for attempting a mutation on properties that are made readonly through magic getters and setters.
+ */
+class Forbidden_Property_Mutation_Exception extends RuntimeException {
+
+	/**
+	 * Creates a Forbidden_Property_Mutation_Exception exception when an attempt is made
+	 * to assign a value to an immutable property.
+	 *
+	 * @param string $property_name The name of the immutable property.
+	 *
+	 * @return Forbidden_Property_Mutation_Exception The exception.
+	 */
+	public static function cannot_set_because_property_is_immutable( $property_name ) {
+		return new self( \sprintf( 'Setting property $%s is not supported.', $property_name ) );
+	}
+
+	/**
+	 * Creates a Forbidden_Property_Mutation_Exception exception when an attempt is made to unset an immutable property.
+	 *
+	 * @param string $property_name The name of the immutable property.
+	 *
+	 * @return Forbidden_Property_Mutation_Exception The exception.
+	 */
+	public static function cannot_unset_because_property_is_immutable( $property_name ) {
+		return new self( \sprintf( 'Unsetting property $%s is not supported.', $property_name ) );
+	}
+}

--- a/src/surfaces/helpers-surface.php
+++ b/src/surfaces/helpers-surface.php
@@ -119,7 +119,8 @@ class Helpers_Surface {
 	}
 
 	/**
-	 * Prevents setting dynamic properties.
+	 * Prevents setting dynamic properties and unsetting declared properties
+	 * from an inaccessible context.
 	 *
 	 * @param string $name  The property name.
 	 * @param mixed  $value The property value.
@@ -133,7 +134,8 @@ class Helpers_Surface {
 	}
 
 	/**
-	 * Prevents unsetting dynamic properties.
+	 * Prevents unsetting dynamic properties and unsetting declared properties
+	 * from an inaccessible context.
 	 *
 	 * @param string $name The property name.
 	 *

--- a/src/surfaces/helpers-surface.php
+++ b/src/surfaces/helpers-surface.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\WP\SEO\Surfaces;
 
+use Yoast\WP\SEO\Exceptions\Forbidden_Property_Mutation_Exception;
 use Yoast\WP\SEO\Helpers;
 use YoastSEO_Vendor\Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -111,10 +112,37 @@ class Helpers_Surface {
 	 *
 	 * @param string $helper The helper to get.
 	 *
-	 * @return bool The helper class.
+	 * @return bool Whether the helper exists.
 	 */
 	public function __isset( $helper ) {
 		return $this->container->has( $this->get_helper_class( $helper ) );
+	}
+
+	/**
+	 * Prevents setting dynamic properties.
+	 *
+	 * @param string $name  The property name.
+	 * @param mixed  $value The property value.
+	 *
+	 * @return void
+	 *
+	 * @throws Forbidden_Property_Mutation_Exception Set is never meant to be called.
+	 */
+	public function __set( $name, $value ) { // @phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- __set must have a name and value.
+		throw Forbidden_Property_Mutation_Exception::cannot_set_because_property_is_immutable( $name );
+	}
+
+	/**
+	 * Prevents unsetting dynamic properties.
+	 *
+	 * @param string $name The property name.
+	 *
+	 * @return void
+	 *
+	 * @throws Forbidden_Property_Mutation_Exception Unset is never meant to be called.
+	 */
+	public function __unset( $name ) {
+		throw Forbidden_Property_Mutation_Exception::cannot_unset_because_property_is_immutable( $name );
 	}
 
 	/**

--- a/src/surfaces/open-graph-helpers-surface.php
+++ b/src/surfaces/open-graph-helpers-surface.php
@@ -54,7 +54,8 @@ class Open_Graph_Helpers_Surface {
 	}
 
 	/**
-	 * Prevents setting dynamic properties.
+	 * Prevents setting dynamic properties and unsetting declared properties
+	 * from an inaccessible context.
 	 *
 	 * @param string $name  The property name.
 	 * @param mixed  $value The property value.
@@ -68,7 +69,8 @@ class Open_Graph_Helpers_Surface {
 	}
 
 	/**
-	 * Prevents unsetting dynamic properties.
+	 * Prevents unsetting dynamic properties and unsetting declared properties
+	 * from an inaccessible context.
 	 *
 	 * @param string $name The property name.
 	 *

--- a/src/surfaces/open-graph-helpers-surface.php
+++ b/src/surfaces/open-graph-helpers-surface.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\WP\SEO\Surfaces;
 
+use Yoast\WP\SEO\Exceptions\Forbidden_Property_Mutation_Exception;
 use Yoast\WP\SEO\Helpers\Open_Graph;
 use YoastSEO_Vendor\Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -46,10 +47,37 @@ class Open_Graph_Helpers_Surface {
 	 *
 	 * @param string $helper The helper to get.
 	 *
-	 * @return bool The helper class.
+	 * @return bool Whether the helper exists.
 	 */
 	public function __isset( $helper ) {
 		return $this->container->has( $this->get_helper_class( $helper ) );
+	}
+
+	/**
+	 * Prevents setting dynamic properties.
+	 *
+	 * @param string $name  The property name.
+	 * @param mixed  $value The property value.
+	 *
+	 * @return void
+	 *
+	 * @throws Forbidden_Property_Mutation_Exception Set is never meant to be called.
+	 */
+	public function __set( $name, $value ) { // @phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- __set must have a name and value.
+		throw Forbidden_Property_Mutation_Exception::cannot_set_because_property_is_immutable( $name );
+	}
+
+	/**
+	 * Prevents unsetting dynamic properties.
+	 *
+	 * @param string $name The property name.
+	 *
+	 * @return void
+	 *
+	 * @throws Forbidden_Property_Mutation_Exception Unset is never meant to be called.
+	 */
+	public function __unset( $name ) {
+		throw Forbidden_Property_Mutation_Exception::cannot_unset_because_property_is_immutable( $name );
 	}
 
 	/**

--- a/src/surfaces/schema-helpers-surface.php
+++ b/src/surfaces/schema-helpers-surface.php
@@ -65,7 +65,8 @@ class Schema_Helpers_Surface {
 	}
 
 	/**
-	 * Prevents setting dynamic properties.
+	 * Prevents setting dynamic properties and unsetting declared properties
+	 * from an inaccessible context.
 	 *
 	 * @param string $name  The property name.
 	 * @param mixed  $value The property value.
@@ -79,7 +80,8 @@ class Schema_Helpers_Surface {
 	}
 
 	/**
-	 * Prevents unsetting dynamic properties.
+	 * Prevents unsetting dynamic properties and unsetting declared properties
+	 * from an inaccessible context.
 	 *
 	 * @param string $name The property name.
 	 *

--- a/src/surfaces/schema-helpers-surface.php
+++ b/src/surfaces/schema-helpers-surface.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\WP\SEO\Surfaces;
 
+use Yoast\WP\SEO\Exceptions\Forbidden_Property_Mutation_Exception;
 use Yoast\WP\SEO\Helpers\Schema;
 use YoastSEO_Vendor\Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -57,10 +58,37 @@ class Schema_Helpers_Surface {
 	 *
 	 * @param string $helper The helper to get.
 	 *
-	 * @return bool The helper class.
+	 * @return bool Whether the helper exists.
 	 */
 	public function __isset( $helper ) {
 		return $this->container->has( $this->get_helper_class( $helper ) );
+	}
+
+	/**
+	 * Prevents setting dynamic properties.
+	 *
+	 * @param string $name  The property name.
+	 * @param mixed  $value The property value.
+	 *
+	 * @return void
+	 *
+	 * @throws Forbidden_Property_Mutation_Exception Set is never meant to be called.
+	 */
+	public function __set( $name, $value ) { // @phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- __set must have a name and value.
+		throw Forbidden_Property_Mutation_Exception::cannot_set_because_property_is_immutable( $name );
+	}
+
+	/**
+	 * Prevents unsetting dynamic properties.
+	 *
+	 * @param string $name The property name.
+	 *
+	 * @return void
+	 *
+	 * @throws Forbidden_Property_Mutation_Exception Unset is never meant to be called.
+	 */
+	public function __unset( $name ) {
+		throw Forbidden_Property_Mutation_Exception::cannot_unset_because_property_is_immutable( $name );
 	}
 
 	/**

--- a/src/surfaces/twitter-helpers-surface.php
+++ b/src/surfaces/twitter-helpers-surface.php
@@ -54,7 +54,8 @@ class Twitter_Helpers_Surface {
 	}
 
 	/**
-	 * Prevents setting dynamic properties.
+	 * Prevents setting dynamic properties and unsetting declared properties
+	 * from an inaccessible context.
 	 *
 	 * @param string $name  The property name.
 	 * @param mixed  $value The property value.
@@ -68,7 +69,8 @@ class Twitter_Helpers_Surface {
 	}
 
 	/**
-	 * Prevents unsetting dynamic properties.
+	 * Prevents unsetting dynamic properties and unsetting declared properties
+	 * from an inaccessible context.
 	 *
 	 * @param string $name The property name.
 	 *

--- a/src/surfaces/twitter-helpers-surface.php
+++ b/src/surfaces/twitter-helpers-surface.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\WP\SEO\Surfaces;
 
+use Yoast\WP\SEO\Exceptions\Forbidden_Property_Mutation_Exception;
 use Yoast\WP\SEO\Helpers\Twitter;
 use YoastSEO_Vendor\Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -46,10 +47,37 @@ class Twitter_Helpers_Surface {
 	 *
 	 * @param string $helper The helper to get.
 	 *
-	 * @return bool The helper class.
+	 * @return bool Whether the helper exists.
 	 */
 	public function __isset( $helper ) {
 		return $this->container->has( $this->get_helper_class( $helper ) );
+	}
+
+	/**
+	 * Prevents setting dynamic properties.
+	 *
+	 * @param string $name  The property name.
+	 * @param mixed  $value The property value.
+	 *
+	 * @return void
+	 *
+	 * @throws Forbidden_Property_Mutation_Exception Set is never meant to be called.
+	 */
+	public function __set( $name, $value ) { // @phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- __set must have a name and value.
+		throw Forbidden_Property_Mutation_Exception::cannot_set_because_property_is_immutable( $name );
+	}
+
+	/**
+	 * Prevents unsetting dynamic properties.
+	 *
+	 * @param string $name The property name.
+	 *
+	 * @return void
+	 *
+	 * @throws Forbidden_Property_Mutation_Exception Unset is never meant to be called.
+	 */
+	public function __unset( $name ) {
+		throw Forbidden_Property_Mutation_Exception::cannot_unset_because_property_is_immutable( $name );
 	}
 
 	/**

--- a/tests/unit/TestCase.php
+++ b/tests/unit/TestCase.php
@@ -4,7 +4,14 @@ namespace Yoast\WP\SEO\Tests\Unit;
 
 use Brain\Monkey;
 use WPSEO_Options;
+use Yoast\WP\SEO\Surfaces\Classes_Surface;
+use Yoast\WP\SEO\Surfaces\Helpers_Surface;
+use Yoast\WP\SEO\Surfaces\Open_Graph_Helpers_Surface;
+use Yoast\WP\SEO\Surfaces\Schema_Helpers_Surface;
+use Yoast\WP\SEO\Surfaces\Twitter_Helpers_Surface;
 use Yoast\WPTestUtils\BrainMonkey\YoastTestCase;
+use YoastSEO_Vendor\Symfony\Component\DependencyInjection\Container;
+use YoastSEO_Vendor\Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * TestCase base class.
@@ -27,7 +34,7 @@ abstract class TestCase extends YoastTestCase {
 		Monkey\Functions\stubs(
 			[
 				// Null makes it so the function returns its first argument.
-				'is_admin'             => false,
+				'is_admin' => false,
 			]
 		);
 
@@ -43,5 +50,56 @@ abstract class TestCase extends YoastTestCase {
 
 		// This is required to ensure backfill and other statics are set.
 		WPSEO_Options::get_instance();
+	}
+
+	/**
+	 * Create a container.
+	 *
+	 * @param array $services The services to make available in the container as key-value pairs. The key of this should
+	 *                        be the classname of the service to expose or an identifier used in rare cases. The value is
+	 *                        the instance that you want to make available for the key in the DI container.
+	 *
+	 * @return ContainerInterface
+	 */
+	protected function create_container_with( $services = [] ) {
+		$container = new Container();
+		foreach ( $services as $classname_or_id => $service ) {
+			$container->set( $classname_or_id, $service );
+		}
+
+		return $container;
+	}
+
+	/**
+	 * Constructs a helper_surface that accepts a (mocked) containerInterface.
+	 * This exists, so you don't have to mock the surface (which is part of our system),
+	 * but allows for easily changing the services within the surfaces by mocking the container
+	 * (which is not part of our system) instead.
+	 *
+	 * @param ContainerInterface $container The container to use in the surface and its children.
+	 *
+	 * @return Helpers_Surface The helpers surface instance.
+	 */
+	protected function create_helper_surface( ContainerInterface $container ) {
+		return new Helpers_Surface(
+			$container,
+			new Open_Graph_Helpers_Surface( $container ),
+			new Schema_Helpers_Surface( $container ),
+			new Twitter_Helpers_Surface( $container )
+		);
+	}
+
+	/**
+	 * Constructs a classes_surface that accepts a (mocked) containerInterface.
+	 * This exists, so you don't have to mock the surface (which is part of our system),
+	 * but allows for easily changing the services within the surfaces by mocking the container
+	 * (which is not part of our system) instead.
+	 *
+	 * @param ContainerInterface $container The container to use in the surface and its children.
+	 *
+	 * @return Classes_Surface The helpers surface instance.
+	 */
+	protected function create_classes_surface( ContainerInterface $container ) {
+		return new Classes_Surface( $container );
 	}
 }

--- a/tests/unit/admin/admin-features-test.php
+++ b/tests/unit/admin/admin-features-test.php
@@ -9,7 +9,7 @@ use WPSEO_Admin;
 use WPSEO_Primary_Term_Admin;
 use Yoast\WP\SEO\Helpers\Current_Page_Helper;
 use Yoast\WP\SEO\Helpers\Product_Helper;
-use Yoast\WP\SEO\Surfaces\Helpers_Surface;
+use Yoast\WP\SEO\Helpers\Url_Helper;
 use Yoast\WP\SEO\Tests\Unit\Doubles\Shortlinker_Double;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 use Yoast_Dashboard_Widget;
@@ -58,16 +58,21 @@ class Admin_Features_Test extends TestCase {
 
 		$product_helper = Mockery::mock( Product_Helper::class );
 		$product_helper->expects( 'is_premium' )->times( 5 )->andReturn( false );
+
 		$url_helper = Mockery::mock( Url_Helper::class );
 		$url_helper->expects( 'is_plugin_network_active' )->twice()->andReturn( false );
 
-		$helper_surface               = Mockery::mock( Helpers_Surface::class );
-		$helper_surface->current_page = $current_page_helper;
-		$helper_surface->product      = $product_helper;
-		$helper_surface->url          = $url_helper;
+		$container = $this->create_container_with(
+			[
+				Current_Page_Helper::class => $current_page_helper,
+				Product_Helper::class      => $product_helper,
+				Url_Helper::class          => $url_helper,
+			]
+		);
 
 		Monkey\Functions\expect( 'YoastSEO' )
-			->andReturn( (object) [ 'helpers' => $helper_surface ] );
+			->times( 8 )
+			->andReturn( (object) [ 'helpers' => $this->create_helper_surface( $container ) ] );
 	}
 
 	/**

--- a/tests/unit/admin/tracking/tracking-test.php
+++ b/tests/unit/admin/tracking/tracking-test.php
@@ -7,7 +7,6 @@ use Mockery;
 use WPSEO_Options;
 use WPSEO_Tracking;
 use Yoast\WP\SEO\Helpers\Environment_Helper;
-use Yoast\WP\SEO\Surfaces\Helpers_Surface;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
@@ -34,11 +33,10 @@ class WPSEO_Tracking_Test extends TestCase {
 		$environment_helper = Mockery::mock( Environment_Helper::class );
 		$environment_helper->expects( 'is_production_mode' )->once()->andReturn( false );
 
-		$helper_surface              = Mockery::mock( Helpers_Surface::class );
-		$helper_surface->environment = $environment_helper;
+		$container = $this->create_container_with( [ Environment_Helper::class => $environment_helper ] );
 
 		Monkey\Functions\expect( 'YoastSEO' )
-			->andReturn( (object) [ 'helpers' => $helper_surface ] );
+			->andReturn( (object) [ 'helpers' => $this->create_helper_surface( $container ) ] );
 
 		$instance = new WPSEO_Tracking( 'https://tracking.yoast.com/stats', ( \WEEK_IN_SECONDS * 2 ) );
 
@@ -65,11 +63,10 @@ class WPSEO_Tracking_Test extends TestCase {
 		$environment_helper = Mockery::mock( Environment_Helper::class );
 		$environment_helper->expects( 'is_production_mode' )->once()->andReturn( true );
 
-		$helper_surface              = Mockery::mock( Helpers_Surface::class );
-		$helper_surface->environment = $environment_helper;
+		$container = $this->create_container_with( [ Environment_Helper::class => $environment_helper ] );
 
 		Monkey\Functions\expect( 'YoastSEO' )
-			->andReturn( (object) [ 'helpers' => $helper_surface ] );
+			->andReturn( (object) [ 'helpers' => $this->create_helper_surface( $container ) ] );
 
 		$instance = new WPSEO_Tracking( 'https://tracking.yoast.com/stats', ( \WEEK_IN_SECONDS * 2 ) );
 

--- a/tests/unit/admin/views/feature-toggles-test.php
+++ b/tests/unit/admin/views/feature-toggles-test.php
@@ -111,8 +111,11 @@ class Yoast_Feature_Toggles_Test extends TestCase {
 		$product_helper_mock = Mockery::mock( Product_Helper::class );
 		$product_helper_mock->expects( 'is_premium' )->once()->andReturn( false );
 
-		$helpers_mock = (object) [ 'product' => $product_helper_mock ];
-		Functions\expect( 'YoastSEO' )->once()->andReturn( (object) [ 'helpers' => $helpers_mock ] );
+		$container = $this->create_container_with( [ Product_Helper::class => $product_helper_mock ] );
+
+		Functions\expect( 'YoastSEO' )
+			->once()
+			->andReturn( (object) [ 'helpers' => $this->create_helper_surface( $container ) ] );
 
 		$instance = new Yoast_Feature_Toggles();
 		$result   = $instance->get_all();
@@ -175,8 +178,11 @@ class Yoast_Feature_Toggles_Test extends TestCase {
 		$product_helper_mock = Mockery::mock( Product_Helper::class );
 		$product_helper_mock->expects( 'is_premium' )->once()->andReturn( false );
 
-		$helpers_mock = (object) [ 'product' => $product_helper_mock ];
-		Functions\expect( 'YoastSEO' )->once()->andReturn( (object) [ 'helpers' => $helpers_mock ] );
+		$container = $this->create_container_with( [ Product_Helper::class => $product_helper_mock ] );
+
+		Functions\expect( 'YoastSEO' )
+			->once()
+			->andReturn( (object) [ 'helpers' => $this->create_helper_surface( $container ) ] );
 
 		Filters\expectApplied( 'wpseo_feature_toggles' )
 			->once()

--- a/tests/unit/inc/addon-manager-test.php
+++ b/tests/unit/inc/addon-manager-test.php
@@ -256,8 +256,15 @@ class Addon_Manager_Test extends TestCase {
 		$product_helper_mock = Mockery::mock( Product_Helper::class );
 		$product_helper_mock->expects( 'is_premium' )->once()->andReturn( false );
 
-		$helpers_mock = (object) [ 'product' => $product_helper_mock ];
-		Monkey\Functions\expect( 'YoastSEO' )->once()->andReturn( (object) [ 'helpers' => $helpers_mock ] );
+		$container = $this->create_container_with(
+			[
+				Product_Helper::class => $product_helper_mock,
+			]
+		);
+
+		Monkey\Functions\expect( 'YoastSEO' )
+			->once()
+			->andReturn( (object) [ 'helpers' => $this->create_helper_surface( $container ) ] );
 
 		$this->assertEquals(
 			[
@@ -362,8 +369,15 @@ class Addon_Manager_Test extends TestCase {
 		$product_helper_mock = Mockery::mock( Product_Helper::class );
 		$product_helper_mock->expects( 'is_premium' )->once()->andReturn( false );
 
-		$helpers_mock = (object) [ 'product' => $product_helper_mock ];
-		Monkey\Functions\expect( 'YoastSEO' )->once()->andReturn( (object) [ 'helpers' => $helpers_mock ] );
+		$container = $this->create_container_with(
+			[
+				Product_Helper::class => $product_helper_mock,
+			]
+		);
+
+		Monkey\Functions\expect( 'YoastSEO' )
+			->once()
+			->andReturn( (object) [ 'helpers' => $this->create_helper_surface( $container ) ] );
 
 		$this->assertEquals(
 			[
@@ -502,8 +516,16 @@ class Addon_Manager_Test extends TestCase {
 		if ( ! empty( $addons ) ) {
 			$product_helper_mock = Mockery::mock( Product_Helper::class );
 			$product_helper_mock->shouldReceive( 'is_premium' )->atMost()->times( 2 )->andReturn( false );
-			$helpers_mock = (object) [ 'product' => $product_helper_mock ];
-			Monkey\Functions\expect( 'YoastSEO' )->atMost()->times( 2 )->andReturn( (object) [ 'helpers' => $helpers_mock ] );
+
+			$container = $this->create_container_with(
+				[
+					Product_Helper::class => $product_helper_mock,
+				]
+			);
+
+			Monkey\Functions\expect( 'YoastSEO' )
+				->atMost()->times( 2 )
+				->andReturn( (object) [ 'helpers' => $this->create_helper_surface( $container ) ] );
 		}
 
 		Monkey\Functions\expect( 'get_plugin_updates' )
@@ -539,8 +561,16 @@ class Addon_Manager_Test extends TestCase {
 	public function test_is_yoast_addon() {
 		$product_helper_mock = Mockery::mock( Product_Helper::class );
 		$product_helper_mock->expects( 'is_premium' )->twice()->andReturn( false );
-		$helpers_mock = (object) [ 'product' => $product_helper_mock ];
-		Monkey\Functions\expect( 'YoastSEO' )->twice()->andReturn( (object) [ 'helpers' => $helpers_mock ] );
+
+		$container = $this->create_container_with(
+			[
+				Product_Helper::class => $product_helper_mock,
+			]
+		);
+
+		Monkey\Functions\expect( 'YoastSEO' )
+			->twice()
+			->andReturn( (object) [ 'helpers' => $this->create_helper_surface( $container ) ] );
 
 		$this->assertTrue( $this->instance->is_yoast_addon( 'wp-seo-premium.php' ) );
 		$this->assertFalse( $this->instance->is_yoast_addon( 'non-wp-seo-addon.php' ) );
@@ -554,8 +584,16 @@ class Addon_Manager_Test extends TestCase {
 	public function test_get_slug_by_plugin_file() {
 		$product_helper_mock = Mockery::mock( Product_Helper::class );
 		$product_helper_mock->expects( 'is_premium' )->twice()->andReturn( false );
-		$helpers_mock = (object) [ 'product' => $product_helper_mock ];
-		Monkey\Functions\expect( 'YoastSEO' )->twice()->andReturn( (object) [ 'helpers' => $helpers_mock ] );
+
+		$container = $this->create_container_with(
+			[
+				Product_Helper::class => $product_helper_mock,
+			]
+		);
+
+		Monkey\Functions\expect( 'YoastSEO' )
+			->twice()
+			->andReturn( (object) [ 'helpers' => $this->create_helper_surface( $container ) ] );
 
 		$this->assertEquals( 'yoast-seo-wordpress-premium', $this->instance->get_slug_by_plugin_file( 'wp-seo-premium.php' ) );
 		$this->assertEquals( '', $this->instance->get_slug_by_plugin_file( 'non-wp-seo-addon.php' ) );
@@ -631,8 +669,16 @@ class Addon_Manager_Test extends TestCase {
 
 		$product_helper_mock = Mockery::mock( Product_Helper::class );
 		$product_helper_mock->expects( 'is_premium' )->once()->andReturn( false );
-		$helpers_mock = (object) [ 'product' => $product_helper_mock ];
-		Monkey\Functions\expect( 'YoastSEO' )->once()->andReturn( (object) [ 'helpers' => $helpers_mock ] );
+
+		$container = $this->create_container_with(
+			[
+				Product_Helper::class => $product_helper_mock,
+			]
+		);
+
+		Monkey\Functions\expect( 'YoastSEO' )
+			->once()
+			->andReturn( (object) [ 'helpers' => $this->create_helper_surface( $container ) ] );
 
 		$this->assertEquals(
 			[],
@@ -679,8 +725,16 @@ class Addon_Manager_Test extends TestCase {
 
 		$product_helper_mock = Mockery::mock( Product_Helper::class );
 		$product_helper_mock->expects( 'is_premium' )->once()->andReturn( false );
-		$helpers_mock = (object) [ 'product' => $product_helper_mock ];
-		Monkey\Functions\expect( 'YoastSEO' )->once()->andReturn( (object) [ 'helpers' => $helpers_mock ] );
+
+		$container = $this->create_container_with(
+			[
+				Product_Helper::class => $product_helper_mock,
+			]
+		);
+
+		Monkey\Functions\expect( 'YoastSEO' )
+			->once()
+			->andReturn( (object) [ 'helpers' => $this->create_helper_surface( $container ) ] );
 
 		$this->assertEquals(
 			[
@@ -716,8 +770,16 @@ class Addon_Manager_Test extends TestCase {
 
 		$product_helper_mock = Mockery::mock( Product_Helper::class );
 		$product_helper_mock->expects( 'is_premium' )->times( 3 )->andReturn( false );
-		$helpers_mock = (object) [ 'product' => $product_helper_mock ];
-		Monkey\Functions\expect( 'YoastSEO' )->times( 3 )->andReturn( (object) [ 'helpers' => $helpers_mock ] );
+
+		$container = $this->create_container_with(
+			[
+				Product_Helper::class => $product_helper_mock,
+			]
+		);
+
+		Monkey\Functions\expect( 'YoastSEO' )
+			->times( 3 )
+			->andReturn( (object) [ 'helpers' => $this->create_helper_surface( $container ) ] );
 
 		$this->assertEquals(
 			[

--- a/tests/unit/inc/language-utils-test.php
+++ b/tests/unit/inc/language-utils-test.php
@@ -5,6 +5,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Inc;
 use Brain\Monkey;
 use Mockery;
 use WPSEO_Language_Utils;
+use Yoast\WP\SEO\Helpers\Product_Helper;
 use Yoast\WP\SEO\Tests\Unit\Doubles\Shortlinker_Double;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
@@ -66,8 +67,12 @@ class Language_Utils_Test extends TestCase {
 
 		$product_helper_mock = Mockery::mock( Product_Helper::class );
 		$product_helper_mock->expects( 'is_premium' )->twice()->andReturn( false );
-		$helpers_mock = (object) [ 'product' => $product_helper_mock ];
-		Monkey\Functions\expect( 'YoastSEO' )->twice()->andReturn( (object) [ 'helpers' => $helpers_mock ] );
+
+		$container = $this->create_container_with( [ Product_Helper::class => $product_helper_mock ] );
+
+		Monkey\Functions\expect( 'YoastSEO' )
+			->twice()
+			->andReturn( (object) [ 'helpers' => $this->create_helper_surface( $container ) ] );
 
 		$shortlinker = new Shortlinker_Double();
 

--- a/tests/unit/inc/sitemaps/sitemaps-admin-test.php
+++ b/tests/unit/inc/sitemaps/sitemaps-admin-test.php
@@ -9,7 +9,6 @@ use WP_Rewrite;
 use WPSEO_Options;
 use WPSEO_Sitemaps_Admin;
 use Yoast\WP\SEO\Helpers\Environment_Helper;
-use Yoast\WP\SEO\Surfaces\Helpers_Surface;
 use Yoast\WP\SEO\Tests\Unit\Doubles\Inc\Options\Options_Double;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
@@ -84,11 +83,10 @@ class WPSEO_Sitemaps_Admin_Test extends TestCase {
 		$environment_helper = Mockery::mock( Environment_Helper::class );
 		$environment_helper->expects( 'is_production_mode' )->once()->andReturn( false );
 
-		$helper_surface              = Mockery::mock( Helpers_Surface::class );
-		$helper_surface->environment = $environment_helper;
+		$container = $this->create_container_with( [ Environment_Helper::class => $environment_helper ] );
 
 		Monkey\Functions\expect( 'YoastSEO' )
-			->andReturn( (object) [ 'helpers' => $helper_surface ] );
+			->andReturn( (object) [ 'helpers' => $this->create_helper_surface( $container ) ] );
 
 		$this->instance->status_transition( 'publish', 'draft', $this->mock_post );
 	}
@@ -138,11 +136,10 @@ class WPSEO_Sitemaps_Admin_Test extends TestCase {
 		$environment_helper = Mockery::mock( Environment_Helper::class );
 		$environment_helper->expects( 'is_production_mode' )->once()->andReturn( true );
 
-		$helper_surface              = Mockery::mock( Helpers_Surface::class );
-		$helper_surface->environment = $environment_helper;
+		$container = $this->create_container_with( [ Environment_Helper::class => $environment_helper ] );
 
 		Monkey\Functions\expect( 'YoastSEO' )
-			->andReturn( (object) [ 'helpers' => $helper_surface ] );
+			->andReturn( (object) [ 'helpers' => $this->create_helper_surface( $container ) ] );
 
 		$this->instance->status_transition( 'publish', 'draft', $this->mock_post );
 	}

--- a/tests/unit/integrations/admin/deactivated-premium-integration-test.php
+++ b/tests/unit/integrations/admin/deactivated-premium-integration-test.php
@@ -103,14 +103,11 @@ class Deactivated_Premium_Integration_Test extends TestCase {
 		$conditional = Mockery::mock( Indexables_Page_Conditional::class );
 		$conditional->expects( 'is_met' )->once()->andReturnFalse();
 
-		$classes = Mockery::mock();
-		$classes->expects( 'get' )->once()->with( Indexables_Page_Conditional::class )->andReturn( $conditional );
+		$container = $this->create_container_with( [ Indexables_Page_Conditional::class => $conditional ] );
 
-		Monkey\Functions\expect( 'YoastSEO' )->once()->andReturn(
-			(object) [
-				'classes' => $classes,
-			]
-		);
+		Monkey\Functions\expect( 'YoastSEO' )
+			->once()
+			->andReturn( (object) [ 'classes' => $this->create_classes_surface( $container ) ] );
 
 		// Output should contain the nonce URL.
 		$this->expectOutputContains( 'plugins.php?action=activate&plugin=' . $premium_file );

--- a/tests/unit/integrations/admin/migration-error-integration-test.php
+++ b/tests/unit/integrations/admin/migration-error-integration-test.php
@@ -7,6 +7,7 @@ use Mockery;
 use WPSEO_Shortlinker;
 use Yoast\WP\SEO\Conditionals\Admin_Conditional;
 use Yoast\WP\SEO\Config\Migration_Status;
+use Yoast\WP\SEO\Helpers\Product_Helper;
 use Yoast\WP\SEO\Integrations\Admin\Migration_Error_Integration;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
@@ -116,8 +117,12 @@ class Migration_Error_Integration_Test extends TestCase {
 
 		$product_helper_mock = Mockery::mock( Product_Helper::class );
 		$product_helper_mock->expects( 'is_premium' )->twice()->andReturn( false );
-		$helpers_mock = (object) [ 'product' => $product_helper_mock ];
-		Monkey\Functions\expect( 'YoastSEO' )->twice()->andReturn( (object) [ 'helpers' => $helpers_mock ] );
+
+		$container = $this->create_container_with( [ Product_Helper::class => $product_helper_mock ] );
+
+		Monkey\Functions\expect( 'YoastSEO' )
+			->twice()
+			->andReturn( (object) [ 'helpers' => $this->create_helper_surface( $container ) ] );
 
 		$expected  = '<div class="notice notice-error">';
 		$expected .= '<p>Yoast SEO had problems creating the database tables needed to speed up your site.</p>';

--- a/tests/unit/integrations/watchers/option-wpseo-watcher-test.php
+++ b/tests/unit/integrations/watchers/option-wpseo-watcher-test.php
@@ -7,7 +7,6 @@ use Mockery;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Wordproof_Helper;
 use Yoast\WP\SEO\Integrations\Watchers\Option_Wpseo_Watcher;
-use Yoast\WP\SEO\Surfaces\Helpers_Surface;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
@@ -63,11 +62,12 @@ class Option_Wpseo_Watcher_Test extends TestCase {
 		$options_helper = Mockery::mock( Options_Helper::class );
 		$options_helper->expects( 'set' )->once()->andReturn( true );
 
-		$helper_surface          = Mockery::mock( Helpers_Surface::class );
-		$helper_surface->options = $options_helper;
+		$container = $this->create_container_with( [ Options_Helper::class => $options_helper ] );
 
 		Monkey\Functions\expect( 'YoastSEO' )
-			->andReturn( (object) [ 'helpers' => $helper_surface ] );
+			->once()
+			->andReturn( (object) [ 'helpers' => $this->create_helper_surface( $container ) ] );
+
 
 		$this->assertTrue( $this->instance->check_semrush_option_disabled( null, [ 'semrush_integration_active' => false ] ) );
 	}

--- a/tests/unit/main-test.php
+++ b/tests/unit/main-test.php
@@ -3,8 +3,10 @@
 namespace Yoast\WP\SEO\Tests\Unit;
 
 use Brain\Monkey;
+use Exception;
 use Mockery;
 use wpdb;
+use Yoast\WP\SEO\Exceptions\Forbidden_Property_Mutation_Exception;
 use Yoast\WP\SEO\Integrations\Third_Party\Elementor;
 use Yoast\WP\SEO\Integrations\Watchers\Indexable_Category_Permalink_Watcher;
 use Yoast\WP\SEO\Integrations\Watchers\Indexable_Permalink_Watcher;
@@ -85,5 +87,88 @@ class Main_Test extends TestCase {
 
 			$this->assertInstanceOf( $service_id, $container->get( $service_id ) );
 		}
+	}
+
+	/**
+	 * Verify that null is returned by the magic __get() method when an attempt is made
+	 * to access a (declared) protected or private property from outside the class.
+	 *
+	 * {@internal This test is on the Main class as the Abstract_main class is... abstract.}
+	 *
+	 * @covers       Yoast\WP\Lib\Abstract_Main::__get
+	 * @dataProvider data_declared_inaccessible_properties
+	 *
+	 * @param string $name Property name.
+	 */
+	public function test_get_on_inaccessible_property_is_forbidden( $name ) {
+		$this->expectException( Exception::class );
+		$this->expectExceptionMessage( "Property \$$name does not exist." );
+
+		$this->instance->$name;
+	}
+
+	/**
+	 * The magic set method should prevent setting dynamic properties, as well as prevent
+	 * overloading the value of protected/private properties from a context in which they
+	 * are inaccessible.
+	 *
+	 * {@internal This test is on the Main class as the Abstract_main class is... abstract.}
+	 *
+	 * @covers Yoast\WP\Lib\Abstract_Main::__set
+	 *
+	 * @dataProvider data_declared_inaccessible_properties
+	 * @dataProvider data_undeclared_properties
+	 *
+	 * @param string $name Property name.
+	 */
+	public function test_set_is_forbidden( $name ) {
+		$this->expectException( Forbidden_Property_Mutation_Exception::class );
+		$this->expectExceptionMessage( "Setting property \$$name is not supported." );
+
+		$this->instance->$name = 'dynamic property';
+	}
+
+	/**
+	 * The magic unset method should prevent unsetting dynamic properties, as well as prevent
+	 * unsetting protected/private properties from a context in which they are inaccessible.
+	 *
+	 * {@internal This test is on the Main class as the Abstract_main class is... abstract.}
+	 *
+	 * @covers Yoast\WP\Lib\Abstract_Main::__unset
+	 *
+	 * @dataProvider data_declared_inaccessible_properties
+	 * @dataProvider data_undeclared_properties
+	 *
+	 * @param string $name Property name.
+	 */
+	public function test_unset_is_forbidden( $name ) {
+		$this->expectException( Forbidden_Property_Mutation_Exception::class );
+		$this->expectExceptionMessage( "Unsetting property \$$name is not supported." );
+
+		unset( $this->instance->$name );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_declared_inaccessible_properties() {
+		return [
+			'container'       => [ 'container' ],
+			'cached_surfaces' => [ 'cached_surfaces' ],
+		];
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_undeclared_properties() {
+		return [
+			'xyz'     => [ 'xyz' ],
+			'unknown' => [ 'unknown' ],
+		];
 	}
 }

--- a/tests/unit/presenters/admin/migration-error-presenter-test.php
+++ b/tests/unit/presenters/admin/migration-error-presenter-test.php
@@ -5,6 +5,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Presenters\Admin;
 use Brain\Monkey;
 use Mockery;
 use WPSEO_Shortlinker;
+use Yoast\WP\SEO\Helpers\Product_Helper;
 use Yoast\WP\SEO\Presenters\Admin\Migration_Error_Presenter;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
@@ -33,8 +34,12 @@ class Migration_Error_Presenter_Test extends TestCase {
 
 		$product_helper_mock = Mockery::mock( Product_Helper::class );
 		$product_helper_mock->expects( 'is_premium' )->twice()->andReturn( false );
-		$helpers_mock = (object) [ 'product' => $product_helper_mock ];
-		Monkey\Functions\expect( 'YoastSEO' )->twice()->andReturn( (object) [ 'helpers' => $helpers_mock ] );
+
+		$container = $this->create_container_with( [ Product_Helper::class => $product_helper_mock ] );
+
+		Monkey\Functions\expect( 'YoastSEO' )
+			->twice()
+			->andReturn( (object) [ 'helpers' => $this->create_helper_surface( $container ) ] );
 
 		$expected  = '<div class="notice notice-error">';
 		$expected .= '<p>Yoast SEO had problems creating the database tables needed to speed up your site.</p>';

--- a/tests/unit/presenters/admin/notice-presenter-test.php
+++ b/tests/unit/presenters/admin/notice-presenter-test.php
@@ -37,17 +37,7 @@ class Notice_Presenter_Test extends TestCase {
 	public function test_construct() {
 		Monkey\Functions\expect( 'wp_enqueue_style' )->once();
 
-		$conditional = Mockery::mock( Indexables_Page_Conditional::class );
-		$conditional->expects( 'is_met' )->once()->andReturnFalse();
-
-		$classes = Mockery::mock();
-		$classes->expects( 'get' )->once()->with( Indexables_Page_Conditional::class )->andReturn( $conditional );
-
-		Monkey\Functions\expect( 'YoastSEO' )->once()->andReturn(
-			(object) [
-				'classes' => $classes,
-			]
-		);
+		$this->setup_indexables_page_condition_is_met( true );
 
 		$test = new Notice_Presenter( 'title', 'content', 'image.png', null, true );
 
@@ -70,17 +60,7 @@ class Notice_Presenter_Test extends TestCase {
 	public function test_default_notice() {
 		Monkey\Functions\expect( 'wp_enqueue_style' )->once();
 
-		$conditional = Mockery::mock( Indexables_Page_Conditional::class );
-		$conditional->expects( 'is_met' )->once()->andReturnFalse();
-
-		$classes = Mockery::mock();
-		$classes->expects( 'get' )->once()->with( Indexables_Page_Conditional::class )->andReturn( $conditional );
-
-		Monkey\Functions\expect( 'YoastSEO' )->once()->andReturn(
-			(object) [
-				'classes' => $classes,
-			]
-		);
+		$this->setup_indexables_page_condition_is_met( true );
 
 		$test = new Notice_Presenter( 'title', 'content' );
 
@@ -108,17 +88,7 @@ class Notice_Presenter_Test extends TestCase {
 	public function test_notice_with_image() {
 		Monkey\Functions\expect( 'wp_enqueue_style' )->once();
 
-		$conditional = Mockery::mock( Indexables_Page_Conditional::class );
-		$conditional->expects( 'is_met' )->once()->andReturnFalse();
-
-		$classes = Mockery::mock();
-		$classes->expects( 'get' )->once()->with( Indexables_Page_Conditional::class )->andReturn( $conditional );
-
-		Monkey\Functions\expect( 'YoastSEO' )->once()->andReturn(
-			(object) [
-				'classes' => $classes,
-			]
-		);
+		$this->setup_indexables_page_condition_is_met( true );
 
 		$test = new Notice_Presenter( 'title', 'content', 'image.png' );
 
@@ -148,17 +118,7 @@ class Notice_Presenter_Test extends TestCase {
 	public function test_dismissble_notice() {
 		Monkey\Functions\expect( 'wp_enqueue_style' )->once();
 
-		$conditional = Mockery::mock( Indexables_Page_Conditional::class );
-		$conditional->expects( 'is_met' )->once()->andReturnFalse();
-
-		$classes = Mockery::mock();
-		$classes->expects( 'get' )->once()->with( Indexables_Page_Conditional::class )->andReturn( $conditional );
-
-		Monkey\Functions\expect( 'YoastSEO' )->once()->andReturn(
-			(object) [
-				'classes' => $classes,
-			]
-		);
+		$this->setup_indexables_page_condition_is_met( true );
 
 		$test = new Notice_Presenter( 'title', 'content', null, null, true );
 
@@ -187,17 +147,7 @@ class Notice_Presenter_Test extends TestCase {
 	public function test_dismissble_notice_with_image() {
 		Monkey\Functions\expect( 'wp_enqueue_style' )->once();
 
-		$conditional = Mockery::mock( Indexables_Page_Conditional::class );
-		$conditional->expects( 'is_met' )->once()->andReturnFalse();
-
-		$classes = Mockery::mock();
-		$classes->expects( 'get' )->once()->with( Indexables_Page_Conditional::class )->andReturn( $conditional );
-
-		Monkey\Functions\expect( 'YoastSEO' )->once()->andReturn(
-			(object) [
-				'classes' => $classes,
-			]
-		);
+		$this->setup_indexables_page_condition_is_met( true );
 
 		$test = new Notice_Presenter( 'title', 'content', 'image.png', null, true );
 
@@ -227,17 +177,7 @@ class Notice_Presenter_Test extends TestCase {
 	public function test_dismissble_notice_with_image_and_button() {
 		Monkey\Functions\expect( 'wp_enqueue_style' )->once();
 
-		$conditional = Mockery::mock( Indexables_Page_Conditional::class );
-		$conditional->expects( 'is_met' )->once()->andReturnFalse();
-
-		$classes = Mockery::mock();
-		$classes->expects( 'get' )->once()->with( Indexables_Page_Conditional::class )->andReturn( $conditional );
-
-		Monkey\Functions\expect( 'YoastSEO' )->once()->andReturn(
-			(object) [
-				'classes' => $classes,
-			]
-		);
+		$this->setup_indexables_page_condition_is_met( true );
 
 		$button = '<a class="yoast-button yoast-button-upsell" href="https://yoa.st/somewhere">Some text</a>';
 
@@ -260,5 +200,23 @@ class Notice_Presenter_Test extends TestCase {
 		Monkey\Functions\expect( 'plugin_dir_url' )->andReturn( '' );
 
 		$this->assertEquals( $expected, (string) $test );
+	}
+
+	/**
+	 * Prepares the Indexables_Page_Conditional in the classes surface and mock a return value for is_met.
+	 *
+	 * @param boolean $is_met Whether the Indexable_Page_Conditional is met.
+	 *
+	 * @return void
+	 */
+	private function setup_indexables_page_condition_is_met( $is_met ) {
+		$conditional = Mockery::mock( Indexables_Page_Conditional::class );
+		$conditional->expects( 'is_met' )->once()->andReturn( $is_met );
+
+		$container = $this->create_container_with( [ Indexables_Page_Conditional::class => $conditional ] );
+
+		Monkey\Functions\expect( 'YoastSEO' )
+			->once()
+			->andReturn( (object) [ 'classes' => $this->create_classes_surface( $container ) ] );
 	}
 }

--- a/tests/unit/surfaces/classes-surface-test.php
+++ b/tests/unit/surfaces/classes-surface-test.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Surfaces;
+
+use stdClass;
+use Yoast\WP\SEO\Surfaces\Classes_Surface;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+use YoastSEO_Vendor\Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
+
+/**
+ * Class Meta_Surface_Test.
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Surfaces\Classes_Surface
+ *
+ * @group surfaces
+ */
+class Classes_Surface_Test extends TestCase {
+
+	/**
+	 * The instance.
+	 *
+	 * @var Classes_Surface
+	 */
+	protected $instance;
+
+	/**
+	 * An example instance that can be retrieved from the DI container with the Yoast\WP\SEO\Example id.
+	 *
+	 * @var stdClass
+	 */
+	private $example_service_instance;
+
+	/**
+	 * Sets up the test instance.
+	 *
+	 * @return void
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->example_service_instance = new stdClass();
+		$container                      = $this->create_container_with( [ 'Yoast\WP\SEO\Example' => $this->example_service_instance ] );
+
+		$this->instance = new Classes_Surface( $container );
+	}
+
+	/**
+	 * Tests the get function.
+	 *
+	 * @covers ::get
+	 */
+	public function test_get() {
+		$actual = $this->instance->get( 'Yoast\WP\SEO\Example' );
+
+		$this->assertSame( $this->example_service_instance, $actual );
+	}
+
+	/**
+	 * The get method should rethrow exceptions from the container.
+	 *
+	 * @covers ::get
+	 */
+	public function test_get_invalid_service() {
+		$this->expectException( ServiceNotFoundException::class );
+
+		$this->instance->get( 'Yoast\WP\SEO\Example_Does_Not_Exist' );
+	}
+}

--- a/tests/unit/surfaces/helpers-surface-test.php
+++ b/tests/unit/surfaces/helpers-surface-test.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Surfaces;
+
+use stdClass;
+use Yoast\WP\SEO\Exceptions\Forbidden_Property_Mutation_Exception;
+use Yoast\WP\SEO\Surfaces\Helpers_Surface;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+use YoastSEO_Vendor\Symfony\Component\DependencyInjection\ContainerInterface;
+use YoastSEO_Vendor\Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
+
+/**
+ * Class Helpers_Surface_Test.
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Surfaces\Helpers_Surface
+ *
+ * @group surfaces
+ */
+class Helpers_Surface_Test extends TestCase {
+
+	/**
+	 * The container.
+	 *
+	 * @var ContainerInterface
+	 */
+	protected $container;
+
+	/**
+	 * The instance.
+	 *
+	 * @var Helpers_Surface
+	 */
+	protected $instance;
+
+	/**
+	 * Sets up the test instance.
+	 *
+	 * @return void
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->container = $this->create_container_with( [] );
+		$this->instance  = $this->create_helper_surface( $this->container );
+	}
+
+	/**
+	 * Tests the magic get function.
+	 *
+	 * @covers ::__get
+	 * @dataProvider provide_classes
+	 *
+	 * @param string $helper_name Helper name.
+	 * @param string $classname   Expected class name.
+	 */
+	public function test_magic_get( $helper_name, $classname ) {
+		$test_service = new stdClass();
+		$this->container->set( $classname, $test_service );
+
+		$actual = $this->instance->$helper_name;
+
+		$this->assertSame( $test_service, $actual );
+	}
+
+	/**
+	 * The get method should rethrow exceptions from the container.
+	 *
+	 * @covers ::get
+	 * @dataProvider provide_classes
+	 *
+	 * @param string $helper_name Helper name.
+	 */
+	public function test_get_invalid_service( $helper_name ) {
+		$this->expectException( ServiceNotFoundException::class );
+
+		$_ = $this->instance->$helper_name;
+	}
+
+	/**
+	 * Tests the magic isset function.
+	 *
+	 * @covers ::__isset
+	 * @dataProvider provide_classes
+	 *
+	 * @param string $helper_name Helper name.
+	 * @param string $classname   Expected class name.
+	 */
+	public function test_isset_exists( $helper_name, $classname ) {
+		$this->container->set( $classname, new stdClass() );
+
+		$actual = isset( $this->instance->$helper_name );
+
+		$this->assertTrue( $actual );
+	}
+
+	/**
+	 * Tests the magic isset function.
+	 *
+	 * @covers ::__isset
+	 * @dataProvider provide_classes
+	 *
+	 * @param string $helper_name Helper name.
+	 */
+	public function test_isset_does_not_exist( $helper_name ) {
+		$actual = isset( $this->instance->$helper_name );
+
+		$this->assertFalse( $actual );
+	}
+
+	/**
+	 * The magic set method should prevent setting dynamic properties.
+	 *
+	 * @covers ::__set
+	 * @dataProvider provide_classes
+	 *
+	 * @param string $helper_name Helper name.
+	 */
+	public function test_set_is_forbidden( $helper_name ) {
+		$this->expectException( Forbidden_Property_Mutation_Exception::class );
+		$this->expectExceptionMessage( "Setting property \$$helper_name is not supported." );
+
+		$this->instance->$helper_name = 'dynamic property';
+	}
+
+	/**
+	 * The magic unset method should prevent unsetting dynamic properties.
+	 *
+	 * @covers ::__unset
+	 * @dataProvider provide_classes
+	 *
+	 * @param string $helper_name Helper name.
+	 */
+	public function test_unset_is_forbidden( $helper_name ) {
+		$this->expectException( Forbidden_Property_Mutation_Exception::class );
+		$this->expectExceptionMessage( "Unsetting property \$$helper_name is not supported." );
+
+		unset( $this->instance->$helper_name );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function provide_classes() {
+		return [
+			'get helpers from the helpers namespace'        => [
+				'helper_name' => 'test',
+				'classname'   => 'Yoast\WP\SEO\Helpers\Test_Helper',
+			],
+			'camelcase classnames'                          => [
+				'helper_name' => 'my_own_Thing',
+				'classname'   => 'Yoast\WP\SEO\Helpers\My_Own_Thing_Helper',
+			],
+			'does not expose privately declared properties' => [
+				'helper_name' => 'container',
+				'classname'   => 'Yoast\WP\SEO\Helpers\Container_Helper',
+			],
+		];
+	}
+}

--- a/tests/unit/surfaces/meta-surface-test.php
+++ b/tests/unit/surfaces/meta-surface-test.php
@@ -27,35 +27,35 @@ use YoastSEO_Vendor\Symfony\Component\DependencyInjection\ContainerInterface;
 class Meta_Surface_Test extends TestCase {
 
 	/**
-	 * The container
+	 * The container.
 	 *
 	 * @var ContainerInterface
 	 */
 	protected $container;
 
 	/**
-	 * The context memoizer
+	 * The context memoizer.
 	 *
 	 * @var Meta_Tags_Context_Memoizer
 	 */
 	protected $context_memoizer;
 
 	/**
-	 * The repository
+	 * The repository.
 	 *
 	 * @var Indexable_Repository
 	 */
 	protected $repository;
 
 	/**
-	 * The context
+	 * The context.
 	 *
 	 * @var Meta_Tags_Context_Mock
 	 */
 	protected $context;
 
 	/**
-	 * The indexable
+	 * The indexable.
 	 *
 	 * @var Indexable_Mock
 	 */
@@ -76,7 +76,7 @@ class Meta_Surface_Test extends TestCase {
 	private $indexable_helper;
 
 	/**
-	 * The instance
+	 * The instance.
 	 *
 	 * @var Meta_Surface
 	 */

--- a/tests/unit/surfaces/open-graph-helpers-surface-test.php
+++ b/tests/unit/surfaces/open-graph-helpers-surface-test.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Surfaces;
+
+use stdClass;
+use Yoast\WP\SEO\Exceptions\Forbidden_Property_Mutation_Exception;
+use Yoast\WP\SEO\Surfaces\Open_Graph_Helpers_Surface;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+use YoastSEO_Vendor\Symfony\Component\DependencyInjection\ContainerInterface;
+use YoastSEO_Vendor\Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
+
+/**
+ * Class Open_Graph_Helpers_Surface_Test.
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Surfaces\Open_Graph_Helpers_Surface
+ *
+ * @group surfaces
+ */
+class Open_Graph_Helpers_Surface_Test extends TestCase {
+
+	/**
+	 * The container.
+	 *
+	 * @var ContainerInterface
+	 */
+	protected $container;
+
+	/**
+	 * The instance.
+	 *
+	 * @var Open_Graph_Helpers_Surface
+	 */
+	protected $instance;
+
+	/**
+	 * Sets up the test instance.
+	 *
+	 * @return void
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->container = $this->create_container_with( [] );
+		$this->instance  = new Open_Graph_Helpers_Surface( $this->container );
+	}
+
+	/**
+	 * Tests the magic get function.
+	 *
+	 * @covers ::__get
+	 * @dataProvider provide_classes
+	 *
+	 * @param string $helper_name Helper name.
+	 * @param string $classname   Expected class name.
+	 */
+	public function test_magic_get( $helper_name, $classname ) {
+		$test_service = new stdClass();
+		$this->container->set( $classname, $test_service );
+
+		$actual = $this->instance->$helper_name;
+
+		$this->assertSame( $test_service, $actual );
+	}
+
+	/**
+	 * The get method should rethrow exceptions from the container.
+	 *
+	 * @covers ::get
+	 * @dataProvider provide_classes
+	 *
+	 * @param string $helper_name Helper name.
+	 */
+	public function test_get_invalid_service( $helper_name ) {
+		$this->expectException( ServiceNotFoundException::class );
+
+		$_ = $this->instance->$helper_name;
+	}
+
+	/**
+	 * Tests the magic isset function.
+	 *
+	 * @covers ::__isset
+	 * @dataProvider provide_classes
+	 *
+	 * @param string $helper_name Helper name.
+	 * @param string $classname   Expected class name.
+	 */
+	public function test_isset_exists( $helper_name, $classname ) {
+		$this->container->set( $classname, new stdClass() );
+
+		$actual = isset( $this->instance->$helper_name );
+
+		$this->assertTrue( $actual );
+	}
+
+	/**
+	 * Tests the magic isset function.
+	 *
+	 * @covers ::__isset
+	 * @dataProvider provide_classes
+	 *
+	 * @param string $helper_name Helper name.
+	 */
+	public function test_isset_does_not_exist( $helper_name ) {
+		$actual = isset( $this->instance->$helper_name );
+
+		$this->assertFalse( $actual );
+	}
+
+	/**
+	 * The magic set method should prevent setting dynamic properties.
+	 *
+	 * @covers ::__set
+	 * @dataProvider provide_classes
+	 *
+	 * @param string $helper_name Helper name.
+	 */
+	public function test_set_is_forbidden( $helper_name ) {
+		$this->expectException( Forbidden_Property_Mutation_Exception::class );
+		$this->expectExceptionMessage( "Setting property \$$helper_name is not supported." );
+
+		$this->instance->$helper_name = 'dynamic property';
+	}
+
+	/**
+	 * The magic unset method should prevent unsetting dynamic properties.
+	 *
+	 * @covers ::__unset
+	 * @dataProvider provide_classes
+	 *
+	 * @param string $helper_name Helper name.
+	 */
+	public function test_unset_is_forbidden( $helper_name ) {
+		$this->expectException( Forbidden_Property_Mutation_Exception::class );
+		$this->expectExceptionMessage( "Unsetting property \$$helper_name is not supported." );
+
+		unset( $this->instance->$helper_name );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function provide_classes() {
+		return [
+			'get helpers from the helpers namespace'        => [
+				'helper_name' => 'test',
+				'classname'   => 'Yoast\WP\SEO\Helpers\Open_Graph\Test_Helper',
+			],
+			'camelcase classnames'                          => [
+				'helper_name' => 'my_own_Thing',
+				'classname'   => 'Yoast\WP\SEO\Helpers\Open_Graph\My_Own_Thing_Helper',
+			],
+			'does not expose privately declared properties' => [
+				'helper_name' => 'container',
+				'classname'   => 'Yoast\WP\SEO\Helpers\Open_Graph\Container_Helper',
+			],
+		];
+	}
+}

--- a/tests/unit/surfaces/schema-helpers-surface-test.php
+++ b/tests/unit/surfaces/schema-helpers-surface-test.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Surfaces;
+
+use stdClass;
+use Yoast\WP\SEO\Exceptions\Forbidden_Property_Mutation_Exception;
+use Yoast\WP\SEO\Surfaces\Schema_Helpers_Surface;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+use YoastSEO_Vendor\Symfony\Component\DependencyInjection\ContainerInterface;
+use YoastSEO_Vendor\Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
+
+/**
+ * Class Schema_Helpers_Surface_Test.
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Surfaces\Schema_Helpers_Surface
+ *
+ * @group surfaces
+ */
+class Schema_Helpers_Surface_Test extends TestCase {
+
+	/**
+	 * The container.
+	 *
+	 * @var ContainerInterface
+	 */
+	protected $container;
+
+	/**
+	 * The instance.
+	 *
+	 * @var Schema_Helpers_Surface
+	 */
+	protected $instance;
+
+	/**
+	 * Sets up the test instance.
+	 *
+	 * @return void
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->container = $this->create_container_with( [] );
+		$this->instance  = new Schema_Helpers_Surface( $this->container );
+	}
+
+	/**
+	 * Tests the magic get function.
+	 *
+	 * @covers ::__get
+	 * @dataProvider provide_classes
+	 *
+	 * @param string $helper_name Helper name.
+	 * @param string $classname   Expected class name.
+	 */
+	public function test_magic_get( $helper_name, $classname ) {
+		$test_service = new stdClass();
+		$this->container->set( $classname, $test_service );
+
+		$actual = $this->instance->$helper_name;
+
+		$this->assertSame( $test_service, $actual );
+	}
+
+	/**
+	 * The get method should rethrow exceptions from the container.
+	 *
+	 * @covers ::get
+	 * @dataProvider provide_classes
+	 *
+	 * @param string $helper_name Helper name.
+	 */
+	public function test_get_invalid_service( $helper_name ) {
+		$this->expectException( ServiceNotFoundException::class );
+
+		$_ = $this->instance->$helper_name;
+	}
+
+	/**
+	 * Tests the magic isset function.
+	 *
+	 * @covers ::__isset
+	 * @dataProvider provide_classes
+	 *
+	 * @param string $helper_name Helper name.
+	 * @param string $classname   Expected class name.
+	 */
+	public function test_isset_exists( $helper_name, $classname ) {
+		$this->container->set( $classname, new stdClass() );
+
+		$actual = isset( $this->instance->$helper_name );
+
+		$this->assertTrue( $actual );
+	}
+
+	/**
+	 * Tests the magic isset function.
+	 *
+	 * @covers ::__isset
+	 * @dataProvider provide_classes
+	 *
+	 * @param string $helper_name Helper name.
+	 */
+	public function test_isset_does_not_exist( $helper_name ) {
+
+		$actual = isset( $this->instance->$helper_name );
+
+		$this->assertFalse( $actual );
+	}
+
+	/**
+	 * The magic set method should prevent setting dynamic properties.
+	 *
+	 * @covers ::__set
+	 * @dataProvider provide_classes
+	 *
+	 * @param string $helper_name Helper name.
+	 */
+	public function test_set_is_forbidden( $helper_name ) {
+		$this->expectException( Forbidden_Property_Mutation_Exception::class );
+		$this->expectExceptionMessage( "Setting property \$$helper_name is not supported." );
+
+		$this->instance->$helper_name = 'dynamic property';
+	}
+
+	/**
+	 * The magic unset method should prevent unsetting dynamic properties.
+	 *
+	 * @covers ::__unset
+	 * @dataProvider provide_classes
+	 *
+	 * @param string $helper_name Helper name.
+	 */
+	public function test_unset_is_forbidden( $helper_name ) {
+		$this->expectException( Forbidden_Property_Mutation_Exception::class );
+		$this->expectExceptionMessage( "Unsetting property \$$helper_name is not supported." );
+
+		unset( $this->instance->$helper_name );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function provide_classes() {
+		return [
+			'get helpers from the helpers namespace'        => [
+				'helper_name' => 'test',
+				'classname'   => 'Yoast\WP\SEO\Helpers\Schema\Test_Helper',
+			],
+			'camelcase classnames'                          => [
+				'helper_name' => 'my_own_Thing',
+				'classname'   => 'Yoast\WP\SEO\Helpers\Schema\My_Own_Thing_Helper',
+			],
+			'capitalize the ID helper'                      => [
+				'helper_name' => 'id',
+				'classname'   => 'Yoast\WP\SEO\Helpers\Schema\ID_Helper',
+			],
+			'capitalize the HTML helper'                    => [
+				'helper_name' => 'html',
+				'classname'   => 'Yoast\WP\SEO\Helpers\Schema\HTML_Helper',
+			],
+			'does not expose privately declared properties' => [
+				'helper_name' => 'container',
+				'classname'   => 'Yoast\WP\SEO\Helpers\Schema\Container_Helper',
+			],
+		];
+	}
+}

--- a/tests/unit/surfaces/twitter-helpers-surface-test.php
+++ b/tests/unit/surfaces/twitter-helpers-surface-test.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Surfaces;
+
+use stdClass;
+use Yoast\WP\SEO\Exceptions\Forbidden_Property_Mutation_Exception;
+use Yoast\WP\SEO\Surfaces\Twitter_Helpers_Surface;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+use YoastSEO_Vendor\Symfony\Component\DependencyInjection\ContainerInterface;
+use YoastSEO_Vendor\Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
+
+/**
+ * Class Twitter_Helpers_Surface_Test.
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Surfaces\Twitter_Helpers_Surface
+ *
+ * @group surfaces
+ */
+class Twitter_Helpers_Surface_Test extends TestCase {
+
+	/**
+	 * The container.
+	 *
+	 * @var ContainerInterface
+	 */
+	protected $container;
+
+	/**
+	 * The instance.
+	 *
+	 * @var Twitter_Helpers_Surface
+	 */
+	protected $instance;
+
+	/**
+	 * Sets up the test instance.
+	 *
+	 * @return void
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->container = $this->create_container_with( [] );
+		$this->instance  = new Twitter_Helpers_Surface( $this->container );
+	}
+
+	/**
+	 * Tests the magic get function.
+	 *
+	 * @covers ::__get
+	 * @dataProvider provide_classes
+	 *
+	 * @param string $helper_name Helper name.
+	 * @param string $classname   Expected class name.
+	 */
+	public function test_magic_get( $helper_name, $classname ) {
+		$test_service = new stdClass();
+		$this->container->set( $classname, $test_service );
+
+		$actual = $this->instance->$helper_name;
+
+		$this->assertSame( $test_service, $actual );
+	}
+
+	/**
+	 * The get method should rethrow exceptions from the container.
+	 *
+	 * @covers ::get
+	 * @dataProvider provide_classes
+	 *
+	 * @param string $helper_name Helper name.
+	 */
+	public function test_get_invalid_service( $helper_name ) {
+		$this->expectException( ServiceNotFoundException::class );
+
+		$_ = $this->instance->$helper_name;
+	}
+
+	/**
+	 * Tests the magic isset function.
+	 *
+	 * @covers ::__isset
+	 * @dataProvider provide_classes
+	 *
+	 * @param string $helper_name Helper name.
+	 * @param string $classname   Expected class name.
+	 */
+	public function test_isset_exists( $helper_name, $classname ) {
+		$this->container->set( $classname, new stdClass() );
+
+		$actual = isset( $this->instance->$helper_name );
+
+		$this->assertTrue( $actual );
+	}
+
+	/**
+	 * Tests the magic isset function.
+	 *
+	 * @covers ::__isset
+	 * @dataProvider provide_classes
+	 *
+	 * @param string $helper_name Helper name.
+	 */
+	public function test_isset_does_not_exist( $helper_name ) {
+
+		$actual = isset( $this->instance->$helper_name );
+
+		$this->assertFalse( $actual );
+	}
+
+	/**
+	 * The magic set method should prevent setting dynamic properties.
+	 *
+	 * @covers ::__set
+	 * @dataProvider provide_classes
+	 *
+	 * @param string $helper_name Helper name.
+	 */
+	public function test_set_is_forbidden( $helper_name ) {
+		$this->expectException( Forbidden_Property_Mutation_Exception::class );
+		$this->expectExceptionMessage( "Setting property \$$helper_name is not supported." );
+
+		$this->instance->$helper_name = 'dynamic property';
+	}
+
+	/**
+	 * The magic unset method should prevent unsetting dynamic properties.
+	 *
+	 * @covers ::__unset
+	 * @dataProvider provide_classes
+	 *
+	 * @param string $helper_name Helper name.
+	 */
+	public function test_unset_is_forbidden( $helper_name ) {
+		$this->expectException( Forbidden_Property_Mutation_Exception::class );
+		$this->expectExceptionMessage( "Unsetting property \$$helper_name is not supported." );
+
+		unset( $this->instance->$helper_name );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function provide_classes() {
+		return [
+			'get helpers from the helpers namespace'        => [
+				'helper_name' => 'test',
+				'classname'   => 'Yoast\WP\SEO\Helpers\Twitter\Test_Helper',
+			],
+			'camelcase classnames'                          => [
+				'helper_name' => 'my_own_Thing',
+				'classname'   => 'Yoast\WP\SEO\Helpers\Twitter\My_Own_Thing_Helper',
+			],
+			'does not expose privately declared properties' => [
+				'helper_name' => 'container',
+				'classname'   => 'Yoast\WP\SEO\Helpers\Twitter\Container_Helper',
+			],
+		];
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

PHP 8.2 deprecates the use of dynamic properties.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improve compatibility with PHP 8.2
* Disallow setting or unsetting any dynamic properties on Abstract_Main.

## Relevant technical choices:

* The isset implemenation used to call the magic __get as part of its implementation. This is not how it is intended.
* To further prevent any dynamic properties being set, the __set and __unset will always throw an exception, because there is no reason to set any dynamic properties anymore.
* When mocking away our surfaces_helper, we often combine it with setting dynamic properties. This is deprecated since PHP 8.2 and will fail tests on PHP >= 8.2. Also, when we mock away our internals, we hide potential issues in our own code. So, with these helpers in the testCase, we can mock the Symfony DI container and leave the rest of our system intact.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Smoketest the plugin with and without addons enabled. No behaviour should have changed.
	* You could look at schema output for example - as that for sure is touched by this PR.	

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* This may impact other plugins which wrongfully modify the contents our surface helpers or main class by setting properties on it. This also applies to our own addons (though we didn't spot any incorrect usages) 

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.
