### PR TITLE
Implement toggle deps for author archives and crawl optimization

### DIFF
--- a/packages/js/src/settings/routes/author-archives.js
+++ b/packages/js/src/settings/routes/author-archives.js
@@ -75,7 +75,11 @@ const AuthorArchives = () => {
 
 	const { values } = useFormikContext();
 	const { opengraph } = values.wpseo_social;
-	const { "disable-author": isAuthorArchivesDisabled, "noindex-author-wpseo": isAuthorNoIndex } = values.wpseo_titles;
+	const {
+		"disable-author": isAuthorArchivesDisabled,
+		"noindex-author-wpseo": isAuthorNoIndex,
+		"noindex-author-noposts-wpseo": isAuthorNoIndexNoPosts,
+	} = values.wpseo_titles;
 
 	return (
 		<RouteLayout
@@ -144,6 +148,7 @@ const AuthorArchives = () => {
 								__( "Disabling this means that %1$s without any posts will not be indexed by search engines and will be excluded from XML sitemaps.", "wordpress-seo" ),
 								labelLower
 							) }
+							checked={ ! isAuthorNoIndex && ! isAuthorNoIndexNoPosts }
 							disabled={ isAuthorArchivesDisabled || isAuthorNoIndex }
 							className="yst-max-w-sm"
 						/>

--- a/packages/js/src/settings/routes/breadcrumbs.js
+++ b/packages/js/src/settings/routes/breadcrumbs.js
@@ -1,5 +1,5 @@
 import { __, sprintf } from "@wordpress/i18n";
-import { SelectField, TextField, ToggleField } from "@yoast/ui-library";
+import { SelectField, TextField, ToggleField, Code } from "@yoast/ui-library";
 import { Field } from "formik";
 import { map } from "lodash";
 import { addLinkToString } from "../../helpers/stringHelpers";
@@ -103,7 +103,7 @@ const Breadcrumbs = () => {
 					</FieldsetLayout>
 					<hr className="yst-my-8" />
 					<FieldsetLayout
-						title={ __( "Breadcrumbs for Post types", "wordpress-seo" ) }
+						title={ __( "Breadcrumbs for post types", "wordpress-seo" ) }
 						description={ __( "Choose which Taxonomy you wish to show in the breadcrumbs for Post types.", "wordpress-seo" ) }
 					>
 						{ map( breadcrumbsForPostTypes, ( postTypes, postTypeName ) => <FormikValueChangeField
@@ -117,7 +117,7 @@ const Breadcrumbs = () => {
 					</FieldsetLayout>
 					<hr className="yst-my-8" />
 					<FieldsetLayout
-						title={ __( "Breadcrumbs for Taxonomies", "wordpress-seo" ) }
+						title={ __( "Breadcrumbs for taxonomies", "wordpress-seo" ) }
 						description={ __( "Choose which Post type you wish to show in the breadcrumbs for Taxonomies.", "wordpress-seo" ) }
 					>
 						{ map( breadcrumbsForTaxonomies, ( { name, label, options } ) => (
@@ -126,7 +126,11 @@ const Breadcrumbs = () => {
 								as={ SelectField }
 								name={ `wpseo_titles.taxonomy-${ name }-ptparent` }
 								data-id={ `input-wpseo_titles-taxonomy-${ name }-ptparent` }
-								label={ label }
+								label={ <>
+									{ label }
+									&nbsp;
+									(<Code>{ name }</Code>)
+								</> }
 								options={ options }
 							/>
 						) ) }

--- a/packages/js/src/settings/routes/crawl-optimization.js
+++ b/packages/js/src/settings/routes/crawl-optimization.js
@@ -253,6 +253,8 @@ const CrawlOptimization = () => {
 		remove_feed_global_comments: removeFeedGlobalComments,
 		remove_feed_post_comments: removeFeedPostComments,
 		search_cleanup: searchCleanup,
+		search_cleanup_emoji: searchCleanupEmoji,
+		search_cleanup_patterns: searchCleanupPatterns,
 		clean_permalinks: cleanPermalinks,
 	} = values.wpseo;
 
@@ -580,6 +582,7 @@ const CrawlOptimization = () => {
 							label={ __( "Filter searches with emojis and other special characters", "wordpress-seo" ) }
 							description={ __( "Block internal site searches which contain complex and non-alphanumeric characters, as they may be part of a spam attack.", "wordpress-seo" ) }
 							disabled={ ! searchCleanup }
+							checked={ searchCleanup && searchCleanupEmoji }
 							isDummy={ ! isPremium }
 							className="yst-max-w-2xl"
 						/>
@@ -591,6 +594,7 @@ const CrawlOptimization = () => {
 							label={ __( "Filter searches with common spam patterns", "wordpress-seo" ) }
 							description={ __( "Block internal site searches which match the patterns of known spam attacks.", "wordpress-seo" ) }
 							disabled={ ! searchCleanup }
+							checked={ searchCleanup && searchCleanupPatterns }
 							isDummy={ ! isPremium }
 							className="yst-max-w-2xl"
 						/>

--- a/packages/ui-library/src/elements/code/style.css
+++ b/packages/ui-library/src/elements/code/style.css
@@ -4,6 +4,7 @@
 			@apply
 			yst-inline-block
 			yst-text-xs
+			yst-leading-tight
 			yst-text-slate-900
 			yst-bg-slate-200
 			yst-p-1

--- a/packages/ui-library/src/elements/label/style.css
+++ b/packages/ui-library/src/elements/label/style.css
@@ -2,7 +2,6 @@
 	.yst-root {
 		.yst-label {
 			@apply
-			yst-flex
 			yst-text-sm
 			yst-font-medium
 			yst-text-slate-800;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Improve toggle dependencies when overarching toggle is set to disabled.
* Adds taxonomy `name` to taxonomy breadcrumb selects on `Breadcrumbs` route.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improve toggle dependencies when overarching toggle is set to disabled.
* Adds taxonomy `name` to taxonomy breadcrumb selects on `Breadcrumbs` route.

## Relevant technical choices:

* Flipped toggles need negating when setting the `checked` prop manually.
* Improve the line-height of `Code` element a bit.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* On the `Crawl optimization` route:
  * Verify that when the `Filter search terms` is toggled ON, you are able to change the `Filter searches with emojis and other special characters` and `Filter searches with common spam patterns` toggles freely and its state is persisted after save and refresh.
  * Verify that when the `Filter search terms` is toggled OFF, you are unable to change the `Filter searches with emojis and other special characters` and `Filter searches with common spam patterns` toggles and both toggles are automatically checked OFF (even if they were toggled ON before) and its state is persisted after save and refresh.

* On the `Author archives` route:
  * Verify that when the `Show author archives in search results` is toggled ON, you are able to change the `Show author archives without posts in search results` toggle freely and its state is persisted after save and refresh.
  * Verify that when the `Show author archives in search results` is toggled OFF, you are unable to change the `Show author archives without posts in search results` toggle both it is automatically checked OFF (even if it was toggled ON before) and its state is persisted after save and refresh.

* On the `Breadcrumbs` route:
  * Verify that the selects in the `Breadcrumbs for taxonomies` section now contain the taxonomy `name` in a code block next to the label.
<img width="441" alt="image" src="https://user-images.githubusercontent.com/24573520/204337601-b4ed75f0-d4ec-457f-8658-769cf7e1e65e.png">


#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [x] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
