### PR TITLE
PHP 8.2 | utf8_decode deprecation

### DIFF
--- a/inc/class-wpseo-replace-vars.php
+++ b/inc/class-wpseo-replace-vars.php
@@ -406,7 +406,7 @@ class WPSEO_Replace_Vars {
 				$content = strip_shortcodes( $this->args->post_content );
 				$content = wp_strip_all_tags( $content );
 
-				if ( strlen( utf8_decode( $content ) ) <= $limit ) {
+				if ( mb_strlen( $content ) <= $limit ) {
 					return $content;
 				}
 
@@ -414,7 +414,7 @@ class WPSEO_Replace_Vars {
 
 				// Check if the description has space and trim the auto-generated string to a word boundary.
 				if ( strrpos( $replacement, ' ' ) ) {
-						$replacement = substr( $replacement, 0, strrpos( $replacement, ' ' ) );
+					$replacement = substr( $replacement, 0, strrpos( $replacement, ' ' ) );
 				}
 			}
 		}

--- a/inc/class-wpseo-replace-vars.php
+++ b/inc/class-wpseo-replace-vars.php
@@ -395,7 +395,9 @@ class WPSEO_Replace_Vars {
 	private function retrieve_excerpt() {
 		$replacement = null;
 		$locale      = \get_locale();
-		$limit       = ( $locale === 'ja' ) ? 80 : 156;
+
+		// Japanese doesn't have a jp_JP variant in WP.
+		$limit = ( $locale === 'ja' ) ? 80 : 156;
 
 		// The check `post_password_required` is because excerpt must be hidden for a post with a password.
 		if ( ! empty( $this->args->ID ) && ! post_password_required( $this->args->ID ) ) {

--- a/tests/integration/test-wpseo-functions.php
+++ b/tests/integration/test-wpseo-functions.php
@@ -14,6 +14,8 @@ class WPSEO_Functions_Test extends WPSEO_UnitTestCase {
 	 * Tests whether wpseo_replace_vars correctly replaces replacevars.
 	 *
 	 * @covers ::wpseo_replace_vars
+	 *
+	 * @return void
 	 */
 	public function test_wpseo_replace_vars() {
 
@@ -42,7 +44,7 @@ class WPSEO_Functions_Test extends WPSEO_UnitTestCase {
 		$input    = '%%title%% %%excerpt%% %%date%% %%name%%';
 		$expected = 'Post_Title Post_Excerpt ' . mysql2date( get_option( 'date_format' ), $post->post_date, true ) . ' User_Nicename';
 		$output   = wpseo_replace_vars( $input, (array) $post );
-		$this->assertEquals( $expected, $output );
+		$this->assertSame( $expected, $output );
 
 		/*
 		 * @todo
@@ -52,9 +54,212 @@ class WPSEO_Functions_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
+	 * Tests whether wpseo_replace_vars correctly replaces the excerpt replacevar.
+	 *
+	 * @covers ::wpseo_replace_vars
+	 * @covers WPSEO_Replace_Vars::retrieve_excerpt
+	 *
+	 * @dataProvider provide_excerpt_replace_var_data
+	 *
+	 * @param array|null $post_data            An associative array containing post data for which a post will be created.
+	 * @param string     $locale               The site language locale to use during this test.
+	 * @param string     $expected             The expected value after replacing replacevars.
+	 * @param string     $required_php_version The minimum required version of PHP to run this test.
+	 *
+	 * @return void
+	 */
+	public function test_wpseo_replace_vars_excerpt( $post_data, $locale, $expected, $required_php_version = '' ) {
+		if ( $required_php_version !== '' && version_compare( PHP_VERSION, $required_php_version, '<' ) ) {
+			$this->markTestSkipped( 'This test requires PHP ' . $required_php_version . ' or higher' );
+		}
+
+		add_filter(
+			'locale',
+			function () use ( $locale ) {
+				return $locale;
+			}
+		);
+
+		$post = null;
+		// Create post.
+		if ( is_array( $post_data ) ) {
+			$post_id = $this->factory->post->create( $post_data );
+			$post    = get_post( $post_id );
+		}
+
+		$input  = 'The replaced excerpt: %%excerpt%%';
+		$output = wpseo_replace_vars( $input, (array) $post );
+		$this->assertSame( $expected, $output );
+	}
+
+	/**
+	 * Provides test data for the excerpt replacevar test.
+	 *
+	 * @return Generator
+	 */
+	public function provide_excerpt_replace_var_data() {
+		yield 'Generates an empty excerpt without any post data' => [
+			'post_data' => null,
+			'locale'    => 'en',
+			'expected'  => 'The replaced excerpt:',
+		];
+
+		yield 'Generates an empty excerpt for password protected posts' => [
+			'post_data' => [
+				'post_content'  => 'post content',
+				'post_excerpt'  => 'post excerpt',
+				'post_password' => 'welcome123',
+			],
+			'locale'    => 'en',
+			'expected'  => 'The replaced excerpt:',
+		];
+
+		yield 'Uses the post excerpt if it is set' => [
+			'post_data' => [
+				'post_content' => 'ignore the post content',
+				'post_excerpt' => 'always use the post excerpt if it is set',
+			],
+			'locale'    => 'en',
+			'expected'  => 'The replaced excerpt: always use the post excerpt if it is set',
+		];
+
+		yield 'Strips all tags from the excerpt' => [
+			'post_data' => [
+				'post_content' => '',
+				'post_excerpt' => 'This is <h2>an excerpt</h2><br> with <img src="example.jpg"> tags.',
+			],
+			'locale'    => 'en',
+			'expected'  => 'The replaced excerpt: This is an excerpt with tags.',
+		];
+
+		yield 'Falls back to post content if there is no excerpt' => [
+			'post_data' => [
+				'post_content' => 'post content',
+				'post_excerpt' => '',
+			],
+			'locale'    => 'en',
+			'expected'  => 'The replaced excerpt: post content',
+		];
+
+		yield 'Strips shortcodes' => [
+			'post_data' => [
+				'post_content' => 'This is post content with a [caption align="alignright"]This should be stripped[/caption] shortcode.',
+				'post_excerpt' => '',
+			],
+			'locale'    => 'nl',
+			'expected'  => 'The replaced excerpt: This is post content with a shortcode.',
+		];
+
+		yield 'Strips all tags from the generated excerpt' => [
+			'post_data' => [
+				'post_content' => 'This is <b>post content</b><br> with <img src="example.jpg"> tags.',
+				'post_excerpt' => '',
+			],
+			'locale'    => 'nl',
+			'expected'  => 'The replaced excerpt: This is post content with tags.',
+		];
+
+		yield 'Limits the generated excerpt to a maximum of 156 characters for non-Japanese locales regardless of the written language (183 single-byte characters long)' => [
+			'post_data' => [
+				'post_content' => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum quam velit, mollis a velit ac, mollis posuere lacus. Donec venenatis eleifend metus, ac elementum ligula scelerisqu',
+				'post_excerpt' => '',
+			],
+			'locale'    => 'de_DE_formal',
+			'expected'  => 'The replaced excerpt: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum quam velit, mollis a velit ac, mollis posuere lacus. Donec venenatis eleifend metus,',
+		];
+
+		yield 'Limits the generated excerpt to a maximum of 80 characters for Japanese locales regardless of the written language (183 single-byte characters long)' => [
+			'post_data' => [
+				'post_content' => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum quam velit, mollis a velit ac, mollis posuere lacus. Donec venenatis eleifend metus, ac elementum ligula scelerisqu',
+				'post_excerpt' => '',
+			],
+			'locale'    => 'ja',
+			'expected'  => 'The replaced excerpt: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum quam',
+		];
+
+		yield 'Limits the generated excerpt to a maximum of 156 characters for non-Japanese locales regardless of the written language (167 multi-byte characters long)' => [
+			'post_data' => [
+				'post_content' => '治クツワ警集クカナユ設者本い児化76促縮繰壌7成ゅりとあ親別るぎく公来こさみふ地部れみゅ政週ゆら図現よぜフを田報ロユ速年文みーがま郎在ぎフ。塾ちッり暮検ラヌコリ信字花キ口昇動フス季紅ネキロフ殺佐ず持容フよ並道ネホル長英ツヤ第野ヒソア問適チホレ番参び給財がをざイ同綸乾んみ。治クツワ警集クカナユ設者本い児化促縮繰壌7成ゅりとあ親別る',
+				'post_excerpt' => '',
+			],
+			'locale'    => 'dzo',
+			'expected'  => 'The replaced excerpt: 治クツワ警集クカナユ設者本い児化76促縮繰壌7成ゅりとあ親別るぎく公来こさみふ地部れみゅ政週ゆら図現よぜフを田報ロユ速年文みーがま郎在ぎフ。塾ちッり暮検ラヌコリ信字花キ口昇動フス季紅ネキロフ殺佐ず持容フよ並道ネホル長英ツヤ第野ヒソア問適チホレ番参び給財がをざイ同綸乾んみ。治クツワ警集クカナユ設者本い児化促縮繰壌',
+		];
+
+		yield 'Limits the generated excerpt to a maximum of 80 characters for Japanese locales regardless of the written language (167 multi-byte characters long)' => [
+			'post_data' => [
+				'post_content' => '治クツワ警集クカナユ設者本い児化76促縮繰壌7成ゅりとあ親別るぎく公来こさみふ地部れみゅ政週ゆら図現よぜフを田報ロユ速年文みーがま郎在ぎフ。塾ちッり暮検ラヌコリ信字花キ口昇動フス季紅ネキロフ殺佐ず持容フよ並道ネホル長英ツヤ第野ヒソア問適チホレ番参び給財がをざイ同綸乾んみ。治クツワ警集クカナユ設者本い児化促縮繰壌7成ゅりとあ親別る',
+				'post_excerpt' => '',
+			],
+			'locale'    => 'ja',
+			'expected'  => 'The replaced excerpt: 治クツワ警集クカナユ設者本い児化76促縮繰壌7成ゅりとあ親別るぎく公来こさみふ地部れみゅ政週ゆら図現よぜフを田報ロユ速年文みーがま郎在ぎフ。塾ちッり暮検ラヌコリ',
+		];
+
+		yield 'Trims leading and trailing spaces when generating an excerpt' => [
+			'post_data' => [
+				'post_content' => '  excerpt is generated from post content ',
+				'post_excerpt' => '',
+			],
+			'locale'    => 'ja',
+			'expected'  => 'The replaced excerpt: excerpt is generated from post content',
+		];
+
+		yield 'Trims leading and trailing tabs when generating an excerpt' => [
+			'post_data' => [
+				'post_content' => '	excerpt is generated from post content	',
+				'post_excerpt' => '',
+			],
+			'locale'    => 'ja',
+			'expected'  => 'The replaced excerpt: excerpt is generated from post content',
+		];
+
+		yield 'Trims leading and trailing newlines when generating an excerpt' => [
+			'post_data' => [
+				'post_content' => PHP_EOL . 'excerpt is generated from post content' . PHP_EOL,
+				'post_excerpt' => '',
+			],
+			'locale'    => 'ja',
+			'expected'  => 'The replaced excerpt: excerpt is generated from post content',
+		];
+
+		yield 'Trims a combination of leading and trailing whitespace characters when generating an excerpt' => [
+			'post_data' => [
+				'post_content' => "\n\r  \t  excerpt is generated from post content \n\r 	  \n \r \t  " . PHP_EOL,
+				'post_excerpt' => '',
+			],
+			'locale'    => 'en',
+			'expected'  => 'The replaced excerpt: excerpt is generated from post content',
+		];
+
+		yield 'Doesn\'t trim unicode whitespaces characters when generating an excerpt' => [
+			'post_data'            => [
+				// phpcs:ignore PHPCompatibility.TextStrings.NewUnicodeEscapeSequence -- This test is only ran on PHP 7 and up.
+				'post_content' => "excerpt is generated from post content \u{2002} " . PHP_EOL,
+				'post_excerpt' => '',
+			],
+			'locale'               => 'en',
+			// phpcs:ignore PHPCompatibility.TextStrings.NewUnicodeEscapeSequence -- This test is only ran on PHP 7 and up.
+			'expected'             => "The replaced excerpt: excerpt is generated from post content \u{2002}",
+			'required_php_version' => '7.0',
+			// Unicode codepoint escape syntax is a PHP 7+ feature.
+		];
+
+		yield 'Strips the last characters after the last whitespace from a generated excerpt to prevent incomplete words' => [
+			'post_data' => [
+				'post_content' => 'This sentence has a word at the 80 character mark that would\'ve been split up because the word "because" spans the 78th-85th characters',
+				'post_excerpt' => '',
+			],
+			'locale'    => 'ja',
+			'expected'  => 'The replaced excerpt: This sentence has a word at the 80 character mark that would\'ve been split up',
+		];
+	}
+
+	/**
 	 * Tests test_wpseo_get_capabilities correctly retrieves capabilities.
 	 *
 	 * @covers ::wpseo_get_capabilities
+	 *
+	 * @return void
 	 */
 	public function test_wpseo_get_capabilities() {
 		$capabilities = wpseo_get_capabilities();


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* utf8_decode is deprecated since PHP 8.2.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improve PHP 8.2 compatibility.

## Relevant technical choices:

* We used utf8_decode before to transform multibyte characters like Japanese to singlebyte `?` characters so we could count them. PHP already has a function to count mb strings, which is also [polyfilled by WordPress core](https://github.com/WordPress/WordPress/blob/f3b087164dcb42eb18bd7fa1e66e6ea116ccb0c2/wp-includes/compat.php#L151).

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* This PR brings _no_ functionality change. This is a regression test.
* Change the site language to Japanese.
* Create a post and insert the `excerpt` replace var in the meta description.
* In the post content, paste this:
	* 治クツワ警集クカナユ設者本い児化76促縮繰壌7成ゅりとあ親別るぎく公来こさみふ地部れみゅ政週ゆら図現よぜフを田報ロユ速年文みーがま郎在ぎフ。塾ちッり暮検ラヌコリ信字花キ口昇動フス季紅ネキロフ殺佐ず持容フよ並道ネホル長英ツヤ第野ヒソア問適チホレ番参び給財がをざイ同綸乾んみ。治クツワ警集クカナユ設者本い児化促縮繰壌7成ゅりとあ親別る
* Publish the post, view it on the frontend and inspect the page source.
* The meta description tag should now be a shorter version of your content, limited to 80 characters. 
	* 治クツワ警集クカナユ設者本い児化76促縮繰壌7成ゅりとあ親別るぎく公来こさみふ地部れみゅ政週ゆら図現よぜフを田報ロユ速年文みーがま郎在ぎフ。塾ちッり暮検ラヌコリ
* Change the site language back to what it was before. 
* iew it on the frontend and inspect the page source.
* The meta description tag should now be a shorter version of your content, limited to 156 characters. 
	* 治クツワ警集クカナユ設者本い児化76促縮繰壌7成ゅりとあ親別るぎく公来こさみふ地部れみゅ政週ゆら図現よぜフを田報ロユ速年文みーがま郎在ぎフ。塾ちッり暮検ラヌコリ信字花キ口昇動フス季紅ネキロフ殺佐ず持容フよ並道ネホル長英ツヤ第野ヒソア問適チホレ番参び給財がをざイ同綸乾んみ。治クツワ警集クカナユ設者本い児化促縮繰壌

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* just the excerpt replace variable.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

