### PR TITLE
Add context parameter to upsell buttons

### DIFF
--- a/packages/js/src/components/modals/MultipleKeywords.js
+++ b/packages/js/src/components/modals/MultipleKeywords.js
@@ -3,7 +3,7 @@ import { makeOutboundLink } from "@yoast/helpers";
 import { __, sprintf } from "@wordpress/i18n";
 import UpsellBox from "../UpsellBox";
 import PropTypes from "prop-types";
-import useRootContext from "../contexts/use-root-context";
+import { useRootContext }  from "@yoast/externals/contexts";
 import { addQueryArgs } from "@wordpress/url";
 
 const PremiumLandingPageLink = makeOutboundLink();
@@ -44,7 +44,7 @@ const MultipleKeywords = ( props ) => {
 	// Interpolate links
 	const interpolated = interpolateComponents( {
 		mixedString: intro,
-		components: { link: <PremiumLandingPageLink href={ addQueryArgs( props.link , { context: locationContext } ) } /> },
+		components: { link: <PremiumLandingPageLink href={ addQueryArgs( props.link, { context: locationContext } ) } /> },
 	} );
 
 	const otherBenefits = sprintf(
@@ -66,7 +66,7 @@ const MultipleKeywords = ( props ) => {
 				)
 			}
 			upsellButton={ {
-				href: addQueryArgs( props.buyLink , { context: locationContext } ),
+				href: addQueryArgs( props.buyLink, { context: locationContext } ),
 				className: "yoast-button-upsell",
 				rel: null,
 				"data-ctb-id": "57d6a568-783c-45e2-a388-847cff155897",

--- a/packages/js/src/components/modals/MultipleKeywords.js
+++ b/packages/js/src/components/modals/MultipleKeywords.js
@@ -3,6 +3,8 @@ import { makeOutboundLink } from "@yoast/helpers";
 import { __, sprintf } from "@wordpress/i18n";
 import UpsellBox from "../UpsellBox";
 import PropTypes from "prop-types";
+import useRootContext from "../contexts/use-root-context";
+import { addQueryArgs } from "@wordpress/url";
 
 const PremiumLandingPageLink = makeOutboundLink();
 
@@ -38,10 +40,11 @@ const MultipleKeywords = ( props ) => {
 		`<strong>${__( "No ads!", "wordpress-seo" )}</strong>`,
 	];
 
+	const { locationContext } = useRootContext();
 	// Interpolate links
 	const interpolated = interpolateComponents( {
 		mixedString: intro,
-		components: { link: <PremiumLandingPageLink href={ props.link } /> },
+		components: { link: <PremiumLandingPageLink href={ addQueryArgs( props.link , { context: locationContext } ) } /> },
 	} );
 
 	const otherBenefits = sprintf(
@@ -49,6 +52,7 @@ const MultipleKeywords = ( props ) => {
 		__( "Other benefits of %s for you:", "wordpress-seo" ),
 		"Yoast SEO Premium"
 	);
+
 
 	return (
 		<UpsellBox
@@ -62,7 +66,7 @@ const MultipleKeywords = ( props ) => {
 				)
 			}
 			upsellButton={ {
-				href: props.buyLink,
+				href: addQueryArgs( props.buyLink , { context: locationContext } ),
 				className: "yoast-button-upsell",
 				rel: null,
 				"data-ctb-id": "57d6a568-783c-45e2-a388-847cff155897",

--- a/packages/js/src/components/modals/PremiumSEOAnalysisUpsell.js
+++ b/packages/js/src/components/modals/PremiumSEOAnalysisUpsell.js
@@ -3,7 +3,7 @@
 import { __, sprintf } from "@wordpress/i18n";
 import UpsellBox from "../UpsellBox";
 import PropTypes from "prop-types";
-import useRootContext from "../contexts/use-root-context";
+import { useRootContext }  from "@yoast/externals/contexts";
 import { addQueryArgs } from "@wordpress/url";
 
 /**

--- a/packages/js/src/components/modals/PremiumSEOAnalysisUpsell.js
+++ b/packages/js/src/components/modals/PremiumSEOAnalysisUpsell.js
@@ -3,6 +3,8 @@
 import { __, sprintf } from "@wordpress/i18n";
 import UpsellBox from "../UpsellBox";
 import PropTypes from "prop-types";
+import useRootContext from "../contexts/use-root-context";
+import { addQueryArgs } from "@wordpress/url";
 
 /**
  * Creates the content for a PremiumSEOAnalysisUpsell modal.
@@ -12,14 +14,16 @@ import PropTypes from "prop-types";
  * @returns {wp.Element} The PremiumSEOAnalysisUpsell component.
  */
 const PremiumSEOAnalysisUpsell = ( props ) => {
-	const intro =  __( "Get extra, smarter recommendations about your site’s structure, content, and SEO opportunities.", "wordpress-seo" );
+	const intro = __( "Get extra, smarter recommendations about your site’s structure, content, and SEO opportunities.", "wordpress-seo" );
 
 	const benefits = [
 		__( "Target multiple focus keyphrases", "wordpress-seo" ),
 		__( "Use synonyms, plurals, and variations", "wordpress-seo" ),
 		__( "Unlock expert workouts and workflows", "wordpress-seo" ),
 	];
-	const buyLink = wpseoAdminL10n[ props.buyLink ];
+
+	const { locationContext } = useRootContext();
+	const buyLink = addQueryArgs( wpseoAdminL10n[ props.buyLink ], { context: locationContext } );
 
 	return (
 		<UpsellBox

--- a/packages/js/src/components/social/SocialUpsell.js
+++ b/packages/js/src/components/social/SocialUpsell.js
@@ -7,7 +7,7 @@ import { __, sprintf } from "@wordpress/i18n";
 import { Alert } from "@yoast/components";
 import { makeOutboundLink } from "@yoast/helpers";
 import { addQueryArgs } from "@wordpress/url";
-import useRootContext from "../contexts/use-root-context";
+import { useRootContext }  from "@yoast/externals/contexts";
 
 const PremiumInfoText = styled( Alert )`
 	p {

--- a/packages/js/src/externals/contexts.js
+++ b/packages/js/src/externals/contexts.js
@@ -1,4 +1,6 @@
 import { LocationConsumer, LocationContext, LocationProvider } from "../components/contexts/location";
+import Root, { RootContext } from "../components/contexts/root";
+import useRootContext from "../components/contexts/use-root-context";
 
 window.yoast = window.yoast || {};
 window.yoast.externals = window.yoast.externals || {};
@@ -6,4 +8,7 @@ window.yoast.externals.contexts = {
 	LocationContext,
 	LocationProvider,
 	LocationConsumer,
+	RootContext,
+	Root,
+	useRootContext,
 };

--- a/packages/js/src/helpers/classicEditor.js
+++ b/packages/js/src/helpers/classicEditor.js
@@ -2,7 +2,7 @@ import { render, Component as wpComponent, createRef } from "@wordpress/element"
 import { SlotFillProvider } from "@wordpress/components";
 import MetaboxPortal from "../components/portals/MetaboxPortal";
 import getL10nObject from "../analysis/getL10nObject";
-import Root from "../components/contexts/root";
+import { Root } from "@yoast/externals/contexts";
 
 const registeredComponents = [];
 let containerRef = null;

--- a/packages/js/src/initializers/block-editor-integration.js
+++ b/packages/js/src/initializers/block-editor-integration.js
@@ -15,6 +15,7 @@ import { registerFormatType } from "@wordpress/rich-text";
 import { get } from "lodash-es";
 import { Slot } from "@wordpress/components";
 import { actions } from "@yoast/externals/redux";
+import { Root } from "@yoast/externals/contexts";
 import initializeWordProofForBlockEditor from "../../../../vendor_prefixed/wordproof/wordpress-sdk/resources/js/initializers/blockEditor";
 
 /* Internal dependencies */
@@ -31,7 +32,6 @@ import WincherPostPublish from "../containers/WincherPostPublish";
 import getL10nObject from "../analysis/getL10nObject";
 import YoastIcon from "../components/PluginIcon";
 import { isWordProofIntegrationActive } from "../helpers/wordproof";
-import Root from "../components/contexts/root";
 
 
 /**

--- a/packages/js/src/initializers/elementor-editor-integration.js
+++ b/packages/js/src/initializers/elementor-editor-integration.js
@@ -7,7 +7,7 @@ import { registerElementorDataHookAfter } from "../helpers/elementorHook";
 import { registerReactComponent, renderReactRoot } from "../helpers/reactRoot";
 import ElementorSlot from "../elementor/components/slots/ElementorSlot";
 import ElementorFill from "../elementor/containers/ElementorFill";
-import Root from "../components/contexts/root";
+import { Root } from "@yoast/externals/contexts";
 
 // Keep track of unsaved SEO setting changes.
 let hasUnsavedSeoChanges = false;

--- a/packages/js/src/insights/components/prominent-words.js
+++ b/packages/js/src/insights/components/prominent-words.js
@@ -6,6 +6,8 @@ import { get } from "lodash";
 import PropTypes from "prop-types";
 import createInterpolateElement from "../../helpers/createInterpolateElement";
 import DataModel from "./data-model";
+import { addQueryArgs } from "@wordpress/url";
+import useRootContext from "../../components/contexts/use-root-context";
 
 const OutboundLink = makeOutboundLink();
 
@@ -64,6 +66,8 @@ const ProminentWords = ( { location } ) => { // eslint-disable-line complexity
 		return null;
 	}
 
+	const { locationContext } = useRootContext();
+
 	return (
 		<div className="yoast-prominent-words">
 			<div className="yoast-field-group__title">
@@ -82,7 +86,7 @@ const ProminentWords = ( { location } ) => { // eslint-disable-line complexity
 				}
 			</p> }
 			{ shouldUpsell && <p>{ upsellDescription }</p> }
-			{ shouldUpsell && <OutboundLink href={ upsellLink } data-action="load-nfd-ctb" data-ctb-id="57d6a568-783c-45e2-a388-847cff155897" className="yoast-button yoast-button-upsell">
+			{ shouldUpsell && <OutboundLink href={ addQueryArgs( upsellLink , { context: locationContext } ) } data-action="load-nfd-ctb" data-ctb-id="57d6a568-783c-45e2-a388-847cff155897" className="yoast-button yoast-button-upsell">
 				{ sprintf(
 					// translators: %s expands to `Premium` (part of add-on name).
 					__( "Unlock with %s", "wordpress-seo" ),

--- a/packages/js/src/insights/components/prominent-words.js
+++ b/packages/js/src/insights/components/prominent-words.js
@@ -7,7 +7,7 @@ import PropTypes from "prop-types";
 import createInterpolateElement from "../../helpers/createInterpolateElement";
 import DataModel from "./data-model";
 import { addQueryArgs } from "@wordpress/url";
-import useRootContext from "../../components/contexts/use-root-context";
+import { useRootContext }  from "@yoast/externals/contexts";
 
 const OutboundLink = makeOutboundLink();
 
@@ -86,7 +86,7 @@ const ProminentWords = ( { location } ) => { // eslint-disable-line complexity
 				}
 			</p> }
 			{ shouldUpsell && <p>{ upsellDescription }</p> }
-			{ shouldUpsell && <OutboundLink href={ addQueryArgs( upsellLink , { context: locationContext } ) } data-action="load-nfd-ctb" data-ctb-id="57d6a568-783c-45e2-a388-847cff155897" className="yoast-button yoast-button-upsell">
+			{ shouldUpsell && <OutboundLink href={ addQueryArgs( upsellLink, { context: locationContext } ) } data-action="load-nfd-ctb" data-ctb-id="57d6a568-783c-45e2-a388-847cff155897" className="yoast-button yoast-button-upsell">
 				{ sprintf(
 					// translators: %s expands to `Premium` (part of add-on name).
 					__( "Unlock with %s", "wordpress-seo" ),


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to add some more parameters to our upsell buttons

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds a context parameter to upsell button links to add more context on where the button lives in the plugin.

## Relevant technical choices:

* Disable premium
* Do the following in the block editor, classic and elementor.
* For the meta box, elementor and the sidebar open the following tabs and and make sure all the buttons and links that lead to a [RTU page](https://yoast.com/rtu-premium-analysis/) and with a context variable. and they start with the editor you are using and then location so for example `elementor-sidebar`
* Also make sure that when you hit a button or link it still sends you to the url attached to the button.
SEO analysis tab
Premium SEO analysis
Add related keyphrase
Readability analysis
Facebook preview
Twitter preview
Insights

_It could be that the links for the social previews go to the yoast.com homepage. These were changed in https://github.com/Yoast/wordpress-seo/pull/19272 and can be not added to the yoa.st shortlinker yet_

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

*

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [X] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
