### PR TITLE
Settings UI: only save the user profiles when allowed and when the user ID is a number of 1 or higher

### DIFF
--- a/packages/js/src/settings/helpers/submit.js
+++ b/packages/js/src/settings/helpers/submit.js
@@ -65,7 +65,7 @@ export const handleSubmit = async( values, { resetForm } ) => {
 	const canManageOptions = selectPreference( "canManageOptions", false );
 	const { person_social_profiles: personSocialProfiles } = values;
 	const { company_or_person_user_id: userId } = values.wpseo_titles;
-	const canSaveUserProfiles = selectCanEditUser( userId ) && isNumber( userId ) && userId > 0;
+	const canSaveUserProfiles = isNumber( userId ) && userId > 0 && selectCanEditUser( userId );
 
 	try {
 		await Promise.all( [

--- a/packages/js/src/settings/helpers/submit.js
+++ b/packages/js/src/settings/helpers/submit.js
@@ -1,6 +1,6 @@
 import { dispatch, select } from "@wordpress/data";
 import { __ } from "@wordpress/i18n";
-import { forEach, get, isArray, isObject, omit, includes } from "lodash";
+import { forEach, get, includes, isArray, isNumber, isObject, omit } from "lodash";
 import { STORE_NAME } from "../constants";
 import { submitUserSocialProfiles } from "./user-social-profiles";
 
@@ -65,12 +65,14 @@ export const handleSubmit = async( values, { resetForm } ) => {
 	const canManageOptions = selectPreference( "canManageOptions", false );
 	const { person_social_profiles: personSocialProfiles } = values;
 	const { company_or_person_user_id: userId } = values.wpseo_titles;
+	const canSaveUserProfiles = selectCanEditUser( userId ) && isNumber( userId ) && userId > 0;
 
 	try {
 		await Promise.all( [
 			// Ensure we do not save WP options when the user is not allowed to.
 			submitSettings( canManageOptions ? values : omit( values, [ "blogname", "blogdescription" ] ) ),
-			selectCanEditUser( userId ) && submitUserSocialProfiles( userId, personSocialProfiles ),
+			// Only save the user profiles when allowed and when the user ID is a number of 1 or higher.
+			canSaveUserProfiles && submitUserSocialProfiles( userId, personSocialProfiles ),
 		] );
 
 		addNotification( {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Fixes a settings save on fresh installs. Before this fix it would try to save the user' social profiles when the user id would be `false`.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the settings would error on the user' social profiles because no user was selected.

## Relevant technical choices:

* Check if the user ID is a number and if it is higher than `0` before we try to submit them.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Have a fresh install, or remove the `company_or_person_user_id` from the `wpseo_titles` options row.
* Go to the Settings UI
* Verify that the site representation user is not set to a user (Site representation > Organization/person > Person > Select a user)
* Change some other option to be able to save and save
* Verify you can save successfully, instead of getting a status `400` error from the `person_social_profiles` route like before this PR:
![image](https://user-images.githubusercontent.com/35524806/203349336-fa930a19-f6bf-46b1-811e-a65f7bef5ad9.png)

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [x] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes https://yoast.atlassian.net/browse/DUPP-768
