### PR TITLE
DUPP-670 Refactor filter_input calls in class-wpseo-shortlinker

### DIFF
--- a/inc/class-wpseo-shortlinker.php
+++ b/inc/class-wpseo-shortlinker.php
@@ -26,9 +26,13 @@ class WPSEO_Shortlinker {
 			'user_language'    => $this->get_user_language(),
 		];
 
-		$admin_page = filter_input( INPUT_GET, 'page' );
-		if ( ! empty( $admin_page ) ) {
-			$data['screen'] = $admin_page;
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Reason: We are not processing form information.
+		if ( isset( $_GET['page'] ) && is_string( $_GET['page'] ) ) {
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Reason: We are not processing form information.
+			$admin_page = sanitize_text_field( wp_unslash( $_GET['page'] ) );
+			if ( ! empty( $admin_page ) ) {
+				$data['screen'] = $admin_page;
+			}
 		}
 
 		return $data;

--- a/tests/integration/inc/test-class-wpseo-shortlinker.php
+++ b/tests/integration/inc/test-class-wpseo-shortlinker.php
@@ -30,6 +30,51 @@ class WPSEO_Shortlinker_Test extends TestCase {
 	}
 
 	/**
+	 * Tests building a shortlink with page.
+	 *
+	 * @covers WPSEO_Shortlinker::build_shortlink
+	 * @covers WPSEO_Shortlinker::collect_additional_shortlink_data
+	 */
+	public function test_build_shortlink_page_set() {
+		$_GET['page'] = 'wpseo_dashboard';
+		$shortlinks   = new WPSEO_Shortlinker();
+
+		$shortlink = $shortlinks->build_shortlink( 'http://yoa.st/abcdefg' );
+
+		$this->assertStringContainsString( 'screen', $shortlink );
+	}
+
+	/**
+	 * Tests building a shortlink with page set to null.
+	 *
+	 * @covers WPSEO_Shortlinker::build_shortlink
+	 * @covers WPSEO_Shortlinker::collect_additional_shortlink_data
+	 */
+	public function test_build_shortlink_page_set_to_null() {
+		$_GET['page'] = null;
+		$shortlinks   = new WPSEO_Shortlinker();
+
+		$shortlink = $shortlinks->build_shortlink( 'http://yoa.st/abcdefg' );
+
+		$this->assertStringNotContainsString( 'screen', $shortlink );
+	}
+
+	/**
+	 * Tests building a shortlink with page set to something else than a string.
+	 *
+	 * @covers WPSEO_Shortlinker::build_shortlink
+	 * @covers WPSEO_Shortlinker::collect_additional_shortlink_data
+	 */
+	public function test_build_shortlink_page_set_to_int() {
+		$_GET['page'] = 13;
+		$shortlinks   = new WPSEO_Shortlinker();
+
+		$shortlink = $shortlinks->build_shortlink( 'http://yoa.st/abcdefg' );
+
+		$this->assertStringNotContainsString( 'screen', $shortlink );
+	}
+
+	/**
 	 * Tests getting a shortlink.
 	 *
 	 * @covers WPSEO_Shortlinker::get


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to replace all `filter_input` calls in our codebase.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Refactors `class-wpseo-shortlinker` to not use `filter_input`.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install and activate Yoast SEO.
* Go to the Yoast administration dashboard and inspect the link "Get Yoast SEO Premium".
* Verify that the link has a `screen` GET parameter of `wpseo_dashboard`.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
