### PR TITLE
Settings UI: allow using arrow up down to navigate through search results with keyboard command palette

### DIFF
--- a/css/src/new-settings.css
+++ b/css/src/new-settings.css
@@ -70,12 +70,20 @@
 			z-index: 99999;
 		}
 
+		.yst-modal.yst-modal--top {
+			@apply yst-p-4 sm:yst-p-6 md:yst-p-20;
+
+			.yst-modal__center {
+				@apply yst-hidden;
+			}
+		}
+
 		.yst-replacevar {
 			@apply yst-relative;
 
 			/* This needs additional nesting, specificity wise. */
 			.emoji-select-popover {
-				@apply yst-z-20 yst-right-auto yst-left-0;	
+				@apply yst-z-20 yst-right-auto yst-left-0;
 			}
 		}
 
@@ -92,7 +100,7 @@
 			.emoji-select-button {
 				@apply yst-cursor-not-allowed;
 			}
-			
+
 			.emoji-select-button {
 				@apply yst-pointer-events-none;
 			}

--- a/packages/js/src/settings/components/search.js
+++ b/packages/js/src/settings/components/search.js
@@ -129,6 +129,7 @@ const Search = () => {
 			) }
 		</button>
 		<Modal
+			className="yst-modal--top"
 			onClose={ setClose }
 			isOpen={ isOpen }
 			initialFocus={ inputRef }
@@ -151,7 +152,7 @@ const Search = () => {
 				{ query.length >= QUERY_MIN_CHARS && ! isEmpty( results ) && (
 					<Combobox.Options
 						static={ true }
-						className="yst-max-h-80 yst-scroll-pt-11 yst-scroll-pb-2 yst-space-y-2 yst-overflow-y-auto yst-pb-2"
+						className="yst-max-h-[calc(90vh-10rem)] yst-scroll-pt-11 yst-scroll-pb-2 yst-space-y-2 yst-overflow-y-auto yst-pb-2"
 					>
 						{ map( results, ( groupedItems, index ) => (
 							<li key={ groupedItems?.[ 0 ]?.route || `group-${ index }` }>

--- a/packages/js/src/settings/components/search.js
+++ b/packages/js/src/settings/components/search.js
@@ -4,6 +4,7 @@ import { SearchIcon } from "@heroicons/react/outline";
 import { useCallback, useRef, useState } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
 import { Modal, Title, useSvgAria, useToggleState } from "@yoast/ui-library";
+import classNames from "classnames";
 import { debounce, first, groupBy, includes, isEmpty, map, max, reduce, split, trim, values } from "lodash";
 import PropTypes from "prop-types";
 import { useHotkeys } from "react-hotkeys-hook";
@@ -111,6 +112,11 @@ const Search = () => {
 		debouncedSearch( event.target.value );
 	}, [ setQuery, debouncedSearch ] );
 
+	const handleOptionActiveState = useCallback( ( { active } ) => classNames(
+		"yst-group yst-block yst-no-underline yst-text-sm yst-text-slate-800 yst-select-none yst-py-3 yst-px-4 hover:yst-bg-primary-600 hover:yst-text-white focus:yst-bg-primary-600 focus:yst-text-white",
+		active && "yst-text-white yst-bg-primary-600"
+	), [] );
+
 	return <>
 		<button
 			type="button"
@@ -162,7 +168,7 @@ const Search = () => {
 										<Combobox.Option
 											key={ name }
 											value={ item }
-											className="yst-group yst-block yst-no-underline yst-text-sm yst-text-slate-800 yst-select-none yst-py-3 yst-px-4 hover:yst-bg-primary-600 hover:yst-text-white focus:yst-bg-primary-600 focus:yst-text-white"
+											className={ handleOptionActiveState }
 										>
 											{ item.fieldLabel }
 										</Combobox.Option>
@@ -188,3 +194,4 @@ const Search = () => {
 };
 
 export default Search;
+

--- a/packages/js/src/settings/components/search.js
+++ b/packages/js/src/settings/components/search.js
@@ -1,19 +1,20 @@
 /* eslint-disable complexity */
+import { Combobox } from "@headlessui/react";
 import { SearchIcon } from "@heroicons/react/outline";
-import PropTypes from "prop-types";
 import { useCallback, useRef, useState } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
-import { Modal, useSvgAria, useToggleState, TextInput, Title } from "@yoast/ui-library";
-import { debounce, max, first, isEmpty, map, reduce, trim, includes, split, values, groupBy } from "lodash";
-import { Link } from "react-router-dom";
+import { Modal, Title, useSvgAria, useToggleState } from "@yoast/ui-library";
+import { debounce, first, groupBy, includes, isEmpty, map, max, reduce, split, trim, values } from "lodash";
+import PropTypes from "prop-types";
 import { useHotkeys } from "react-hotkeys-hook";
-import { useSelectSettings, useParsedUserAgent } from "../hooks";
+import { useNavigate } from "react-router-dom";
+import { useParsedUserAgent, useSelectSettings } from "../hooks";
 
 const QUERY_MIN_CHARS = 3;
 
 /**
- * @param {string} props.title The title.
- * @param {JSX.node} props.children The children nodes.
+ * @param {string} title The title.
+ * @param {JSX.node} children The children nodes.
  * @returns {JSX.Element} The SearchNoResultsContent component.
  */
 const SearchNoResultsContent = ( { title, children } ) => (
@@ -38,6 +39,7 @@ const Search = () => {
 	const queryableSearchIndex = useSelectSettings( "selectQueryableSearchIndex" );
 	const [ results, setResults ] = useState( [] );
 	const ariaSvgProps = useSvgAria();
+	const navigate = useNavigate();
 	const inputRef = useRef( null );
 	const { platform, os } = useParsedUserAgent();
 
@@ -49,10 +51,11 @@ const Search = () => {
 		}
 	}, [ isOpen, setOpen ] );
 
-	const handleNavigate = useCallback( () => {
+	const handleNavigate = useCallback( ( { route, fieldId } ) => {
 		setClose();
 		setQuery( "" );
 		setResults( [] );
+		navigate( `${ route }#${ fieldId }` );
 	}, [ setClose, setQuery ] );
 
 	const debouncedSearch = useCallback( debounce( newQuery => {
@@ -130,13 +133,13 @@ const Search = () => {
 			isOpen={ isOpen }
 			initialFocus={ inputRef }
 		>
-			<div className="yst--m-6 yst--mt-5">
+			<Combobox as="div" className="yst--m-6 yst--mt-5" onChange={ handleNavigate }>
 				<div className="yst-relative">
 					<SearchIcon
 						className="yst-pointer-events-none yst-absolute yst-top-3.5 yst-left-4 yst-h-5 yst-w-5 yst-text-slate-400"
 						{ ...ariaSvgProps }
 					/>
-					<TextInput
+					<Combobox.Input
 						ref={ inputRef }
 						id="input-search"
 						placeholder={ __( "Search...", "wordpress-seo" ) }
@@ -146,26 +149,27 @@ const Search = () => {
 					/>
 				</div>
 				{ query.length >= QUERY_MIN_CHARS && ! isEmpty( results ) && (
-					<ul className="yst-max-h-80 yst-scroll-pt-11 yst-scroll-pb-2 yst-overflow-y-auto yst-pb-2">
+					<Combobox.Options
+						static={ true }
+						className="yst-max-h-80 yst-scroll-pt-11 yst-scroll-pb-2 yst-space-y-2 yst-overflow-y-auto yst-pb-2"
+					>
 						{ map( results, ( groupedItems, index ) => (
 							<li key={ groupedItems?.[ 0 ]?.route || `group-${ index }` }>
 								<Title as="h4" size="3" className="yst-bg-slate-100 yst-py-3 yst-px-4">{ first( groupedItems ).routeLabel }</Title>
 								<ul>
 									{ map( groupedItems, ( item, name ) => (
-										<li key={ name }>
-											<Link
-												to={ `${ item.route }#${ item.fieldId }` }
-												onClick={ handleNavigate }
-												className="yst-group yst-block yst-no-underline yst-text-sm yst-text-slate-800 yst-select-none yst-py-3 yst-px-4 hover:yst-bg-primary-600 hover:yst-text-white focus:yst-bg-primary-600 focus:yst-text-white"
-											>
-												{ item.fieldLabel }
-											</Link>
-										</li>
+										<Combobox.Option
+											key={ name }
+											value={ item }
+											className="yst-group yst-block yst-no-underline yst-text-sm yst-text-slate-800 yst-select-none yst-py-3 yst-px-4 hover:yst-bg-primary-600 hover:yst-text-white focus:yst-bg-primary-600 focus:yst-text-white"
+										>
+											{ item.fieldLabel }
+										</Combobox.Option>
 									) ) }
 								</ul>
 							</li>
 						) ) }
-					</ul>
+					</Combobox.Options>
 				) }
 				{ query.length < QUERY_MIN_CHARS && (
 					<SearchNoResultsContent title={ __( "Search", "wordpress-seo" ) }>
@@ -177,7 +181,7 @@ const Search = () => {
 						<p className="yst-text-slate-500">{ __( "We couldn’t find anything with that term.", "wordpress-seo" ) }</p>
 					</SearchNoResultsContent>
 				) }
-			</div>
+			</Combobox>
 		</Modal>
 	</>;
 };

--- a/packages/js/tests/settings/__snapshots__/search.test.js.snap
+++ b/packages/js/tests/settings/__snapshots__/search.test.js.snap
@@ -8,18 +8,18 @@ exports[`Search test should match search snapshot 1`] = `
       Quick search...
     </span>
   </button>
-  <Modal onClose={[Function (anonymous)]} isOpen={false} initialFocus={{...}} hasCloseButton={true} closeButtonScreenReaderText=\\"Close\\" className=\\"\\">
-    <div className=\\"yst--m-6 yst--mt-5\\">
+  <Modal className=\\"yst-modal--top\\" onClose={[Function (anonymous)]} isOpen={false} initialFocus={{...}} hasCloseButton={true} closeButtonScreenReaderText=\\"Close\\">
+    <ComboboxFn as=\\"div\\" className=\\"yst--m-6 yst--mt-5\\" onChange={[Function (anonymous)]}>
       <div className=\\"yst-relative\\">
         <ForwardRef(SearchIcon) className=\\"yst-pointer-events-none yst-absolute yst-top-3.5 yst-left-4 yst-h-5 yst-w-5 yst-text-slate-400\\" role=\\"img\\" aria-hidden=\\"true\\" />
-        <ForwardRef id=\\"input-search\\" placeholder=\\"Search...\\" value=\\"\\" onChange={[Function (anonymous)]} className=\\"yst-h-12 yst-w-full yst-border-0 yst-bg-transparent yst-px-11 yst-text-slate-800 yst-placeholder-slate-400 focus:yst-ring-0 sm:yst-text-sm\\" />
+        <Input2 id=\\"input-search\\" placeholder=\\"Search...\\" value=\\"\\" onChange={[Function (anonymous)]} className=\\"yst-h-12 yst-w-full yst-border-0 yst-bg-transparent yst-px-11 yst-text-slate-800 yst-placeholder-slate-400 focus:yst-ring-0 sm:yst-text-sm\\" />
       </div>
       <SearchNoResultsContent title=\\"Search\\">
         <p className=\\"yst-text-slate-500\\">
           Please enter a search term with at least 3 characters.
         </p>
       </SearchNoResultsContent>
-    </div>
+    </ComboboxFn>
   </Modal>
 </Fragment>"
 `;

--- a/packages/js/tests/settings/search.test.js
+++ b/packages/js/tests/settings/search.test.js
@@ -1,6 +1,8 @@
 import Search from "../../src/settings/components/search";
 import { shallow } from "enzyme";
 
+jest.mock( "react-router-dom" );
+
 describe( "Search test", () => {
 	let wrapper;
 	beforeEach( () => {

--- a/packages/ui-library/src/components/modal/style.css
+++ b/packages/ui-library/src/components/modal/style.css
@@ -5,7 +5,7 @@
 		}
 
 		.yst-modal__body {
-			@apply yst-min-h-screen yst-px-4 yst-text-center;
+			@apply yst-min-h-screen yst-text-center;
 		}
 
 		.yst-modal__overlay {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Refactors the Search modal in the Settings UI. Uses the Headless UI combobox and sticks it to the top to prevent jumping around depending on how many search results there are.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Go to Settings UI > Search
* Type something with a longer list like `open g` for `open graph`
* Verify you can now use the up & down arrows
* Verify the top of the search modal stays at the same spot

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [x] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes https://yoast.atlassian.net/browse/DUPP-775
Fixes https://yoast.atlassian.net/browse/DUPP-805