### PR TITLE
Lowercase query before searching in new settings UI

### DIFF
--- a/packages/js/src/settings/components/search.js
+++ b/packages/js/src/settings/components/search.js
@@ -5,10 +5,11 @@ import { useCallback, useRef, useState } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
 import { Modal, Title, useSvgAria, useToggleState } from "@yoast/ui-library";
 import classNames from "classnames";
-import { debounce, first, groupBy, includes, isEmpty, map, max, reduce, split, trim, values, toLower } from "lodash";
+import { debounce, first, groupBy, includes, isEmpty, map, max, reduce, split, trim, values } from "lodash";
 import PropTypes from "prop-types";
 import { useHotkeys } from "react-hotkeys-hook";
 import { useNavigate } from "react-router-dom";
+import { safeToLocaleLower } from "../helpers";
 import { useParsedUserAgent, useSelectSettings } from "../hooks";
 
 const QUERY_MIN_CHARS = 3;
@@ -37,6 +38,7 @@ const Search = () => {
 	// eslint-disable-next-line no-unused-vars
 	const [ isOpen, , , setOpen, setClose ] = useToggleState( false );
 	const [ query, setQuery ] = useState( "" );
+	const userLocale = useSelectSettings( "selectPreference", [], "userLocale" );
 	const queryableSearchIndex = useSelectSettings( "selectQueryableSearchIndex" );
 	const [ results, setResults ] = useState( [] );
 	const ariaSvgProps = useSvgAria();
@@ -78,7 +80,7 @@ const Search = () => {
 		}
 
 		// Lowercase and split query into words.
-		const splitQuery = split( toLower( trimmedQuery ), " " );
+		const splitQuery = split( safeToLocaleLower( trimmedQuery, userLocale ), " " );
 
 		// Filter search index by split query and store number of hits.
 		// A hit is registered if a single word from split query in found in a fields keywords.
@@ -115,7 +117,7 @@ const Search = () => {
 		} );
 
 		setResults( sortedGroupedQueryResults );
-	}, 100 ), [ queryableSearchIndex ] );
+	}, 100 ), [ queryableSearchIndex, userLocale ] );
 
 	const handleQueryChange = useCallback( event => {
 		setQuery( event.target.value );

--- a/packages/js/src/settings/components/search.js
+++ b/packages/js/src/settings/components/search.js
@@ -5,7 +5,7 @@ import { useCallback, useRef, useState } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
 import { Modal, Title, useSvgAria, useToggleState } from "@yoast/ui-library";
 import classNames from "classnames";
-import { debounce, first, groupBy, includes, isEmpty, map, max, reduce, split, trim, values } from "lodash";
+import { debounce, first, groupBy, includes, isEmpty, map, max, reduce, split, trim, values, toLower } from "lodash";
 import PropTypes from "prop-types";
 import { useHotkeys } from "react-hotkeys-hook";
 import { useNavigate } from "react-router-dom";
@@ -77,8 +77,8 @@ const Search = () => {
 			return false;
 		}
 
-		// Split query into words.
-		const splitQuery = split( trimmedQuery, " " );
+		// Lowercase and split query into words.
+		const splitQuery = split( toLower( trimmedQuery ), " " );
 
 		// Filter search index by split query and store number of hits.
 		// A hit is registered if a single word from split query in found in a fields keywords.

--- a/packages/js/src/settings/helpers/i18n.js
+++ b/packages/js/src/settings/helpers/i18n.js
@@ -1,0 +1,14 @@
+/**
+ * Lowercase a string in a locale, but with invalid locale safety.
+ * @param {string} string The string to lowercase.
+ * @param {string} locale The locale string.
+ * @returns {string} The lower case string if locale is valid, the string if locale is invalid.
+ */
+export const safeToLocaleLower = ( string, locale ) => {
+	try {
+		return string.toLocaleLowerCase( locale );
+	} catch ( error ) {
+		console.error( error.message );
+		return string;
+	}
+};

--- a/packages/js/src/settings/helpers/index.js
+++ b/packages/js/src/settings/helpers/index.js
@@ -1,3 +1,4 @@
+export * from "./i18n";
 export * from "./user-social-profiles";
 export * from "./search";
 export * from "./submit";

--- a/packages/js/src/settings/helpers/search.js
+++ b/packages/js/src/settings/helpers/search.js
@@ -2,13 +2,16 @@
 import { __, sprintf } from "@wordpress/i18n";
 import { Code } from "@yoast/ui-library";
 import { createInterpolateElement } from "@wordpress/element";
-import { omit, reduce, times, toLower, filter, includes, isEmpty } from "lodash";
+import { omit, reduce, times, filter, includes, isEmpty } from "lodash";
+import { safeToLocaleLower } from "./i18n";
 
 /**
  * @param {Object} postType The post type.
+ * @param {Object} options The options.
+ * @param {string} options.userLocale The user locale string.
  * @returns {Object} The search index for the post type.
  */
-export const createPostTypeSearchIndex = ( { name, label, route, hasArchive } ) => ( {
+export const createPostTypeSearchIndex = ( { name, label, route, hasArchive }, { userLocale } ) => ( {
 	[ `title-${ name }` ]: {
 		route: `/post-type/${ route }`,
 		routeLabel: label,
@@ -30,7 +33,7 @@ export const createPostTypeSearchIndex = ( { name, label, route, hasArchive } ) 
 		fieldLabel: sprintf(
 			// translators: %1$s expands to the post type plural, e.g. Posts.
 			__( "Show %1$s in search results", "wordpress-seo" ),
-			toLower( label )
+			safeToLocaleLower( label, userLocale )
 		),
 		keywords: [],
 	},
@@ -120,7 +123,7 @@ export const createPostTypeSearchIndex = ( { name, label, route, hasArchive } ) 
 			fieldLabel: sprintf(
 				// translators: %1$s expands to the post type plural, e.g. Posts.
 				__( "Show the archive for %1$s in search results", "wordpress-seo" ),
-				toLower( label )
+				safeToLocaleLower( label, userLocale )
 			),
 			keywords: [],
 		},
@@ -150,9 +153,11 @@ export const createPostTypeSearchIndex = ( { name, label, route, hasArchive } ) 
 
 /**
  * @param {Object} taxonomy The taxonomy.
+ * @param {Object} options The options.
+ * @param {string} options.userLocale The user locale string.
  * @returns {Object} The search index for the taxonomy.
  */
-export const createTaxonomySearchIndex = ( { name, label, route } ) => ( {
+export const createTaxonomySearchIndex = ( { name, label, route }, { userLocale } ) => ( {
 	[ `title-tax-${ name }` ]: {
 		route: `/taxonomy/${ route }`,
 		routeLabel: label,
@@ -175,7 +180,7 @@ export const createTaxonomySearchIndex = ( { name, label, route } ) => ( {
 			/* translators: %1$s expands to "Yoast SEO". %2$s expands to the taxonomy plural, e.g. Categories. */
 			__( "Enable %1$s for %2$s", "wordpress-seo" ),
 			"Yoast SEO",
-			toLower( label )
+			safeToLocaleLower( label, userLocale )
 		),
 		keywords: [],
 	},
@@ -193,7 +198,7 @@ export const createTaxonomySearchIndex = ( { name, label, route } ) => ( {
 		fieldLabel: sprintf(
 			// translators: %1$s expands to the taxonomy plural, e.g. Categories.
 			__( "Show %1$s in search results", "wordpress-seo" ),
-			toLower( label )
+			safeToLocaleLower( label, userLocale )
 		),
 		keywords: [],
 	},
@@ -232,9 +237,11 @@ export const createTaxonomySearchIndex = ( { name, label, route } ) => ( {
 /**
  * @param {Object} postTypes The post types.
  * @param {Object} taxonomies The taxonomies.
+ * @param {Object} options The options.
+ * @param {string} options.userLocale The user locale string.
  * @returns {Object} The search index.
  */
-export const createSearchIndex = ( postTypes, taxonomies ) => ( {
+export const createSearchIndex = ( postTypes, taxonomies, { userLocale = {} } = {} ) => ( {
 	blogdescription: {
 		route: "/site-basics",
 		routeLabel: __( "Site basics", "wordpress-seo" ),
@@ -751,7 +758,7 @@ export const createSearchIndex = ( postTypes, taxonomies ) => ( {
 					fieldId: `input-wpseo_titles-post_types-${ postType.name }-maintax`,
 					fieldLabel: createInterpolateElement(
 						// translators: %1$s expands to the post type plural, e.g. posts.
-						sprintf( __( "Breadcrumbs for %1$s<code />", "wordpress-seo" ), toLower( postType.label ) ),
+						sprintf( __( "Breadcrumbs for %1$s<code />", "wordpress-seo" ), safeToLocaleLower( postType.label, userLocale ) ),
 						{
 							code: <Code className="yst-ml-2 group-hover:yst-bg-primary-200 group-hover:yst-text-primary-800">{ postType.name }</Code>,
 						}
@@ -768,7 +775,7 @@ export const createSearchIndex = ( postTypes, taxonomies ) => ( {
 				fieldId: `input-wpseo_titles-taxonomy-${ taxonomy.name }-ptparent`,
 				fieldLabel: createInterpolateElement(
 					// translators: %1$s expands to the taxonomy plural, e.g. categories.
-					sprintf( __( "Breadcrumbs for %1$s<code />", "wordpress-seo" ), toLower( taxonomy.label ) ),
+					sprintf( __( "Breadcrumbs for %1$s<code />", "wordpress-seo" ), safeToLocaleLower( taxonomy.label, userLocale ) ),
 					{
 						code: <Code className="yst-ml-2 group-hover:yst-bg-primary-200 group-hover:yst-text-primary-800">{ taxonomy.name }</Code>,
 					}
@@ -1056,12 +1063,12 @@ export const createSearchIndex = ( postTypes, taxonomies ) => ( {
 		// Post types - Attachments are handled separately above.
 		...reduce( omit( postTypes, [ "attachment" ] ), ( acc, postType ) => ( {
 			...acc,
-			...createPostTypeSearchIndex( postType ),
+			...createPostTypeSearchIndex( postType, { userLocale } ),
 		} ), {} ),
 		// Taxonomies
 		...reduce( omit( taxonomies, [ "post_format" ] ), ( acc, taxonomy ) => ( {
 			...acc,
-			...createTaxonomySearchIndex( taxonomy ),
+			...createTaxonomySearchIndex( taxonomy, { userLocale } ),
 		} ), {} ),
 	},
 	wpseo_social: {

--- a/packages/js/src/settings/helpers/search.js
+++ b/packages/js/src/settings/helpers/search.js
@@ -241,7 +241,7 @@ export const createTaxonomySearchIndex = ( { name, label, route }, { userLocale 
  * @param {string} options.userLocale The user locale string.
  * @returns {Object} The search index.
  */
-export const createSearchIndex = ( postTypes, taxonomies, { userLocale = {} } = {} ) => ( {
+export const createSearchIndex = ( postTypes, taxonomies, { userLocale } = {} ) => ( {
 	blogdescription: {
 		route: "/site-basics",
 		routeLabel: __( "Site basics", "wordpress-seo" ),

--- a/packages/js/src/settings/routes/author-archives.js
+++ b/packages/js/src/settings/routes/author-archives.js
@@ -4,7 +4,6 @@ import { __, sprintf } from "@wordpress/i18n";
 import { Badge, Code, Link } from "@yoast/ui-library";
 import FeatureUpsell from "@yoast/ui-library/src/components/feature-upsell";
 import { useFormikContext } from "formik";
-import { toLower } from "lodash";
 import {
 	FieldsetLayout,
 	FormikFlippedToggleField,
@@ -14,6 +13,7 @@ import {
 	OpenGraphDisabledAlert,
 	RouteLayout,
 } from "../components";
+import { safeToLocaleLower } from "../helpers";
 import { withFormikDummyField } from "../hocs";
 import { useSelectSettings } from "../hooks";
 
@@ -25,8 +25,9 @@ const FormikReplacementVariableEditorFieldWithDummy = withFormikDummyField( Form
 const AuthorArchives = () => {
 	const label = __( "Author archives", "wordpress-seo" );
 	const singularLabel = __( "Author archive", "wordpress-seo" );
-	const labelLower = useMemo( () => toLower( label ), [ label ] );
-	const singularLabelLower = useMemo( () => toLower( singularLabel ), [ singularLabel ] );
+	const userLocale = useSelectSettings( "selectPreference", [], "userLocale" );
+	const labelLower = useMemo( () => safeToLocaleLower( label, userLocale ), [ label, userLocale ] );
+	const singularLabelLower = useMemo( () => safeToLocaleLower( singularLabel, userLocale ), [ singularLabel, userLocale ] );
 
 	const premiumUpsellConfig = useSelectSettings( "selectUpsellSettingsAsProps" );
 	const replacementVariables = useSelectSettings( "selectReplacementVariablesFor", [], "author_archives", "custom-post-type_archive" );

--- a/packages/js/src/settings/routes/date-archives.js
+++ b/packages/js/src/settings/routes/date-archives.js
@@ -3,7 +3,6 @@ import { createInterpolateElement, useMemo } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
 import { Badge, Code, FeatureUpsell, Link } from "@yoast/ui-library";
 import { useFormikContext } from "formik";
-import { toLower } from "lodash";
 import {
 	FieldsetLayout,
 	FormikFlippedToggleField,
@@ -13,6 +12,7 @@ import {
 	OpenGraphDisabledAlert,
 	RouteLayout,
 } from "../components";
+import { safeToLocaleLower } from "../helpers";
 import { withFormikDummyField } from "../hocs";
 import { useSelectSettings } from "../hooks";
 
@@ -23,7 +23,8 @@ const FormikReplacementVariableEditorFieldWithDummy = withFormikDummyField( Form
  */
 const DateArchives = () => {
 	const label = __( "Date archives", "wordpress-seo" );
-	const labelLower = useMemo( () => toLower( label ), [ label ] );
+	const userLocale = useSelectSettings( "selectPreference", [], "userLocale" );
+	const labelLower = useMemo( () => safeToLocaleLower( label, userLocale ), [ label, userLocale ] );
 
 	const premiumUpsellConfig = useSelectSettings( "selectUpsellSettingsAsProps" );
 	const replacementVariables = useSelectSettings( "selectReplacementVariablesFor", [], "date_archive", "custom-post-type_archive" );

--- a/packages/js/src/settings/routes/format-archives.js
+++ b/packages/js/src/settings/routes/format-archives.js
@@ -3,7 +3,6 @@ import { createInterpolateElement, useMemo } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
 import { Badge, Code, FeatureUpsell, Link } from "@yoast/ui-library";
 import { useFormikContext } from "formik";
-import { toLower } from "lodash";
 import {
 	FieldsetLayout,
 	FormikFlippedToggleField,
@@ -13,6 +12,7 @@ import {
 	OpenGraphDisabledAlert,
 	RouteLayout,
 } from "../components";
+import { safeToLocaleLower } from "../helpers";
 import { withFormikDummyField } from "../hocs";
 import { useSelectSettings } from "../hooks";
 
@@ -29,8 +29,9 @@ const FormikReplacementVariableEditorFieldWithDummy = withFormikDummyField( Form
  */
 const FormatArchives = () => {
 	const { name, label, singularLabel } = useSelectSettings( "selectTaxonomy", [], "post_format" );
-	const labelLower = useMemo( () => toLower( label ), [ label ] );
-	const singularLabelLower = useMemo( () => toLower( singularLabel ), [ singularLabel ] );
+	const userLocale = useSelectSettings( "selectPreference", [], "userLocale" );
+	const labelLower = useMemo( () => safeToLocaleLower( label, userLocale ), [ label, userLocale ] );
+	const singularLabelLower = useMemo( () => safeToLocaleLower( singularLabel, userLocale ), [ singularLabel, userLocale ] );
 
 	const premiumUpsellConfig = useSelectSettings( "selectUpsellSettingsAsProps" );
 	const replacementVariables = useSelectSettings( "selectReplacementVariablesFor", [ name ], name, "term-in-custom-taxonomy" );

--- a/packages/js/src/settings/routes/media-pages.js
+++ b/packages/js/src/settings/routes/media-pages.js
@@ -2,7 +2,6 @@ import { createInterpolateElement, useMemo } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
 import { Link, SelectField, ToggleField } from "@yoast/ui-library";
 import { useFormikContext } from "formik";
-import { toLower } from "lodash";
 import {
 	FieldsetLayout,
 	FormikFlippedToggleField,
@@ -11,6 +10,7 @@ import {
 	FormLayout,
 	RouteLayout,
 } from "../components";
+import { safeToLocaleLower } from "../helpers";
 import { useSelectSettings } from "../hooks";
 
 /**
@@ -18,7 +18,8 @@ import { useSelectSettings } from "../hooks";
  */
 const MediaPages = () => {
 	const { name, label, hasSchemaArticleType } = useSelectSettings( "selectPostType", [], "attachment" );
-	const labelLower = useMemo( () => toLower( label ), [ label ] );
+	const userLocale = useSelectSettings( "selectPreference", [], "userLocale" );
+	const labelLower = useMemo( () => safeToLocaleLower( label, userLocale ), [ label, userLocale ] );
 
 	const replacementVariables = useSelectSettings( "selectReplacementVariablesFor", [ name ], name, "custom_post_type" );
 	const recommendedReplacementVariables = useSelectSettings( "selectRecommendedReplacementVariablesFor", [ name ], name, "custom_post_type" );

--- a/packages/js/src/settings/routes/site-basics.js
+++ b/packages/js/src/settings/routes/site-basics.js
@@ -190,6 +190,7 @@ const SiteBasics = () => {
 									__( "%1$s has auto-detected whether it needs to force rewrite the titles for your pages, if you think it's wrong and you know what you're doing, you can change the setting here.", "wordpress-seo" ),
 									"Yoast SEO"
 								) }
+								className="yst-max-w-sm"
 							/>
 						) }
 						<FormikValueChangeField

--- a/packages/js/src/settings/routes/templates/post-type.js
+++ b/packages/js/src/settings/routes/templates/post-type.js
@@ -3,7 +3,6 @@ import { createInterpolateElement, useMemo } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
 import { Badge, FeatureUpsell, Link, SelectField, TextField, Title, ToggleField } from "@yoast/ui-library";
 import { Field, useFormikContext } from "formik";
-import { toLower } from "lodash";
 import PropTypes from "prop-types";
 import { addLinkToString } from "../../../helpers/stringHelpers";
 import {
@@ -17,6 +16,7 @@ import {
 	OpenGraphDisabledAlert,
 	RouteLayout,
 } from "../../components";
+import { safeToLocaleLower } from "../../helpers";
 import { withFormikDummyField } from "../../hocs";
 import { useSelectSettings } from "../../hooks";
 
@@ -45,13 +45,14 @@ const PostType = ( { name, label, singularLabel, hasArchive, hasSchemaArticleTyp
 	const hasWooCommerceShopPage = useSelectSettings( "selectPreference", [], "hasWooCommerceShopPage" );
 	const editWooCommerceShopPageUrl = useSelectSettings( "selectPreference", [], "editWooCommerceShopPageUrl" );
 	const wooCommerceShopPageSettingUrl = useSelectSettings( "selectPreference", [], "wooCommerceShopPageSettingUrl" );
+	const userLocale = useSelectSettings( "selectPreference", [], "userLocale" );
 	const noIndexInfoLink = useSelectSettings( "selectLink", [], "https://yoa.st/show-x" );
 	const socialAppearancePremiumLink = useSelectSettings( "selectLink", [], "https://yoa.st/4e0" );
 	const pageAnalysisPremiumLink = useSelectSettings( "selectLink", [], "https://yoa.st/get-custom-fields" );
 	const schemaLink = useSelectSettings( "selectLink", [], "https://yoa.st/post-type-schema" );
 
-	const labelLower = useMemo( () => toLower( label ), [ label ] );
-	const singularLabelLower = useMemo( () => toLower( singularLabel ), [ singularLabel ] );
+	const labelLower = useMemo( () => safeToLocaleLower( label, userLocale ), [ label, userLocale ] );
+	const singularLabelLower = useMemo( () => safeToLocaleLower( singularLabel, userLocale ), [ singularLabel, userLocale ] );
 	const recommendedSize = useMemo( () => createInterpolateElement(
 		sprintf(
 			/**

--- a/packages/js/src/settings/routes/templates/taxonomy.js
+++ b/packages/js/src/settings/routes/templates/taxonomy.js
@@ -2,7 +2,7 @@ import { createInterpolateElement, useMemo } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
 import { Badge, Code, FeatureUpsell, Link, ToggleField } from "@yoast/ui-library";
 import { useFormikContext } from "formik";
-import { initial, last, map, values, toLower, isEmpty } from "lodash";
+import { initial, last, map, values, isEmpty } from "lodash";
 import PropTypes from "prop-types";
 import {
 	FieldsetLayout,
@@ -14,6 +14,7 @@ import {
 	OpenGraphDisabledAlert,
 	RouteLayout,
 } from "../../components";
+import { safeToLocaleLower } from "../../helpers";
 import { withFormikDummyField } from "../../hocs";
 import { useSelectSettings } from "../../hooks";
 
@@ -32,9 +33,10 @@ const Taxonomy = ( { name, label, postTypes: postTypeNames } ) => {
 	const recommendedReplacementVariables = useSelectSettings( "selectRecommendedReplacementVariablesFor", [ name ], name, "term-in-custom-taxonomy" );
 	const noIndexInfoLink = useSelectSettings( "selectLink", [], "https://yoa.st/show-x" );
 	const isPremium = useSelectSettings( "selectPreference", [], "isPremium" );
+	const userLocale = useSelectSettings( "selectPreference", [], "userLocale" );
 	const socialAppearancePremiumLink = useSelectSettings( "selectLink", [], "https://yoa.st/4e0" );
 
-	const labelLower = useMemo( () => toLower( label ), [ label ] );
+	const labelLower = useMemo( () => safeToLocaleLower( label, userLocale ), [ label, userLocale ] );
 	const postTypeValues = useMemo( () => values( postTypes ), [ postTypes ] );
 	const initialPostTypeValues = useMemo( () => initial( postTypeValues ), [ postTypeValues ] );
 	const lastPostTypeValue = useMemo( () => last( postTypeValues ), [ postTypeValues ] );

--- a/src/integrations/settings-integration.php
+++ b/src/integrations/settings-integration.php
@@ -408,6 +408,7 @@ class Settings_Integration implements Integration_Interface {
 			'canCreateUsers'                => \current_user_can( 'create_users' ),
 			'canEditUsers'                  => \current_user_can( 'edit_users' ),
 			'canManageOptions'              => \current_user_can( 'manage_options' ),
+			'userLocale'                    => \str_replace( '_', '-', \get_user_locale() ),
 			'pluginUrl'                     => \plugins_url( '', \WPSEO_FILE ),
 			'showForceRewriteTitlesSetting' => ! \current_theme_supports( 'title-tag' ) && ! ( \function_exists( 'wp_is_block_theme' ) && \wp_is_block_theme() ),
 			'upsellSettings'                => $this->get_upsell_settings(),


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Makes the search in new settings UI case insensitive.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Makes the search in new settings UI case insensitive.

## Relevant technical choices:

* Move from Lodash `toLower` to `string.toLocaleLowerCase` for locale specific lowercasing.
* Added a `safeToLocaleLower` helper that doesn't throw breaking errors when `locale` is invalid.
* Added a max width to the `Force rewrite titles` toggle.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Open the search in the new settings UI.
* Verify that `SEO` and `seo` give you the same search results.
* Verify that `XML` and `xml` give you the same search results.
* Verify that section descriptions for post types and taxonomies still contain lowercase post type or taxonomy name:
<img width="354" alt="image" src="https://user-images.githubusercontent.com/24573520/205662956-f55679bb-26aa-4cab-88fa-432464778779.png">

* Verify that the `Force rewrite titles` toggle is now the same width as toggles below it. _This toggle is only visible in non block themes that don't support the `title-tag`_
<img width="868" alt="image" src="https://user-images.githubusercontent.com/24573520/205663260-cc17e663-b557-4946-8443-43aa9301136f.png">

**Dev only additional test**
* On line `411` of `settings-integration.php`, assign something invalid to the `userLocale` variable, ie. `false` or `10`. Then verify that above lowercasing fails and you have console errors, but the new settings UI doesn't break.


#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Only affects the new settings UI.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [x] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
https://yoast.atlassian.net/browse/DUPP-826