### PR TITLE
Add upsell configuration to buy buttons

### DIFF
--- a/packages/js/src/settings/app.js
+++ b/packages/js/src/settings/app.js
@@ -158,6 +158,7 @@ Menu.propTypes = {
  */
 const PremiumUpsellList = () => {
 	const getPremiumLink = useSelectSettings( "selectLink", [], "https://yoa.st/17h" );
+	const getPremiumUpsellConfig =  useSelectSettings( "selectUpsellSetting", [] );
 
 	return (
 		<div className="yst-p-6 xl:yst-max-w-3xl yst-rounded-lg yst-bg-white yst-shadow">
@@ -190,6 +191,7 @@ const PremiumUpsellList = () => {
 			</ul>
 			<Button
 				as="a" variant="upsell" size="large" href={ getPremiumLink }
+				data-action={ getPremiumUpsellConfig.actionId } data-ctb-id={ getPremiumUpsellConfig.premiumCtbId }
 				className="yst-gap-2 yst-mt-4"
 			>
 				{ sprintf(

--- a/packages/js/src/settings/components/sidebar-recommendations.js
+++ b/packages/js/src/settings/components/sidebar-recommendations.js
@@ -13,6 +13,8 @@ import { ReactComponent as G2Logo } from "./g2-logo-white-rgb.svg";
  */
 const PremiumUpsellCard = () => {
 	const getPremiumLink = useSelectSettings( "selectLink", [], "https://yoa.st/jj" );
+	const getPremiumUpsellConfig =  useSelectSettings( "selectUpsellSetting", [] );
+
 	const info = useMemo( () => createInterpolateElement(
 		sprintf(
 			/* translators: %1$s and %2$s expand to opening and closing <strong> tags. */
@@ -44,6 +46,8 @@ const PremiumUpsellCard = () => {
 			<Button
 				as="a" variant="upsell" size="large" href={ getPremiumLink }
 				className="yst-flex yst-justify-center yst-gap-2 yst-mt-4 yst-px-4 sm:yst-px-0"
+				data-action={ getPremiumUpsellConfig.actionId }
+				data-ctb-id={ getPremiumUpsellConfig.premiumCtbId }
 			>
 				{ getPremium }
 				<ArrowNarrowRightIcon className="yst-w-4 yst-h-4" />

--- a/packages/js/src/settings/routes/author-archives.js
+++ b/packages/js/src/settings/routes/author-archives.js
@@ -28,6 +28,7 @@ const AuthorArchives = () => {
 	const labelLower = useMemo( ()=> toLower( label ), [ label ] );
 	const singularLabelLower = useMemo( ()=> toLower( singularLabel ), [ singularLabel ] );
 
+	const getPremiumUpsellConfig =  useSelectSettings( "selectUpsellSetting", [] );
 	const replacementVariables = useSelectSettings( "selectReplacementVariablesFor", [], "author_archives", "custom-post-type_archive" );
 	const recommendedReplacementVariables = useSelectSettings( "selectRecommendedReplacementVariablesFor", [], "author_archives", "custom-post-type_archive" );
 	const duplicateContentInfoLink = useSelectSettings( "selectLink", [], "https://yoa.st/duplicate-content" );
@@ -182,6 +183,8 @@ const AuthorArchives = () => {
 									shouldUpsell={ ! isPremium }
 									variant="card"
 									cardLink={ socialAppearancePremiumLink }
+									upsellButtonAction={ getPremiumUpsellConfig.actionId }
+									upsellButtonCtbId={ getPremiumUpsellConfig.premiumCtbId }
 									cardText={ sprintf(
 										/* translators: %1$s expands to Premium. */
 										__( "Unlock with %1$s", "wordpress-seo" ),

--- a/packages/js/src/settings/routes/crawl-optimization.js
+++ b/packages/js/src/settings/routes/crawl-optimization.js
@@ -17,6 +17,7 @@ const FormikValueChangeFieldWithDummy = withFormikDummyField( FormikValueChangeF
  */
 const CrawlOptimization = () => {
 	const crawlSettingsLink = useSelectSettings( "selectLink", [], "https://yoa.st/crawl-settings" );
+	const getPremiumUpsellConfig =  useSelectSettings( "selectUpsellSetting", [] );
 	const permalinkCleanupLink = useSelectSettings( "selectLink", [], "https://yoa.st/permalink-cleanup" );
 	const isPremium = useSelectSettings( "selectPreference", [], "isPremium" );
 	const premiumLink = useSelectSettings( "selectLink", [], "https://yoa.st/crawl-settings-upsell" );
@@ -259,7 +260,10 @@ const CrawlOptimization = () => {
 			description={ <>
 				{ descriptions.page }
 				{ ! isPremium && <div className="yst-mt-6">
-					<Button as="a" className="yst-gap-2" variant="upsell" href={ premiumLink } target="_blank" rel="noopener">
+					<Button
+						as="a" className="yst-gap-2" variant="upsell" href={ premiumLink } target="_blank" rel="noopener"
+						data-action={ getPremiumUpsellConfig.actionId } data-ctb-id={ getPremiumUpsellConfig.premiumCtbId }
+					>
 						<LockOpenIcon className="yst-w-5 yst-h-5 yst--ml-1 yst-shrink-0" { ...svgAriaProps } />
 						{ sprintf(
 						/* translators: %1$s expands to Premium. */

--- a/packages/js/src/settings/routes/date-archives.js
+++ b/packages/js/src/settings/routes/date-archives.js
@@ -25,6 +25,7 @@ const DateArchives = () => {
 	const label = __( "Date archives", "wordpress-seo" );
 	const labelLower = useMemo( ()=> toLower( label ), [ label ] );
 
+	const getPremiumUpsellConfig =  useSelectSettings( "selectUpsellSetting", [] );
 	const replacementVariables = useSelectSettings( "selectReplacementVariablesFor", [], "date_archive", "custom-post-type_archive" );
 	const recommendedReplacementVariables = useSelectSettings( "selectRecommendedReplacementVariablesFor", [], "date_archive", "custom-post-type_archive" );
 	const noIndexInfoLink = useSelectSettings( "selectLink", [], "https://yoa.st/show-x" );
@@ -163,6 +164,8 @@ const DateArchives = () => {
 									shouldUpsell={ ! isPremium }
 									variant="card"
 									cardLink={ socialAppearancePremiumLink }
+									upsellButtonAction={ getPremiumUpsellConfig.actionId }
+									upsellButtonCtbId={ getPremiumUpsellConfig.premiumCtbId }
 									cardText={ sprintf(
 										// translators: %1$s expands to Premium.
 										__( "Unlock with %1$s", "wordpress-seo" ),

--- a/packages/js/src/settings/routes/format-archives.js
+++ b/packages/js/src/settings/routes/format-archives.js
@@ -31,6 +31,7 @@ const FormatArchives = () => {
 	const { name, label } = useSelectSettings( "selectTaxonomy", [], "post_format" );
 	const labelLower = useMemo( ()=> toLower( label ), [ label ] );
 
+	const getPremiumUpsellConfig =  useSelectSettings( "selectUpsellSetting", [] );
 	const replacementVariables = useSelectSettings( "selectReplacementVariablesFor", [ name ], name, "term-in-custom-taxonomy" );
 	const recommendedReplacementVariables = useSelectSettings( "selectRecommendedReplacementVariablesFor", [ name ], name, "term-in-custom-taxonomy" );
 	const noIndexInfoLink = useSelectSettings( "selectLink", [], "https://yoa.st/show-x" );
@@ -157,6 +158,8 @@ const FormatArchives = () => {
 									shouldUpsell={ ! isPremium }
 									variant="card"
 									cardLink={ socialAppearancePremiumLink }
+									upsellButtonAction={ getPremiumUpsellConfig.actionId }
+									upsellButtonCtbId={ getPremiumUpsellConfig.premiumCtbId }
 									cardText={ sprintf(
 									/* translators: %1$s expands to Premium. */
 										__( "Unlock with %1$s", "wordpress-seo" ),

--- a/packages/js/src/settings/routes/site-features.js
+++ b/packages/js/src/settings/routes/site-features.js
@@ -76,6 +76,7 @@ LearnMoreLink.propTypes = {
 const SiteFeatures = () => {
 	const isPremium = useSelectSettings( "selectPreference", [], "isPremium" );
 	const sitemapUrl = useSelectSettings( "selectPreference", [], "sitemapUrl" );
+	const getPremiumUpsellConfig =  useSelectSettings( "selectUpsellSetting", [] );
 	const getInclusiveLanguageAnalysisLink = useSelectSettings( "selectLink", [], "https://yoa.st/get-inclusive-language" );
 	const getLinkSuggestionsLink = useSelectSettings( "selectLink", [], "https://yoa.st/get-link-suggestions" );
 	const getIndexNowLink = useSelectSettings( "selectLink", [], "https://yoa.st/get-indexnow" );
@@ -193,7 +194,10 @@ const SiteFeatures = () => {
 										label={ __( "Enable feature", "wordpress-seo" ) }
 									/> }
 									{ ! isPremium && (
-										<Button as="a" className="yst-gap-2 yst-w-full" variant="upsell" href={ getInclusiveLanguageAnalysisLink } target="_blank" rel="noopener">
+										<Button
+											as="a" className="yst-gap-2 yst-w-full" variant="upsell" href={ getInclusiveLanguageAnalysisLink } target="_blank" rel="noopener"
+											data-action={ getPremiumUpsellConfig.actionId } data-ctb-id={ getPremiumUpsellConfig.premiumCtbId }
+										>
 											<LockOpenIcon className="yst-w-5 yst-h-5 yst--ml-1 yst-shrink-0" { ...svgAriaProps } />
 											{ sprintf(
 											/* translators: %1$s expands to Premium. */
@@ -306,7 +310,10 @@ const SiteFeatures = () => {
 										label={ __( "Enable feature", "wordpress-seo" ) }
 									/> }
 									{ ! isPremium && (
-										<Button as="a" className="yst-gap-2 yst-w-full" variant="upsell" href={ getLinkSuggestionsLink } target="_blank" rel="noopener">
+										<Button
+											as="a" className="yst-gap-2 yst-w-full" variant="upsell" href={ getLinkSuggestionsLink } target="_blank" rel="noopener"
+											data-action={ getPremiumUpsellConfig.actionId } data-ctb-id={ getPremiumUpsellConfig.premiumCtbId }
+										>
 											<LockOpenIcon className="yst-w-5 yst-h-5 yst--ml-1 yst-shrink-0" { ...svgAriaProps } />
 											{ sprintf(
 											/* translators: %1$s expands to Premium. */
@@ -525,7 +532,10 @@ const SiteFeatures = () => {
 										label={ __( "Enable feature", "wordpress-seo" ) }
 									/> }
 									{ ! isPremium && (
-										<Button as="a" className="yst-gap-2 yst-w-full" variant="upsell" href={ getIndexNowLink } target="_blank" rel="noopener">
+										<Button
+											as="a" className="yst-gap-2 yst-w-full" variant="upsell" href={ getIndexNowLink } target="_blank" rel="noopener"
+											data-action={ getPremiumUpsellConfig.actionId } data-ctb-id={ getPremiumUpsellConfig.premiumCtbId }
+										>
 											<LockOpenIcon className="yst-w-5 yst-h-5 yst--ml-1 yst-shrink-0" { ...svgAriaProps } />
 											{ sprintf(
 											/* translators: %1$s expands to Premium. */

--- a/packages/js/src/settings/routes/templates/post-type.js
+++ b/packages/js/src/settings/routes/templates/post-type.js
@@ -33,6 +33,7 @@ const FormikReplacementVariableEditorFieldWithDummy = withFormikDummyField( Form
  */
 const PostType = ( { name, label, singularLabel, hasArchive, hasSchemaArticleType } ) => {
 	const replacementVariables = useSelectSettings( "selectReplacementVariablesFor", [ name ], name, "custom_post_type" );
+	const getPremiumUpsellConfig =  useSelectSettings( "selectUpsellSetting", [] );
 	const recommendedReplacementVariables = useSelectSettings( "selectRecommendedReplacementVariablesFor", [ name ], name, "custom_post_type" );
 	const replacementVariablesArchives = useSelectSettings( "selectReplacementVariablesFor", [ name ], `${ name }_archive`, "custom-post-type_archive" );
 	const recommendedReplacementVariablesArchives = useSelectSettings( "selectRecommendedReplacementVariablesFor", [ name ], `${ name }_archive`, "custom-post-type_archive" );
@@ -201,6 +202,8 @@ const PostType = ( { name, label, singularLabel, hasArchive, hasSchemaArticleTyp
 							shouldUpsell={ ! isPremium }
 							variant="card"
 							cardLink={ socialAppearancePremiumLink }
+							upsellButtonAction={ getPremiumUpsellConfig.actionId }
+							upsellButtonCtbId={ getPremiumUpsellConfig.premiumCtbId }
 							cardText={ sprintf(
 							/* translators: %1$s expands to Premium. */
 								__( "Unlock with %1$s", "wordpress-seo" ),
@@ -280,6 +283,8 @@ const PostType = ( { name, label, singularLabel, hasArchive, hasSchemaArticleTyp
 							shouldUpsell={ ! isPremium }
 							variant="card"
 							cardLink={ pageAnalysisPremiumLink }
+							upsellButtonAction={ getPremiumUpsellConfig.actionId }
+							upsellButtonCtbId={ getPremiumUpsellConfig.premiumCtbId }
 							cardText={ sprintf(
 							/* translators: %1$s expands to Premium. */
 								__( "Unlock with %1$s", "wordpress-seo" ),
@@ -377,6 +382,8 @@ const PostType = ( { name, label, singularLabel, hasArchive, hasSchemaArticleTyp
 									shouldUpsell={ ! isPremium }
 									variant="card"
 									cardLink={ socialAppearancePremiumLink }
+									upsellButtonAction={ getPremiumUpsellConfig.actionId }
+									upsellButtonCtbId={ getPremiumUpsellConfig.premiumCtbId }
 									cardText={ sprintf(
 										// translators: %1$s expands to Premium.
 										__( "Unlock with %1$s", "wordpress-seo" ),

--- a/packages/js/src/settings/routes/templates/taxonomy.js
+++ b/packages/js/src/settings/routes/templates/taxonomy.js
@@ -27,6 +27,7 @@ const FormikReplacementVariableEditorFieldWithDummy = withFormikDummyField( Form
  */
 const Taxonomy = ( { name, label, postTypes: postTypeNames } ) => {
 	const postTypes = useSelectSettings( "selectPostTypes", [ postTypeNames ], postTypeNames );
+	const getPremiumUpsellConfig =  useSelectSettings( "selectUpsellSetting", [] );
 	const replacementVariables = useSelectSettings( "selectReplacementVariablesFor", [ name ], name, "term-in-custom-taxonomy" );
 	const recommendedReplacementVariables = useSelectSettings( "selectRecommendedReplacementVariablesFor", [ name ], name, "term-in-custom-taxonomy" );
 	const noIndexInfoLink = useSelectSettings( "selectLink", [], "https://yoa.st/show-x" );
@@ -186,6 +187,8 @@ const Taxonomy = ( { name, label, postTypes: postTypeNames } ) => {
 							shouldUpsell={ ! isPremium }
 							variant="card"
 							cardLink={ socialAppearancePremiumLink }
+							upsellButtonAction={ getPremiumUpsellConfig.actionId }
+							upsellButtonCtbId={ getPremiumUpsellConfig.premiumCtbId }
 							cardText={ sprintf(
 							/* translators: %1$s expands to Premium. */
 								__( "Unlock with %1$s", "wordpress-seo" ),

--- a/packages/js/src/settings/store/default-settings.js
+++ b/packages/js/src/settings/store/default-settings.js
@@ -4,7 +4,10 @@ import { get } from "lodash";
 /**
  * @returns {Object} The initial state.
  */
-export const createInitialDefaultSettingsState = () => get( window, "wpseoScriptData.defaultSettings", {} );
+export const createInitialDefaultSettingsState = () => ( {
+	...get( window, "wpseoScriptData.defaultSettings", {} ),
+	upsellSettings: get( window, "wpseoScriptData.upsellSettings", {} ),
+} );
 
 const slice = createSlice( {
 	name: "defaultSettings",
@@ -14,6 +17,7 @@ const slice = createSlice( {
 
 export const defaultSettingsSelectors = {
 	selectDefaultSetting: ( state, setting, defaultValue = {} ) => get( state, `defaultSettings.${ setting }`, defaultValue ),
+	selectUpsellSetting: state => get( state, "defaultSettings.upsellSettings", {} ),
 	selectDefaultSettings: state => get( state, "defaultSettings", {} ),
 };
 

--- a/packages/ui-library/src/components/feature-upsell/index.js
+++ b/packages/ui-library/src/components/feature-upsell/index.js
@@ -18,9 +18,11 @@ const classNameMap = {
  * @param {string} [variant] The variant. See `classNameMap.variant`.
  * @param {string} [cardLink] The card' URL to link to. Required if the variant is `card`.
  * @param {string} [cardText] The card' button text. Used when the variant is `card`.
+ * @param {string} [upsellButtonAction] The value for the data-action attribute.
+ * @param {string} [upsellButtonCtbId] The value for the data-ctb-id attribute.
  * @returns {JSX.Element} The feature or the upsell around the feature.
  */
-const FeatureUpsell = ( { children, shouldUpsell = true, className = "", variant = "default", cardLink = "", cardText = "" } ) => {
+const FeatureUpsell = ( { children, shouldUpsell = true, className = "", variant = "default", cardLink = "", cardText = "", upsellButtonAction = "", upsellButtonCtbId = "" } ) => {
 	const svgAriaProps = useSvgAria();
 
 	if ( ! shouldUpsell ) {
@@ -37,7 +39,10 @@ const FeatureUpsell = ( { children, shouldUpsell = true, className = "", variant
 					className="yst-absolute yst-inset-0 yst-z-10 yst-bg-white yst-bg-opacity-50 yst-ring-1 yst-ring-black yst-ring-opacity-5 yst-shadow-lg yst-rounded-md"
 				/>
 				<div className="yst-absolute yst-inset-0 yst-z-20 yst-flex yst-items-center yst-justify-center">
-					<Button as="a" className="yst-gap-2 yst-shadow-lg yst-shadow-amber-700/30" variant="upsell" href={ cardLink } target="_blank" rel="noopener">
+					<Button
+						as="a" className="yst-gap-2 yst-shadow-lg yst-shadow-amber-700/30" variant="upsell" href={ cardLink } target="_blank" rel="noopener"
+						data-action={ upsellButtonAction } data-ctb-id={ upsellButtonCtbId }
+					>
 						<LockOpenIcon className="yst-w-5 yst-h-5 yst--ml-1 yst-shrink-0" { ...svgAriaProps } />
 						{ cardText }
 					</Button>
@@ -61,6 +66,8 @@ FeatureUpsell.propTypes = {
 	variant: PropTypes.oneOf( Object.keys( classNameMap.variant ) ),
 	cardLink: PropTypes.string,
 	cardText: PropTypes.string,
+	upsellButtonAction: PropTypes.string,
+	upsellButtonCtbId: PropTypes.string,
 };
 
 export default FeatureUpsell;

--- a/src/integrations/settings-integration.php
+++ b/src/integrations/settings-integration.php
@@ -345,6 +345,7 @@ class Settings_Integration implements Integration_Interface {
 		return [
 			'settings'             => $this->transform_settings( $settings ),
 			'defaultSettings'      => $default_settings,
+			'upsellSettings'       => $this->get_upsell_settings(),
 			'disabledSettings'     => $this->get_disabled_settings( $settings ),
 			'endpoint'             => \admin_url( 'options.php' ),
 			'nonce'                => \wp_create_nonce( self::PAGE . '-options' ),
@@ -399,6 +400,18 @@ class Settings_Integration implements Integration_Interface {
 			'canManageOptions'              => \current_user_can( 'manage_options' ),
 			'pluginUrl'                     => \plugins_url( '', \WPSEO_FILE ),
 			'showForceRewriteTitlesSetting' => ! \current_theme_supports( 'title-tag' ) && ! ( \function_exists( 'wp_is_block_theme' ) && \wp_is_block_theme() ),
+		];
+	}
+
+	/**
+	 * Returns settings for the CTB buttons.
+	 *
+	 * @return string[] The array of CTB settings.
+	 */
+	public function get_upsell_settings() {
+		return [
+			'actionId'     => 'load-nfd-ctb',
+			'premiumCtbId' => '57d6a568-783c-45e2-a388-847cff155897',
 		];
 	}
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

We want to add some configuration options to our buy buttons.
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds upsell data attributes to the new settings ui

## Relevant technical choices:

* I added the data to the default settings store so we have one source of truth.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Open the following pages and make sure all the buttons have `data-action` with value `load-nfd-ctb` and `data-ctb-id` with value `57d6a568-783c-45e2-a388-847cff155897`. Also make sure that when you hit a button or link it still sends you to the url attached to the button.
 https://basic.wordpress.test/wp-admin/admin.php?page=wpseo_settings#/site-features
https://basic.wordpress.test/wp-admin/admin.php?page=wpseo_settings#/crawl-optimization
https://basic.wordpress.test/wp-admin/admin.php?page=wpseo_settings#/post-type/posts
https://basic.wordpress.test/wp-admin/admin.php?page=wpseo_settings#/taxonomy/categories
https://basic.wordpress.test/wp-admin/admin.php?page=wpseo_settings#/author-archives
https://basic.wordpress.test/wp-admin/admin.php?page=wpseo_settings#/date-archives
https://basic.wordpress.test/wp-admin/admin.php?page=wpseo_settings#/format-archives

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
