### PR TITLE
Settings UI: Remove code blocks from breadcrumb settings for post type or tax in s…

### DIFF
--- a/packages/js/src/settings/components/search.js
+++ b/packages/js/src/settings/components/search.js
@@ -1,9 +1,9 @@
 /* eslint-disable complexity */
 import { Combobox } from "@headlessui/react";
 import { SearchIcon } from "@heroicons/react/outline";
-import { useCallback, useRef, useState } from "@wordpress/element";
+import { useCallback, useRef, useState, useMemo } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
-import { Modal, Title, useSvgAria, useToggleState } from "@yoast/ui-library";
+import { Modal, Title, useSvgAria, useToggleState, Code } from "@yoast/ui-library";
 import classNames from "classnames";
 import { debounce, first, groupBy, includes, isEmpty, map, max, reduce, split, trim, values } from "lodash";
 import PropTypes from "prop-types";
@@ -13,6 +13,42 @@ import { safeToLocaleLower } from "../helpers";
 import { useParsedUserAgent, useSelectSettings } from "../hooks";
 
 const QUERY_MIN_CHARS = 3;
+const POST_TYPE_OR_TAXONOMY_BREADCRUMB_SETTING_REGEXP = new RegExp( /^input-wpseo_titles-(post_types|taxonomy)-(?<name>\S+)-(maintax|ptparent)$/is );
+
+/**
+ * @param {string} fieldId The item field ID.
+ * @param {string} fieldLabel The item label.
+ * @returns {JSX.Element} The SearchResultLabel element.
+ */
+const SearchResultLabel = ( { fieldId, fieldLabel } ) => {
+	// Deduce wether field is a breadcrumb option for post type or taxonomy.
+	const { isPostTypeOrTaxonomyBreadcrumbSetting, postTypeOrTaxonomyName } = useMemo( () => {
+		const matches = POST_TYPE_OR_TAXONOMY_BREADCRUMB_SETTING_REGEXP.exec( fieldId );
+		return {
+			isPostTypeOrTaxonomyBreadcrumbSetting: Boolean( matches ),
+			postTypeOrTaxonomyName: matches?.groups?.name,
+		};
+	}, [ fieldId, POST_TYPE_OR_TAXONOMY_BREADCRUMB_SETTING_REGEXP ] );
+
+	// Render additional code block with post type or taxonomy name if applicable.
+	if ( isPostTypeOrTaxonomyBreadcrumbSetting ) {
+		return (
+			<>
+				{ fieldLabel }
+				{ postTypeOrTaxonomyName && (
+					<Code className="yst-ml-2 group-hover:yst-bg-primary-200 group-hover:yst-text-primary-800">{ postTypeOrTaxonomyName }</Code>
+				) }
+			</>
+		);
+	}
+
+	return fieldLabel;
+};
+
+SearchResultLabel.propTypes = {
+	fieldId: PropTypes.string.isRequired,
+	fieldLabel: PropTypes.string.isRequired,
+};
 
 /**
  * @param {string} title The title.
@@ -176,13 +212,13 @@ const Search = () => {
 							<li key={ groupedItems?.[ 0 ]?.route || `group-${ index }` }>
 								<Title as="h4" size="3" className="yst-bg-slate-100 yst-py-3 yst-px-4">{ first( groupedItems ).routeLabel }</Title>
 								<ul>
-									{ map( groupedItems, ( item, name ) => (
+									{ map( groupedItems, ( item ) =>  (
 										<Combobox.Option
-											key={ name }
+											key={ item.fieldId }
 											value={ item }
 											className={ handleOptionActiveState }
 										>
-											{ item.fieldLabel }
+											<SearchResultLabel { ...item } />
 										</Combobox.Option>
 									) ) }
 								</ul>

--- a/packages/js/src/settings/helpers/search.js
+++ b/packages/js/src/settings/helpers/search.js
@@ -1,7 +1,5 @@
 /* eslint-disable camelcase */
 import { __, sprintf } from "@wordpress/i18n";
-import { Code } from "@yoast/ui-library";
-import { createInterpolateElement } from "@wordpress/element";
 import { omit, reduce, times, filter, includes, isEmpty } from "lodash";
 import { safeToLocaleLower } from "./i18n";
 
@@ -756,13 +754,8 @@ export const createSearchIndex = ( postTypes, taxonomies, { userLocale } = {} ) 
 					route: "/breadcrumbs",
 					routeLabel: __( "Breadcrumbs", "wordpress-seo" ),
 					fieldId: `input-wpseo_titles-post_types-${ postType.name }-maintax`,
-					fieldLabel: createInterpolateElement(
-						// translators: %1$s expands to the post type plural, e.g. posts.
-						sprintf( __( "Breadcrumbs for %1$s<code />", "wordpress-seo" ), safeToLocaleLower( postType.label, userLocale ) ),
-						{
-							code: <Code className="yst-ml-2 group-hover:yst-bg-primary-200 group-hover:yst-text-primary-800">{ postType.name }</Code>,
-						}
-					),
+					// translators: %1$s expands to the post type plural, e.g. posts.
+					fieldLabel: sprintf( __( "Breadcrumbs for %1$s", "wordpress-seo" ), safeToLocaleLower( postType.label, userLocale ) ),
 					keywords: [],
 				},
 			} );
@@ -773,13 +766,8 @@ export const createSearchIndex = ( postTypes, taxonomies, { userLocale } = {} ) 
 				route: "/breadcrumbs",
 				routeLabel: __( "Breadcrumbs", "wordpress-seo" ),
 				fieldId: `input-wpseo_titles-taxonomy-${ taxonomy.name }-ptparent`,
-				fieldLabel: createInterpolateElement(
-					// translators: %1$s expands to the taxonomy plural, e.g. categories.
-					sprintf( __( "Breadcrumbs for %1$s<code />", "wordpress-seo" ), safeToLocaleLower( taxonomy.label, userLocale ) ),
-					{
-						code: <Code className="yst-ml-2 group-hover:yst-bg-primary-200 group-hover:yst-text-primary-800">{ taxonomy.name }</Code>,
-					}
-				),
+				// translators: %1$s expands to the taxonomy plural, e.g. categories.
+				fieldLabel: sprintf( __( "Breadcrumbs for %1$s", "wordpress-seo" ), safeToLocaleLower( taxonomy.label, userLocale ) ),
 				keywords: [],
 			},
 		} ), {} ),


### PR DESCRIPTION
…earch index

## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Move `code` blocks (JSX) from search index to search component (place of rendering).

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Move `code` blocks (JSX) from search index to search component (place of rendering).

## Relevant technical choices:

* Used a `RegExp` in `Search` component to determine with what options we're dealing with based on `fieldId`.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Verify that searching for `post` will get you the `Breadcrumbs for posts` search result and that search result contains a `code` block with post type name `post`.
* Optionally test for other post types.
* Verify that searching for `category` will get you the `Breadcrumbs for categories` search result and that search result contains a `code` block with taxonomy name `category`.
* Optionally test for other taxonomies.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* No impact outside of new settings UI.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [x] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
https://yoast.atlassian.net/browse/DUPP-833