### PR TITLE
Dupp 684 revisit disabled fields and sections

### DIFF
--- a/packages/js/src/settings/components/formik-media-select-field.js
+++ b/packages/js/src/settings/components/formik-media-select-field.js
@@ -40,7 +40,7 @@ const FormikMediaSelectField = ( {
 	label = "",
 	description = "",
 	icon: Icon = PhotographIcon,
-	disabled = false,
+	disabled: isDisabled = false,
 	isDummy = false,
 	libraryType = "image",
 	variant = "landscape",
@@ -62,6 +62,7 @@ const FormikMediaSelectField = ( {
 	const fallbackMedia = useSelectSettings( "selectMediaById", [ fallbackMediaId ], fallbackMediaId );
 	const { fetchMedia, addOneMedia } = useDispatchSettings();
 	const error = useMemo( () => get( errors, mediaIdName, "" ), [ errors, mediaIdName ] );
+	const disabled = useMemo( () => isDisabled || isDummy, [ isDummy, isDisabled ] );
 	const { ids: describedByIds, describedBy } = useDescribedBy( `field-${ id }-id`, { description, error } );
 	const previewMedia = useMemo( () => {
 		if ( mediaId > 0 ) {

--- a/packages/js/src/settings/components/formik-replacement-variable-editor-field.js
+++ b/packages/js/src/settings/components/formik-replacement-variable-editor-field.js
@@ -4,12 +4,13 @@ import { useField } from "formik";
 import PropTypes from "prop-types";
 
 /**
- * @param {string} className The wrapper class.
  * @param {Object} props The props to pass down to the component.
  * @param {string} props.name The field name.
+ * @param {string} props.name The field name.
+ * @param {boolean} props.disabled Disabled state.
  * @returns {JSX.Element} The Formik compatible element.
  */
-const FormikReplacementVariableEditorField = ( { className = "", ...props } ) => {
+const FormikReplacementVariableEditorField = ( { className = "", disabled = false, ...props } ) => {
 	const [ editorRef, setEditorRef ] = useState( null );
 	const [ field, , { setTouched, setValue } ] = useField( props );
 
@@ -39,6 +40,7 @@ const FormikReplacementVariableEditorField = ( { className = "", ...props } ) =>
 				onChange={ handleChange }
 				editorRef={ setEditorRef }
 				onFocus={ handleFocus }
+				isDisabled={ disabled }
 				{ ...props }
 			/>
 		</div>
@@ -47,6 +49,7 @@ const FormikReplacementVariableEditorField = ( { className = "", ...props } ) =>
 
 FormikReplacementVariableEditorField.propTypes = {
 	name: PropTypes.string.isRequired,
+	disabled: PropTypes.bool,
 	className: PropTypes.string,
 };
 

--- a/packages/js/src/settings/hocs/with-formik-dummy-field.js
+++ b/packages/js/src/settings/hocs/with-formik-dummy-field.js
@@ -21,6 +21,7 @@ const withFormikDummyField = Component => {
 				name={ name }
 				{ ...props }
 				// Override value and change handler with dummy values.
+				disabled={ true }
 				value={ defaultValue }
 				onChange={ noop }
 				// Specific override for checkbox type components.

--- a/packages/js/src/settings/hocs/with-formik-dummy-field.js
+++ b/packages/js/src/settings/hocs/with-formik-dummy-field.js
@@ -21,7 +21,6 @@ const withFormikDummyField = Component => {
 				name={ name }
 				{ ...props }
 				// Override value and change handler with dummy values.
-				disabled={ false }
 				value={ defaultValue }
 				onChange={ noop }
 				// Specific override for checkbox type components.

--- a/packages/js/src/settings/routes/author-archives.js
+++ b/packages/js/src/settings/routes/author-archives.js
@@ -5,7 +5,6 @@ import { Badge, Code, Link } from "@yoast/ui-library";
 import FeatureUpsell from "@yoast/ui-library/src/components/feature-upsell";
 import { useFormikContext } from "formik";
 import { toLower } from "lodash";
-import AnimateHeight from "react-animate-height";
 import {
 	FieldsetLayout,
 	FormikFlippedToggleField,
@@ -76,7 +75,7 @@ const AuthorArchives = () => {
 
 	const { values } = useFormikContext();
 	const { opengraph } = values.wpseo_social;
-	const { "disable-author": isAuthorDisabled, "noindex-author-wpseo": isAuthorNoIndex } = values.wpseo_titles;
+	const { "disable-author": isAuthorArchivesDisabled, "noindex-author-wpseo": isAuthorNoIndex } = values.wpseo_titles;
 
 	return (
 		<RouteLayout
@@ -129,7 +128,7 @@ const AuthorArchives = () => {
 								</Link>
 								.
 							</> }
-							disabled={ isAuthorDisabled }
+							disabled={ isAuthorArchivesDisabled }
 							className="yst-max-w-sm"
 						/>
 						<FormikFlippedToggleField
@@ -145,7 +144,7 @@ const AuthorArchives = () => {
 								__( "Disabling this means that %1$s without any posts will not be indexed by search engines and will be excluded from XML sitemaps.", "wordpress-seo" ),
 								labelLower
 							) }
-							disabled={ isAuthorDisabled || isAuthorNoIndex }
+							disabled={ isAuthorArchivesDisabled || isAuthorNoIndex }
 							className="yst-max-w-sm"
 						/>
 						<FormikReplacementVariableEditorField
@@ -155,7 +154,7 @@ const AuthorArchives = () => {
 							label={ __( "SEO title", "wordpress-seo" ) }
 							replacementVariables={ replacementVariables }
 							recommendedReplacementVariables={ recommendedReplacementVariables }
-							isDisabled={ isAuthorDisabled }
+							isDisabled={ isAuthorArchivesDisabled }
 						/>
 						<FormikReplacementVariableEditorField
 							type="description"
@@ -164,7 +163,7 @@ const AuthorArchives = () => {
 							label={ __( "Meta description", "wordpress-seo" ) }
 							replacementVariables={ replacementVariables }
 							recommendedReplacementVariables={ recommendedReplacementVariables }
-							isDisabled={ isAuthorDisabled }
+							isDisabled={ isAuthorArchivesDisabled }
 							className="yst-replacevar--description"
 						/>
 					</FieldsetLayout>
@@ -198,7 +197,7 @@ const AuthorArchives = () => {
 								previewLabel={ recommendedSize }
 								mediaUrlName="wpseo_titles.social-image-url-author-wpseo"
 								mediaIdName="wpseo_titles.social-image-id-author-wpseo"
-								disabled={ isAuthorDisabled || ! opengraph }
+								disabled={ isAuthorArchivesDisabled || ! opengraph }
 								isDummy={ ! isPremium }
 							/>
 							<FormikReplacementVariableEditorFieldWithDummy
@@ -208,7 +207,7 @@ const AuthorArchives = () => {
 								label={ __( "Social title", "wordpress-seo" ) }
 								replacementVariables={ replacementVariables }
 								recommendedReplacementVariables={ recommendedReplacementVariables }
-								isDisabled={ isAuthorDisabled || ! opengraph }
+								isDisabled={ isAuthorArchivesDisabled || ! opengraph }
 								isDummy={ ! isPremium }
 							/>
 							<FormikReplacementVariableEditorFieldWithDummy
@@ -219,7 +218,7 @@ const AuthorArchives = () => {
 								replacementVariables={ replacementVariables }
 								recommendedReplacementVariables={ recommendedReplacementVariables }
 								className="yst-replacevar--description"
-								isDisabled={ isAuthorDisabled || ! opengraph }
+								isDisabled={ isAuthorArchivesDisabled || ! opengraph }
 								isDummy={ ! isPremium }
 							/>
 						</FeatureUpsell>

--- a/packages/js/src/settings/routes/author-archives.js
+++ b/packages/js/src/settings/routes/author-archives.js
@@ -1,3 +1,4 @@
+/* eslint-disable complexity */
 import { createInterpolateElement, useMemo } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
 import { Badge, Code, Link } from "@yoast/ui-library";
@@ -100,135 +101,129 @@ const AuthorArchives = () => {
 						className="yst-max-w-sm"
 					/>
 					<hr className="yst-my-8" />
-					<div className="yst-relative">
-						<AnimateHeight
-							easing="ease-in-out"
-							duration={ 300 }
-							height={ isAuthorDisabled ? 0 : "auto" }
-							animateOpacity={ true }
-						>
-							<FieldsetLayout
-								title={ __( "Search appearance", "wordpress-seo" ) }
-								description={ sprintf(
+					<FieldsetLayout
+						title={ __( "Search appearance", "wordpress-seo" ) }
+						description={ sprintf(
+							// translators: %1$s expands to "author archives".
+							__( "Determine how your %1$s should look in search engines.", "wordpress-seo" ),
+							labelLower
+						) }
+					>
+						<FormikFlippedToggleField
+							name="wpseo_titles.noindex-author-wpseo"
+							data-id="input-wpseo_titles-noindex-author-wpseo"
+							label={ sprintf(
+								// translators: %1$s expands to "author archives".
+								__( "Show %1$s in search results", "wordpress-seo" ),
+								labelLower
+							) }
+							description={ <>
+								{ sprintf(
 									// translators: %1$s expands to "author archives".
-									__( "Determine how your %1$s should look in search engines.", "wordpress-seo" ),
+									__( "Disabling this means that %1$s will not be indexed by search engines and will be excluded from XML sitemaps.", "wordpress-seo" ),
 									labelLower
 								) }
-							>
-								<FormikFlippedToggleField
-									name="wpseo_titles.noindex-author-wpseo"
-									data-id="input-wpseo_titles-noindex-author-wpseo"
-									label={ sprintf(
-										// translators: %1$s expands to "author archives".
-										__( "Show %1$s in search results", "wordpress-seo" ),
-										labelLower
-									) }
-									description={ <>
-										{ sprintf(
-											// translators: %1$s expands to "author archives".
-											__( "Disabling this means that %1$s will not be indexed by search engines and will be excluded from XML sitemaps.", "wordpress-seo" ),
-											labelLower
-										) }
 										&nbsp;
-										<Link href={ noIndexInfoLink } target="_blank" rel="noopener">
-											{ __( "Read more about the search results settings", "wordpress-seo" ) }
-										</Link>
-										.
-									</> }
-									className="yst-max-w-sm"
-								/>
-								<FormikFlippedToggleField
-									name="wpseo_titles.noindex-author-noposts-wpseo"
-									data-id="input-wpseo_titles-noindex-author-noposts-wpseo"
-									label={ sprintf(
-										// translators: %1$s expands to "author archives".
-										__( "Show %1$s without posts in search results", "wordpress-seo" ),
-										labelLower
-									) }
-									description={ sprintf(
-										// translators: %1$s expands to "author archives".
-										__( "Disabling this means that %1$s without any posts will not be indexed by search engines and will be excluded from XML sitemaps.", "wordpress-seo" ),
-										labelLower
-									) }
-									className="yst-max-w-sm"
-									disabled={ isAuthorNoIndex }
-								/>
-								<FormikReplacementVariableEditorField
-									type="title"
-									name="wpseo_titles.title-author-wpseo"
-									fieldId="input-wpseo_titles-title-author-wpseo"
-									label={ __( "SEO title", "wordpress-seo" ) }
-									replacementVariables={ replacementVariables }
-									recommendedReplacementVariables={ recommendedReplacementVariables }
-								/>
-								<FormikReplacementVariableEditorField
-									type="description"
-									name="wpseo_titles.metadesc-author-wpseo"
-									fieldId="input-wpseo_titles-metadesc-author-wpseo"
-									label={ __( "Meta description", "wordpress-seo" ) }
-									replacementVariables={ replacementVariables }
-									recommendedReplacementVariables={ recommendedReplacementVariables }
-									className="yst-replacevar--description"
-								/>
-							</FieldsetLayout>
-							<hr className="yst-my-8" />
-							<FieldsetLayout
-								title={ <div className="yst-flex yst-items-center yst-gap-1.5">
-									<span>{ __( "Social appearance", "wordpress-seo" ) }</span>
-									{ isPremium && <Badge variant="upsell">Premium</Badge> }
-								</div> }
-								description={ sprintf(
-									// translators: %1$s expands to "author archives".
-									__( "Determine how your %1$s should look on social media by default.", "wordpress-seo" ),
-									labelLower
-								) }
-							>
-								<FeatureUpsell
-									shouldUpsell={ ! isPremium }
-									variant="card"
-									cardLink={ socialAppearancePremiumLink }
-									cardText={ sprintf(
-										/* translators: %1$s expands to Premium. */
-										__( "Unlock with %1$s", "wordpress-seo" ),
-										"Premium"
-									) }
-									{ ...premiumUpsellConfig }
-								>
-									<OpenGraphDisabledAlert isEnabled={ ! isPremium || opengraph } />
-									<FormikMediaSelectField
-										id="wpseo_titles-social-image-author-wpseo"
-										label={ __( "Social image", "wordpress-seo" ) }
-										previewLabel={ recommendedSize }
-										mediaUrlName="wpseo_titles.social-image-url-author-wpseo"
-										mediaIdName="wpseo_titles.social-image-id-author-wpseo"
-										disabled={ ! opengraph }
-										isDummy={ ! isPremium }
-									/>
-									<FormikReplacementVariableEditorFieldWithDummy
-										type="title"
-										name="wpseo_titles.social-title-author-wpseo"
-										fieldId="input-wpseo_titles-social-title-author-wpseo"
-										label={ __( "Social title", "wordpress-seo" ) }
-										replacementVariables={ replacementVariables }
-										recommendedReplacementVariables={ recommendedReplacementVariables }
-										isDisabled={ ! opengraph }
-										isDummy={ ! isPremium }
-									/>
-									<FormikReplacementVariableEditorFieldWithDummy
-										type="description"
-										name="wpseo_titles.social-description-author-wpseo"
-										fieldId="input-wpseo_titles-social-description-author-wpseo"
-										label={ __( "Social description", "wordpress-seo" ) }
-										replacementVariables={ replacementVariables }
-										recommendedReplacementVariables={ recommendedReplacementVariables }
-										className="yst-replacevar--description"
-										isDisabled={ ! opengraph }
-										isDummy={ ! isPremium }
-									/>
-								</FeatureUpsell>
-							</FieldsetLayout>
-						</AnimateHeight>
-					</div>
+								<Link href={ noIndexInfoLink } target="_blank" rel="noopener">
+									{ __( "Read more about the search results settings", "wordpress-seo" ) }
+								</Link>
+								.
+							</> }
+							disabled={ isAuthorDisabled }
+							className="yst-max-w-sm"
+						/>
+						<FormikFlippedToggleField
+							name="wpseo_titles.noindex-author-noposts-wpseo"
+							data-id="input-wpseo_titles-noindex-author-noposts-wpseo"
+							label={ sprintf(
+								// translators: %1$s expands to "author archives".
+								__( "Show %1$s without posts in search results", "wordpress-seo" ),
+								labelLower
+							) }
+							description={ sprintf(
+								// translators: %1$s expands to "author archives".
+								__( "Disabling this means that %1$s without any posts will not be indexed by search engines and will be excluded from XML sitemaps.", "wordpress-seo" ),
+								labelLower
+							) }
+							disabled={ isAuthorDisabled || isAuthorNoIndex }
+							className="yst-max-w-sm"
+						/>
+						<FormikReplacementVariableEditorField
+							type="title"
+							name="wpseo_titles.title-author-wpseo"
+							fieldId="input-wpseo_titles-title-author-wpseo"
+							label={ __( "SEO title", "wordpress-seo" ) }
+							replacementVariables={ replacementVariables }
+							recommendedReplacementVariables={ recommendedReplacementVariables }
+							isDisabled={ isAuthorDisabled }
+						/>
+						<FormikReplacementVariableEditorField
+							type="description"
+							name="wpseo_titles.metadesc-author-wpseo"
+							fieldId="input-wpseo_titles-metadesc-author-wpseo"
+							label={ __( "Meta description", "wordpress-seo" ) }
+							replacementVariables={ replacementVariables }
+							recommendedReplacementVariables={ recommendedReplacementVariables }
+							isDisabled={ isAuthorDisabled }
+							className="yst-replacevar--description"
+						/>
+					</FieldsetLayout>
+					<hr className="yst-my-8" />
+					<FieldsetLayout
+						title={ <div className="yst-flex yst-items-center yst-gap-1.5">
+							<span>{ __( "Social appearance", "wordpress-seo" ) }</span>
+							{ isPremium && <Badge variant="upsell">Premium</Badge> }
+						</div> }
+						description={ sprintf(
+							// translators: %1$s expands to "author archives".
+							__( "Determine how your %1$s should look on social media by default.", "wordpress-seo" ),
+							labelLower
+						) }
+					>
+						<FeatureUpsell
+							shouldUpsell={ ! isPremium }
+							variant="card"
+							cardLink={ socialAppearancePremiumLink }
+							cardText={ sprintf(
+								/* translators: %1$s expands to Premium. */
+								__( "Unlock with %1$s", "wordpress-seo" ),
+								"Premium"
+							) }
+							{ ...premiumUpsellConfig }
+						>
+							<OpenGraphDisabledAlert isEnabled={ ! isPremium || opengraph } />
+							<FormikMediaSelectField
+								id="wpseo_titles-social-image-author-wpseo"
+								label={ __( "Social image", "wordpress-seo" ) }
+								previewLabel={ recommendedSize }
+								mediaUrlName="wpseo_titles.social-image-url-author-wpseo"
+								mediaIdName="wpseo_titles.social-image-id-author-wpseo"
+								disabled={ isAuthorDisabled || ! opengraph }
+								isDummy={ ! isPremium }
+							/>
+							<FormikReplacementVariableEditorFieldWithDummy
+								type="title"
+								name="wpseo_titles.social-title-author-wpseo"
+								fieldId="input-wpseo_titles-social-title-author-wpseo"
+								label={ __( "Social title", "wordpress-seo" ) }
+								replacementVariables={ replacementVariables }
+								recommendedReplacementVariables={ recommendedReplacementVariables }
+								isDisabled={ isAuthorDisabled || ! opengraph }
+								isDummy={ ! isPremium }
+							/>
+							<FormikReplacementVariableEditorFieldWithDummy
+								type="description"
+								name="wpseo_titles.social-description-author-wpseo"
+								fieldId="input-wpseo_titles-social-description-author-wpseo"
+								label={ __( "Social description", "wordpress-seo" ) }
+								replacementVariables={ replacementVariables }
+								recommendedReplacementVariables={ recommendedReplacementVariables }
+								className="yst-replacevar--description"
+								isDisabled={ isAuthorDisabled || ! opengraph }
+								isDummy={ ! isPremium }
+							/>
+						</FeatureUpsell>
+					</FieldsetLayout>
 				</div>
 			</FormLayout>
 		</RouteLayout>

--- a/packages/js/src/settings/routes/author-archives.js
+++ b/packages/js/src/settings/routes/author-archives.js
@@ -154,7 +154,7 @@ const AuthorArchives = () => {
 							label={ __( "SEO title", "wordpress-seo" ) }
 							replacementVariables={ replacementVariables }
 							recommendedReplacementVariables={ recommendedReplacementVariables }
-							isDisabled={ isAuthorArchivesDisabled }
+							disabled={ isAuthorArchivesDisabled }
 						/>
 						<FormikReplacementVariableEditorField
 							type="description"
@@ -163,7 +163,7 @@ const AuthorArchives = () => {
 							label={ __( "Meta description", "wordpress-seo" ) }
 							replacementVariables={ replacementVariables }
 							recommendedReplacementVariables={ recommendedReplacementVariables }
-							isDisabled={ isAuthorArchivesDisabled }
+							disabled={ isAuthorArchivesDisabled }
 							className="yst-replacevar--description"
 						/>
 					</FieldsetLayout>
@@ -207,7 +207,7 @@ const AuthorArchives = () => {
 								label={ __( "Social title", "wordpress-seo" ) }
 								replacementVariables={ replacementVariables }
 								recommendedReplacementVariables={ recommendedReplacementVariables }
-								isDisabled={ isAuthorArchivesDisabled || ! opengraph }
+								disabled={ isAuthorArchivesDisabled || ! opengraph }
 								isDummy={ ! isPremium }
 							/>
 							<FormikReplacementVariableEditorFieldWithDummy
@@ -218,7 +218,7 @@ const AuthorArchives = () => {
 								replacementVariables={ replacementVariables }
 								recommendedReplacementVariables={ recommendedReplacementVariables }
 								className="yst-replacevar--description"
-								isDisabled={ isAuthorArchivesDisabled || ! opengraph }
+								disabled={ isAuthorArchivesDisabled || ! opengraph }
 								isDummy={ ! isPremium }
 							/>
 						</FeatureUpsell>

--- a/packages/js/src/settings/routes/crawl-optimization.js
+++ b/packages/js/src/settings/routes/crawl-optimization.js
@@ -1,7 +1,9 @@
+/* eslint-disable complexity */
 import { LockOpenIcon } from "@heroicons/react/outline";
 import { createInterpolateElement, useMemo } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
-import { Alert, Button, Code, FeatureUpsell, TextField, ToggleField, useSvgAria } from "@yoast/ui-library";
+import { Alert, Button, Code, TextField, ToggleField, useSvgAria } from "@yoast/ui-library";
+import classNames from "classnames";
 import { Field, useFormikContext } from "formik";
 import { addLinkToString } from "../../helpers/stringHelpers";
 import { FieldsetLayout, FormikTagField, FormikValueChangeField, FormLayout, RouteLayout } from "../components";
@@ -36,15 +38,16 @@ const CrawlOptimization = () => {
 		"<code2/>"
 	), [] );
 	const descriptions = useMemo( () => ( {
-		page: addLinkToString(
+		page: createInterpolateElement(
 			sprintf(
 				/* translators: %1$s and %2$s are replaced by opening and closing <a> tags. */
 				__( "Make your site more efficient and more environmentally friendly by preventing search engines from crawling things they don’t need to, and by removing unused WordPress features. %1$sLearn more about crawl settings and how they could benefit your site%2$s.", "wordpress-seo" ),
 				"<a>",
 				"</a>"
-			),
-			crawlSettingsLink,
-			"link-crawl-settings-info"
+			), {
+				// eslint-disable-next-line jsx-a11y/anchor-has-content
+				a: <a id="link-crawl-settings-info" href={ crawlSettingsLink } target="_blank" rel="noopener noreferrer" />,
+			}
 		),
 
 		// Remove unwanted metadata.
@@ -281,376 +284,397 @@ const CrawlOptimization = () => {
 		>
 			<FormLayout>
 				<div className="yst-max-w-5xl">
-					<FeatureUpsell shouldUpsell={ ! isPremium }>
-						<FieldsetLayout
-							title={ __( "Remove unwanted metadata", "wordpress-seo" ) }
-							description={ descriptions.removeUnwantedMetadata }
+					<FieldsetLayout
+						title={ __( "Remove unwanted metadata", "wordpress-seo" ) }
+						description={ descriptions.removeUnwantedMetadata }
+					>
+						<FormikValueChangeFieldWithDummy
+							as={ ToggleField }
+							type="checkbox"
+							name="wpseo.remove_shortlinks"
+							data-id="input-wpseo-remove_shortlinks"
+							label={ __( "Remove shortlinks", "wordpress-seo" ) }
+							isDummy={ ! isPremium }
+							disabled={ ! isPremium }
+							className="yst-max-w-2xl"
 						>
-							<FormikValueChangeFieldWithDummy
-								as={ ToggleField }
-								type="checkbox"
-								name="wpseo.remove_shortlinks"
-								data-id="input-wpseo-remove_shortlinks"
-								label={ __( "Remove shortlinks", "wordpress-seo" ) }
-								isDummy={ ! isPremium }
-								className="yst-max-w-2xl"
-							>
-								{ __( "Remove links to WordPress' internal 'shortlink' URLs for your posts.", "wordpress-seo" ) }
+							{ __( "Remove links to WordPress' internal 'shortlink' URLs for your posts.", "wordpress-seo" ) }
 								&nbsp;
-								{ descriptions.removeShortlinks }
-							</FormikValueChangeFieldWithDummy>
-							<FormikValueChangeFieldWithDummy
-								as={ ToggleField }
-								type="checkbox"
-								name="wpseo.remove_rest_api_links"
-								data-id="input-wpseo-remove_rest_api_links"
-								label={ __( "Remove REST API links", "wordpress-seo" ) }
-								isDummy={ ! isPremium }
-								className="yst-max-w-2xl"
-							>
-								{ __( "Remove links to the location of your site’s REST API endpoints.", "wordpress-seo" ) }
-								&nbsp;
-								{ descriptions.removeRestApiLinks }
-							</FormikValueChangeFieldWithDummy>
-							<FormikValueChangeFieldWithDummy
-								as={ ToggleField }
-								type="checkbox"
-								name="wpseo.remove_rsd_wlw_links"
-								data-id="input-wpseo-remove_rsd_wlw_links"
-								label={ __( "Remove RSD / WLW links", "wordpress-seo" ) }
-								isDummy={ ! isPremium }
-								className="yst-max-w-2xl"
-							>
-								{ __( "Remove links used by external systems for publishing content to your blog.", "wordpress-seo" ) }
-								&nbsp;
-								{ descriptions.removeRsdWlwLinks }
-							</FormikValueChangeFieldWithDummy>
-							<FormikValueChangeFieldWithDummy
-								as={ ToggleField }
-								type="checkbox"
-								name="wpseo.remove_oembed_links"
-								data-id="input-wpseo-remove_oembed_links"
-								label={ __( "Remove oEmbed links", "wordpress-seo" ) }
-								isDummy={ ! isPremium }
-								className="yst-max-w-2xl"
-							>
-								{ __( "Remove links used for embedding your content on other sites.", "wordpress-seo" ) }
-								&nbsp;
-								{ descriptions.removeOembedLinks }
-							</FormikValueChangeFieldWithDummy>
-							<FormikValueChangeFieldWithDummy
-								as={ ToggleField }
-								type="checkbox"
-								name="wpseo.remove_generator"
-								data-id="input-wpseo-remove_generator"
-								label={ __( "Remove generator tag", "wordpress-seo" ) }
-								isDummy={ ! isPremium }
-								className="yst-max-w-2xl"
-							>
-								{ __( "Remove information about the plugins and software used by your site.", "wordpress-seo" ) }
-								&nbsp;
-								{ descriptions.removeGenerator }
-							</FormikValueChangeFieldWithDummy>
-							<FormikValueChangeFieldWithDummy
-								as={ ToggleField }
-								type="checkbox"
-								name="wpseo.remove_pingback_header"
-								data-id="input-wpseo-remove_pingback_header"
-								label={ __( "Pingback HTTP header", "wordpress-seo" ) }
-								isDummy={ ! isPremium }
-								className="yst-max-w-2xl"
-							>
-								{ __( "Remove links which allow others sites to ‘ping’ yours when they link to you.", "wordpress-seo" ) }
-								&nbsp;
-								{ descriptions.removePingbackHeader }
-							</FormikValueChangeFieldWithDummy>
-							<FormikValueChangeFieldWithDummy
-								as={ ToggleField }
-								type="checkbox"
-								name="wpseo.remove_powered_by_header"
-								data-id="input-wpseo-remove_powered_by_header"
-								label={ __( "Remove powered by HTTP header", "wordpress-seo" ) }
-								isDummy={ ! isPremium }
-								className="yst-max-w-2xl"
-							>
-								{ __( "Remove information about the plugins and software used by your site.", "wordpress-seo" ) }
-								&nbsp;
-								{ descriptions.removePoweredByHeader }
-							</FormikValueChangeFieldWithDummy>
-						</FieldsetLayout>
-						<hr className="yst-my-8" />
-						<FieldsetLayout
-							title={ __( "Disable unwanted content formats", "wordpress-seo" ) }
-							description={ __( "WordPress outputs your content in many different formats, across many different URLs (like RSS feeds of your posts and categories). It’s generally good practice to disable the formats you’re not actively using.", "wordpress-seo" ) }
+							{ descriptions.removeShortlinks }
+						</FormikValueChangeFieldWithDummy>
+						<FormikValueChangeFieldWithDummy
+							as={ ToggleField }
+							type="checkbox"
+							name="wpseo.remove_rest_api_links"
+							data-id="input-wpseo-remove_rest_api_links"
+							label={ __( "Remove REST API links", "wordpress-seo" ) }
+							isDummy={ ! isPremium }
+							disabled={ ! isPremium }
+							className="yst-max-w-2xl"
 						>
-							<FormikValueChangeFieldWithDummy
-								as={ ToggleField }
-								type="checkbox"
-								name="wpseo.remove_feed_global"
-								data-id="input-wpseo-remove_feed_global"
-								label={ __( "Remove global feed", "wordpress-seo" ) }
-								isDummy={ ! isPremium }
-								className="yst-max-w-2xl"
-							>
-								{ __( "Remove URLs which provide an overview of your recent posts.", "wordpress-seo" ) }
+							{ __( "Remove links to the location of your site’s REST API endpoints.", "wordpress-seo" ) }
 								&nbsp;
-								{ descriptions.removeFeedGlobal }
-							</FormikValueChangeFieldWithDummy>
-							<FormikValueChangeFieldWithDummy
-								as={ ToggleField }
-								type="checkbox"
-								name="wpseo.remove_feed_global_comments"
-								data-id="input-wpseo-remove_feed_global_comments"
-								label={ __( "Remove global comment feeds", "wordpress-seo" ) }
-								isDummy={ ! isPremium }
-								className="yst-max-w-2xl"
-							>
-								{ __( "Remove URLs which provide an overview of recent comments on your site.", "wordpress-seo" ) }
-								&nbsp;
-								{ descriptions.removeFeedGlobalComments }
-								{ __( "Also disables post comment feeds.", "wordpress-seo" ) }
-							</FormikValueChangeFieldWithDummy>
-							<FormikValueChangeFieldWithDummy
-								as={ ToggleField }
-								type="checkbox"
-								name="wpseo.remove_feed_post_comments"
-								data-id="input-wpseo-remove_feed_post_comments"
-								label={ __( "Remove post comments feeds", "wordpress-seo" ) }
-								disabled={ removeFeedGlobalComments }
-								checked={ removeFeedGlobalComments || removeFeedPostComments }
-								isDummy={ ! isPremium }
-								className="yst-max-w-2xl"
-							>
-								{ __( "Remove URLs which provide information about recent comments on each post.", "wordpress-seo" ) }
-								&nbsp;
-								{ descriptions.removeFeedPostComments }
-							</FormikValueChangeFieldWithDummy>
-							<FormikValueChangeFieldWithDummy
-								as={ ToggleField }
-								type="checkbox"
-								name="wpseo.remove_feed_authors"
-								data-id="input-wpseo-remove_feed_authors"
-								label={ __( "Remove post authors feeds", "wordpress-seo" ) }
-								isDummy={ ! isPremium }
-								className="yst-max-w-2xl"
-							>
-								{ __( "Remove URLs which provide information about recent posts by specific authors.", "wordpress-seo" ) }
-								&nbsp;
-								{ descriptions.removeFeedAuthors }
-							</FormikValueChangeFieldWithDummy>
-							<FormikValueChangeFieldWithDummy
-								as={ ToggleField }
-								type="checkbox"
-								name="wpseo.remove_feed_post_types"
-								data-id="input-wpseo-remove_feed_post_types"
-								label={ __( "Remove post type feeds", "wordpress-seo" ) }
-								isDummy={ ! isPremium }
-								className="yst-max-w-2xl"
-							>
-								{ __( "Remove URLs which provide information about your recent posts, for each post type.", "wordpress-seo" ) }
-								&nbsp;
-								{ descriptions.removeFeedPostTypes }
-							</FormikValueChangeFieldWithDummy>
-							<FormikValueChangeFieldWithDummy
-								as={ ToggleField }
-								type="checkbox"
-								name="wpseo.remove_feed_categories"
-								data-id="input-wpseo-remove_feed_categories"
-								label={ __( "Remove category feeds", "wordpress-seo" ) }
-								isDummy={ ! isPremium }
-								className="yst-max-w-2xl"
-							>
-								{ __( "Remove URLs which provide information about your recent posts, for each category.", "wordpress-seo" ) }
-								&nbsp;
-								{ descriptions.removeFeedCategories }
-							</FormikValueChangeFieldWithDummy>
-							<FormikValueChangeFieldWithDummy
-								as={ ToggleField }
-								type="checkbox"
-								name="wpseo.remove_feed_tags"
-								data-id="input-wpseo-remove_feed_tags"
-								label={ __( "Remove tag feeds", "wordpress-seo" ) }
-								isDummy={ ! isPremium }
-								className="yst-max-w-2xl"
-							>
-								{ __( "Remove URLs which provide information about your recent posts, for each tag.", "wordpress-seo" ) }
-								&nbsp;
-								{ descriptions.removeFeedTags }
-							</FormikValueChangeFieldWithDummy>
-							<FormikValueChangeFieldWithDummy
-								as={ ToggleField }
-								type="checkbox"
-								name="wpseo.remove_feed_custom_taxonomies"
-								data-id="input-wpseo-remove_feed_custom_taxonomies"
-								label={ __( "Remove custom taxonomy feeds", "wordpress-seo" ) }
-								isDummy={ ! isPremium }
-								className="yst-max-w-2xl"
-							>
-								{ __( "Remove URLs which provide information about your recent posts, for each custom taxonomy.", "wordpress-seo" ) }
-								&nbsp;
-								{ descriptions.removeFeedCustomTaxonomies }
-							</FormikValueChangeFieldWithDummy>
-							<FormikValueChangeFieldWithDummy
-								as={ ToggleField }
-								type="checkbox"
-								name="wpseo.remove_feed_search"
-								data-id="input-wpseo-remove_feed_search"
-								label={ __( "Remove search results feeds", "wordpress-seo" ) }
-								isDummy={ ! isPremium }
-								className="yst-max-w-2xl"
-							>
-								{ __( "Remove URLs which provide information about your search results.", "wordpress-seo" ) }
-								&nbsp;
-								{ descriptions.removeFeedSearch }
-							</FormikValueChangeFieldWithDummy>
-							<FormikValueChangeFieldWithDummy
-								as={ ToggleField }
-								type="checkbox"
-								name="wpseo.remove_atom_rdf_feeds"
-								data-id="input-wpseo-remove_atom_rdf_feeds"
-								label={ __( "Remove Atom / RDF feeds", "wordpress-seo" ) }
-								isDummy={ ! isPremium }
-								className="yst-max-w-2xl"
-							>
-								{ __( "Remove URLs which provide alternative (legacy) formats of all of the above.", "wordpress-seo" ) }
-								&nbsp;
-								{ descriptions.removeAtomRdfFeeds }
-							</FormikValueChangeFieldWithDummy>
-						</FieldsetLayout>
-						<hr className="yst-my-8" />
-						<FieldsetLayout
-							title={ __( "Remove unused resources", "wordpress-seo" ) }
-							description={ __( "WordPress loads lots of resources, some of which your site might not need. If you’re not using these, removing them can speed up your pages and save resources.", "wordpress-seo" ) }
+							{ descriptions.removeRestApiLinks }
+						</FormikValueChangeFieldWithDummy>
+						<FormikValueChangeFieldWithDummy
+							as={ ToggleField }
+							type="checkbox"
+							name="wpseo.remove_rsd_wlw_links"
+							data-id="input-wpseo-remove_rsd_wlw_links"
+							label={ __( "Remove RSD / WLW links", "wordpress-seo" ) }
+							isDummy={ ! isPremium }
+							disabled={ ! isPremium }
+							className="yst-max-w-2xl"
 						>
-							<FormikValueChangeFieldWithDummy
-								as={ ToggleField }
-								type="checkbox"
-								name="wpseo.remove_emoji_scripts"
-								data-id="input-wpseo-remove_emoji_scripts"
-								label={ __( "Remove emoji scripts", "wordpress-seo" ) }
-								description={ __( "Remove JavaScript used for converting emoji characters in older browsers.", "wordpress-seo" ) }
-								isDummy={ ! isPremium }
-								className="yst-max-w-2xl"
-							/>
-							<FormikValueChangeFieldWithDummy
-								as={ ToggleField }
-								type="checkbox"
-								name="wpseo.deny_wp_json_crawling"
-								data-id="input-wpseo-deny_wp_json_crawling"
-								label={ __( "Remove WP-JSON API", "wordpress-seo" ) }
-								isDummy={ ! isPremium }
-								className="yst-max-w-2xl"
-							>
-								{ __( "Add a ‘disallow’ rule to your robots.txt file to prevent crawling of WordPress' JSON API endpoints.", "wordpress-seo" ) }
+							{ __( "Remove links used by external systems for publishing content to your blog.", "wordpress-seo" ) }
 								&nbsp;
-								{ descriptions.denyWpJsonCrawling }
-							</FormikValueChangeFieldWithDummy>
-						</FieldsetLayout>
-						<hr className="yst-my-8" />
-						<FieldsetLayout
-							title={ __( "Internal site search cleanup", "wordpress-seo" ) }
-							description={ __( "Your internal site search can create lots of confusing URLs for search engines, and can even be used as a way for SEO spammers to attack your site. Most sites will benefit from experimenting with these protections and optimizations, even if you don’t have a search feature in your theme.", "wordpress-seo" ) }
+							{ descriptions.removeRsdWlwLinks }
+						</FormikValueChangeFieldWithDummy>
+						<FormikValueChangeFieldWithDummy
+							as={ ToggleField }
+							type="checkbox"
+							name="wpseo.remove_oembed_links"
+							data-id="input-wpseo-remove_oembed_links"
+							label={ __( "Remove oEmbed links", "wordpress-seo" ) }
+							isDummy={ ! isPremium }
+							disabled={ ! isPremium }
+							className="yst-max-w-2xl"
 						>
-							<FormikValueChangeFieldWithDummy
-								as={ ToggleField }
-								type="checkbox"
-								name="wpseo.search_cleanup"
-								data-id="input-wpseo-search_cleanup"
-								label={ __( "Filter search terms", "wordpress-seo" ) }
-								description={ __( "Enables advanced settings for protecting your internal site search URLs.", "wordpress-seo" ) }
-								isDummy={ ! isPremium }
-								className="yst-max-w-2xl"
-							/>
-							<FormikFieldWithDummy
-								as={ TextField }
-								type="text"
-								name="wpseo.search_character_limit"
-								id="input-wpseo-search_character_limit"
-								label={ __( "Max number of characters to allow in searches", "wordpress-seo" ) }
-								description={ __( "Limit the length of internal site search queries to reduce the impact of spam attacks and confusing URLs.", "wordpress-seo" ) }
-								disabled={ ! searchCleanup }
-								isDummy={ ! isPremium }
-							/>
-							<FormikValueChangeFieldWithDummy
-								as={ ToggleField }
-								type="checkbox"
-								name="wpseo.search_cleanup_emoji"
-								data-id="input-wpseo-search_cleanup_emoji"
-								label={ __( "Filter searches with emojis and other special characters", "wordpress-seo" ) }
-								description={ __( "Block internal site searches which contain complex and non-alphanumeric characters, as they may be part of a spam attack.", "wordpress-seo" ) }
-								disabled={ ! searchCleanup }
-								isDummy={ ! isPremium }
-								className="yst-max-w-2xl"
-							/>
-							<FormikValueChangeFieldWithDummy
-								as={ ToggleField }
-								type="checkbox"
-								name="wpseo.search_cleanup_patterns"
-								data-id="input-wpseo-search_cleanup_patterns"
-								label={ __( "Filter searches with common spam patterns", "wordpress-seo" ) }
-								description={ __( "Block internal site searches which match the patterns of known spam attacks.", "wordpress-seo" ) }
-								disabled={ ! searchCleanup }
-								isDummy={ ! isPremium }
-								className="yst-max-w-2xl"
-							/>
-							<FormikValueChangeFieldWithDummy
-								as={ ToggleField }
-								type="checkbox"
-								name="wpseo.deny_search_crawling"
-								data-id="input-wpseo-deny_search_crawling"
-								label={ __( "Prevent crawling of internal site search URLs", "wordpress-seo" ) }
-								description={ descriptions.denySearchCrawling }
-								isDummy={ ! isPremium }
-								className="yst-max-w-2xl"
-							/>
-						</FieldsetLayout>
-						<hr className="yst-my-8" />
-						<FieldsetLayout
-							title={ __( "Advanced: URL cleanup", "wordpress-seo" ) }
-							description={ descriptions.advancedUrlCleanup }
+							{ __( "Remove links used for embedding your content on other sites.", "wordpress-seo" ) }
+								&nbsp;
+							{ descriptions.removeOembedLinks }
+						</FormikValueChangeFieldWithDummy>
+						<FormikValueChangeFieldWithDummy
+							as={ ToggleField }
+							type="checkbox"
+							name="wpseo.remove_generator"
+							data-id="input-wpseo-remove_generator"
+							label={ __( "Remove generator tag", "wordpress-seo" ) }
+							isDummy={ ! isPremium }
+							disabled={ ! isPremium }
+							className="yst-max-w-2xl"
 						>
-							<Alert id="alert-permalink-cleanup-settings" variant="warning">
-								{ addLinkToString(
-									sprintf(
-										// translators: %1$s and %2$s are replaced by opening and closing <a> tags.
-										__( "These are expert features, so make sure you know what you're doing before removing the parameters. %1$sRead more about how your site can be affected%2$s.", "wordpress-seo" ),
-										"<a>",
-										"</a>"
-									),
-									permalinkCleanupLink,
-									"link-permalink-cleanup-info"
-								) }
-							</Alert>
-							<FormikValueChangeFieldWithDummy
-								as={ ToggleField }
-								type="checkbox"
-								name="wpseo.clean_campaign_tracking_urls"
-								data-id="input-wpseo-clean_campaign_tracking_urls"
-								label={ __( "Optimize Google Analytics utm tracking parameters", "wordpress-seo" ) }
-								description={ descriptions.cleanCampaignTrackingUrls }
-								isDummy={ ! isPremium }
-								className="yst-max-w-2xl"
-							/>
-							<FormikValueChangeFieldWithDummy
-								as={ ToggleField }
-								type="checkbox"
-								name="wpseo.clean_permalinks"
-								data-id="input-wpseo-clean_permalinks"
-								label={ __( "Remove unregistered URL parameters", "wordpress-seo" ) }
-								description={ descriptions.cleanPermalinks }
-								isDummy={ ! isPremium }
-								className="yst-max-w-2xl"
-							/>
-							<FormikTagFieldWithDummy
-								name="wpseo.clean_permalinks_extra_variables"
-								id="input-wpseo-clean_permalinks_extra_variables"
-								label={ __( "Additional URL parameters to allow", "wordpress-seo" ) }
-								description={ descriptions.cleanPermalinksExtraVariables }
-								disabled={ ! cleanPermalinks }
-								isDummy={ ! isPremium }
-							/>
-						</FieldsetLayout>
-					</FeatureUpsell>
+							{ __( "Remove information about the plugins and software used by your site.", "wordpress-seo" ) }
+								&nbsp;
+							{ descriptions.removeGenerator }
+						</FormikValueChangeFieldWithDummy>
+						<FormikValueChangeFieldWithDummy
+							as={ ToggleField }
+							type="checkbox"
+							name="wpseo.remove_pingback_header"
+							data-id="input-wpseo-remove_pingback_header"
+							label={ __( "Pingback HTTP header", "wordpress-seo" ) }
+							isDummy={ ! isPremium }
+							disabled={ ! isPremium }
+							className="yst-max-w-2xl"
+						>
+							{ __( "Remove links which allow others sites to ‘ping’ yours when they link to you.", "wordpress-seo" ) }
+								&nbsp;
+							{ descriptions.removePingbackHeader }
+						</FormikValueChangeFieldWithDummy>
+						<FormikValueChangeFieldWithDummy
+							as={ ToggleField }
+							type="checkbox"
+							name="wpseo.remove_powered_by_header"
+							data-id="input-wpseo-remove_powered_by_header"
+							label={ __( "Remove powered by HTTP header", "wordpress-seo" ) }
+							isDummy={ ! isPremium }
+							disabled={ ! isPremium }
+							className="yst-max-w-2xl"
+						>
+							{ __( "Remove information about the plugins and software used by your site.", "wordpress-seo" ) }
+								&nbsp;
+							{ descriptions.removePoweredByHeader }
+						</FormikValueChangeFieldWithDummy>
+					</FieldsetLayout>
+					<hr className="yst-my-8" />
+					<FieldsetLayout
+						title={ __( "Disable unwanted content formats", "wordpress-seo" ) }
+						description={ __( "WordPress outputs your content in many different formats, across many different URLs (like RSS feeds of your posts and categories). It’s generally good practice to disable the formats you’re not actively using.", "wordpress-seo" ) }
+					>
+						<FormikValueChangeFieldWithDummy
+							as={ ToggleField }
+							type="checkbox"
+							name="wpseo.remove_feed_global"
+							data-id="input-wpseo-remove_feed_global"
+							label={ __( "Remove global feed", "wordpress-seo" ) }
+							isDummy={ ! isPremium }
+							disabled={ ! isPremium }
+							className="yst-max-w-2xl"
+						>
+							{ __( "Remove URLs which provide an overview of your recent posts.", "wordpress-seo" ) }
+								&nbsp;
+							{ descriptions.removeFeedGlobal }
+						</FormikValueChangeFieldWithDummy>
+						<FormikValueChangeFieldWithDummy
+							as={ ToggleField }
+							type="checkbox"
+							name="wpseo.remove_feed_global_comments"
+							data-id="input-wpseo-remove_feed_global_comments"
+							label={ __( "Remove global comment feeds", "wordpress-seo" ) }
+							isDummy={ ! isPremium }
+							disabled={ ! isPremium }
+							className="yst-max-w-2xl"
+						>
+							{ __( "Remove URLs which provide an overview of recent comments on your site.", "wordpress-seo" ) }
+								&nbsp;
+							{ descriptions.removeFeedGlobalComments }
+							{ __( "Also disables post comment feeds.", "wordpress-seo" ) }
+						</FormikValueChangeFieldWithDummy>
+						<FormikValueChangeFieldWithDummy
+							as={ ToggleField }
+							type="checkbox"
+							name="wpseo.remove_feed_post_comments"
+							data-id="input-wpseo-remove_feed_post_comments"
+							label={ __( "Remove post comments feeds", "wordpress-seo" ) }
+							disabled={ ! isPremium || removeFeedGlobalComments }
+							checked={ removeFeedGlobalComments || removeFeedPostComments }
+							isDummy={ ! isPremium }
+							className="yst-max-w-2xl"
+						>
+							{ __( "Remove URLs which provide information about recent comments on each post.", "wordpress-seo" ) }
+								&nbsp;
+							{ descriptions.removeFeedPostComments }
+						</FormikValueChangeFieldWithDummy>
+						<FormikValueChangeFieldWithDummy
+							as={ ToggleField }
+							type="checkbox"
+							name="wpseo.remove_feed_authors"
+							data-id="input-wpseo-remove_feed_authors"
+							label={ __( "Remove post authors feeds", "wordpress-seo" ) }
+							isDummy={ ! isPremium }
+							disabled={ ! isPremium }
+							className="yst-max-w-2xl"
+						>
+							{ __( "Remove URLs which provide information about recent posts by specific authors.", "wordpress-seo" ) }
+								&nbsp;
+							{ descriptions.removeFeedAuthors }
+						</FormikValueChangeFieldWithDummy>
+						<FormikValueChangeFieldWithDummy
+							as={ ToggleField }
+							type="checkbox"
+							name="wpseo.remove_feed_post_types"
+							data-id="input-wpseo-remove_feed_post_types"
+							label={ __( "Remove post type feeds", "wordpress-seo" ) }
+							isDummy={ ! isPremium }
+							disabled={ ! isPremium }
+							className="yst-max-w-2xl"
+						>
+							{ __( "Remove URLs which provide information about your recent posts, for each post type.", "wordpress-seo" ) }
+								&nbsp;
+							{ descriptions.removeFeedPostTypes }
+						</FormikValueChangeFieldWithDummy>
+						<FormikValueChangeFieldWithDummy
+							as={ ToggleField }
+							type="checkbox"
+							name="wpseo.remove_feed_categories"
+							data-id="input-wpseo-remove_feed_categories"
+							label={ __( "Remove category feeds", "wordpress-seo" ) }
+							isDummy={ ! isPremium }
+							disabled={ ! isPremium }
+							className="yst-max-w-2xl"
+						>
+							{ __( "Remove URLs which provide information about your recent posts, for each category.", "wordpress-seo" ) }
+								&nbsp;
+							{ descriptions.removeFeedCategories }
+						</FormikValueChangeFieldWithDummy>
+						<FormikValueChangeFieldWithDummy
+							as={ ToggleField }
+							type="checkbox"
+							name="wpseo.remove_feed_tags"
+							data-id="input-wpseo-remove_feed_tags"
+							label={ __( "Remove tag feeds", "wordpress-seo" ) }
+							isDummy={ ! isPremium }
+							disabled={ ! isPremium }
+							className="yst-max-w-2xl"
+						>
+							{ __( "Remove URLs which provide information about your recent posts, for each tag.", "wordpress-seo" ) }
+								&nbsp;
+							{ descriptions.removeFeedTags }
+						</FormikValueChangeFieldWithDummy>
+						<FormikValueChangeFieldWithDummy
+							as={ ToggleField }
+							type="checkbox"
+							name="wpseo.remove_feed_custom_taxonomies"
+							data-id="input-wpseo-remove_feed_custom_taxonomies"
+							label={ __( "Remove custom taxonomy feeds", "wordpress-seo" ) }
+							isDummy={ ! isPremium }
+							disabled={ ! isPremium }
+							className="yst-max-w-2xl"
+						>
+							{ __( "Remove URLs which provide information about your recent posts, for each custom taxonomy.", "wordpress-seo" ) }
+								&nbsp;
+							{ descriptions.removeFeedCustomTaxonomies }
+						</FormikValueChangeFieldWithDummy>
+						<FormikValueChangeFieldWithDummy
+							as={ ToggleField }
+							type="checkbox"
+							name="wpseo.remove_feed_search"
+							data-id="input-wpseo-remove_feed_search"
+							label={ __( "Remove search results feeds", "wordpress-seo" ) }
+							isDummy={ ! isPremium }
+							disabled={ ! isPremium }
+							className="yst-max-w-2xl"
+						>
+							{ __( "Remove URLs which provide information about your search results.", "wordpress-seo" ) }
+								&nbsp;
+							{ descriptions.removeFeedSearch }
+						</FormikValueChangeFieldWithDummy>
+						<FormikValueChangeFieldWithDummy
+							as={ ToggleField }
+							type="checkbox"
+							name="wpseo.remove_atom_rdf_feeds"
+							data-id="input-wpseo-remove_atom_rdf_feeds"
+							label={ __( "Remove Atom / RDF feeds", "wordpress-seo" ) }
+							isDummy={ ! isPremium }
+							disabled={ ! isPremium }
+							className="yst-max-w-2xl"
+						>
+							{ __( "Remove URLs which provide alternative (legacy) formats of all of the above.", "wordpress-seo" ) }
+								&nbsp;
+							{ descriptions.removeAtomRdfFeeds }
+						</FormikValueChangeFieldWithDummy>
+					</FieldsetLayout>
+					<hr className="yst-my-8" />
+					<FieldsetLayout
+						title={ __( "Remove unused resources", "wordpress-seo" ) }
+						description={ __( "WordPress loads lots of resources, some of which your site might not need. If you’re not using these, removing them can speed up your pages and save resources.", "wordpress-seo" ) }
+					>
+						<FormikValueChangeFieldWithDummy
+							as={ ToggleField }
+							type="checkbox"
+							name="wpseo.remove_emoji_scripts"
+							data-id="input-wpseo-remove_emoji_scripts"
+							label={ __( "Remove emoji scripts", "wordpress-seo" ) }
+							description={ __( "Remove JavaScript used for converting emoji characters in older browsers.", "wordpress-seo" ) }
+							isDummy={ ! isPremium }
+							disabled={ ! isPremium }
+							className="yst-max-w-2xl"
+						/>
+						<FormikValueChangeFieldWithDummy
+							as={ ToggleField }
+							type="checkbox"
+							name="wpseo.deny_wp_json_crawling"
+							data-id="input-wpseo-deny_wp_json_crawling"
+							label={ __( "Remove WP-JSON API", "wordpress-seo" ) }
+							isDummy={ ! isPremium }
+							disabled={ ! isPremium }
+							className="yst-max-w-2xl"
+						>
+							{ __( "Add a ‘disallow’ rule to your robots.txt file to prevent crawling of WordPress' JSON API endpoints.", "wordpress-seo" ) }
+								&nbsp;
+							{ descriptions.denyWpJsonCrawling }
+						</FormikValueChangeFieldWithDummy>
+					</FieldsetLayout>
+					<hr className="yst-my-8" />
+					<FieldsetLayout
+						title={ __( "Internal site search cleanup", "wordpress-seo" ) }
+						description={ __( "Your internal site search can create lots of confusing URLs for search engines, and can even be used as a way for SEO spammers to attack your site. Most sites will benefit from experimenting with these protections and optimizations, even if you don’t have a search feature in your theme.", "wordpress-seo" ) }
+					>
+						<FormikValueChangeFieldWithDummy
+							as={ ToggleField }
+							type="checkbox"
+							name="wpseo.search_cleanup"
+							data-id="input-wpseo-search_cleanup"
+							label={ __( "Filter search terms", "wordpress-seo" ) }
+							description={ __( "Enables advanced settings for protecting your internal site search URLs.", "wordpress-seo" ) }
+							isDummy={ ! isPremium }
+							disabled={ ! isPremium }
+							className="yst-max-w-2xl"
+						/>
+						<FormikFieldWithDummy
+							as={ TextField }
+							type="text"
+							name="wpseo.search_character_limit"
+							id="input-wpseo-search_character_limit"
+							label={ __( "Max number of characters to allow in searches", "wordpress-seo" ) }
+							description={ __( "Limit the length of internal site search queries to reduce the impact of spam attacks and confusing URLs.", "wordpress-seo" ) }
+							disabled={ ! isPremium || ! searchCleanup }
+							isDummy={ ! isPremium }
+						/>
+						<FormikValueChangeFieldWithDummy
+							as={ ToggleField }
+							type="checkbox"
+							name="wpseo.search_cleanup_emoji"
+							data-id="input-wpseo-search_cleanup_emoji"
+							label={ __( "Filter searches with emojis and other special characters", "wordpress-seo" ) }
+							description={ __( "Block internal site searches which contain complex and non-alphanumeric characters, as they may be part of a spam attack.", "wordpress-seo" ) }
+							disabled={ ! isPremium || ! searchCleanup }
+							isDummy={ ! isPremium }
+							className="yst-max-w-2xl"
+						/>
+						<FormikValueChangeFieldWithDummy
+							as={ ToggleField }
+							type="checkbox"
+							name="wpseo.search_cleanup_patterns"
+							data-id="input-wpseo-search_cleanup_patterns"
+							label={ __( "Filter searches with common spam patterns", "wordpress-seo" ) }
+							description={ __( "Block internal site searches which match the patterns of known spam attacks.", "wordpress-seo" ) }
+							disabled={ ! isPremium || ! searchCleanup }
+							isDummy={ ! isPremium }
+							className="yst-max-w-2xl"
+						/>
+						<FormikValueChangeFieldWithDummy
+							as={ ToggleField }
+							type="checkbox"
+							name="wpseo.deny_search_crawling"
+							data-id="input-wpseo-deny_search_crawling"
+							label={ __( "Prevent crawling of internal site search URLs", "wordpress-seo" ) }
+							description={ descriptions.denySearchCrawling }
+							isDummy={ ! isPremium }
+							disabled={ ! isPremium }
+							className="yst-max-w-2xl"
+						/>
+					</FieldsetLayout>
+					<hr className="yst-my-8" />
+					<FieldsetLayout
+						title={ __( "Advanced: URL cleanup", "wordpress-seo" ) }
+						description={ descriptions.advancedUrlCleanup }
+					>
+						<Alert id="alert-permalink-cleanup-settings" variant="warning" className={ classNames( ! isPremium && "yst-opacity-50 yst-cursor-not-allowed" ) }>
+							{ createInterpolateElement(
+								sprintf(
+									// translators: %1$s and %2$s are replaced by opening and closing <a> tags.
+									__( "These are expert features, so make sure you know what you're doing before removing the parameters. %1$sRead more about how your site can be affected%2$s.", "wordpress-seo" ),
+									"<a>",
+									"</a>"
+								), {
+									// eslint-disable-next-line jsx-a11y/anchor-has-content
+									a: <a id="link-permalink-cleanup-info" href={ permalinkCleanupLink } target="_blank" rel="noopener noreferrer" className={ classNames( ! isPremium && "yst-pointer-events-none" ) } />,
+								}
+							) }
+						</Alert>
+						<FormikValueChangeFieldWithDummy
+							as={ ToggleField }
+							type="checkbox"
+							name="wpseo.clean_campaign_tracking_urls"
+							data-id="input-wpseo-clean_campaign_tracking_urls"
+							label={ __( "Optimize Google Analytics utm tracking parameters", "wordpress-seo" ) }
+							description={ descriptions.cleanCampaignTrackingUrls }
+							isDummy={ ! isPremium }
+							disabled={ ! isPremium }
+							className="yst-max-w-2xl"
+						/>
+						<FormikValueChangeFieldWithDummy
+							as={ ToggleField }
+							type="checkbox"
+							name="wpseo.clean_permalinks"
+							data-id="input-wpseo-clean_permalinks"
+							label={ __( "Remove unregistered URL parameters", "wordpress-seo" ) }
+							description={ descriptions.cleanPermalinks }
+							isDummy={ ! isPremium }
+							disabled={ ! isPremium }
+							className="yst-max-w-2xl"
+						/>
+						<FormikTagFieldWithDummy
+							name="wpseo.clean_permalinks_extra_variables"
+							id="input-wpseo-clean_permalinks_extra_variables"
+							label={ __( "Additional URL parameters to allow", "wordpress-seo" ) }
+							description={ descriptions.cleanPermalinksExtraVariables }
+							disabled={ ! isPremium || ! cleanPermalinks }
+							isDummy={ ! isPremium }
+						/>
+					</FieldsetLayout>
 				</div>
 			</FormLayout>
 		</RouteLayout>

--- a/packages/js/src/settings/routes/crawl-optimization.js
+++ b/packages/js/src/settings/routes/crawl-optimization.js
@@ -5,7 +5,6 @@ import { __, sprintf } from "@wordpress/i18n";
 import { Alert, Button, Code, TextField, ToggleField, useSvgAria } from "@yoast/ui-library";
 import classNames from "classnames";
 import { Field, useFormikContext } from "formik";
-import { addLinkToString } from "../../helpers/stringHelpers";
 import { FieldsetLayout, FormikTagField, FormikValueChangeField, FormLayout, RouteLayout } from "../components";
 import { withDisabledMessageSupport, withFormikDummyField } from "../hocs";
 import { useSelectSettings } from "../hooks";

--- a/packages/js/src/settings/routes/crawl-optimization.js
+++ b/packages/js/src/settings/routes/crawl-optimization.js
@@ -294,7 +294,6 @@ const CrawlOptimization = () => {
 							data-id="input-wpseo-remove_shortlinks"
 							label={ __( "Remove shortlinks", "wordpress-seo" ) }
 							isDummy={ ! isPremium }
-							disabled={ ! isPremium }
 							className="yst-max-w-2xl"
 						>
 							{ __( "Remove links to WordPress' internal 'shortlink' URLs for your posts.", "wordpress-seo" ) }
@@ -308,7 +307,6 @@ const CrawlOptimization = () => {
 							data-id="input-wpseo-remove_rest_api_links"
 							label={ __( "Remove REST API links", "wordpress-seo" ) }
 							isDummy={ ! isPremium }
-							disabled={ ! isPremium }
 							className="yst-max-w-2xl"
 						>
 							{ __( "Remove links to the location of your site’s REST API endpoints.", "wordpress-seo" ) }
@@ -322,7 +320,6 @@ const CrawlOptimization = () => {
 							data-id="input-wpseo-remove_rsd_wlw_links"
 							label={ __( "Remove RSD / WLW links", "wordpress-seo" ) }
 							isDummy={ ! isPremium }
-							disabled={ ! isPremium }
 							className="yst-max-w-2xl"
 						>
 							{ __( "Remove links used by external systems for publishing content to your blog.", "wordpress-seo" ) }
@@ -336,7 +333,6 @@ const CrawlOptimization = () => {
 							data-id="input-wpseo-remove_oembed_links"
 							label={ __( "Remove oEmbed links", "wordpress-seo" ) }
 							isDummy={ ! isPremium }
-							disabled={ ! isPremium }
 							className="yst-max-w-2xl"
 						>
 							{ __( "Remove links used for embedding your content on other sites.", "wordpress-seo" ) }
@@ -350,7 +346,6 @@ const CrawlOptimization = () => {
 							data-id="input-wpseo-remove_generator"
 							label={ __( "Remove generator tag", "wordpress-seo" ) }
 							isDummy={ ! isPremium }
-							disabled={ ! isPremium }
 							className="yst-max-w-2xl"
 						>
 							{ __( "Remove information about the plugins and software used by your site.", "wordpress-seo" ) }
@@ -364,7 +359,6 @@ const CrawlOptimization = () => {
 							data-id="input-wpseo-remove_pingback_header"
 							label={ __( "Pingback HTTP header", "wordpress-seo" ) }
 							isDummy={ ! isPremium }
-							disabled={ ! isPremium }
 							className="yst-max-w-2xl"
 						>
 							{ __( "Remove links which allow others sites to ‘ping’ yours when they link to you.", "wordpress-seo" ) }
@@ -378,7 +372,6 @@ const CrawlOptimization = () => {
 							data-id="input-wpseo-remove_powered_by_header"
 							label={ __( "Remove powered by HTTP header", "wordpress-seo" ) }
 							isDummy={ ! isPremium }
-							disabled={ ! isPremium }
 							className="yst-max-w-2xl"
 						>
 							{ __( "Remove information about the plugins and software used by your site.", "wordpress-seo" ) }
@@ -398,7 +391,6 @@ const CrawlOptimization = () => {
 							data-id="input-wpseo-remove_feed_global"
 							label={ __( "Remove global feed", "wordpress-seo" ) }
 							isDummy={ ! isPremium }
-							disabled={ ! isPremium }
 							className="yst-max-w-2xl"
 						>
 							{ __( "Remove URLs which provide an overview of your recent posts.", "wordpress-seo" ) }
@@ -412,7 +404,6 @@ const CrawlOptimization = () => {
 							data-id="input-wpseo-remove_feed_global_comments"
 							label={ __( "Remove global comment feeds", "wordpress-seo" ) }
 							isDummy={ ! isPremium }
-							disabled={ ! isPremium }
 							className="yst-max-w-2xl"
 						>
 							{ __( "Remove URLs which provide an overview of recent comments on your site.", "wordpress-seo" ) }
@@ -426,7 +417,7 @@ const CrawlOptimization = () => {
 							name="wpseo.remove_feed_post_comments"
 							data-id="input-wpseo-remove_feed_post_comments"
 							label={ __( "Remove post comments feeds", "wordpress-seo" ) }
-							disabled={ ! isPremium || removeFeedGlobalComments }
+							disabled={ removeFeedGlobalComments }
 							checked={ removeFeedGlobalComments || removeFeedPostComments }
 							isDummy={ ! isPremium }
 							className="yst-max-w-2xl"
@@ -442,7 +433,6 @@ const CrawlOptimization = () => {
 							data-id="input-wpseo-remove_feed_authors"
 							label={ __( "Remove post authors feeds", "wordpress-seo" ) }
 							isDummy={ ! isPremium }
-							disabled={ ! isPremium }
 							className="yst-max-w-2xl"
 						>
 							{ __( "Remove URLs which provide information about recent posts by specific authors.", "wordpress-seo" ) }
@@ -456,7 +446,6 @@ const CrawlOptimization = () => {
 							data-id="input-wpseo-remove_feed_post_types"
 							label={ __( "Remove post type feeds", "wordpress-seo" ) }
 							isDummy={ ! isPremium }
-							disabled={ ! isPremium }
 							className="yst-max-w-2xl"
 						>
 							{ __( "Remove URLs which provide information about your recent posts, for each post type.", "wordpress-seo" ) }
@@ -470,7 +459,6 @@ const CrawlOptimization = () => {
 							data-id="input-wpseo-remove_feed_categories"
 							label={ __( "Remove category feeds", "wordpress-seo" ) }
 							isDummy={ ! isPremium }
-							disabled={ ! isPremium }
 							className="yst-max-w-2xl"
 						>
 							{ __( "Remove URLs which provide information about your recent posts, for each category.", "wordpress-seo" ) }
@@ -484,7 +472,6 @@ const CrawlOptimization = () => {
 							data-id="input-wpseo-remove_feed_tags"
 							label={ __( "Remove tag feeds", "wordpress-seo" ) }
 							isDummy={ ! isPremium }
-							disabled={ ! isPremium }
 							className="yst-max-w-2xl"
 						>
 							{ __( "Remove URLs which provide information about your recent posts, for each tag.", "wordpress-seo" ) }
@@ -498,7 +485,6 @@ const CrawlOptimization = () => {
 							data-id="input-wpseo-remove_feed_custom_taxonomies"
 							label={ __( "Remove custom taxonomy feeds", "wordpress-seo" ) }
 							isDummy={ ! isPremium }
-							disabled={ ! isPremium }
 							className="yst-max-w-2xl"
 						>
 							{ __( "Remove URLs which provide information about your recent posts, for each custom taxonomy.", "wordpress-seo" ) }
@@ -512,7 +498,6 @@ const CrawlOptimization = () => {
 							data-id="input-wpseo-remove_feed_search"
 							label={ __( "Remove search results feeds", "wordpress-seo" ) }
 							isDummy={ ! isPremium }
-							disabled={ ! isPremium }
 							className="yst-max-w-2xl"
 						>
 							{ __( "Remove URLs which provide information about your search results.", "wordpress-seo" ) }
@@ -526,7 +511,6 @@ const CrawlOptimization = () => {
 							data-id="input-wpseo-remove_atom_rdf_feeds"
 							label={ __( "Remove Atom / RDF feeds", "wordpress-seo" ) }
 							isDummy={ ! isPremium }
-							disabled={ ! isPremium }
 							className="yst-max-w-2xl"
 						>
 							{ __( "Remove URLs which provide alternative (legacy) formats of all of the above.", "wordpress-seo" ) }
@@ -547,7 +531,6 @@ const CrawlOptimization = () => {
 							label={ __( "Remove emoji scripts", "wordpress-seo" ) }
 							description={ __( "Remove JavaScript used for converting emoji characters in older browsers.", "wordpress-seo" ) }
 							isDummy={ ! isPremium }
-							disabled={ ! isPremium }
 							className="yst-max-w-2xl"
 						/>
 						<FormikValueChangeFieldWithDummy
@@ -557,7 +540,6 @@ const CrawlOptimization = () => {
 							data-id="input-wpseo-deny_wp_json_crawling"
 							label={ __( "Remove WP-JSON API", "wordpress-seo" ) }
 							isDummy={ ! isPremium }
-							disabled={ ! isPremium }
 							className="yst-max-w-2xl"
 						>
 							{ __( "Add a ‘disallow’ rule to your robots.txt file to prevent crawling of WordPress' JSON API endpoints.", "wordpress-seo" ) }
@@ -578,7 +560,6 @@ const CrawlOptimization = () => {
 							label={ __( "Filter search terms", "wordpress-seo" ) }
 							description={ __( "Enables advanced settings for protecting your internal site search URLs.", "wordpress-seo" ) }
 							isDummy={ ! isPremium }
-							disabled={ ! isPremium }
 							className="yst-max-w-2xl"
 						/>
 						<FormikFieldWithDummy
@@ -588,7 +569,7 @@ const CrawlOptimization = () => {
 							id="input-wpseo-search_character_limit"
 							label={ __( "Max number of characters to allow in searches", "wordpress-seo" ) }
 							description={ __( "Limit the length of internal site search queries to reduce the impact of spam attacks and confusing URLs.", "wordpress-seo" ) }
-							disabled={ ! isPremium || ! searchCleanup }
+							disabled={ ! searchCleanup }
 							isDummy={ ! isPremium }
 						/>
 						<FormikValueChangeFieldWithDummy
@@ -598,7 +579,7 @@ const CrawlOptimization = () => {
 							data-id="input-wpseo-search_cleanup_emoji"
 							label={ __( "Filter searches with emojis and other special characters", "wordpress-seo" ) }
 							description={ __( "Block internal site searches which contain complex and non-alphanumeric characters, as they may be part of a spam attack.", "wordpress-seo" ) }
-							disabled={ ! isPremium || ! searchCleanup }
+							disabled={ ! searchCleanup }
 							isDummy={ ! isPremium }
 							className="yst-max-w-2xl"
 						/>
@@ -609,7 +590,7 @@ const CrawlOptimization = () => {
 							data-id="input-wpseo-search_cleanup_patterns"
 							label={ __( "Filter searches with common spam patterns", "wordpress-seo" ) }
 							description={ __( "Block internal site searches which match the patterns of known spam attacks.", "wordpress-seo" ) }
-							disabled={ ! isPremium || ! searchCleanup }
+							disabled={ ! searchCleanup }
 							isDummy={ ! isPremium }
 							className="yst-max-w-2xl"
 						/>
@@ -621,7 +602,6 @@ const CrawlOptimization = () => {
 							label={ __( "Prevent crawling of internal site search URLs", "wordpress-seo" ) }
 							description={ descriptions.denySearchCrawling }
 							isDummy={ ! isPremium }
-							disabled={ ! isPremium }
 							className="yst-max-w-2xl"
 						/>
 					</FieldsetLayout>
@@ -651,7 +631,6 @@ const CrawlOptimization = () => {
 							label={ __( "Optimize Google Analytics utm tracking parameters", "wordpress-seo" ) }
 							description={ descriptions.cleanCampaignTrackingUrls }
 							isDummy={ ! isPremium }
-							disabled={ ! isPremium }
 							className="yst-max-w-2xl"
 						/>
 						<FormikValueChangeFieldWithDummy
@@ -662,7 +641,6 @@ const CrawlOptimization = () => {
 							label={ __( "Remove unregistered URL parameters", "wordpress-seo" ) }
 							description={ descriptions.cleanPermalinks }
 							isDummy={ ! isPremium }
-							disabled={ ! isPremium }
 							className="yst-max-w-2xl"
 						/>
 						<FormikTagFieldWithDummy
@@ -670,7 +648,7 @@ const CrawlOptimization = () => {
 							id="input-wpseo-clean_permalinks_extra_variables"
 							label={ __( "Additional URL parameters to allow", "wordpress-seo" ) }
 							description={ descriptions.cleanPermalinksExtraVariables }
-							disabled={ ! isPremium || ! cleanPermalinks }
+							disabled={ ! cleanPermalinks }
 							isDummy={ ! isPremium }
 						/>
 					</FieldsetLayout>

--- a/packages/js/src/settings/routes/date-archives.js
+++ b/packages/js/src/settings/routes/date-archives.js
@@ -2,7 +2,6 @@ import { createInterpolateElement, useMemo } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
 import { Badge, Code, FeatureUpsell, Link } from "@yoast/ui-library";
 import { useFormikContext } from "formik";
-import AnimateHeight from "react-animate-height";
 import { toLower } from "lodash";
 import {
 	FieldsetLayout,
@@ -68,7 +67,7 @@ const DateArchives = () => {
 
 	const { values } = useFormikContext();
 	const { opengraph } = values.wpseo_social;
-	const { "disable-date": disableDate } = values.wpseo_titles;
+	const { "disable-date": isDateArchivesDisabled } = values.wpseo_titles;
 
 	return (
 		<RouteLayout
@@ -95,119 +94,113 @@ const DateArchives = () => {
 						/>
 					</fieldset>
 					<hr className="yst-my-8" />
-					<div className="yst-relative">
-						<AnimateHeight
-							easing="ease-in-out"
-							duration={ 300 }
-							height={ disableDate ? 0 : "auto" }
-							animateOpacity={ true }
-						>
-							<FieldsetLayout
-								title={ __( "Search appearance", "wordpress-seo" ) }
-								description={ sprintf(
+					<FieldsetLayout
+						title={ __( "Search appearance", "wordpress-seo" ) }
+						description={ sprintf(
+							// translators: %1$s expands to "date archives".
+							__( "Determine how your %1$s should look in search engines.", "wordpress-seo" ),
+							labelLower
+						) }
+					>
+						<FormikFlippedToggleField
+							name="wpseo_titles.noindex-archive-wpseo"
+							data-id="input-wpseo_titles-noindex-archive-wpseo"
+							label={ sprintf(
+								// translators: %1$s expands to "date archives".
+								__( "Show %1$s in search results", "wordpress-seo" ),
+								labelLower
+							) }
+							description={ <>
+								{ sprintf(
 									// translators: %1$s expands to "date archives".
-									__( "Determine how your %1$s should look in search engines.", "wordpress-seo" ),
+									__( "Disabling this means that %1$s will not be indexed by search engines and will be excluded from XML sitemaps. We recommend that you disable this setting.", "wordpress-seo" ),
 									labelLower
 								) }
-							>
-								<FormikFlippedToggleField
-									name="wpseo_titles.noindex-archive-wpseo"
-									data-id="input-wpseo_titles-noindex-archive-wpseo"
-									label={ sprintf(
-										// translators: %1$s expands to "date archives".
-										__( "Show %1$s in search results", "wordpress-seo" ),
-										labelLower
-									) }
-									description={ <>
-										{ sprintf(
-											// translators: %1$s expands to "date archives".
-											__( "Disabling this means that %1$s will not be indexed by search engines and will be excluded from XML sitemaps. We recommend that you disable this setting.", "wordpress-seo" ),
-											labelLower
-										) }
 										&nbsp;
-										<Link href={ noIndexInfoLink } target="_blank" rel="noopener">
-											{ __( "Read more about the search results settings", "wordpress-seo" ) }
-										</Link>
-										.
-									</> }
-									className="yst-max-w-sm"
-								/>
-								<FormikReplacementVariableEditorField
-									type="title"
-									name="wpseo_titles.title-archive-wpseo"
-									fieldId="input-wpseo_titles-title-archive-wpseo"
-									label={ __( "SEO title", "wordpress-seo" ) }
-									replacementVariables={ replacementVariables }
-									recommendedReplacementVariables={ recommendedReplacementVariables }
-								/>
-								<FormikReplacementVariableEditorField
-									type="description"
-									name="wpseo_titles.metadesc-archive-wpseo"
-									fieldId="input-wpseo_titles-metadesc-archive-wpseo"
-									label={ __( "Meta description", "wordpress-seo" ) }
-									replacementVariables={ replacementVariables }
-									recommendedReplacementVariables={ recommendedReplacementVariables }
-									className="yst-replacevar--description"
-								/>
-							</FieldsetLayout>
-							<hr className="yst-my-8" />
-							<FieldsetLayout
-								title={ <div className="yst-flex yst-items-center yst-gap-1.5">
-									<span>{ __( "Social appearance", "wordpress-seo" ) }</span>
-									{ isPremium && <Badge variant="upsell">Premium</Badge> }
-								</div> }
-								description={ sprintf(
-									// translators: %1$s expands to "date archives".
-									__( "Determine how your %1$s should look on social media by default.", "wordpress-seo" ),
-									labelLower
-								) }
-							>
-								<FeatureUpsell
-									shouldUpsell={ ! isPremium }
-									variant="card"
-									cardLink={ socialAppearancePremiumLink }
-									cardText={ sprintf(
-										// translators: %1$s expands to Premium.
-										__( "Unlock with %1$s", "wordpress-seo" ),
-										"Premium"
-									) }
-									{ ...premiumUpsellConfig }
-								>
-									<OpenGraphDisabledAlert isEnabled={ ! isPremium || opengraph } />
-									<FormikMediaSelectField
-										id="wpseo_titles-social-image-archive-wpseo"
-										label={ __( "Social image", "wordpress-seo" ) }
-										previewLabel={ recommendedSize }
-										mediaUrlName="wpseo_titles.social-image-url-archive-wpseo"
-										mediaIdName="wpseo_titles.social-image-id-archive-wpseo"
-										disabled={ ! opengraph }
-										isDummy={ ! isPremium }
-									/>
-									<FormikReplacementVariableEditorFieldWithDummy
-										type="title"
-										name="wpseo_titles.social-title-archive-wpseo"
-										fieldId="input-wpseo_titles-social-title-archive-wpseo"
-										label={ __( "Social title", "wordpress-seo" ) }
-										replacementVariables={ replacementVariables }
-										recommendedReplacementVariables={ recommendedReplacementVariables }
-										isDisabled={ ! opengraph }
-										isDummy={ ! isPremium }
-									/>
-									<FormikReplacementVariableEditorFieldWithDummy
-										type="description"
-										name="wpseo_titles.social-description-archive-wpseo"
-										fieldId="input-wpseo_titles-social-description-archive-wpseo"
-										label={ __( "Social description", "wordpress-seo" ) }
-										replacementVariables={ replacementVariables }
-										recommendedReplacementVariables={ recommendedReplacementVariables }
-										className="yst-replacevar--description"
-										isDisabled={ ! opengraph }
-										isDummy={ ! isPremium }
-									/>
-								</FeatureUpsell>
-							</FieldsetLayout>
-						</AnimateHeight>
-					</div>
+								<Link href={ noIndexInfoLink } target="_blank" rel="noopener">
+									{ __( "Read more about the search results settings", "wordpress-seo" ) }
+								</Link>
+								.
+							</> }
+							disabled={ isDateArchivesDisabled }
+							className="yst-max-w-sm"
+						/>
+						<FormikReplacementVariableEditorField
+							type="title"
+							name="wpseo_titles.title-archive-wpseo"
+							fieldId="input-wpseo_titles-title-archive-wpseo"
+							label={ __( "SEO title", "wordpress-seo" ) }
+							replacementVariables={ replacementVariables }
+							recommendedReplacementVariables={ recommendedReplacementVariables }
+							isDisabled={ isDateArchivesDisabled }
+						/>
+						<FormikReplacementVariableEditorField
+							type="description"
+							name="wpseo_titles.metadesc-archive-wpseo"
+							fieldId="input-wpseo_titles-metadesc-archive-wpseo"
+							label={ __( "Meta description", "wordpress-seo" ) }
+							replacementVariables={ replacementVariables }
+							recommendedReplacementVariables={ recommendedReplacementVariables }
+							isDisabled={ isDateArchivesDisabled }
+							className="yst-replacevar--description"
+						/>
+					</FieldsetLayout>
+					<hr className="yst-my-8" />
+					<FieldsetLayout
+						title={ <div className="yst-flex yst-items-center yst-gap-1.5">
+							<span>{ __( "Social appearance", "wordpress-seo" ) }</span>
+							{ isPremium && <Badge variant="upsell">Premium</Badge> }
+						</div> }
+						description={ sprintf(
+							// translators: %1$s expands to "date archives".
+							__( "Determine how your %1$s should look on social media by default.", "wordpress-seo" ),
+							labelLower
+						) }
+					>
+						<FeatureUpsell
+							shouldUpsell={ ! isPremium }
+							variant="card"
+							cardLink={ socialAppearancePremiumLink }
+							cardText={ sprintf(
+								// translators: %1$s expands to Premium.
+								__( "Unlock with %1$s", "wordpress-seo" ),
+								"Premium"
+							) }
+							{ ...premiumUpsellConfig }
+						>
+							<OpenGraphDisabledAlert isEnabled={ ! isPremium || opengraph } />
+							<FormikMediaSelectField
+								id="wpseo_titles-social-image-archive-wpseo"
+								label={ __( "Social image", "wordpress-seo" ) }
+								previewLabel={ recommendedSize }
+								mediaUrlName="wpseo_titles.social-image-url-archive-wpseo"
+								mediaIdName="wpseo_titles.social-image-id-archive-wpseo"
+								disabled={ isDateArchivesDisabled || ! opengraph }
+								isDummy={ ! isPremium }
+							/>
+							<FormikReplacementVariableEditorFieldWithDummy
+								type="title"
+								name="wpseo_titles.social-title-archive-wpseo"
+								fieldId="input-wpseo_titles-social-title-archive-wpseo"
+								label={ __( "Social title", "wordpress-seo" ) }
+								replacementVariables={ replacementVariables }
+								recommendedReplacementVariables={ recommendedReplacementVariables }
+								isDisabled={ isDateArchivesDisabled || ! opengraph }
+								isDummy={ ! isPremium }
+							/>
+							<FormikReplacementVariableEditorFieldWithDummy
+								type="description"
+								name="wpseo_titles.social-description-archive-wpseo"
+								fieldId="input-wpseo_titles-social-description-archive-wpseo"
+								label={ __( "Social description", "wordpress-seo" ) }
+								replacementVariables={ replacementVariables }
+								recommendedReplacementVariables={ recommendedReplacementVariables }
+								className="yst-replacevar--description"
+								isDisabled={ isDateArchivesDisabled || ! opengraph }
+								isDummy={ ! isPremium }
+							/>
+						</FeatureUpsell>
+					</FieldsetLayout>
 				</div>
 			</FormLayout>
 		</RouteLayout>

--- a/packages/js/src/settings/routes/format-archives.js
+++ b/packages/js/src/settings/routes/format-archives.js
@@ -124,7 +124,7 @@ const FormatArchives = () => {
 							label={ __( "SEO title", "wordpress-seo" ) }
 							replacementVariables={ replacementVariables }
 							recommendedReplacementVariables={ recommendedReplacementVariables }
-							isDisabled={ isFormatArchivesDisabled }
+							disabled={ isFormatArchivesDisabled }
 						/>
 						<FormikReplacementVariableEditorField
 							type="description"
@@ -133,7 +133,7 @@ const FormatArchives = () => {
 							label={ __( "Meta description", "wordpress-seo" ) }
 							replacementVariables={ replacementVariables }
 							recommendedReplacementVariables={ recommendedReplacementVariables }
-							isDisabled={ isFormatArchivesDisabled }
+							disabled={ isFormatArchivesDisabled }
 							className="yst-replacevar--description"
 						/>
 					</FieldsetLayout>
@@ -179,7 +179,7 @@ const FormatArchives = () => {
 								label={ __( "Social title", "wordpress-seo" ) }
 								replacementVariables={ replacementVariables }
 								recommendedReplacementVariables={ recommendedReplacementVariables }
-								isDisabled={ isFormatArchivesDisabled || ! opengraph }
+								disabled={ isFormatArchivesDisabled || ! opengraph }
 								isDummy={ ! isPremium }
 							/>
 							<FormikReplacementVariableEditorFieldWithDummy
@@ -190,7 +190,7 @@ const FormatArchives = () => {
 								replacementVariables={ replacementVariables }
 								recommendedReplacementVariables={ recommendedReplacementVariables }
 								className="yst-replacevar--description"
-								isDisabled={ isFormatArchivesDisabled || ! opengraph }
+								disabled={ isFormatArchivesDisabled || ! opengraph }
 								isDummy={ ! isPremium }
 							/>
 						</FeatureUpsell>

--- a/packages/js/src/settings/routes/format-archives.js
+++ b/packages/js/src/settings/routes/format-archives.js
@@ -2,7 +2,6 @@ import { createInterpolateElement, useMemo } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
 import { Badge, Code, FeatureUpsell, Link } from "@yoast/ui-library";
 import { useFormikContext } from "formik";
-import AnimateHeight from "react-animate-height";
 import { toLower } from "lodash";
 import {
 	FieldsetLayout,
@@ -68,7 +67,7 @@ const FormatArchives = () => {
 
 	const { values } = useFormikContext();
 	const { opengraph } = values.wpseo_social;
-	const { "disable-post_format": disablePostFormat } = values.wpseo_titles;
+	const { "disable-post_format": isFormatArchivesDisabled } = values.wpseo_titles;
 
 	return (
 		<RouteLayout
@@ -85,123 +84,117 @@ const FormatArchives = () => {
 						className="yst-max-w-sm"
 					/>
 					<hr className="yst-my-8" />
-					<div className="yst-relative">
-						<AnimateHeight
-							easing="ease-in-out"
-							duration={ 300 }
-							height={ disablePostFormat ? 0 : "auto" }
-							animateOpacity={ true }
-						>
-							<FieldsetLayout
-								title={ __( "Search appearance", "wordpress-seo" ) }
-								description={ sprintf(
-									// eslint-disable-next-line max-len
-									// translators: %1$s expands to "formats". %2$s expands to "Yoast SEO".
-									__( "Determine how your %1$s should look in search engines. You can always customize the settings for individual %1$s in the %2$s metabox.", "wordpress-seo" ),
-									labelLower,
-									"Yoast SEO"
+					<FieldsetLayout
+						title={ __( "Search appearance", "wordpress-seo" ) }
+						description={ sprintf(
+							// eslint-disable-next-line max-len
+							// translators: %1$s expands to "formats". %2$s expands to "Yoast SEO".
+							__( "Determine how your %1$s should look in search engines. You can always customize the settings for individual %1$s in the %2$s metabox.", "wordpress-seo" ),
+							labelLower,
+							"Yoast SEO"
+						) }
+					>
+						<FormikFlippedToggleField
+							name={ `wpseo_titles.noindex-tax-${ name }` }
+							data-id={ `input-wpseo_titles-noindex-tax-${ name }` }
+							label={ sprintf(
+								// translators: %1$s expands to "formats".
+								__( "Show %1$s in search results", "wordpress-seo" ),
+								labelLower
+							) }
+							description={ <>
+								{ sprintf(
+									// translators: %1$s expands to "formats".
+									__( "Disabling this means that %1$s will not be indexed by search engines and will be excluded from XML sitemaps. We recommend that you disable this setting.", "wordpress-seo" ),
+									labelLower
 								) }
-							>
-								<FormikFlippedToggleField
-									name={ `wpseo_titles.noindex-tax-${ name }` }
-									data-id={ `input-wpseo_titles-noindex-tax-${ name }` }
-									label={ sprintf(
-										// translators: %1$s expands to "formats".
-										__( "Show %1$s in search results", "wordpress-seo" ),
-										labelLower
-									) }
-									description={ <>
-										{ sprintf(
-											// translators: %1$s expands to "formats".
-											__( "Disabling this means that %1$s will not be indexed by search engines and will be excluded from XML sitemaps. We recommend that you disable this setting.", "wordpress-seo" ),
-											labelLower
-										) }
 										&nbsp;
-										<Link href={ noIndexInfoLink } target="_blank" rel="noopener">
-											{ __( "Read more about the search results settings", "wordpress-seo" ) }
-										</Link>
-										.
-									</> }
-									className="yst-max-w-sm"
-								/>
-								<FormikReplacementVariableEditorField
-									type="title"
-									name={ `wpseo_titles.title-tax-${ name }` }
-									fieldId={ `input-wpseo_titles-title-tax-${ name }` }
-									label={ __( "SEO title", "wordpress-seo" ) }
-									replacementVariables={ replacementVariables }
-									recommendedReplacementVariables={ recommendedReplacementVariables }
-								/>
-								<FormikReplacementVariableEditorField
-									type="description"
-									name={ `wpseo_titles.metadesc-tax-${ name }` }
-									fieldId={ `input-wpseo_titles-metadesc-tax-${ name }` }
-									label={ __( "Meta description", "wordpress-seo" ) }
-									replacementVariables={ replacementVariables }
-									recommendedReplacementVariables={ recommendedReplacementVariables }
-									className="yst-replacevar--description"
-								/>
-							</FieldsetLayout>
-							<hr className="yst-my-8" />
-							<FieldsetLayout
-								title={ <div className="yst-flex yst-items-center yst-gap-1.5">
-									<span>{ __( "Social appearance", "wordpress-seo" ) }</span>
-									{ isPremium && <Badge variant="upsell">Premium</Badge> }
-								</div> }
-								description={ sprintf(
-								// eslint-disable-next-line max-len
-								// translators: %1$s expands to "formats". %2$s expands to "Yoast SEO".
-									__( "Determine how your %1$s should look on social media by default. You can always customize the settings for individual %1$s in the %2$s metabox.", "wordpress-seo" ),
-									labelLower,
-									"Yoast SEO"
-								) }
-							>
-								<FeatureUpsell
-									shouldUpsell={ ! isPremium }
-									variant="card"
-									cardLink={ socialAppearancePremiumLink }
-									cardText={ sprintf(
-									/* translators: %1$s expands to Premium. */
-										__( "Unlock with %1$s", "wordpress-seo" ),
-										"Premium"
-									) }
-									{ ...premiumUpsellConfig }
-								>
-									<OpenGraphDisabledAlert isEnabled={ ! isPremium || opengraph } />
-									<FormikMediaSelectField
-										id={ `wpseo_titles-social-image-tax-${ name }` }
-										label={ __( "Social image", "wordpress-seo" ) }
-										previewLabel={ recommendedSize }
-										mediaUrlName={ `wpseo_titles.social-image-url-tax-${ name }` }
-										mediaIdName={ `wpseo_titles.social-image-id-tax-${ name }` }
-										disabled={ ! opengraph }
-										isDummy={ ! isPremium }
-									/>
-									<FormikReplacementVariableEditorFieldWithDummy
-										type="title"
-										name={ `wpseo_titles.social-title-tax-${ name }` }
-										fieldId={ `input-wpseo_titles-social-title-tax-${ name }` }
-										label={ __( "Social title", "wordpress-seo" ) }
-										replacementVariables={ replacementVariables }
-										recommendedReplacementVariables={ recommendedReplacementVariables }
-										isDisabled={ ! opengraph }
-										isDummy={ ! isPremium }
-									/>
-									<FormikReplacementVariableEditorFieldWithDummy
-										type="description"
-										name={ `wpseo_titles.social-description-tax-${ name }` }
-										fieldId={ `input-wpseo_titles-social-description-tax-${ name }` }
-										label={ __( "Social description", "wordpress-seo" ) }
-										replacementVariables={ replacementVariables }
-										recommendedReplacementVariables={ recommendedReplacementVariables }
-										className="yst-replacevar--description"
-										isDisabled={ ! opengraph }
-										isDummy={ ! isPremium }
-									/>
-								</FeatureUpsell>
-							</FieldsetLayout>
-						</AnimateHeight>
-					</div>
+								<Link href={ noIndexInfoLink } target="_blank" rel="noopener">
+									{ __( "Read more about the search results settings", "wordpress-seo" ) }
+								</Link>
+								.
+							</> }
+							disabled={ isFormatArchivesDisabled }
+							className="yst-max-w-sm"
+						/>
+						<FormikReplacementVariableEditorField
+							type="title"
+							name={ `wpseo_titles.title-tax-${ name }` }
+							fieldId={ `input-wpseo_titles-title-tax-${ name }` }
+							label={ __( "SEO title", "wordpress-seo" ) }
+							replacementVariables={ replacementVariables }
+							recommendedReplacementVariables={ recommendedReplacementVariables }
+							isDisabled={ isFormatArchivesDisabled }
+						/>
+						<FormikReplacementVariableEditorField
+							type="description"
+							name={ `wpseo_titles.metadesc-tax-${ name }` }
+							fieldId={ `input-wpseo_titles-metadesc-tax-${ name }` }
+							label={ __( "Meta description", "wordpress-seo" ) }
+							replacementVariables={ replacementVariables }
+							recommendedReplacementVariables={ recommendedReplacementVariables }
+							isDisabled={ isFormatArchivesDisabled }
+							className="yst-replacevar--description"
+						/>
+					</FieldsetLayout>
+					<hr className="yst-my-8" />
+					<FieldsetLayout
+						title={ <div className="yst-flex yst-items-center yst-gap-1.5">
+							<span>{ __( "Social appearance", "wordpress-seo" ) }</span>
+							{ isPremium && <Badge variant="upsell">Premium</Badge> }
+						</div> }
+						description={ sprintf(
+							// eslint-disable-next-line max-len
+							// translators: %1$s expands to "formats". %2$s expands to "Yoast SEO".
+							__( "Determine how your %1$s should look on social media by default. You can always customize the settings for individual %1$s in the %2$s metabox.", "wordpress-seo" ),
+							labelLower,
+							"Yoast SEO"
+						) }
+					>
+						<FeatureUpsell
+							shouldUpsell={ ! isPremium }
+							variant="card"
+							cardLink={ socialAppearancePremiumLink }
+							cardText={ sprintf(
+								/* translators: %1$s expands to Premium. */
+								__( "Unlock with %1$s", "wordpress-seo" ),
+								"Premium"
+							) }
+							{ ...premiumUpsellConfig }
+						>
+							<OpenGraphDisabledAlert isEnabled={ ! isPremium || opengraph } />
+							<FormikMediaSelectField
+								id={ `wpseo_titles-social-image-tax-${ name }` }
+								label={ __( "Social image", "wordpress-seo" ) }
+								previewLabel={ recommendedSize }
+								mediaUrlName={ `wpseo_titles.social-image-url-tax-${ name }` }
+								mediaIdName={ `wpseo_titles.social-image-id-tax-${ name }` }
+								disabled={ isFormatArchivesDisabled || ! opengraph }
+								isDummy={ ! isPremium }
+							/>
+							<FormikReplacementVariableEditorFieldWithDummy
+								type="title"
+								name={ `wpseo_titles.social-title-tax-${ name }` }
+								fieldId={ `input-wpseo_titles-social-title-tax-${ name }` }
+								label={ __( "Social title", "wordpress-seo" ) }
+								replacementVariables={ replacementVariables }
+								recommendedReplacementVariables={ recommendedReplacementVariables }
+								isDisabled={ isFormatArchivesDisabled || ! opengraph }
+								isDummy={ ! isPremium }
+							/>
+							<FormikReplacementVariableEditorFieldWithDummy
+								type="description"
+								name={ `wpseo_titles.social-description-tax-${ name }` }
+								fieldId={ `input-wpseo_titles-social-description-tax-${ name }` }
+								label={ __( "Social description", "wordpress-seo" ) }
+								replacementVariables={ replacementVariables }
+								recommendedReplacementVariables={ recommendedReplacementVariables }
+								className="yst-replacevar--description"
+								isDisabled={ isFormatArchivesDisabled || ! opengraph }
+								isDummy={ ! isPremium }
+							/>
+						</FeatureUpsell>
+					</FieldsetLayout>
 				</div>
 			</FormLayout>
 		</RouteLayout>

--- a/packages/js/src/settings/routes/media.js
+++ b/packages/js/src/settings/routes/media.js
@@ -120,7 +120,7 @@ const Media = () => {
 							label={ __( "SEO title", "wordpress-seo" ) }
 							replacementVariables={ replacementVariables }
 							recommendedReplacementVariables={ recommendedReplacementVariables }
-							isDisabled={ isAttachmentPagesDisabled }
+							disabled={ isAttachmentPagesDisabled }
 						/>
 						<FormikReplacementVariableEditorField
 							type="description"
@@ -129,7 +129,7 @@ const Media = () => {
 							label={ __( "Meta description", "wordpress-seo" ) }
 							replacementVariables={ replacementVariables }
 							recommendedReplacementVariables={ recommendedReplacementVariables }
-							isDisabled={ isAttachmentPagesDisabled }
+							disabled={ isAttachmentPagesDisabled }
 							className="yst-replacevar--description"
 						/>
 					</FieldsetLayout>

--- a/packages/js/src/settings/routes/media.js
+++ b/packages/js/src/settings/routes/media.js
@@ -2,7 +2,6 @@ import { createInterpolateElement, useMemo } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
 import { Link, SelectField, ToggleField } from "@yoast/ui-library";
 import { useFormikContext } from "formik";
-import AnimateHeight from "react-animate-height";
 import { toLower } from "lodash";
 import {
 	FieldsetLayout,

--- a/packages/js/src/settings/routes/media.js
+++ b/packages/js/src/settings/routes/media.js
@@ -29,7 +29,7 @@ const Media = () => {
 	const noIndexInfoLink = useSelectSettings( "selectLink", [], "https://yoa.st/show-x" );
 
 	const { values } = useFormikContext();
-	const { "disable-attachment": disableAttachment } = values.wpseo_titles;
+	const { "disable-attachment": isAttachmentPagesDisabled } = values.wpseo_titles;
 
 	const description = useMemo( () => createInterpolateElement(
 		sprintf(
@@ -81,105 +81,102 @@ const Media = () => {
 						/>
 					</fieldset>
 					<hr className="yst-my-8" />
-					<div className="yst-relative">
-						<AnimateHeight
-							easing="ease-in-out"
-							duration={ 300 }
-							height={ disableAttachment ? 0 : "auto" }
-							animateOpacity={ true }
-						>
-							<FieldsetLayout
-								title={ __( "Search appearance", "wordpress-seo" ) }
-								description={ sprintf(
-									// eslint-disable-next-line max-len
-									// translators: %1$s expands to "media". %3$s expands to "Yoast SEO".
-									__( "Determine how your %1$s pages should look in search engines. You can always customize the settings for individual %1$s pages in the %2$s metabox.", "wordpress-seo" ),
-									labelLower,
-									"Yoast SEO"
+					<FieldsetLayout
+						title={ __( "Search appearance", "wordpress-seo" ) }
+						description={ sprintf(
+							// eslint-disable-next-line max-len
+							// translators: %1$s expands to "media". %3$s expands to "Yoast SEO".
+							__( "Determine how your %1$s pages should look in search engines. You can always customize the settings for individual %1$s pages in the %2$s metabox.", "wordpress-seo" ),
+							labelLower,
+							"Yoast SEO"
+						) }
+					>
+						<FormikFlippedToggleField
+							name={ `wpseo_titles.noindex-${ name }` }
+							data-id={ `input-wpseo_titles-noindex-${ name }` }
+							label={ sprintf(
+								// translators: %1$s expands to "media".
+								__( "Show %1$s pages in search results", "wordpress-seo" ),
+								labelLower
+							) }
+							description={ <>
+								{ sprintf(
+									// translators: %1$s expands to "media".
+									__( "Disabling this means that %1$s pages created by WordPress will not be indexed by search engines and will be excluded from XML sitemaps.", "wordpress-seo" ),
+									labelLower
 								) }
-							>
-								<FormikFlippedToggleField
-									name={ `wpseo_titles.noindex-${ name }` }
-									data-id={ `input-wpseo_titles-noindex-${ name }` }
-									label={ sprintf(
-										// translators: %1$s expands to "media".
-										__( "Show %1$s pages in search results", "wordpress-seo" ),
-										labelLower
-									) }
-									description={ <>
-										{ sprintf(
-											// translators: %1$s expands to "media".
-											__( "Disabling this means that %1$s pages created by WordPress will not be indexed by search engines and will be excluded from XML sitemaps.", "wordpress-seo" ),
-											labelLower
-										) }
-										<br />
-										<Link href={ noIndexInfoLink } target="_blank" rel="noopener">
-											{ __( "Read more about the search results settings", "wordpress-seo" ) }
-										</Link>
-										.
-									</> }
-									className="yst-max-w-sm"
-								/>
-								<FormikReplacementVariableEditorField
-									type="title"
-									name={ `wpseo_titles.title-${ name }` }
-									fieldId={ `input-wpseo_titles-title-${ name }` }
-									label={ __( "SEO title", "wordpress-seo" ) }
-									replacementVariables={ replacementVariables }
-									recommendedReplacementVariables={ recommendedReplacementVariables }
-								/>
-								<FormikReplacementVariableEditorField
-									type="description"
-									name={ `wpseo_titles.metadesc-${ name }` }
-									fieldId={ `input-wpseo_titles-metadesc-${ name }` }
-									label={ __( "Meta description", "wordpress-seo" ) }
-									replacementVariables={ replacementVariables }
-									recommendedReplacementVariables={ recommendedReplacementVariables }
-									className="yst-replacevar--description"
-								/>
-							</FieldsetLayout>
-							<hr className="yst-my-8" />
-							<FieldsetLayout
-								title={ __( "Schema", "wordpress-seo" ) }
-								description={ sprintf(
-									// eslint-disable-next-line max-len
-									// translators: %1$s expands to "media". %3$s expands to "Yoast SEO".
-									__( "Determine how your %1$s pages should be described by default in your site's Schema.org markup. You can always customize the settings for individual %1$s pages in the %2$s metabox.", "wordpress-seo" ),
-									labelLower,
-									"Yoast SEO"
-								) }
-							>
-								<FormikValueChangeField
-									as={ SelectField }
-									type="select"
-									name={ `wpseo_titles.schema-page-type-${ name }` }
-									id={ `input-wpseo_titles-schema-page-type-${ name }` }
-									label={ __( "Page type", "wordpress-seo" ) }
-									options={ pageTypes }
-								/>
-								{ hasSchemaArticleType && <FormikValueChangeField
-									as={ SelectField }
-									type="select"
-									name={ `wpseo_titles.schema-article-type-${ name }` }
-									id={ `input-wpseo_titles-schema-article-type-${ name }` }
-									label={ __( "Article type", "wordpress-seo" ) }
-									options={ articleTypes }
-								/> }
-							</FieldsetLayout>
-							<hr className="yst-my-8" />
-							<FieldsetLayout title={ __( "Additional settings", "wordpress-seo" ) }>
-								<FormikValueChangeField
-									as={ ToggleField }
-									type="checkbox"
-									name={ `wpseo_titles.display-metabox-pt-${ name }` }
-									data-id={ `input-wpseo_titles-display-metabox-pt-${ name }` }
-									label={ __( "Enable SEO controls and assessments", "wordpress-seo" ) }
-									description={ __( "Show or hide our tools and controls in the attachment editor.", "wordpress-seo" ) }
-									className="yst-max-w-sm"
-								/>
-							</FieldsetLayout>
-						</AnimateHeight>
-					</div>
+								<br />
+								<Link href={ noIndexInfoLink } target="_blank" rel="noopener">
+									{ __( "Read more about the search results settings", "wordpress-seo" ) }
+								</Link>
+								.
+							</> }
+							disabled={ isAttachmentPagesDisabled }
+							className="yst-max-w-sm"
+						/>
+						<FormikReplacementVariableEditorField
+							type="title"
+							name={ `wpseo_titles.title-${ name }` }
+							fieldId={ `input-wpseo_titles-title-${ name }` }
+							label={ __( "SEO title", "wordpress-seo" ) }
+							replacementVariables={ replacementVariables }
+							recommendedReplacementVariables={ recommendedReplacementVariables }
+							isDisabled={ isAttachmentPagesDisabled }
+						/>
+						<FormikReplacementVariableEditorField
+							type="description"
+							name={ `wpseo_titles.metadesc-${ name }` }
+							fieldId={ `input-wpseo_titles-metadesc-${ name }` }
+							label={ __( "Meta description", "wordpress-seo" ) }
+							replacementVariables={ replacementVariables }
+							recommendedReplacementVariables={ recommendedReplacementVariables }
+							isDisabled={ isAttachmentPagesDisabled }
+							className="yst-replacevar--description"
+						/>
+					</FieldsetLayout>
+					<hr className="yst-my-8" />
+					<FieldsetLayout
+						title={ __( "Schema", "wordpress-seo" ) }
+						description={ sprintf(
+							// eslint-disable-next-line max-len
+							// translators: %1$s expands to "media". %3$s expands to "Yoast SEO".
+							__( "Determine how your %1$s pages should be described by default in your site's Schema.org markup. You can always customize the settings for individual %1$s pages in the %2$s metabox.", "wordpress-seo" ),
+							labelLower,
+							"Yoast SEO"
+						) }
+					>
+						<FormikValueChangeField
+							as={ SelectField }
+							type="select"
+							name={ `wpseo_titles.schema-page-type-${ name }` }
+							id={ `input-wpseo_titles-schema-page-type-${ name }` }
+							label={ __( "Page type", "wordpress-seo" ) }
+							options={ pageTypes }
+							disabled={ isAttachmentPagesDisabled }
+						/>
+						{ hasSchemaArticleType && <FormikValueChangeField
+							as={ SelectField }
+							type="select"
+							name={ `wpseo_titles.schema-article-type-${ name }` }
+							id={ `input-wpseo_titles-schema-article-type-${ name }` }
+							label={ __( "Article type", "wordpress-seo" ) }
+							options={ articleTypes }
+							disabled={ isAttachmentPagesDisabled }
+						/> }
+					</FieldsetLayout>
+					<hr className="yst-my-8" />
+					<FieldsetLayout title={ __( "Additional settings", "wordpress-seo" ) }>
+						<FormikValueChangeField
+							as={ ToggleField }
+							type="checkbox"
+							name={ `wpseo_titles.display-metabox-pt-${ name }` }
+							data-id={ `input-wpseo_titles-display-metabox-pt-${ name }` }
+							label={ __( "Enable SEO controls and assessments", "wordpress-seo" ) }
+							description={ __( "Show or hide our tools and controls in the attachment editor.", "wordpress-seo" ) }
+							disabled={ isAttachmentPagesDisabled }
+							className="yst-max-w-sm"
+						/>
+					</FieldsetLayout>
 				</div>
 			</FormLayout>
 		</RouteLayout>

--- a/packages/js/src/settings/routes/templates/post-type.js
+++ b/packages/js/src/settings/routes/templates/post-type.js
@@ -227,7 +227,7 @@ const PostType = ( { name, label, singularLabel, hasArchive, hasSchemaArticleTyp
 								label={ __( "Social title", "wordpress-seo" ) }
 								replacementVariables={ replacementVariables }
 								recommendedReplacementVariables={ recommendedReplacementVariables }
-								isDisabled={ ! opengraph }
+								disabled={ ! opengraph }
 								isDummy={ ! isPremium }
 							/>
 							<FormikReplacementVariableEditorFieldWithDummy
@@ -238,7 +238,7 @@ const PostType = ( { name, label, singularLabel, hasArchive, hasSchemaArticleTyp
 								replacementVariables={ replacementVariables }
 								recommendedReplacementVariables={ recommendedReplacementVariables }
 								className="yst-replacevar--description"
-								isDisabled={ ! opengraph }
+								disabled={ ! opengraph }
 								isDummy={ ! isPremium }
 							/>
 						</FeatureUpsell>
@@ -296,13 +296,16 @@ const PostType = ( { name, label, singularLabel, hasArchive, hasSchemaArticleTyp
 								id={ `input-wpseo_titles-page-analyse-extra-${ name }` }
 								label={ __( "Add custom fields to page analysis", "wordpress-seo" ) }
 								labelSuffix={ isPremium && <Badge className="yst-ml-1.5" size="small" variant="upsell">Premium</Badge> }
-								description={ customFieldsDescription }
+								description={ <>
+									{ customFieldsDescription }
+									<br />
+									<Link id={ `link-custom-fields-page-analysis-${ name }` } href={ customFieldAnalysisLink } target="_blank" rel="noopener">
+										{ __( "Read more about our custom field analysis", "wordpress-seo" ) }
+									</Link>
+									.
+								</> }
 								isDummy={ ! isPremium }
 							/>
-							<Link id={ `link-custom-fields-page-analysis-${ name }` } href={ customFieldAnalysisLink } target="_blank" rel="noopener">
-								{ __( "Read more about our custom field analysis", "wordpress-seo" ) }
-							</Link>
-							.
 						</FeatureUpsell>
 					</FieldsetLayout>
 					{ hasArchive && <>
@@ -406,7 +409,7 @@ const PostType = ( { name, label, singularLabel, hasArchive, hasSchemaArticleTyp
 										label={ __( "Social title", "wordpress-seo" ) }
 										replacementVariables={ replacementVariablesArchives }
 										recommendedReplacementVariables={ recommendedReplacementVariablesArchives }
-										isDisabled={ ! opengraph }
+										disabled={ ! opengraph }
 										isDummy={ ! isPremium }
 									/>
 									<FormikReplacementVariableEditorFieldWithDummy
@@ -417,7 +420,7 @@ const PostType = ( { name, label, singularLabel, hasArchive, hasSchemaArticleTyp
 										replacementVariables={ replacementVariablesArchives }
 										recommendedReplacementVariables={ recommendedReplacementVariablesArchives }
 										className="yst-replacevar--description"
-										isDisabled={ ! opengraph }
+										disabled={ ! opengraph }
 										isDummy={ ! isPremium }
 									/>
 								</FeatureUpsell>

--- a/packages/js/src/settings/routes/templates/taxonomy.js
+++ b/packages/js/src/settings/routes/templates/taxonomy.js
@@ -144,7 +144,7 @@ const Taxonomy = ( { name, label, postTypes: postTypeNames } ) => {
 									__( "Disabling this means that %1$s will not be indexed by search engines and will be excluded from XML sitemaps.", "wordpress-seo" ),
 									labelLower
 								) }
-								<br />
+								&nbsp;
 								<Link href={ noIndexInfoLink } target="_blank" rel="noopener">
 									{ __( "Read more about the search results settings", "wordpress-seo" ) }
 								</Link>

--- a/packages/js/src/settings/routes/templates/taxonomy.js
+++ b/packages/js/src/settings/routes/templates/taxonomy.js
@@ -213,7 +213,7 @@ const Taxonomy = ( { name, label, postTypes: postTypeNames } ) => {
 								label={ __( "Social title", "wordpress-seo" ) }
 								replacementVariables={ replacementVariables }
 								recommendedReplacementVariables={ recommendedReplacementVariables }
-								isDisabled={ ! opengraph }
+								disabled={ ! opengraph }
 								isDummy={ ! isPremium }
 							/>
 							<FormikReplacementVariableEditorFieldWithDummy
@@ -224,7 +224,7 @@ const Taxonomy = ( { name, label, postTypes: postTypeNames } ) => {
 								replacementVariables={ replacementVariables }
 								recommendedReplacementVariables={ recommendedReplacementVariables }
 								className="yst-replacevar--description"
-								isDisabled={ ! opengraph }
+								disabled={ ! opengraph }
 								isDummy={ ! isPremium }
 							/>
 						</FeatureUpsell>

--- a/packages/ui-library/src/components/feature-upsell/index.js
+++ b/packages/ui-library/src/components/feature-upsell/index.js
@@ -21,44 +21,33 @@ const classNameMap = {
  * @param {Object} [cardProps] Any extra card/button props.
  * @returns {JSX.Element} The feature or the upsell around the feature.
  */
-const FeatureUpsell = ( { children, shouldUpsell = true, className = "", variant = "default", cardLink = "", cardText = "", ...cardProps } ) => {
+const FeatureUpsell = ( { children, shouldUpsell = true, className = "", variant = "card", cardLink = "", cardText = "", ...cardProps } ) => {
 	const svgAriaProps = useSvgAria();
 
 	if ( ! shouldUpsell ) {
 		return children;
 	}
 
-	if ( variant === "card" ) {
-		return (
-			<div className={ classNames( "yst-feature-upsell", classNameMap.variant[ variant ], className ) }>
-				<div className="yst-space-y-8 yst-grayscale">
-					{ children }
-				</div>
-				<div
-					className="yst-absolute yst-inset-0 yst-z-10 yst-bg-white yst-bg-opacity-50 yst-ring-1 yst-ring-black yst-ring-opacity-5 yst-shadow-lg yst-rounded-md"
-				/>
-				<div className="yst-absolute yst-inset-0 yst-z-20 yst-flex yst-items-center yst-justify-center">
-					<Button
-						as="a"
-						className="yst-gap-2 yst-shadow-lg yst-shadow-amber-700/30"
-						variant="upsell"
-						href={ cardLink }
-						target="_blank"
-						rel="noopener"
-						{ ...cardProps }
-					>
-						<LockOpenIcon className="yst-w-5 yst-h-5 yst--ml-1 yst-shrink-0" { ...svgAriaProps } />
-						{ cardText }
-					</Button>
-				</div>
-			</div>
-		);
-	}
-
 	return (
 		<div className={ classNames( "yst-feature-upsell", classNameMap.variant[ variant ], className ) }>
-			{ children }
-			<div className="yst-absolute yst-inset-0 yst-bg-white yst-bg-opacity-50 yst-z-10" />
+			<div className="yst-space-y-8 yst-grayscale">
+				{ children }
+			</div>
+			<div className="yst-absolute yst-inset-0 yst-ring-1 yst-ring-black yst-ring-opacity-5 yst-shadow-lg yst-rounded-md" />
+			<div className="yst-absolute yst-inset-0 yst-flex yst-items-center yst-justify-center">
+				<Button
+					as="a"
+					className="yst-gap-2 yst-shadow-lg yst-shadow-amber-700/30"
+					variant="upsell"
+					href={ cardLink }
+					target="_blank"
+					rel="noopener"
+					{ ...cardProps }
+				>
+					<LockOpenIcon className="yst-w-5 yst-h-5 yst--ml-1 yst-shrink-0" { ...svgAriaProps } />
+					{ cardText }
+				</Button>
+			</div>
 		</div>
 	);
 };

--- a/packages/ui-library/src/components/select-field/index.js
+++ b/packages/ui-library/src/components/select-field/index.js
@@ -7,6 +7,7 @@ import { useDescribedBy } from "../../hooks";
  * @param {string} id Identifier.
  * @param {JSX.Element} error Error node.
  * @param {string} [className] Optional CSS class.
+ * @param {boolean} [disabled] Disabled state.
  * @param {string} label Label.
  * @param {JSX.node} [description] Optional description.
  * @param {Object} [props] Any extra props.
@@ -16,6 +17,7 @@ const SelectField = ( {
 	id,
 	label,
 	description,
+	disabled = false,
 	error = null,
 	className = "",
 	...props
@@ -23,7 +25,7 @@ const SelectField = ( {
 	const { ids, describedBy } = useDescribedBy( id, { error, description } );
 
 	return (
-		<div className={ classNames( "yst-select-field", className ) }>
+		<div className={ classNames( "yst-select-field", disabled && "yst-select-field--disabled", className ) }>
 			<Select
 				id={ id }
 				label={ label }
@@ -31,6 +33,7 @@ const SelectField = ( {
 					as: "label",
 					className: "yst-label yst-select-field__label",
 				} }
+				disabled={ disabled }
 				isError={ Boolean( error ) }
 				className="yst-select-field__select"
 				buttonProps={ { "aria-describedby": describedBy } }
@@ -47,6 +50,7 @@ SelectField.propTypes = {
 	name: PropTypes.string.isRequired,
 	label: PropTypes.string.isRequired,
 	description: PropTypes.node,
+	disabled: PropTypes.bool,
 	error: PropTypes.node,
 	className: PropTypes.string,
 };

--- a/packages/ui-library/src/components/select-field/style.css
+++ b/packages/ui-library/src/components/select-field/style.css
@@ -1,5 +1,14 @@
 @layer components {
 	.yst-root {
+		.yst-select-field {}
+
+		.yst-select-field--disabled {
+			.yst-select-field__label,
+			.yst-select-field__description {
+				@apply yst-opacity-50 yst-cursor-not-allowed;
+			}
+		}
+
 		.yst-select-field__options {
 			@apply
 			yst-flex

--- a/packages/ui-library/src/elements/select/index.js
+++ b/packages/ui-library/src/elements/select/index.js
@@ -49,6 +49,7 @@ Option.propTypes = optionPropType;
  * @param {Object} [labelProps] Extra label props.
  * @param {JSX.node} [labelSuffix] Optional label suffix.
  * @param {Function} onChange Change callback.
+ * @param {boolean} [disabled] Disabled state.
  * @param {boolean} [isError] Error message.
  * @param {string} [className] CSS class.
  * @param {Object} [buttonProps] Any extra props for the button.
@@ -65,6 +66,7 @@ const Select = ( {
 	labelProps = {},
 	labelSuffix = null,
 	onChange,
+	disabled = false,
 	isError = false,
 	className = "",
 	buttonProps,
@@ -84,6 +86,7 @@ const Select = ( {
 			onChange={ onChange }
 			className={ classNames(
 				"yst-select",
+				disabled && "yst-select--disabled",
 				isError && "yst-select--error",
 				className,
 			) }
@@ -128,6 +131,7 @@ Select.propTypes = {
 	labelProps: PropTypes.object,
 	labelSuffix: PropTypes.node,
 	onChange: PropTypes.func.isRequired,
+	disabled: PropTypes.bool,
 	isError: PropTypes.bool,
 	className: PropTypes.string,
 	buttonProps: PropTypes.object,

--- a/packages/ui-library/src/elements/select/style.css
+++ b/packages/ui-library/src/elements/select/style.css
@@ -4,6 +4,13 @@
 			@apply yst-max-w-sm yst-relative;
 		}
 
+		.yst-select--disabled {
+			.yst-select__label,
+			.yst-select__button {
+				@apply yst-opacity-50 yst-cursor-not-allowed;
+			}
+		}
+
 		.yst-select--error {
 			.yst-select__button {
 				@apply


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Disable fields instead hiding based on `enable` toggles for archive and media routes.
* Disable fields instead of sections based on Premium state for crawl optimization route.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves the new settings UI by disabling fields instead of completely hiding them or blurring out entire sections.

## Relevant technical choices:

* Adds `disabled` support to `Select` element and `SelectField` component in UI library.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Go to the new settings UI.
* For the `Author archives`, `Date archives`, `Format archives` and `Media pages` routes:
  * Verify that the main `enable` toggle on top of the route now disabled all fields for that route instead of hiding them completely.
  * with Premium disabled, verify that disabling he main `enable` toggle on top of the route does not blur the upsell fields more (because they are already blurred).
* For the `Crawl optimization` route, verify that with Premium disabled only fields are disabled instead of entire sections. Also verify that the `warning` alert ('expert features... etc.') is disabled and the link inside it doesn't work.
<img width="718" alt="image" src="https://user-images.githubusercontent.com/24573520/204268279-c3d18c94-7f75-4442-b472-66ee6a350ece.png">


#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [x] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
