### PR TITLE
Change new settings UI page id

### DIFF
--- a/packages/js/src/settings/helpers/submit.js
+++ b/packages/js/src/settings/helpers/submit.js
@@ -12,8 +12,8 @@ const submitSettings = async( values ) => {
 	const { endpoint, nonce } = get( window, "wpseoScriptData", {} );
 	const formData = new FormData();
 
-	formData.set( "option_page", "wpseo_settings" );
-	formData.set( "_wp_http_referer", "admin.php?page=wpseo_settings_saved" );
+	formData.set( "option_page", "wpseo_page_settings" );
+	formData.set( "_wp_http_referer", "admin.php?page=wpseo_page_settings_saved" );
 	formData.set( "action", "update" );
 	formData.set( "_wpnonce", nonce );
 

--- a/src/integrations/settings-integration.php
+++ b/src/integrations/settings-integration.php
@@ -27,7 +27,7 @@ use Yoast\WP\SEO\Integrations\Admin\Social_Profiles_Helper;
  */
 class Settings_Integration implements Integration_Interface {
 
-	const PAGE = 'wpseo_settings';
+	const PAGE = 'wpseo_page_settings';
 
 	/**
 	 * Holds the included WordPress options.

--- a/tests/unit/integrations/settings-integration-test.php
+++ b/tests/unit/integrations/settings-integration-test.php
@@ -85,7 +85,7 @@ class Settings_Integration_Test extends TestCase {
 	public function test_add_submenu_page() {
 
 		Monkey\Functions\expect( 'add_submenu_page' )
-			->with( '', '', '', 'wpseo_manage_options', 'wpseo_settings_saved', Mockery::type( 'Closure' ) );
+			->with( '', '', '', 'wpseo_manage_options', 'wpseo_page_settings_saved', Mockery::type( 'Closure' ) );
 
 		$submenu_pages = [
 			'array',


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* New settings UI page id conflicts with admin bar settings submenu id.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where `SEO Settings` admin bar submenu would not show when new settings UI is enabled.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Test with [this Premium PR](https://github.com/Yoast/wordpress-seo-premium/pull/3756).
* On `trunk` branch (before merge) with the new settings UI enabled, verify that the `SEO Settings` submenu is not showing in our admin bar menu.
* On this branch, verify that above issue is fixed.
* On this branch, verify that you can still correctly save your settings in the new UI.
![image](https://user-images.githubusercontent.com/24573520/203094093-8cd90914-eea2-4e83-b68a-b1479b630f2f.png)


#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
#DUPP-767