### PR TITLE
UI library: prepare autocomplete autocomplete field components for release

### DIFF
--- a/packages/ui-library/src/components/autocomplete-field/stories.js
+++ b/packages/ui-library/src/components/autocomplete-field/stories.js
@@ -1,18 +1,17 @@
+import AutocompleteField from ".";
 import { useCallback, useMemo, useState } from "@wordpress/element";
 import { filter, find, includes, toLower } from "lodash";
-import Autocomplete from ".";
 
 export default {
-	title: "1. Elements/Autocomplete",
-	component: Autocomplete,
+	title: "2. Components/AutocompleteField",
+	component: AutocompleteField,
 	argTypes: {
-		children: { control: "text" },
-		as: { options: [ "span", "div" ] },
+		id: "1",
 	},
 	parameters: {
 		docs: {
 			description: {
-				component: "A simple autocomplete select component.",
+				component: "A simple autocomplete select component with error message and description message.",
 			},
 		},
 	},
@@ -31,7 +30,7 @@ const dummyOptions = [
 	},
 ];
 
-const Template = ( args ) => {
+const Template = ( { ...args } ) => {
 	const [ value, setValue ] = useState( "" );
 	const [ query, setQuery ] = useState( "" );
 	const selectedOption = useMemo( () => find( dummyOptions, [ "value", value ] ), [ value ] );
@@ -43,9 +42,9 @@ const Template = ( args ) => {
 	const handleQueryChange = useCallback( event => setQuery( event.target.value ), [ setQuery ] );
 
 	return (
-		// Min height to make room for options dropdown.
+	// Min height to make room for options dropdown.
 		<div style={ { minHeight: 200 } }>
-			<Autocomplete
+			<AutocompleteField
 				selectedLabel={ selectedOption?.label || "" }
 				{ ...args }
 				value={ value }
@@ -53,14 +52,15 @@ const Template = ( args ) => {
 				onQueryChange={ handleQueryChange }
 			>
 				{ filteredOptions.map( option => (
-					<Autocomplete.Option key={ option.value } value={ option.value }>
+					<AutocompleteField.Option key={ option.value } value={ option.value }>
 						{ option.label }
-					</Autocomplete.Option>
+					</AutocompleteField.Option>
 				) ) }
-			</Autocomplete>
+			</AutocompleteField>
 		</div>
 	);
 };
+
 
 export const Factory = Template.bind( {} );
 Factory.parameters = {
@@ -68,48 +68,39 @@ Factory.parameters = {
 };
 Factory.args = {
 	id: "factory",
-	value: "",
-	placeholder: "Type to autocomplete options",
-};
-
-export const WithLabel = Template.bind( {} );
-
-WithLabel.parameters = {
-	controls: { disable: false },
-	docs: { description: { story: "An example with a label using `label` prop." } },
-};
-
-WithLabel.args = {
-	id: "with-label",
-	value: "",
-	label: "Example label",
+	name: "factory",
+	label: "AutocompleteField label",
+	description: "AutocompleteField description",
+	placeholder: "Search an option...",
 };
 
 export const WithError = Template.bind( {} );
 
 WithError.parameters = {
 	controls: { disable: false },
-	docs: { description: { story: "An exampe with error using `isError` prop." } },
+	docs: { description: { story: "An exampe with error message using `error` prop." } },
 };
+
 WithError.args = {
 	id: "with-error",
-	value: "",
+	name: "with-error",
 	label: "Example label",
 	labelProps: { className: "yoast-field-group__label" },
 	isError: true,
+	error: "This is an error message",
 };
 
-export const WithPlaceholder = Template.bind( {} );
+export const WithDescription = Template.bind( {} );
 
-WithPlaceholder.parameters = {
+WithDescription.parameters = {
 	controls: { disable: false },
-	docs: { description: { story: "An example with placeholder using `placeholder` prop." } },
+	docs: { description: { story: "An exampe with description message using `description`." } },
 };
-
-WithPlaceholder.args = {
-	id: "with-placeholder",
-	value: "",
-	placeholder: "Search a value...",
+WithDescription.args = {
+	id: "with-description",
+	name: "with-description",
+	label: "Example label",
+	description: "This is a description message",
 };
 
 export const WithSelectedLabel = Template.bind( {} );
@@ -120,7 +111,23 @@ WithSelectedLabel.parameters = {
 };
 
 WithSelectedLabel.args = {
-	value: "option-1",
 	id: "selected-label",
+	name: "selected-label",
+	label: "Example label",
 	selectedLabel: "Option 1",
 };
+
+export const WithPlaceholder = Template.bind( {} );
+
+WithPlaceholder.parameters = {
+	controls: { disable: false },
+	docs: { description: { story: "An example with placeholder." } },
+};
+
+WithPlaceholder.args = {
+	id: "with-placeholder",
+	name: "with-placeholder",
+	label: "Example label",
+	placeholder: "Search a value...",
+};
+

--- a/packages/ui-library/src/components/autocomplete-field/stories.js
+++ b/packages/ui-library/src/components/autocomplete-field/stories.js
@@ -6,7 +6,8 @@ export default {
 	title: "2. Components/AutocompleteField",
 	component: AutocompleteField,
 	argTypes: {
-		id: "1",
+		description: { control: "text" },
+		error: { control: "text" },
 	},
 	parameters: {
 		docs: {

--- a/packages/ui-library/src/elements/autocomplete/stories.js
+++ b/packages/ui-library/src/elements/autocomplete/stories.js
@@ -69,4 +69,29 @@ Factory.parameters = {
 };
 Factory.args = {
 	id: "autocomplete",
+	value: "",
+};
+
+export const WithError = Template.bind( {} );
+
+WithError.parameters = {
+	controls: { disable: false },
+};
+WithError.args = {
+	id: "autocomplete",
+	value: "",
+	label: "Auto complete with error and label",
+	isError: true,
+};
+
+export const WithPlaceholder = Template.bind( {} );
+
+WithPlaceholder.parameters = {
+	controls: { disable: false },
+};
+
+WithPlaceholder.args = {
+	id: "autocomplete",
+	value: "",
+	placeholder: "Search a value...",
 };

--- a/packages/ui-library/src/elements/autocomplete/stories.js
+++ b/packages/ui-library/src/elements/autocomplete/stories.js
@@ -7,7 +7,7 @@ export default {
 	component: Autocomplete,
 	argTypes: {
 		children: { control: "text" },
-		as: { options: [ "span", "div" ] },
+		labelSuffix: { control: "text" },
 	},
 	parameters: {
 		docs: {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Add stories for Autocomplete and AutocompleteFields

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds stories for Autocomplete and AutocompleteFields.
* Autocomplete stories: With label, With error, with selected label, with placeholder.
* AutocompleteField stories: With error message, with description, with selected label, with placeholder.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Open storybook and check stories for Autocomplete and AutocompleteField

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [X] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes https://yoast.atlassian.net/browse/DUPP-723
