### PR TITLE
Remove duplicated integration cards

### DIFF
--- a/packages/js/src/integrations-page/integrations-grid.js
+++ b/packages/js/src/integrations-page/integrations-grid.js
@@ -101,7 +101,7 @@ export default function IntegrationsGrid() {
 				<hr className="yst-my-12" />
 
 				<Section
-					title={ __( "SEO Tool integrations", "wordpress-seo" ) }
+					title={ __( "Other integrations", "wordpress-seo" ) }
 					elements={ SEOToolsIntegrations }
 				/>
 

--- a/packages/js/src/integrations-page/seo-tools-integrations.js
+++ b/packages/js/src/integrations-page/seo-tools-integrations.js
@@ -2,65 +2,11 @@ import { createInterpolateElement } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
 
 import { getInitialState, getIsNetworkControlEnabled, updateIntegrationState, getIsMultisiteAvailable } from "./helper";
-import { ReactComponent as SemrushLogo } from "../../images/semrush-logo.svg";
-import { ReactComponent as WincherLogo } from "../../images/wincher-logo.svg";
 import { ReactComponent as ZapierLogo } from "../../images/zapier-logo.svg";
 import { ReactComponent as WordproofLogo } from "../../images/wordproof-logo.svg";
 import { ToggleableIntegration } from "./toggleable-integration";
 
 const integrations = [
-	{
-		name: "Semrush",
-		claim: createInterpolateElement(
-			sprintf(
-				/* translators: 1: bold open tag; 2: Semrush; 3: bold close tag. */
-				__( "Use %1$s%2$s%3$s to do keyword research - without leaving your post", "wordpress-seo" ),
-				"<strong>",
-				"Semrush",
-				"</strong>"
-			), {
-				strong: <strong />,
-			}
-		),
-		learnMoreLink: "https://yoa.st/integrations-about-semrush",
-		logoLink: "http://yoa.st/semrush-prices-wordpress",
-		slug: "semrush",
-		description: sprintf(
-			/* translators: 1: Semrush */
-			__( "Find out what your audience is searching for with %s data right in your sidebar.", "wordpress-seo" ),
-			"Semrush"
-		),
-		isPremium: false,
-		isNew: false,
-		isMultisiteAvailable: true,
-		logo: SemrushLogo,
-	},
-	{
-		name: "Wincher",
-		claim: createInterpolateElement(
-			sprintf(
-				/* translators: 1: bold open tag; 2: Wincher; 3: bold close tag. */
-				__( "Track your rankings through time with %1$s%2$s%3$s", "wordpress-seo" ),
-				"<strong>",
-				"Wincher",
-				"</strong>"
-			), {
-				strong: <strong />,
-			}
-		),
-		learnMoreLink: "https://yoa.st/integrations-about-wincher",
-		logoLink: "https://yoa.st/integrations-logo-wincher",
-		slug: "wincher",
-		description: sprintf(
-			/* translators: 1: Wincher */
-			__( "Keep an eye on how your posts are ranking by connecting to your %s account.", "wordpress-seo" ),
-			"Wincher"
-		),
-		isPremium: false,
-		isNew: false,
-		isMultisiteAvailable: false,
-		logo: WincherLogo,
-	},
 	{
 		name: "WordProof",
 		claim: createInterpolateElement(


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Hides the Semrush and Wincher cards from the last section of the Integrations page
* Renames the "SEO Tools Integrations" to "Other Integrations"

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Visually check the page

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes [DUPP-825]


[DUPP-825]: https://yoast.atlassian.net/browse/DUPP-825?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ