### PR TITLE
Adds the possibility to add options to the Inclusive language assessor.

### DIFF
--- a/packages/yoastseo/src/worker/AnalysisWebWorker.js
+++ b/packages/yoastseo/src/worker/AnalysisWebWorker.js
@@ -135,6 +135,7 @@ export default class AnalysisWebWorker {
 		this.setCustomCornerstoneRelatedKeywordAssessorClass = this.setCustomCornerstoneRelatedKeywordAssessorClass.bind( this );
 		this.registerAssessor = this.registerAssessor.bind( this );
 		this.registerResearch = this.registerResearch.bind( this );
+		this.setInclusiveLanguageOptions = this.setInclusiveLanguageOptions.bind( this );
 
 		// Bind event handlers to this scope.
 		this.handleMessage = this.handleMessage.bind( this );

--- a/packages/yoastseo/src/worker/AnalysisWebWorker.js
+++ b/packages/yoastseo/src/worker/AnalysisWebWorker.js
@@ -269,7 +269,7 @@ export default class AnalysisWebWorker {
 	 *
 	 * @returns {void}
 	 */
-	setInclusiveLanguageConfiguration( options ) {
+	setInclusiveLanguageOptions( options ) {
 		this._inclusiveLanguageOptions = options;
 	}
 

--- a/packages/yoastseo/src/worker/AnalysisWebWorker.js
+++ b/packages/yoastseo/src/worker/AnalysisWebWorker.js
@@ -80,6 +80,8 @@ export default class AnalysisWebWorker {
 
 		this.additionalAssessors = {};
 
+		this._inclusiveLanguageOptions = {};
+
 		/*
 		 * The cached analyses results.
 		 *
@@ -258,6 +260,17 @@ export default class AnalysisWebWorker {
 		this._CustomCornerstoneRelatedKeywordAssessorClasses[ customAnalysisType ] = CornerstoneRelatedKeywordAssessorClass;
 		this._CustomCornerstoneRelatedKeywordAssessorOptions[ customAnalysisType ] = customAssessorOptions;
 		this._relatedKeywordAssessor = this.createRelatedKeywordsAssessor();
+	}
+
+	/**
+	 * Sets the options to use for the Inclusive language analysis.
+	 *
+	 * @param {{infoLinks: {}}} options The options to use.
+	 *
+	 * @returns {void}
+	 */
+	setInclusiveLanguageConfiguration( options ) {
+		this._inclusiveLanguageOptions = options;
 	}
 
 	/**
@@ -531,7 +544,7 @@ export default class AnalysisWebWorker {
 			return null;
 		}
 
-		return new InclusiveLanguageAssessor( this._researcher );
+		return new InclusiveLanguageAssessor( this._researcher, this._inclusiveLanguageOptions );
 	}
 
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We need to be able to override the shortlinks within the Inclusive language analysis from within Shopify SEO so we can determine from which platform the traffic to the website is coming from. This PR adds a method to do that.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [yoastseo] Adds the possibility to change the links to the "learn more" URLs in the Inclusive language assessments.

## Relevant technical choices:

* **Do NOT merge `trunk` into this branch**. This branch has been created based on the release branch, will be used in Shopify, and should not contain any unstable changes.
* **Do NOT remove this branch after merging**. This branch will be used in Shopify.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* For Shopify SEO, please follow [the steps described in this PR](https://github.com/Yoast/shopify-seo/pull/922). For WordPress SEO, please follow the steps described in the _Impact check_ below.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
   * Not specifically needed, but good to do anyway in case of errors in the JavaScript code.
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* This PR could impact the links used in the Inclusive language analysis results. 
   * Make sure that the "learn more" links used within the Inclusive language assessment results are still correct:
      * For assessments about age, the link should be https://yoa.st/inclusive-language-age.
        * Example phrases: "elderly", "senile". 
      * For assessments about appearance, the link should be https://yoa.st/inclusive-language-appearance.
        * Example phrases: "obesity", "midget". 
      * For assessments about culture, the link should be https://yoa.st/inclusive-language-culture. 
        * Example phrases: "third world country", "colored people". 
      * For assessments about disability, the link should be https://yoa.st/inclusive-language-disability.
        * Example phrases: "sociopath", "addict".
      * For assessments about gender, the link should be https://yoa.st/inclusive-language-gender.
        * Example phrases: "man-made", "husband and wife".
      * For assessments about socio-economic status, the link should be https://yoa.st/inclusive-language-ses.
        * Example phrases: "poverty stricken", "illegal immigrants". 
      * For other assessments, the link should be https://yoa.st/inclusive-language-other.
        * Example phrases: "felon", "minorities".

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes https://yoast.atlassian.net/browse/PC-976
