### PR TITLE
Bugfix: Create indexable hierarchy the first time an indexable is created

### DIFF
--- a/src/builders/indexable-builder.php
+++ b/src/builders/indexable-builder.php
@@ -354,18 +354,19 @@ class Indexable_Builder {
 						return $indexable;
 					}
 
+					// Save indexable, to make sure it can be queried when building related objects like the author indexable and hierarchy.
+					$indexable = $this->save_indexable( $indexable, $indexable_before );
+
 					// Always rebuild the primary term.
 					$this->primary_term_builder->build( $indexable->object_id );
 
 					// Always rebuild the hierarchy; this needs the primary term to run correctly.
 					$this->hierarchy_builder->build( $indexable );
 
-					// Save indexable, to make sure that it can be queried when determining if an author has public posts.
-					$indexable = $this->save_indexable( $indexable, $indexable_before );
-
 					$this->maybe_build_author_indexable( $indexable->author_id );
 
-					break;
+					// The indexable is already saved, so return early.
+					return $indexable;
 
 				case 'user':
 					$indexable = $this->author_builder->build( $indexable->object_id, $indexable );
@@ -374,8 +375,13 @@ class Indexable_Builder {
 				case 'term':
 					$indexable = $this->term_builder->build( $indexable->object_id, $indexable );
 
+					// Save indexable, to make sure it can be queried when building hierarchy.
+					$indexable = $this->save_indexable( $indexable, $indexable_before );
+
 					$this->hierarchy_builder->build( $indexable );
-					break;
+
+					// The indexable is already saved, so return early.
+					return $indexable;
 
 				case 'home-page':
 					$indexable = $this->home_page_builder->build( $indexable );

--- a/tests/integration/admin/watchers/test-class-indexable-post-watcher.php
+++ b/tests/integration/admin/watchers/test-class-indexable-post-watcher.php
@@ -1,0 +1,191 @@
+<?php
+/**
+ * WPSEO plugin test file.
+ *
+ * @package WPSEO\Tests\Admin\Watchers
+ */
+
+use Yoast\WP\Lib\Model;
+use Yoast\WP\SEO\Models\Indexable;
+use Yoast\WP\SEO\Models\Indexable_Hierarchy;
+
+/**
+ * Tests the post watcher, which creates indexables and related objects when a post object is created/updated/deleted.
+ *
+ * TODO: add tests for
+ * - Attachments
+ * - Multisite (while being switched)
+ * - Setting/updating the has_public_posts property
+ * - Building links
+ * - Unexpected filter/hook input
+ * - Building author indexables
+ * - Unhappy paths
+ */
+class Test_Class_Indexable_Post_Watcher extends WPSEO_UnitTestCase {
+
+	/**
+	 * An indexable should be created whenever a post is created.
+	 *
+	 * @covers \Yoast\WP\SEO\Integrations\Watchers\Indexable_Post_Watcher::build_indexable
+	 * @covers \Yoast\WP\SEO\Builders\Indexable_Builder::build
+	 *
+	 * @return void
+	 */
+	public function test_create_post() {
+		$post = $this->factory()->post->create_and_get();
+
+		$indexables = $this->get_indexables_for( $post );
+
+		$this->assertCount( 1, $indexables );
+	}
+
+	/**
+	 * The indexable should be deleted when the post is deleted.
+	 *
+	 * @covers \Yoast\WP\SEO\Integrations\Watchers\Indexable_Post_Watcher::delete_indexable
+	 *
+	 * @return void
+	 */
+	public function test_delete_post() {
+		$post = $this->factory()->post->create_and_get();
+
+		wp_delete_post( $post->ID, true );
+
+		$indexables = $this->get_indexables_for( $post );
+
+		$this->assertCount( 0, $indexables );
+	}
+
+	/**
+	 * The deletion of the indexable removal should be idempotent: removing a post that had its indexable removed
+	 * (or not created) should result in there being no indexable.
+	 *
+	 * @covers \Yoast\WP\SEO\Integrations\Watchers\Indexable_Post_Watcher::delete_indexable
+	 *
+	 * @return void
+	 */
+	public function test_delete_post_indexable_removed_after_creation() {
+		$post = $this->factory()->post->create_and_get();
+
+		$this->delete_indexables_for( $post );
+		$indexables = $this->get_indexables_for( $post );
+
+		$this->assertCount( 0, $indexables );
+
+		wp_delete_post( $post->ID, true );
+
+		$this->assertCount( 0, $indexables );
+	}
+
+	/**
+	 * An indexable hierarchy should be created whenever a post is created.
+	 *
+	 * @covers \Yoast\WP\SEO\Integrations\Watchers\Indexable_Post_Watcher::build_indexable
+	 * @covers \Yoast\WP\SEO\Builders\Indexable_Builder::build
+	 *
+	 * @return void
+	 */
+	public function test_create_post_with_hierarchy() {
+		$parent = $this->factory()->post->create_and_get(
+			[
+				'post_type' => 'page',
+			]
+		);
+		$child  = $this->factory()->post->create_and_get(
+			[
+				'post_type'   => 'page',
+				'post_parent' => $parent->ID,
+			]
+		);
+
+		$parent_indexable = \current( $this->get_indexables_for( $parent ) );
+		$child_indexable  = \current( $this->get_indexables_for( $child ) );
+
+		$parent_hierarchy = $this->get_hierarchy_for( $parent_indexable );
+		$child_hierarchy  = $this->get_hierarchy_for( $child_indexable );
+
+		$this->assertCount( 1, $parent_hierarchy );
+		$this->assertCount( 1, $child_hierarchy );
+		$this->assertSame( $parent_hierarchy[0]->ancestor_id, 0 );
+		$this->assertSame( $child_hierarchy[0]->ancestor_id, (int) $parent_indexable->id() );
+	}
+
+	/**
+	 * Indexable hierarchy should be deleted whenever a post is deleted.
+	 *
+	 * @covers \Yoast\WP\SEO\Integrations\Watchers\Indexable_Post_Watcher::delete_indexable
+	 */
+	public function test_delete_post_with_hierarchy() {
+		$parent = $this->factory()->post->create_and_get(
+			[
+				'post_type' => 'page',
+			]
+		);
+		$child  = $this->factory()->post->create_and_get(
+			[
+				'post_type'   => 'page',
+				'post_parent' => $parent->ID,
+			]
+		);
+
+		$parent_indexable = \current( $this->get_indexables_for( $parent ) );
+		$child_indexable  = \current( $this->get_indexables_for( $child ) );
+
+		wp_delete_post( $parent->ID, true );
+
+		$parent_hierarchy = $this->get_hierarchy_for( $parent_indexable );
+		$child_hierarchy  = $this->get_hierarchy_for( $child_indexable );
+
+		$this->assertCount( 0, $parent_hierarchy );
+		$this->assertCount( 1, $child_hierarchy );
+	}
+
+	/**
+	 * Gets all indexable records for a post.
+	 *
+	 * @param WP_Post $post The post to get indexables for.
+	 *
+	 * @return Indexable[] The indexbales for hte post.
+	 */
+	protected function get_indexables_for( WP_Post $post ) {
+		$orm = Model::of_type( 'Indexable' );
+
+		return $orm
+			->where( 'object_id', $post->ID )
+			->where( 'object_type', 'post' )
+			->where( 'object_sub_type', $post->post_type )
+			->find_many();
+	}
+
+	/**
+	 * Deletes all indexable records for a post.
+	 *
+	 * @param WP_Post $post The post to delete indexables for.
+	 *
+	 * @return int|bool The number of deleted records. False on failure.
+	 */
+	protected function delete_indexables_for( WP_Post $post ) {
+		$orm = Model::of_type( 'Indexable' );
+
+		return $orm
+			->where( 'object_id', $post->ID )
+			->where( 'object_type', 'post' )
+			->where( 'object_sub_type', $post->post_type )
+			->delete_many();
+	}
+
+	/**
+	 * Gets indexable hierarchy records for a particular indexable.
+	 *
+	 * @param Indexable $indexable The indexable to build hierarchy for.
+	 *
+	 * @return Indexable_Hierarchy[] THe hierarchy objects for the indexable.
+	 */
+	protected function get_hierarchy_for( Indexable $indexable ) {
+		$orm = Model::of_type( 'Indexable_Hierarchy' );
+
+		return $orm
+			->where( 'indexable_id', $indexable->id() )
+			->find_many();
+	}
+}

--- a/tests/unit/builders/indexable-builder-test.php
+++ b/tests/unit/builders/indexable-builder-test.php
@@ -188,7 +188,7 @@ class Indexable_Builder_Test extends TestCase {
 	public function test_build_for_id_and_type_with_post_given_and_no_author_indexable_found() {
 		$this->indexable
 			->expects( 'save' )
-			->twice();
+			->once();
 
 		$this->indexable
 			->expects( 'as_array' )
@@ -224,7 +224,7 @@ class Indexable_Builder_Test extends TestCase {
 
 		$this->indexable_helper
 			->expects( 'should_index_indexables' )
-			->times( 3 )
+			->twice()
 			->withNoArgs()
 			->andReturnTrue();
 
@@ -308,7 +308,7 @@ class Indexable_Builder_Test extends TestCase {
 		// The test is complex enough in its current state.
 		$this->indexable_helper
 			->expects( 'should_index_indexables' )
-			->times( 3 )
+			->times( 2 )
 			->withNoArgs()
 			->andReturnFalse();
 
@@ -399,7 +399,7 @@ class Indexable_Builder_Test extends TestCase {
 		// The test is complex enough in its current state.
 		$this->indexable_helper
 			->expects( 'should_index_indexables' )
-			->times( 3 )
+			->times( 2 )
 			->withNoArgs()
 			->andReturnFalse();
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

When performing a full reindex, I noticed that indexable hierarchy is not created. This is due to a problem where we rely on the indexable being saved to the database (and thus having an indexable id) when we generate hierarchy, but when we index a post we:
1. Create the indexable
2. Generate hierarchy (for indexableId = null)
3. Save the indexable to the database, giving it an indexable id.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where indexable hierarchy wasn't built when the Indexable is built for the first time.

## Relevant technical choices:

* I've added some (very basic) integration tests to prove that my solution works and to pinpoint the origin of the problem. There's still a lot of tests that need to be added, which I've described in a comment.
* I've added an early return in the indexable builder _if_ the indexable has already been saved. This is the case for posts and authors. This should have a small performance increase. I verified that there is no need for saving the indexable again after creating hierarchy, author indexables and primary terms. 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Indexing through post events
1. With the test helper plugin, reset all indexables with the "Reset Indexables tables & migrations" button.
1. Make sure the author archives are active. This is just to make sure author indexables still work.
1. Create a new post with a parent page. You can use the `page` post type or any hierarchical post type for this.
1. Create a new term with a parent term. You can use the `category` post taxonomy or any hierarchical taxonomy for this.
1. Check that your `wp_yoast_indexable` table find the indexable ID for your parent and child posts and terms (usually the ones with the highest number)
1. Check that your `wp_yoast_indexable_hierarchy` table now includes 2 records:
	- one with `ancestor_id = 0` and `indexable_id = [the indexable_id of the parent post]`
	- one with `ancestor_id = [the indexable_id of the other record and the parent post]` and `indexable_id = [the indexable id of your child post]`.
1. Also make sure there is an indexable for the author of your post.

#### Indexing through frontend indexing
1. Have at least one page with a parent page. You can use the `page` post type or any hierarchical post type for this.
1. Have at least one term with a parent term. You can use the `category` post taxonomy or any hierarchical taxonomy for this.
1. With the test helper plugin, reset all indexables with the "Reset Indexables tables & migrations" button.
1. Check that your `wp_yoast_indexable_hierarchy` table is empty.
1. Go the the Tools section of Yoast SEO and click Optimize now.
1. Check that your `wp_yoast_indexable` table find the indexable ID for your parent and child posts and terms (usually the ones with the highest value for object_id)
1. Check that your `wp_yoast_indexable_hierarchy` table now includes at least these 2 records:
	- one with `ancestor_id = 0` and `indexable_id = [the indexable_id of the parent post]`
	- one with `ancestor_id = [the indexable_id of the other record and the parent post]` and `indexable_id = [the indexable id of your child post]`.

#### Indexing through CLI
1. Have at least one page with a parent page. You can use the `page` post type or any hierarchical post type for this.
1. Have at least one term with a parent term. You can use the `category` post taxonomy or any hierarchical taxonomy for this.
1. With the test helper plugin, reset all indexables with the "Reset Indexables tables & migrations" button.
1. Check that your `wp_yoast_indexable_hierarchy` table is empty.
1. Run the following WP_CLI command: `wp yoast index` 
1. Check that your `wp_yoast_indexable` table find the indexable ID for your parent and child posts and terms (usually the ones with the highest values for object_id)
1. Check that your `wp_yoast_indexable_hierarchy` table now includes at least these 2 records:
	- one with `ancestor_id = 0` and `indexable_id = [the indexable_id of the parent post]`
	- one with `ancestor_id = [the indexable_id of the other record and the parent post]` and `indexable_id = [the indexable id of your child post]`.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

The impact is limited to creating and updating indexables for post and terms.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

DUPP-831