### PR TITLE
DUPP-670 Refactor filter_input calls in current-page-helper class

### DIFF
--- a/src/helpers/current-page-helper.php
+++ b/src/helpers/current-page-helper.php
@@ -415,8 +415,12 @@ class Current_Page_Helper {
 		static $is_yoast_seo;
 
 		if ( $is_yoast_seo === null ) {
-			$current_page = \filter_input( \INPUT_GET, 'page' );
-			$is_yoast_seo = ( \is_string( $current_page ) && \strpos( $current_page, 'wpseo_' ) === 0 );
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Reason: We are not processing form information.
+			if ( isset( $_GET['page'] ) && \is_string( $_GET['page'] ) ) {
+				// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Reason: We are not processing form information, We are only using the variable in the strpos function.
+				$current_page = \wp_unslash( $_GET['page'] );
+				$is_yoast_seo = \strpos( $current_page, 'wpseo_' ) === 0;
+			}
 		}
 
 		return $is_yoast_seo;
@@ -432,7 +436,11 @@ class Current_Page_Helper {
 		static $current_yoast_seo_page;
 
 		if ( $current_yoast_seo_page === null ) {
-			$current_yoast_seo_page = \filter_input( \INPUT_GET, 'page' );
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Reason: We are not processing form information.
+			if ( isset( $_GET['page'] ) && \is_string( $_GET['page'] ) ) {
+				// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Reason: We are not processing form information.
+				$current_yoast_seo_page = \sanitize_text_field( \wp_unslash( $_GET['page'] ) );
+			}
 		}
 
 		return $current_yoast_seo_page;

--- a/src/helpers/current-page-helper.php
+++ b/src/helpers/current-page-helper.php
@@ -428,17 +428,13 @@ class Current_Page_Helper {
 	 * @return string The current Yoast SEO page.
 	 */
 	public function get_current_yoast_seo_page() {
-		static $current_yoast_seo_page;
-
-		if ( $current_yoast_seo_page === null ) {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Reason: We are not processing form information.
+		if ( isset( $_GET['page'] ) && \is_string( $_GET['page'] ) ) {
 			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Reason: We are not processing form information.
-			if ( isset( $_GET['page'] ) && \is_string( $_GET['page'] ) ) {
-				// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Reason: We are not processing form information.
-				$current_yoast_seo_page = \sanitize_text_field( \wp_unslash( $_GET['page'] ) );
-			}
+			return \sanitize_text_field( \wp_unslash( $_GET['page'] ) );
 		}
 
-		return $current_yoast_seo_page;
+		return null;
 	}
 
 	/**

--- a/src/helpers/current-page-helper.php
+++ b/src/helpers/current-page-helper.php
@@ -412,7 +412,7 @@ class Current_Page_Helper {
 	 * @return bool True when current page is a yoast seo plugin page.
 	 */
 	public function is_yoast_seo_page() {
-		static $is_yoast_seo;
+		private $is_yoast_seo;
 
 		if ( $is_yoast_seo === null ) {
 			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Reason: We are not processing form information.

--- a/src/helpers/current-page-helper.php
+++ b/src/helpers/current-page-helper.php
@@ -412,18 +412,13 @@ class Current_Page_Helper {
 	 * @return bool True when current page is a yoast seo plugin page.
 	 */
 	public function is_yoast_seo_page() {
-		private $is_yoast_seo;
-
-		if ( $is_yoast_seo === null ) {
-			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Reason: We are not processing form information.
-			if ( isset( $_GET['page'] ) && \is_string( $_GET['page'] ) ) {
-				// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Reason: We are not processing form information, We are only using the variable in the strpos function.
-				$current_page = \wp_unslash( $_GET['page'] );
-				$is_yoast_seo = \strpos( $current_page, 'wpseo_' ) === 0;
-			}
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Reason: We are not processing form information.
+		if ( isset( $_GET['page'] ) && \is_string( $_GET['page'] ) ) {
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Reason: We are not processing form information, We are only using the variable in the strpos function.
+			$current_page = \wp_unslash( $_GET['page'] );
+			return \strpos( $current_page, 'wpseo_' ) === 0;
 		}
-
-		return $is_yoast_seo;
+		return null;
 	}
 
 	/**

--- a/src/helpers/current-page-helper.php
+++ b/src/helpers/current-page-helper.php
@@ -412,13 +412,18 @@ class Current_Page_Helper {
 	 * @return bool True when current page is a yoast seo plugin page.
 	 */
 	public function is_yoast_seo_page() {
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Reason: We are not processing form information.
-		if ( isset( $_GET['page'] ) && \is_string( $_GET['page'] ) ) {
-			// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Reason: We are not processing form information, We are only using the variable in the strpos function.
-			$current_page = \wp_unslash( $_GET['page'] );
-			return \strpos( $current_page, 'wpseo_' ) === 0;
+		private $is_yoast_seo;
+
+		if ( $is_yoast_seo === null ) {
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Reason: We are not processing form information.
+			if ( isset( $_GET['page'] ) && \is_string( $_GET['page'] ) ) {
+				// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Reason: We are not processing form information, We are only using the variable in the strpos function.
+				$current_page = \wp_unslash( $_GET['page'] );
+				$is_yoast_seo = \strpos( $current_page, 'wpseo_' ) === 0;
+			}
 		}
-		return null;
+
+		return $is_yoast_seo;
 	}
 
 	/**

--- a/src/helpers/current-page-helper.php
+++ b/src/helpers/current-page-helper.php
@@ -412,18 +412,13 @@ class Current_Page_Helper {
 	 * @return bool True when current page is a yoast seo plugin page.
 	 */
 	public function is_yoast_seo_page() {
-		$is_yoast_seo = null;
-
-		if ( $is_yoast_seo === null ) {
-			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Reason: We are not processing form information.
-			if ( isset( $_GET['page'] ) && \is_string( $_GET['page'] ) ) {
-				// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Reason: We are not processing form information, We are only using the variable in the strpos function.
-				$current_page = \wp_unslash( $_GET['page'] );
-				$is_yoast_seo = \strpos( $current_page, 'wpseo_' ) === 0;
-			}
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Reason: We are not processing form information.
+		if ( isset( $_GET['page'] ) && \is_string( $_GET['page'] ) ) {
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Reason: We are not processing form information, We are only using the variable in the strpos function.
+			$current_page = \wp_unslash( $_GET['page'] );
+			return \strpos( $current_page, 'wpseo_' ) === 0;
 		}
-
-		return $is_yoast_seo;
+		return null;
 	}
 
 	/**

--- a/src/helpers/current-page-helper.php
+++ b/src/helpers/current-page-helper.php
@@ -412,7 +412,7 @@ class Current_Page_Helper {
 	 * @return bool True when current page is a yoast seo plugin page.
 	 */
 	public function is_yoast_seo_page() {
-		static $is_yoast_seo;
+		$is_yoast_seo = null;
 
 		if ( $is_yoast_seo === null ) {
 			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Reason: We are not processing form information.

--- a/src/helpers/current-page-helper.php
+++ b/src/helpers/current-page-helper.php
@@ -412,7 +412,7 @@ class Current_Page_Helper {
 	 * @return bool True when current page is a yoast seo plugin page.
 	 */
 	public function is_yoast_seo_page() {
-		private $is_yoast_seo;
+		static $is_yoast_seo;
 
 		if ( $is_yoast_seo === null ) {
 			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Reason: We are not processing form information.

--- a/tests/unit/helpers/current-page-helper-test.php
+++ b/tests/unit/helpers/current-page-helper-test.php
@@ -755,56 +755,6 @@ class Current_Page_Helper_Test extends TestCase {
 	}
 
 	/**
-	 * Test is_yoast_seo_page function.
-	 *
-	 * @covers ::is_yoast_seo_page
-	 */
-	// public function test_is_yoast_seo_page() {
-	// 	$_GET['page'] = 'wpseo_something';
-
-	// 	$this->assertEquals( true, $this->instance->is_yoast_seo_page() );
-	// }
-
-	/**
-	 * Test is_yoast_seo_page function when page is not set.
-	 *
-	 * @covers ::is_yoast_seo_page
-	 *
-	 * @runInSeparateProcess
-	 */
-	// public function test_is_yoast_seo_page_page_not_set() {
-	// 	unset( $_GET['page'] );
-
-	// 	$this->assertEquals( null, $this->instance->is_yoast_seo_page() );
-	// }
-
-	/**
-	 * Test is_yoast_seo_page function when page is null.
-	 *
-	 * @covers ::is_yoast_seo_page
-	 *
-	 * @runInSeparateProcess
-	 */
-	// public function test_is_yoast_seo_page_page_is_null() {
-	// 	$_GET['page'] = null;
-
-	// 	$this->assertEquals( null, $this->instance->is_yoast_seo_page() );
-	// }
-
-	/**
-	 * Test is_yoast_seo_page function when page is something else than a string.
-	 *
-	 * @covers ::is_yoast_seo_page
-	 *
-	 * @runInSeparateProcess
-	 */
-	// public function test_is_yoast_seo_page_page_is_int() {
-	// 	$_GET['page'] = 13;
-
-	// 	$this->assertEquals( null, $this->instance->is_yoast_seo_page() );
-	// }
-
-	/**
 	 * Test get_current_yoast_seo_page function.
 	 *
 	 * @covers ::get_current_yoast_seo_page

--- a/tests/unit/helpers/current-page-helper-test.php
+++ b/tests/unit/helpers/current-page-helper-test.php
@@ -759,11 +759,11 @@ class Current_Page_Helper_Test extends TestCase {
 	 *
 	 * @covers ::is_yoast_seo_page
 	 */
-	public function test_is_yoast_seo_page() {
-		$_GET['page'] = 'wpseo_something';
+	// public function test_is_yoast_seo_page() {
+	// 	$_GET['page'] = 'wpseo_something';
 
-		$this->assertEquals( true, $this->instance->is_yoast_seo_page() );
-	}
+	// 	$this->assertEquals( true, $this->instance->is_yoast_seo_page() );
+	// }
 
 	/**
 	 * Test is_yoast_seo_page function when page is not set.
@@ -772,11 +772,11 @@ class Current_Page_Helper_Test extends TestCase {
 	 *
 	 * @runInSeparateProcess
 	 */
-	public function test_is_yoast_seo_page_page_not_set() {
-		unset( $_GET['page'] );
+	// public function test_is_yoast_seo_page_page_not_set() {
+	// 	unset( $_GET['page'] );
 
-		$this->assertEquals( null, $this->instance->is_yoast_seo_page() );
-	}
+	// 	$this->assertEquals( null, $this->instance->is_yoast_seo_page() );
+	// }
 
 	/**
 	 * Test is_yoast_seo_page function when page is null.
@@ -785,11 +785,11 @@ class Current_Page_Helper_Test extends TestCase {
 	 *
 	 * @runInSeparateProcess
 	 */
-	public function test_is_yoast_seo_page_page_is_null() {
-		$_GET['page'] = null;
+	// public function test_is_yoast_seo_page_page_is_null() {
+	// 	$_GET['page'] = null;
 
-		$this->assertEquals( null, $this->instance->is_yoast_seo_page() );
-	}
+	// 	$this->assertEquals( null, $this->instance->is_yoast_seo_page() );
+	// }
 
 	/**
 	 * Test is_yoast_seo_page function when page is something else than a string.
@@ -798,11 +798,11 @@ class Current_Page_Helper_Test extends TestCase {
 	 *
 	 * @runInSeparateProcess
 	 */
-	public function test_is_yoast_seo_page_page_is_int() {
-		$_GET['page'] = 13;
+	// public function test_is_yoast_seo_page_page_is_int() {
+	// 	$_GET['page'] = 13;
 
-		$this->assertEquals( null, $this->instance->is_yoast_seo_page() );
-	}
+	// 	$this->assertEquals( null, $this->instance->is_yoast_seo_page() );
+	// }
 
 	/**
 	 * Test get_current_yoast_seo_page function.

--- a/tests/unit/helpers/current-page-helper-test.php
+++ b/tests/unit/helpers/current-page-helper-test.php
@@ -753,4 +753,88 @@ class Current_Page_Helper_Test extends TestCase {
 
 		$this->assertTrue( $this->instance->is_multiple_terms_page() );
 	}
+
+	/**
+	 * Test is_yoast_seo_page function.
+	 *
+	 * @covers ::is_yoast_seo_page
+	 */
+	public function test_is_yoast_seo_page() {
+		$_GET['page'] = 'wpseo_something';
+
+		$this->assertEquals( true, $this->instance->is_yoast_seo_page() );
+	}
+
+	/**
+	 * Test is_yoast_seo_page function when page is not set.
+	 *
+	 * @covers ::is_yoast_seo_page
+	 */
+	public function test_is_yoast_seo_page_page_not_set() {
+		$this->assertEquals( false, $this->instance->is_yoast_seo_page() );
+	}
+
+	/**
+	 * Test is_yoast_seo_page function when page is null.
+	 *
+	 * @covers ::is_yoast_seo_page
+	 */
+	public function test_is_yoast_seo_page_page_is_null() {
+		$_GET['page'] = null;
+
+		$this->assertEquals( false, $this->instance->is_yoast_seo_page() );
+	}
+
+	/**
+	 * Test is_yoast_seo_page function when page is something else than a string.
+	 *
+	 * @covers ::is_yoast_seo_page
+	 */
+	public function test_is_yoast_seo_page_page_is_int() {
+		$_GET['page'] = 13;
+
+		$this->assertEquals( false, $this->instance->is_yoast_seo_page() );
+	}
+
+	/**
+	 * Test get_current_yoast_seo_page function.
+	 *
+	 * @covers ::get_current_yoast_seo_page
+	 */
+	public function test_get_current_yoast_seo_page() {
+		$_GET['page'] = 'wpseo_something';
+
+		$this->assertEquals( 'wpseo_something', $this->instance->get_current_yoast_seo_page() );
+	}
+
+	/**
+	 * Test get_current_yoast_seo_page function when page is not set.
+	 *
+	 * @covers ::get_current_yoast_seo_page
+	 */
+	public function test_get_current_yoast_seo_page_page_not_set() {
+		$this->assertEquals( null, $this->instance->get_current_yoast_seo_page() );
+	}
+
+	/**
+	 * Test get_current_yoast_seo_page function when page is null.
+	 *
+	 * @covers ::get_current_yoast_seo_page
+	 */
+	public function test_get_current_yoast_seo_page_page_is_null() {
+		$_GET['page'] = null;
+
+		$this->assertEquals( null, $this->instance->get_current_yoast_seo_page() );
+	}
+
+	/**
+	 * Test get_current_yoast_seo_page function when page is something else than a string.
+	 *
+	 * @covers ::get_current_yoast_seo_page
+	 */
+	public function test_get_current_yoast_seo_page_page_is_int() {
+		$_GET['page'] = 13;
+
+		$this->assertEquals( null, $this->instance->get_current_yoast_seo_page() );
+	}
 }

--- a/tests/unit/helpers/current-page-helper-test.php
+++ b/tests/unit/helpers/current-page-helper-test.php
@@ -755,6 +755,56 @@ class Current_Page_Helper_Test extends TestCase {
 	}
 
 	/**
+	 * Test is_yoast_seo_page function.
+	 *
+	 * @covers ::is_yoast_seo_page
+	 */
+	public function test_is_yoast_seo_page() {
+		$_GET['page'] = 'wpseo_something';
+
+		$this->assertEquals( true, $this->instance->is_yoast_seo_page() );
+	}
+
+	/**
+	 * Test is_yoast_seo_page function when page is not set.
+	 *
+	 * @covers ::is_yoast_seo_page
+	 *
+	 * @runInSeparateProcess
+	 */
+	public function test_is_yoast_seo_page_page_not_set() {
+		unset( $_GET['page'] );
+
+		$this->assertEquals( null, $this->instance->is_yoast_seo_page() );
+	}
+
+	/**
+	 * Test is_yoast_seo_page function when page is null.
+	 *
+	 * @covers ::is_yoast_seo_page
+	 *
+	 * @runInSeparateProcess
+	 */
+	public function test_is_yoast_seo_page_page_is_null() {
+		$_GET['page'] = null;
+
+		$this->assertEquals( null, $this->instance->is_yoast_seo_page() );
+	}
+
+	/**
+	 * Test is_yoast_seo_page function when page is something else than a string.
+	 *
+	 * @covers ::is_yoast_seo_page
+	 *
+	 * @runInSeparateProcess
+	 */
+	public function test_is_yoast_seo_page_page_is_int() {
+		$_GET['page'] = 13;
+
+		$this->assertEquals( null, $this->instance->is_yoast_seo_page() );
+	}
+
+	/**
 	 * Test get_current_yoast_seo_page function.
 	 *
 	 * @covers ::get_current_yoast_seo_page

--- a/tests/unit/helpers/current-page-helper-test.php
+++ b/tests/unit/helpers/current-page-helper-test.php
@@ -769,37 +769,47 @@ class Current_Page_Helper_Test extends TestCase {
 	 * Test is_yoast_seo_page function when page is not set.
 	 *
 	 * @covers ::is_yoast_seo_page
+	 *
+	 * @runInSeparateProcess
 	 */
 	public function test_is_yoast_seo_page_page_not_set() {
-		$this->assertEquals( false, $this->instance->is_yoast_seo_page() );
+		unset( $_GET['page'] );
+
+		$this->assertEquals( null, $this->instance->is_yoast_seo_page() );
 	}
 
 	/**
 	 * Test is_yoast_seo_page function when page is null.
 	 *
 	 * @covers ::is_yoast_seo_page
+	 *
+	 * @runInSeparateProcess
 	 */
 	public function test_is_yoast_seo_page_page_is_null() {
 		$_GET['page'] = null;
 
-		$this->assertEquals( false, $this->instance->is_yoast_seo_page() );
+		$this->assertEquals( null, $this->instance->is_yoast_seo_page() );
 	}
 
 	/**
 	 * Test is_yoast_seo_page function when page is something else than a string.
 	 *
 	 * @covers ::is_yoast_seo_page
+	 *
+	 * @runInSeparateProcess
 	 */
 	public function test_is_yoast_seo_page_page_is_int() {
 		$_GET['page'] = 13;
 
-		$this->assertEquals( false, $this->instance->is_yoast_seo_page() );
+		$this->assertEquals( null, $this->instance->is_yoast_seo_page() );
 	}
 
 	/**
 	 * Test get_current_yoast_seo_page function.
 	 *
 	 * @covers ::get_current_yoast_seo_page
+	 *
+	 * @runInSeparateProcess
 	 */
 	public function test_get_current_yoast_seo_page() {
 		$_GET['page'] = 'wpseo_something';
@@ -811,8 +821,12 @@ class Current_Page_Helper_Test extends TestCase {
 	 * Test get_current_yoast_seo_page function when page is not set.
 	 *
 	 * @covers ::get_current_yoast_seo_page
+	 *
+	 * @runInSeparateProcess
 	 */
 	public function test_get_current_yoast_seo_page_page_not_set() {
+		unset( $_GET['page'] );
+
 		$this->assertEquals( null, $this->instance->get_current_yoast_seo_page() );
 	}
 
@@ -820,6 +834,8 @@ class Current_Page_Helper_Test extends TestCase {
 	 * Test get_current_yoast_seo_page function when page is null.
 	 *
 	 * @covers ::get_current_yoast_seo_page
+	 *
+	 * @runInSeparateProcess
 	 */
 	public function test_get_current_yoast_seo_page_page_is_null() {
 		$_GET['page'] = null;
@@ -831,6 +847,8 @@ class Current_Page_Helper_Test extends TestCase {
 	 * Test get_current_yoast_seo_page function when page is something else than a string.
 	 *
 	 * @covers ::get_current_yoast_seo_page
+	 *
+	 * @runInSeparateProcess
 	 */
 	public function test_get_current_yoast_seo_page_page_is_int() {
 		$_GET['page'] = 13;

--- a/tests/unit/helpers/current-page-helper-test.php
+++ b/tests/unit/helpers/current-page-helper-test.php
@@ -41,6 +41,13 @@ class Current_Page_Helper_Test extends TestCase {
 	private $instance;
 
 	/**
+	 * The original value of $_GET['page'].
+	 *
+	 * @var string
+	 */
+	private $original_get_page;
+
+	/**
 	 * Sets up the test class.
 	 */
 	protected function set_up() {
@@ -52,6 +59,19 @@ class Current_Page_Helper_Test extends TestCase {
 		$this->instance = Mockery::mock( Current_Page_Helper::class, [ $this->wp_query_wrapper ] )
 			->makePartial()
 			->shouldAllowMockingProtectedMethods();
+
+		if ( isset( $_GET['page'] ) ) {
+			$this->original_get_page = $_GET['page'];
+		}
+	}
+
+	/**
+	 * Performs the operations to restore the status quo ante.
+	 */
+	protected function tear_down() {
+		$_GET['page'] = $this->original_get_page;
+
+		parent::tear_down();
 	}
 
 	/**
@@ -769,8 +789,6 @@ class Current_Page_Helper_Test extends TestCase {
 	 * Test is_yoast_seo_page function when page is not set.
 	 *
 	 * @covers ::is_yoast_seo_page
-	 *
-	 * @runInSeparateProcess
 	 */
 	public function test_is_yoast_seo_page_page_not_set() {
 		unset( $_GET['page'] );
@@ -782,8 +800,6 @@ class Current_Page_Helper_Test extends TestCase {
 	 * Test is_yoast_seo_page function when page is null.
 	 *
 	 * @covers ::is_yoast_seo_page
-	 *
-	 * @runInSeparateProcess
 	 */
 	public function test_is_yoast_seo_page_page_is_null() {
 		$_GET['page'] = null;
@@ -795,8 +811,6 @@ class Current_Page_Helper_Test extends TestCase {
 	 * Test is_yoast_seo_page function when page is something else than a string.
 	 *
 	 * @covers ::is_yoast_seo_page
-	 *
-	 * @runInSeparateProcess
 	 */
 	public function test_is_yoast_seo_page_page_is_int() {
 		$_GET['page'] = 13;
@@ -808,8 +822,6 @@ class Current_Page_Helper_Test extends TestCase {
 	 * Test get_current_yoast_seo_page function.
 	 *
 	 * @covers ::get_current_yoast_seo_page
-	 *
-	 * @runInSeparateProcess
 	 */
 	public function test_get_current_yoast_seo_page() {
 		$_GET['page'] = 'wpseo_something';
@@ -821,8 +833,6 @@ class Current_Page_Helper_Test extends TestCase {
 	 * Test get_current_yoast_seo_page function when page is not set.
 	 *
 	 * @covers ::get_current_yoast_seo_page
-	 *
-	 * @runInSeparateProcess
 	 */
 	public function test_get_current_yoast_seo_page_page_not_set() {
 		unset( $_GET['page'] );
@@ -834,8 +844,6 @@ class Current_Page_Helper_Test extends TestCase {
 	 * Test get_current_yoast_seo_page function when page is null.
 	 *
 	 * @covers ::get_current_yoast_seo_page
-	 *
-	 * @runInSeparateProcess
 	 */
 	public function test_get_current_yoast_seo_page_page_is_null() {
 		$_GET['page'] = null;
@@ -847,8 +855,6 @@ class Current_Page_Helper_Test extends TestCase {
 	 * Test get_current_yoast_seo_page function when page is something else than a string.
 	 *
 	 * @covers ::get_current_yoast_seo_page
-	 *
-	 * @runInSeparateProcess
 	 */
 	public function test_get_current_yoast_seo_page_page_is_int() {
 		$_GET['page'] = 13;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to replace all `filter_input` calls in our codebase.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Refactors URL parameters fetching for `current-page-helper` class.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install and activate Yoast SEO.
* Go to the reading settings of WordPress (`/wp-admin/options-reading.php`) and enable `Discourage search engines from indexing this site`.
* Now go to the Yoast SEO dashboard (`/wp-admin/admin.php?page=wpseo_dashboard`) and verify that the Huge SEO Issue shows up *only* in the problems section.
* Now go to the admin dashboard (`/wp-admin/index.php`) and verify that the Huge SEO Issue shows up in a normal notification.
* Now visit the Yoast SEO > Tools page and verify that the Huge SEO Issue shows up in a normal notification.
* visit Yoast SEO > Settings
  * smoke test the Settings UI to check that it's displayed as expected, and you can save changes.
* visit Yoast SEO > Premium
  * check that the styles are loaded and the look of the page is the expected one.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
