### PR TITLE
Settings UI: add support for website name and alternate name for both website and organization

### DIFF
--- a/packages/js/src/settings/helpers/search.js
+++ b/packages/js/src/settings/helpers/search.js
@@ -590,6 +590,13 @@ export const createSearchIndex = ( postTypes, taxonomies ) => ( {
 			fieldLabel: __( "Organization name", "wordpress-seo" ),
 			keywords: [],
 		},
+		company_alternate_name: {
+			route: "/site-representation",
+			routeLabel: __( "Site representation", "wordpress-seo" ),
+			fieldId: "input-wpseo_titles-company_alternate_name",
+			fieldLabel: __( "Alternate organization name", "wordpress-seo" ),
+			keywords: [],
+		},
 		company_logo_id: {
 			route: "/site-representation",
 			routeLabel: __( "Site representation", "wordpress-seo" ),

--- a/packages/js/src/settings/helpers/search.js
+++ b/packages/js/src/settings/helpers/search.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 import { __, sprintf } from "@wordpress/i18n";
-import { reduce, times, omit } from "lodash";
+import { omit, reduce, times } from "lodash";
 
 /**
  * @param {Object} postType The post type.
@@ -211,13 +211,6 @@ export const createTaxonomySearchIndex = ( { name, label, route } ) => ( {
  * @returns {Object} The search index.
  */
 export const createSearchIndex = ( postTypes, taxonomies ) => ( {
-	blogname: {
-		route: "/site-basics",
-		routeLabel: __( "Site basics", "wordpress-seo" ),
-		fieldId: "input-blogname",
-		fieldLabel: __( "Site title", "wordpress-seo" ),
-		keywords: [],
-	},
 	blogdescription: {
 		route: "/site-basics",
 		routeLabel: __( "Site basics", "wordpress-seo" ),
@@ -553,6 +546,20 @@ export const createSearchIndex = ( postTypes, taxonomies ) => ( {
 		},
 	},
 	wpseo_titles: {
+		website_name: {
+			route: "/site-basics",
+			routeLabel: __( "Site basics", "wordpress-seo" ),
+			fieldId: "input-wpseo_titles-website_name",
+			fieldLabel: __( "Website name", "wordpress-seo" ),
+			keywords: [],
+		},
+		alternate_website_name: {
+			route: "/site-basics",
+			routeLabel: __( "Site basics", "wordpress-seo" ),
+			fieldId: "input-wpseo_titles-alternate_website_name",
+			fieldLabel: __( "Alternate website name", "wordpress-seo" ),
+			keywords: [],
+		},
 		forcerewritetitles: {
 			route: "/site-basics",
 			routeLabel: __( "Site basics", "wordpress-seo" ),

--- a/packages/js/src/settings/helpers/submit.js
+++ b/packages/js/src/settings/helpers/submit.js
@@ -70,7 +70,7 @@ export const handleSubmit = async( values, { resetForm } ) => {
 	try {
 		await Promise.all( [
 			// Ensure we do not save WP options when the user is not allowed to.
-			submitSettings( canManageOptions ? values : omit( values, [ "blogname", "blogdescription" ] ) ),
+			submitSettings( canManageOptions ? values : omit( values, [ "blogdescription" ] ) ),
 			// Only save the user profiles when allowed and when the user ID is a number of 1 or higher.
 			canSaveUserProfiles && submitUserSocialProfiles( userId, personSocialProfiles ),
 		] );

--- a/packages/js/src/settings/routes/site-basics.js
+++ b/packages/js/src/settings/routes/site-basics.js
@@ -7,6 +7,7 @@ import {
 	FieldsetLayout,
 	FormikMediaSelectField,
 	FormikValueChangeField,
+	FormikWithErrorField,
 	FormLayout,
 	OpenGraphDisabledAlert,
 	RouteLayout,
@@ -26,6 +27,7 @@ const SiteBasics = () => {
 	const showForceRewriteTitlesSetting = useSelectSettings( "selectPreference", [], "showForceRewriteTitlesSetting", false );
 	const replacementVariablesLink = useSelectSettings( "selectLink", [], "https://yoa.st/site-basics-replacement-variables" );
 	const usageTrackingLink = useSelectSettings( "selectLink", [], "https://yoa.st/usage-tracking-2" );
+	const siteTitle = useSelectSettings( "selectPreference", [], "siteTitle", "" );
 
 	const usageTrackingDescription = useMemo( () => createInterpolateElement(
 		sprintf(
@@ -80,21 +82,6 @@ const SiteBasics = () => {
 			strong: <strong className="yst-font-semibold" />,
 		}
 	), [] );
-	const siteTitleDescription = useMemo( () => createInterpolateElement(
-		sprintf(
-			/**
-			 * translators: %1$s expands to an opening anchor tag.
-			 * %2$s expands to a closing anchor tag.
-			 */
-			__( "This field updates the %1$ssite title in your WordPress settings%2$s.", "wordpress-seo" ),
-			"<a>",
-			"</a>"
-		),
-		{
-			// eslint-disable-next-line jsx-a11y/anchor-has-content
-			a: <a href={ `${ generalSettingsUrl }#blogname` } target="_blank" rel="noopener noreferrer" />,
-		}
-	), [] );
 	const taglineDescription = useMemo( () => createInterpolateElement(
 		sprintf(
 			/**
@@ -127,18 +114,23 @@ const SiteBasics = () => {
 					>
 						{ ! canManageOptions && (
 							<Alert variant="warning" id="alert-site-defaults-variables" className="yst-mb-8">
-								{  canNotManageOptionsAlertText }
+								{ canNotManageOptionsAlertText }
 							</Alert>
 						) }
 						<div className="lg:yst-mt-0 lg:yst-col-span-2 yst-space-y-8">
-							<Field
+							<FormikWithErrorField
 								as={ TextField }
-								type="text"
-								name="blogname"
-								id="input-blogname"
-								label={ __( "Site title", "wordpress-seo" ) }
-								description={ canManageOptions && siteTitleDescription }
-								readOnly={ ! canManageOptions }
+								name="wpseo_titles.website_name"
+								id="input-wpseo_titles-website_name"
+								label={ __( "Website name", "wordpress-seo" ) }
+								placeholder={ siteTitle }
+							/>
+							<FormikWithErrorField
+								as={ TextField }
+								name="wpseo_titles.alternate_website_name"
+								id="input-wpseo_titles-alternate_website_name"
+								label={ __( "Alternate website name", "wordpress-seo" ) }
+								description={ __( "Use the alternate website name for acronyms, or a shorter version of your website's name.", "wordpress-seo" ) }
 							/>
 							<Field
 								as={ TextField }
@@ -169,7 +161,7 @@ const SiteBasics = () => {
 						<OpenGraphDisabledAlert
 							isEnabled={ opengraph }
 							text={
-							/* translators: %1$s expands to an opening emphasis tag. %2$s expands to a closing emphasis tag. */
+								/* translators: %1$s expands to an opening emphasis tag. %2$s expands to a closing emphasis tag. */
 								__( "The %1$sSite image%2$s requires Open Graph data, which is currently disabled in the ‘Social sharing’ section in %3$sSite features%4$s.", "wordpress-seo" )
 							}
 						/>
@@ -194,7 +186,7 @@ const SiteBasics = () => {
 								data-id="input-wpseo_titles-forcerewritetitle"
 								label={ __( "Force rewrite titles", "wordpress-seo" ) }
 								description={ sprintf(
-								/* translators: %1$s expands to "Yoast SEO" */
+									/* translators: %1$s expands to "Yoast SEO" */
 									__( "%1$s has auto-detected whether it needs to force rewrite the titles for your pages, if you think it's wrong and you know what you're doing, you can change the setting here.", "wordpress-seo" ),
 									"Yoast SEO"
 								) }
@@ -207,7 +199,7 @@ const SiteBasics = () => {
 							data-id="input-wpseo-disableadvanced_meta"
 							label={ __( "Restrict advanced settings for authors", "wordpress-seo" ) }
 							description={ sprintf(
-							/* translators: %1$s expands to "Yoast SEO" */
+								/* translators: %1$s expands to "Yoast SEO" */
 								__( "By default only editors and administrators can access the Advanced and Schema section of the %1$s sidebar. Disabling this allows access to all users.", "wordpress-seo" ),
 								"Yoast SEO"
 							) }

--- a/packages/js/src/settings/routes/site-representation.js
+++ b/packages/js/src/settings/routes/site-representation.js
@@ -86,9 +86,9 @@ const PersonSocialProfiles = () => {
  */
 const SiteRepresentation = () => {
 	const { values } = useFormikContext();
-	const { blogname } = values;
 	// eslint-disable-next-line camelcase
 	const {
+		website_name: websiteName,
 		company_or_person: companyOrPerson,
 		company_or_person_user_id: companyOrPersonId,
 		company_name: companyName,
@@ -168,11 +168,11 @@ const SiteRepresentation = () => {
 								description={ __( "Please tell us more about your organization. This information will help Google to understand your website, and improve your chance of getting rich results.", "wordpress-seo" ) }
 							>
 								{ ( ! companyName || companyLogoId < 1 ) && (
-									<Alert id="alert-organization-name-logo" variant="warning">
+									<Alert id="alert-organization-name-logo" variant="info">
 										{ addLinkToString(
 											sprintf(
 												// translators: %1$s and %2$s are replaced by opening and closing <a> tags.
-												__( "An organization name and logo need to be set for structured data to work properly. %1$sLearn more about the importance of structured data%2$s.", "wordpress-seo" ),
+												__( "An organization name and logo need to be set for structured data to work properly. Since you haven’t set these yet, we are using the site name and logo as default values. %1$sLearn more about the importance of structured data%2$s.", "wordpress-seo" ),
 												"<a>",
 												"</a>"
 											),
@@ -186,7 +186,14 @@ const SiteRepresentation = () => {
 									name="wpseo_titles.company_name"
 									id="input-wpseo_titles-company_name"
 									label={ __( "Organization name", "wordpress-seo" ) }
-									placeholder={ blogname }
+									placeholder={ websiteName }
+								/>
+								<Field
+									as={ TextField }
+									name="wpseo_titles.company_alternate_name"
+									id="input-wpseo_titles-company_alternate_name"
+									label={ __( "Alternate organization name", "wordpress-seo" ) }
+									description={ __( "Use the alternate organization name for acronyms, or a shorter version of your organization's name.", "wordpress-seo" ) }
 								/>
 								<FormikMediaSelectField
 									id="wpseo_titles-company_logo"

--- a/src/integrations/settings-integration.php
+++ b/src/integrations/settings-integration.php
@@ -34,7 +34,7 @@ class Settings_Integration implements Integration_Interface {
 	 *
 	 * @var string[]
 	 */
-	const WP_OPTIONS = [ 'blogname', 'blogdescription' ];
+	const WP_OPTIONS = [ 'blogdescription' ];
 
 	/**
 	 * Holds the allowed option groups.
@@ -519,11 +519,6 @@ class Settings_Integration implements Integration_Interface {
 		/**
 		 * Decode some WP options.
 		 */
-		$settings['blogname']        = \html_entity_decode(
-			$settings['blogname'],
-			( \ENT_NOQUOTES | \ENT_HTML5 ),
-			'UTF-8'
-		);
 		$settings['blogdescription'] = \html_entity_decode(
 			$settings['blogdescription'],
 			( \ENT_NOQUOTES | \ENT_HTML5 ),


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Adding the same [support that was done for our existing settings](https://github.com/Yoast/wordpress-seo/pull/19066) to the Settings UI.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds support for website name, alternate website name and alternate organization name in the new settings.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Go to the Settings UI > Site basics
  * Verify the Site title is gone
  * Verify that Website name and Alternate website name took its place
    * Verify that changing the values of the above will get reflected in the old settings
* Go to the Settings UI > Site representation
  * Ensure you are representing an organization
  * Verify that Alternate organization name is now below the Organization name
    * Verify that changing the values of the above will get reflected in the old settings
  * Verify that when you have no Organization name or no Organization logo, an alert is shown
    * The alert was already there, but has changed from a warning (yellow) to an info (blue) alert
    * Verify it has an extra sentence in between the first and the link: `Since you haven’t set these yet, we are using the site name and logo as default values`. This is copied from the old settings
  * Verify that the Organization name' placeholder text is the same as your Website name
    * You can go and edit the Website name and it will change, no need for saving

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [x] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes [DUPP-694]


[DUPP-694]: https://yoast.atlassian.net/browse/DUPP-694?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ