### PR TITLE
PC-981 Adds 'stupid' to non-inclusive phrases

### DIFF
--- a/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessmentsSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessmentsSpec.js
@@ -112,13 +112,25 @@ describe( "Disability assessments", function() {
 	} );
 
 	it( "should target 'stupid'.", () => {
-		const assessment = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "stupid" ) );
-
 		const testSentence = "Stupid, that's just how they're acting.";
 		const mockPaper = new Paper( testSentence );
 		const mockResearcher = Factory.buildMockResearcher( [ testSentence ] );
 
-		expect( assessment.isApplicable( mockPaper, mockResearcher ) ).toBe( true );
+		const assessor = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "stupid" ) );
+		const isApplicable = assessor.isApplicable( mockPaper, mockResearcher );
+		const assessmentResult = assessor.getResult();
+
+		expect( isApplicable ).toBeTruthy();
+		expect( assessmentResult.getScore() ).toEqual( 3 );
+		expect( assessmentResult.getText() ).toEqual(
+			"Avoid using <i>stupid</i> as it is potentially harmful. " +
+			"Consider using an alternative, such as <i>uninformed, ignorant, foolish, inconsiderate, irrational, reckless</i>. " +
+			"<a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>" );
+		expect( assessmentResult.hasMarks() ).toBeTruthy();
+		expect( assessor.getMarks() ).toEqual( [ new Mark( {
+			original: testSentence,
+			marked: `<yoastmark class='yoast-text-mark'>${ testSentence }</yoastmark>`,
+		} ) ] );
 	} );
 
 	it( "should not target 'dumb' if preceded by 'deaf and'.", () => {

--- a/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessmentsSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessmentsSpec.js
@@ -111,7 +111,17 @@ describe( "Disability assessments", function() {
 		} );
 	} );
 
-	it( "should not dumb if preceded by 'deaf and'.", () => {
+	it( "should target 'stupid'.", () => {
+		const assessment = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "stupid" ) );
+
+		const testSentence = "Stupid, that's just how they're acting.";
+		const mockPaper = new Paper( testSentence );
+		const mockResearcher = Factory.buildMockResearcher( [ testSentence ] );
+
+		expect( assessment.isApplicable( mockPaper, mockResearcher ) ).toBe( true );
+	} );
+
+	it( "should not target 'dumb' if preceded by 'deaf and'.", () => {
 		const assessment = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "dumb" ) );
 
 		const testSentence = "He is deaf and dumb.";

--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessments.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessments.js
@@ -232,6 +232,13 @@ const disabilityAssessments =  [
 		feedbackFormat: potentiallyHarmful,
 	},
 	{
+		identifier: "stupid",
+		nonInclusivePhrases: [ "stupid" ],
+		inclusiveAlternatives: [ "<i>uninformed, ignorant, foolish, inconsiderate, irrational, reckless</i>" ],
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmful,
+	},
+	{
 		identifier: "dumb",
 		nonInclusivePhrases: [ "dumb" ],
 		inclusiveAlternatives: [ "<i>uninformed, ignorant, foolish, inconsiderate, irrational, reckless</i>" ],


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Like 'dumb', 'stupid' is [ableist language](http://deareverybody.hollandbloorview.ca/wp-content/uploads/2018/08/DearEverybodyTipsonAbleistLanguage2018-19.pdf) and its use should be avoided. This PR adds 'stupid' as a target to our inclusive language analysis, with the same inclusive alternatives as for 'dumb'.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds 'stupid' as a non-inclusive phrase in the inclusive language analysis.

## Relevant technical choices:

* None.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install and activate Yoast SEO
* Set the site language to English
* Enable the Inclusive language analysis feature in Yoast SEO > General > Features
* Create a post
* Add the word 'stupid' to the post
* Confirm that the inclusive language analysis assessment gives the following feedback:
  * Bullet: **red**
  * Feedback: "Avoid using _stupid_ as it is potentially harmful. Consider using an alternative, such as _uninformed, ignorant, foolish, inconsiderate, irrational, reckless_."
* Click on the eye icon and make sure the sentence that contains 'stupid' is highlighted

##### Upgrade from previous version
* Install and activate the previous version of Yoast SEO
   * Please note that in Yoast SEO version 19.11 and older, you'd also need the install and activate Yoast SEO Premium to be able to use the _inclusive language analysis_ feature
* Set the site language to English
* Enable the Inclusive language analysis feature in Yoast SEO > General > Features
* Create a post
* Add the word 'stupid' to the post
* Confirm that the inclusive language analysis returns no feedback (green bullet).
* Install and activate the new version of Yoast SEO (that contains this PR fix)
* Open the post that you created
* Confirm that the inclusive language analysis returns the following feedback:
  * Bullet: **red**
  * Feedback: "Avoid using _stupid_ as it is potentially harmful. Consider using an alternative, such as _uninformed, ignorant, foolish, inconsiderate, irrational, reckless_."

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [x] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* No impact outside of the inclusive language analysis, and there it only adds a new assessment. 

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes https://yoast.atlassian.net/browse/PC-981
