### PR TITLE
Dupp 806 improve search index

### DIFF
--- a/packages/js/src/settings/components/search.js
+++ b/packages/js/src/settings/components/search.js
@@ -110,6 +110,7 @@ const Search = () => {
 
 	return <>
 		<button
+			type="button"
 			className="yst-w-full yst-flex yst-items-center yst-bg-white yst-text-sm yst-leading-6 yst-text-slate-500 yst-rounded-md yst-border yst-border-slate-300 yst-shadow-sm yst-py-1.5 yst-pl-2 yst-pr-3 focus:yst-outline-none focus:yst-ring-2 focus:yst-ring-offset-2 focus:yst-ring-primary-500"
 			onClick={ setOpen }
 		>
@@ -117,7 +118,7 @@ const Search = () => {
 				className="yst-flex-none yst-w-5 yst-h-5 yst-mr-3 yst-text-slate-400"
 				{ ...ariaSvgProps }
 			/>
-			<span>{ query || __( "Quick search...", "wordpress-seo" ) }</span>
+			<span className="yst-overflow-hidden yst-whitespace-nowrap yst-text-ellipsis">{ query || __( "Quick search...", "wordpress-seo" ) }</span>
 			{ platform?.type === "desktop" && (
 				<span className="yst-ml-auto yst-flex-none yst-text-xs yst-font-semibold yst-text-slate-400">
 					{ os?.name === "macOS" ? __( "⌘K", "wordpress-seo" ) : __( "CtrlK", "wordpress-seo" ) }

--- a/packages/js/src/settings/components/search.js
+++ b/packages/js/src/settings/components/search.js
@@ -156,7 +156,7 @@ const Search = () => {
 											<Link
 												to={ `${ item.route }#${ item.fieldId }` }
 												onClick={ handleNavigate }
-												className="yst-block yst-no-underline yst-text-sm yst-text-slate-800 yst-select-none yst-py-3 yst-px-4 hover:yst-bg-primary-600 hover:yst-text-white focus:yst-bg-primary-600 focus:yst-text-white"
+												className="yst-group yst-block yst-no-underline yst-text-sm yst-text-slate-800 yst-select-none yst-py-3 yst-px-4 hover:yst-bg-primary-600 hover:yst-text-white focus:yst-bg-primary-600 focus:yst-text-white"
 											>
 												{ item.fieldLabel }
 											</Link>

--- a/packages/js/src/settings/helpers/search.js
+++ b/packages/js/src/settings/helpers/search.js
@@ -604,7 +604,7 @@ export const createSearchIndex = ( postTypes, taxonomies ) => ( {
 			route: "/site-representation",
 			routeLabel: __( "Site representation", "wordpress-seo" ),
 			fieldId: "input-wpseo_titles-company_or_person-company",
-			fieldLabel: __( "Organization or a person", "wordpress-seo" ),
+			fieldLabel: __( "Organization/person", "wordpress-seo" ),
 			keywords: [],
 		},
 		company_name: {
@@ -1085,13 +1085,6 @@ export const createSearchIndex = ( postTypes, taxonomies ) => ( {
 			],
 		},
 		og_default_image_id: {
-			route: "/site-basics",
-			routeLabel: __( "Site basics", "wordpress-seo" ),
-			fieldId: "button-wpseo_social-og_default_image-preview",
-			fieldLabel: __( "Site image", "wordpress-seo" ),
-			keywords: [],
-		},
-		og_default_image: {
 			route: "/site-basics",
 			routeLabel: __( "Site basics", "wordpress-seo" ),
 			fieldId: "button-wpseo_social-og_default_image-preview",

--- a/packages/js/src/settings/helpers/search.js
+++ b/packages/js/src/settings/helpers/search.js
@@ -886,16 +886,16 @@ export const createSearchIndex = ( postTypes, taxonomies ) => ( {
 		// Special pages
 		"title-search-wpseo": {
 			route: "/special-pages",
-			routeLabel: __( "Search pages", "wordpress-seo" ),
+			routeLabel: __( "Special pages", "wordpress-seo" ),
 			fieldId: "input-wpseo_titles-title-search-wpseo",
-			fieldLabel: __( "SEO title", "wordpress-seo" ),
+			fieldLabel: __( "Search pages title", "wordpress-seo" ),
 			keywords: [],
 		},
 		"title-404-wpseo": {
 			route: "/special-pages",
-			routeLabel: __( "404 pages", "wordpress-seo" ),
+			routeLabel: __( "Special pages", "wordpress-seo" ),
 			fieldId: "input-wpseo_titles-title-404-wpseo",
-			fieldLabel: __( "SEO title", "wordpress-seo" ),
+			fieldLabel: __( "404 pages title", "wordpress-seo" ),
 			keywords: [],
 		},
 		// Media pages

--- a/packages/js/src/settings/helpers/search.js
+++ b/packages/js/src/settings/helpers/search.js
@@ -1,6 +1,8 @@
 /* eslint-disable camelcase */
 import { __, sprintf } from "@wordpress/i18n";
-import { omit, reduce, times } from "lodash";
+import { Code } from "@yoast/ui-library";
+import { createInterpolateElement } from "@wordpress/element";
+import { omit, reduce, times, toLower, filter, includes, isEmpty } from "lodash";
 
 /**
  * @param {Object} postType The post type.
@@ -28,7 +30,7 @@ export const createPostTypeSearchIndex = ( { name, label, route, hasArchive } ) 
 		fieldLabel: sprintf(
 			// translators: %1$s expands to the post type plural, e.g. Posts.
 			__( "Show %1$s in search results", "wordpress-seo" ),
-			label
+			toLower( label )
 		),
 		keywords: [],
 	},
@@ -42,7 +44,7 @@ export const createPostTypeSearchIndex = ( { name, label, route, hasArchive } ) 
 	[ `schema-page-type-${ name }` ]: {
 		route: `/post-type/${ route }`,
 		routeLabel: label,
-		fieldId: `input-wpseo_titles-schema-page-type-${ name }`,
+		fieldId: `input-wpseo_titles-schema-page-type-${ name }-button`,
 		fieldLabel: __( "Page type", "wordpress-seo" ),
 		keywords: [
 			__( "Schema", "wordpress-seo" ),
@@ -52,12 +54,19 @@ export const createPostTypeSearchIndex = ( { name, label, route, hasArchive } ) 
 	[ `schema-article-type-${ name }` ]: {
 		route: `/post-type/${ route }`,
 		routeLabel: label,
-		fieldId: `input-wpseo_titles-schema-article-type-${ name }`,
+		fieldId: `input-wpseo_titles-schema-article-type-${ name }-button`,
 		fieldLabel: __( "Article type", "wordpress-seo" ),
 		keywords: [
 			__( "Schema", "wordpress-seo" ),
 			__( "Structured data", "wordpress-seo" ),
 		],
+	},
+	[ `page-analyse-extra-${ name }` ]: {
+		route: `/post-type/${ route }`,
+		routeLabel: label,
+		fieldId: `input-wpseo_titles-page-analyse-extra-${ name }`,
+		fieldLabel: __( "Add custom fields to page analysis", "wordpress-seo" ),
+		keywords: [],
 	},
 	...( name !== "attachment" && {
 		[ `social-title-${ name }` ]: {
@@ -111,7 +120,7 @@ export const createPostTypeSearchIndex = ( { name, label, route, hasArchive } ) 
 			fieldLabel: sprintf(
 				// translators: %1$s expands to the post type plural, e.g. Posts.
 				__( "Show the archive for %1$s in search results", "wordpress-seo" ),
-				label
+				toLower( label )
 			),
 			keywords: [],
 		},
@@ -166,7 +175,7 @@ export const createTaxonomySearchIndex = ( { name, label, route } ) => ( {
 			/* translators: %1$s expands to "Yoast SEO". %2$s expands to the taxonomy plural, e.g. Categories. */
 			__( "Enable %1$s for %2$s", "wordpress-seo" ),
 			"Yoast SEO",
-			label
+			toLower( label )
 		),
 		keywords: [],
 	},
@@ -184,7 +193,7 @@ export const createTaxonomySearchIndex = ( { name, label, route } ) => ( {
 		fieldLabel: sprintf(
 			// translators: %1$s expands to the taxonomy plural, e.g. Categories.
 			__( "Show %1$s in search results", "wordpress-seo" ),
-			label
+			toLower( label )
 		),
 		keywords: [],
 	},
@@ -209,6 +218,15 @@ export const createTaxonomySearchIndex = ( { name, label, route } ) => ( {
 		fieldLabel: __( "Social image", "wordpress-seo" ),
 		keywords: [],
 	},
+	...( name === "category" && {
+		stripcategorybase: {
+			route: `/taxonomy/${ route }`,
+			routeLabel: label,
+			fieldId: "input-wpseo_titles-stripcategorybase",
+			fieldLabel: __( "Show the categories prefix in the slug", "wordpress-seo" ),
+			keywords: [],
+		},
+	} ),
 } );
 
 /**
@@ -312,15 +330,15 @@ export const createSearchIndex = ( postTypes, taxonomies ) => ( {
 			keywords: [],
 		},
 		disableadvanced_meta: {
-			route: "/site-features",
-			routeLabel: __( "Site features", "wordpress-seo" ),
+			route: "/site-basics",
+			routeLabel: __( "Site basics", "wordpress-seo" ),
 			fieldId: "input-wpseo-disableadvanced_meta",
 			fieldLabel: __( "Restrict advanced settings for authors", "wordpress-seo" ),
 			keywords: [],
 		},
 		tracking: {
-			route: "/site-features",
-			routeLabel: __( "Site features", "wordpress-seo" ),
+			route: "/site-basics",
+			routeLabel: __( "Site basics", "wordpress-seo" ),
 			fieldId: "input-wpseo-tracking",
 			fieldLabel: __( "Usage tracking", "wordpress-seo" ),
 			keywords: [],
@@ -365,35 +383,35 @@ export const createSearchIndex = ( postTypes, taxonomies ) => ( {
 			route: "/crawl-optimization",
 			routeLabel: __( "Crawl optimization", "wordpress-seo" ),
 			fieldId: "input-wpseo-remove_shortlinks",
-			fieldLabel: __( "Shortlinks", "wordpress-seo" ),
+			fieldLabel: __( "Remove shortlinks", "wordpress-seo" ),
 			keywords: [],
 		},
 		remove_rest_api_links: {
 			route: "/crawl-optimization",
 			routeLabel: __( "Crawl optimization", "wordpress-seo" ),
 			fieldId: "input-wpseo-remove_rest_api_links",
-			fieldLabel: __( "REST API links", "wordpress-seo" ),
+			fieldLabel: __( "Remove REST API links", "wordpress-seo" ),
 			keywords: [],
 		},
 		remove_rsd_wlw_links: {
 			route: "/crawl-optimization",
 			routeLabel: __( "Crawl optimization", "wordpress-seo" ),
 			fieldId: "input-wpseo-remove_rsd_wlw_links",
-			fieldLabel: __( "RSD / WLW links", "wordpress-seo" ),
+			fieldLabel: __( "Remove RSD / WLW links", "wordpress-seo" ),
 			keywords: [],
 		},
 		remove_oembed_links: {
 			route: "/crawl-optimization",
 			routeLabel: __( "Crawl optimization", "wordpress-seo" ),
 			fieldId: "input-wpseo-remove_oembed_links",
-			fieldLabel: __( "oEmbed links", "wordpress-seo" ),
+			fieldLabel: __( "Remove oEmbed links", "wordpress-seo" ),
 			keywords: [],
 		},
 		remove_generator: {
 			route: "/crawl-optimization",
 			routeLabel: __( "Crawl optimization", "wordpress-seo" ),
 			fieldId: "input-wpseo-remove_generator",
-			fieldLabel: __( "Generator tag", "wordpress-seo" ),
+			fieldLabel: __( "Remove generator tag", "wordpress-seo" ),
 			keywords: [],
 		},
 		remove_pingback_header: {
@@ -407,91 +425,91 @@ export const createSearchIndex = ( postTypes, taxonomies ) => ( {
 			route: "/crawl-optimization",
 			routeLabel: __( "Crawl optimization", "wordpress-seo" ),
 			fieldId: "input-wpseo-remove_powered_by_header",
-			fieldLabel: __( "Powered by HTTP header", "wordpress-seo" ),
+			fieldLabel: __( "Remove powered by HTTP header", "wordpress-seo" ),
 			keywords: [],
 		},
 		remove_feed_global: {
 			route: "/crawl-optimization",
 			routeLabel: __( "Crawl optimization", "wordpress-seo" ),
 			fieldId: "input-wpseo-remove_feed_global",
-			fieldLabel: __( "Global feed", "wordpress-seo" ),
+			fieldLabel: __( "Remove global feed", "wordpress-seo" ),
 			keywords: [],
 		},
 		remove_feed_global_comments: {
 			route: "/crawl-optimization",
 			routeLabel: __( "Crawl optimization", "wordpress-seo" ),
 			fieldId: "input-wpseo-remove_feed_global_comments",
-			fieldLabel: __( "Global comment feeds", "wordpress-seo" ),
+			fieldLabel: __( "Remove global comment feeds", "wordpress-seo" ),
 			keywords: [],
 		},
 		remove_feed_post_comments: {
 			route: "/crawl-optimization",
 			routeLabel: __( "Crawl optimization", "wordpress-seo" ),
 			fieldId: "input-wpseo-remove_feed_post_comments",
-			fieldLabel: __( "Post comments feeds", "wordpress-seo" ),
+			fieldLabel: __( "Remove post comments feeds", "wordpress-seo" ),
 			keywords: [],
 		},
 		remove_feed_authors: {
 			route: "/crawl-optimization",
 			routeLabel: __( "Crawl optimization", "wordpress-seo" ),
 			fieldId: "input-wpseo-remove_feed_authors",
-			fieldLabel: __( "Post authors feeds", "wordpress-seo" ),
+			fieldLabel: __( "Remove post authors feeds", "wordpress-seo" ),
 			keywords: [],
 		},
 		remove_feed_post_types: {
 			route: "/crawl-optimization",
 			routeLabel: __( "Crawl optimization", "wordpress-seo" ),
 			fieldId: "input-wpseo-remove_feed_post_types",
-			fieldLabel: __( "Post type feeds", "wordpress-seo" ),
+			fieldLabel: __( "Remove post type feeds", "wordpress-seo" ),
 			keywords: [],
 		},
 		remove_feed_categories: {
 			route: "/crawl-optimization",
 			routeLabel: __( "Crawl optimization", "wordpress-seo" ),
 			fieldId: "input-wpseo-remove_feed_categories",
-			fieldLabel: __( "Category feeds", "wordpress-seo" ),
+			fieldLabel: __( "Remove category feeds", "wordpress-seo" ),
 			keywords: [],
 		},
 		remove_feed_tags: {
 			route: "/crawl-optimization",
 			routeLabel: __( "Crawl optimization", "wordpress-seo" ),
 			fieldId: "input-wpseo-remove_feed_tags",
-			fieldLabel: __( "Tag feeds", "wordpress-seo" ),
+			fieldLabel: __( "Remove tag feeds", "wordpress-seo" ),
 			keywords: [],
 		},
 		remove_feed_custom_taxonomies: {
 			route: "/crawl-optimization",
 			routeLabel: __( "Crawl optimization", "wordpress-seo" ),
 			fieldId: "input-wpseo-remove_feed_custom_taxonomies",
-			fieldLabel: __( "Custom taxonomy feeds", "wordpress-seo" ),
+			fieldLabel: __( "Remove custom taxonomy feeds", "wordpress-seo" ),
 			keywords: [],
 		},
 		remove_feed_search: {
 			route: "/crawl-optimization",
 			routeLabel: __( "Crawl optimization", "wordpress-seo" ),
 			fieldId: "input-wpseo-remove_feed_search",
-			fieldLabel: __( "Search results feeds", "wordpress-seo" ),
+			fieldLabel: __( "Remove search results feeds", "wordpress-seo" ),
 			keywords: [],
 		},
 		remove_atom_rdf_feeds: {
 			route: "/crawl-optimization",
 			routeLabel: __( "Crawl optimization", "wordpress-seo" ),
 			fieldId: "input-wpseo-remove_atom_rdf_feeds",
-			fieldLabel: __( "Atom/RDF feeds", "wordpress-seo" ),
+			fieldLabel: __( "Remove Atom/RDF feeds", "wordpress-seo" ),
 			keywords: [],
 		},
 		remove_emoji_scripts: {
 			route: "/crawl-optimization",
 			routeLabel: __( "Crawl optimization", "wordpress-seo" ),
 			fieldId: "input-wpseo-remove_emoji_scripts",
-			fieldLabel: __( "Emoji scripts", "wordpress-seo" ),
+			fieldLabel: __( "Remove emoji scripts", "wordpress-seo" ),
 			keywords: [],
 		},
 		deny_wp_json_crawling: {
 			route: "/crawl-optimization",
 			routeLabel: __( "Crawl optimization", "wordpress-seo" ),
 			fieldId: "input-wpseo-deny_wp_json_crawling",
-			fieldLabel: __( "WP-JSON API", "wordpress-seo" ),
+			fieldLabel: __( "Remove WP-JSON API", "wordpress-seo" ),
 			keywords: [],
 		},
 		search_cleanup: {
@@ -533,14 +551,14 @@ export const createSearchIndex = ( postTypes, taxonomies ) => ( {
 			route: "/crawl-optimization",
 			routeLabel: __( "Crawl optimization", "wordpress-seo" ),
 			fieldId: "input-wpseo-clean_campaign_tracking_urls",
-			fieldLabel: __( "Google Analytics utm tracking parameters", "wordpress-seo" ),
+			fieldLabel: __( "Optimize Google Analytics utm tracking parameters", "wordpress-seo" ),
 			keywords: [],
 		},
 		clean_permalinks: {
 			route: "/crawl-optimization",
 			routeLabel: __( "Crawl optimization", "wordpress-seo" ),
 			fieldId: "input-wpseo-clean_permalinks",
-			fieldLabel: __( "Unregistered URL parameters", "wordpress-seo" ),
+			fieldLabel: __( "Remove unregistered URL parameters", "wordpress-seo" ),
 			keywords: [],
 		},
 		clean_permalinks_extra_variables: {
@@ -670,7 +688,7 @@ export const createSearchIndex = ( postTypes, taxonomies ) => ( {
 			route: "/breadcrumbs",
 			routeLabel: __( "Breadcrumbs", "wordpress-seo" ),
 			fieldId: "input-wpseo_titles-breadcrumbs-home",
-			fieldLabel: __( "Anchor text for the Homepage", "wordpress-seo" ),
+			fieldLabel: __( "Anchor text for the homepage", "wordpress-seo" ),
 			keywords: [],
 		},
 		"breadcrumbs-prefix": {
@@ -684,14 +702,14 @@ export const createSearchIndex = ( postTypes, taxonomies ) => ( {
 			route: "/breadcrumbs",
 			routeLabel: __( "Breadcrumbs", "wordpress-seo" ),
 			fieldId: "input-wpseo_titles-breadcrumbs-archiveprefix",
-			fieldLabel: __( "Prefix for Archive breadcrumbs", "wordpress-seo" ),
+			fieldLabel: __( "Prefix for archive breadcrumbs", "wordpress-seo" ),
 			keywords: [],
 		},
 		"breadcrumbs-searchprefix": {
 			route: "/breadcrumbs",
 			routeLabel: __( "Breadcrumbs", "wordpress-seo" ),
 			fieldId: "input-wpseo_titles-breadcrumbs-searchprefix",
-			fieldLabel: __( "Prefix for Search page breadcrumbs", "wordpress-seo" ),
+			fieldLabel: __( "Prefix for search page breadcrumbs", "wordpress-seo" ),
 			keywords: [],
 		},
 		"breadcrumbs-404crumb": {
@@ -705,7 +723,7 @@ export const createSearchIndex = ( postTypes, taxonomies ) => ( {
 			route: "/breadcrumbs",
 			routeLabel: __( "Breadcrumbs", "wordpress-seo" ),
 			fieldId: "input-wpseo_titles-breadcrumbs-display-blog-page",
-			fieldLabel: __( "Show Blog page in breadcrumbs", "wordpress-seo" ),
+			fieldLabel: __( "Show blog page in breadcrumbs", "wordpress-seo" ),
 			keywords: [],
 		},
 		"breadcrumbs-boldlast": {
@@ -722,25 +740,39 @@ export const createSearchIndex = ( postTypes, taxonomies ) => ( {
 			fieldLabel: __( "Enable breadcrumbs for your theme", "wordpress-seo" ),
 			keywords: [],
 		},
-		...reduce( postTypes, ( acc, postType ) => ( {
-			...acc,
-			[ `post_types-${ postType.name }-maintax` ]: {
-				route: "/breadcrumbs",
-				routeLabel: __( "Breadcrumbs", "wordpress-seo" ),
-				fieldId: `input-wpseo_titles-post_types-${ postType.name }-maintax`,
-				// translators: %1$s expands to the post type plural, e.g. Posts.
-				fieldLabel: sprintf( __( "Breadcrumbs for %1$s", "wordpress-seo" ), postType.label ),
-				keywords: [],
-			},
-		} ), {} ),
+		...reduce( postTypes, ( acc, postType ) => {
+			const isTaxLinked = filter( taxonomies, taxonomy => includes( taxonomy.postTypes, postType.name ) );
+
+			return isEmpty( isTaxLinked ) ? acc : ( {
+				...acc,
+				[ `post_types-${ postType.name }-maintax` ]: {
+					route: "/breadcrumbs",
+					routeLabel: __( "Breadcrumbs", "wordpress-seo" ),
+					fieldId: `input-wpseo_titles-post_types-${ postType.name }-maintax`,
+					fieldLabel: createInterpolateElement(
+						// translators: %1$s expands to the post type plural, e.g. posts.
+						sprintf( __( "Breadcrumbs for %1$s <code />", "wordpress-seo" ), toLower( postType.label ) ),
+						{
+							code: <Code>{ postType.name }</Code>,
+						}
+					),
+					keywords: [],
+				},
+			} );
+		}, {} ),
 		...reduce( taxonomies, ( acc, taxonomy ) => ( {
 			...acc,
 			[ `taxonomy-${ taxonomy.name }-ptparent` ]: {
 				route: "/breadcrumbs",
 				routeLabel: __( "Breadcrumbs", "wordpress-seo" ),
 				fieldId: `input-wpseo_titles-taxonomy-${ taxonomy.name }-ptparent`,
-				// translators: %1$s expands to the taxonomy plural, e.g. Categories.
-				fieldLabel: sprintf( __( "Breadcrumbs for %1$s", "wordpress-seo" ), taxonomy.label ),
+				fieldLabel: createInterpolateElement(
+					// translators: %1$s expands to the taxonomy plural, e.g. categories.
+					sprintf( __( "Breadcrumbs for %1$s <code />", "wordpress-seo" ), toLower( taxonomy.label ) ),
+					{
+						code: <Code>{ taxonomy.name }</Code>,
+					}
+				),
 				keywords: [],
 			},
 		} ), {} ),
@@ -749,14 +781,14 @@ export const createSearchIndex = ( postTypes, taxonomies ) => ( {
 			route: "/author-archives",
 			routeLabel: __( "Author archives", "wordpress-seo" ),
 			fieldId: "input-wpseo_titles-disable-author",
-			fieldLabel: __( "Author archives", "wordpress-seo" ),
+			fieldLabel: __( "Enable author archives", "wordpress-seo" ),
 			keywords: [],
 		},
 		"noindex-author-wpseo": {
 			route: "/author-archives",
 			routeLabel: __( "Author archives", "wordpress-seo" ),
 			fieldId: "input-wpseo_titles-noindex-author-wpseo",
-			fieldLabel: __( "Show Author archives in search results", "wordpress-seo" ),
+			fieldLabel: __( "Show author archives in search results", "wordpress-seo" ),
 			keywords: [],
 		},
 		"noindex-author-noposts-wpseo": {
@@ -806,14 +838,14 @@ export const createSearchIndex = ( postTypes, taxonomies ) => ( {
 			route: "/date-archives",
 			routeLabel: __( "Date archives", "wordpress-seo" ),
 			fieldId: "input-wpseo_titles-disable-date",
-			fieldLabel: __( "Date archives", "wordpress-seo" ),
+			fieldLabel: __( "Enable date archives", "wordpress-seo" ),
 			keywords: [],
 		},
 		"noindex-archive-wpseo": {
 			route: "/date-archives",
 			routeLabel: __( "Date archives", "wordpress-seo" ),
 			fieldId: "input-wpseo_titles-noindex-archive-wpseo",
-			fieldLabel: __( "Show Date archives in search results", "wordpress-seo" ),
+			fieldLabel: __( "Show date archives in search results", "wordpress-seo" ),
 			keywords: [],
 		},
 		"title-archive-wpseo": {
@@ -884,7 +916,7 @@ export const createSearchIndex = ( postTypes, taxonomies ) => ( {
 			route: "/media",
 			routeLabel: __( "Media pages", "wordpress-seo" ),
 			fieldId: "input-wpseo_titles-noindex-attachment",
-			fieldLabel: __( "Show Media pages in search results", "wordpress-seo" ),
+			fieldLabel: __( "Show media pages in search results", "wordpress-seo" ),
 			keywords: [
 				__( "Image", "wordpress-seo" ),
 				__( "Video", "wordpress-seo" ),
@@ -961,14 +993,14 @@ export const createSearchIndex = ( postTypes, taxonomies ) => ( {
 			route: "/format-archives",
 			routeLabel: __( "Format archives", "wordpress-seo" ),
 			fieldId: "input-wpseo_titles-disable-post_format",
-			fieldLabel: __( "Format-based archives", "wordpress-seo" ),
+			fieldLabel: __( "Enable format-based archives", "wordpress-seo" ),
 			keywords: [],
 		},
 		"noindex-tax-post_format": {
 			route: "/format-archives",
 			routeLabel: __( "Format archives", "wordpress-seo" ),
 			fieldId: "input-wpseo_titles-noindex-tax-post_format",
-			fieldLabel: __( "Show Format archives in search results", "wordpress-seo" ),
+			fieldLabel: __( "Show format archives in search results", "wordpress-seo" ),
 			keywords: [],
 		},
 		"title-tax-post_format": {

--- a/packages/js/src/settings/helpers/search.js
+++ b/packages/js/src/settings/helpers/search.js
@@ -44,7 +44,7 @@ export const createPostTypeSearchIndex = ( { name, label, route, hasArchive } ) 
 	[ `schema-page-type-${ name }` ]: {
 		route: `/post-type/${ route }`,
 		routeLabel: label,
-		fieldId: `input-wpseo_titles-schema-page-type-${ name }-button`,
+		fieldId: `input-wpseo_titles-schema-page-type-${ name }`,
 		fieldLabel: __( "Page type", "wordpress-seo" ),
 		keywords: [
 			__( "Schema", "wordpress-seo" ),
@@ -54,7 +54,7 @@ export const createPostTypeSearchIndex = ( { name, label, route, hasArchive } ) 
 	[ `schema-article-type-${ name }` ]: {
 		route: `/post-type/${ route }`,
 		routeLabel: label,
-		fieldId: `input-wpseo_titles-schema-article-type-${ name }-button`,
+		fieldId: `input-wpseo_titles-schema-article-type-${ name }`,
 		fieldLabel: __( "Article type", "wordpress-seo" ),
 		keywords: [
 			__( "Schema", "wordpress-seo" ),
@@ -753,7 +753,7 @@ export const createSearchIndex = ( postTypes, taxonomies ) => ( {
 						// translators: %1$s expands to the post type plural, e.g. posts.
 						sprintf( __( "Breadcrumbs for %1$s <code />", "wordpress-seo" ), toLower( postType.label ) ),
 						{
-							code: <Code>{ postType.name }</Code>,
+							code: <Code className="yst-ml-2 group-hover:yst-bg-primary-200 group-hover:yst-text-primary-800">{ postType.name }</Code>,
 						}
 					),
 					keywords: [],
@@ -770,7 +770,7 @@ export const createSearchIndex = ( postTypes, taxonomies ) => ( {
 					// translators: %1$s expands to the taxonomy plural, e.g. categories.
 					sprintf( __( "Breadcrumbs for %1$s <code />", "wordpress-seo" ), toLower( taxonomy.label ) ),
 					{
-						code: <Code>{ taxonomy.name }</Code>,
+						code: <Code className="yst-ml-2 group-hover:yst-bg-primary-200 group-hover:yst-text-primary-800">{ taxonomy.name }</Code>,
 					}
 				),
 				keywords: [],

--- a/packages/js/src/settings/helpers/search.js
+++ b/packages/js/src/settings/helpers/search.js
@@ -751,7 +751,7 @@ export const createSearchIndex = ( postTypes, taxonomies ) => ( {
 					fieldId: `input-wpseo_titles-post_types-${ postType.name }-maintax`,
 					fieldLabel: createInterpolateElement(
 						// translators: %1$s expands to the post type plural, e.g. posts.
-						sprintf( __( "Breadcrumbs for %1$s <code />", "wordpress-seo" ), toLower( postType.label ) ),
+						sprintf( __( "Breadcrumbs for %1$s<code />", "wordpress-seo" ), toLower( postType.label ) ),
 						{
 							code: <Code className="yst-ml-2 group-hover:yst-bg-primary-200 group-hover:yst-text-primary-800">{ postType.name }</Code>,
 						}
@@ -768,7 +768,7 @@ export const createSearchIndex = ( postTypes, taxonomies ) => ( {
 				fieldId: `input-wpseo_titles-taxonomy-${ taxonomy.name }-ptparent`,
 				fieldLabel: createInterpolateElement(
 					// translators: %1$s expands to the taxonomy plural, e.g. categories.
-					sprintf( __( "Breadcrumbs for %1$s <code />", "wordpress-seo" ), toLower( taxonomy.label ) ),
+					sprintf( __( "Breadcrumbs for %1$s<code />", "wordpress-seo" ), toLower( taxonomy.label ) ),
 					{
 						code: <Code className="yst-ml-2 group-hover:yst-bg-primary-200 group-hover:yst-text-primary-800">{ taxonomy.name }</Code>,
 					}

--- a/packages/js/src/settings/routes/author-archives.js
+++ b/packages/js/src/settings/routes/author-archives.js
@@ -90,7 +90,7 @@ const AuthorArchives = () => {
 				<div className="yst-max-w-5xl">
 					<FormikFlippedToggleField
 						name={ "wpseo_titles.disable-author" }
-						data-id={ "input-wpseo_titles-disable-author" }
+						id={ "input-wpseo_titles-disable-author" }
 						label={ sprintf(
 							// translators: %1$s expands to "author archives".
 							__( "Enable %1$s", "wordpress-seo" ),
@@ -114,7 +114,7 @@ const AuthorArchives = () => {
 					>
 						<FormikFlippedToggleField
 							name="wpseo_titles.noindex-author-wpseo"
-							data-id="input-wpseo_titles-noindex-author-wpseo"
+							id="input-wpseo_titles-noindex-author-wpseo"
 							label={ sprintf(
 								// translators: %1$s expands to "author archives".
 								__( "Show %1$s in search results", "wordpress-seo" ),
@@ -137,7 +137,7 @@ const AuthorArchives = () => {
 						/>
 						<FormikFlippedToggleField
 							name="wpseo_titles.noindex-author-noposts-wpseo"
-							data-id="input-wpseo_titles-noindex-author-noposts-wpseo"
+							id="input-wpseo_titles-noindex-author-noposts-wpseo"
 							label={ sprintf(
 								// translators: %1$s expands to "author archives".
 								__( "Show %1$s without posts in search results", "wordpress-seo" ),

--- a/packages/js/src/settings/routes/breadcrumbs.js
+++ b/packages/js/src/settings/routes/breadcrumbs.js
@@ -113,7 +113,6 @@ const Breadcrumbs = () => {
 							id={ `input-wpseo_titles-post_types-${ postTypeName }-maintax` }
 							label={ <>
 								{ postType.label }
-								{ " " }
 								<Code className="yst-ml-2">{ postTypeName }</Code>
 							</> }
 							options={ postType.options }
@@ -132,7 +131,6 @@ const Breadcrumbs = () => {
 								id={ `input-wpseo_titles-taxonomy-${ taxonomy.name }-ptparent` }
 								label={ <>
 									{ taxonomy.label }
-									{ " " }
 									<Code className="yst-ml-2">{ taxonomy.name }</Code>
 								</> }
 								options={ taxonomy.options }

--- a/packages/js/src/settings/routes/breadcrumbs.js
+++ b/packages/js/src/settings/routes/breadcrumbs.js
@@ -114,7 +114,7 @@ const Breadcrumbs = () => {
 							label={ <>
 								{ postType.label }
 								{ " " }
-								(<Code>{ postTypeName }</Code>)
+								<Code className="yst-ml-2">{ postTypeName }</Code>
 							</> }
 							options={ postType.options }
 						/> ) }
@@ -133,7 +133,7 @@ const Breadcrumbs = () => {
 								label={ <>
 									{ taxonomy.label }
 									{ " " }
-									(<Code>{ taxonomy.name }</Code>)
+									<Code className="yst-ml-2">{ taxonomy.name }</Code>
 								</> }
 								options={ taxonomy.options }
 							/>

--- a/packages/js/src/settings/routes/breadcrumbs.js
+++ b/packages/js/src/settings/routes/breadcrumbs.js
@@ -65,7 +65,7 @@ const Breadcrumbs = () => {
 							type="text"
 							name="wpseo_titles.breadcrumbs-archiveprefix"
 							id="input-wpseo_titles-breadcrumbs-archiveprefix"
-							label={ __( "Prefix for Archive breadcrumbs", "wordpress-seo" ) }
+							label={ __( "Prefix for archive breadcrumbs", "wordpress-seo" ) }
 							placeholder={ __( "Add prefix", "wordpress-seo" ) }
 						/>
 						<Field
@@ -73,7 +73,7 @@ const Breadcrumbs = () => {
 							type="text"
 							name="wpseo_titles.breadcrumbs-searchprefix"
 							id="input-wpseo_titles-breadcrumbs-searchprefix"
-							label={ __( "Prefix for Search page breadcrumbs", "wordpress-seo" ) }
+							label={ __( "Prefix for search page breadcrumbs", "wordpress-seo" ) }
 							placeholder={ __( "Add prefix", "wordpress-seo" ) }
 						/>
 						<Field
@@ -88,15 +88,15 @@ const Breadcrumbs = () => {
 							as={ ToggleField }
 							type="checkbox"
 							name="wpseo_titles.breadcrumbs-display-blog-page"
-							data-id="input-wpseo_titles-breadcrumbs-display-blog-page"
-							label={ __( "Show Blog page in breadcrumbs", "wordpress-seo" ) }
+							id="input-wpseo_titles-breadcrumbs-display-blog-page"
+							label={ __( "Show blog page in breadcrumbs", "wordpress-seo" ) }
 							className="yst-max-w-sm"
 						/> }
 						<FormikValueChangeField
 							as={ ToggleField }
 							type="checkbox"
 							name="wpseo_titles.breadcrumbs-boldlast"
-							data-id="input-wpseo_titles-breadcrumbs-boldlast"
+							id="input-wpseo_titles-breadcrumbs-boldlast"
 							label={ __( "Bold the last page", "wordpress-seo" ) }
 							className="yst-max-w-sm"
 						/>
@@ -106,13 +106,17 @@ const Breadcrumbs = () => {
 						title={ __( "Breadcrumbs for post types", "wordpress-seo" ) }
 						description={ __( "Choose which Taxonomy you wish to show in the breadcrumbs for Post types.", "wordpress-seo" ) }
 					>
-						{ map( breadcrumbsForPostTypes, ( postTypes, postTypeName ) => <FormikValueChangeField
+						{ map( breadcrumbsForPostTypes, ( postType, postTypeName ) => <FormikValueChangeField
 							key={ postTypeName }
 							as={ SelectField }
 							name={ `wpseo_titles.post_types-${ postTypeName }-maintax` }
-							data-id={ `input-wpseo_titles-post_types-${ postTypeName }-maintax` }
-							label={ postTypes.label }
-							options={ postTypes.options }
+							id={ `input-wpseo_titles-post_types-${ postTypeName }-maintax` }
+							label={ <>
+								{ postType.label }
+								{ " " }
+								(<Code>{ postTypeName }</Code>)
+							</> }
+							options={ postType.options }
 						/> ) }
 					</FieldsetLayout>
 					<hr className="yst-my-8" />
@@ -120,18 +124,18 @@ const Breadcrumbs = () => {
 						title={ __( "Breadcrumbs for taxonomies", "wordpress-seo" ) }
 						description={ __( "Choose which Post type you wish to show in the breadcrumbs for Taxonomies.", "wordpress-seo" ) }
 					>
-						{ map( breadcrumbsForTaxonomies, ( { name, label, options } ) => (
+						{ map( breadcrumbsForTaxonomies, ( taxonomy ) => (
 							<FormikValueChangeField
-								key={ name }
+								key={ taxonomy.name }
 								as={ SelectField }
-								name={ `wpseo_titles.taxonomy-${ name }-ptparent` }
-								data-id={ `input-wpseo_titles-taxonomy-${ name }-ptparent` }
+								name={ `wpseo_titles.taxonomy-${ taxonomy.name }-ptparent` }
+								id={ `input-wpseo_titles-taxonomy-${ taxonomy.name }-ptparent` }
 								label={ <>
-									{ label }
-									&nbsp;
-									(<Code>{ name }</Code>)
+									{ taxonomy.label }
+									{ " " }
+									(<Code>{ taxonomy.name }</Code>)
 								</> }
-								options={ options }
+								options={ taxonomy.options }
 							/>
 						) ) }
 					</FieldsetLayout>

--- a/packages/js/src/settings/routes/crawl-optimization.js
+++ b/packages/js/src/settings/routes/crawl-optimization.js
@@ -293,7 +293,7 @@ const CrawlOptimization = () => {
 							as={ ToggleField }
 							type="checkbox"
 							name="wpseo.remove_shortlinks"
-							data-id="input-wpseo-remove_shortlinks"
+							id="input-wpseo-remove_shortlinks"
 							label={ __( "Remove shortlinks", "wordpress-seo" ) }
 							isDummy={ ! isPremium }
 							className="yst-max-w-2xl"
@@ -306,7 +306,7 @@ const CrawlOptimization = () => {
 							as={ ToggleField }
 							type="checkbox"
 							name="wpseo.remove_rest_api_links"
-							data-id="input-wpseo-remove_rest_api_links"
+							id="input-wpseo-remove_rest_api_links"
 							label={ __( "Remove REST API links", "wordpress-seo" ) }
 							isDummy={ ! isPremium }
 							className="yst-max-w-2xl"
@@ -319,7 +319,7 @@ const CrawlOptimization = () => {
 							as={ ToggleField }
 							type="checkbox"
 							name="wpseo.remove_rsd_wlw_links"
-							data-id="input-wpseo-remove_rsd_wlw_links"
+							id="input-wpseo-remove_rsd_wlw_links"
 							label={ __( "Remove RSD / WLW links", "wordpress-seo" ) }
 							isDummy={ ! isPremium }
 							className="yst-max-w-2xl"
@@ -332,7 +332,7 @@ const CrawlOptimization = () => {
 							as={ ToggleField }
 							type="checkbox"
 							name="wpseo.remove_oembed_links"
-							data-id="input-wpseo-remove_oembed_links"
+							id="input-wpseo-remove_oembed_links"
 							label={ __( "Remove oEmbed links", "wordpress-seo" ) }
 							isDummy={ ! isPremium }
 							className="yst-max-w-2xl"
@@ -345,7 +345,7 @@ const CrawlOptimization = () => {
 							as={ ToggleField }
 							type="checkbox"
 							name="wpseo.remove_generator"
-							data-id="input-wpseo-remove_generator"
+							id="input-wpseo-remove_generator"
 							label={ __( "Remove generator tag", "wordpress-seo" ) }
 							isDummy={ ! isPremium }
 							className="yst-max-w-2xl"
@@ -358,7 +358,7 @@ const CrawlOptimization = () => {
 							as={ ToggleField }
 							type="checkbox"
 							name="wpseo.remove_pingback_header"
-							data-id="input-wpseo-remove_pingback_header"
+							id="input-wpseo-remove_pingback_header"
 							label={ __( "Pingback HTTP header", "wordpress-seo" ) }
 							isDummy={ ! isPremium }
 							className="yst-max-w-2xl"
@@ -371,7 +371,7 @@ const CrawlOptimization = () => {
 							as={ ToggleField }
 							type="checkbox"
 							name="wpseo.remove_powered_by_header"
-							data-id="input-wpseo-remove_powered_by_header"
+							id="input-wpseo-remove_powered_by_header"
 							label={ __( "Remove powered by HTTP header", "wordpress-seo" ) }
 							isDummy={ ! isPremium }
 							className="yst-max-w-2xl"
@@ -390,7 +390,7 @@ const CrawlOptimization = () => {
 							as={ ToggleField }
 							type="checkbox"
 							name="wpseo.remove_feed_global"
-							data-id="input-wpseo-remove_feed_global"
+							id="input-wpseo-remove_feed_global"
 							label={ __( "Remove global feed", "wordpress-seo" ) }
 							isDummy={ ! isPremium }
 							className="yst-max-w-2xl"
@@ -403,7 +403,7 @@ const CrawlOptimization = () => {
 							as={ ToggleField }
 							type="checkbox"
 							name="wpseo.remove_feed_global_comments"
-							data-id="input-wpseo-remove_feed_global_comments"
+							id="input-wpseo-remove_feed_global_comments"
 							label={ __( "Remove global comment feeds", "wordpress-seo" ) }
 							isDummy={ ! isPremium }
 							className="yst-max-w-2xl"
@@ -417,7 +417,7 @@ const CrawlOptimization = () => {
 							as={ ToggleField }
 							type="checkbox"
 							name="wpseo.remove_feed_post_comments"
-							data-id="input-wpseo-remove_feed_post_comments"
+							id="input-wpseo-remove_feed_post_comments"
 							label={ __( "Remove post comments feeds", "wordpress-seo" ) }
 							disabled={ removeFeedGlobalComments }
 							checked={ removeFeedGlobalComments || removeFeedPostComments }
@@ -432,7 +432,7 @@ const CrawlOptimization = () => {
 							as={ ToggleField }
 							type="checkbox"
 							name="wpseo.remove_feed_authors"
-							data-id="input-wpseo-remove_feed_authors"
+							id="input-wpseo-remove_feed_authors"
 							label={ __( "Remove post authors feeds", "wordpress-seo" ) }
 							isDummy={ ! isPremium }
 							className="yst-max-w-2xl"
@@ -445,7 +445,7 @@ const CrawlOptimization = () => {
 							as={ ToggleField }
 							type="checkbox"
 							name="wpseo.remove_feed_post_types"
-							data-id="input-wpseo-remove_feed_post_types"
+							id="input-wpseo-remove_feed_post_types"
 							label={ __( "Remove post type feeds", "wordpress-seo" ) }
 							isDummy={ ! isPremium }
 							className="yst-max-w-2xl"
@@ -458,7 +458,7 @@ const CrawlOptimization = () => {
 							as={ ToggleField }
 							type="checkbox"
 							name="wpseo.remove_feed_categories"
-							data-id="input-wpseo-remove_feed_categories"
+							id="input-wpseo-remove_feed_categories"
 							label={ __( "Remove category feeds", "wordpress-seo" ) }
 							isDummy={ ! isPremium }
 							className="yst-max-w-2xl"
@@ -471,7 +471,7 @@ const CrawlOptimization = () => {
 							as={ ToggleField }
 							type="checkbox"
 							name="wpseo.remove_feed_tags"
-							data-id="input-wpseo-remove_feed_tags"
+							id="input-wpseo-remove_feed_tags"
 							label={ __( "Remove tag feeds", "wordpress-seo" ) }
 							isDummy={ ! isPremium }
 							className="yst-max-w-2xl"
@@ -484,7 +484,7 @@ const CrawlOptimization = () => {
 							as={ ToggleField }
 							type="checkbox"
 							name="wpseo.remove_feed_custom_taxonomies"
-							data-id="input-wpseo-remove_feed_custom_taxonomies"
+							id="input-wpseo-remove_feed_custom_taxonomies"
 							label={ __( "Remove custom taxonomy feeds", "wordpress-seo" ) }
 							isDummy={ ! isPremium }
 							className="yst-max-w-2xl"
@@ -497,7 +497,7 @@ const CrawlOptimization = () => {
 							as={ ToggleField }
 							type="checkbox"
 							name="wpseo.remove_feed_search"
-							data-id="input-wpseo-remove_feed_search"
+							id="input-wpseo-remove_feed_search"
 							label={ __( "Remove search results feeds", "wordpress-seo" ) }
 							isDummy={ ! isPremium }
 							className="yst-max-w-2xl"
@@ -510,7 +510,7 @@ const CrawlOptimization = () => {
 							as={ ToggleField }
 							type="checkbox"
 							name="wpseo.remove_atom_rdf_feeds"
-							data-id="input-wpseo-remove_atom_rdf_feeds"
+							id="input-wpseo-remove_atom_rdf_feeds"
 							label={ __( "Remove Atom / RDF feeds", "wordpress-seo" ) }
 							isDummy={ ! isPremium }
 							className="yst-max-w-2xl"
@@ -529,7 +529,7 @@ const CrawlOptimization = () => {
 							as={ ToggleField }
 							type="checkbox"
 							name="wpseo.remove_emoji_scripts"
-							data-id="input-wpseo-remove_emoji_scripts"
+							id="input-wpseo-remove_emoji_scripts"
 							label={ __( "Remove emoji scripts", "wordpress-seo" ) }
 							description={ __( "Remove JavaScript used for converting emoji characters in older browsers.", "wordpress-seo" ) }
 							isDummy={ ! isPremium }
@@ -539,7 +539,7 @@ const CrawlOptimization = () => {
 							as={ ToggleField }
 							type="checkbox"
 							name="wpseo.deny_wp_json_crawling"
-							data-id="input-wpseo-deny_wp_json_crawling"
+							id="input-wpseo-deny_wp_json_crawling"
 							label={ __( "Remove WP-JSON API", "wordpress-seo" ) }
 							isDummy={ ! isPremium }
 							className="yst-max-w-2xl"
@@ -558,7 +558,7 @@ const CrawlOptimization = () => {
 							as={ ToggleField }
 							type="checkbox"
 							name="wpseo.search_cleanup"
-							data-id="input-wpseo-search_cleanup"
+							id="input-wpseo-search_cleanup"
 							label={ __( "Filter search terms", "wordpress-seo" ) }
 							description={ __( "Enables advanced settings for protecting your internal site search URLs.", "wordpress-seo" ) }
 							isDummy={ ! isPremium }
@@ -578,7 +578,7 @@ const CrawlOptimization = () => {
 							as={ ToggleField }
 							type="checkbox"
 							name="wpseo.search_cleanup_emoji"
-							data-id="input-wpseo-search_cleanup_emoji"
+							id="input-wpseo-search_cleanup_emoji"
 							label={ __( "Filter searches with emojis and other special characters", "wordpress-seo" ) }
 							description={ __( "Block internal site searches which contain complex and non-alphanumeric characters, as they may be part of a spam attack.", "wordpress-seo" ) }
 							disabled={ ! searchCleanup }
@@ -590,7 +590,7 @@ const CrawlOptimization = () => {
 							as={ ToggleField }
 							type="checkbox"
 							name="wpseo.search_cleanup_patterns"
-							data-id="input-wpseo-search_cleanup_patterns"
+							id="input-wpseo-search_cleanup_patterns"
 							label={ __( "Filter searches with common spam patterns", "wordpress-seo" ) }
 							description={ __( "Block internal site searches which match the patterns of known spam attacks.", "wordpress-seo" ) }
 							disabled={ ! searchCleanup }
@@ -602,7 +602,7 @@ const CrawlOptimization = () => {
 							as={ ToggleField }
 							type="checkbox"
 							name="wpseo.deny_search_crawling"
-							data-id="input-wpseo-deny_search_crawling"
+							id="input-wpseo-deny_search_crawling"
 							label={ __( "Prevent crawling of internal site search URLs", "wordpress-seo" ) }
 							description={ descriptions.denySearchCrawling }
 							isDummy={ ! isPremium }
@@ -631,7 +631,7 @@ const CrawlOptimization = () => {
 							as={ ToggleField }
 							type="checkbox"
 							name="wpseo.clean_campaign_tracking_urls"
-							data-id="input-wpseo-clean_campaign_tracking_urls"
+							id="input-wpseo-clean_campaign_tracking_urls"
 							label={ __( "Optimize Google Analytics utm tracking parameters", "wordpress-seo" ) }
 							description={ descriptions.cleanCampaignTrackingUrls }
 							isDummy={ ! isPremium }
@@ -641,7 +641,7 @@ const CrawlOptimization = () => {
 							as={ ToggleField }
 							type="checkbox"
 							name="wpseo.clean_permalinks"
-							data-id="input-wpseo-clean_permalinks"
+							id="input-wpseo-clean_permalinks"
 							label={ __( "Remove unregistered URL parameters", "wordpress-seo" ) }
 							description={ descriptions.cleanPermalinks }
 							isDummy={ ! isPremium }

--- a/packages/js/src/settings/routes/date-archives.js
+++ b/packages/js/src/settings/routes/date-archives.js
@@ -79,7 +79,7 @@ const DateArchives = () => {
 					<fieldset className="yst-min-width-0 yst-space-y-8">
 						<FormikFlippedToggleField
 							name={ "wpseo_titles.disable-date" }
-							data-id={ "input-wpseo_titles-disable-date" }
+							id={ "input-wpseo_titles-disable-date" }
 							label={ sprintf(
 								// translators: %1$s expands to "date archives".
 								__( "Enable %1$s", "wordpress-seo" ),
@@ -104,7 +104,7 @@ const DateArchives = () => {
 					>
 						<FormikFlippedToggleField
 							name="wpseo_titles.noindex-archive-wpseo"
-							data-id="input-wpseo_titles-noindex-archive-wpseo"
+							id="input-wpseo_titles-noindex-archive-wpseo"
 							label={ sprintf(
 								// translators: %1$s expands to "date archives".
 								__( "Show %1$s in search results", "wordpress-seo" ),

--- a/packages/js/src/settings/routes/format-archives.js
+++ b/packages/js/src/settings/routes/format-archives.js
@@ -27,8 +27,9 @@ const FormikReplacementVariableEditorFieldWithDummy = withFormikDummyField( Form
  * @returns {JSX.Element} The format archives element.
  */
 const FormatArchives = () => {
-	const { name, label } = useSelectSettings( "selectTaxonomy", [], "post_format" );
+	const { name, label, singularLabel } = useSelectSettings( "selectTaxonomy", [], "post_format" );
 	const labelLower = useMemo( ()=> toLower( label ), [ label ] );
+	const singularLabelLower = useMemo( () => toLower( singularLabel ), [ singularLabel ] );
 
 	const premiumUpsellConfig = useSelectSettings( "selectUpsellSettingsAsProps" );
 	const replacementVariables = useSelectSettings( "selectReplacementVariablesFor", [ name ], name, "term-in-custom-taxonomy" );
@@ -78,7 +79,7 @@ const FormatArchives = () => {
 				<div className="yst-max-w-5xl">
 					<FormikFlippedToggleField
 						name="wpseo_titles.disable-post_format"
-						data-id="input-wpseo_titles-disable-post_format"
+						id="input-wpseo_titles-disable-post_format"
 						label={ __( "Enable format-based archives", "wordpress-seo" ) }
 						description={ __( "Format-based archives can cause duplicate content issues. For most sites, we recommend that you disable this setting.", "wordpress-seo" ) }
 						className="yst-max-w-sm"
@@ -96,11 +97,11 @@ const FormatArchives = () => {
 					>
 						<FormikFlippedToggleField
 							name={ `wpseo_titles.noindex-tax-${ name }` }
-							data-id={ `input-wpseo_titles-noindex-tax-${ name }` }
+							id={ `input-wpseo_titles-noindex-tax-${ name }` }
 							label={ sprintf(
-								// translators: %1$s expands to "formats".
-								__( "Show %1$s in search results", "wordpress-seo" ),
-								labelLower
+								// translators: %1$s expands to "format".
+								__( "Show %1$s archives in search results", "wordpress-seo" ),
+								singularLabelLower
 							) }
 							description={ <>
 								{ sprintf(

--- a/packages/js/src/settings/routes/media.js
+++ b/packages/js/src/settings/routes/media.js
@@ -65,7 +65,7 @@ const Media = () => {
 					<fieldset className="yst-min-width-0 yst-space-y-8">
 						<FormikFlippedToggleField
 							name={ `wpseo_titles.disable-${ name }` }
-							data-id={ `input-wpseo_titles-disable-${ name }` }
+							id={ `input-wpseo_titles-disable-${ name }` }
 							label={ sprintf(
 								// translators: %1$s expands to "media".
 								__( "Enable %1$s pages", "wordpress-seo" ),
@@ -92,7 +92,7 @@ const Media = () => {
 					>
 						<FormikFlippedToggleField
 							name={ `wpseo_titles.noindex-${ name }` }
-							data-id={ `input-wpseo_titles-noindex-${ name }` }
+							id={ `input-wpseo_titles-noindex-${ name }` }
 							label={ sprintf(
 								// translators: %1$s expands to "media".
 								__( "Show %1$s pages in search results", "wordpress-seo" ),
@@ -169,7 +169,7 @@ const Media = () => {
 							as={ ToggleField }
 							type="checkbox"
 							name={ `wpseo_titles.display-metabox-pt-${ name }` }
-							data-id={ `input-wpseo_titles-display-metabox-pt-${ name }` }
+							id={ `input-wpseo_titles-display-metabox-pt-${ name }` }
 							label={ __( "Enable SEO controls and assessments", "wordpress-seo" ) }
 							description={ __( "Show or hide our tools and controls in the attachment editor.", "wordpress-seo" ) }
 							disabled={ isAttachmentPagesDisabled }

--- a/packages/js/src/settings/routes/site-basics.js
+++ b/packages/js/src/settings/routes/site-basics.js
@@ -183,7 +183,7 @@ const SiteBasics = () => {
 								as={ ToggleField }
 								type="checkbox"
 								name="wpseo_titles.forcerewritetitle"
-								data-id="input-wpseo_titles-forcerewritetitle"
+								id="input-wpseo_titles-forcerewritetitle"
 								label={ __( "Force rewrite titles", "wordpress-seo" ) }
 								description={ sprintf(
 									/* translators: %1$s expands to "Yoast SEO" */
@@ -196,7 +196,7 @@ const SiteBasics = () => {
 							as={ ToggleField }
 							type="checkbox"
 							name="wpseo.disableadvanced_meta"
-							data-id="input-wpseo-disableadvanced_meta"
+							id="input-wpseo-disableadvanced_meta"
 							label={ __( "Restrict advanced settings for authors", "wordpress-seo" ) }
 							description={ sprintf(
 								/* translators: %1$s expands to "Yoast SEO" */
@@ -209,7 +209,7 @@ const SiteBasics = () => {
 							as={ ToggleFieldWithDisabledMessageSupport }
 							type="checkbox"
 							name="wpseo.tracking"
-							data-id="input-wpseo-tracking"
+							id="input-wpseo-tracking"
 							label={ __( "Usage tracking", "wordpress-seo" ) }
 							description={ usageTrackingDescription }
 							className="yst-max-w-sm"

--- a/packages/js/src/settings/routes/site-features.js
+++ b/packages/js/src/settings/routes/site-features.js
@@ -79,7 +79,7 @@ const FeatureCard = ( {
 					as={ ToggleField }
 					type="checkbox"
 					name={ name }
-					data-id={ inputId }
+					id={ inputId }
 					label={ __( "Enable feature", "wordpress-seo" ) }
 					disabled={ isDisabled }
 				/> }

--- a/packages/js/src/settings/routes/templates/post-type.js
+++ b/packages/js/src/settings/routes/templates/post-type.js
@@ -146,7 +146,7 @@ const PostType = ( { name, label, singularLabel, hasArchive, hasSchemaArticleTyp
 					>
 						<FormikFlippedToggleField
 							name={ `wpseo_titles.noindex-${ name }` }
-							data-id={ `input-wpseo_titles-noindex-${ name }` }
+							id={ `input-wpseo_titles-noindex-${ name }` }
 							label={ sprintf(
 								// translators: %1$s expands to the post type plural, e.g. posts.
 								__( "Show %1$s in search results", "wordpress-seo" ),
@@ -275,7 +275,7 @@ const PostType = ( { name, label, singularLabel, hasArchive, hasSchemaArticleTyp
 							as={ ToggleField }
 							type="checkbox"
 							name={ `wpseo_titles.display-metabox-pt-${ name }` }
-							data-id={ `input-wpseo_titles-display-metabox-pt-${ name }` }
+							id={ `input-wpseo_titles-display-metabox-pt-${ name }` }
 							label={ __( "Enable SEO controls and assessments", "wordpress-seo" ) }
 							description={ __( "Show or hide our tools and controls in the content editor.", "wordpress-seo" ) }
 							className="yst-max-w-sm"
@@ -339,7 +339,7 @@ const PostType = ( { name, label, singularLabel, hasArchive, hasSchemaArticleTyp
 							>
 								<FormikFlippedToggleField
 									name={ `wpseo_titles.noindex-ptarchive-${ name }` }
-									data-id={ `input-wpseo_titles-noindex-ptarchive-${ name }` }
+									id={ `input-wpseo_titles-noindex-ptarchive-${ name }` }
 									label={ sprintf(
 										// translators: %1$s expands to the post type plural, e.g. posts.
 										__( "Show the archive for %1$s in search results", "wordpress-seo" ),

--- a/packages/js/src/settings/routes/templates/taxonomy.js
+++ b/packages/js/src/settings/routes/templates/taxonomy.js
@@ -132,7 +132,7 @@ const Taxonomy = ( { name, label, postTypes: postTypeNames } ) => {
 					>
 						<FormikFlippedToggleField
 							name={ `wpseo_titles.noindex-tax-${ name }` }
-							data-id={ `input-wpseo_titles-noindex-tax-${ name }` }
+							id={ `input-wpseo_titles-noindex-tax-${ name }` }
 							label={ sprintf(
 							// translators: %1$s expands to the taxonomy plural, e.g. Categories.
 								__( "Show %1$s in search results", "wordpress-seo" ),
@@ -237,14 +237,14 @@ const Taxonomy = ( { name, label, postTypes: postTypeNames } ) => {
 							as={ ToggleField }
 							type="checkbox"
 							name={ `wpseo_titles.display-metabox-tax-${ name }` }
-							data-id={ `input-wpseo_titles-display-metabox-tax-${ name }` }
+							id={ `input-wpseo_titles-display-metabox-tax-${ name }` }
 							label={ __( "Enable SEO controls and assessments", "wordpress-seo" ) }
 							description={ __( "Show or hide our tools and controls in the content editor.", "wordpress-seo" ) }
 							className="yst-max-w-sm"
 						/>
 						{ name === "category" && <FormikFlippedToggleField
 							name="wpseo_titles.stripcategorybase"
-							data-id="input-wpseo_titles-stripcategorybase"
+							id="input-wpseo_titles-stripcategorybase"
 							label={ __( "Show the categories prefix in the slug", "wordpress-seo" ) }
 							description={ stripCategoryBaseDescription }
 							className="yst-max-w-sm"

--- a/packages/js/src/settings/store/breadcrumbs.js
+++ b/packages/js/src/settings/store/breadcrumbs.js
@@ -18,7 +18,7 @@ export const breadcrumbsSelectors = {
 				const linkedTaxonomies = filter( taxonomies, taxonomy => includes( taxonomy.postTypes, postTypeName ) );
 				if ( ! isEmpty( linkedTaxonomies ) ) {
 					options[ postTypeName ] = {
-						label: postType.label,
+						...postType,
 						options: [
 							none,
 							...map( linkedTaxonomies, ( { name, label } ) => ( { value: name, label } ) ),

--- a/packages/ui-library/src/elements/autocomplete/index.js
+++ b/packages/ui-library/src/elements/autocomplete/index.js
@@ -80,7 +80,6 @@ const Autocomplete = ( {
 
 	return (
 		<Combobox
-			id={ id }
 			as="div"
 			value={ value }
 			onChange={ onChange }
@@ -98,6 +97,7 @@ const Autocomplete = ( {
 			<div className="yst-relative">
 				<div className="yst-relative">
 					<Combobox.Button
+						data-id={ id }
 						className="yst-autocomplete__button"
 						{ ...buttonProps }
 						as="div"

--- a/packages/ui-library/src/elements/select/index.js
+++ b/packages/ui-library/src/elements/select/index.js
@@ -80,7 +80,6 @@ const Select = ( {
 
 	return (
 		<Listbox
-			id={ id }
 			as="div"
 			value={ value }
 			onChange={ onChange }
@@ -96,7 +95,7 @@ const Select = ( {
 				<Listbox.Label { ...labelProps }>{ label }</Listbox.Label>
 				{ labelSuffix }
 			</div> }
-			<Listbox.Button className="yst-select__button" { ...buttonProps }>
+			<Listbox.Button data-id={ id } className="yst-select__button" { ...buttonProps }>
 				<span className="yst-select__button-label">{ selectedLabel || selectedOption?.label || "" }</span>
 				{ isError ? (
 					<ExclamationCircleIcon className="yst-select__button-icon yst-select__button-icon--error" { ...svgAriaProps } />

--- a/packages/ui-library/src/elements/toggle/index.js
+++ b/packages/ui-library/src/elements/toggle/index.js
@@ -6,6 +6,7 @@ import PropTypes from "prop-types";
 import { useSvgAria } from "../../hooks";
 
 /**
+ * @param {string} id ID.
  * @param {string|JSX.Element} [as="button"] Base component.
  * @param {boolean} checked Default state.
  * @param {string} screenReaderLabel The label for screen readers.
@@ -16,6 +17,7 @@ import { useSvgAria } from "../../hooks";
  * @returns {JSX.Element} Toggle component.
  */
 const Toggle = ( {
+	id,
 	as: Component = "button",
 	checked,
 	screenReaderLabel,
@@ -39,6 +41,7 @@ const Toggle = ( {
 				disabled && "yst-toggle--disabled",
 				className,
 			) }
+			data-id={ id }
 			{ ...props }
 			// Force type button when component is button for proper behavior in HTML forms.
 			type={ Component === "button" ? "button" : type }
@@ -77,6 +80,7 @@ const Toggle = ( {
 
 Toggle.propTypes = {
 	as: PropTypes.elementType,
+	id: PropTypes.string.isRequired,
 	checked: PropTypes.bool,
 	screenReaderLabel: PropTypes.string.isRequired,
 	onChange: PropTypes.func.isRequired,


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Improves the search index in the new settings UI.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves the search index in the new settings UI.

## Relevant technical choices:

* Move rewrite of `id` prop to `data-id` prop to UI library for `Select` and `Autocomplete` components. Allows us to always write `id` props on implementation level.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Verify that typing a very long search term results in text overflow in the search field in sidebar:
<img width="257" alt="image" src="https://user-images.githubusercontent.com/24573520/204499863-1ab5501c-d8a8-4c15-b093-5260651943b3.png">
* Verify that select labels on the breadcrumbs route now contain code blocks containing post type or taxonomy name. This should also be the case for these fields in the search results.
<img width="489" alt="image" src="https://user-images.githubusercontent.com/24573520/204501370-e2fb3138-fadf-42c0-8d6f-d618c9b8c942.png">

* Verify you can now search and find the `Add custom fields to page analysis` fields for post types.
* Verify you can now search and find the `Show the categories prefix in the slug` field for category.
* Verify that searching for `Site image` results in one hit for the `Site basics` route and that hit works.


#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [x] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
