### PR TITLE
DUPP-668 Use WHIP to deprecate PHP < 7.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
 	},
 	"require": {
 		"php": "^5.6.20 || ^7.0 || ^8.0",
-		"composer/installers": "^1.12 || ^2.0"
+		"composer/installers": "^1.12 || ^2.0",
+		"yoast/whip": "^1.2"
 	},
 	"require-dev": {
 		"humbug/php-scoper": "^0.13.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "143a8d1d08eaf6aa8a4d6be0316997c8",
+    "content-hash": "547cd9c05b8752223aa703f8e206660e",
     "packages": [
         {
             "name": "composer/installers",
@@ -156,6 +156,57 @@
                 }
             ],
             "time": "2021-09-13T08:19:44+00:00"
+        },
+        {
+            "name": "yoast/whip",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Yoast/whip.git",
+                "reference": "49a6120d89a53874391d1451be8ef279feec0eae"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Yoast/whip/zipball/49a6120d89a53874391d1451be8ef279feec0eae",
+                "reference": "49a6120d89a53874391d1451be8ef279feec0eae",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^0.5",
+                "php-parallel-lint/php-parallel-lint": "^1.3",
+                "phpunit/phpunit": "^4.5 || ^5.7 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
+                "roave/security-advisories": "dev-master",
+                "yoast/yoastcs": "^2.1.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/facades/wordpress.php"
+                ],
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Team Yoast",
+                    "email": "support@yoast.com"
+                }
+            ],
+            "description": "A WordPress package to nudge users to upgrade their software versions (starting with PHP)",
+            "homepage": "https://github.com/Yoast/whip",
+            "support": {
+                "issues": "https://github.com/Yoast/whip/issues",
+                "source": "https://github.com/Yoast/whip"
+            },
+            "time": "2021-07-20T11:22:45+00:00"
         }
     ],
     "packages-dev": [

--- a/src/integrations/admin/unsupported-php-version.php
+++ b/src/integrations/admin/unsupported-php-version.php
@@ -1,0 +1,167 @@
+<?php
+
+namespace Yoast\WP\SEO\Integrations\Admin;
+
+use Whip_InvalidType;
+use Whip_InvalidVersionComparisonString;
+use Whip_Message;
+use Whip_MessageDismisser;
+use Whip_MessageFormatter;
+use Whip_RequirementsChecker;
+use Whip_VersionRequirement;
+use Whip_WPDismissOption;
+use Whip_WPMessagePresenter;
+use WPSEO_Shortlinker;
+use Yoast\WP\SEO\Conditionals\Yoast_Admin_And_Dashboard_Conditional;
+use Yoast\WP\SEO\Integrations\Integration_Interface;
+
+/**
+ * Class Unsupported_PHP_Version.
+ *
+ * @package Yoast\WP\SEO\Integrations\Admin
+ */
+class Unsupported_PHP_Version implements Integration_Interface, Whip_Message {
+
+	/**
+	 * Returns the conditionals based on which this integration should be active.
+	 *
+	 * @return array The array of conditionals.
+	 */
+	public static function get_conditionals() {
+		return [
+			Yoast_Admin_And_Dashboard_Conditional::class,
+		];
+	}
+
+	/**
+	 * Register hooks.
+	 *
+	 * @return void
+	 */
+	public function register_hooks() {
+		\add_action( 'admin_init', [ $this, 'check_php_version' ], 10 );
+	}
+
+	/**
+	 * Checks the current PHP version.
+	 *
+	 * @return void
+	 */
+	public function check_php_version() {
+		// If the user isn't an admin, don't display anything.
+		if ( ! $this->has_right_capabilities() ) {
+			return;
+		}
+
+		if ( ! $this->on_dashboard_page( $GLOBALS['pagenow'] ) ) {
+			return;
+		}
+
+		// Checks if the user is running at least PHP 7.2.
+		if ( $this->is_supported_php_version_installed() === false ) {
+			$this->show_unsupported_php_message();
+		}
+	}
+
+	/**
+	 * Composes the body of the message to display.
+	 *
+	 * @return string The message to display.
+	 */
+	public function body() {
+		$message   = [];
+		$message[] = Whip_MessageFormatter::strongParagraph( \__( 'Upgrade your PHP version', 'wordpress-seo' ) ) . '<br />';
+		$message[] = Whip_MessageFormatter::paragraph(
+			\sprintf(
+				/* translators: 1: Yoast SEO, 2: Yoast SEO Premium */
+				\__(
+					'By March 1st, 2023, we’ll update the minimum PHP requirement for %1$s, %2$s and all our add-ons to PHP 7.2. This, to ensure we can keep delivering state of the art features.',
+					'wordpress-seo'
+				),
+				'Yoast SEO',
+				'Yoast SEO Premium'
+			)
+		) . '<br />';
+		$message[] = Whip_MessageFormatter::strongParagraph( \__( 'Can’t upgrade yourself? Ask your host!', 'wordpress-seo' ) ) . '<br />';
+		$message[] = Whip_MessageFormatter::paragraph(
+			\sprintf(
+				/* translators: 1: Link tag to WordPress Hosts page on Yoast.com; 2: Link closing tag */
+				\__(
+					'Upgrading your PHP version is something your hosting provider can help you out with. If they can’t upgrade your PHP version, we advise you to consider %1$sswitching to a hosting provider%2$s that can provide the security and features a modern host should provide.',
+					'wordpress-seo'
+				),
+				'<a href="' . WPSEO_Shortlinker::get( 'https://yoast.com/wordpress-hosting/' ) . '">',
+				'</a>'
+			)
+		) . '<br />';
+
+		return \implode( PHP_EOL, $message );
+	}
+
+	/**
+	 * Checks if the current user has the right capabilities.
+	 *
+	 * @return bool True when user has right capabilities.
+	 */
+	protected function has_right_capabilities() {
+		return \current_user_can( 'wpseo_manage_options' );
+	}
+
+	/**
+	 * Whether we are on the admin dashboard page or in the Yoast dashboard page.
+	 *
+	 * We need to have the notice in the main admin otherwise the dismissal mechanism won't work.
+	 *
+	 * @param string $current_page The current page.
+	 *
+	 * @return bool True if current page is the index.php.
+	 */
+	protected function on_dashboard_page( $current_page ) {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Date is not processed or saved.
+		if ( $current_page === 'admin.php' && isset( $_GET['page'] ) && \sanitize_text_field( \wp_unslash( $_GET['page'] ) ) === 'wpseo_dashboard' ) {
+			return true;
+		}
+
+		return ( $current_page === 'index.php' );
+	}
+
+	/**
+	 * Checks if the installed php version is supported.
+	 *
+	 * @codeCoverageIgnore
+	 *
+	 * @return bool True when the php version is support.
+	 */
+	protected function is_supported_php_version_installed() {
+		try {
+			$checker = new Whip_RequirementsChecker( [ 'php' => PHP_VERSION ] );
+
+			$checker->addRequirement( Whip_VersionRequirement::fromCompareString( 'php', '>=7.2' ) );
+			$checker->check();
+
+			return $checker->hasMessages() === false;
+		}
+		catch ( Whip_InvalidVersionComparisonString $e ) {
+			return true;
+		}
+		catch ( Whip_InvalidType $e ) {
+			return true;
+		}
+	}
+
+	/**
+	 * Creates a new message to display regarding the usage of PHP 7.1 (or lower).
+	 *
+	 * @codeCoverageIgnore
+	 *
+	 * @return void
+	 */
+	protected function show_unsupported_php_message() {
+		$presenter = new Whip_WPMessagePresenter(
+			$this,
+			new Whip_MessageDismisser( \time(), ( WEEK_IN_SECONDS * 4 ), new Whip_WPDismissOption() ),
+			\__( 'Remind me again in 4 weeks.', 'wordpress-seo' )
+		);
+		$presenter->registerHooks();
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to throw a notice to admins to notify we're dropping compatibility with PHP < 7.2 starting March 1st, 2023

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Introduces a notice on the WordPress dashboard and the Yoast SEO dashboard to let users know we're dropping support for PHP < 7.2 starting March 1st, 2023.

## Relevant technical choices:

* `yoast/whip` is not vendor prefixed because it's not namespaced. Also, it takes care of version differences by itself (on a version bump method names should change)

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Run `grunt artifact` to create a zip. This makes it way easier to test on different envs.
* Find a way to have WP running on PHP 5.6, 7.0 and 7.1.
  * e.g. I was able to have a Local by Flywheel site on PHP 5.6. I'm on Linux, I know other people could not...
  * Switching the docker env to an older version doesn't seem to work
  * you can also _hack_ the requirement: make sure you are on PHP 7.4, change the line 139 of `src/integrations/admin/unsupported-php-version.php` from 
  ```
  $checker->addRequirement( Whip_VersionRequirement::fromCompareString( 'php', '>=7.2' ) );
  ```
  to 
  ```
  $checker->addRequirement( Whip_VersionRequirement::fromCompareString( 'php', '>=8.0' ) );
  ```
  (you can do this directly after having uploaded the artifact)
* upload the artifact
* activate Yoast SEO
* see that you get a notice on the WP dashboard and in the Yoast SEO General page:
![Screenshot 2022-11-23 at 12-22-17 General - Yoast SEO ‹ test5 6 — WordPress](https://user-images.githubusercontent.com/15989132/203534597-f8b55677-790a-4d17-b52b-afc2e434939e.png)
* Click on "Remind me in 4 weeks"
  * you should be redirected to the WP Dashboard and the notice should be hidden
* inspect the `options` table and set the `whip_dismiss_timestamp` to at least four weeks ago, e.g `1663929217`.
* see that you get the notice again on the WP dashboard and in the Yoast SEO General page.

* Upload the artifact to a 7.2+ env and check that you don't see any notice.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [x] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->
Note that the notice will be displayed in the subsites and not in the network admin. Each site will manage its own setting for the dismissal (dismissing in subsite A won't hide it in subsite B)

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes [DUPP-668]


[DUPP-668]: https://yoast.atlassian.net/browse/DUPP-668?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ