### PR TITLE
Add deprecated class to prevent fatal error from removing the I18n package.

### DIFF
--- a/src/deprecated/i18n/i18n-v3.php
+++ b/src/deprecated/i18n/i18n-v3.php
@@ -25,7 +25,7 @@ class Yoast_I18n_v3 {
 	 * @param bool  $show_translation_box Whether the translation box should be shown.
 	 */
 	public function __construct( $args, $show_translation_box = true ) {
-		\_deprecated_function( __METHOD__, 'WPSEO 19.13' );
+		\_deprecated_function( __METHOD__, 'WPSEO 19.12' );
 	}
 
 	/**
@@ -39,7 +39,7 @@ class Yoast_I18n_v3 {
 	 * @return bool Returns true if the language is en_US.
 	 */
 	protected function is_default_language( $language ) {
-		\_deprecated_function( __METHOD__, 'WPSEO 19.13' );
+		\_deprecated_function( __METHOD__, 'WPSEO 19.12' );
 		return true;
 	}
 
@@ -54,7 +54,7 @@ class Yoast_I18n_v3 {
 	 * @return string The i18n promo message.
 	 */
 	public function get_promo_message() {
-		\_deprecated_function( __METHOD__, 'WPSEO 19.13' );
+		\_deprecated_function( __METHOD__, 'WPSEO 19.12' );
 		return '';
 	}
 
@@ -69,7 +69,7 @@ class Yoast_I18n_v3 {
 	 * @return string
 	 */
 	public function get_dismiss_i18n_message_button() {
-		\_deprecated_function( __METHOD__, 'WPSEO 19.13' );
+		\_deprecated_function( __METHOD__, 'WPSEO 19.12' );
 		return '';
 	}
 
@@ -82,7 +82,7 @@ class Yoast_I18n_v3 {
 	 * @access public
 	 */
 	public function promo() {
-		\_deprecated_function( __METHOD__, 'WPSEO 19.13' );
+		\_deprecated_function( __METHOD__, 'WPSEO 19.12' );
 	}
 
 	/**
@@ -94,6 +94,6 @@ class Yoast_I18n_v3 {
 	 * @param string $api_url The new API URL.
 	 */
 	public function set_api_url( $api_url ) {
-		\_deprecated_function( __METHOD__, 'WPSEO 19.13' );
+		\_deprecated_function( __METHOD__, 'WPSEO 19.12' );
 	}
 }

--- a/src/deprecated/i18n/i18n-v3.php
+++ b/src/deprecated/i18n/i18n-v3.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Yoast I18n module.
+ *
+ * @package Yoast\I18n-module
+ */
+
+/**
+ * This class defines a promo box and checks your translation site's API for stats about it,
+ * then shows them to the user.
+ *
+ * @deprecated 19.13
+ * @codeCoverageIgnore
+ * @phpcs:disable PEAR.NamingConventions.ValidClassName.Invalid
+ */
+class Yoast_I18n_v3 {
+
+	/**
+	 * Class constructor.
+	 *
+	 * @deprecated 19.12
+	 * @codeCoverageIgnore
+	 *
+	 * @param array $args                 Contains the settings for the class.
+	 * @param bool  $show_translation_box Whether the translation box should be shown.
+	 */
+	public function __construct( $args, $show_translation_box = true ) {
+		\_deprecated_function( __METHOD__, 'WPSEO 19.13' );
+	}
+
+	/**
+	 * Returns whether the language is en_US.
+	 *
+	 * @deprecated 19.12
+	 * @codeCoverageIgnore
+	 *
+	 * @param string $language The language to check.
+	 *
+	 * @return bool Returns true if the language is en_US.
+	 */
+	protected function is_default_language( $language ) {
+		\_deprecated_function( __METHOD__, 'WPSEO 19.13' );
+		return true;
+	}
+
+	/**
+	 * Returns the i18n_promo message from the i18n_module. Returns en empty string if the promo shouldn't be shown.
+	 *
+	 * @deprecated 19.12
+	 * @codeCoverageIgnore
+	 *
+	 * @access public
+	 *
+	 * @return string The i18n promo message.
+	 */
+	public function get_promo_message() {
+		\_deprecated_function( __METHOD__, 'WPSEO 19.13' );
+		return '';
+	}
+
+	/**
+	 * Returns a button that can be used to dismiss the i18n-message.
+	 *
+	 * @deprecated 19.12
+	 * @codeCoverageIgnore
+	 *
+	 * @access private
+	 *
+	 * @return string
+	 */
+	public function get_dismiss_i18n_message_button() {
+		\_deprecated_function( __METHOD__, 'WPSEO 19.13' );
+		return '';
+	}
+
+	/**
+	 * Outputs a promo box.
+	 *
+	 * @deprecated 19.12
+	 * @codeCoverageIgnore
+	 *
+	 * @access public
+	 */
+	public function promo() {
+		\_deprecated_function( __METHOD__, 'WPSEO 19.13' );
+	}
+
+	/**
+	 * The API URL to use when requesting translation information.
+	 *
+	 * @deprecated 19.12
+	 * @codeCoverageIgnore
+	 *
+	 * @param string $api_url The new API URL.
+	 */
+	public function set_api_url( $api_url ) {
+		\_deprecated_function( __METHOD__, 'WPSEO 19.13' );
+	}
+}

--- a/src/deprecated/i18n/i18n-v3.php
+++ b/src/deprecated/i18n/i18n-v3.php
@@ -9,7 +9,7 @@
  * This class defines a promo box and checks your translation site's API for stats about it,
  * then shows them to the user.
  *
- * @deprecated 19.13
+ * @deprecated 19.12
  * @codeCoverageIgnore
  * @phpcs:disable PEAR.NamingConventions.ValidClassName.Invalid
  */


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* By removing the I18n package dependancy in free we introduce a fatal error in premium 19.15 and below.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a non released bug where premium would give a fatal error on the redirect page when the version was lower than 19.16.

## Relevant technical choices:

* We chose to add a deprecation class instead of reintroducing the package to keep the impact as low as possible.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install and activate Free 19.12-rc6 + Premium 19.5
* Go to the redirects page. You should get a fatal error (make sure you run composer install in both)
* Activate this pr/RC and run composer again (not needed in the RC) and refresh the page. The error should be gone.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes [DUPP-830](https://yoast.atlassian.net/browse/DUPP-830)
