### PR TITLE
Abstract_Presentation: brute force allow dynamic properties

### DIFF
--- a/src/presentations/abstract-presentation.php
+++ b/src/presentations/abstract-presentation.php
@@ -2,11 +2,13 @@
 
 namespace Yoast\WP\SEO\Presentations;
 
+use AllowDynamicProperties;
 use Exception;
 
 /**
  * The abstract presentation class.
  */
+#[AllowDynamicProperties]
 class Abstract_Presentation {
 
 	/**


### PR DESCRIPTION
## Context

* Improve PHP 8.2 compatibility

## Summary

This PR can be summarized in the following changelog entry:

* Improve PHP 8.2 compatibility

## Relevant technical choices:

### Abstract_Presentation: brute force allow dynamic properties

... for now.

Realistically, the magic methods should be fixed, but even more realistically, we should probably have a look at injecting the `Presentation` objects into the `Presenter` classes using the `Abstract_Presentation::of()` method.

This is, however, out of scope for the current task at hand. An issue will be opened to address this at a later date.

In the mean time, we'll hide the PHP 8.2 "Creation of dynamic properties is deprecated" notices by applying the `#[AllowDynamicProperties]` attribute to the `Abstract_Presentation` class.

As this attribute is inherited by child classes, this also fixes the remaining issues with the `Meta_Tags_Context` class, the `Indexable_Presentation` class, the `Indexable_*[_Archive]_Presentation` classes and the `Abstract_Presentation_Mock` class.


## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_ This just hides a bunch of deprecation notices on PHP 8.2.