### PR TITLE
Dupp 793 settings UI last run ux feedback

### DIFF
--- a/css/src/new-settings.css
+++ b/css/src/new-settings.css
@@ -187,12 +187,12 @@
 					yst-text-sm
 					yst-text-slate-800
 					yst-no-underline
-					hover:yst-bg-slate-100
+					hover:yst-bg-slate-200
 					hover:yst-text-slate-900
 					yst-cursor-pointer;
 
 					&[aria-selected] {
-						@apply yst-bg-slate-100 yst-text-slate-900
+						@apply yst-bg-slate-200 yst-text-slate-900
 					}
 				}
 			}

--- a/packages/js/src/settings/components/search.js
+++ b/packages/js/src/settings/components/search.js
@@ -163,7 +163,7 @@ const Search = () => {
 				) }
 				{ query.length < QUERY_MIN_CHARS && (
 					<SearchNoResultsContent title={ __( "Search", "wordpress-seo" ) }>
-						<p className="yst-text-slate-500">{ __( "Please enter a search term that is longer than 3 characters.", "wordpress-seo" ) }</p>
+						<p className="yst-text-slate-500">{ __( "Please enter a search term with at leat 3 characters.", "wordpress-seo" ) }</p>
 					</SearchNoResultsContent>
 				) }
 				{ query.length >= QUERY_MIN_CHARS && isEmpty( results ) && (

--- a/packages/js/src/settings/components/search.js
+++ b/packages/js/src/settings/components/search.js
@@ -42,7 +42,12 @@ const Search = () => {
 	const { platform, os } = useParsedUserAgent();
 
 	// Only bind hotkeys when platform type is desktop.
-	useHotkeys( "ctrl+k, meta+k", () => platform?.type === "desktop" && ! isOpen && setOpen(), [ isOpen, setOpen ] );
+	useHotkeys( "ctrl+k, meta+k", event => {
+		event.preventDefault();
+		if ( platform?.type === "desktop" && ! isOpen ) {
+			setOpen();
+		}
+	}, [ isOpen, setOpen ] );
 
 	const handleNavigate = useCallback( () => {
 		setClose();
@@ -163,7 +168,7 @@ const Search = () => {
 				) }
 				{ query.length < QUERY_MIN_CHARS && (
 					<SearchNoResultsContent title={ __( "Search", "wordpress-seo" ) }>
-						<p className="yst-text-slate-500">{ __( "Please enter a search term with at leat 3 characters.", "wordpress-seo" ) }</p>
+						<p className="yst-text-slate-500">{ __( "Please enter a search term with at least 3 characters.", "wordpress-seo" ) }</p>
 					</SearchNoResultsContent>
 				) }
 				{ query.length >= QUERY_MIN_CHARS && isEmpty( results ) && (

--- a/packages/js/src/settings/helpers/search.js
+++ b/packages/js/src/settings/helpers/search.js
@@ -44,14 +44,20 @@ export const createPostTypeSearchIndex = ( { name, label, route, hasArchive } ) 
 		routeLabel: label,
 		fieldId: `input-wpseo_titles-schema-page-type-${ name }`,
 		fieldLabel: __( "Page type", "wordpress-seo" ),
-		keywords: [],
+		keywords: [
+			__( "Schema", "wordpress-seo" ),
+			__( "Structured data", "wordpress-seo" ),
+		],
 	},
 	[ `schema-article-type-${ name }` ]: {
 		route: `/post-type/${ route }`,
 		routeLabel: label,
 		fieldId: `input-wpseo_titles-schema-article-type-${ name }`,
 		fieldLabel: __( "Article type", "wordpress-seo" ),
-		keywords: [],
+		keywords: [
+			__( "Schema", "wordpress-seo" ),
+			__( "Structured data", "wordpress-seo" ),
+		],
 	},
 	...( name !== "attachment" && {
 		[ `social-title-${ name }` ]: {
@@ -916,6 +922,8 @@ export const createSearchIndex = ( postTypes, taxonomies ) => ( {
 			fieldId: "input-wpseo_titles-schema-page-type-attachment",
 			fieldLabel: __( "Page type", "wordpress-seo" ),
 			keywords: [
+				__( "Schema", "wordpress-seo" ),
+				__( "Structured data", "wordpress-seo" ),
 				__( "Image", "wordpress-seo" ),
 				__( "Video", "wordpress-seo" ),
 				__( "PDF", "wordpress-seo" ),
@@ -928,6 +936,8 @@ export const createSearchIndex = ( postTypes, taxonomies ) => ( {
 			fieldId: "input-wpseo_titles-schema-article-type-attachment",
 			fieldLabel: __( "Article type", "wordpress-seo" ),
 			keywords: [
+				__( "Schema", "wordpress-seo" ),
+				__( "Structured data", "wordpress-seo" ),
 				__( "Image", "wordpress-seo" ),
 				__( "Video", "wordpress-seo" ),
 				__( "PDF", "wordpress-seo" ),

--- a/packages/js/src/settings/routes/author-archives.js
+++ b/packages/js/src/settings/routes/author-archives.js
@@ -128,7 +128,7 @@ const AuthorArchives = () => {
 											__( "Disabling this means that %1$s will not be indexed by search engines and will be excluded from XML sitemaps.", "wordpress-seo" ),
 											labelLower
 										) }
-										<br />
+										&nbsp;
 										<Link href={ noIndexInfoLink } target="_blank" rel="noopener">
 											{ __( "Read more about the search results settings", "wordpress-seo" ) }
 										</Link>

--- a/packages/js/src/settings/routes/author-archives.js
+++ b/packages/js/src/settings/routes/author-archives.js
@@ -97,6 +97,7 @@ const AuthorArchives = () => {
 							__( "Disabling this will redirect the %1$s to your site's homepage.", "wordpress-seo" ),
 							singularLabelLower
 						) }
+						className="yst-max-w-sm"
 					/>
 					<hr className="yst-my-8" />
 					<div className="yst-relative">
@@ -134,6 +135,7 @@ const AuthorArchives = () => {
 										</Link>
 										.
 									</> }
+									className="yst-max-w-sm"
 								/>
 								{ ! isAuthorNoIndex && <FormikFlippedToggleField
 									name="wpseo_titles.noindex-author-noposts-wpseo"
@@ -148,6 +150,7 @@ const AuthorArchives = () => {
 										__( "Disabling this means that %1$s without any posts will not be indexed by search engines and will be excluded from XML sitemaps.", "wordpress-seo" ),
 										labelLower
 									) }
+									className="yst-max-w-sm"
 								/> }
 								<FormikReplacementVariableEditorField
 									type="title"

--- a/packages/js/src/settings/routes/author-archives.js
+++ b/packages/js/src/settings/routes/author-archives.js
@@ -137,7 +137,7 @@ const AuthorArchives = () => {
 									</> }
 									className="yst-max-w-sm"
 								/>
-								{ ! isAuthorNoIndex && <FormikFlippedToggleField
+								<FormikFlippedToggleField
 									name="wpseo_titles.noindex-author-noposts-wpseo"
 									data-id="input-wpseo_titles-noindex-author-noposts-wpseo"
 									label={ sprintf(
@@ -151,7 +151,8 @@ const AuthorArchives = () => {
 										labelLower
 									) }
 									className="yst-max-w-sm"
-								/> }
+									disabled={ isAuthorNoIndex }
+								/>
 								<FormikReplacementVariableEditorField
 									type="title"
 									name="wpseo_titles.title-author-wpseo"

--- a/packages/js/src/settings/routes/breadcrumbs.js
+++ b/packages/js/src/settings/routes/breadcrumbs.js
@@ -90,6 +90,7 @@ const Breadcrumbs = () => {
 							name="wpseo_titles.breadcrumbs-display-blog-page"
 							data-id="input-wpseo_titles-breadcrumbs-display-blog-page"
 							label={ __( "Show Blog page in breadcrumbs", "wordpress-seo" ) }
+							className="yst-max-w-sm"
 						/> }
 						<FormikValueChangeField
 							as={ ToggleField }
@@ -97,6 +98,7 @@ const Breadcrumbs = () => {
 							name="wpseo_titles.breadcrumbs-boldlast"
 							data-id="input-wpseo_titles-breadcrumbs-boldlast"
 							label={ __( "Bold the last page", "wordpress-seo" ) }
+							className="yst-max-w-sm"
 						/>
 					</FieldsetLayout>
 					<hr className="yst-my-8" />
@@ -153,6 +155,7 @@ const Breadcrumbs = () => {
 							name="wpseo_titles.breadcrumbs-enable"
 							id="input-wpseo_titles-breadcrumbs-enable"
 							label={ __( "Enable breadcrumbs for your theme", "wordpress-seo" ) }
+							className="yst-max-w-sm"
 						/>
 					</FieldsetLayout>
 				</div>

--- a/packages/js/src/settings/routes/crawl-optimization.js
+++ b/packages/js/src/settings/routes/crawl-optimization.js
@@ -293,6 +293,7 @@ const CrawlOptimization = () => {
 								data-id="input-wpseo-remove_shortlinks"
 								label={ __( "Remove shortlinks", "wordpress-seo" ) }
 								isDummy={ ! isPremium }
+								className="yst-max-w-2xl"
 							>
 								{ __( "Remove links to WordPress' internal 'shortlink' URLs for your posts.", "wordpress-seo" ) }
 								&nbsp;
@@ -305,6 +306,7 @@ const CrawlOptimization = () => {
 								data-id="input-wpseo-remove_rest_api_links"
 								label={ __( "Remove REST API links", "wordpress-seo" ) }
 								isDummy={ ! isPremium }
+								className="yst-max-w-2xl"
 							>
 								{ __( "Remove links to the location of your site’s REST API endpoints.", "wordpress-seo" ) }
 								&nbsp;
@@ -317,6 +319,7 @@ const CrawlOptimization = () => {
 								data-id="input-wpseo-remove_rsd_wlw_links"
 								label={ __( "Remove RSD / WLW links", "wordpress-seo" ) }
 								isDummy={ ! isPremium }
+								className="yst-max-w-2xl"
 							>
 								{ __( "Remove links used by external systems for publishing content to your blog.", "wordpress-seo" ) }
 								&nbsp;
@@ -329,6 +332,7 @@ const CrawlOptimization = () => {
 								data-id="input-wpseo-remove_oembed_links"
 								label={ __( "Remove oEmbed links", "wordpress-seo" ) }
 								isDummy={ ! isPremium }
+								className="yst-max-w-2xl"
 							>
 								{ __( "Remove links used for embedding your content on other sites.", "wordpress-seo" ) }
 								&nbsp;
@@ -341,6 +345,7 @@ const CrawlOptimization = () => {
 								data-id="input-wpseo-remove_generator"
 								label={ __( "Remove generator tag", "wordpress-seo" ) }
 								isDummy={ ! isPremium }
+								className="yst-max-w-2xl"
 							>
 								{ __( "Remove information about the plugins and software used by your site.", "wordpress-seo" ) }
 								&nbsp;
@@ -353,6 +358,7 @@ const CrawlOptimization = () => {
 								data-id="input-wpseo-remove_pingback_header"
 								label={ __( "Pingback HTTP header", "wordpress-seo" ) }
 								isDummy={ ! isPremium }
+								className="yst-max-w-2xl"
 							>
 								{ __( "Remove links which allow others sites to ‘ping’ yours when they link to you.", "wordpress-seo" ) }
 								&nbsp;
@@ -365,6 +371,7 @@ const CrawlOptimization = () => {
 								data-id="input-wpseo-remove_powered_by_header"
 								label={ __( "Remove powered by HTTP header", "wordpress-seo" ) }
 								isDummy={ ! isPremium }
+								className="yst-max-w-2xl"
 							>
 								{ __( "Remove information about the plugins and software used by your site.", "wordpress-seo" ) }
 								&nbsp;
@@ -383,6 +390,7 @@ const CrawlOptimization = () => {
 								data-id="input-wpseo-remove_feed_global"
 								label={ __( "Remove global feed", "wordpress-seo" ) }
 								isDummy={ ! isPremium }
+								className="yst-max-w-2xl"
 							>
 								{ __( "Remove URLs which provide an overview of your recent posts.", "wordpress-seo" ) }
 								&nbsp;
@@ -395,6 +403,7 @@ const CrawlOptimization = () => {
 								data-id="input-wpseo-remove_feed_global_comments"
 								label={ __( "Remove global comment feeds", "wordpress-seo" ) }
 								isDummy={ ! isPremium }
+								className="yst-max-w-2xl"
 							>
 								{ __( "Remove URLs which provide an overview of recent comments on your site.", "wordpress-seo" ) }
 								&nbsp;
@@ -410,6 +419,7 @@ const CrawlOptimization = () => {
 								disabled={ removeFeedGlobalComments }
 								checked={ removeFeedGlobalComments || removeFeedPostComments }
 								isDummy={ ! isPremium }
+								className="yst-max-w-2xl"
 							>
 								{ __( "Remove URLs which provide information about recent comments on each post.", "wordpress-seo" ) }
 								&nbsp;
@@ -422,6 +432,7 @@ const CrawlOptimization = () => {
 								data-id="input-wpseo-remove_feed_authors"
 								label={ __( "Remove post authors feeds", "wordpress-seo" ) }
 								isDummy={ ! isPremium }
+								className="yst-max-w-2xl"
 							>
 								{ __( "Remove URLs which provide information about recent posts by specific authors.", "wordpress-seo" ) }
 								&nbsp;
@@ -434,6 +445,7 @@ const CrawlOptimization = () => {
 								data-id="input-wpseo-remove_feed_post_types"
 								label={ __( "Remove post type feeds", "wordpress-seo" ) }
 								isDummy={ ! isPremium }
+								className="yst-max-w-2xl"
 							>
 								{ __( "Remove URLs which provide information about your recent posts, for each post type.", "wordpress-seo" ) }
 								&nbsp;
@@ -446,6 +458,7 @@ const CrawlOptimization = () => {
 								data-id="input-wpseo-remove_feed_categories"
 								label={ __( "Remove category feeds", "wordpress-seo" ) }
 								isDummy={ ! isPremium }
+								className="yst-max-w-2xl"
 							>
 								{ __( "Remove URLs which provide information about your recent posts, for each category.", "wordpress-seo" ) }
 								&nbsp;
@@ -458,6 +471,7 @@ const CrawlOptimization = () => {
 								data-id="input-wpseo-remove_feed_tags"
 								label={ __( "Remove tag feeds", "wordpress-seo" ) }
 								isDummy={ ! isPremium }
+								className="yst-max-w-2xl"
 							>
 								{ __( "Remove URLs which provide information about your recent posts, for each tag.", "wordpress-seo" ) }
 								&nbsp;
@@ -470,6 +484,7 @@ const CrawlOptimization = () => {
 								data-id="input-wpseo-remove_feed_custom_taxonomies"
 								label={ __( "Remove custom taxonomy feeds", "wordpress-seo" ) }
 								isDummy={ ! isPremium }
+								className="yst-max-w-2xl"
 							>
 								{ __( "Remove URLs which provide information about your recent posts, for each custom taxonomy.", "wordpress-seo" ) }
 								&nbsp;
@@ -482,6 +497,7 @@ const CrawlOptimization = () => {
 								data-id="input-wpseo-remove_feed_search"
 								label={ __( "Remove search results feeds", "wordpress-seo" ) }
 								isDummy={ ! isPremium }
+								className="yst-max-w-2xl"
 							>
 								{ __( "Remove URLs which provide information about your search results.", "wordpress-seo" ) }
 								&nbsp;
@@ -494,6 +510,7 @@ const CrawlOptimization = () => {
 								data-id="input-wpseo-remove_atom_rdf_feeds"
 								label={ __( "Remove Atom / RDF feeds", "wordpress-seo" ) }
 								isDummy={ ! isPremium }
+								className="yst-max-w-2xl"
 							>
 								{ __( "Remove URLs which provide alternative (legacy) formats of all of the above.", "wordpress-seo" ) }
 								&nbsp;
@@ -513,6 +530,7 @@ const CrawlOptimization = () => {
 								label={ __( "Remove emoji scripts", "wordpress-seo" ) }
 								description={ __( "Remove JavaScript used for converting emoji characters in older browsers.", "wordpress-seo" ) }
 								isDummy={ ! isPremium }
+								className="yst-max-w-2xl"
 							/>
 							<FormikValueChangeFieldWithDummy
 								as={ ToggleField }
@@ -521,6 +539,7 @@ const CrawlOptimization = () => {
 								data-id="input-wpseo-deny_wp_json_crawling"
 								label={ __( "Remove WP-JSON API", "wordpress-seo" ) }
 								isDummy={ ! isPremium }
+								className="yst-max-w-2xl"
 							>
 								{ __( "Add a ‘disallow’ rule to your robots.txt file to prevent crawling of WordPress' JSON API endpoints.", "wordpress-seo" ) }
 								&nbsp;
@@ -540,6 +559,7 @@ const CrawlOptimization = () => {
 								label={ __( "Filter search terms", "wordpress-seo" ) }
 								description={ __( "Enables advanced settings for protecting your internal site search URLs.", "wordpress-seo" ) }
 								isDummy={ ! isPremium }
+								className="yst-max-w-2xl"
 							/>
 							<FormikFieldWithDummy
 								as={ TextField }
@@ -560,6 +580,7 @@ const CrawlOptimization = () => {
 								description={ __( "Block internal site searches which contain complex and non-alphanumeric characters, as they may be part of a spam attack.", "wordpress-seo" ) }
 								disabled={ ! searchCleanup }
 								isDummy={ ! isPremium }
+								className="yst-max-w-2xl"
 							/>
 							<FormikValueChangeFieldWithDummy
 								as={ ToggleField }
@@ -570,6 +591,7 @@ const CrawlOptimization = () => {
 								description={ __( "Block internal site searches which match the patterns of known spam attacks.", "wordpress-seo" ) }
 								disabled={ ! searchCleanup }
 								isDummy={ ! isPremium }
+								className="yst-max-w-2xl"
 							/>
 							<FormikValueChangeFieldWithDummy
 								as={ ToggleField }
@@ -579,6 +601,7 @@ const CrawlOptimization = () => {
 								label={ __( "Prevent crawling of internal site search URLs", "wordpress-seo" ) }
 								description={ descriptions.denySearchCrawling }
 								isDummy={ ! isPremium }
+								className="yst-max-w-2xl"
 							/>
 						</FieldsetLayout>
 						<hr className="yst-my-8" />
@@ -606,6 +629,7 @@ const CrawlOptimization = () => {
 								label={ __( "Optimize Google Analytics utm tracking parameters", "wordpress-seo" ) }
 								description={ descriptions.cleanCampaignTrackingUrls }
 								isDummy={ ! isPremium }
+								className="yst-max-w-2xl"
 							/>
 							<FormikValueChangeFieldWithDummy
 								as={ ToggleField }
@@ -615,6 +639,7 @@ const CrawlOptimization = () => {
 								label={ __( "Remove unregistered URL parameters", "wordpress-seo" ) }
 								description={ descriptions.cleanPermalinks }
 								isDummy={ ! isPremium }
+								className="yst-max-w-2xl"
 							/>
 							<FormikTagFieldWithDummy
 								name="wpseo.clean_permalinks_extra_variables"

--- a/packages/js/src/settings/routes/crawl-optimization.js
+++ b/packages/js/src/settings/routes/crawl-optimization.js
@@ -408,7 +408,7 @@ const CrawlOptimization = () => {
 								{ __( "Remove URLs which provide an overview of recent comments on your site.", "wordpress-seo" ) }
 								&nbsp;
 								{ descriptions.removeFeedGlobalComments }
-								{ __( "Also disables Post comment feeds.", "wordpress-seo" ) }
+								{ __( "Also disables post comment feeds.", "wordpress-seo" ) }
 							</FormikValueChangeFieldWithDummy>
 							<FormikValueChangeFieldWithDummy
 								as={ ToggleField }

--- a/packages/js/src/settings/routes/date-archives.js
+++ b/packages/js/src/settings/routes/date-archives.js
@@ -91,6 +91,7 @@ const DateArchives = () => {
 								__( "%1$s can cause duplicate content issues. For most sites, we recommend that you disable this setting.", "wordpress-seo" ),
 								label
 							) }
+							className="yst-max-w-sm"
 						/>
 					</fieldset>
 					<hr className="yst-my-8" />
@@ -129,6 +130,7 @@ const DateArchives = () => {
 										</Link>
 										.
 									</> }
+									className="yst-max-w-sm"
 								/>
 								<FormikReplacementVariableEditorField
 									type="title"

--- a/packages/js/src/settings/routes/date-archives.js
+++ b/packages/js/src/settings/routes/date-archives.js
@@ -123,7 +123,7 @@ const DateArchives = () => {
 											__( "Disabling this means that %1$s will not be indexed by search engines and will be excluded from XML sitemaps. We recommend that you disable this setting.", "wordpress-seo" ),
 											labelLower
 										) }
-										<br />
+										&nbsp;
 										<Link href={ noIndexInfoLink } target="_blank" rel="noopener">
 											{ __( "Read more about the search results settings", "wordpress-seo" ) }
 										</Link>

--- a/packages/js/src/settings/routes/format-archives.js
+++ b/packages/js/src/settings/routes/format-archives.js
@@ -115,7 +115,7 @@ const FormatArchives = () => {
 											__( "Disabling this means that %1$s will not be indexed by search engines and will be excluded from XML sitemaps. We recommend that you disable this setting.", "wordpress-seo" ),
 											labelLower
 										) }
-										<br />
+										&nbsp;
 										<Link href={ noIndexInfoLink } target="_blank" rel="noopener">
 											{ __( "Read more about the search results settings", "wordpress-seo" ) }
 										</Link>

--- a/packages/js/src/settings/routes/format-archives.js
+++ b/packages/js/src/settings/routes/format-archives.js
@@ -82,6 +82,7 @@ const FormatArchives = () => {
 						data-id="input-wpseo_titles-disable-post_format"
 						label={ __( "Enable format-based archives", "wordpress-seo" ) }
 						description={ __( "Format-based archives can cause duplicate content issues. For most sites, we recommend that you disable this setting.", "wordpress-seo" ) }
+						className="yst-max-w-sm"
 					/>
 					<hr className="yst-my-8" />
 					<div className="yst-relative">
@@ -121,6 +122,7 @@ const FormatArchives = () => {
 										</Link>
 										.
 									</> }
+									className="yst-max-w-sm"
 								/>
 								<FormikReplacementVariableEditorField
 									type="title"

--- a/packages/js/src/settings/routes/media.js
+++ b/packages/js/src/settings/routes/media.js
@@ -77,6 +77,7 @@ const Media = () => {
 								__( "We recommend disabling %1$s pages. Disabling %1$s pages will cause all attachment URLs to redirect to the media itself.", "wordpress-seo" ),
 								labelLower
 							) }
+							className="yst-max-w-sm"
 						/>
 					</fieldset>
 					<hr className="yst-my-8" />
@@ -117,6 +118,7 @@ const Media = () => {
 										</Link>
 										.
 									</> }
+									className="yst-max-w-sm"
 								/>
 								<FormikReplacementVariableEditorField
 									type="title"
@@ -173,6 +175,7 @@ const Media = () => {
 									data-id={ `input-wpseo_titles-display-metabox-pt-${ name }` }
 									label={ __( "Enable SEO controls and assessments", "wordpress-seo" ) }
 									description={ __( "Show or hide our tools and controls in the attachment editor.", "wordpress-seo" ) }
+									className="yst-max-w-sm"
 								/>
 							</FieldsetLayout>
 						</AnimateHeight>

--- a/packages/js/src/settings/routes/rss.js
+++ b/packages/js/src/settings/routes/rss.js
@@ -8,7 +8,7 @@ import { FieldsetLayout, FormLayout, RouteLayout } from "../components";
  * @param {JSX.node} children The content.
  * @returns {JSX.Element} The element.
  */
-const VariableCell = ( { children } ) => <Table.Cell className="yst-whitespace-nowrap yst-font-medium yst-text-slate-800">{ children }</Table.Cell>;
+const VariableCell = ( { children } ) => <Table.Cell className="yst-font-medium"><span className="yst-text-slate-900">{ children }</span></Table.Cell>;
 
 VariableCell.propTypes = {
 	children: PropTypes.node.isRequired,
@@ -49,34 +49,32 @@ const Rss = () => {
 						title={ __( "Available variables", "wordpress-seo" ) }
 						description={ __( "You can use the following variables within the content, they will be replaced by the value on the right.", "wordpress-seo" ) }
 					>
-						<div className="yst-overflow-hidden yst-border yst-border-slate-200 yst-shadow-sm yst-rounded-lg">
-							<Table>
-								<Table.Head>
-									<Table.Row>
-										<Table.Header>{ __( "Variable", "wordpress-seo" ) }</Table.Header>
-										<Table.Header>{ __( "Description", "wordpress-seo" ) }</Table.Header>
-									</Table.Row>
-								</Table.Head>
-								<Table.Body>
-									<Table.Row>
-										<VariableCell>%%AUTHORLINK%%</VariableCell>
-										<Table.Cell>{ __( "A link to the archive for the post author, with the author's name as anchor text.", "wordpress-seo" ) }</Table.Cell>
-									</Table.Row>
-									<Table.Row>
-										<VariableCell>%%POSTLINK%%</VariableCell>
-										<Table.Cell>{ __( "A link to the post, with the title as anchor text.", "wordpress-seo" ) }</Table.Cell>
-									</Table.Row>
-									<Table.Row>
-										<VariableCell>%%BLOGLINK%%</VariableCell>
-										<Table.Cell>{ __( "A link to your site, with your site's name as anchor text.", "wordpress-seo" ) }</Table.Cell>
-									</Table.Row>
-									<Table.Row>
-										<VariableCell>%%BLOGDESCLINK%%</VariableCell>
-										<Table.Cell>{ __( "A link to your site, with your site's name and description as anchor text.", "wordpress-seo" ) }</Table.Cell>
-									</Table.Row>
-								</Table.Body>
-							</Table>
-						</div>
+						<Table>
+							<Table.Head>
+								<Table.Row>
+									<Table.Header scope="col">{ __( "Variable", "wordpress-seo" ) }</Table.Header>
+									<Table.Header scope="col">{ __( "Description", "wordpress-seo" ) }</Table.Header>
+								</Table.Row>
+							</Table.Head>
+							<Table.Body>
+								<Table.Row>
+									<VariableCell>%%AUTHORLINK%%</VariableCell>
+									<Table.Cell>{ __( "A link to the archive for the post author, with the author's name as anchor text.", "wordpress-seo" ) }</Table.Cell>
+								</Table.Row>
+								<Table.Row>
+									<VariableCell>%%POSTLINK%%</VariableCell>
+									<Table.Cell>{ __( "A link to the post, with the title as anchor text.", "wordpress-seo" ) }</Table.Cell>
+								</Table.Row>
+								<Table.Row>
+									<VariableCell>%%BLOGLINK%%</VariableCell>
+									<Table.Cell>{ __( "A link to your site, with your site's name as anchor text.", "wordpress-seo" ) }</Table.Cell>
+								</Table.Row>
+								<Table.Row>
+									<VariableCell>%%BLOGDESCLINK%%</VariableCell>
+									<Table.Cell>{ __( "A link to your site, with your site's name and description as anchor text.", "wordpress-seo" ) }</Table.Cell>
+								</Table.Row>
+							</Table.Body>
+						</Table>
 					</FieldsetLayout>
 				</div>
 			</FormLayout>

--- a/packages/js/src/settings/routes/site-basics.js
+++ b/packages/js/src/settings/routes/site-basics.js
@@ -203,6 +203,7 @@ const SiteBasics = () => {
 								__( "By default only editors and administrators can access the Advanced and Schema section of the %1$s sidebar. Disabling this allows access to all users.", "wordpress-seo" ),
 								"Yoast SEO"
 							) }
+							className="yst-max-w-sm"
 						/>
 						<FormikValueChangeField
 							as={ ToggleFieldWithDisabledMessageSupport }
@@ -211,6 +212,7 @@ const SiteBasics = () => {
 							data-id="input-wpseo-tracking"
 							label={ __( "Usage tracking", "wordpress-seo" ) }
 							description={ usageTrackingDescription }
+							className="yst-max-w-sm"
 						/>
 					</FieldsetLayout>
 				</div>

--- a/packages/js/src/settings/routes/site-features.js
+++ b/packages/js/src/settings/routes/site-features.js
@@ -2,7 +2,7 @@
 import { ArrowNarrowRightIcon, LockOpenIcon, ExternalLinkIcon } from "@heroicons/react/outline";
 import { useMemo } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
-import { Alert, Badge, Button, Card, Title, ToggleField, useSvgAria } from "@yoast/ui-library";
+import { Badge, Button, Card, Title, ToggleField, useSvgAria } from "@yoast/ui-library";
 import classNames from "classnames";
 import { useFormikContext } from "formik";
 import { get } from "lodash";
@@ -154,7 +154,6 @@ const SiteFeatures = () => {
 	const sitemapUrl = useSelectSettings( "selectPreference", [], "sitemapUrl" );
 	const { values } = useFormikContext();
 	const { enable_xml_sitemap: enableXmlSitemap } = values.wpseo;
-	const { opengraph } = values.wpseo_social;
 
 	// grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
 	// yst-grid yst-grid-cols-1 yst-gap-6 sm:yst-grid-cols-2 md:yst-grid-cols-2 lg:yst-grid-cols-3 xl:yst-grid-cols-4

--- a/packages/js/src/settings/routes/site-features.js
+++ b/packages/js/src/settings/routes/site-features.js
@@ -1,8 +1,8 @@
 /* eslint-disable complexity */
-import { ArrowNarrowRightIcon, LockOpenIcon } from "@heroicons/react/outline";
+import { ArrowNarrowRightIcon, LockOpenIcon, ExternalLinkIcon } from "@heroicons/react/outline";
 import { useMemo } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
-import { Alert, Badge, Button, Card, Link, Title, ToggleField, useSvgAria } from "@yoast/ui-library";
+import { Alert, Badge, Button, Card, Title, ToggleField, useSvgAria } from "@yoast/ui-library";
 import classNames from "classnames";
 import { useFormikContext } from "formik";
 import { get } from "lodash";
@@ -413,9 +413,18 @@ const SiteFeatures = () => {
 										"Yoast SEO"
 									) }
 								</p>
-								{ enableXmlSitemap && <Link id="link-xml-sitemaps" href={ sitemapUrl } target="_blank" rel="noopener">
+								{ enableXmlSitemap && <Button
+									as="a"
+									id="link-xml-sitemaps"
+									href={ sitemapUrl }
+									variant="secondary"
+									target="_blank"
+									rel="noopener"
+									className="yst-self-start"
+								>
 									{ __( "View the XML sitemap", "wordpress-seo" ) }
-								</Link> }
+									<ExternalLinkIcon className="yst--mr-1 yst-ml-1 yst-h-5 yst-w-5 yst-text-slate-400" />
+								</Button> }
 								<LearnMoreLink id="link-xml-sitemaps" link="https://yoa.st/2a-" />
 							</FeatureCard>
 							<FeatureCard

--- a/packages/js/src/settings/routes/site-features.js
+++ b/packages/js/src/settings/routes/site-features.js
@@ -154,6 +154,7 @@ const SiteFeatures = () => {
 	const sitemapUrl = useSelectSettings( "selectPreference", [], "sitemapUrl" );
 	const { values } = useFormikContext();
 	const { enable_xml_sitemap: enableXmlSitemap } = values.wpseo;
+	const { opengraph } = values.wpseo_social;
 
 	// grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
 	// yst-grid yst-grid-cols-1 yst-gap-6 sm:yst-grid-cols-2 md:yst-grid-cols-2 lg:yst-grid-cols-3 xl:yst-grid-cols-4
@@ -295,9 +296,6 @@ const SiteFeatures = () => {
 							<Title as="legend" size="2" className="yst-mb-2">
 								{ __( "Social sharing", "wordpress-seo" ) }
 							</Title>
-							<Alert id="alert-social-sharing">
-								{ __( "Facebook, Twitter and Pinterest all use Facebook's Open Graph data, so be sure to keep the 'Open Graph data' setting below enabled if you want to optimize your site for these social platforms.", "wordpress-seo" ) }
-							</Alert>
 						</div>
 						<div className={ gridClassNames }>
 							<FeatureCard
@@ -311,6 +309,12 @@ const SiteFeatures = () => {
 									{ __( "Open Graph data", "wordpress-seo" ) }
 								</Title>
 								<p>{ __( "Allows for Facebook and other social media to display a preview with images and a text excerpt when a link to your site is shared.", "wordpress-seo" ) }</p>
+								{ ! opengraph && (
+									<Alert id="alert-social-sharing">
+										{ __( "Facebook, Twitter and Pinterest all use Facebook's Open Graph data, so be sure to keep the 'Open Graph data' setting below enabled if you want to optimize your site for these social platforms.", "wordpress-seo" ) }
+									</Alert>
+
+								) }
 								<LearnMoreLink id="link-open-graph-data" link="https://yoa.st/site-features-open-graph-data" />
 
 							</FeatureCard>

--- a/packages/js/src/settings/routes/site-features.js
+++ b/packages/js/src/settings/routes/site-features.js
@@ -296,11 +296,6 @@ const SiteFeatures = () => {
 							<Title as="legend" size="2" className="yst-mb-2">
 								{ __( "Social sharing", "wordpress-seo" ) }
 							</Title>
-							{ ! opengraph && (
-								<Alert id="alert-social-sharing">
-									{ __( "Facebook, Twitter and Pinterest all use Facebook's Open Graph data, so be sure to keep the 'Open Graph data' setting below enabled if you want to optimize your site for these social platforms.", "wordpress-seo" ) }
-								</Alert>
-							) }
 						</div>
 						<div className={ gridClassNames }>
 							<FeatureCard
@@ -313,7 +308,9 @@ const SiteFeatures = () => {
 								<Title as="h3">
 									{ __( "Open Graph data", "wordpress-seo" ) }
 								</Title>
-								<p>{ __( "Allows for Facebook and other social media to display a preview with images and a text excerpt when a link to your site is shared.", "wordpress-seo" ) }</p>
+								<p>
+									{ __( "Allows for Facebook and other social media to display a preview with images and a text excerpt when a link to your site is shared. Keep this feature enabled to optimize your site for social media.", "wordpress-seo" ) }
+								</p>
 								<LearnMoreLink id="link-open-graph-data" link="https://yoa.st/site-features-open-graph-data" />
 							</FeatureCard>
 							<FeatureCard

--- a/packages/js/src/settings/routes/site-features.js
+++ b/packages/js/src/settings/routes/site-features.js
@@ -296,6 +296,11 @@ const SiteFeatures = () => {
 							<Title as="legend" size="2" className="yst-mb-2">
 								{ __( "Social sharing", "wordpress-seo" ) }
 							</Title>
+							{ ! opengraph && (
+								<Alert id="alert-social-sharing">
+									{ __( "Facebook, Twitter and Pinterest all use Facebook's Open Graph data, so be sure to keep the 'Open Graph data' setting below enabled if you want to optimize your site for these social platforms.", "wordpress-seo" ) }
+								</Alert>
+							) }
 						</div>
 						<div className={ gridClassNames }>
 							<FeatureCard
@@ -309,14 +314,7 @@ const SiteFeatures = () => {
 									{ __( "Open Graph data", "wordpress-seo" ) }
 								</Title>
 								<p>{ __( "Allows for Facebook and other social media to display a preview with images and a text excerpt when a link to your site is shared.", "wordpress-seo" ) }</p>
-								{ ! opengraph && (
-									<Alert id="alert-social-sharing">
-										{ __( "Facebook, Twitter and Pinterest all use Facebook's Open Graph data, so be sure to keep the 'Open Graph data' setting below enabled if you want to optimize your site for these social platforms.", "wordpress-seo" ) }
-									</Alert>
-
-								) }
 								<LearnMoreLink id="link-open-graph-data" link="https://yoa.st/site-features-open-graph-data" />
-
 							</FeatureCard>
 							<FeatureCard
 								name="wpseo_social.twitter"

--- a/packages/js/src/settings/routes/site-representation.js
+++ b/packages/js/src/settings/routes/site-representation.js
@@ -253,14 +253,14 @@ const SiteRepresentation = () => {
 														placeholder={ __( "E.g. https://example.com/yoast", "wordpress-seo" ) }
 														className="yst-grow"
 													/>
-													<button
-														type="button"
+													<Button
+														variant="secondary"
 														// eslint-disable-next-line react/jsx-no-bind
 														onClick={ arrayHelpers.remove.bind( null, index ) }
-														className="yst-mt-7 yst-p-2.5 yst-rounded-md focus:yst-outline-none focus:yst-ring-2 focus:yst-ring-primary-500"
+														className="yst-mt-7 yst-p-2.5"
 													>
 														<TrashIcon className="yst-h-5 yst-w-5" />
-													</button>
+													</Button>
 												</div>
 											) ) }
 											{ /* eslint-disable-next-line react/jsx-no-bind */ }

--- a/packages/js/src/settings/routes/site-representation.js
+++ b/packages/js/src/settings/routes/site-representation.js
@@ -2,7 +2,7 @@
 import { Transition } from "@headlessui/react";
 import { TrashIcon } from "@heroicons/react/outline";
 import { PlusIcon } from "@heroicons/react/solid";
-import { createInterpolateElement, useEffect, useMemo } from "@wordpress/element";
+import { createInterpolateElement, Fragment, useEffect, useMemo } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
 import { Alert, Button, Radio, RadioGroup, TextField, usePrevious } from "@yoast/ui-library";
 import { Field, FieldArray, useFormikContext } from "formik";
@@ -240,28 +240,38 @@ const SiteRepresentation = () => {
 									{ arrayHelpers => (
 										<>
 											{ otherSocialUrls.map( ( _, index ) => (
-												<div
+												<Transition
 													key={ `wpseo_social.other_social_urls.${ index }` }
-													className="yst-w-full yst-flex yst-items-start yst-gap-2"
+													as={ Fragment }
+													appear={ true }
+													show={ true }
+													enter="yst-transition yst-ease-out yst-duration-300"
+													enterFrom="yst-transform yst-opacity-0"
+													enterTo="yst-transform yst-opacity-100"
+													leave="yst-transition yst-ease-out yst-duration-300"
+													leaveFrom="yst-transform yst-opacity-100"
+													leaveTo="yst-transform yst-opacity-0"
 												>
-													<FormikWithErrorField
-														as={ TextField }
-														name={ `wpseo_social.other_social_urls.${ index }` }
-														id={ `input-wpseo_social-other_social_urls-${ index }` }
-														// translators: %1$s expands to array index + 1.
-														label={ sprintf( __( "Other profile %1$s", "wordpress-seo" ), index + 1 ) }
-														placeholder={ __( "E.g. https://example.com/yoast", "wordpress-seo" ) }
-														className="yst-grow"
-													/>
-													<Button
-														variant="secondary"
-														// eslint-disable-next-line react/jsx-no-bind
-														onClick={ arrayHelpers.remove.bind( null, index ) }
-														className="yst-mt-7 yst-p-2.5"
-													>
-														<TrashIcon className="yst-h-5 yst-w-5" />
-													</Button>
-												</div>
+													<div className="yst-w-full yst-flex yst-items-start yst-gap-2">
+														<FormikWithErrorField
+															as={ TextField }
+															name={ `wpseo_social.other_social_urls.${ index }` }
+															id={ `input-wpseo_social-other_social_urls-${ index }` }
+															// translators: %1$s expands to array index + 1.
+															label={ sprintf( __( "Other profile %1$s", "wordpress-seo" ), index + 1 ) }
+															placeholder={ __( "E.g. https://example.com/yoast", "wordpress-seo" ) }
+															className="yst-grow"
+														/>
+														<Button
+															variant="secondary"
+															// eslint-disable-next-line react/jsx-no-bind
+															onClick={ arrayHelpers.remove.bind( null, index ) }
+															className="yst-mt-7 yst-p-2.5"
+														>
+															<TrashIcon className="yst-h-5 yst-w-5" />
+														</Button>
+													</div>
+												</Transition>
 											) ) }
 											{ /* eslint-disable-next-line react/jsx-no-bind */ }
 											<Button id="button-add-social-profile" variant="secondary" onClick={ arrayHelpers.push.bind( null, "" ) }>

--- a/packages/js/src/settings/routes/templates/post-type.js
+++ b/packages/js/src/settings/routes/templates/post-type.js
@@ -164,6 +164,7 @@ const PostType = ( { name, label, singularLabel, hasArchive, hasSchemaArticleTyp
 								</Link>
 								.
 							</> }
+							className="yst-max-w-sm"
 						/>
 						<hr className="yst-my-8" />
 						<FormikReplacementVariableEditorField
@@ -277,6 +278,7 @@ const PostType = ( { name, label, singularLabel, hasArchive, hasSchemaArticleTyp
 							data-id={ `input-wpseo_titles-display-metabox-pt-${ name }` }
 							label={ __( "Enable SEO controls and assessments", "wordpress-seo" ) }
 							description={ __( "Show or hide our tools and controls in the content editor.", "wordpress-seo" ) }
+							className="yst-max-w-sm"
 						/>
 						<FeatureUpsell
 							shouldUpsell={ ! isPremium }
@@ -345,6 +347,7 @@ const PostType = ( { name, label, singularLabel, hasArchive, hasSchemaArticleTyp
 										__( "Disabling this means that the archive for %1$s will not be indexed by search engines and will be excluded from XML sitemaps.", "wordpress-seo" ),
 										labelLower
 									) }
+									className="yst-max-w-sm"
 								/>
 								<FormikReplacementVariableEditorField
 									type="title"

--- a/packages/js/src/settings/routes/templates/post-type.js
+++ b/packages/js/src/settings/routes/templates/post-type.js
@@ -158,7 +158,7 @@ const PostType = ( { name, label, singularLabel, hasArchive, hasSchemaArticleTyp
 									__( "Disabling this means that %1$s will not be indexed by search engines and will be excluded from XML sitemaps.", "wordpress-seo" ),
 									labelLower
 								) }
-								<br />
+								&nbsp;
 								<Link href={ noIndexInfoLink } target="_blank" rel="noopener">
 									{ __( "Read more about the search results settings", "wordpress-seo" ) }
 								</Link>

--- a/packages/js/src/settings/routes/templates/taxonomy.js
+++ b/packages/js/src/settings/routes/templates/taxonomy.js
@@ -113,7 +113,7 @@ const Taxonomy = ( { name, label, postTypes: postTypeNames } ) => {
 					__( "Determine how your %1$s should look in search engines and on social media.", "wordpress-seo" ),
 					labelLower
 				) }
-				<br />
+				&nbsp;
 				{ initialPostTypeValues.length > 1 ? taxonomyMultiplePostTypesMessage : taxonomySinglePostTypeMessage }
 			</> }
 		>

--- a/packages/js/src/settings/routes/templates/taxonomy.js
+++ b/packages/js/src/settings/routes/templates/taxonomy.js
@@ -2,7 +2,7 @@ import { createInterpolateElement, useMemo } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
 import { Badge, Code, FeatureUpsell, Link, ToggleField } from "@yoast/ui-library";
 import { useFormikContext } from "formik";
-import { initial, last, map, values, toLower } from "lodash";
+import { initial, last, map, values, toLower, isEmpty } from "lodash";
 import PropTypes from "prop-types";
 import {
 	FieldsetLayout,
@@ -68,11 +68,9 @@ const Taxonomy = ( { name, label, postTypes: postTypeNames } ) => {
 	const taxonomyMultiplePostTypesMessage = useMemo( () => createInterpolateElement(
 		sprintf(
 			/**
-			 * translators: %1$s expands to the taxonomy plural, e.g. Categories.
-			 * %2$s and %3$s expand to post type plurals in code blocks, e.g. Posts Pages and Custom Post Type.
+			 * translators: %1$s and %2$s expand to post type plurals in code blocks, e.g. Posts Pages and Custom Post Type.
 			 */
-			__( "%1$s are used for %2$s and %3$s.", "wordpress-seo" ),
-			label,
+			__( "This taxonomy is used for %1$s and %2$s.", "wordpress-seo" ),
 			"<code1 />",
 			"<code2 />"
 		), {
@@ -90,10 +88,9 @@ const Taxonomy = ( { name, label, postTypes: postTypeNames } ) => {
 	const taxonomySinglePostTypeMessage = useMemo( () => createInterpolateElement(
 		sprintf(
 			/**
-			 * translators: %1$s expands to the taxonomy plural, e.g. Categories.
-			 * %2$s expands to the post type plural in code block, e.g. Posts.
+			 * translators: %1$s expands to the post type plural in code block, e.g. Posts.
 			 */
-			__( "%1$s are used for %2$s.", "wordpress-seo" ),
+			__( "This taxonomy is used for %2$s.", "wordpress-seo" ),
 			label,
 			"<code />"
 		), {
@@ -113,8 +110,12 @@ const Taxonomy = ( { name, label, postTypes: postTypeNames } ) => {
 					__( "Determine how your %1$s should look in search engines and on social media.", "wordpress-seo" ),
 					labelLower
 				) }
-				&nbsp;
-				{ initialPostTypeValues.length > 1 ? taxonomyMultiplePostTypesMessage : taxonomySinglePostTypeMessage }
+				{ ! isEmpty( initialPostTypeValues ) && (
+					<>
+						<br />
+						{ initialPostTypeValues.length > 1 ? taxonomyMultiplePostTypesMessage : taxonomySinglePostTypeMessage }
+					</>
+				) }
 			</> }
 		>
 			<FormLayout>

--- a/packages/js/src/settings/routes/templates/taxonomy.js
+++ b/packages/js/src/settings/routes/templates/taxonomy.js
@@ -77,12 +77,12 @@ const Taxonomy = ( { name, label, postTypes: postTypeNames } ) => {
 			code1: <>
 				{ map( initialPostTypeValues, ( postType, index ) => (
 					<>
-						<Code key={ postType?.name }>{ toLower( postType?.label ) }</Code>
+						<Code key={ postType?.name }>{ postType?.label }</Code>
 						{ index < initialPostTypeValues.length - 1 && " " }
 					</>
 				) ) }
 			</>,
-			code2: <Code>{ toLower( lastPostTypeValue?.label ) }</Code>,
+			code2: <Code>{ lastPostTypeValue?.label }</Code>,
 		}
 	), [ label, initialPostTypeValues, lastPostTypeValue ] );
 	const taxonomySinglePostTypeMessage = useMemo( () => createInterpolateElement(
@@ -94,7 +94,7 @@ const Taxonomy = ( { name, label, postTypes: postTypeNames } ) => {
 			label,
 			"<code />"
 		), {
-			code: <Code>{ toLower( lastPostTypeValue?.label ) }</Code>,
+			code: <Code>{ lastPostTypeValue?.label }</Code>,
 		}
 	), [ label, lastPostTypeValue ] );
 
@@ -110,7 +110,7 @@ const Taxonomy = ( { name, label, postTypes: postTypeNames } ) => {
 					__( "Determine how your %1$s should look in search engines and on social media.", "wordpress-seo" ),
 					labelLower
 				) }
-				{ ! isEmpty( initialPostTypeValues ) && (
+				{ ! isEmpty( postTypeValues ) && (
 					<>
 						<br />
 						{ initialPostTypeValues.length > 1 ? taxonomyMultiplePostTypesMessage : taxonomySinglePostTypeMessage }

--- a/packages/js/src/settings/routes/templates/taxonomy.js
+++ b/packages/js/src/settings/routes/templates/taxonomy.js
@@ -150,6 +150,7 @@ const Taxonomy = ( { name, label, postTypes: postTypeNames } ) => {
 								</Link>
 								.
 							</> }
+							className="yst-max-w-sm"
 						/>
 						<hr className="yst-my-8" />
 						<FormikReplacementVariableEditorField
@@ -239,12 +240,14 @@ const Taxonomy = ( { name, label, postTypes: postTypeNames } ) => {
 							data-id={ `input-wpseo_titles-display-metabox-tax-${ name }` }
 							label={ __( "Enable SEO controls and assessments", "wordpress-seo" ) }
 							description={ __( "Show or hide our tools and controls in the content editor.", "wordpress-seo" ) }
+							className="yst-max-w-sm"
 						/>
 						{ name === "category" && <FormikFlippedToggleField
 							name="wpseo_titles.stripcategorybase"
 							data-id="input-wpseo_titles-stripcategorybase"
 							label={ __( "Show the categories prefix in the slug", "wordpress-seo" ) }
 							description={ stripCategoryBaseDescription }
+							className="yst-max-w-sm"
 						/> }
 					</FieldsetLayout>
 				</div>

--- a/packages/js/tests/settings/__snapshots__/search.test.js.snap
+++ b/packages/js/tests/settings/__snapshots__/search.test.js.snap
@@ -16,7 +16,7 @@ exports[`Search test should match search snapshot 1`] = `
       </div>
       <SearchNoResultsContent title=\\"Search\\">
         <p className=\\"yst-text-slate-500\\">
-          Please enter a search term that is longer than 3 characters.
+          Please enter a search term with at least 3 characters.
         </p>
       </SearchNoResultsContent>
     </div>

--- a/packages/js/tests/settings/search.test.js
+++ b/packages/js/tests/settings/search.test.js
@@ -24,7 +24,7 @@ describe( "Search test", () => {
 	it( "Should not search under 3 characters", () => {
 		wrapper.find( "button" ).at( 0 ).simulate( "click" );
 		wrapper.find( "#input-search" ).at( 0 ).simulate( "change", { target: { value: "se" } } );
-		expect( wrapper.find( "SearchNoResultsContent" ).find( "p" ).text() ).toContain( "Please enter a search term that is longer than 3 characters." );
+		expect( wrapper.find( "SearchNoResultsContent" ).find( "p" ).text() ).toContain( "Please enter a search term with at least 3 characters." );
 	} );
 
 	it( "should match button text to input value", () => {

--- a/packages/ui-library/src/components/toggle-field/style.css
+++ b/packages/ui-library/src/components/toggle-field/style.css
@@ -4,6 +4,7 @@
 			@apply
 			yst-flex
 			yst-flex-col
+			yst-gap-1
 			yst-max-w-sm;
 		}
 

--- a/packages/ui-library/src/components/toggle-field/style.css
+++ b/packages/ui-library/src/components/toggle-field/style.css
@@ -4,8 +4,7 @@
 			@apply
 			yst-flex
 			yst-flex-col
-			yst-gap-1
-			yst-max-w-sm;
+			yst-gap-1;
 		}
 
 		.yst-toggle-field--disabled {

--- a/packages/ui-library/src/components/toggle-field/style.css
+++ b/packages/ui-library/src/components/toggle-field/style.css
@@ -4,7 +4,6 @@
 			@apply
 			yst-flex
 			yst-flex-col
-			yst-gap-2
 			yst-max-w-sm;
 		}
 

--- a/packages/ui-library/src/elements/autocomplete/style.css
+++ b/packages/ui-library/src/elements/autocomplete/style.css
@@ -88,7 +88,7 @@
 			yst-text-slate-700;
 
 			&--active {
-				@apply yst-bg-primary-200;
+				@apply yst-bg-slate-200;
 			}
 
 			&--selected {

--- a/packages/ui-library/src/elements/code/style.css
+++ b/packages/ui-library/src/elements/code/style.css
@@ -14,6 +14,9 @@
 		.yst-code--block {
 			@apply
 			yst-block
+			yst-my-2
+			yst-px-2
+			yst-py-1
 			yst-whitespace-nowrap
 			yst-max-w-full
 			yst-overflow-x-auto;

--- a/packages/ui-library/src/elements/select/style.css
+++ b/packages/ui-library/src/elements/select/style.css
@@ -87,7 +87,7 @@
 			yst-text-slate-700;
 
 			&--active {
-				@apply yst-bg-primary-200;
+				@apply yst-bg-slate-200;
 			}
 
 			&--selected {

--- a/packages/ui-library/src/elements/table/index.js
+++ b/packages/ui-library/src/elements/table/index.js
@@ -15,7 +15,7 @@ const rowClassNameMap = {
  * @returns {JSX.Element} The element.
  */
 const Cell = ( { children, className = "", ...props } ) => (
-	<td className={ classNames( "yst-px-6 yst-py-4 yst-text-sm", className ) } { ...props }>
+	<td className={ classNames( "yst-whitespace-nowrap yst-px-3 yst-py-4 yst-text-sm yst-text-slate-500", className ) } { ...props }>
 		{ children }
 	</td>
 );
@@ -33,7 +33,7 @@ Cell.propTypes = {
  * @param {Object} [props] Optional table props.
  * @returns {JSX.Element} The element.
  */
-const Row = ( { children, variant = "striped", className = "", ...props } ) => (
+const Row = ( { children, variant = "plain", className = "", ...props } ) => (
 	<tr className={ classNames( rowClassNameMap.variant[ variant ], className ) } { ...props }>
 		{ children }
 	</tr>
@@ -53,7 +53,7 @@ Row.propTypes = {
  */
 const Header = ( { children, className = "", ...props } ) => (
 	<th
-		className={ classNames( "yst-px-6 yst-py-3 yst-text-left yst-text-xs yst-font-medium yst-text-slate-600 yst-bg-slate-50 yst-uppercase yst-tracking-wider", className ) }
+		className={ classNames( "yst-px-3 yst-py-4 yst-text-left yst-text-sm yst-font-semibold yst-text-slate-900", className ) }
 		{ ...props }
 	>
 		{ children }
@@ -67,15 +67,17 @@ Header.propTypes = {
 
 /**
  * @param {JSX.node} children The content.
+ * @param {string} [className] Optional class name.
  * @param {Object} [props] Optional table props.
  * @returns {JSX.Element} The element.
  */
-const Head = ( { children, ...props } ) => (
-	<thead { ...props }>{ children }</thead>
+const Head = ( { children, className = "", ...props } ) => (
+	<thead className={ classNames( "yst-bg-slate-50", className ) } { ...props }>{ children }</thead>
 );
 
 Head.propTypes = {
 	children: PropTypes.node.isRequired,
+	className: PropTypes.string,
 };
 
 /**
@@ -84,8 +86,8 @@ Head.propTypes = {
  * @param {Object} [props] Optional table props.
  * @returns {JSX.Element} The element.
  */
-const Body = ( { children, ...props } ) => (
-	<tbody { ...props }>{ children }</tbody>
+const Body = ( { children, className = "", ...props } ) => (
+	<tbody className={ classNames( "yst-divide-y yst-divide-gray-200 yst-bg-white", className ) } { ...props }>{ children }</tbody>
 );
 
 Body.propTypes = {
@@ -100,9 +102,11 @@ Body.propTypes = {
  * @returns {JSX.Element} The element.
  */
 const Table = ( { children, className = "", ...props } ) => (
-	<table className={ classNames( "yst-min-w-full yst-divide-y yst-divide-slate-200", className ) } { ...props }>
-		{ children }
-	</table>
+	<div className="yst-overflow-hidden yst-shadow yst-ring-1 yst-ring-black yst-ring-opacity-5 yst-rounded-lg">
+		<table className={ classNames( "yst-min-w-full yst-divide-y yst-divide-slate-300", className ) } { ...props }>
+			{ children }
+		</table>
+	</div>
 );
 
 Table.propTypes = {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Fixes various small UX feedback points on new settings UI.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes various small UX feedback points on new settings UI.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Verify that the `OpenGraph` feature card now contains `Keep this feature enabled to optimize your site for social media.` copy.
* Verify that the `XML sitemaps` feature card now contains a `View XML sitemap` **button** when enabled.
* Verify that the remove social profile icon on `Site representation` organization entity is now a button with a trash icon instead of just a trash icon.
* Verify that the copy+toggles on `Crawl optimization` are now wider than all the others, see a post type for instance.
* Verify that when you disable the `Show author archives in search results` toggle on `Author archives`, the `Show author archives without posts in search results` toggle below is disabled instead of disappear.
* Verify that you now get search results when searching for `schema` and `structured data`.
* Verify that the copy `Please enter a search term with at leat 3 characters.` is shown in the search modal when you type less than 3 chars.
* Please note that this PR also contains some arbitrary styling changes that we deliberately left out of test instructions. These were verified with UX.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
