### PR TITLE
Settings UI: site features on network admin

### DIFF
--- a/packages/js/src/settings/app.js
+++ b/packages/js/src/settings/app.js
@@ -158,8 +158,8 @@ Menu.propTypes = {
  * @returns {JSX.Element} The element.
  */
 const PremiumUpsellList = () => {
-	const getPremiumLink = useSelectSettings( "selectLink", [], "https://yoa.st/17h" );
-	const getPremiumUpsellConfig =  useSelectSettings( "selectUpsellSetting", [] );
+	const premiumLink = useSelectSettings( "selectLink", [], "https://yoa.st/17h" );
+	const premiumUpsellConfig = useSelectSettings( "selectUpsellSettingsAsProps" );
 
 	return (
 		<div className="yst-p-6 xl:yst-max-w-3xl yst-rounded-lg yst-bg-white yst-shadow">
@@ -191,9 +191,12 @@ const PremiumUpsellList = () => {
 				<li><span className="yst-font-semibold">{ __( "No ads!", "wordpress-seo" ) }</span></li>
 			</ul>
 			<Button
-				as="a" variant="upsell" size="large" href={ getPremiumLink }
-				data-action={ getPremiumUpsellConfig.actionId } data-ctb-id={ getPremiumUpsellConfig.premiumCtbId }
+				as="a"
+				variant="upsell"
+				size="large"
+				href={ premiumLink }
 				className="yst-gap-2 yst-mt-4"
+				{ ...premiumUpsellConfig }
 			>
 				{ sprintf(
 					/* translators: %s expands to "Yoast SEO" Premium */

--- a/packages/js/src/settings/components/sidebar-recommendations.js
+++ b/packages/js/src/settings/components/sidebar-recommendations.js
@@ -12,8 +12,8 @@ import { ReactComponent as G2Logo } from "./g2-logo-white-rgb.svg";
  * @returns {JSX.Element} The premium upsell card.
  */
 const PremiumUpsellCard = () => {
-	const getPremiumLink = useSelectSettings( "selectLink", [], "https://yoa.st/jj" );
-	const getPremiumUpsellConfig =  useSelectSettings( "selectUpsellSetting", [] );
+	const premiumLink = useSelectSettings( "selectLink", [], "https://yoa.st/jj" );
+	const premiumUpsellConfig = useSelectSettings( "selectUpsellSettingsAsProps" );
 
 	const info = useMemo( () => createInterpolateElement(
 		sprintf(
@@ -44,10 +44,9 @@ const PremiumUpsellCard = () => {
 			</h2>
 			<p className="yst-mt-2">{ info }</p>
 			<Button
-				as="a" variant="upsell" size="large" href={ getPremiumLink }
+				as="a" variant="upsell" size="large" href={ premiumLink }
 				className="yst-flex yst-justify-center yst-gap-2 yst-mt-4 yst-px-4 sm:yst-px-0"
-				data-action={ getPremiumUpsellConfig.actionId }
-				data-ctb-id={ getPremiumUpsellConfig.premiumCtbId }
+				{ ...premiumUpsellConfig }
 			>
 				{ getPremium }
 				<ArrowNarrowRightIcon className="yst-w-4 yst-h-4" />

--- a/packages/js/src/settings/hocs/with-disabled-message-support.js
+++ b/packages/js/src/settings/hocs/with-disabled-message-support.js
@@ -1,9 +1,6 @@
-import { useMemo } from "@wordpress/element";
-import { __ } from "@wordpress/i18n";
 import { Badge } from "@yoast/ui-library";
-import { get, isEmpty } from "lodash";
 import PropTypes from "prop-types";
-import { useSelectSettings } from "../hooks";
+import { useDisabledMessage } from "../hooks";
 
 /**
  * Adds disabled message support around a component.
@@ -17,31 +14,14 @@ const withDisabledMessageSupport = ( Component ) => {
 	 * @returns {JSX.Element} The element.
 	 */
 	const WithDisabledMessageSupport = ( { name, ...props } ) => {
-		const isNetworkAdmin = useSelectSettings( "selectPreference", [], "isNetworkAdmin" );
-		const isMainSite = useSelectSettings( "selectPreference", [], "isMainSite" );
-		const disabledSetting = useMemo( () => get( window, `wpseoScriptData.disabledSettings.${ name }`, "" ), [] );
-		const isDisabledTracking = useMemo(
-			() => name === "wpseo.tracking" && ! isNetworkAdmin && ! isMainSite,
-			[ name, isNetworkAdmin, isMainSite ]
-		);
-		const text = useMemo( () => {
-			if ( isDisabledTracking ) {
-				return __( "Unavailable for sub-sites", "wordpress-seo" );
-			}
-			switch ( disabledSetting ) {
-				case "multisite":
-					return __( "Unavailable for multi-sites", "wordpress-seo" );
-				default:
-					return __( "Network disabled", "wordpress-seo" );
-			}
-		}, [ disabledSetting, isDisabledTracking ] );
+		const { isDisabled, message } = useDisabledMessage( { name } );
 
-		if ( ! isEmpty( disabledSetting ) || isDisabledTracking ) {
+		if ( isDisabled ) {
 			return <Component
 				name={ name }
 				{ ...props }
 				disabled={ true }
-				labelSuffix={ <Badge variant="plain" size="small" className="yst-ml-1.5">{ text }</Badge> }
+				labelSuffix={ <Badge variant="plain" size="small" className="yst-ml-1.5">{ message }</Badge> }
 			/>;
 		}
 		return <Component name={ name } { ...props } />;

--- a/packages/js/src/settings/hooks/index.js
+++ b/packages/js/src/settings/hooks/index.js
@@ -1,3 +1,4 @@
+export { default as useDisabledMessage } from "./use-disabled-message";
 export { default as useDispatchSettings } from "./use-dispatch-settings";
 export { default as useFormikError } from "./use-formik-error";
 export { default as useRouterScrollRestore } from "./use-router-scroll-restore";

--- a/packages/js/src/settings/hooks/use-disabled-message.js
+++ b/packages/js/src/settings/hooks/use-disabled-message.js
@@ -1,0 +1,39 @@
+import { useMemo } from "@wordpress/element";
+import { __ } from "@wordpress/i18n";
+import { get, isEmpty } from "lodash";
+import { useSelectSettings } from "./index";
+
+/**
+ * @param {string} name The field name.
+ * @returns {{isDisabled: boolean, message: string}} The disabled state.
+ */
+const useDisabledMessage = ( { name } ) => {
+	const isNetworkAdmin = useSelectSettings( "selectPreference", [], "isNetworkAdmin" );
+	const isMainSite = useSelectSettings( "selectPreference", [], "isMainSite" );
+	const isDisabledTracking = useMemo(
+		() => name === "wpseo.tracking" && ! isNetworkAdmin && ! isMainSite,
+		[ name, isNetworkAdmin, isMainSite ]
+	);
+	const disabledSetting = useMemo( () => get( window, `wpseoScriptData.disabledSettings.${ name }`, "" ), [] );
+	const message = useMemo( () => {
+		if ( isDisabledTracking ) {
+			return __( "Unavailable for sub-sites", "wordpress-seo" );
+		}
+		switch ( disabledSetting ) {
+			case "multisite":
+				return __( "Unavailable for multisites", "wordpress-seo" );
+			case "network":
+				return __( "Network disabled", "wordpress-seo" );
+			default:
+				return "";
+		}
+	}, [ disabledSetting, isDisabledTracking ] );
+	const isDisabled = useMemo( () => ! isEmpty( message ), [ message ] );
+
+	return {
+		isDisabled,
+		message,
+	};
+};
+
+export default useDisabledMessage;

--- a/packages/js/src/settings/routes/author-archives.js
+++ b/packages/js/src/settings/routes/author-archives.js
@@ -3,8 +3,8 @@ import { __, sprintf } from "@wordpress/i18n";
 import { Badge, Code, Link } from "@yoast/ui-library";
 import FeatureUpsell from "@yoast/ui-library/src/components/feature-upsell";
 import { useFormikContext } from "formik";
-import AnimateHeight from "react-animate-height";
 import { toLower } from "lodash";
+import AnimateHeight from "react-animate-height";
 import {
 	FieldsetLayout,
 	FormikFlippedToggleField,
@@ -25,10 +25,10 @@ const FormikReplacementVariableEditorFieldWithDummy = withFormikDummyField( Form
 const AuthorArchives = () => {
 	const label = __( "Author archives", "wordpress-seo" );
 	const singularLabel = __( "Author archive", "wordpress-seo" );
-	const labelLower = useMemo( ()=> toLower( label ), [ label ] );
-	const singularLabelLower = useMemo( ()=> toLower( singularLabel ), [ singularLabel ] );
+	const labelLower = useMemo( () => toLower( label ), [ label ] );
+	const singularLabelLower = useMemo( () => toLower( singularLabel ), [ singularLabel ] );
 
-	const getPremiumUpsellConfig =  useSelectSettings( "selectUpsellSetting", [] );
+	const premiumUpsellConfig = useSelectSettings( "selectUpsellSettingsAsProps" );
 	const replacementVariables = useSelectSettings( "selectReplacementVariablesFor", [], "author_archives", "custom-post-type_archive" );
 	const recommendedReplacementVariables = useSelectSettings( "selectRecommendedReplacementVariablesFor", [], "author_archives", "custom-post-type_archive" );
 	const duplicateContentInfoLink = useSelectSettings( "selectLink", [], "https://yoa.st/duplicate-content" );
@@ -183,13 +183,12 @@ const AuthorArchives = () => {
 									shouldUpsell={ ! isPremium }
 									variant="card"
 									cardLink={ socialAppearancePremiumLink }
-									upsellButtonAction={ getPremiumUpsellConfig.actionId }
-									upsellButtonCtbId={ getPremiumUpsellConfig.premiumCtbId }
 									cardText={ sprintf(
 										/* translators: %1$s expands to Premium. */
 										__( "Unlock with %1$s", "wordpress-seo" ),
 										"Premium"
 									) }
+									{ ...premiumUpsellConfig }
 								>
 									<OpenGraphDisabledAlert isEnabled={ ! isPremium || opengraph } />
 									<FormikMediaSelectField

--- a/packages/js/src/settings/routes/crawl-optimization.js
+++ b/packages/js/src/settings/routes/crawl-optimization.js
@@ -16,8 +16,8 @@ const FormikValueChangeFieldWithDummy = withFormikDummyField( withDisabledMessag
  * @returns {JSX.Element} The crawl optimization route.
  */
 const CrawlOptimization = () => {
+	const premiumUpsellConfig = useSelectSettings( "selectUpsellSettingsAsProps" );
 	const crawlSettingsLink = useSelectSettings( "selectLink", [], "https://yoa.st/crawl-settings" );
-	const getPremiumUpsellConfig =  useSelectSettings( "selectUpsellSetting", [] );
 	const permalinkCleanupLink = useSelectSettings( "selectLink", [], "https://yoa.st/permalink-cleanup" );
 	const isPremium = useSelectSettings( "selectPreference", [], "isPremium" );
 	const premiumLink = useSelectSettings( "selectLink", [], "https://yoa.st/crawl-settings-upsell" );
@@ -261,8 +261,13 @@ const CrawlOptimization = () => {
 				{ descriptions.page }
 				{ ! isPremium && <div className="yst-mt-6">
 					<Button
-						as="a" className="yst-gap-2" variant="upsell" href={ premiumLink } target="_blank" rel="noopener"
-						data-action={ getPremiumUpsellConfig.actionId } data-ctb-id={ getPremiumUpsellConfig.premiumCtbId }
+						as="a"
+						className="yst-gap-2"
+						variant="upsell"
+						href={ premiumLink }
+						target="_blank"
+						rel="noopener"
+						{ ...premiumUpsellConfig }
 					>
 						<LockOpenIcon className="yst-w-5 yst-h-5 yst--ml-1 yst-shrink-0" { ...svgAriaProps } />
 						{ sprintf(

--- a/packages/js/src/settings/routes/date-archives.js
+++ b/packages/js/src/settings/routes/date-archives.js
@@ -25,7 +25,7 @@ const DateArchives = () => {
 	const label = __( "Date archives", "wordpress-seo" );
 	const labelLower = useMemo( ()=> toLower( label ), [ label ] );
 
-	const getPremiumUpsellConfig =  useSelectSettings( "selectUpsellSetting", [] );
+	const premiumUpsellConfig = useSelectSettings( "selectUpsellSettingsAsProps" );
 	const replacementVariables = useSelectSettings( "selectReplacementVariablesFor", [], "date_archive", "custom-post-type_archive" );
 	const recommendedReplacementVariables = useSelectSettings( "selectRecommendedReplacementVariablesFor", [], "date_archive", "custom-post-type_archive" );
 	const noIndexInfoLink = useSelectSettings( "selectLink", [], "https://yoa.st/show-x" );
@@ -164,13 +164,12 @@ const DateArchives = () => {
 									shouldUpsell={ ! isPremium }
 									variant="card"
 									cardLink={ socialAppearancePremiumLink }
-									upsellButtonAction={ getPremiumUpsellConfig.actionId }
-									upsellButtonCtbId={ getPremiumUpsellConfig.premiumCtbId }
 									cardText={ sprintf(
 										// translators: %1$s expands to Premium.
 										__( "Unlock with %1$s", "wordpress-seo" ),
 										"Premium"
 									) }
+									{ ...premiumUpsellConfig }
 								>
 									<OpenGraphDisabledAlert isEnabled={ ! isPremium || opengraph } />
 									<FormikMediaSelectField

--- a/packages/js/src/settings/routes/format-archives.js
+++ b/packages/js/src/settings/routes/format-archives.js
@@ -31,7 +31,7 @@ const FormatArchives = () => {
 	const { name, label } = useSelectSettings( "selectTaxonomy", [], "post_format" );
 	const labelLower = useMemo( ()=> toLower( label ), [ label ] );
 
-	const getPremiumUpsellConfig =  useSelectSettings( "selectUpsellSetting", [] );
+	const premiumUpsellConfig = useSelectSettings( "selectUpsellSettingsAsProps" );
 	const replacementVariables = useSelectSettings( "selectReplacementVariablesFor", [ name ], name, "term-in-custom-taxonomy" );
 	const recommendedReplacementVariables = useSelectSettings( "selectRecommendedReplacementVariablesFor", [ name ], name, "term-in-custom-taxonomy" );
 	const noIndexInfoLink = useSelectSettings( "selectLink", [], "https://yoa.st/show-x" );
@@ -158,13 +158,12 @@ const FormatArchives = () => {
 									shouldUpsell={ ! isPremium }
 									variant="card"
 									cardLink={ socialAppearancePremiumLink }
-									upsellButtonAction={ getPremiumUpsellConfig.actionId }
-									upsellButtonCtbId={ getPremiumUpsellConfig.premiumCtbId }
 									cardText={ sprintf(
 									/* translators: %1$s expands to Premium. */
 										__( "Unlock with %1$s", "wordpress-seo" ),
 										"Premium"
 									) }
+									{ ...premiumUpsellConfig }
 								>
 									<OpenGraphDisabledAlert isEnabled={ ! isPremium || opengraph } />
 									<FormikMediaSelectField

--- a/packages/js/src/settings/routes/site-features.js
+++ b/packages/js/src/settings/routes/site-features.js
@@ -2,48 +2,121 @@
 import { ArrowNarrowRightIcon, LockOpenIcon } from "@heroicons/react/outline";
 import { useMemo } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
-import { Alert, Badge, Button, Card, Link, Title, ToggleField as PureToggleField, useSvgAria } from "@yoast/ui-library";
+import { Alert, Badge, Button, Card, Link, Title, ToggleField, useSvgAria } from "@yoast/ui-library";
 import classNames from "classnames";
 import { useFormikContext } from "formik";
+import { get } from "lodash";
 import PropTypes from "prop-types";
 import { FormikValueChangeField, FormLayout, RouteLayout } from "../components";
-import { withDisabledMessageSupport } from "../hocs";
-import { useSelectSettings } from "../hooks";
-
-const ToggleField = withDisabledMessageSupport( PureToggleField );
+import { useDisabledMessage, useSelectSettings } from "../hooks";
 
 /**
- * @param {string} src The image source.
- * @param {string} alt The image alt text.
- * @param {JSX.node} [children] Optional extra content.
- * @param {boolean} [disabled] Whether to use the disabled style.
- * @returns {JSX.Element} The card header.
+ * @param {string} name The field name.
+ * @param {string} cardId The card ID.
+ * @param {string} inputId The input ID.
+ * @param {string} imageSrc The image src, will get prefixed with the plugin URL.
+ * @param {string} imageAlt The image alt text.
+ * @param {JSX.node} children The card content.
+ * @param {boolean} isPremiumFeature Whether this card is for a premium feature.
+ * @param {boolean}  isBetaFeature Whether this card is for a beta feature.
+ * @param {string} isPremiumLink The link to use for the upsell. Required for premium features.
+ * @returns {JSX.Element} The card.
  */
-const CardHeader = ( {
-	src,
-	alt,
-	children = null,
-	disabled = false,
-} ) => (
-	<Card.Header className="yst-h-auto yst-p-0">
-		<img
-			className={ classNames( "yst-w-full", disabled && "yst-opacity-50 yst-filter yst-grayscale" ) }
-			src={ src }
-			alt={ alt }
-			width={ 500 }
-			height={ 250 }
-			loading="lazy"
-			decoding="async"
-		/>
-		{ children }
-	</Card.Header>
-);
+const FeatureCard = ( {
+	name,
+	cardId,
+	inputId,
+	children,
+	imageSrc: rawImageSrc,
+	imageAlt,
+	isPremiumFeature = false,
+	isPremiumLink = "",
+	isBetaFeature = false,
+} ) => {
+	const isPremium = useSelectSettings( "selectPreference", [], "isPremium" );
+	const imageSrc = useSelectSettings( "selectPluginUrl", [ rawImageSrc ], rawImageSrc );
+	const { isDisabled, message } = useDisabledMessage( { name } );
+	const { values } = useFormikContext();
+	const isPremiumHref = useSelectSettings( "selectLink", [ isPremiumLink ], isPremiumLink );
+	const premiumUpsellConfig = useSelectSettings( "selectUpsellSetting", [] );
+	const svgAriaProps = useSvgAria();
+	const value = useMemo( () => get( values, name, false ), [ values, name ] );
+	const shouldUpsell = useMemo( () => ! isPremium && isPremiumFeature, [ isPremium, isPremiumFeature ] );
+	const shouldDimHeaderImage = useMemo( () => isDisabled || ( shouldUpsell ? false : ! value ), [ isDisabled, shouldUpsell, value ] );
+	const shouldRenderBadgeContainer = useMemo(
+		() => isDisabled || ( isPremium && isPremiumFeature ) || isBetaFeature,
+		[ isDisabled, isPremium, isPremiumFeature, isBetaFeature ]
+	);
 
-CardHeader.propTypes = {
-	src: PropTypes.string.isRequired,
-	alt: PropTypes.string.isRequired,
-	children: PropTypes.node,
-	disabled: PropTypes.bool,
+	return (
+		<Card id={ cardId }>
+			<Card.Header className="yst-h-auto yst-p-0">
+				<img
+					className={ classNames(
+						"yst-w-full",
+						shouldDimHeaderImage && "yst-opacity-50 yst-filter yst-grayscale"
+					) }
+					src={ imageSrc }
+					alt={ imageAlt }
+					width={ 500 }
+					height={ 250 }
+					loading="lazy"
+					decoding="async"
+				/>
+				{ shouldRenderBadgeContainer && (
+					<div className="yst-absolute yst-top-2 yst-right-2 yst-flex yst-gap-1.5">
+						{ isDisabled && <Badge size="small" variant="plain">{ message }</Badge> }
+						{ isPremium && isPremiumFeature && <Badge size="small" variant="upsell">Premium</Badge> }
+						{ isBetaFeature && <Badge size="small" variant="info">Beta</Badge> }
+					</div>
+				) }
+			</Card.Header>
+			<Card.Content className="yst-flex yst-flex-col yst-gap-3">
+				{ children }
+			</Card.Content>
+			<Card.Footer>
+				{ ! shouldUpsell && <FormikValueChangeField
+					as={ ToggleField }
+					type="checkbox"
+					name={ name }
+					data-id={ inputId }
+					label={ __( "Enable feature", "wordpress-seo" ) }
+					disabled={ isDisabled }
+				/> }
+				{ shouldUpsell && (
+					<Button
+						as="a"
+						className="yst-gap-2 yst-w-full"
+						variant="upsell"
+						href={ isPremiumHref }
+						target="_blank"
+						rel="noopener"
+						data-action={ premiumUpsellConfig.actionId }
+						data-ctb-id={ premiumUpsellConfig.premiumCtbId }
+					>
+						<LockOpenIcon className="yst-w-5 yst-h-5 yst--ml-1 yst-shrink-0" { ...svgAriaProps } />
+						{ sprintf(
+							/* translators: %1$s expands to Premium. */
+							__( "Unlock with %1$s", "wordpress-seo" ),
+							"Premium"
+						) }
+					</Button>
+				) }
+			</Card.Footer>
+		</Card>
+	);
+};
+
+FeatureCard.propTypes = {
+	name: PropTypes.string.isRequired,
+	cardId: PropTypes.string.isRequired,
+	inputId: PropTypes.string.isRequired,
+	children: PropTypes.node.isRequired,
+	imageSrc: PropTypes.string.isRequired,
+	imageAlt: PropTypes.string.isRequired,
+	isPremiumFeature: PropTypes.bool,
+	isBetaFeature: PropTypes.bool,
+	isPremiumLink: PropTypes.string,
 };
 
 /**
@@ -80,29 +153,8 @@ LearnMoreLink.propTypes = {
 const SiteFeatures = () => {
 	const isPremium = useSelectSettings( "selectPreference", [], "isPremium" );
 	const sitemapUrl = useSelectSettings( "selectPreference", [], "sitemapUrl" );
-	const getPremiumUpsellConfig = useSelectSettings( "selectUpsellSetting", [] );
-	const getInclusiveLanguageAnalysisLink = useSelectSettings( "selectLink", [], "https://yoa.st/get-inclusive-language" );
-	const getLinkSuggestionsLink = useSelectSettings( "selectLink", [], "https://yoa.st/get-link-suggestions" );
-	const getIndexNowLink = useSelectSettings( "selectLink", [], "https://yoa.st/get-indexnow" );
-	const svgAriaProps = useSvgAria();
-
 	const { values } = useFormikContext();
 	const { enable_xml_sitemap: enableXmlSitemap } = values.wpseo;
-
-	const seoAnalysisImage = useSelectSettings( "selectPluginUrl", [], "/images/seo_analysis.png" );
-	const readabilityAnalysisImage = useSelectSettings( "selectPluginUrl", [], "/images/readability_analysis.png" );
-	const inclusiveLanguageAnalysisImage = useSelectSettings( "selectPluginUrl", [], "/images/inclusive_language_analysis.png" );
-	const insightsImage = useSelectSettings( "selectPluginUrl", [], "/images/insights.png" );
-	const cornerstoneContentImage = useSelectSettings( "selectPluginUrl", [], "/images/cornerstone_content.png" );
-	const textLinkCounterImage = useSelectSettings( "selectPluginUrl", [], "/images/text_link_counter.png" );
-	const linkSuggestionsImage = useSelectSettings( "selectPluginUrl", [], "/images/link_suggestions.png" );
-	const openGraphImage = useSelectSettings( "selectPluginUrl", [], "/images/open_graph.png" );
-	const twitterImage = useSelectSettings( "selectPluginUrl", [], "/images/twitter_card.png" );
-	const slackSharingImage = useSelectSettings( "selectPluginUrl", [], "/images/slack_sharing.png" );
-	const adminBarImage = useSelectSettings( "selectPluginUrl", [], "/images/admin_bar.png" );
-	const restApiImage = useSelectSettings( "selectPluginUrl", [], "/images/rest_api.png" );
-	const xmlSitemapsImage = useSelectSettings( "selectPluginUrl", [], "/images/xml_sitemaps.png" );
-	const indexNowImage = useSelectSettings( "selectPluginUrl", [], "/images/indexnow.png" );
 
 	// grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
 	// yst-grid yst-grid-cols-1 yst-gap-6 sm:yst-grid-cols-2 md:yst-grid-cols-2 lg:yst-grid-cols-3 xl:yst-grid-cols-4
@@ -128,122 +180,61 @@ const SiteFeatures = () => {
 							</Title>
 						</div>
 						<div className={ gridClassNames }>
-							<Card id="card-wpseo-keyword_analysis_active">
-								<CardHeader
-									src={ seoAnalysisImage }
-									alt={ __( "SEO analysis", "wordpress-seo" ) }
-									disabled={ ! values.wpseo.keyword_analysis_active }
-								/>
-								<Card.Content className="yst-flex yst-flex-col yst-gap-3">
-									<Title as="h3">
-										{ __( "SEO analysis", "wordpress-seo" ) }
-									</Title>
-									<p>{ __( "The SEO analysis offers suggestions to improve the findability of your text and makes sure that your content meets best practices.", "wordpress-seo" ) }</p>
-									<LearnMoreLink id="link-seo-analysis" link="https://yoa.st/2ak" />
-								</Card.Content>
-								<Card.Footer>
-									<FormikValueChangeField
-										as={ ToggleField }
-										type="checkbox"
-										name="wpseo.keyword_analysis_active"
-										data-id="input-wpseo-keyword_analysis_active"
-										label={ __( "Enable feature", "wordpress-seo" ) }
-									/>
-								</Card.Footer>
-							</Card>
-							<Card id="card-wpseo-content_analysis_active">
-								<CardHeader
-									src={ readabilityAnalysisImage }
-									alt={ __( "Readability analysis", "wordpress-seo" ) }
-									disabled={ ! values.wpseo.content_analysis_active }
-								/>
-								<Card.Content className="yst-flex yst-flex-col yst-gap-3">
-									<Title as="h3">
-										{ __( "Readability analysis", "wordpress-seo" ) }
-									</Title>
-									<p>{ __( "The readability analysis offers suggestions to improve the structure and style of your text.", "wordpress-seo" ) }</p>
-									<LearnMoreLink id="link-readability-analysis" link="https://yoa.st/2ao" />
-								</Card.Content>
-								<Card.Footer>
-									<FormikValueChangeField
-										as={ ToggleField }
-										type="checkbox"
-										name="wpseo.content_analysis_active"
-										data-id="input-wpseo-content_analysis_active"
-										label={ __( "Enable feature", "wordpress-seo" ) }
-									/>
-								</Card.Footer>
-							</Card>
-							<Card id="card-wpseo-inclusive_language_analysis_active">
-								<CardHeader
-									src={ inclusiveLanguageAnalysisImage }
-									alt={ __( "Inclusive language analysis", "wordpress-seo" ) }
-									disabled={ isPremium && ! values.wpseo.inclusive_language_analysis_active }
-								>
-									<div className="yst-absolute yst-top-2 yst-right-2 yst-flex yst-gap-1.5">
-										{ isPremium && <Badge size="small" variant="upsell">Premium</Badge> }
-										<Badge size="small" variant="info">Beta</Badge>
-									</div>
-								</CardHeader>
-								<Card.Content className="yst-flex yst-flex-col yst-gap-3">
-									<Title as="h3">
-										{ __( "Inclusive language analysis", "wordpress-seo" ) }
-									</Title>
-									<p>{ __( "The inclusive language analysis offers suggestions to write more inclusive copy, so more people will be able to relate to your content.", "wordpress-seo" ) }</p>
-									<LearnMoreLink id="link-inclusive-language-analysis" link="https://yoa.st/inclusive-language-analysis" />
-								</Card.Content>
-								<Card.Footer>
-									{ isPremium && <FormikValueChangeField
-										as={ ToggleField }
-										type="checkbox"
-										name="wpseo.inclusive_language_analysis_active"
-										data-id="input-wpseo-inclusive_language_analysis_active"
-										label={ __( "Enable feature", "wordpress-seo" ) }
-									/> }
-									{ ! isPremium && (
-										<Button
-											as="a"
-											className="yst-gap-2 yst-w-full"
-											variant="upsell"
-											href={ getInclusiveLanguageAnalysisLink }
-											target="_blank"
-											rel="noopener"
-											data-action={ getPremiumUpsellConfig.actionId }
-											data-ctb-id={ getPremiumUpsellConfig.premiumCtbId }
-										>
-											<LockOpenIcon className="yst-w-5 yst-h-5 yst--ml-1 yst-shrink-0" { ...svgAriaProps } />
-											{ sprintf(
-												/* translators: %1$s expands to Premium. */
-												__( "Unlock with %1$s", "wordpress-seo" ),
-												"Premium"
-											) }
-										</Button>
-									) }
-								</Card.Footer>
-							</Card>
-							<Card id="card-wpseo-enable_metabox_insights">
-								<CardHeader
-									src={ insightsImage }
-									alt={ __( "Insights", "wordpress-seo" ) }
-									disabled={ ! values.wpseo.enable_metabox_insights }
-								/>
-								<Card.Content className="yst-flex yst-flex-col yst-gap-3">
-									<Title as="h3">
-										{ __( "Insights", "wordpress-seo" ) }
-									</Title>
-									<p>{ __( "Get more insights into what you are writing. What words do you use most often? How much time does it take to read your text? Is your text easy to read?", "wordpress-seo" ) }</p>
-									<LearnMoreLink id="link-insights" link="https://yoa.st/4ew" />
-								</Card.Content>
-								<Card.Footer>
-									<FormikValueChangeField
-										as={ ToggleField }
-										type="checkbox"
-										name="wpseo.enable_metabox_insights"
-										data-id="input-wpseo-enable_metabox_insights"
-										label={ __( "Enable feature", "wordpress-seo" ) }
-									/>
-								</Card.Footer>
-							</Card>
+							<FeatureCard
+								name="wpseo.keyword_analysis_active"
+								cardId="card-wpseo-keyword_analysis_active"
+								inputId="input-wpseo-keyword_analysis_active"
+								imageSrc="/images/seo_analysis.png"
+								imageAlt={ __( "SEO analysis", "wordpress-seo" ) }
+							>
+								<Title as="h3">
+									{ __( "SEO analysis", "wordpress-seo" ) }
+								</Title>
+								<p>{ __( "The SEO analysis offers suggestions to improve the findability of your text and makes sure that your content meets best practices.", "wordpress-seo" ) }</p>
+								<LearnMoreLink id="link-seo-analysis" link="https://yoa.st/2ak" />
+							</FeatureCard>
+							<FeatureCard
+								name="wpseo.content_analysis_active"
+								cardId="card-wpseo-content_analysis_active"
+								inputId="input-wpseo-content_analysis_active"
+								imageSrc="/images/readability_analysis.png"
+								imageAlt={ __( "Readability analysis", "wordpress-seo" ) }
+							>
+								<Title as="h3">
+									{ __( "Readability analysis", "wordpress-seo" ) }
+								</Title>
+								<p>{ __( "The readability analysis offers suggestions to improve the structure and style of your text.", "wordpress-seo" ) }</p>
+								<LearnMoreLink id="link-readability-analysis" link="https://yoa.st/2ao" />
+							</FeatureCard>
+							<FeatureCard
+								name="wpseo.inclusive_language_analysis_active"
+								cardId="card-wpseo-inclusive_language_analysis_active"
+								inputId="input-wpseo-inclusive_language_analysis_active"
+								imageSrc="/images/inclusive_language_analysis.png"
+								imageAlt={ __( "Inclusive language analysis", "wordpress-seo" ) }
+								isPremiumFeature={ true }
+								isPremiumLink="https://yoa.st/get-inclusive-language"
+								isBetaFeature={ true }
+							>
+								<Title as="h3">
+									{ __( "Inclusive language analysis", "wordpress-seo" ) }
+								</Title>
+								<p>{ __( "The inclusive language analysis offers suggestions to write more inclusive copy, so more people will be able to relate to your content.", "wordpress-seo" ) }</p>
+								<LearnMoreLink id="link-inclusive-language-analysis" link="https://yoa.st/inclusive-language-analysis" />
+							</FeatureCard>
+							<FeatureCard
+								name="wpseo.enable_metabox_insights"
+								cardId="card-wpseo-enable_metabox_insights"
+								inputId="input-wpseo-enable_metabox_insights"
+								imageSrc="/images/insights.png"
+								imageAlt={ __( "Insights", "wordpress-seo" ) }
+							>
+								<Title as="h3">
+									{ __( "Insights", "wordpress-seo" ) }
+								</Title>
+								<p>{ __( "Get more insights into what you are writing. What words do you use most often? How much time does it take to read your text? Is your text easy to read?", "wordpress-seo" ) }</p>
+								<LearnMoreLink id="link-insights" link="https://yoa.st/4ew" />
+							</FeatureCard>
 						</div>
 					</fieldset>
 					<hr className="yst-my-8" />
@@ -255,98 +246,47 @@ const SiteFeatures = () => {
 							</Title>
 						</div>
 						<div className={ gridClassNames }>
-							<Card id="card-wpseo-enable_cornerstone_content">
-								<CardHeader
-									src={ cornerstoneContentImage }
-									alt={ __( "Cornerstone content", "wordpress-seo" ) }
-									disabled={ ! values.wpseo.enable_cornerstone_content }
-								/>
-								<Card.Content className="yst-flex yst-flex-col yst-gap-3">
-									<Title as="h3">
-										{ __( "Cornerstone content", "wordpress-seo" ) }
-									</Title>
-									<p>{ __( "Mark and filter your cornerstone content to make sure your most important articles get the attention they deserve. To help you write excellent copy, we’ll assess your text more strictly.", "wordpress-seo" ) }</p>
-									<LearnMoreLink id="link-cornerstone-content" link="https://yoa.st/dashboard-help-cornerstone" />
-								</Card.Content>
-								<Card.Footer>
-									<FormikValueChangeField
-										as={ ToggleField }
-										type="checkbox"
-										name="wpseo.enable_cornerstone_content"
-										data-id="input-wpseo-enable_cornerstone_content"
-										label={ __( "Enable feature", "wordpress-seo" ) }
-									/>
-								</Card.Footer>
-							</Card>
-							<Card id="card-wpseo-enable_text_link_counter">
-								<CardHeader
-									src={ textLinkCounterImage }
-									alt={ __( "Text link counter", "wordpress-seo" ) }
-									disabled={ ! values.wpseo.enable_text_link_counter }
-								/>
-								<Card.Content className="yst-flex yst-flex-col yst-gap-3">
-									<Title as="h3">
-										{ __( "Text link counter", "wordpress-seo" ) }
-									</Title>
-									<p>{ __( "Count the number of internal links from and to your posts to improve your site structure.", "wordpress-seo" ) }</p>
-									<LearnMoreLink id="link-text-link-counter" link="https://yoa.st/2aj" />
-								</Card.Content>
-								<Card.Footer>
-									<FormikValueChangeField
-										as={ ToggleField }
-										type="checkbox"
-										name="wpseo.enable_text_link_counter"
-										data-id="input-wpseo-enable_text_link_counter"
-										label={ __( "Enable feature", "wordpress-seo" ) }
-									/>
-								</Card.Footer>
-							</Card>
-							<Card id="card-wpseo-enable_link_suggestions">
-								<CardHeader
-									src={ linkSuggestionsImage }
-									alt={ __( "Link suggestions", "wordpress-seo" ) }
-									disabled={ isPremium && ! values.wpseo.enable_link_suggestions }
-								>
-									<div className="yst-absolute yst-top-2 yst-right-2 yst-flex yst-gap-1.5">
-										{ isPremium && <Badge size="small" variant="upsell">Premium</Badge> }
-									</div>
-								</CardHeader>
-								<Card.Content className="yst-flex yst-flex-col yst-gap-3">
-									<Title as="h3">
-										{ __( "Link suggestions", "wordpress-seo" ) }
-									</Title>
-									<p>{ __( "Get recommendations for relevant posts to link to and set up a great internal linking structure by connecting related content.", "wordpress-seo" ) }</p>
-									<LearnMoreLink id="link-suggestions-link" link={ isPremium ? "https://yoa.st/17g" : "https://yoa.st/4ev" } />
-								</Card.Content>
-								<Card.Footer>
-									{ isPremium && <FormikValueChangeField
-										as={ ToggleField }
-										type="checkbox"
-										name="wpseo.enable_link_suggestions"
-										data-id="input-wpseo-enable_link_suggestions"
-										label={ __( "Enable feature", "wordpress-seo" ) }
-									/> }
-									{ ! isPremium && (
-										<Button
-											as="a"
-											className="yst-gap-2 yst-w-full"
-											variant="upsell"
-											href={ getLinkSuggestionsLink }
-											target="_blank"
-											rel="noopener"
-											data-action={ getPremiumUpsellConfig.actionId }
-											data-ctb-id={ getPremiumUpsellConfig.premiumCtbId }
-										>
-											<LockOpenIcon className="yst-w-5 yst-h-5 yst--ml-1 yst-shrink-0" { ...svgAriaProps } />
-											{ sprintf(
-												/* translators: %1$s expands to Premium. */
-												__( "Unlock with %1$s", "wordpress-seo" ),
-												"Premium"
-											) }
-										</Button>
-									) }
-								</Card.Footer>
-							</Card>
+							<FeatureCard
+								name="wpseo.enable_cornerstone_content"
+								cardId="card-wpseo-enable_cornerstone_content"
+								inputId="input-wpseo-enable_cornerstone_content"
+								imageSrc="/images/cornerstone_content.png"
+								imageAlt={ __( "Cornerstone content", "wordpress-seo" ) }
+							>
+								<Title as="h3">
+									{ __( "Cornerstone content", "wordpress-seo" ) }
+								</Title>
+								<p>{ __( "Mark and filter your cornerstone content to make sure your most important articles get the attention they deserve. To help you write excellent copy, we’ll assess your text more strictly.", "wordpress-seo" ) }</p>
+								<LearnMoreLink id="link-cornerstone-content" link="https://yoa.st/dashboard-help-cornerstone" />
+							</FeatureCard>
+							<FeatureCard
+								name="wpseo.enable_text_link_counter"
+								cardId="card-wpseo-enable_text_link_counter"
+								inputId="input-wpseo-enable_text_link_counter"
+								imageSrc="/images/text_link_counter.png"
+								imageAlt={ __( "Text link counter", "wordpress-seo" ) }
+							>
+								<Title as="h3">
+									{ __( "Text link counter", "wordpress-seo" ) }
+								</Title>
+								<p>{ __( "Count the number of internal links from and to your posts to improve your site structure.", "wordpress-seo" ) }</p>
+								<LearnMoreLink id="link-text-link-counter" link="https://yoa.st/2aj" />
+							</FeatureCard>
+							<FeatureCard
+								name="wpseo.enable_link_suggestions"
+								cardId="card-wpseo-enable_link_suggestions"
+								inputId="input-wpseo-enable_link_suggestions"
+								imageSrc="/images/link_suggestions.png"
+								imageAlt={ __( "Link suggestions", "wordpress-seo" ) }
+								isPremiumFeature={ true }
+								isPremiumLink="https://yoa.st/get-link-suggestions"
+							>
+								<Title as="h3">
+									{ __( "Link suggestions", "wordpress-seo" ) }
+								</Title>
+								<p>{ __( "Get recommendations for relevant posts to link to and set up a great internal linking structure by connecting related content.", "wordpress-seo" ) }</p>
+								<LearnMoreLink id="link-suggestions-link" link={ isPremium ? "https://yoa.st/17g" : "https://yoa.st/4ev" } />
+							</FeatureCard>
 						</div>
 					</fieldset>
 					<hr className="yst-my-8" />
@@ -361,75 +301,46 @@ const SiteFeatures = () => {
 							</Alert>
 						</div>
 						<div className={ gridClassNames }>
-							<Card id="card-wpseo_social-opengraph">
-								<CardHeader
-									src={ openGraphImage }
-									alt={ __( "Open Graph data", "wordpress-seo" ) }
-									disabled={ ! values.wpseo_social.opengraph }
-								/>
-								<Card.Content className="yst-flex yst-flex-col yst-gap-3">
-									<Title as="h3">
-										{ __( "Open Graph data", "wordpress-seo" ) }
-									</Title>
-									<p>{ __( "Allows for Facebook and other social media to display a preview with images and a text excerpt when a link to your site is shared.", "wordpress-seo" ) }</p>
-									<LearnMoreLink id="link-open-graph-data" link="https://yoa.st/site-features-open-graph-data" />
-								</Card.Content>
-								<Card.Footer>
-									<FormikValueChangeField
-										as={ ToggleField }
-										type="checkbox"
-										name="wpseo_social.opengraph"
-										data-id="input-wpseo_social-opengraph"
-										label={ __( "Enable feature", "wordpress-seo" ) }
-									/>
-								</Card.Footer>
-							</Card>
-							<Card id="card-wpseo_social-twitter">
-								<CardHeader
-									src={ twitterImage }
-									alt={ __( "Twitter card data", "wordpress-seo" ) }
-									disabled={ ! values.wpseo_social.twitter }
-								/>
-								<Card.Content className="yst-flex yst-flex-col yst-gap-3">
-									<Title as="h3">
-										{ __( "Twitter card data", "wordpress-seo" ) }
-									</Title>
-									<p>{ __( "Allows for Twitter to display a preview with images and a text excerpt when a link to your site is shared.", "wordpress-seo" ) }</p>
-									<LearnMoreLink id="link-twitter-card-data" link="https://yoa.st/site-features-twitter-card-data" />
-								</Card.Content>
-								<Card.Footer>
-									<FormikValueChangeField
-										as={ ToggleField }
-										type="checkbox"
-										name="wpseo_social.twitter"
-										data-id="input-wpseo_social-twitter"
-										label={ __( "Enable feature", "wordpress-seo" ) }
-									/>
-								</Card.Footer>
-							</Card>
-							<Card id="card-wpseo-enable_enhanced_slack_sharing">
-								<CardHeader
-									src={ slackSharingImage }
-									alt={ __( "Slack sharing", "wordpress-seo" ) }
-									disabled={ ! values.wpseo.enable_enhanced_slack_sharing }
-								/>
-								<Card.Content className="yst-flex yst-flex-col yst-gap-3">
-									<Title as="h3">
-										{ __( "Slack sharing", "wordpress-seo" ) }
-									</Title>
-									<p>{ __( "This adds an author byline and reading time estimate to the article’s snippet when shared on Slack.", "wordpress-seo" ) }</p>
-									<LearnMoreLink id="link-slack-sharing" link="https://yoa.st/help-slack-share" />
-								</Card.Content>
-								<Card.Footer>
-									<FormikValueChangeField
-										as={ ToggleField }
-										type="checkbox"
-										name="wpseo.enable_enhanced_slack_sharing"
-										data-id="input-wpseo-enable_enhanced_slack_sharing"
-										label={ __( "Enable feature", "wordpress-seo" ) }
-									/>
-								</Card.Footer>
-							</Card>
+							<FeatureCard
+								name="wpseo_social.opengraph"
+								cardId="card-wpseo_social-opengraph"
+								inputId="input-wpseo_social-opengraph"
+								imageSrc="/images/open_graph.png"
+								imageAlt={ __( "Open Graph data", "wordpress-seo" ) }
+							>
+								<Title as="h3">
+									{ __( "Open Graph data", "wordpress-seo" ) }
+								</Title>
+								<p>{ __( "Allows for Facebook and other social media to display a preview with images and a text excerpt when a link to your site is shared.", "wordpress-seo" ) }</p>
+								<LearnMoreLink id="link-open-graph-data" link="https://yoa.st/site-features-open-graph-data" />
+
+							</FeatureCard>
+							<FeatureCard
+								name="wpseo_social.twitter"
+								cardId="card-wpseo_social-twitter"
+								inputId="input-wpseo_social-twitter"
+								imageSrc="/images/twitter_card.png"
+								imageAlt={ __( "Twitter card data", "wordpress-seo" ) }
+							>
+								<Title as="h3">
+									{ __( "Twitter card data", "wordpress-seo" ) }
+								</Title>
+								<p>{ __( "Allows for Twitter to display a preview with images and a text excerpt when a link to your site is shared.", "wordpress-seo" ) }</p>
+								<LearnMoreLink id="link-twitter-card-data" link="https://yoa.st/site-features-twitter-card-data" />
+							</FeatureCard>
+							<FeatureCard
+								name="wpseo.enable_enhanced_slack_sharing"
+								cardId="card-wpseo-enable_enhanced_slack_sharing"
+								inputId="input-wpseo-enable_enhanced_slack_sharing"
+								imageSrc="/images/slack_sharing.png"
+								imageAlt={ __( "Slack sharing", "wordpress-seo" ) }
+							>
+								<Title as="h3">
+									{ __( "Slack sharing", "wordpress-seo" ) }
+								</Title>
+								<p>{ __( "This adds an author byline and reading time estimate to the article’s snippet when shared on Slack.", "wordpress-seo" ) }</p>
+								<LearnMoreLink id="link-slack-sharing" link="https://yoa.st/help-slack-share" />
+							</FeatureCard>
 						</div>
 					</fieldset>
 					<hr className="yst-my-8" />
@@ -441,35 +352,25 @@ const SiteFeatures = () => {
 							</Title>
 						</div>
 						<div className={ gridClassNames }>
-							<Card id="card-wpseo-enable_admin_bar_menu">
-								<CardHeader
-									src={ adminBarImage }
-									alt={ __( "Admin bar menu", "wordpress-seo" ) }
-									disabled={ ! values.wpseo.enable_admin_bar_menu }
-								/>
-								<Card.Content className="yst-flex yst-flex-col yst-gap-3">
-									<Title as="h3">
-										{ __( "Admin bar menu", "wordpress-seo" ) }
-									</Title>
-									<p>
-										{ sprintf(
-											// translators: %1$s expands to Yoast.
-											__( "The %1$s icon in the top admin bar provides quick access to third-party tools for analyzing pages and makes it easy to see if you have new notifications.", "wordpress-seo" ),
-											"Yoast"
-										) }
-									</p>
-									<LearnMoreLink id="link-admin-bar" link="https://yoa.st/site-features-admin-bar" />
-								</Card.Content>
-								<Card.Footer>
-									<FormikValueChangeField
-										as={ ToggleField }
-										type="checkbox"
-										name="wpseo.enable_admin_bar_menu"
-										data-id="input-wpseo-enable_admin_bar_menu"
-										label={ __( "Enable feature", "wordpress-seo" ) }
-									/>
-								</Card.Footer>
-							</Card>
+							<FeatureCard
+								name="wpseo.enable_admin_bar_menu"
+								cardId="card-wpseo-enable_admin_bar_menu"
+								inputId="input-wpseo-enable_admin_bar_menu"
+								imageSrc="/images/admin_bar.png"
+								imageAlt={ __( "Admin bar menu", "wordpress-seo" ) }
+							>
+								<Title as="h3">
+									{ __( "Admin bar menu", "wordpress-seo" ) }
+								</Title>
+								<p>
+									{ sprintf(
+										// translators: %1$s expands to Yoast.
+										__( "The %1$s icon in the top admin bar provides quick access to third-party tools for analyzing pages and makes it easy to see if you have new notifications.", "wordpress-seo" ),
+										"Yoast"
+									) }
+								</p>
+								<LearnMoreLink id="link-admin-bar" link="https://yoa.st/site-features-admin-bar" />
+							</FeatureCard>
 						</div>
 					</fieldset>
 					<hr className="yst-my-8" />
@@ -481,107 +382,56 @@ const SiteFeatures = () => {
 							</Title>
 						</div>
 						<div className={ gridClassNames }>
-							<Card id="card-wpseo-enable_headless_rest_endpoints">
-								<CardHeader
-									src={ restApiImage }
-									alt={ __( "REST API endpoint", "wordpress-seo" ) }
-									disabled={ ! values.wpseo.enable_headless_rest_endpoints }
-								/>
-								<Card.Content className="yst-flex yst-flex-col yst-gap-3">
-									<Title as="h3">
-										{ __( "REST API endpoint", "wordpress-seo" ) }
-									</Title>
-									<p>{ __( "This Yoast SEO REST API endpoint gives you all the metadata you need for a specific URL. This will make it very easy for headless WordPress sites to use Yoast SEO for all their SEO meta output.", "wordpress-seo" ) }</p>
-									<LearnMoreLink id="link-rest-api-endpoint" link="https://yoa.st/site-features-rest-api-endpoint" />
-								</Card.Content>
-								<Card.Footer>
-									<FormikValueChangeField
-										as={ ToggleField }
-										type="checkbox"
-										name="wpseo.enable_headless_rest_endpoints"
-										data-id="input-wpseo-enable_headless_rest_endpoints"
-										label={ __( "Enable feature", "wordpress-seo" ) }
-									/>
-								</Card.Footer>
-							</Card>
-							<Card id="card-wpseo-enable_xml_sitemap">
-								<CardHeader
-									src={ xmlSitemapsImage }
-									alt={ __( "XML sitemaps", "wordpress-seo" ) }
-									disabled={ ! values.wpseo.enable_xml_sitemap }
-								/>
-								<Card.Content className="yst-flex yst-flex-col yst-gap-3">
-									<Title as="h3">
-										{ __( "XML sitemaps", "wordpress-seo" ) }
-									</Title>
-									<p>
-										{ sprintf(
-											// translators: %1$s expands to "Yoast SEO".
-											__( "Enable the %1$s XML sitemaps. A sitemap is a file that lists a website's essential pages to make sure search engines can find and crawl them.", "wordpress-seo" ),
-											"Yoast SEO"
-										) }
-									</p>
-									{ enableXmlSitemap && <Link id="link-xml-sitemaps" href={ sitemapUrl } target="_blank" rel="noopener">
-										{ __( "View the XML sitemap", "wordpress-seo" ) }
-									</Link> }
-									<LearnMoreLink id="link-xml-sitemaps" link="https://yoa.st/2a-" />
-								</Card.Content>
-								<Card.Footer>
-									<FormikValueChangeField
-										as={ ToggleField }
-										type="checkbox"
-										name="wpseo.enable_xml_sitemap"
-										data-id="input-wpseo-enable_xml_sitemap"
-										label={ __( "Enable feature", "wordpress-seo" ) }
-									/>
-								</Card.Footer>
-							</Card>
-							<Card id="card-wpseo-enable_index_now">
-								<CardHeader
-									src={ indexNowImage }
-									alt={ __( "IndexNow", "wordpress-seo" ) }
-									disabled={ isPremium && ! values.wpseo.enable_index_now }
-								>
-									<div className="yst-absolute yst-top-2 yst-right-2 yst-flex yst-gap-1.5">
-										{ isPremium && <Badge size="small" variant="upsell">Premium</Badge> }
-									</div>
-								</CardHeader>
-								<Card.Content className="yst-flex yst-flex-col yst-gap-3">
-									<Title as="h3">
-										{ __( "IndexNow", "wordpress-seo" ) }
-									</Title>
-									<p>{ __( "Automatically ping search engines like Bing and Yandex whenever you publish, update or delete a post.", "wordpress-seo" ) }</p>
-									<LearnMoreLink id="link-index-now" link="https://yoa.st/index-now-feature" />
-								</Card.Content>
-								<Card.Footer>
-									{ isPremium && <FormikValueChangeField
-										as={ ToggleField }
-										type="checkbox"
-										name="wpseo.enable_index_now"
-										data-id="input-wpseo-enable_index_now"
-										label={ __( "Enable feature", "wordpress-seo" ) }
-									/> }
-									{ ! isPremium && (
-										<Button
-											as="a"
-											className="yst-gap-2 yst-w-full"
-											variant="upsell"
-											href={ getIndexNowLink }
-											target="_blank"
-											rel="noopener"
-											data-action={ getPremiumUpsellConfig.actionId }
-											data-ctb-id={ getPremiumUpsellConfig.premiumCtbId }
-										>
-											<LockOpenIcon className="yst-w-5 yst-h-5 yst--ml-1 yst-shrink-0" { ...svgAriaProps } />
-											{ sprintf(
-												/* translators: %1$s expands to Premium. */
-												__( "Unlock with %1$s", "wordpress-seo" ),
-												"Premium"
-											) }
-										</Button>
+							<FeatureCard
+								name="wpseo.enable_headless_rest_endpoints"
+								cardId="card-wpseo-enable_headless_rest_endpoints"
+								inputId="input-wpseo-enable_headless_rest_endpoints"
+								imageSrc="/images/rest_api.png"
+								imageAlt={ __( "REST API endpoint", "wordpress-seo" ) }
+							>
+								<Title as="h3">
+									{ __( "REST API endpoint", "wordpress-seo" ) }
+								</Title>
+								<p>{ __( "This Yoast SEO REST API endpoint gives you all the metadata you need for a specific URL. This will make it very easy for headless WordPress sites to use Yoast SEO for all their SEO meta output.", "wordpress-seo" ) }</p>
+								<LearnMoreLink id="link-rest-api-endpoint" link="https://yoa.st/site-features-rest-api-endpoint" />
+							</FeatureCard>
+							<FeatureCard
+								name="wpseo.enable_xml_sitemap"
+								cardId="card-wpseo-enable_xml_sitemap"
+								inputId="input-wpseo-enable_xml_sitemap"
+								imageSrc="/images/xml_sitemaps.png"
+								imageAlt={ __( "XML sitemaps", "wordpress-seo" ) }
+							>
+								<Title as="h3">
+									{ __( "XML sitemaps", "wordpress-seo" ) }
+								</Title>
+								<p>
+									{ sprintf(
+										// translators: %1$s expands to "Yoast SEO".
+										__( "Enable the %1$s XML sitemaps. A sitemap is a file that lists a website's essential pages to make sure search engines can find and crawl them.", "wordpress-seo" ),
+										"Yoast SEO"
 									) }
-								</Card.Footer>
-							</Card>
+								</p>
+								{ enableXmlSitemap && <Link id="link-xml-sitemaps" href={ sitemapUrl } target="_blank" rel="noopener">
+									{ __( "View the XML sitemap", "wordpress-seo" ) }
+								</Link> }
+								<LearnMoreLink id="link-xml-sitemaps" link="https://yoa.st/2a-" />
+							</FeatureCard>
+							<FeatureCard
+								name="wpseo.enable_index_now"
+								cardId="card-wpseo-enable_index_now"
+								inputId="input-wpseo-enable_index_now"
+								imageSrc="/images/indexnow.png"
+								imageAlt={ __( "IndexNow", "wordpress-seo" ) }
+								isPremiumFeature={ true }
+								isPremiumLink="https://yoa.st/get-indexnow"
+							>
+								<Title as="h3">
+									{ __( "IndexNow", "wordpress-seo" ) }
+								</Title>
+								<p>{ __( "Automatically ping search engines like Bing and Yandex whenever you publish, update or delete a post.", "wordpress-seo" ) }</p>
+								<LearnMoreLink id="link-index-now" link="https://yoa.st/index-now-feature" />
+							</FeatureCard>
 						</div>
 					</fieldset>
 				</div>

--- a/packages/js/src/settings/routes/site-features.js
+++ b/packages/js/src/settings/routes/site-features.js
@@ -38,7 +38,7 @@ const FeatureCard = ( {
 	const { isDisabled, message } = useDisabledMessage( { name } );
 	const { values } = useFormikContext();
 	const isPremiumHref = useSelectSettings( "selectLink", [ isPremiumLink ], isPremiumLink );
-	const premiumUpsellConfig = useSelectSettings( "selectUpsellSetting", [] );
+	const premiumUpsellConfig = useSelectSettings( "selectUpsellSettingsAsProps" );
 	const svgAriaProps = useSvgAria();
 	const value = useMemo( () => get( values, name, false ), [ values, name ] );
 	const shouldUpsell = useMemo( () => ! isPremium && isPremiumFeature, [ isPremium, isPremiumFeature ] );
@@ -91,8 +91,7 @@ const FeatureCard = ( {
 						href={ isPremiumHref }
 						target="_blank"
 						rel="noopener"
-						data-action={ premiumUpsellConfig.actionId }
-						data-ctb-id={ premiumUpsellConfig.premiumCtbId }
+						{ ...premiumUpsellConfig }
 					>
 						<LockOpenIcon className="yst-w-5 yst-h-5 yst--ml-1 yst-shrink-0" { ...svgAriaProps } />
 						{ sprintf(

--- a/packages/js/src/settings/routes/site-features.js
+++ b/packages/js/src/settings/routes/site-features.js
@@ -3,6 +3,7 @@ import { ArrowNarrowRightIcon, LockOpenIcon } from "@heroicons/react/outline";
 import { useMemo } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
 import { Alert, Badge, Button, Card, Link, Title, ToggleField as PureToggleField, useSvgAria } from "@yoast/ui-library";
+import classNames from "classnames";
 import { useFormikContext } from "formik";
 import PropTypes from "prop-types";
 import { FormikValueChangeField, FormLayout, RouteLayout } from "../components";
@@ -15,16 +16,18 @@ const ToggleField = withDisabledMessageSupport( PureToggleField );
  * @param {string} src The image source.
  * @param {string} alt The image alt text.
  * @param {JSX.node} [children] Optional extra content.
+ * @param {boolean} [disabled] Whether to use the disabled style.
  * @returns {JSX.Element} The card header.
  */
 const CardHeader = ( {
 	src,
 	alt,
 	children = null,
+	disabled = false,
 } ) => (
 	<Card.Header className="yst-h-auto yst-p-0">
 		<img
-			className="yst-w-full"
+			className={ classNames( "yst-w-full", disabled && "yst-opacity-50 yst-filter yst-grayscale" ) }
 			src={ src }
 			alt={ alt }
 			width={ 500 }
@@ -40,6 +43,7 @@ CardHeader.propTypes = {
 	src: PropTypes.string.isRequired,
 	alt: PropTypes.string.isRequired,
 	children: PropTypes.node,
+	disabled: PropTypes.bool,
 };
 
 /**
@@ -76,7 +80,7 @@ LearnMoreLink.propTypes = {
 const SiteFeatures = () => {
 	const isPremium = useSelectSettings( "selectPreference", [], "isPremium" );
 	const sitemapUrl = useSelectSettings( "selectPreference", [], "sitemapUrl" );
-	const getPremiumUpsellConfig =  useSelectSettings( "selectUpsellSetting", [] );
+	const getPremiumUpsellConfig = useSelectSettings( "selectUpsellSetting", [] );
 	const getInclusiveLanguageAnalysisLink = useSelectSettings( "selectLink", [], "https://yoa.st/get-inclusive-language" );
 	const getLinkSuggestionsLink = useSelectSettings( "selectLink", [], "https://yoa.st/get-link-suggestions" );
 	const getIndexNowLink = useSelectSettings( "selectLink", [], "https://yoa.st/get-indexnow" );
@@ -128,6 +132,7 @@ const SiteFeatures = () => {
 								<CardHeader
 									src={ seoAnalysisImage }
 									alt={ __( "SEO analysis", "wordpress-seo" ) }
+									disabled={ ! values.wpseo.keyword_analysis_active }
 								/>
 								<Card.Content className="yst-flex yst-flex-col yst-gap-3">
 									<Title as="h3">
@@ -150,6 +155,7 @@ const SiteFeatures = () => {
 								<CardHeader
 									src={ readabilityAnalysisImage }
 									alt={ __( "Readability analysis", "wordpress-seo" ) }
+									disabled={ ! values.wpseo.content_analysis_active }
 								/>
 								<Card.Content className="yst-flex yst-flex-col yst-gap-3">
 									<Title as="h3">
@@ -172,6 +178,7 @@ const SiteFeatures = () => {
 								<CardHeader
 									src={ inclusiveLanguageAnalysisImage }
 									alt={ __( "Inclusive language analysis", "wordpress-seo" ) }
+									disabled={ isPremium && ! values.wpseo.inclusive_language_analysis_active }
 								>
 									<div className="yst-absolute yst-top-2 yst-right-2 yst-flex yst-gap-1.5">
 										{ isPremium && <Badge size="small" variant="upsell">Premium</Badge> }
@@ -195,12 +202,18 @@ const SiteFeatures = () => {
 									/> }
 									{ ! isPremium && (
 										<Button
-											as="a" className="yst-gap-2 yst-w-full" variant="upsell" href={ getInclusiveLanguageAnalysisLink } target="_blank" rel="noopener"
-											data-action={ getPremiumUpsellConfig.actionId } data-ctb-id={ getPremiumUpsellConfig.premiumCtbId }
+											as="a"
+											className="yst-gap-2 yst-w-full"
+											variant="upsell"
+											href={ getInclusiveLanguageAnalysisLink }
+											target="_blank"
+											rel="noopener"
+											data-action={ getPremiumUpsellConfig.actionId }
+											data-ctb-id={ getPremiumUpsellConfig.premiumCtbId }
 										>
 											<LockOpenIcon className="yst-w-5 yst-h-5 yst--ml-1 yst-shrink-0" { ...svgAriaProps } />
 											{ sprintf(
-											/* translators: %1$s expands to Premium. */
+												/* translators: %1$s expands to Premium. */
 												__( "Unlock with %1$s", "wordpress-seo" ),
 												"Premium"
 											) }
@@ -212,6 +225,7 @@ const SiteFeatures = () => {
 								<CardHeader
 									src={ insightsImage }
 									alt={ __( "Insights", "wordpress-seo" ) }
+									disabled={ ! values.wpseo.enable_metabox_insights }
 								/>
 								<Card.Content className="yst-flex yst-flex-col yst-gap-3">
 									<Title as="h3">
@@ -245,6 +259,7 @@ const SiteFeatures = () => {
 								<CardHeader
 									src={ cornerstoneContentImage }
 									alt={ __( "Cornerstone content", "wordpress-seo" ) }
+									disabled={ ! values.wpseo.enable_cornerstone_content }
 								/>
 								<Card.Content className="yst-flex yst-flex-col yst-gap-3">
 									<Title as="h3">
@@ -267,6 +282,7 @@ const SiteFeatures = () => {
 								<CardHeader
 									src={ textLinkCounterImage }
 									alt={ __( "Text link counter", "wordpress-seo" ) }
+									disabled={ ! values.wpseo.enable_text_link_counter }
 								/>
 								<Card.Content className="yst-flex yst-flex-col yst-gap-3">
 									<Title as="h3">
@@ -289,6 +305,7 @@ const SiteFeatures = () => {
 								<CardHeader
 									src={ linkSuggestionsImage }
 									alt={ __( "Link suggestions", "wordpress-seo" ) }
+									disabled={ isPremium && ! values.wpseo.enable_link_suggestions }
 								>
 									<div className="yst-absolute yst-top-2 yst-right-2 yst-flex yst-gap-1.5">
 										{ isPremium && <Badge size="small" variant="upsell">Premium</Badge> }
@@ -311,12 +328,18 @@ const SiteFeatures = () => {
 									/> }
 									{ ! isPremium && (
 										<Button
-											as="a" className="yst-gap-2 yst-w-full" variant="upsell" href={ getLinkSuggestionsLink } target="_blank" rel="noopener"
-											data-action={ getPremiumUpsellConfig.actionId } data-ctb-id={ getPremiumUpsellConfig.premiumCtbId }
+											as="a"
+											className="yst-gap-2 yst-w-full"
+											variant="upsell"
+											href={ getLinkSuggestionsLink }
+											target="_blank"
+											rel="noopener"
+											data-action={ getPremiumUpsellConfig.actionId }
+											data-ctb-id={ getPremiumUpsellConfig.premiumCtbId }
 										>
 											<LockOpenIcon className="yst-w-5 yst-h-5 yst--ml-1 yst-shrink-0" { ...svgAriaProps } />
 											{ sprintf(
-											/* translators: %1$s expands to Premium. */
+												/* translators: %1$s expands to Premium. */
 												__( "Unlock with %1$s", "wordpress-seo" ),
 												"Premium"
 											) }
@@ -342,6 +365,7 @@ const SiteFeatures = () => {
 								<CardHeader
 									src={ openGraphImage }
 									alt={ __( "Open Graph data", "wordpress-seo" ) }
+									disabled={ ! values.wpseo_social.opengraph }
 								/>
 								<Card.Content className="yst-flex yst-flex-col yst-gap-3">
 									<Title as="h3">
@@ -364,6 +388,7 @@ const SiteFeatures = () => {
 								<CardHeader
 									src={ twitterImage }
 									alt={ __( "Twitter card data", "wordpress-seo" ) }
+									disabled={ ! values.wpseo_social.twitter }
 								/>
 								<Card.Content className="yst-flex yst-flex-col yst-gap-3">
 									<Title as="h3">
@@ -386,6 +411,7 @@ const SiteFeatures = () => {
 								<CardHeader
 									src={ slackSharingImage }
 									alt={ __( "Slack sharing", "wordpress-seo" ) }
+									disabled={ ! values.wpseo.enable_enhanced_slack_sharing }
 								/>
 								<Card.Content className="yst-flex yst-flex-col yst-gap-3">
 									<Title as="h3">
@@ -419,6 +445,7 @@ const SiteFeatures = () => {
 								<CardHeader
 									src={ adminBarImage }
 									alt={ __( "Admin bar menu", "wordpress-seo" ) }
+									disabled={ ! values.wpseo.enable_admin_bar_menu }
 								/>
 								<Card.Content className="yst-flex yst-flex-col yst-gap-3">
 									<Title as="h3">
@@ -426,7 +453,7 @@ const SiteFeatures = () => {
 									</Title>
 									<p>
 										{ sprintf(
-										// translators: %1$s expands to Yoast.
+											// translators: %1$s expands to Yoast.
 											__( "The %1$s icon in the top admin bar provides quick access to third-party tools for analyzing pages and makes it easy to see if you have new notifications.", "wordpress-seo" ),
 											"Yoast"
 										) }
@@ -458,6 +485,7 @@ const SiteFeatures = () => {
 								<CardHeader
 									src={ restApiImage }
 									alt={ __( "REST API endpoint", "wordpress-seo" ) }
+									disabled={ ! values.wpseo.enable_headless_rest_endpoints }
 								/>
 								<Card.Content className="yst-flex yst-flex-col yst-gap-3">
 									<Title as="h3">
@@ -480,6 +508,7 @@ const SiteFeatures = () => {
 								<CardHeader
 									src={ xmlSitemapsImage }
 									alt={ __( "XML sitemaps", "wordpress-seo" ) }
+									disabled={ ! values.wpseo.enable_xml_sitemap }
 								/>
 								<Card.Content className="yst-flex yst-flex-col yst-gap-3">
 									<Title as="h3">
@@ -487,7 +516,7 @@ const SiteFeatures = () => {
 									</Title>
 									<p>
 										{ sprintf(
-										// translators: %1$s expands to "Yoast SEO".
+											// translators: %1$s expands to "Yoast SEO".
 											__( "Enable the %1$s XML sitemaps. A sitemap is a file that lists a website's essential pages to make sure search engines can find and crawl them.", "wordpress-seo" ),
 											"Yoast SEO"
 										) }
@@ -511,6 +540,7 @@ const SiteFeatures = () => {
 								<CardHeader
 									src={ indexNowImage }
 									alt={ __( "IndexNow", "wordpress-seo" ) }
+									disabled={ isPremium && ! values.wpseo.enable_index_now }
 								>
 									<div className="yst-absolute yst-top-2 yst-right-2 yst-flex yst-gap-1.5">
 										{ isPremium && <Badge size="small" variant="upsell">Premium</Badge> }
@@ -533,12 +563,18 @@ const SiteFeatures = () => {
 									/> }
 									{ ! isPremium && (
 										<Button
-											as="a" className="yst-gap-2 yst-w-full" variant="upsell" href={ getIndexNowLink } target="_blank" rel="noopener"
-											data-action={ getPremiumUpsellConfig.actionId } data-ctb-id={ getPremiumUpsellConfig.premiumCtbId }
+											as="a"
+											className="yst-gap-2 yst-w-full"
+											variant="upsell"
+											href={ getIndexNowLink }
+											target="_blank"
+											rel="noopener"
+											data-action={ getPremiumUpsellConfig.actionId }
+											data-ctb-id={ getPremiumUpsellConfig.premiumCtbId }
 										>
 											<LockOpenIcon className="yst-w-5 yst-h-5 yst--ml-1 yst-shrink-0" { ...svgAriaProps } />
 											{ sprintf(
-											/* translators: %1$s expands to Premium. */
+												/* translators: %1$s expands to Premium. */
 												__( "Unlock with %1$s", "wordpress-seo" ),
 												"Premium"
 											) }

--- a/packages/js/src/settings/routes/templates/post-type.js
+++ b/packages/js/src/settings/routes/templates/post-type.js
@@ -3,8 +3,8 @@ import { createInterpolateElement, useMemo } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
 import { Badge, FeatureUpsell, Link, SelectField, TextField, Title, ToggleField } from "@yoast/ui-library";
 import { Field, useFormikContext } from "formik";
-import PropTypes from "prop-types";
 import { toLower } from "lodash";
+import PropTypes from "prop-types";
 import { addLinkToString } from "../../../helpers/stringHelpers";
 import {
 	FieldsetLayout,
@@ -33,7 +33,7 @@ const FormikReplacementVariableEditorFieldWithDummy = withFormikDummyField( Form
  */
 const PostType = ( { name, label, singularLabel, hasArchive, hasSchemaArticleType } ) => {
 	const replacementVariables = useSelectSettings( "selectReplacementVariablesFor", [ name ], name, "custom_post_type" );
-	const getPremiumUpsellConfig =  useSelectSettings( "selectUpsellSetting", [] );
+	const premiumUpsellConfig = useSelectSettings( "selectUpsellSettingsAsProps" );
 	const recommendedReplacementVariables = useSelectSettings( "selectRecommendedReplacementVariablesFor", [ name ], name, "custom_post_type" );
 	const replacementVariablesArchives = useSelectSettings( "selectReplacementVariablesFor", [ name ], `${ name }_archive`, "custom-post-type_archive" );
 	const recommendedReplacementVariablesArchives = useSelectSettings( "selectRecommendedReplacementVariablesFor", [ name ], `${ name }_archive`, "custom-post-type_archive" );
@@ -127,7 +127,7 @@ const PostType = ( { name, label, singularLabel, hasArchive, hasSchemaArticleTyp
 		<RouteLayout
 			title={ label }
 			description={ sprintf(
-			/* translators: %1$s expands to the post type plural, e.g. posts. */
+				/* translators: %1$s expands to the post type plural, e.g. posts. */
 				__( "Determine how your %1$s should look in search engines and on social media.", "wordpress-seo" ),
 				labelLower
 			) }
@@ -191,8 +191,8 @@ const PostType = ( { name, label, singularLabel, hasArchive, hasSchemaArticleTyp
 							{ isPremium && <Badge variant="upsell">Premium</Badge> }
 						</div> }
 						description={ sprintf(
-						// eslint-disable-next-line max-len
-						// translators: %1$s expands to the post type plural, e.g. posts. %2$s expands to "Yoast SEO".
+							// eslint-disable-next-line max-len
+							// translators: %1$s expands to the post type plural, e.g. posts. %2$s expands to "Yoast SEO".
 							__( "Determine how your %1$s should look on social media by default. You can always customize the settings for individual %1$s in the %2$s sidebar.", "wordpress-seo" ),
 							labelLower,
 							"Yoast SEO"
@@ -202,13 +202,12 @@ const PostType = ( { name, label, singularLabel, hasArchive, hasSchemaArticleTyp
 							shouldUpsell={ ! isPremium }
 							variant="card"
 							cardLink={ socialAppearancePremiumLink }
-							upsellButtonAction={ getPremiumUpsellConfig.actionId }
-							upsellButtonCtbId={ getPremiumUpsellConfig.premiumCtbId }
 							cardText={ sprintf(
-							/* translators: %1$s expands to Premium. */
+								/* translators: %1$s expands to Premium. */
 								__( "Unlock with %1$s", "wordpress-seo" ),
 								"Premium"
 							) }
+							{ ...premiumUpsellConfig }
 						>
 							<OpenGraphDisabledAlert isEnabled={ ! isPremium || opengraph } />
 							<FormikMediaSelectField
@@ -283,13 +282,12 @@ const PostType = ( { name, label, singularLabel, hasArchive, hasSchemaArticleTyp
 							shouldUpsell={ ! isPremium }
 							variant="card"
 							cardLink={ pageAnalysisPremiumLink }
-							upsellButtonAction={ getPremiumUpsellConfig.actionId }
-							upsellButtonCtbId={ getPremiumUpsellConfig.premiumCtbId }
 							cardText={ sprintf(
-							/* translators: %1$s expands to Premium. */
+								/* translators: %1$s expands to Premium. */
 								__( "Unlock with %1$s", "wordpress-seo" ),
 								"Premium"
 							) }
+							{ ...premiumUpsellConfig }
 						>
 							<FormikTagFieldWithDummy
 								name={ `wpseo_titles.page-analyse-extra-${ name }` }
@@ -338,12 +336,12 @@ const PostType = ( { name, label, singularLabel, hasArchive, hasSchemaArticleTyp
 									name={ `wpseo_titles.noindex-ptarchive-${ name }` }
 									data-id={ `input-wpseo_titles-noindex-ptarchive-${ name }` }
 									label={ sprintf(
-									// translators: %1$s expands to the post type plural, e.g. posts.
+										// translators: %1$s expands to the post type plural, e.g. posts.
 										__( "Show the archive for %1$s in search results", "wordpress-seo" ),
 										labelLower
 									) }
 									description={ sprintf(
-									// translators: %1$s expands to the post type plural, e.g. posts.
+										// translators: %1$s expands to the post type plural, e.g. posts.
 										__( "Disabling this means that the archive for %1$s will not be indexed by search engines and will be excluded from XML sitemaps.", "wordpress-seo" ),
 										labelLower
 									) }
@@ -382,13 +380,12 @@ const PostType = ( { name, label, singularLabel, hasArchive, hasSchemaArticleTyp
 									shouldUpsell={ ! isPremium }
 									variant="card"
 									cardLink={ socialAppearancePremiumLink }
-									upsellButtonAction={ getPremiumUpsellConfig.actionId }
-									upsellButtonCtbId={ getPremiumUpsellConfig.premiumCtbId }
 									cardText={ sprintf(
 										// translators: %1$s expands to Premium.
 										__( "Unlock with %1$s", "wordpress-seo" ),
 										"Premium"
 									) }
+									{ ...premiumUpsellConfig }
 								>
 									<FormikMediaSelectField
 										id={ `wpseo_titles-social-image-ptarchive-${ name }` }

--- a/packages/js/src/settings/routes/templates/taxonomy.js
+++ b/packages/js/src/settings/routes/templates/taxonomy.js
@@ -27,7 +27,7 @@ const FormikReplacementVariableEditorFieldWithDummy = withFormikDummyField( Form
  */
 const Taxonomy = ( { name, label, postTypes: postTypeNames } ) => {
 	const postTypes = useSelectSettings( "selectPostTypes", [ postTypeNames ], postTypeNames );
-	const getPremiumUpsellConfig =  useSelectSettings( "selectUpsellSetting", [] );
+	const premiumUpsellConfig = useSelectSettings( "selectUpsellSettingsAsProps" );
 	const replacementVariables = useSelectSettings( "selectReplacementVariablesFor", [ name ], name, "term-in-custom-taxonomy" );
 	const recommendedReplacementVariables = useSelectSettings( "selectRecommendedReplacementVariablesFor", [ name ], name, "term-in-custom-taxonomy" );
 	const noIndexInfoLink = useSelectSettings( "selectLink", [], "https://yoa.st/show-x" );
@@ -187,13 +187,12 @@ const Taxonomy = ( { name, label, postTypes: postTypeNames } ) => {
 							shouldUpsell={ ! isPremium }
 							variant="card"
 							cardLink={ socialAppearancePremiumLink }
-							upsellButtonAction={ getPremiumUpsellConfig.actionId }
-							upsellButtonCtbId={ getPremiumUpsellConfig.premiumCtbId }
 							cardText={ sprintf(
 							/* translators: %1$s expands to Premium. */
 								__( "Unlock with %1$s", "wordpress-seo" ),
 								"Premium"
 							) }
+							{ ...premiumUpsellConfig }
 						>
 							<OpenGraphDisabledAlert isEnabled={ ! isPremium || opengraph } />
 							<FormikMediaSelectField

--- a/packages/js/src/settings/store/default-settings.js
+++ b/packages/js/src/settings/store/default-settings.js
@@ -6,7 +6,6 @@ import { get } from "lodash";
  */
 export const createInitialDefaultSettingsState = () => ( {
 	...get( window, "wpseoScriptData.defaultSettings", {} ),
-	upsellSettings: get( window, "wpseoScriptData.upsellSettings", {} ),
 } );
 
 const slice = createSlice( {
@@ -17,7 +16,6 @@ const slice = createSlice( {
 
 export const defaultSettingsSelectors = {
 	selectDefaultSetting: ( state, setting, defaultValue = {} ) => get( state, `defaultSettings.${ setting }`, defaultValue ),
-	selectUpsellSetting: state => get( state, "defaultSettings.upsellSettings", {} ),
 	selectDefaultSettings: state => get( state, "defaultSettings", {} ),
 };
 

--- a/packages/js/src/settings/store/preferences.js
+++ b/packages/js/src/settings/store/preferences.js
@@ -1,5 +1,5 @@
 import { createSelector, createSlice } from "@reduxjs/toolkit";
-import { get, isEmpty, defaultTo } from "lodash";
+import { defaultTo, get, isEmpty } from "lodash";
 
 /**
  * @returns {Object} The initial state.
@@ -47,6 +47,16 @@ preferencesSelectors.selectPluginUrl = createSelector(
 		( state, path ) => path,
 	],
 	( pluginUrl, path ) => pluginUrl + path
+);
+preferencesSelectors.selectUpsellSettingsAsProps = createSelector(
+	[
+		state => preferencesSelectors.selectPreference( state, "upsellSettings", {} ),
+		( state, ctbName = "premiumCtbId" ) => ctbName,
+	],
+	( upsellSettings, ctbName ) => ( {
+		"data-action": upsellSettings?.actionId,
+		"data-ctb-id": upsellSettings?.[ ctbName ],
+	} )
 );
 
 export const preferencesActions = slice.actions;

--- a/packages/ui-library/src/components/card/style.css
+++ b/packages/ui-library/src/components/card/style.css
@@ -1,42 +1,42 @@
 @layer components {
-    .yst-root {
-        .yst-card {
-            @apply
-            yst-relative
-            yst-flex
-            yst-flex-col
-            yst-bg-white
-            yst-rounded-lg
-            yst-border
-            yst-p-6
-            yst-space-y-6
-            yst-overflow-hidden
-            yst-transition-transform
-            yst-ease-in-out yst-shadow-sm;
-        }
-        
-        .yst-card__header {
-            @apply
-            yst-relative
-            yst-flex
-            yst-items-center
-            yst-justify-center
-            yst-h-24
-            yst-bg-gray-100
-            yst--mx-6
-            yst--mt-6
-            yst-p-6;
-        }
-        
-        .yst-card__content {
-            @apply yst-flex-grow;
-        }
-        
-        .yst-card__footer {
-            @apply
-            yst-border-t
-            yst-border-gray-200
-            yst-pt-6
-        }
-    }
+	.yst-root {
+		.yst-card {
+			@apply
+			yst-relative
+			yst-flex
+			yst-flex-col
+			yst-bg-white
+			yst-rounded-lg
+			yst-border
+			yst-p-6
+			yst-space-y-6
+			yst-overflow-hidden
+			yst-transition-transform
+			yst-ease-in-out yst-shadow-sm;
+		}
+
+		.yst-card__header {
+			@apply
+			yst-relative
+			yst-flex
+			yst-items-center
+			yst-justify-center
+			yst-h-24
+			yst-bg-gray-100
+			yst--mx-6
+			yst--mt-6
+			yst-p-6;
+		}
+
+		.yst-card__content {
+			@apply yst-flex-grow;
+		}
+
+		.yst-card__footer {
+			@apply
+			yst-border-t
+			yst-border-gray-200
+			yst-pt-6
+		}
+	}
 }

--- a/packages/ui-library/src/components/feature-upsell/index.js
+++ b/packages/ui-library/src/components/feature-upsell/index.js
@@ -18,11 +18,10 @@ const classNameMap = {
  * @param {string} [variant] The variant. See `classNameMap.variant`.
  * @param {string} [cardLink] The card' URL to link to. Required if the variant is `card`.
  * @param {string} [cardText] The card' button text. Used when the variant is `card`.
- * @param {string} [upsellButtonAction] The value for the data-action attribute.
- * @param {string} [upsellButtonCtbId] The value for the data-ctb-id attribute.
+ * @param {Object} [cardProps] Any extra card/button props.
  * @returns {JSX.Element} The feature or the upsell around the feature.
  */
-const FeatureUpsell = ( { children, shouldUpsell = true, className = "", variant = "default", cardLink = "", cardText = "", upsellButtonAction = "", upsellButtonCtbId = "" } ) => {
+const FeatureUpsell = ( { children, shouldUpsell = true, className = "", variant = "default", cardLink = "", cardText = "", ...cardProps } ) => {
 	const svgAriaProps = useSvgAria();
 
 	if ( ! shouldUpsell ) {
@@ -40,8 +39,13 @@ const FeatureUpsell = ( { children, shouldUpsell = true, className = "", variant
 				/>
 				<div className="yst-absolute yst-inset-0 yst-z-20 yst-flex yst-items-center yst-justify-center">
 					<Button
-						as="a" className="yst-gap-2 yst-shadow-lg yst-shadow-amber-700/30" variant="upsell" href={ cardLink } target="_blank" rel="noopener"
-						data-action={ upsellButtonAction } data-ctb-id={ upsellButtonCtbId }
+						as="a"
+						className="yst-gap-2 yst-shadow-lg yst-shadow-amber-700/30"
+						variant="upsell"
+						href={ cardLink }
+						target="_blank"
+						rel="noopener"
+						{ ...cardProps }
 					>
 						<LockOpenIcon className="yst-w-5 yst-h-5 yst--ml-1 yst-shrink-0" { ...svgAriaProps } />
 						{ cardText }
@@ -66,8 +70,6 @@ FeatureUpsell.propTypes = {
 	variant: PropTypes.oneOf( Object.keys( classNameMap.variant ) ),
 	cardLink: PropTypes.string,
 	cardText: PropTypes.string,
-	upsellButtonAction: PropTypes.string,
-	upsellButtonCtbId: PropTypes.string,
 };
 
 export default FeatureUpsell;

--- a/packages/ui-library/src/elements/badge/style.css
+++ b/packages/ui-library/src/elements/badge/style.css
@@ -32,8 +32,8 @@
 
 		.yst-badge--plain {
 			@apply
-			yst-bg-slate-100
-			yst-text-slate-800;
+			yst-bg-slate-200
+			yst-text-slate-900;
 		}
 
 		/* Sizes */

--- a/src/integrations/settings-integration.php
+++ b/src/integrations/settings-integration.php
@@ -355,7 +355,6 @@ class Settings_Integration implements Integration_Interface {
 		return [
 			'settings'             => $this->transform_settings( $settings ),
 			'defaultSettings'      => $default_settings,
-			'upsellSettings'       => $this->get_upsell_settings(),
 			'disabledSettings'     => $this->get_disabled_settings( $settings ),
 			'endpoint'             => \admin_url( 'options.php' ),
 			'nonce'                => \wp_create_nonce( self::PAGE . '-options' ),
@@ -412,11 +411,12 @@ class Settings_Integration implements Integration_Interface {
 			'canManageOptions'              => \current_user_can( 'manage_options' ),
 			'pluginUrl'                     => \plugins_url( '', \WPSEO_FILE ),
 			'showForceRewriteTitlesSetting' => ! \current_theme_supports( 'title-tag' ) && ! ( \function_exists( 'wp_is_block_theme' ) && \wp_is_block_theme() ),
+			'upsellSettings'                => $this->get_upsell_settings(),
 		];
 	}
 
 	/**
-	 * Returns settings for the CTB buttons.
+	 * Returns settings for the Call to Buy (CTB) buttons.
 	 *
 	 * @return string[] The array of CTB settings.
 	 */


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Fix the site features cards to make it more inline with the integrations page.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Changes the site features' cards in the Settings UI to match the integrations design more. Specifically the badges and the disabled header image.

## Relevant technical choices:

* Moved the logic out of the higher order component and into a hook so we can re-use it in the site features specific component.
* Made a `FeatureCard` to handle all the specific logic of a site features card. (note: I wish Inverse of Control would be able to make this neater, but I see that making it more complicated in this case.)
* Bit of a scope creep with the [Change the CTB data code](https://github.com/Yoast/wordpress-seo/pull/19237/commits/b8dce67e3f8aa16616c10c0555360b31de0cb5bb) commit. Primarily meant to remove any platform specific code in the UI library. But see the commit message for the list 😉 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Verify the Site features page in the Settings UI still functions as before.
* Verify that disabling a feature means that the card header image turns gray (plus opacity of 50%) like in the Integrations page. Note that any badges of the feature are unaffected by this effect.
* Turn off Premium:
  * Verify that the Premium features have an upsell and no `premium` badge.
  * Verify that the Premium features' header images are never gray (even if with Premium you disabled it).
* Turn on Premium:
  * Verify that the Premium features have a `premium` badge.

#### Switch to a multisite environment
* Disable some site features in the network admin.
* Verify that the Site features page shows you a badge for those disabled features like so (note the color of the badge is different than the Integrations)
![image](https://user-images.githubusercontent.com/35524806/203105333-1d999736-dea4-4186-a853-63b17f4f5923.png)

#### CTB tests (copied from [original PR](https://github.com/Yoast/wordpress-seo/pull/19233))
* Turn off Premium.
* Open the following pages and make sure all the buttons have `data-action` with value `load-nfd-ctb` and `data-ctb-id` with value `57d6a568-783c-45e2-a388-847cff155897`. Also make sure that when you hit a button or link it still sends you to the url attached to the button.
 https://basic.wordpress.test/wp-admin/admin.php?page=wpseo_settings#/site-features
https://basic.wordpress.test/wp-admin/admin.php?page=wpseo_settings#/crawl-optimization
https://basic.wordpress.test/wp-admin/admin.php?page=wpseo_settings#/post-type/posts
https://basic.wordpress.test/wp-admin/admin.php?page=wpseo_settings#/taxonomy/categories
https://basic.wordpress.test/wp-admin/admin.php?page=wpseo_settings#/author-archives
https://basic.wordpress.test/wp-admin/admin.php?page=wpseo_settings#/date-archives
https://basic.wordpress.test/wp-admin/admin.php?page=wpseo_settings#/format-archives

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [x] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [x] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes https://yoast.atlassian.net/browse/DUPP-696
Fixes https://yoast.atlassian.net/browse/DUPP-759
