### PR TITLE
Remove prominent words when its indexable gets deleted

### DIFF
--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -85,6 +85,7 @@ class WPSEO_Upgrade {
 			'19.3-RC0'   => 'upgrade_193',
 			'19.6-RC0'   => 'upgrade_196',
 			'19.11-RC0'  => 'upgrade_1911',
+			'19.12-RC0'  => 'upgrade_1912',
 		];
 
 		array_walk( $routines, [ $this, 'run_upgrade_routine' ], $version );
@@ -958,6 +959,16 @@ class WPSEO_Upgrade {
 		\add_action( 'shutdown', [ $this, 'remove_indexable_rows_for_non_public_taxonomies' ] );
 		$this->deduplicate_unindexed_indexable_rows();
 		$this->remove_indexable_rows_for_disabled_authors_archive();
+		if ( ! \wp_next_scheduled( Cleanup_Integration::START_HOOK ) ) {
+			\wp_schedule_single_event( ( time() + ( MINUTE_IN_SECONDS * 5 ) ), Cleanup_Integration::START_HOOK );
+		}
+	}
+
+	/**
+	 * Performs the 19.12 upgrade routine.
+	 * This just schedules the cleanup routine cron again, since in combination of premium cleans up the prominent words table.
+	 */
+	private function upgrade_1912() {
 		if ( ! \wp_next_scheduled( Cleanup_Integration::START_HOOK ) ) {
 			\wp_schedule_single_event( ( time() + ( MINUTE_IN_SECONDS * 5 ) ), Cleanup_Integration::START_HOOK );
 		}

--- a/src/integrations/watchers/indexable-author-watcher.php
+++ b/src/integrations/watchers/indexable-author-watcher.php
@@ -72,6 +72,7 @@ class Indexable_Author_Watcher implements Integration_Interface {
 		}
 
 		$indexable->delete();
+		\do_action( 'wpseo_indexable_deleted', $indexable );
 	}
 
 	/**

--- a/src/integrations/watchers/indexable-post-watcher.php
+++ b/src/integrations/watchers/indexable-post-watcher.php
@@ -149,6 +149,7 @@ class Indexable_Post_Watcher implements Integration_Interface {
 		$this->hierarchy_repository->clear_ancestors( $indexable->id );
 		$this->link_builder->delete( $indexable );
 		$indexable->delete();
+		\do_action( 'wpseo_indexable_deleted', $indexable );
 	}
 
 	/**

--- a/src/integrations/watchers/indexable-term-watcher.php
+++ b/src/integrations/watchers/indexable-term-watcher.php
@@ -97,6 +97,7 @@ class Indexable_Term_Watcher implements Integration_Interface {
 		}
 
 		$indexable->delete();
+		\do_action( 'wpseo_indexable_deleted', $indexable );
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* This is needed to be able to hook into the removal of an indexable.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds a new `wpseo_indexable_deleted` action that triggers whenever an indexable is removed.
* Registers a run of the cleanup routine.

## Relevant technical choices:

* No prominent words are being generated for terms. This PR adds the hook to the deletion of terms to keep it consistent  and when/if we add prominent words for terms it will just work.
* Same goes for authors, I added the code their since there is a removal of an indexable and I want that to be consistent.
* With this PR if you remove an indexable by hand the action is triggered and it is gone, also the cleanup cron is triggered in an upgrade routine, that removes all orphaned prominent words at the end of the cleanup. So after updating you should have 0 orphaned prominent words and non should be able to show up anymore.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* This has to be tested together with https://github.com/Yoast/wordpress-seo-premium/pull/3764 . The test instructions live in that PR.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [X] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
