### PR TITLE
DUPP-670 Refactor filter_input calls for tool-import-export

### DIFF
--- a/admin/views/tool-import-export.php
+++ b/admin/views/tool-import-export.php
@@ -20,29 +20,30 @@ $yoast_seo_import = false;
  * In case of POST the user is on the Yoast SEO import page and in case of the GET the user sees a notice from
  * Yoast SEO that we can import stuff for that plugin.
  */
-if ( filter_input( INPUT_POST, 'import' ) || filter_input( INPUT_GET, 'import' ) ) {
-	check_admin_referer( 'wpseo-import' );
-
-	$yoast_seo_post_wpseo = filter_input( INPUT_POST, 'wpseo', FILTER_DEFAULT, FILTER_REQUIRE_ARRAY );
-	$yoast_seo_action     = 'import';
-}
-elseif ( filter_input( INPUT_POST, 'import_external' ) ) {
+// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Reason: We are only comparing the variable so no need to sanitize.
+if ( isset( $_POST['import_external'] ) && wp_unslash( $_POST['import_external'] ) === 'Import' ) {
 	check_admin_referer( 'wpseo-import-plugins' );
-
-	$yoast_seo_class = filter_input( INPUT_POST, 'import_external_plugin' );
-	if ( class_exists( $yoast_seo_class ) ) {
-		$yoast_seo_import = new WPSEO_Import_Plugin( new $yoast_seo_class(), 'import' );
+	if ( isset( $_POST['import_external_plugin'] ) && is_string( $_POST['import_external_plugin'] ) ) {
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Reason: We are using the variable as a class name.
+		$yoast_seo_class = wp_unslash( $_POST['import_external_plugin'] );
+		if ( class_exists( $yoast_seo_class ) ) {
+			$yoast_seo_import = new WPSEO_Import_Plugin( new $yoast_seo_class(), 'import' );
+		}
 	}
 }
-elseif ( filter_input( INPUT_POST, 'clean_external' ) ) {
+// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Reason: We are only comparing the variable so no need to sanitize.
+elseif ( isset( $_POST['clean_external'] ) && wp_unslash( $_POST['clean_external'] ) === 'Clean up' ) {
 	check_admin_referer( 'wpseo-clean-plugins' );
-
-	$yoast_seo_class = filter_input( INPUT_POST, 'clean_external_plugin' );
-	if ( class_exists( $yoast_seo_class ) ) {
-		$yoast_seo_import = new WPSEO_Import_Plugin( new $yoast_seo_class(), 'cleanup' );
+	if ( isset( $_POST['clean_external_plugin'] ) && is_string( $_POST['clean_external_plugin'] ) ) {
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Reason: We are using the variable as a class name.
+		$yoast_seo_class = wp_unslash( $_POST['clean_external_plugin'] );
+		if ( class_exists( $yoast_seo_class ) ) {
+			$yoast_seo_import = new WPSEO_Import_Plugin( new $yoast_seo_class(), 'cleanup' );
+		}
 	}
 }
-elseif ( filter_input( INPUT_POST, 'settings_import' ) ) {
+// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Reason: We are only comparing to an empty string.
+elseif ( isset( $_POST['settings_import'] ) && wp_unslash( $_POST['settings_import'] ) !== '' ) {
 	$yoast_seo_import = new WPSEO_Import_Settings();
 	$yoast_seo_import->import();
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to replace all `filter_input` calls in our codebase.
* We want to replace all `FILTER_DEFAULT` filters in our codebase.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Refactor `tool-import-export` class to not use `FILTER_DEFAULT` and `filter_input`.

## Relevant technical choices:

* This PR removes the first branch because it is not used anywhere else.
* I have specifically not sanitized the `$yoast_seo_class` variable as it is used as a class name but we might need to introduce some better sanitization here (e.g. checking against a restricted set of classes). The code now allows for arbitrary class injection.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install and activate Yoast SEO.
* On the administration dashboard, go to Yoast SEO -> Tools.
* Click on `Import and Export`.
* Try all functionality on these tabs. So:
- Try to export the settings (note that if you want to import the same settings then you should not copy the `; These are settings for the Yoast SEO plugin by Yoast.com` line).
- Try to then import the settings and change them a bit.
- Install [Squirrly SEO](https://wordpress.org/plugins/squirrly-seo/) and verify that Importing settings and cleaning settings work (e.g. you get a green notification). After cleaning Squirrly SEO it should also disappear from the options. Specifically do not try this out with All in One SEO because it works with Ajax requests instead of the form POST.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
