### PR TITLE
DUPP-670 Refactor filter_input call in comment-link-fixer

### DIFF
--- a/src/integrations/front-end/comment-link-fixer.php
+++ b/src/integrations/front-end/comment-link-fixer.php
@@ -64,7 +64,7 @@ class Comment_Link_Fixer implements Integration_Interface {
 		}
 
 		// When users view a reply to a comment, this URL parameter is set. These should never be indexed separately.
-		if ( $this->has_replytocom_parameter() ) {
+		if ( $this->get_replytocom_parameter() !== null ) {
 			\add_filter( 'wpseo_robots_array', [ $this->robots, 'set_robots_no_index' ] );
 		}
 	}
@@ -74,10 +74,15 @@ class Comment_Link_Fixer implements Integration_Interface {
 	 *
 	 * @codeCoverageIgnore Wraps the filter input.
 	 *
-	 * @return string The value of replytocom.
+	 * @return string|null The value of replytocom or null if it does not exist.
 	 */
-	protected function has_replytocom_parameter() {
-		return \filter_input( \INPUT_GET, 'replytocom' );
+	protected function get_replytocom_parameter() {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Reason: We are not processing form information.
+		if ( isset( $_GET['replytocom'] ) && \is_string( $_GET['replytocom'] ) ) {
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Reason: We are not processing form information.
+			return \sanitize_text_field( \wp_unslash( $_GET['replytocom'] ) );
+		}
+		return null;
 	}
 
 	/**

--- a/tests/unit/integrations/front-end/comment-link-fixer-test.php
+++ b/tests/unit/integrations/front-end/comment-link-fixer-test.php
@@ -73,9 +73,7 @@ class Comment_Link_Fixer_Test extends TestCase {
 	 * @covers ::register_hooks
 	 */
 	public function test_register_hooks() {
-		$this->instance
-			->expects( 'has_replytocom_parameter' )
-			->andReturnTrue();
+		$_GET['replytocom'] = 'true';
 
 		$this->instance->register_hooks();
 
@@ -84,6 +82,42 @@ class Comment_Link_Fixer_Test extends TestCase {
 		$this->assertNotFalse( \has_filter( 'comment_reply_link', [ $this->instance, 'remove_reply_to_com' ] ) );
 		$this->assertNotFalse( \has_action( 'template_redirect', [ $this->instance, 'replytocom_redirect' ] ) );
 		$this->assertNotFalse( \has_filter( 'wpseo_robots_array', [ $this->robots, 'set_robots_no_index' ] ) );
+	}
+
+	/**
+	 * Tests the registration of the hooks when the replytocom GET parameter is null.
+	 *
+	 * @covers ::__construct
+	 * @covers ::register_hooks
+	 */
+	public function test_register_hooks_replytocom_null() {
+		$_GET['replytocom'] = null;
+
+		$this->instance->register_hooks();
+
+		\add_filter( 'wpseo_remove_reply_to_com', '__return_false' );
+
+		$this->assertNotFalse( \has_filter( 'comment_reply_link', [ $this->instance, 'remove_reply_to_com' ] ) );
+		$this->assertNotFalse( \has_action( 'template_redirect', [ $this->instance, 'replytocom_redirect' ] ) );
+		$this->assertNotTrue( \has_filter( 'wpseo_robots_array', [ $this->robots, 'set_robots_no_index' ] ) );
+	}
+
+	/**
+	 * Tests the registration of the hooks when the replytocom GET parameter is not a string.
+	 *
+	 * @covers ::__construct
+	 * @covers ::register_hooks
+	 */
+	public function test_register_hooks_replytocom_non_string() {
+		$_GET['replytocom'] = 5;
+
+		$this->instance->register_hooks();
+
+		\add_filter( 'wpseo_remove_reply_to_com', '__return_false' );
+
+		$this->assertNotFalse( \has_filter( 'comment_reply_link', [ $this->instance, 'remove_reply_to_com' ] ) );
+		$this->assertNotFalse( \has_action( 'template_redirect', [ $this->instance, 'replytocom_redirect' ] ) );
+		$this->assertNotTrue( \has_filter( 'wpseo_robots_array', [ $this->robots, 'set_robots_no_index' ] ) );
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to remove all calls to `filter_input` in our codebase.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Refactor `filter_input` call in `comment-link-fixer` class.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install and activate Yoast SEO.
* Go to the sites homepage and look at the HTML source, verify that the `<meta name='robots'>` tag has an `index` attribute.
* Now add `?replytocom=true` to the URL and once again go to the HTML source. Verify that the `<meta name='robots'>` tag has an `noindex` attribute.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
