### PR TITLE
Add tracking parameters to URL

### DIFF
--- a/inc/class-wpseo-admin-bar-menu.php
+++ b/inc/class-wpseo-admin-bar-menu.php
@@ -461,17 +461,17 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 			[
 				'id'    => 'wpseo-semrush',
 				'title' => 'Semrush',
-				'href'  => 'https://yoa.st/admin-bar-semrush',
+				'href'  => WPSEO_Shortlinker::get( 'https://yoa.st/admin-bar-semrush' ),
 			],
 			[
 				'id'    => 'wpseo-wincher',
 				'title' => 'Wincher',
-				'href'  => 'https://yoa.st/admin-bar-wincher',
+				'href'  => WPSEO_Shortlinker::get( 'https://yoa.st/admin-bar-wincher' ),
 			],
 			[
 				'id'    => 'wpseo-google-trends',
 				'title' => 'Google trends',
-				'href'  => 'https://yoa.st/admin-bar-gtrends',
+				'href'  => WPSEO_Shortlinker::get( 'https://yoa.st/admin-bar-gtrends' ),
 			],
 		];
 
@@ -498,17 +498,17 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 			[
 				'id'    => 'wpseo-learn-seo',
 				'title' => __( 'Learn more SEO', 'wordpress-seo' ),
-				'href'  => 'https://yoa.st/admin-bar-learn-more-seo',
+				'href'  => WPSEO_Shortlinker::get( 'https://yoa.st/admin-bar-learn-more-seo' ),
 			],
 			[
 				'id'    => 'wpseo-improve-blogpost',
 				'title' => __( 'Improve your blog post', 'wordpress-seo' ),
-				'href'  => 'https://yoa.st/admin-bar-improve-blog-post',
+				'href'  => WPSEO_Shortlinker::get( 'https://yoa.st/admin-bar-improve-blog-post' ),
 			],
 			[
 				'id'    => 'wpseo-write-better-content',
 				'title' => __( 'Write better content', 'wordpress-seo' ),
-				'href'  => 'https://yoa.st/admin-bar-write-better',
+				'href'  => WPSEO_Shortlinker::get( 'https://yoa.st/admin-bar-write-better' ),
 			],
 		];
 
@@ -535,22 +535,22 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 			[
 				'id'    => 'wpseo-yoast-help',
 				'title' => __( 'Yoast.com help section', 'wordpress-seo' ),
-				'href'  => 'https://yoa.st/admin-bar-yoast-help',
+				'href'  => WPSEO_Shortlinker::get( 'https://yoa.st/admin-bar-yoast-help' ),
 			],
 			[
 				'id'    => 'wpseo-premium-support',
 				'title' => __( 'Yoast Premium support', 'wordpress-seo' ),
-				'href'  => 'https://yoa.st/admin-bar-premium-support',
+				'href'  => WPSEO_Shortlinker::get( 'https://yoa.st/admin-bar-premium-support' ),
 			],
 			[
 				'id'    => 'wpseo-wp-support-forums',
 				'title' => __( 'WordPress.org support forums', 'wordpress-seo' ),
-				'href'  => 'https://yoa.st/admin-bar-wp-support-forums',
+				'href'  => WPSEO_Shortlinker::get( 'https://yoa.st/admin-bar-wp-support-forums' ),
 			],
 			[
 				'id'    => 'wpseo-learn-seo-2',
 				'title' => __( 'Learn more SEO', 'wordpress-seo' ),
-				'href'  => 'https://yoa.st/admin-bar-learn-more-seo-help',
+				'href'  => WPSEO_Shortlinker::get( 'https://yoa.st/admin-bar-learn-more-seo-help' ),
 			],
 		];
 

--- a/inc/class-wpseo-admin-bar-menu.php
+++ b/inc/class-wpseo-admin-bar-menu.php
@@ -5,6 +5,7 @@
  * @package WPSEO
  */
 
+use WPSEO_Shortlinker;
 use Yoast\WP\SEO\Helpers\Product_Helper;
 use Yoast\WP\SEO\Helpers\Score_Icon_Helper;
 use Yoast\WP\SEO\Models\Indexable;
@@ -569,7 +570,7 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 				'parent' => self::MENU_IDENTIFIER,
 				'id'     => 'wpseo-get-premium',
 				'title'  => __( 'Get Yoast SEO Premium', 'wordpress-seo' ) . ' &raquo;',
-				'href'   => 'https://yoa.st/admin-bar-get-premium',
+				'href'   => WPSEO_Shortlinker::get( 'https://yoa.st/admin-bar-get-premium' ),
 				'meta'   => [
 					'tabindex' => '0',
 					'target'   => '_blank',


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to add tracking parameters to the `Get Yoast SEO Premium` link in Yoast Admin Bar.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds tracking parameters to the `Get Yoast SEO Premium` link in Yoast Admin Bar.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install and activate Yoast SEO
* Open any page in the frontend
* Go to the Yoast Admin Bar menu and inspect the link `Get Yoast SEO Premium`:
  * Without this PR the link is: `https://yoa.st/admin-bar-get-premium`
  * With this PR the link should be something like (parameters' values may vary): `https://yoa.st/admin-bar-get-premium?php_version=7.4&platform=wordpress&platform_version=6.1.1&software=free&software_version=19.12-RC5&days_active=6-30&user_language=en_US` 
* Perform the same inspection for the following Admin Bar elements:
  * SEO Tools
    * `Semrush` - pointing to `https://yoa.st/admin-bar-semrush`
    * `Wincher` - pointing to `https://yoa.st/admin-bar-wincher`
    * `Google trends` - pointing to `https://yoa.st/admin-bar-gtrends`

  * How to
    * `Learn more SEO` - pointing to `https://yoa.st/admin-bar-learn-more-seo`
    * `Improve your blog post` - pointing to `https://yoa.st/admin-bar-improve-blog-post`
    * `Write better content` - pointing to `https://yoa.st/admin-bar-write-better`

  * Help
    * `Yoast.com help section` - pointing to `https://yoa.st/admin-bar-yoast-help`
    * `Yoast Premium support` - pointing to `https://yoa.st/admin-bar-premium-suppor`
    * `WordPress.org support forums` - pointing to `https://yoa.st/admin-bar-wp-support-forums`
    * `Learn more SEO` - pointing to `https://yoa.st/admin-bar-learn-more-seo-help`
  
#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* No extra testing needed.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes [DUPP-823](https://yoast.atlassian.net/browse/DUPP-823)
