### PR TITLE
Also enrich the defaults for the built-in taxonomies

### DIFF
--- a/inc/options/class-wpseo-option-titles.php
+++ b/inc/options/class-wpseo-option-titles.php
@@ -331,9 +331,7 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 				$enriched_defaults[ 'social-image-url-tax-' . $tax->name ]   = ''; // Hidden input field.
 				$enriched_defaults[ 'social-image-id-tax-' . $tax->name ]    = 0; // Hidden input field.
 
-				if ( ! $tax->_builtin ) {
-					$enriched_defaults[ 'taxonomy-' . $tax->name . '-ptparent' ] = 0; // Select box;.
-				}
+				$enriched_defaults[ 'taxonomy-' . $tax->name . '-ptparent' ] = 0; // Select box;.
 			}
 		}
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

We support the `taxonomy-{$tax->name}-ptparent` options (breadcrumbs) and save them.
However, for the built-in taxonomies (Category, Post tag and Post format) the default and sanitizing was not done correctly.
This PR makes it so it also returns the defaults and sanitizes them (as integer vs string).
⚠️ Caveat ⚠️ 
This fix needs users, with `"0"` already saved, to save again. Why? It seems trivial enough to not introduce complexity for something that will fix itself after a singular `wpseo_titles` save.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the built-in taxonomies would not be compatible with the Settings UI.

## Relevant technical choices:

* Enrich the built-in taxonomies the same. This result in proper defaults and sanitization. This fixes:
  * The Settings UI retrieves the defaults, the built-in taxonomies were missing from there. So only visible to the default `None`, not actually the default value of `0`.
  * After a save in the old settings the built-in taxonomies (with `None`) are saved as a string (`"0"`) instead of an integer: The Settings UI is precise with the options you can provide, which is the number `0` associated to the visible string `None`.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Have a clean environment, or delete the `wpseo_titles` row from your database.
* Go to Settings UI > Advanced > Breadcrumbs
* Verify that under Breadcrumbs for Taxonomies the `Categories`, `Formats` and `Tags` now have the actual values of `None`.
  * If you open the select, `None` should be highlighted like so:
![image](https://user-images.githubusercontent.com/35524806/204289230-75f6c1db-0a65-4c73-8479-10699bf3bd2e.png)
  * If you change it to something else and then change it back to `None`. The save prompt should NOT be there (presuming you do not have other changes of course).

⚠️ Please see the impact section for the functionality ⚠️ 

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

This also influences the old settings! So let's check the functionality too.
For context about the breadcrumbs:  https://yoast.com/help/implement-wordpress-seo-breadcrumbs/#h-what-do-the-yoast-seo-breadcrumbs-do

### Before you check
* Have a clean environment, or delete the `wpseo_titles` row from your database.
* Save the Search appearance settings. Note: this will save the `0` instead of the `"0"` for the built-in taxonomies. E.g. the difference of this PR.

### Check each way of adding breadcrumbs at least once
1. ~~Yoast block in block editor~~ Unless you enable the block editor for categories??
2. Shortcode `[wpseo_breadcrumb]` 
3. Theme file editor  
```
if ( function_exists('yoast_breadcrumb') ) {
  yoast_breadcrumb( '<p id="breadcrumbs">','</p>' );
}
```
4. Block in FSE theme 
5. Widget in non-FSE theme

### Check several taxonomies
* At least a built-in one: Categories, tags or formats.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes https://yoast.atlassian.net/browse/DUPP-695
