### PR TITLE
Settings UI: when globally disabling an archive type, uncheck show in search results toggle

### DIFF
--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "test": "jest -u",
-    "lint": "eslint src tests --max-warnings=119"
+    "lint": "eslint src tests --max-warnings=118"
   },
   "dependencies": {
     "@draft-js-plugins/mention": "^5.0.0",

--- a/packages/js/src/settings/app.js
+++ b/packages/js/src/settings/app.js
@@ -25,7 +25,7 @@ import {
 	DateArchives,
 	FormatArchives,
 	Homepage,
-	Media,
+	MediaPages,
 	PostType,
 	Rss,
 	SiteBasics,
@@ -141,7 +141,7 @@ const Menu = ( { postTypes, taxonomies, idSuffix = "" } ) => {
 				<SidebarNavigation.SubmenuItem to="/date-archives" label={ __( "Date archives", "wordpress-seo" ) } idSuffix={ idSuffix } />
 				<SidebarNavigation.SubmenuItem to="/format-archives" label={ __( "Format archives", "wordpress-seo" ) } idSuffix={ idSuffix } />
 				<SidebarNavigation.SubmenuItem to="/special-pages" label={ __( "Special pages", "wordpress-seo" ) } idSuffix={ idSuffix } />
-				<SidebarNavigation.SubmenuItem to="/media" label={ __( "Media pages", "wordpress-seo" ) } idSuffix={ idSuffix } />
+				<SidebarNavigation.SubmenuItem to="/media-pages" label={ __( "Media pages", "wordpress-seo" ) } idSuffix={ idSuffix } />
 				<SidebarNavigation.SubmenuItem to="/rss" label={ __( "RSS", "wordpress-seo" ) } idSuffix={ idSuffix } />
 			</SidebarNavigation.MenuItem>
 		</div>
@@ -264,7 +264,7 @@ const App = () => {
 											<Route path="date-archives" element={ <DateArchives /> } />
 											<Route path="homepage" element={ <Homepage /> } />
 											<Route path="format-archives" element={ <FormatArchives /> } />
-											<Route path="media" element={ <Media /> } />
+											<Route path="media-pages" element={ <MediaPages /> } />
 											<Route path="rss" element={ <Rss /> } />
 											<Route path="site-basics" element={ <SiteBasics /> } />
 											<Route path="site-connections" element={ <SiteConnections /> } />

--- a/packages/js/src/settings/components/formik-replacement-variable-editor-field.js
+++ b/packages/js/src/settings/components/formik-replacement-variable-editor-field.js
@@ -6,8 +6,8 @@ import PropTypes from "prop-types";
 /**
  * @param {Object} props The props to pass down to the component.
  * @param {string} props.name The field name.
- * @param {string} props.name The field name.
- * @param {boolean} props.disabled Disabled state.
+ * @param {string} [props.className] The field className.
+ * @param {boolean} [props.disabled] Disabled state.
  * @returns {JSX.Element} The Formik compatible element.
  */
 const FormikReplacementVariableEditorField = ( { className = "", disabled = false, ...props } ) => {

--- a/packages/js/src/settings/routes/author-archives.js
+++ b/packages/js/src/settings/routes/author-archives.js
@@ -71,7 +71,7 @@ const AuthorArchives = () => {
 			// eslint-disable-next-line jsx-a11y/anchor-has-content, react/jsx-no-target-blank
 			a: <a href={ duplicateContentInfoLink } target="_blank" rel="noopener" />,
 		}
-	) );
+	), [] );
 
 	const { values } = useFormikContext();
 	const { opengraph } = values.wpseo_social;
@@ -126,7 +126,7 @@ const AuthorArchives = () => {
 									__( "Disabling this means that %1$s will not be indexed by search engines and will be excluded from XML sitemaps.", "wordpress-seo" ),
 									labelLower
 								) }
-										&nbsp;
+								&nbsp;
 								<Link href={ noIndexInfoLink } target="_blank" rel="noopener">
 									{ __( "Read more about the search results settings", "wordpress-seo" ) }
 								</Link>

--- a/packages/js/src/settings/routes/author-archives.js
+++ b/packages/js/src/settings/routes/author-archives.js
@@ -133,6 +133,8 @@ const AuthorArchives = () => {
 								.
 							</> }
 							disabled={ isAuthorArchivesDisabled }
+							/* If the archive is disabled then show as disabled. Otherwise, use the actual value (but flipped). */
+							checked={ isAuthorArchivesDisabled ? false : ! isAuthorNoIndex }
 							className="yst-max-w-sm"
 						/>
 						<FormikFlippedToggleField
@@ -148,7 +150,7 @@ const AuthorArchives = () => {
 								__( "Disabling this means that %1$s without any posts will not be indexed by search engines and will be excluded from XML sitemaps.", "wordpress-seo" ),
 								labelLower
 							) }
-							checked={ ! isAuthorNoIndex && ! isAuthorNoIndexNoPosts }
+							checked={ isAuthorArchivesDisabled ? false : ! isAuthorNoIndex && ! isAuthorNoIndexNoPosts }
 							disabled={ isAuthorArchivesDisabled || isAuthorNoIndex }
 							className="yst-max-w-sm"
 						/>

--- a/packages/js/src/settings/routes/date-archives.js
+++ b/packages/js/src/settings/routes/date-archives.js
@@ -1,3 +1,4 @@
+/* eslint-disable complexity */
 import { createInterpolateElement, useMemo } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
 import { Badge, Code, FeatureUpsell, Link } from "@yoast/ui-library";

--- a/packages/js/src/settings/routes/date-archives.js
+++ b/packages/js/src/settings/routes/date-archives.js
@@ -132,7 +132,7 @@ const DateArchives = () => {
 							label={ __( "SEO title", "wordpress-seo" ) }
 							replacementVariables={ replacementVariables }
 							recommendedReplacementVariables={ recommendedReplacementVariables }
-							isDisabled={ isDateArchivesDisabled }
+							disabled={ isDateArchivesDisabled }
 						/>
 						<FormikReplacementVariableEditorField
 							type="description"
@@ -141,7 +141,7 @@ const DateArchives = () => {
 							label={ __( "Meta description", "wordpress-seo" ) }
 							replacementVariables={ replacementVariables }
 							recommendedReplacementVariables={ recommendedReplacementVariables }
-							isDisabled={ isDateArchivesDisabled }
+							disabled={ isDateArchivesDisabled }
 							className="yst-replacevar--description"
 						/>
 					</FieldsetLayout>
@@ -185,7 +185,7 @@ const DateArchives = () => {
 								label={ __( "Social title", "wordpress-seo" ) }
 								replacementVariables={ replacementVariables }
 								recommendedReplacementVariables={ recommendedReplacementVariables }
-								isDisabled={ isDateArchivesDisabled || ! opengraph }
+								disabled={ isDateArchivesDisabled || ! opengraph }
 								isDummy={ ! isPremium }
 							/>
 							<FormikReplacementVariableEditorFieldWithDummy
@@ -196,7 +196,7 @@ const DateArchives = () => {
 								replacementVariables={ replacementVariables }
 								recommendedReplacementVariables={ recommendedReplacementVariables }
 								className="yst-replacevar--description"
-								isDisabled={ isDateArchivesDisabled || ! opengraph }
+								disabled={ isDateArchivesDisabled || ! opengraph }
 								isDummy={ ! isPremium }
 							/>
 						</FeatureUpsell>

--- a/packages/js/src/settings/routes/date-archives.js
+++ b/packages/js/src/settings/routes/date-archives.js
@@ -22,7 +22,7 @@ const FormikReplacementVariableEditorFieldWithDummy = withFormikDummyField( Form
  */
 const DateArchives = () => {
 	const label = __( "Date archives", "wordpress-seo" );
-	const labelLower = useMemo( ()=> toLower( label ), [ label ] );
+	const labelLower = useMemo( () => toLower( label ), [ label ] );
 
 	const premiumUpsellConfig = useSelectSettings( "selectUpsellSettingsAsProps" );
 	const replacementVariables = useSelectSettings( "selectReplacementVariablesFor", [], "date_archive", "custom-post-type_archive" );
@@ -67,7 +67,10 @@ const DateArchives = () => {
 
 	const { values } = useFormikContext();
 	const { opengraph } = values.wpseo_social;
-	const { "disable-date": isDateArchivesDisabled } = values.wpseo_titles;
+	const {
+		"disable-date": isDateArchivesDisabled,
+		"noindex-archive-wpseo": isDateArchivesNoIndex,
+	} = values.wpseo_titles;
 
 	return (
 		<RouteLayout
@@ -116,13 +119,15 @@ const DateArchives = () => {
 									__( "Disabling this means that %1$s will not be indexed by search engines and will be excluded from XML sitemaps. We recommend that you disable this setting.", "wordpress-seo" ),
 									labelLower
 								) }
-										&nbsp;
+								&nbsp;
 								<Link href={ noIndexInfoLink } target="_blank" rel="noopener">
 									{ __( "Read more about the search results settings", "wordpress-seo" ) }
 								</Link>
 								.
 							</> }
 							disabled={ isDateArchivesDisabled }
+							/* If the archive is disabled then show as disabled. Otherwise, use the actual value (but flipped). */
+							checked={ isDateArchivesDisabled ? false : ! isDateArchivesNoIndex }
 							className="yst-max-w-sm"
 						/>
 						<FormikReplacementVariableEditorField

--- a/packages/js/src/settings/routes/format-archives.js
+++ b/packages/js/src/settings/routes/format-archives.js
@@ -1,3 +1,4 @@
+/* eslint-disable complexity */
 import { createInterpolateElement, useMemo } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
 import { Badge, Code, FeatureUpsell, Link } from "@yoast/ui-library";

--- a/packages/js/src/settings/routes/format-archives.js
+++ b/packages/js/src/settings/routes/format-archives.js
@@ -28,7 +28,7 @@ const FormikReplacementVariableEditorFieldWithDummy = withFormikDummyField( Form
  */
 const FormatArchives = () => {
 	const { name, label, singularLabel } = useSelectSettings( "selectTaxonomy", [], "post_format" );
-	const labelLower = useMemo( ()=> toLower( label ), [ label ] );
+	const labelLower = useMemo( () => toLower( label ), [ label ] );
 	const singularLabelLower = useMemo( () => toLower( singularLabel ), [ singularLabel ] );
 
 	const premiumUpsellConfig = useSelectSettings( "selectUpsellSettingsAsProps" );
@@ -75,7 +75,7 @@ const FormatArchives = () => {
 
 	return (
 		<RouteLayout
-			title={ label }
+			title={ __( "Format archives", "wordpress-seo" ) }
 			description={ description }
 		>
 			<FormLayout>
@@ -112,7 +112,7 @@ const FormatArchives = () => {
 									__( "Disabling this means that %1$s will not be indexed by search engines and will be excluded from XML sitemaps. We recommend that you disable this setting.", "wordpress-seo" ),
 									labelLower
 								) }
-										&nbsp;
+								&nbsp;
 								<Link href={ noIndexInfoLink } target="_blank" rel="noopener">
 									{ __( "Read more about the search results settings", "wordpress-seo" ) }
 								</Link>

--- a/packages/js/src/settings/routes/format-archives.js
+++ b/packages/js/src/settings/routes/format-archives.js
@@ -68,7 +68,10 @@ const FormatArchives = () => {
 
 	const { values } = useFormikContext();
 	const { opengraph } = values.wpseo_social;
-	const { "disable-post_format": isFormatArchivesDisabled } = values.wpseo_titles;
+	const {
+		"disable-post_format": isFormatArchivesDisabled,
+		"noindex-tax-post_format": isFormatArchivesNoIndex,
+	} = values.wpseo_titles;
 
 	return (
 		<RouteLayout
@@ -116,6 +119,8 @@ const FormatArchives = () => {
 								.
 							</> }
 							disabled={ isFormatArchivesDisabled }
+							/* If the archive is disabled then show as disabled. Otherwise, use the actual value (but flipped). */
+							checked={ isFormatArchivesDisabled ? false : ! isFormatArchivesNoIndex }
 							className="yst-max-w-sm"
 						/>
 						<FormikReplacementVariableEditorField

--- a/packages/js/src/settings/routes/homepage.js
+++ b/packages/js/src/settings/routes/homepage.js
@@ -88,7 +88,7 @@ const LatestPosts = () => {
 				label={ __( "Social title", "wordpress-seo" ) }
 				replacementVariables={ replacementVariables }
 				recommendedReplacementVariables={ recommendedReplacementVariables }
-				isDisabled={ ! opengraph }
+				disabled={ ! opengraph }
 			/>
 			<FormikReplacementVariableEditorField
 				type="description"
@@ -98,7 +98,7 @@ const LatestPosts = () => {
 				replacementVariables={ replacementVariables }
 				recommendedReplacementVariables={ recommendedReplacementVariables }
 				className="yst-replacevar--description"
-				isDisabled={ ! opengraph }
+				disabled={ ! opengraph }
 			/>
 		</FieldsetLayout>
 	</>;

--- a/packages/js/src/settings/routes/index.js
+++ b/packages/js/src/settings/routes/index.js
@@ -6,7 +6,7 @@ export { default as CrawlSettings } from "./crawl-optimization";
 export { default as DateArchives } from "./date-archives";
 export { default as FormatArchives } from "./format-archives";
 export { default as Homepage } from "./homepage";
-export { default as Media } from "./media";
+export { default as MediaPages } from "./media-pages";
 export { default as Rss } from "./rss";
 export { default as SiteBasics } from "./site-basics";
 export { default as SiteFeatures } from "./site-features";

--- a/packages/js/src/settings/routes/media-pages.js
+++ b/packages/js/src/settings/routes/media-pages.js
@@ -14,9 +14,9 @@ import {
 import { useSelectSettings } from "../hooks";
 
 /**
- * @returns {JSX.Element} The media route.
+ * @returns {JSX.Element} The media pages route.
  */
-const Media = () => {
+const MediaPages = () => {
 	const { name, label, hasSchemaArticleType } = useSelectSettings( "selectPostType", [], "attachment" );
 	const labelLower = useMemo( ()=> toLower( label ), [ label ] );
 
@@ -182,4 +182,4 @@ const Media = () => {
 	);
 };
 
-export default Media;
+export default MediaPages;

--- a/packages/js/src/settings/routes/media-pages.js
+++ b/packages/js/src/settings/routes/media-pages.js
@@ -18,7 +18,7 @@ import { useSelectSettings } from "../hooks";
  */
 const MediaPages = () => {
 	const { name, label, hasSchemaArticleType } = useSelectSettings( "selectPostType", [], "attachment" );
-	const labelLower = useMemo( ()=> toLower( label ), [ label ] );
+	const labelLower = useMemo( () => toLower( label ), [ label ] );
 
 	const replacementVariables = useSelectSettings( "selectReplacementVariablesFor", [ name ], name, "custom_post_type" );
 	const recommendedReplacementVariables = useSelectSettings( "selectRecommendedReplacementVariablesFor", [ name ], name, "custom_post_type" );
@@ -28,7 +28,10 @@ const MediaPages = () => {
 	const noIndexInfoLink = useSelectSettings( "selectLink", [], "https://yoa.st/show-x" );
 
 	const { values } = useFormikContext();
-	const { "disable-attachment": isAttachmentPagesDisabled } = values.wpseo_titles;
+	const {
+		"disable-attachment": isAttachmentPagesDisabled,
+		"noindex-attachment": isAttachmentPagesNoIndex,
+	} = values.wpseo_titles;
 
 	const description = useMemo( () => createInterpolateElement(
 		sprintf(
@@ -111,6 +114,8 @@ const MediaPages = () => {
 								.
 							</> }
 							disabled={ isAttachmentPagesDisabled }
+							/* If the archive is disabled then show as disabled. Otherwise, use the actual value (but flipped). */
+							checked={ isAttachmentPagesDisabled ? false : ! isAttachmentPagesNoIndex }
 							className="yst-max-w-sm"
 						/>
 						<FormikReplacementVariableEditorField


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* When globally disabling an archive type, uncheck show in search results toggle. This looks like the following in author archives:
![toggle-show-as-unchecked](https://user-images.githubusercontent.com/35524806/205090481-a2e0ce68-a0fa-4689-818b-4c6386922a7a.gif)
* We do this to visually show to the user the other archives are not shown in the search results either. 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves the Settings UI archives and media pages under advanced by showing the "show in search results" as off when the whole feature is disabled.
* Renames the "Formats" page title to "Format archives", for consistency.

## Relevant technical choices:

* Solved with a ternary as override `checked` prop. Checked means it is only visual (not the value). Ternary to only impact it when the overal value is disabled.
* Renamed the `media` route to `media-pages` for consistency.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Affected pages: Author archives, date archives, format archives and media pages
* Go to the Settings UI > Advanced > One of the above pages
* Turn ON the first "Enable ..." toggle.
* Turn ON the "Show ... in search results" toggle.
  * If on author archives: enable the "Show author archives without posts in search results" toggle.
* Turn OFF the first "Enable ..." toggle.
* Verify the "Show ... in search results" toggle is shown as OFF.
  * If on author archives: verify the "Show author archives without posts in search results" toggle is shown as OFF.
#### Verify the toggle keeps its original value
* Turn ON the first "Enable ..." toggle.
* Turn OFF the "Show ... in search results" toggle.
* Turn OFF the first "Enable ..." toggle.
* Verify the "Show ... in search results" toggle is shown as OFF.
  * If on author archives: verify the "Show author archives without posts in search results" toggle is shown as OFF.
* Turn ON the first "Enable ..." toggle.
* Verify the "Show ... in search results" toggle is still OFF. This is due to the actual value.

#### Replacement variable editor API `isDisabled` to `disabled`
Quick sanity check could be performed:
* When disabling settings like the "Enable ..." toggle in Author archives, the replacement variable editors should still be disabled and not respond to clicks etc.

#### Format archives rename
* Verify the format archives page title is now `Format archives`.

#### Media pages
Quick sanity check could be peformed:
* Verify the Media pages can still be visited (renamed the route/URL from `media` to `media-pages`).

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Impacts the Settings UI:
  * Specified pages in the test instructions.
  * Disabling of the replacement variable editors in the Settings UI. I.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [x] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes https://yoast.atlassian.net/browse/DUPP-814
