### PR TITLE
Surfaces\Values\Meta: fix dynamic property setting in magic methods

### DIFF
--- a/src/surfaces/values/meta.php
+++ b/src/surfaces/values/meta.php
@@ -2,9 +2,9 @@
 
 namespace Yoast\WP\SEO\Surfaces\Values;
 
-use Exception;
 use WPSEO_Replace_Vars;
 use Yoast\WP\SEO\Context\Meta_Tags_Context;
+use Yoast\WP\SEO\Exceptions\Forbidden_Property_Mutation_Exception;
 use Yoast\WP\SEO\Integrations\Front_End_Integration;
 use Yoast\WP\SEO\Models\Indexable;
 use Yoast\WP\SEO\Presenters\Abstract_Indexable_Presenter;
@@ -97,6 +97,13 @@ class Meta {
 	protected $replace_vars;
 
 	/**
+	 * Collection of properties dynamically set via the magic __get() method.
+	 *
+	 * @var array<string, mixed> Key is the property name.
+	 */
+	private $properties_bin = [];
+
+	/**
 	 * Create a meta value object.
 	 *
 	 * @param Meta_Tags_Context  $context   The indexable presentation.
@@ -154,18 +161,20 @@ class Meta {
 	 *
 	 * @param string $name The property to get.
 	 *
-	 * @return mixed The value, as presented by teh appropriate presenter.
-	 *
-	 * @throws Exception If an invalid property is accessed.
+	 * @return mixed The value, as presented by the appropriate presenter.
 	 */
 	public function __get( $name ) {
+		if ( \array_key_exists( $name, $this->properties_bin ) ) {
+			return $this->properties_bin[ $name ];
+		}
+
 		/** This filter is documented in src/integrations/front-end-integration.php */
 		$presentation = \apply_filters( 'wpseo_frontend_presentation', $this->context->presentation, $this->context );
 
 		if ( ! isset( $presentation->{$name} ) ) {
 			if ( isset( $this->context->{$name} ) ) {
-				$this->{$name} = $this->context->{$name};
-				return $this->{$name};
+				$this->properties_bin[ $name ] = $this->context->{$name};
+				return $this->properties_bin[ $name ];
 			}
 			return null;
 		}
@@ -199,8 +208,8 @@ class Meta {
 			$value = $presentation->{$name};
 		}
 
-		$this->{$name} = $value;
-		return $this->{$name};
+		$this->properties_bin[ $name ] = $value;
+		return $this->properties_bin[ $name ];
 	}
 
 	/**
@@ -211,7 +220,40 @@ class Meta {
 	 * @return bool Whether or not the requested property exists.
 	 */
 	public function __isset( $name ) {
+		if ( \array_key_exists( $name, $this->properties_bin ) ) {
+			return true;
+		}
+
 		return isset( $this->context->presentation->{$name} );
+	}
+
+	/**
+	 * Prevents setting dynamic properties and overwriting the value of declared properties
+	 * from an inaccessible context.
+	 *
+	 * @param string $name  The property name.
+	 * @param mixed  $value The property value.
+	 *
+	 * @return void
+	 *
+	 * @throws Forbidden_Property_Mutation_Exception Set is never meant to be called.
+	 */
+	public function __set( $name, $value ) { // @phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- __set must have a name and value.
+		throw Forbidden_Property_Mutation_Exception::cannot_set_because_property_is_immutable( $name );
+	}
+
+	/**
+	 * Prevents unsetting dynamic properties and unsetting declared properties
+	 * from an inaccessible context.
+	 *
+	 * @param string $name The property name.
+	 *
+	 * @return void
+	 *
+	 * @throws Forbidden_Property_Mutation_Exception Unset is never meant to be called.
+	 */
+	public function __unset( $name ) {
+		throw Forbidden_Property_Mutation_Exception::cannot_unset_because_property_is_immutable( $name );
 	}
 
 	/**

--- a/tests/unit/surfaces/values/meta-test.php
+++ b/tests/unit/surfaces/values/meta-test.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Surfaces\Values;
+
+use Mockery;
+use WPSEO_Replace_Vars;
+use Yoast\WP\SEO\Exceptions\Forbidden_Property_Mutation_Exception;
+use Yoast\WP\SEO\Integrations\Front_End_Integration;
+use Yoast\WP\SEO\Surfaces\Helpers_Surface;
+use Yoast\WP\SEO\Surfaces\Values\Meta;
+use Yoast\WP\SEO\Tests\Unit\Doubles\Context\Meta_Tags_Context_Mock;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+use YoastSEO_Vendor\Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Class Meta_Test.
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Surfaces\Values\Meta
+ *
+ * @group surfaces
+ */
+class Meta_Test extends TestCase {
+
+	/**
+	 * The context
+	 *
+	 * @var Meta_Tags_Context_Mock
+	 */
+	protected $context;
+
+	/**
+	 * The container.
+	 *
+	 * @var ContainerInterface
+	 */
+	protected $container;
+
+	/**
+	 * The instance.
+	 *
+	 * @var Meta
+	 */
+	protected $instance;
+
+	/**
+	 * Sets up the test instance.
+	 *
+	 * @return void
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->context = Mockery::mock( Meta_Tags_Context_Mock::class );
+
+		$helpers         = Mockery::mock( Helpers_Surface::class );
+		$replace_vars    = Mockery::mock( WPSEO_Replace_Vars::class );
+		$front_end       = Mockery::mock( Front_End_Integration::class );
+		$this->container = $this->create_container_with(
+			[
+				Helpers_Surface::class       => $helpers,
+				WPSEO_Replace_Vars::class    => $replace_vars,
+				Front_End_Integration::class => $front_end,
+			]
+		);
+
+		$this->instance = new Meta(
+			$this->context,
+			$this->container
+		);
+	}
+
+	/**
+	 * Verify that null is returned by the magic __get() method when an attempt is made
+	 * to access a (declared) protected or private property from outside the class.
+	 *
+	 * @covers       ::__get
+	 * @dataProvider data_declared_inaccessible_properties
+	 *
+	 * @param string $name Property name.
+	 */
+	public function test_get_on_inaccessible_property_returns_null( $name ) {
+		$this->assertNull( $this->instance->$name );
+	}
+
+	/**
+	 * The magic set method should prevent setting dynamic properties, as well as prevent
+	 * overloading the value of protected/private properties from a context in which they
+	 * are inaccessible.
+	 *
+	 * @covers ::__set
+	 *
+	 * @dataProvider data_declared_inaccessible_properties
+	 * @dataProvider data_undeclared_properties
+	 *
+	 * @param string $name Property name.
+	 */
+	public function test_set_is_forbidden( $name ) {
+		$this->expectException( Forbidden_Property_Mutation_Exception::class );
+		$this->expectExceptionMessage( "Setting property \$$name is not supported." );
+
+		$this->instance->$name = 'dynamic property';
+	}
+
+	/**
+	 * The magic unset method should prevent unsetting dynamic properties, as well as prevent
+	 * unsetting protected/private properties from a context in which they are inaccessible.
+	 *
+	 * @covers ::__unset
+	 *
+	 * @dataProvider data_declared_inaccessible_properties
+	 * @dataProvider data_undeclared_properties
+	 *
+	 * @param string $name Property name.
+	 */
+	public function test_unset_is_forbidden( $name ) {
+		$this->expectException( Forbidden_Property_Mutation_Exception::class );
+		$this->expectExceptionMessage( "Unsetting property \$$name is not supported." );
+
+		unset( $this->instance->$name );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_declared_inaccessible_properties() {
+		return [
+			'container'      => [ 'container' ],
+			'context'        => [ 'context' ],
+			'front_end'      => [ 'front_end' ],
+			'helpers'        => [ 'helpers' ],
+			'replace_vars'   => [ 'replace_vars' ],
+			'properties_bin' => [ 'properties_bin' ],
+		];
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_undeclared_properties() {
+		return [
+			'xyz'     => [ 'xyz' ],
+			'unknown' => [ 'unknown' ],
+		];
+	}
+}


### PR DESCRIPTION
## Context

* Improve PHP 8.2 compatibility

## Summary

This PR can be summarized in the following changelog entry:

* Improve PHP 8.2 compatibility

## Relevant technical choices:

The magic `Surfaces\Values\Meta::__get()` method was creating dynamic properties on the class, where dynamic properties are properties not declared on the class which subsequently created on the fly as `public` properties.

As of PHP 8.2, creating dynamic properties is deprecated.

This commit fixes this by:
* Declaring a `private` `$properties_bin` array property to the class.
* Adjusting the magic `__get()` method to save the values for the properties in the `$properties_bin` instead of dynamically creating properties.
* Adjusting the magic `__get()` method to take values previously saved to the `$properties_bin` into account.
* Adjusting the magic `__isset()` method to also look in the `$properties_bin` when determining whether a property is set or not.
* Forbidding setting and unsetting properties other than the declared ones and those supported via the magic `__get()` method by adding new magic `__set()` and `__unset()` methods which will throw an exception.

Note: this does mean to access these properties once set, the magic `__get()` method will now always be called, where previously it would be bypassed. This may have a very very tiny impact on performance.

Also note that there are a few caveats/changes in behaviour:
* Setting dynamic properties on the class is now forbidden, not just for the above case, but in all cases. Previously dynamic properties could still be assigned to the class.
* The class is not `final` and potential child classes and (inaccessible) properties of those are not taken into account in the magic `__get()` method.
    We did do some extensive searches to check if the class _is_ being extended and those searches didn't yield any usable results.

What hasn't changed: access to the already declared `protected` properties from outside the class was previously not supported via the magic methods and is still not supported.

Includes tests for the new `__set()` and `__unset()` methods and a safeguard that the magic `__get()` method does not return the values for `protected` or `private` properties.

---
Internal: if anyone is wondering why this implementation was chosen:
- Hard declaring the properties would be maintenance unfriendly and error-prone as each of the properties would need to be `unset()` in the class constructor as otherwise the magic methods would not be triggered to lazily set the value for the property.
    It would also mean that "sets" and "unsets" cannot be blocked as once the property is declared/initialized, the magic methods are bypassed.
    I.e. the constructor would need to be updated every time a property would be added/removed, but only for the properties supported by magic, which means that the cognitive load when updating the class would also increase.
- Now, you may wonder "why not declare these properties anyway, but make them `private` and not bother with the `unset()` ?" Good question, but access to `private` properties from within the class does not go via the magic methods _unless_ the property is _unset_.
- We also discussed having initial `null` values for all supported properties in the `$properties_bin`, which would then effectively function as an "allow list" for the properties supported by the magic methods.
    We decided against that as a) that would give a special meaning to a `null` value, which means that if the "lazy initialization" would result in a `null` value, the lazy initialization could no longer be short-circuited and b) this would again cause maintenance overhead making it error prone.
---

Tests for the real functionality of the preexisting `__get()` and `__isset()` methods should be added by the team at a later date.


## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* ... ?
