### PR TITLE
Pass the shortlinker as a parameter to the constructor

### DIFF
--- a/inc/class-wpseo-admin-bar-menu.php
+++ b/inc/class-wpseo-admin-bar-menu.php
@@ -114,7 +114,7 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 	 * @param Indexable_Repository|null      $indexable_repository Optional. The Indexable_Repository.
 	 * @param Score_Icon_Helper|null         $score_icon_helper    Optional. The Score_Icon_Helper.
 	 * @param Product_Helper|null            $product_helper       Optional. The product helper.
-	 * @param WPSEO_Shortlinker|null         $shortlinker          Optional. The shortlinker.
+	 * @param WPSEO_Shortlinker|null         $shortlinker          The shortlinker.
 	 */
 	public function __construct(
 		WPSEO_Admin_Asset_Manager $asset_manager = null,
@@ -258,13 +258,11 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 						[
 							'parent' => self::MENU_IDENTIFIER,
 							'id'     => 'wpseo-frontend-inspector',
-							'title'  => sprintf(
-								'<a href="%1$s" target="_blank" data-action="load-nfd-ctb" data-ctb-id="57d6a568-783c-45e2-a388-847cff155897" style="padding:0;">%2$s</a>',
-								$this->shortlinker->build_shortlink( 'https://yoa.st/admin-bar-frontend-inspector' ),
-								__( 'Front-end SEO inspector', 'wordpress-seo' ) . new Premium_Badge_Presenter( 'wpseo-frontend-inspector-badge' )
-							),
+							'href'   => $this->shortlinker->build_shortlink( 'https://yoa.st/admin-bar-frontend-inspector' ),
+							'title'  => __( 'Front-end SEO inspector', 'wordpress-seo' ) . new Premium_Badge_Presenter( 'wpseo-frontend-inspector-badge' ),
 							'meta'   => [
 								'tabindex' => '0',
+								'target'   => '_blank',
 							],
 						]
 					);

--- a/inc/class-wpseo-admin-bar-menu.php
+++ b/inc/class-wpseo-admin-bar-menu.php
@@ -5,7 +5,6 @@
  * @package WPSEO
  */
 
-use WPSEO_Shortlinker;
 use Yoast\WP\SEO\Helpers\Product_Helper;
 use Yoast\WP\SEO\Helpers\Score_Icon_Helper;
 use Yoast\WP\SEO\Models\Indexable;
@@ -81,6 +80,13 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 	protected $product_helper;
 
 	/**
+	 * Holds the shortlinker instance.
+	 *
+	 * @var WPSEO_Shortlinker
+	 */
+	protected $shortlinker;
+
+	/**
 	 * Whether SEO Score is enabled.
 	 *
 	 * @var bool
@@ -108,12 +114,14 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 	 * @param Indexable_Repository|null      $indexable_repository Optional. The Indexable_Repository.
 	 * @param Score_Icon_Helper|null         $score_icon_helper    Optional. The Score_Icon_Helper.
 	 * @param Product_Helper|null            $product_helper       Optional. The product helper.
+	 * @param WPSEO_Shortlinker|null         $shortlinker          The shortlinker.
 	 */
 	public function __construct(
 		WPSEO_Admin_Asset_Manager $asset_manager = null,
 		Indexable_Repository $indexable_repository = null,
 		Score_Icon_Helper $score_icon_helper = null,
-		Product_Helper $product_helper = null
+		Product_Helper $product_helper = null,
+		WPSEO_Shortlinker $shortlinker = null
 	) {
 		if ( ! $asset_manager ) {
 			$asset_manager = new WPSEO_Admin_Asset_Manager();
@@ -127,11 +135,15 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 		if ( ! $product_helper ) {
 			$product_helper = YoastSEO()->helpers->product;
 		}
+		if ( ! $shortlinker ) {
+			$shortlinker = new WPSEO_Shortlinker();
+		}
 
 		$this->product_helper       = $product_helper;
 		$this->asset_manager        = $asset_manager;
 		$this->indexable_repository = $indexable_repository;
 		$this->score_icon_helper    = $score_icon_helper;
+		$this->shortlinker          = $shortlinker;
 	}
 
 	/**
@@ -461,17 +473,17 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 			[
 				'id'    => 'wpseo-semrush',
 				'title' => 'Semrush',
-				'href'  => WPSEO_Shortlinker::get( 'https://yoa.st/admin-bar-semrush' ),
+				'href'  => $this->shortlinker->build_shortlink( 'https://yoa.st/admin-bar-semrush' ),
 			],
 			[
 				'id'    => 'wpseo-wincher',
 				'title' => 'Wincher',
-				'href'  => WPSEO_Shortlinker::get( 'https://yoa.st/admin-bar-wincher' ),
+				'href'  => $this->shortlinker->build_shortlink( 'https://yoa.st/admin-bar-wincher' ),
 			],
 			[
 				'id'    => 'wpseo-google-trends',
 				'title' => 'Google trends',
-				'href'  => WPSEO_Shortlinker::get( 'https://yoa.st/admin-bar-gtrends' ),
+				'href'  => $this->shortlinker->build_shortlink( 'https://yoa.st/admin-bar-gtrends' ),
 			],
 		];
 
@@ -498,17 +510,17 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 			[
 				'id'    => 'wpseo-learn-seo',
 				'title' => __( 'Learn more SEO', 'wordpress-seo' ),
-				'href'  => WPSEO_Shortlinker::get( 'https://yoa.st/admin-bar-learn-more-seo' ),
+				'href'  => $this->shortlinker->build_shortlink( 'https://yoa.st/admin-bar-learn-more-seo' ),
 			],
 			[
 				'id'    => 'wpseo-improve-blogpost',
 				'title' => __( 'Improve your blog post', 'wordpress-seo' ),
-				'href'  => WPSEO_Shortlinker::get( 'https://yoa.st/admin-bar-improve-blog-post' ),
+				'href'  => $this->shortlinker->build_shortlink( 'https://yoa.st/admin-bar-improve-blog-post' ),
 			],
 			[
 				'id'    => 'wpseo-write-better-content',
 				'title' => __( 'Write better content', 'wordpress-seo' ),
-				'href'  => WPSEO_Shortlinker::get( 'https://yoa.st/admin-bar-write-better' ),
+				'href'  => $this->shortlinker->build_shortlink( 'https://yoa.st/admin-bar-write-better' ),
 			],
 		];
 
@@ -535,22 +547,22 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 			[
 				'id'    => 'wpseo-yoast-help',
 				'title' => __( 'Yoast.com help section', 'wordpress-seo' ),
-				'href'  => WPSEO_Shortlinker::get( 'https://yoa.st/admin-bar-yoast-help' ),
+				'href'  => $this->shortlinker->build_shortlink( 'https://yoa.st/admin-bar-yoast-help' ),
 			],
 			[
 				'id'    => 'wpseo-premium-support',
 				'title' => __( 'Yoast Premium support', 'wordpress-seo' ),
-				'href'  => WPSEO_Shortlinker::get( 'https://yoa.st/admin-bar-premium-support' ),
+				'href'  => $this->shortlinker->build_shortlink( 'https://yoa.st/admin-bar-premium-support' ),
 			],
 			[
 				'id'    => 'wpseo-wp-support-forums',
 				'title' => __( 'WordPress.org support forums', 'wordpress-seo' ),
-				'href'  => WPSEO_Shortlinker::get( 'https://yoa.st/admin-bar-wp-support-forums' ),
+				'href'  => $this->shortlinker->build_shortlink( 'https://yoa.st/admin-bar-wp-support-forums' ),
 			],
 			[
 				'id'    => 'wpseo-learn-seo-2',
 				'title' => __( 'Learn more SEO', 'wordpress-seo' ),
-				'href'  => WPSEO_Shortlinker::get( 'https://yoa.st/admin-bar-learn-more-seo-help' ),
+				'href'  => $this->shortlinker->build_shortlink( 'https://yoa.st/admin-bar-learn-more-seo-help' ),
 			],
 		];
 
@@ -572,7 +584,7 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 				// Circumvent an issue in the WP admin bar API in order to pass `data` attributes. See https://core.trac.wordpress.org/ticket/38636.
 				'title'  => sprintf(
 					'<a href="%1$s" target="_blank" data-action="load-nfd-ctb" data-ctb-id="57d6a568-783c-45e2-a388-847cff155897" style="padding:0;">%2$s &raquo;</a>',
-					WPSEO_Shortlinker::get( 'https://yoa.st/admin-bar-get-premium' ),
+					$this->shortlinker->build_shortlink( 'https://yoa.st/admin-bar-get-premium' ),
 					__( 'Get Yoast SEO Premium', 'wordpress-seo' )
 				),
 				'meta'   => [

--- a/inc/class-wpseo-admin-bar-menu.php
+++ b/inc/class-wpseo-admin-bar-menu.php
@@ -114,7 +114,7 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 	 * @param Indexable_Repository|null      $indexable_repository Optional. The Indexable_Repository.
 	 * @param Score_Icon_Helper|null         $score_icon_helper    Optional. The Score_Icon_Helper.
 	 * @param Product_Helper|null            $product_helper       Optional. The product helper.
-	 * @param WPSEO_Shortlinker|null         $shortlinker          The shortlinker.
+	 * @param WPSEO_Shortlinker|null         $shortlinker          Optional. The shortlinker.
 	 */
 	public function __construct(
 		WPSEO_Admin_Asset_Manager $asset_manager = null,
@@ -258,11 +258,13 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 						[
 							'parent' => self::MENU_IDENTIFIER,
 							'id'     => 'wpseo-frontend-inspector',
-							'href'   => 'https://yoa.st/admin-bar-frontend-inspector',
-							'title'  => __( 'Front-end SEO inspector', 'wordpress-seo' ) . new Premium_Badge_Presenter( 'wpseo-frontend-inspector-badge' ),
+							'title'  => sprintf(
+								'<a href="%1$s" target="_blank" data-action="load-nfd-ctb" data-ctb-id="57d6a568-783c-45e2-a388-847cff155897" style="padding:0;">%2$s</a>',
+								$this->shortlinker->build_shortlink( 'https://yoa.st/admin-bar-frontend-inspector' ),
+								__( 'Front-end SEO inspector', 'wordpress-seo' ) . new Premium_Badge_Presenter( 'wpseo-frontend-inspector-badge' )
+							),
 							'meta'   => [
 								'tabindex' => '0',
-								'target'   => '_blank',
 							],
 						]
 					);


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to change the way we use the `WPSEO_Shortlinker` class in the `WPSEO_Admin_Bar_Menu` class to a cleaner implementation.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Refactors `WPSEO_Admin_Bar_Menu`  to accept `WPSEO_Shortlinker` as a constructor parameter.

## Relevant technical choices:

* N/A

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Open a post in the front-end
* When Premium is not enabled, the Frontend Inspector link should:
  * Still points to `https://yoa.st/admin-bar-frontend-inspector`
  * It now adds parameters like `?php_version=8.0&platform=wordpress&platform_version=6.1.1&software=free&software_version=19.12-RC6&days_active=6-30&user_language=en_US`
* See the **Impact check** section for regression testing

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [X] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* To verify the change did not break the functionality already implemented, perform again the test steps in https://github.com/Yoast/wordpress-seo/pull/19335

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes [DUPP-829](https://yoast.atlassian.net/browse/DUPP-829)
