### PR TITLE
DUPP-670 Fix PHP 8.1 compatibility for elementor-edit-conditional class

### DIFF
--- a/src/conditionals/third-party/elementor-edit-conditional.php
+++ b/src/conditionals/third-party/elementor-edit-conditional.php
@@ -11,23 +11,29 @@ use Yoast\WP\SEO\Conditionals\Conditional;
 class Elementor_Edit_Conditional implements Conditional {
 
 	/**
-	 * Returns whether or not this conditional is met.
+	 * Returns whether this conditional is met.
 	 *
-	 * @return bool Whether or not the conditional is met.
+	 * @return bool Whether the conditional is met.
 	 */
 	public function is_met() {
 		global $pagenow;
 
-		// Check if we are on an Elementor edit page.
-		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- This deprecation will be addressed later.
-		$get_action = \filter_input( \INPUT_GET, 'action', @\FILTER_SANITIZE_STRING );
-		if ( $pagenow === 'post.php' && $get_action === 'elementor' ) {
-			return true;
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Reason: We are not processing form information.
+		if ( isset( $_GET['action'] ) && \is_string( $_GET['action'] ) ) {
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Reason: We are not processing form information, We are only strictly comparing.
+			$get_action = \wp_unslash( $_GET['action'] );
+			if ( $pagenow === 'post.php' && $get_action === 'elementor' ) {
+				return true;
+			}
 		}
 
-		// Check if we are in our Elementor ajax request.
-		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- This deprecation will be addressed later.
-		$post_action = \filter_input( \INPUT_POST, 'action', @\FILTER_SANITIZE_STRING );
-		return \wp_doing_ajax() && $post_action === 'wpseo_elementor_save';
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Reason: We are not processing form information.
+		if ( isset( $_POST['action'] ) && \is_string( $_POST['action'] ) ) {
+			// phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Reason: We are not processing form information, We are only strictly comparing.
+			$post_action = \wp_unslash( $_POST['action'] );
+			return \wp_doing_ajax() && $post_action === 'wpseo_elementor_save';
+		}
+
+		return false;
 	}
 }

--- a/tests/unit/conditionals/third-party/elementor-edit-conditional-test.php
+++ b/tests/unit/conditionals/third-party/elementor-edit-conditional-test.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Conditionals\Third_Party;
+
+use Yoast\WP\SEO\Conditionals\Third_Party\Elementor_Edit_Conditional;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+use Brain\Monkey;
+
+/**
+ * Class Elementor_Edit_Conditional_Test.
+ *
+ * @group conditionals
+ * @group third-party
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Conditionals\Third_Party\Elementor_Edit_Conditional
+ */
+class Elementor_Edit_Conditional_Test extends TestCase {
+
+	/**
+	 * The instance under test.
+	 *
+	 * @var Elementor_Edit_Conditional
+	 */
+	protected $instance;
+
+	/**
+	 * Sets up the class under test and mock objects.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->instance = new Elementor_Edit_Conditional();
+	}
+
+	/**
+	 * Tests that the condition is not met when the Elementor plugin is not active.
+	 *
+	 * @param string    $pagenow_new  The value of global pagenow.
+	 * @param mixed     $get_action   The value of action in $_GET['action'].
+	 * @param mixed     $post_action  The value of action in $_POST['action'].
+	 * @param bool|null $doing_ajax   What wp_doing_ajax should return, if false it should not be called.
+	 * @param bool      $return_value The expected return value.
+	 *
+	 * @dataProvider is_met_dataprovider
+	 *
+	 * @covers ::is_met
+	 */
+	public function test_is_met( $pagenow_new, $get_action, $post_action, $doing_ajax, $return_value ) {
+		global $pagenow;
+
+		$pagenow = $pagenow_new;
+
+		$_GET['action']  = $get_action;
+		$_POST['action'] = $post_action;
+
+		if ( $doing_ajax !== null ) {
+			Monkey\Functions\expect( 'wp_doing_ajax' )
+				->andReturn( $doing_ajax );
+		}
+
+		self::assertEquals( $return_value, $this->instance->is_met() );
+	}
+
+	/**
+	 * Data provider for test_is_met.
+	 *
+	 * @return array[] The data for test_is_met.
+	 */
+	public function is_met_dataprovider() {
+		$action_in_get          = [
+			'pagenow_new'   => 'post.php',
+			'get_action'    => 'elementor',
+			'post_action'   => null,
+			'wp_doing_ajax' => null,
+			'return_value'  => true,
+		];
+		$action_in_post         = [
+			'pagenow_new'   => 'post.php',
+			'get_action'    => null,
+			'post_action'   => 'wpseo_elementor_save',
+			'wp_doing_ajax' => true,
+			'return_value'  => true,
+		];
+		$not_doing_ajax         = [
+			'pagenow_new'   => 'post.php',
+			'get_action'    => null,
+			'post_action'   => 'wpseo_elementor_save',
+			'wp_doing_ajax' => false,
+			'return_value'  => false,
+		];
+		$wrong_get_action       = [
+			'pagenow_new'   => 'post.php',
+			'get_action'    => 'wrong',
+			'post_action'   => null,
+			'wp_doing_ajax' => null,
+			'return_value'  => false,
+		];
+		$wrong_post_action      = [
+			'pagenow_new'   => 'post.php',
+			'get_action'    => null,
+			'post_action'   => 'wrong',
+			'wp_doing_ajax' => true,
+			'return_value'  => false,
+		];
+		$wrong_get_action_type  = [
+			'pagenow_new'   => 'post.php',
+			'get_action'    => 13,
+			'post_action'   => null,
+			'wp_doing_ajax' => null,
+			'return_value'  => false,
+		];
+		$wrong_post_action_type = [
+			'pagenow_new'   => 'post.php',
+			'get_action'    => null,
+			'post_action'   => 13,
+			'wp_doing_ajax' => null,
+			'return_value'  => false,
+		];
+		return [
+			'Action in GET'          => $action_in_get,
+			'Action in POST'         => $action_in_post,
+			'Not doing AJAX'         => $not_doing_ajax,
+			'Wrong GET action'       => $wrong_get_action,
+			'Wrong POST action'      => $wrong_post_action,
+			'Wrong GET action type'  => $wrong_get_action_type,
+			'Wrong POST action type' => $wrong_post_action_type,
+		];
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to be compatible with PHP 8.1.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fix PHP 8.1 compatibility for `elementor-edit-conditional` class.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install and activate Yoast SEO and Elementor.
* Edit a post with Elementor and verify whether the Yoast SEO tool shows up and works as expected.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
