### PR TITLE
DUPP-670 Refactor calls to filter_var in conflicting-plugins-service

### DIFF
--- a/src/services/importing/conflicting-plugins-service.php
+++ b/src/services/importing/conflicting-plugins-service.php
@@ -84,8 +84,10 @@ class Conflicting_Plugins_Service {
 	 * @return array The remaining active plugins.
 	 */
 	protected function ignore_deactivating_plugin( $all_active_plugins ) {
-		if ( isset( $_GET['action'] ) && isset( $_GET['plugin'] ) && \filter_var( \wp_unslash( $_GET['action'] ) ) === 'deactivate' ) {
-			$deactivated_plugin = \filter_var( \wp_unslash( $_GET['plugin'] ) );
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Reason: We are strictly comparing only.
+		if ( isset( $_GET['action'] ) && isset( $_GET['plugin'] ) && \is_string( $_GET['action'] ) && \is_string( $_GET['plugin'] ) && \wp_unslash( $_GET['action'] ) === 'deactivate' ) {
+			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Reason: We are strictly comparing only.
+			$deactivated_plugin = \wp_unslash( $_GET['plugin'] );
 
 			\check_admin_referer( 'deactivate-plugin_' . $deactivated_plugin );
 

--- a/tests/unit/services/importing/conflicting-plugins-service-test.php
+++ b/tests/unit/services/importing/conflicting-plugins-service-test.php
@@ -146,30 +146,30 @@ class Conflicting_Plugins_Service_Test extends TestCase {
 	 * @return array[] Data to use for test_detect_deactivating_conflicting_plugins_plugin_is_int.
 	 */
 	public function detect_deactivating_conflicting_plugins_dataprovider() {
-		$action_is_null = [
-			'action' => null,
-			'plugin' => 'xml-sitemaps/xml-sitemaps.php',
-			'expected' => ['xml-sitemaps/xml-sitemaps.php']
+		$action_is_null       = [
+			'action'   => null,
+			'plugin'   => 'xml-sitemaps/xml-sitemaps.php',
+			'expected' => [ 'xml-sitemaps/xml-sitemaps.php' ],
 		];
 		$action_is_not_string = [
-			'action' => 13,
-			'plugin' => 'xml-sitemaps/xml-sitemaps.php',
-			'expected' => ['xml-sitemaps/xml-sitemaps.php']
+			'action'   => 13,
+			'plugin'   => 'xml-sitemaps/xml-sitemaps.php',
+			'expected' => [ 'xml-sitemaps/xml-sitemaps.php' ],
 		];
-		$plugin_is_null = [
-			'action' => 'deactivate',
-			'plugin' => null,
-			'expected' => ['xml-sitemaps/xml-sitemaps.php']
+		$plugin_is_null       = [
+			'action'   => 'deactivate',
+			'plugin'   => null,
+			'expected' => [ 'xml-sitemaps/xml-sitemaps.php' ],
 		];
 		$plugin_is_not_string = [
-			'action' => 'deactivate',
-			'plugin' => 13,
-			'expected' => ['xml-sitemaps/xml-sitemaps.php']
+			'action'   => 'deactivate',
+			'plugin'   => 13,
+			'expected' => [ 'xml-sitemaps/xml-sitemaps.php' ],
 		];
 		return [
-			'Action is null' => $action_is_null,
+			'Action is null'       => $action_is_null,
 			'Action is not string' => $action_is_not_string,
-			'Plugin is null' => $plugin_is_null,
+			'Plugin is null'       => $plugin_is_null,
 			'Plugin is not string' => $plugin_is_not_string,
 		];
 	}

--- a/tests/unit/services/importing/conflicting-plugins-service-test.php
+++ b/tests/unit/services/importing/conflicting-plugins-service-test.php
@@ -109,4 +109,68 @@ class Conflicting_Plugins_Service_Test extends TestCase {
 		// Assert.
 		$this->assertEquals( [], $result );
 	}
+
+	/**
+	 * Test the ignore_deactivating_plugin when GET variables are not set correctly.
+	 *
+	 * @param mixed $action The value of $_GET['action'].
+	 * @param mixed $plugin The value of $_GET['plugin'].
+	 * @param array $expected The expected return value of detect_conflicting_plugins.
+	 *
+	 * @dataProvider detect_deactivating_conflicting_plugins_dataprovider
+	 *
+	 * @covers ::ignore_deactivating_plugin
+	 */
+	public function test_detect_deactivating_conflicting_plugins_plugin_is_int( $action, $plugin, $expected ) {
+		Monkey\Functions\expect( 'get_option' )
+			->with( 'active_plugins' )
+			->once()
+			->andReturn(
+				[
+					'xml-sitemaps/xml-sitemaps.php',
+					'not-conflicting/plugin.php',
+				]
+			);
+
+		$_GET['action'] = $action;
+		$_GET['plugin'] = $plugin;
+
+		$result = $this->conflicting_plugins_service->detect_conflicting_plugins();
+
+		$this->assertEquals( $expected, $result );
+	}
+
+	/**
+	 * Data provider for test_detect_deactivating_conflicting_plugins_plugin_is_int.
+	 *
+	 * @return array[] Data to use for test_detect_deactivating_conflicting_plugins_plugin_is_int.
+	 */
+	public function detect_deactivating_conflicting_plugins_dataprovider() {
+		$action_is_null = [
+			'action' => null,
+			'plugin' => 'xml-sitemaps/xml-sitemaps.php',
+			'expected' => ['xml-sitemaps/xml-sitemaps.php']
+		];
+		$action_is_not_string = [
+			'action' => 13,
+			'plugin' => 'xml-sitemaps/xml-sitemaps.php',
+			'expected' => ['xml-sitemaps/xml-sitemaps.php']
+		];
+		$plugin_is_null = [
+			'action' => 'deactivate',
+			'plugin' => null,
+			'expected' => ['xml-sitemaps/xml-sitemaps.php']
+		];
+		$plugin_is_not_string = [
+			'action' => 'deactivate',
+			'plugin' => 13,
+			'expected' => ['xml-sitemaps/xml-sitemaps.php']
+		];
+		return [
+			'Action is null' => $action_is_null,
+			'Action is not string' => $action_is_not_string,
+			'Plugin is null' => $plugin_is_null,
+			'Plugin is not string' => $plugin_is_not_string,
+		];
+	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Refactor calls to `filter_var` in conflicting-plugins-service class.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

It seems that this class is not being used anymore so I can't write test instructions.

Igor here, I'm not sure this properly tests the path, but at least the code gets run:
* Either add a add & activate a plugin of your own, then add it to [a conflicting plugins list](https://github.com/Yoast/wordpress-seo/blob/trunk/src/config/conflicting-plugins.php), or add & activate one of those conflicting plugins.
* You should get a notification in our notification center about this detected conflict, including a deactivate button
* Click on the deactivate button
* Verify the plugin deactivated

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [x] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
