### PR TITLE
Test helper for inclusive language

### DIFF
--- a/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/ageAssessmentsSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/ageAssessmentsSpec.js
@@ -3,149 +3,110 @@ import Mark from "../../../../../src/values/Mark";
 import InclusiveLanguageAssessment from "../../../../../src/scoring/assessments/inclusiveLanguage/InclusiveLanguageAssessment";
 import ageAssessments from "../../../../../src/scoring/assessments/inclusiveLanguage/configuration/ageAssessments";
 import Factory from "../../../../specHelpers/factory.js";
+import { inclusiveLanguageAssessmentTestHelper } from "./testHelpers/inclusiveLanguageTestHelper";
+
 
 describe( "Age assessments", function() {
 	it( "should target non-inclusive phrases", function() {
 		const mockText = "This ad is aimed at aging dependants";
-		const mockPaper = new Paper( mockText );
-		const mockResearcher = Factory.buildMockResearcher( [ mockText ] );
-		const assessor = new InclusiveLanguageAssessment( ageAssessments.find( obj => obj.identifier === "agingDependants" ) );
+		const mockSentences = [ mockText ];
+		const expectedFeedback = "Avoid using <i>aging dependants</i> as it is potentially harmful. Consider using an alternative," +
+		" such as <i>older people</i>, unless referring to someone who explicitly wants to be referred to with this term." +
+		" Or, if possible, be specific about the group you are referring to (e.g. <i>people older than 70</i>)." +
+		" <a href='https://yoa.st/inclusive-language-age' target='_blank'>Learn more.</a>";
 
-		const isApplicable = assessor.isApplicable( mockPaper, mockResearcher );
-		const assessmentResult = assessor.getResult();
-
-		expect( isApplicable ).toBeTruthy();
-		expect( assessmentResult.getScore() ).toEqual( 3 );
-		expect( assessmentResult.getText() ).toEqual(
-			"Avoid using <i>aging dependants</i> as it is potentially harmful. Consider using an alternative," +
-			" such as <i>older people</i>, unless referring to someone who explicitly wants to be referred to with this term." +
-			" Or, if possible, be specific about the group you are referring to (e.g. <i>people older than 70</i>)." +
-			" <a href='https://yoa.st/inclusive-language-age' target='_blank'>Learn more.</a>" );
-		expect( assessmentResult.hasMarks() ).toBeTruthy();
-		expect( assessor.getMarks() ).toEqual( [ new Mark( {
+		const expectedMarks = [ new Mark( {
 			original: mockText,
 			marked: "<yoastmark class='yoast-text-mark'>" + mockText + "</yoastmark>",
-		} ) ] );
+		} ) ];
+		inclusiveLanguageAssessmentTestHelper( ageAssessments, mockText, mockSentences, "agingDependants", true, 3, expectedFeedback, expectedMarks );
 	} );
 
 	it( "should target potentially non-inclusive phrases", function() {
-		const mockPaper = new Paper( "This ad is aimed at senior citizens. But this ad is aimed at the youth." );
-		const mockResearcher = Factory.buildMockResearcher( [ "This ad is aimed at senior citizens.", "But this ad is aimed at the youth." ] );
-		const assessor = new InclusiveLanguageAssessment( ageAssessments.find( obj => obj.identifier === "seniorCitizens" ) );
-
-		const isApplicable = assessor.isApplicable( mockPaper, mockResearcher );
-		const assessmentResult = assessor.getResult();
-
-		expect( isApplicable ).toBeTruthy();
-		expect( assessmentResult.getScore() ).toEqual( 6 );
-		expect( assessmentResult.getText() ).toEqual(
-			"Be careful when using <i>senior citizens</i> as it is potentially harmful. Consider using an alternative," +
-			" such as <i>older citizen(s)</i>, unless referring to someone who explicitly wants to be referred to with this term." +
-			" Or, if possible, be specific about the group you are referring to (e.g. <i>people older than 70</i>)." +
-			" <a href='https://yoa.st/inclusive-language-age' target='_blank'>Learn more.</a>" );
-		expect( assessmentResult.hasMarks() ).toBeTruthy();
-		expect( assessor.getMarks() ).toEqual( [ new Mark( {
+		const mockText = "This ad is aimed at senior citizens. But this ad is aimed at the youth.";
+		const mockSentences = [ "This ad is aimed at senior citizens.", "But this ad is aimed at the youth." ];
+		const expectedFeedback = "Be careful when using <i>senior citizens</i> as it is potentially harmful. Consider using an alternative," +
+		" such as <i>older citizen(s)</i>, unless referring to someone who explicitly wants to be referred to with this term." +
+		" Or, if possible, be specific about the group you are referring to (e.g. <i>people older than 70</i>)." +
+		" <a href='https://yoa.st/inclusive-language-age' target='_blank'>Learn more.</a>";
+		const expectedMarks = [ new Mark( {
 			original: "This ad is aimed at senior citizens.",
 			marked: "<yoastmark class='yoast-text-mark'>This ad is aimed at senior citizens.</yoastmark>",
-		} ) ] );
+		} ) ];
+
+		inclusiveLanguageAssessmentTestHelper( ageAssessments, mockText, mockSentences, "seniorCitizens", true, 6, expectedFeedback, expectedMarks );
 	} );
 
+
 	it( "should not target phrases preceded by certain words", function() {
-		const mockPaper = new Paper( "This ad is aimed at high school seniors." );
-		const mockResearcher = Factory.buildMockResearcher( [ "This ad is aimed at high school seniors." ] );
-		const assessor = new InclusiveLanguageAssessment( ageAssessments.find( obj => obj.identifier === "seniors" ) );
+		const mockText = "This ad is aimed at high school seniors.";
+		const mockSentences = [ mockText ];
 
-		const isApplicable = assessor.isApplicable( mockPaper, mockResearcher );
-
-		expect( isApplicable ).toBeFalsy();
-		expect( assessor.getMarks() ).toEqual( [] );
+		inclusiveLanguageAssessmentTestHelper( ageAssessments, mockText, mockSentences, "seniors", false );
 	} );
 
 	it( "should not target phrases followed by by certain words", function() {
-		const mockPaper = new Paper( "This ad is aimed at seniors who are graduating." );
-		const mockResearcher = Factory.buildMockResearcher( [ "This ad is aimed at seniors who are graduating." ] );
-		const assessor = new InclusiveLanguageAssessment( ageAssessments.find( obj => obj.identifier === "seniors" ) );
+		const mockText = "This ad is aimed at seniors who are graduating.";
+		const mockSentences = [ mockText ];
 
-		const isApplicable = assessor.isApplicable( mockPaper, mockResearcher );
-
-		expect( isApplicable ).toBeFalsy();
-		expect( assessor.getMarks() ).toEqual( [] );
+		inclusiveLanguageAssessmentTestHelper( ageAssessments, mockText, mockSentences, "seniors", false );
 	} );
 
 	it( "should not target other phrases", function() {
-		const mockPaper = new Paper( "This ad is aimed at the youth" );
-		const mockResearcher = Factory.buildMockResearcher( [ "This ad is aimed at the youth" ] );
-		const assessor = new InclusiveLanguageAssessment( ageAssessments.find( obj => obj.identifier === "seniorCitizens" ) );
+		const mockText =  "This ad is aimed at the youth";
+		const mockSentences = [ mockText ];
 
-		const isApplicable = assessor.isApplicable( mockPaper, mockResearcher );
-
-		expect( isApplicable ).toBeFalsy();
-		expect( assessor.getMarks() ).toEqual( [] );
+		inclusiveLanguageAssessmentTestHelper( ageAssessments, mockText, mockSentences, "seniorCitizens", false );
 	} );
 
 	it( "correctly identifies a phrase that is only recognized when followed by participle or simple past tense", () => {
-		const mockPaper = new Paper( "The aged worked, the better they are." );
-		const mockResearcher = Factory.buildMockResearcher( [ "The aged worked, the better they are." ] );
-		const assessor = new InclusiveLanguageAssessment( ageAssessments.find( obj => obj.identifier === "theAged" ) );
-		const isApplicable = assessor.isApplicable( mockPaper, mockResearcher );
-		const assessmentResult = assessor.getResult();
+		const mockText = "The aged worked, the better they are.";
+		const mockSentences = [ mockText ];
+		const expectedFeedback = "Avoid using <i>the aged</i> as it is potentially harmful. " +
+		"Consider using an alternative, such as <i>older people</i>. " +
+		"Or, if possible, be specific about the group you are referring to (e.g. <i>people older than 70</i>). " +
+		"<a href='https://yoa.st/inclusive-language-age' target='_blank'>Learn more.</a>";
 
-		expect( isApplicable ).toBeTruthy();
-		expect( assessmentResult.getScore() ).toEqual( 3 );
-		expect( assessmentResult.getText() ).toEqual(
-			"Avoid using <i>the aged</i> as it is potentially harmful. Consider using an alternative, such as <i>older people</i>. " +
-			"Or, if possible, be specific about the group you are referring to (e.g. <i>people older than 70</i>). " +
-			"<a href='https://yoa.st/inclusive-language-age' target='_blank'>Learn more.</a>" );
-		expect( assessmentResult.hasMarks() ).toBeTruthy();
-		expect( assessor.getMarks() ).toEqual( [ new Mark( {
+		const expectedMarks = [ new Mark( {
 			original: "The aged worked, the better they are.",
 			marked: "<yoastmark class='yoast-text-mark'>The aged worked, the better they are.</yoastmark>",
-		} ) ] );
+		} ) ];
+		inclusiveLanguageAssessmentTestHelper( ageAssessments, mockText, mockSentences, "theAged", true, 3, expectedFeedback, expectedMarks );
 	} );
-	it( "correctly identifies a phrase that is only recognized when followed by a function word", () => {
-		const mockPaper = new Paper( "The aged however, did not go to the zoo." );
-		const mockResearcher = Factory.buildMockResearcher( [ "The aged however, did not go to the zoo." ] );
-		const assessor = new InclusiveLanguageAssessment( ageAssessments.find( obj => obj.identifier === "theAged" ) );
-		const isApplicable = assessor.isApplicable( mockPaper, mockResearcher );
-		const assessmentResult = assessor.getResult();
 
-		expect( isApplicable ).toBeTruthy();
-		expect( assessmentResult.getScore() ).toEqual( 3 );
-		expect( assessmentResult.getText() ).toEqual(
-			"Avoid using <i>the aged</i> as it is potentially harmful. Consider using an alternative, such as <i>older people</i>. " +
-			"Or, if possible, be specific about the group you are referring to (e.g. <i>people older than 70</i>). " +
-			"<a href='https://yoa.st/inclusive-language-age' target='_blank'>Learn more.</a>" );
-		expect( assessmentResult.hasMarks() ).toBeTruthy();
-		expect( assessor.getMarks() ).toEqual( [ new Mark( {
+	it( "correctly identifies a phrase that is only recognized when followed by a function word", () => {
+		const mockText = "The aged however, did not go to the zoo.";
+		const mockSentences = [ mockText ];
+		const expectedFeedback = "Avoid using <i>the aged</i> as it is potentially harmful. " +
+		"Consider using an alternative, such as <i>older people</i>. " +
+		"Or, if possible, be specific about the group you are referring to (e.g. <i>people older than 70</i>). " +
+		"<a href='https://yoa.st/inclusive-language-age' target='_blank'>Learn more.</a>";
+
+		const expectedMarks = [ new Mark( {
 			original: "The aged however, did not go to the zoo.",
 			marked: "<yoastmark class='yoast-text-mark'>The aged however, did not go to the zoo.</yoastmark>",
-		} ) ] );
+		} ) ];
+		inclusiveLanguageAssessmentTestHelper( ageAssessments, mockText, mockSentences, "theAged", true, 3, expectedFeedback, expectedMarks );
 	} );
 	it( "correctly identifies a phrase that is only recognized when followed by a punctuation mark", () => {
-		const mockPaper = new Paper( "I have always loved the aged!" );
-		const mockResearcher = Factory.buildMockResearcher( [ "I have always loved the aged!" ] );
-		const assessor = new InclusiveLanguageAssessment( ageAssessments.find( obj => obj.identifier === "theAged" ) );
-		const isApplicable = assessor.isApplicable( mockPaper, mockResearcher );
-		const assessmentResult = assessor.getResult();
+		const mockText = "I have always loved the aged!";
+		const mockSentences = [ mockText ];
+		const expectedFeedback = "Avoid using <i>the aged</i> as it is potentially harmful. " +
+		"Consider using an alternative, such as <i>older people</i>. " +
+		"Or, if possible, be specific about the group you are referring to (e.g. <i>people older than 70</i>). " +
+		"<a href='https://yoa.st/inclusive-language-age' target='_blank'>Learn more.</a>";
 
-		expect( isApplicable ).toBeTruthy();
-		expect( assessmentResult.getScore() ).toEqual( 3 );
-		expect( assessmentResult.getText() ).toEqual(
-			"Avoid using <i>the aged</i> as it is potentially harmful. Consider using an alternative, such as <i>older people</i>. " +
-			"Or, if possible, be specific about the group you are referring to (e.g. <i>people older than 70</i>). " +
-			"<a href='https://yoa.st/inclusive-language-age' target='_blank'>Learn more.</a>" );
-		expect( assessmentResult.hasMarks() ).toBeTruthy();
-		expect( assessor.getMarks() ).toEqual( [ new Mark( {
+		const expectedMarks = [ new Mark( {
 			original: "I have always loved the aged!",
 			marked: "<yoastmark class='yoast-text-mark'>I have always loved the aged!</yoastmark>",
-		} ) ] );
+		} ) ];
+		inclusiveLanguageAssessmentTestHelper( ageAssessments, mockText, mockSentences, "theAged", true, 3, expectedFeedback, expectedMarks );
 	} );
-	it( "does not identify 'the aged' when not followed by punctuation, function word or participle", () => {
-		const mockPaper = new Paper( "The aged cheese is the best." );
-		const mockResearcher = Factory.buildMockResearcher( [ "The aged cheese is the best." ] );
-		const assessor = new InclusiveLanguageAssessment( ageAssessments.find( obj => obj.identifier === "theAged" ) );
-		const isApplicable = assessor.isApplicable( mockPaper, mockResearcher );
 
-		expect( isApplicable ).toBeFalsy();
+	it( "does not identify 'the aged' when not followed by punctuation, function word or participle", () => {
+		const mockText =  "The aged cheese is the best.";
+		const mockSentences = [ mockText ];
+
+		inclusiveLanguageAssessmentTestHelper( ageAssessments, mockText, mockSentences, "theAged", false );
 	} );
 } );

--- a/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/testHelpers/inclusiveLanguageTestHelper.js
+++ b/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/testHelpers/inclusiveLanguageTestHelper.js
@@ -1,0 +1,37 @@
+import Paper from "../../../../../../src/values/Paper";
+import InclusiveLanguageAssessment from "../../../../../../src/scoring/assessments/inclusiveLanguage/InclusiveLanguageAssessment";
+import Factory from "../../../../../specHelpers/factory.js";
+
+/**
+ * As.
+ * @param {object} assessments A
+ * @param {string} testSentence A
+ * @param {object} assessmentIdentifier A
+ * @param {boolean} expectedApplicable A
+ * @param {number} [expectedScore] A
+ * @param {string} [expectedFeedback] A
+ * @param {object} [expectedMarks] A
+ * @returns {null} Has no return value.
+ */
+export const inclusiveLanguageAssessmentTestHelper = function(
+	assessments, mocktext, mockSentences, assessmentIdentifier, expectedApplicable, expectedScore, expectedFeedback, expectedMarks ) {
+	const mockPaper = new Paper( mocktext );
+	const mockResearcher = Factory.buildMockResearcher( mockSentences );
+	const assessor = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === assessmentIdentifier ) );
+	const isApplicable = assessor.isApplicable( mockPaper, mockResearcher );
+
+
+	if ( expectedApplicable ) {
+		expect( isApplicable ).toBeTruthy();
+
+		const assessmentResult = assessor.getResult();
+
+		expect( assessmentResult.getScore() ).toEqual( expectedScore );
+		expect( assessmentResult.getText() ).toEqual( expectedFeedback );
+		expect( assessmentResult.hasMarks() ).toBeTruthy();
+		expect( assessor.getMarks() ).toEqual( expectedMarks );
+	} else {
+		expect( isApplicable ).toBeFalsy();
+		expect( assessor.getMarks() ).toEqual( [] );
+	}
+};


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

*

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

*

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
