### PR TITLE
UI library: improve stories for form field components that render options as children checkbox group radio group select autocomplete

### DIFF
--- a/packages/ui-library/src/components/autocomplete-field/stories.js
+++ b/packages/ui-library/src/components/autocomplete-field/stories.js
@@ -132,3 +132,17 @@ WithPlaceholder.args = {
 	placeholder: "Search a value...",
 };
 
+export const ChildrenProp = Template.bind();
+ChildrenProp.args = {
+	id: "with-children-prop",
+	name: "with-children-prop",
+	children: <>
+		<AutocompleteField.Option value="child 1" label="Option 1" id="option-1" name="option-1" />
+		<AutocompleteField.Option value="child 2" label="Option 2" id="option-2" name="option-2" />
+		<AutocompleteField.Option value="child 3" label="Option 3" id="option-3" name="option-3" />
+	</>,
+};
+
+ChildrenProp.parameters = { docs: { description: { story: "The `children` prop can be used to render custom content. The options are rendered using the sub component `Option` (`AutocompleteField.Option` is equal to `Autocomplete` element). Default values should be set inside the child component and not the `selectedLabel` prop." } } };
+
+

--- a/packages/ui-library/src/components/autocomplete-field/stories.js
+++ b/packages/ui-library/src/components/autocomplete-field/stories.js
@@ -3,7 +3,7 @@ import { useCallback, useMemo, useState } from "@wordpress/element";
 import { filter, find, includes, toLower } from "lodash";
 
 export default {
-	title: "2. Components/AutocompleteField",
+	title: "2. Components/Autocomplete Field",
 	component: AutocompleteField,
 	argTypes: {
 		description: { control: "text" },
@@ -70,8 +70,8 @@ Factory.parameters = {
 Factory.args = {
 	id: "factory",
 	name: "factory",
-	label: "AutocompleteField label",
-	description: "AutocompleteField description",
+	label: "Autocomplete field label",
+	description: "Autocomplete field description",
 	placeholder: "Search an option...",
 };
 
@@ -108,7 +108,7 @@ export const WithSelectedLabel = Template.bind( {} );
 
 WithSelectedLabel.parameters = {
 	controls: { disable: false },
-	docs: { description: { story: "An example with default value using `selectedLabel` prop." } },
+	docs: { description: { story: "When using `children` prop, `selectedLabel` prop is used to set default/selected value." } },
 };
 
 WithSelectedLabel.args = {
@@ -116,6 +116,11 @@ WithSelectedLabel.args = {
 	name: "selected-label",
 	label: "Example label",
 	selectedLabel: "Option 1",
+	children: <>
+		<AutocompleteField.Option value="child 1" label="Option 1" id="option-1" name="option-1" />
+		<AutocompleteField.Option value="child 2" label="Option 2" id="option-2" name="option-2" />
+		<AutocompleteField.Option value="child 3" label="Option 3" id="option-3" name="option-3" />
+	</>,
 };
 
 export const WithPlaceholder = Template.bind( {} );
@@ -136,6 +141,7 @@ export const ChildrenProp = Template.bind();
 ChildrenProp.args = {
 	id: "with-children-prop",
 	name: "with-children-prop",
+	label: "Example label",
 	children: <>
 		<AutocompleteField.Option value="child 1" label="Option 1" id="option-1" name="option-1" />
 		<AutocompleteField.Option value="child 2" label="Option 2" id="option-2" name="option-2" />

--- a/packages/ui-library/src/components/checkbox-group/stories.js
+++ b/packages/ui-library/src/components/checkbox-group/stories.js
@@ -77,11 +77,11 @@ ChildrenProp.args = {
 	name: "name-3",
 	label: "Checkbox group label.",
 	children: <>
-		<CheckboxGroup.Option value="child 1" label="Option 1" id="option-1" name="option-1" />
-		<CheckboxGroup.Option value="child 2" label="Option 2" id="option-2" name="option-2" />
-		<CheckboxGroup.Option value="child 3" label="Option 3" id="option-3" name="option-3" />
+		<CheckboxGroup.Checkbox value="child 1" label="Option 1" id="option-1" name="option-1" />
+		<CheckboxGroup.Checkbox value="child 2" label="Option 2" id="option-2" name="option-2" />
+		<CheckboxGroup.Checkbox value="child 3" label="Option 3" id="option-3" name="option-3" />
 	</>,
 };
 
-ChildrenProp.parameters = { docs: { description: { story: "The `children` prop can be used to render custom content. The options are rendered using the sub component `Option` (`CheckboxGroup.Option` is equal to `Checkbox` element). Default values should be set inside the child component and not the `value` prop." } } };
+ChildrenProp.parameters = { docs: { description: { story: "The `children` prop can be used to render custom content. The options are rendered using the sub component `Checkbox` (`CheckboxGroup.Checkbox` is equal to `Checkbox` element). Default values should be set inside the child component and not the `value` prop." } } };
 

--- a/packages/ui-library/src/components/checkbox-group/stories.js
+++ b/packages/ui-library/src/components/checkbox-group/stories.js
@@ -83,5 +83,5 @@ ChildrenProp.args = {
 	</>,
 };
 
-ChildrenProp.parameters = { docs: { description: { story: "The `children` prop can be used to render custom content. The options are rendered using the sub component `Option` (`CheckboxGroup.Option` is equal to `Checkbox` component). Default values should be set inside the child component and not the `value` prop." } } };
+ChildrenProp.parameters = { docs: { description: { story: "The `children` prop can be used to render custom content. The options are rendered using the sub component `Option` (`CheckboxGroup.Option` is equal to `Checkbox` element). Default values should be set inside the child component and not the `value` prop." } } };
 

--- a/packages/ui-library/src/components/checkbox-group/stories.js
+++ b/packages/ui-library/src/components/checkbox-group/stories.js
@@ -73,16 +73,15 @@ WithValues.args = {
 
 export const ChildrenProp = Template.bind();
 ChildrenProp.args = {
-	id: "checkbox-group-2",
-	name: "name-2",
-	values: [ "2", "3" ],
+	id: "checkbox-group-3",
+	name: "name-3",
 	label: "Checkbox group label.",
 	children: <>
-		<CheckboxGroup.Option value="child 1" label="Option 1" />
-		<CheckboxGroup.Option value="child 2" label="Option 2" />
-		<CheckboxGroup.Option value="child 3" label="Option 3" />
+		<CheckboxGroup.Option value="child 1" label="Option 1" id="option-1" name="option-1" />
+		<CheckboxGroup.Option value="child 2" label="Option 2" id="option-2" name="option-2" />
+		<CheckboxGroup.Option value="child 3" label="Option 3" id="option-3" name="option-3" />
 	</>,
 };
 
-ChildrenProp.parameters = { docs: { description: { story: "The `children` prop can be used to render custom content. The options are rendered using the sub component `Option` (`CheckboxGroup.Option` is equal to `Checkbox` component)." } } };
+ChildrenProp.parameters = { docs: { description: { story: "The `children` prop can be used to render custom content. The options are rendered using the sub component `Option` (`CheckboxGroup.Option` is equal to `Checkbox` component). Default values should be set inside the child component and not the `value` prop." } } };
 

--- a/packages/ui-library/src/components/checkbox-group/stories.js
+++ b/packages/ui-library/src/components/checkbox-group/stories.js
@@ -71,3 +71,18 @@ WithValues.args = {
 	],
 };
 
+export const ChildrenProp = Template.bind();
+ChildrenProp.args = {
+	id: "checkbox-group-2",
+	name: "name-2",
+	values: [ "2", "3" ],
+	label: "Checkbox group label.",
+	children: <>
+		<CheckboxGroup.Option value="child 1" label="Option 1" />
+		<CheckboxGroup.Option value="child 2" label="Option 2" />
+		<CheckboxGroup.Option value="child 3" label="Option 3" />
+	</>,
+};
+
+ChildrenProp.parameters = { docs: { description: { story: "The `children` prop can be used to render custom content. The options are rendered using the sub component `Option` (`CheckboxGroup.Option` is equal to `Checkbox` component)." } } };
+

--- a/packages/ui-library/src/components/radio-group/stories.js
+++ b/packages/ui-library/src/components/radio-group/stories.js
@@ -116,12 +116,12 @@ ChildrenProp.args = {
 	name: "name-5",
 	label: "Radio group label.",
 	children: <>
-		<RadioGroup.Option value="child 1" label="Option 1" id="radio-1" name="radio-1" />
-		<RadioGroup.Option value="child 2" label="Option 2" id="radio-2" name="radio-2" />
-		<RadioGroup.Option value="child 3" label="Option 3" id="radio-3" name="radio-3" />
+		<RadioGroup.Radio value="child 1" label="Option 1" id="radio-1" name="radio-1" />
+		<RadioGroup.Radio value="child 2" label="Option 2" id="radio-2" name="radio-2" />
+		<RadioGroup.Radio value="child 3" label="Option 3" id="radio-3" name="radio-3" />
 	</>,
 };
 
-ChildrenProp.parameters = { docs: { description: { story: "The `children` prop can be used to render custom content. The options are rendered using the sub component `Option` (`RadioGroup.Option` is equal to `Radio` element). Default values should be set inside the child component and not the `value` prop." } } };
+ChildrenProp.parameters = { docs: { description: { story: "The `children` prop can be used to render custom content. The options are rendered using the sub component `Radio` (`RadioGroup.Radio` is equal to `Radio` element). Default values should be set inside the child component and not the `value` prop." } } };
 
 

--- a/packages/ui-library/src/components/radio-group/stories.js
+++ b/packages/ui-library/src/components/radio-group/stories.js
@@ -122,6 +122,6 @@ ChildrenProp.args = {
 	</>,
 };
 
-ChildrenProp.parameters = { docs: { description: { story: "The `children` prop can be used to render custom content. The options are rendered using the sub component `Option` (`RadioGroup.Option` is equal to `Radio` component). Default values should be set inside the child component and not the `value` prop." } } };
+ChildrenProp.parameters = { docs: { description: { story: "The `children` prop can be used to render custom content. The options are rendered using the sub component `Option` (`RadioGroup.Option` is equal to `Radio` element). Default values should be set inside the child component and not the `value` prop." } } };
 
 

--- a/packages/ui-library/src/components/radio-group/stories.js
+++ b/packages/ui-library/src/components/radio-group/stories.js
@@ -109,3 +109,19 @@ WithValue.args = {
 		{ value: "4", label: "4", screenReaderLabel: "Option #4" },
 	],
 };
+
+export const ChildrenProp = Template.bind();
+ChildrenProp.args = {
+	id: "radio-group-5",
+	name: "name-5",
+	label: "Radio group label.",
+	children: <>
+		<RadioGroup.Option value="child 1" label="Option 1" id="radio-1" name="radio-1" />
+		<RadioGroup.Option value="child 2" label="Option 2" id="radio-2" name="radio-2" />
+		<RadioGroup.Option value="child 3" label="Option 3" id="radio-3" name="radio-3" />
+	</>,
+};
+
+ChildrenProp.parameters = { docs: { description: { story: "The `children` prop can be used to render custom content. The options are rendered using the sub component `Option` (`RadioGroup.Option` is equal to `Radio` component). Default values should be set inside the child component and not the `value` prop." } } };
+
+


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Add stories for `children` prop story in `CheckboxGroup`,`RadioGroup` and `AutocompleteField` components. 
* `SelectField` has the `children` story from [DUPP-717 Revisit stories for Select element and SelectField component ](https://yoast.atlassian.net/browse/DUPP-718)

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds stories for `children` prop story in `CheckboxGroup`,`RadioGroup` and `AutocompleteField` components. 

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Open storybook and check `CheckboxGroup`,`RadioGroup` and `AutocompleteField` components for `children` prop stories.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes https://yoast.atlassian.net/browse/DUPP-738
