### PR TITLE
DUPP-670 Refactor filter_input calls in class-addon-manager

### DIFF
--- a/inc/class-addon-manager.php
+++ b/inc/class-addon-manager.php
@@ -671,7 +671,12 @@ class WPSEO_Addon_Manager {
 		global $pagenow;
 
 		// Force re-check on license & dashboard pages.
-		$current_page = $this->get_current_page();
+		$current_page = null;
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Reason: We are not processing form information.
+		if ( isset( $_GET['page'] ) && is_string( $_GET['page'] ) ) {
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Reason: We are not processing form information, We are only strictly comparing and thus no need to sanitize.
+			$current_page = wp_unslash( $_GET['page'] );
+		}
 
 		// Check whether the licenses are valid or whether we need to show notifications.
 		$quick = ( $current_page === 'wpseo_licenses' || $current_page === 'wpseo_dashboard' );
@@ -685,17 +690,6 @@ class WPSEO_Addon_Manager {
 		}
 
 		return get_transient( self::SITE_INFORMATION_TRANSIENT );
-	}
-
-	/**
-	 * Returns the current page.
-	 *
-	 * @codeCoverageIgnore
-	 *
-	 * @return string The current page.
-	 */
-	protected function get_current_page() {
-		return filter_input( INPUT_GET, 'page' );
 	}
 
 	/**

--- a/tests/unit/inc/addon-manager-test.php
+++ b/tests/unit/inc/addon-manager-test.php
@@ -1016,4 +1016,86 @@ class Addon_Manager_Test extends TestCase {
 
 		return $this->past_date;
 	}
+
+	/**
+	 * Test get_myyoast_site_information function.
+	 *
+	 * Note that this only tests when a transient can be retrieved.
+	 *
+	 * @param string $pagenow_new What the value of global pagenow should be.
+	 * @param mixed  $page What the value of $_GET['page'] should be.
+	 * @param bool   $call_quick Whether the quick transient will be used.
+	 * @param mixed  $transient_return The value the transient should return.
+	 * @param mixed  $return_value The return value.
+	 *
+	 * @dataProvider get_myyoast_site_information_dataprovider
+	 *
+	 * @covers ::get_myyoast_site_information
+	 */
+	public function test_get_myyoast_site_information( $pagenow_new, $page, $call_quick, $transient_return, $return_value ) {
+		global $pagenow;
+		$pagenow      = $pagenow_new;
+		$_GET['page'] = $page;
+		if ( $call_quick ) {
+			Monkey\Functions\expect( 'get_transient' )
+				->with( 'wpseo_site_information_quick' )
+				->andReturn( $transient_return );
+		}
+		else {
+			Monkey\Functions\expect( 'get_transient' )
+				->with( 'wpseo_site_information' )
+				->andReturn( $transient_return );
+		}
+		$this->assertEquals( $return_value, $this->instance->get_myyoast_site_information() );
+	}
+
+	/**
+	 * Data provider for test_get_myyoast_site_information.
+	 *
+	 * @return array[] The data for test_get_myyoast_site_information.
+	 */
+	public function get_myyoast_site_information_dataprovider() {
+		$normal_call            = [
+			'pagenow_new'      => 'plugins.php',
+			'page'             => 'wpseo_licences',
+			'call_quick'       => true,
+			'transient_return' => 'test',
+			'return_value'     => 'test',
+		];
+		$pagenow_other          = [
+			'pagenow_new'      => 'non-existent.php',
+			'page'             => 'wpseo_licences',
+			'call_quick'       => true,
+			'transient_return' => 'test',
+			'return_value'     => 'test',
+		];
+		$no_quick_call          = [
+			'pagenow_new'      => 'non-existent.php',
+			'page'             => 'non_existent',
+			'call_quick'       => false,
+			'transient_return' => 'test',
+			'return_value'     => 'test',
+		];
+		$page_null              = [
+			'pagenow_new'      => 'non-existent.php',
+			'page'             => null,
+			'call_quick'       => false,
+			'transient_return' => 'test',
+			'return_value'     => 'test',
+		];
+		$page_other_than_string = [
+			'pagenow_new'      => 'non-existent.php',
+			'page'             => 13,
+			'call_quick'       => false,
+			'transient_return' => 'test',
+			'return_value'     => 'test',
+		];
+		return [
+			'Normal call'                        => $normal_call,
+			'Pagenow set to something else than plugins.php or update-core.php' => $pagenow_other,
+			'No quick call'                      => $no_quick_call,
+			'Page is set to null'                => $page_null,
+			'Page is something else than string' => $page_other_than_string,
+		];
+	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to replace all `filter_input` calls in our codebase.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Refactors `class-addon-manager` to not use `filter_input`.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install and activate Yoast SEO.
* Install and activate Yoast SEO Local.
* Install and activate [Code Snippets](https://wordpress.org/plugins/code-snippets/#:~:text=A%20snippet%20is%20a%20small,to%20your%20active%20theme's%20functions.).
* On the administration dashboard, go to Snippets and add a new snippet.
* In the snippet content, put the following PHP code:
```
add_filter( 'transient_wpseo_site_information_quick', 'set_transient_for_site_information' );

function set_transient_for_site_information($value) {
	return (object) [
		'url' => 'basic.wordpress.test/',
		'subscriptions' => [
			(object) [
				'renewal_url' => '',
				'expiry_date' => '2017-02-01T00:00:00.000Z',
				'product' => (object) [
					'version' => '14.7',
					'name' => 'Yoast SEO Local',
					'slug' => 'yoast-seo-local',
					'last_updated' => '2022-11-22T10:45:08.000Z',
					'store_url' => 'https://yoast.com/product/local-seo-wordpress-plugin/',
					'download' => 'https://yoast.com/app/uploads/2022/11/wordpress-seo-local-14.7.zip',
					'changelog' => ''
				]
			]
		]
	];
}
```
* Select `Only run in administration area` and click `Save changes and activate`
* Now go to the Yoast SEO dashboard (`/wp-admin/admin.php?page=wpseo_dashboard`) and verify that the following notification pops up "You are not receiving updates or support! Fix this problem by adding this site and enabling Local SEO for it in [My Yoast](https://yoa.st/13j?php_version=7.4&platform=wordpress&platform_version=6.1.1&software=free&software_version=19.11-RC8&days_active=365plus&user_language=en_US&screen=wpseo_dashboard).".

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
