### PR TITLE
DUPP-670 Refactor filter_input calls in class-taxonomy-columns

### DIFF
--- a/admin/taxonomy/class-taxonomy-columns.php
+++ b/admin/taxonomy/class-taxonomy-columns.php
@@ -118,12 +118,24 @@ class WPSEO_Taxonomy_Columns {
 	}
 
 	/**
-	 * Retrieves the taxonomy from the $_GET variable.
+	 * Retrieves the taxonomy from the $_GET or $_POST variable.
 	 *
-	 * @return string The current taxonomy.
+	 * @return string|null The current taxonomy or null when it is not set.
 	 */
 	public function get_current_taxonomy() {
-		return filter_input( $this->get_taxonomy_input_type(), 'taxonomy' );
+		// phpcs:disable WordPress.Security.NonceVerification.Missing, WordPress.Security.NonceVerification.Recommended -- Reason: We are not processing form information.
+		if ( ! empty( $_SERVER['REQUEST_METHOD'] ) && $_SERVER['REQUEST_METHOD'] === 'POST' ) {
+			if ( isset( $_POST['taxonomy'] ) && is_string( $_POST['taxonomy'] ) ) {
+				return sanitize_text_field( wp_unslash( $_POST['taxonomy'] ) );
+			}
+		}
+		else {
+			if ( isset( $_GET['taxonomy'] ) && is_string( $_GET['taxonomy'] ) ) {
+				return sanitize_text_field( wp_unslash( $_GET['taxonomy'] ) );
+			}
+		}
+		// phpcs:enable WordPress.Security.NonceVerification.Missing, WordPress.Security.NonceVerification.Recommended
+		return null;
 	}
 
 	/**
@@ -132,11 +144,19 @@ class WPSEO_Taxonomy_Columns {
 	 * @return string|null
 	 */
 	private function get_taxonomy() {
+		// phpcs:disable WordPress.Security.NonceVerification.Missing, WordPress.Security.NonceVerification.Recommended -- Reason: We are not processing form information.
 		if ( wp_doing_ajax() ) {
-			return FILTER_INPUT( INPUT_POST, 'taxonomy' );
+			if ( isset( $_POST['taxonomy'] ) && is_string( $_POST['taxonomy'] ) ) {
+				return sanitize_text_field( wp_unslash( $_POST['taxonomy'] ) );
+			}
 		}
-
-		return FILTER_INPUT( INPUT_GET, 'taxonomy' );
+		else {
+			if ( isset( $_GET['taxonomy'] ) && is_string( $_GET['taxonomy'] ) ) {
+				return sanitize_text_field( wp_unslash( $_GET['taxonomy'] ) );
+			}
+		}
+		// phpcs:enable WordPress.Security.NonceVerification.Missing, WordPress.Security.NonceVerification.Recommended
+		return null;
 	}
 
 	/**
@@ -170,7 +190,7 @@ class WPSEO_Taxonomy_Columns {
 	 *
 	 * @param mixed $term The current term.
 	 *
-	 * @return bool Whether or not the term is indexable.
+	 * @return bool Whether the term is indexable.
 	 */
 	private function is_indexable( $term ) {
 		// When the no_index value is not empty and not default, check if its value is index.
@@ -192,19 +212,6 @@ class WPSEO_Taxonomy_Columns {
 	}
 
 	/**
-	 * Checks if a taxonomy is being added via a POST method. If not, it defaults to a GET request.
-	 *
-	 * @return int
-	 */
-	private function get_taxonomy_input_type() {
-		if ( ! empty( $_SERVER['REQUEST_METHOD'] ) && $_SERVER['REQUEST_METHOD'] === 'POST' ) {
-			return INPUT_POST;
-		}
-
-		return INPUT_GET;
-	}
-
-	/**
 	 * Wraps the WPSEO_Metabox check to determine whether the metabox should be displayed either by
 	 * choice of the admin or because the taxonomy is not public.
 	 *
@@ -212,10 +219,10 @@ class WPSEO_Taxonomy_Columns {
 	 *
 	 * @param string|null $taxonomy Optional. The taxonomy to test, defaults to the current taxonomy.
 	 *
-	 * @return bool Whether or not the meta box (and associated columns etc) should be hidden.
+	 * @return bool Whether the meta box (and associated columns etc) should be hidden.
 	 */
 	private function display_metabox( $taxonomy = null ) {
-		$current_taxonomy = sanitize_text_field( $this->get_current_taxonomy() );
+		$current_taxonomy = $this->get_current_taxonomy();
 
 		if ( ! isset( $taxonomy ) && ! empty( $current_taxonomy ) ) {
 			$taxonomy = $current_taxonomy;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to replace all `filter_input` calls in our codebase.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Refactor `class-taxonomy-columns` to not use `filter_input`.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install and activate Yoast SEO.
* Go to the categories overview page (`/wp-admin/edit-tags.php?taxonomy=category`).
* Verify whether the Yoast columns pop up correctly.
* Now go to Yoast SEO -> Search appearance settings.
* Go to the taxonomies tab and disable `Show SEO settings for Categories?`.
* Save and head back to the categories overview page, verify that the Yoast columns are gone.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
