### PR TITLE
Adds links to front-end admin bar

### DIFF
--- a/src/integrations/admin/integrations-page.php
+++ b/src/integrations/admin/integrations-page.php
@@ -4,8 +4,8 @@ namespace Yoast\WP\SEO\Integrations\Admin;
 
 use WPSEO_Admin_Asset_Manager;
 use WPSEO_Plugin_Availability;
-use Yoast\WP\SEO\Conditionals\Admin_Conditional;
 use Yoast\WP\SEO\Conditionals\Jetpack_Conditional;
+use Yoast\WP\SEO\Conditionals\No_Conditionals;
 use Yoast\WP\SEO\Conditionals\Third_Party\Elementor_Activated_Conditional;
 use Yoast\WP\SEO\Conditionals\WooCommerce_Conditional;
 use Yoast\WP\SEO\Helpers\Options_Helper;
@@ -15,6 +15,8 @@ use Yoast\WP\SEO\Integrations\Integration_Interface;
  * Integrations_Page class
  */
 class Integrations_Page implements Integration_Interface {
+
+	use No_Conditionals;
 
 	/**
 	 * The admin asset manager.
@@ -29,13 +31,6 @@ class Integrations_Page implements Integration_Interface {
 	 * @var Options_Helper
 	 */
 	private $options_helper;
-
-	/**
-	 * {@inheritDoc}
-	 */
-	public static function get_conditionals() {
-		return [];
-	}
 
 	/**
 	 * Workouts_Integration constructor.

--- a/src/integrations/admin/integrations-page.php
+++ b/src/integrations/admin/integrations-page.php
@@ -34,7 +34,7 @@ class Integrations_Page implements Integration_Interface {
 	 * {@inheritDoc}
 	 */
 	public static function get_conditionals() {
-		return [ Admin_Conditional::class ];
+		return [];
 	}
 
 	/**

--- a/src/integrations/admin/redirects-integration.php
+++ b/src/integrations/admin/redirects-integration.php
@@ -29,7 +29,6 @@ class Redirects_Integration implements Integration_Interface {
 	 */
 	public static function get_conditionals() {
 		return [
-			Admin_Conditional::class,
 			Premium_Inactive_Conditional::class,
 		];
 	}

--- a/src/integrations/admin/workouts-integration.php
+++ b/src/integrations/admin/workouts-integration.php
@@ -5,6 +5,7 @@ namespace Yoast\WP\SEO\Integrations\Admin;
 use WPSEO_Addon_Manager;
 use WPSEO_Admin_Asset_Manager;
 use Yoast\WP\SEO\Conditionals\Admin_Conditional;
+use Yoast\WP\SEO\Conditionals\No_Conditionals;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Product_Helper;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
@@ -14,6 +15,8 @@ use Yoast\WP\SEO\Presenters\Admin\Notice_Presenter;
  * WorkoutsIntegration class
  */
 class Workouts_Integration implements Integration_Interface {
+
+	use No_Conditionals;
 
 	/**
 	 * The admin asset manager.
@@ -42,13 +45,6 @@ class Workouts_Integration implements Integration_Interface {
 	 * @var Product_Helper
 	 */
 	private $product_helper;
-
-	/**
-	 * {@inheritDoc}
-	 */
-	public static function get_conditionals() {
-		return [];
-	}
 
 	/**
 	 * Workouts_Integration constructor.

--- a/src/integrations/admin/workouts-integration.php
+++ b/src/integrations/admin/workouts-integration.php
@@ -47,7 +47,7 @@ class Workouts_Integration implements Integration_Interface {
 	 * {@inheritDoc}
 	 */
 	public static function get_conditionals() {
-		return [ Admin_Conditional::class ];
+		return [];
 	}
 
 	/**

--- a/tests/unit/integrations/admin/redirects-integration-test.php
+++ b/tests/unit/integrations/admin/redirects-integration-test.php
@@ -41,10 +41,7 @@ class Redirects_Integration_Test extends TestCase {
 	 */
 	public function test_get_conditionals() {
 		static::assertEquals(
-			[
-				Admin_Conditional::class,
-				Premium_Inactive_Conditional::class,
-			],
+			[ Premium_Inactive_Conditional::class ],
 			Redirects_Integration::get_conditionals()
 		);
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to display the same links in the admin bar menu as in the normal menu

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds integrations, workouts and redirection menu option to the front-end admin bar.

## Relevant technical choices:

* This PR removes the admin conditional from certain integration, but this only impact the menu adding. The asset enqueue happens in an admin_init.
* the Workouts and Redirects menu item will be displayed without the "Premium" to avoid cluttering the menu

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* This pr has to be tested together with https://github.com/Yoast/wordpress-seo-premium/pull/3763 and https://github.com/Yoast/wpseo-woocommerce/pull/855
* Verify that the menu items are the same on /wp-admin/admin.php?page=wpseo_dashboard and when looking in the front-end at the menu in the screenshot: 
<img width="417" alt="image" src="https://user-images.githubusercontent.com/6975345/204749693-b3236d9f-9858-4197-a842-f3171e246756.png">

 * Make sure that when you disable an add-on the menu item disappears.
 * Make sure all the links end up in the same location.
 * With premium active make sure the following scrips do no appear in the front-end. This can be checked in the network tab of the chrome dev tools. On the top-left of the box you can filter the files.
 * wp-content/plugins/wordpress-seo/js/dist/integrations-page.js
	wp-content/plugins/wordpress-seo/js/dist/workouts.js
	assets/js/dist/wp-seo-premium-admin-redirects-1950.js


#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [x] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [X] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
