### PR TITLE
Adds Extra link in the plugin overview.

### DIFF
--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -229,7 +229,7 @@ class WPSEO_Admin {
 		$faq_link = '<a href="' . esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/1yc' ) ) . '" target="_blank">' . __( 'FAQ', 'wordpress-seo' ) . '</a>';
 		array_unshift( $links, $faq_link );
 
-		if ( $first_time_configuration_notice_helper->first_time_configuration_not_finished() ) {
+		if ( $first_time_configuration_notice_helper->first_time_configuration_not_finished() && ! is_network_admin() ) {
 			$configuration_title = ( ! $first_time_configuration_notice_helper->should_show_alternate_message() ) ? 'first-time configuration' : 'SEO configuration';
 			/* translators: CTA to finish the first time configuration. %s: Either first-time SEO configuration or SEO configuration. */
 			$message  = sprintf( __( 'Finish your %s', 'wordpress-seo' ), $configuration_title );

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -230,12 +230,12 @@ class WPSEO_Admin {
 		array_unshift( $links, $faq_link );
 
 		if ( $first_time_configuration_notice_helper->first_time_configuration_not_finished() ) {
-			/* translators: CTA to finish the first time configuration. %s: Network title. */
-			$message = __( sprintf( 'Finish your %s', strtolower($first_time_configuration_notice_helper->get_first_time_configuration_title() )), 'wordpress-seo' );
+			$configuration_title = ( ! $first_time_configuration_notice_helper->should_show_alternate_message() ) ? 'first-time configuration' : 'SEO configuration';
+			/* translators: CTA to finish the first time configuration. %s: Either first-time SEO configuration or SEO configuration. */
+			$message  = sprintf( __( 'Finish your %s', 'wordpress-seo' ), $configuration_title );
 			$ftc_link = '<a href="' . esc_url( admin_url( 'admin.php?page=wpseo_dashboard#top#first-time-configuration' ) ) . '" target="_blank">' . $message . '</a>';
 			array_unshift( $links, $ftc_link );
 		}
-
 
 
 		$addon_manager = new WPSEO_Addon_Manager();
@@ -245,9 +245,9 @@ class WPSEO_Admin {
 			unset( $links['deactivate'] );
 			$no_deactivation_explanation = '<span style="color: #32373c">' . sprintf(
 				/* translators: %s expands to Yoast SEO Premium. */
-					__( 'Required by %s', 'wordpress-seo' ),
-					'Yoast SEO Premium'
-				) . '</span>';
+				__( 'Required by %s', 'wordpress-seo' ),
+				'Yoast SEO Premium'
+			) . '</span>';
 
 			array_unshift( $links, $no_deactivation_explanation );
 

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -212,6 +212,8 @@ class WPSEO_Admin {
 	 * @return array
 	 */
 	public function add_action_link( $links, $file ) {
+		$first_time_configuration_notice_helper = \YoastSEO()->helpers->first_time_configuration_notice;
+
 		if ( $file === WPSEO_BASENAME && WPSEO_Capability_Utils::current_user_can( 'wpseo_manage_options' ) ) {
 			if ( is_network_admin() ) {
 				$settings_url = network_admin_url( 'admin.php?page=' . self::PAGE_IDENTIFIER );
@@ -227,6 +229,15 @@ class WPSEO_Admin {
 		$faq_link = '<a href="' . esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/1yc' ) ) . '" target="_blank">' . __( 'FAQ', 'wordpress-seo' ) . '</a>';
 		array_unshift( $links, $faq_link );
 
+		if ( $first_time_configuration_notice_helper->first_time_configuration_not_finished() ) {
+			/* translators: CTA to finish the first time configuration. %s: Network title. */
+			$message = __( sprintf( 'Finish your %s', strtolower($first_time_configuration_notice_helper->get_first_time_configuration_title() )), 'wordpress-seo' );
+			$ftc_link = '<a href="' . esc_url( admin_url( 'admin.php?page=wpseo_dashboard#top#first-time-configuration' ) ) . '" target="_blank">' . $message . '</a>';
+			array_unshift( $links, $ftc_link );
+		}
+
+
+
 		$addon_manager = new WPSEO_Addon_Manager();
 		if ( YoastSEO()->helpers->product->is_premium() ) {
 
@@ -234,9 +245,9 @@ class WPSEO_Admin {
 			unset( $links['deactivate'] );
 			$no_deactivation_explanation = '<span style="color: #32373c">' . sprintf(
 				/* translators: %s expands to Yoast SEO Premium. */
-				__( 'Required by %s', 'wordpress-seo' ),
-				'Yoast SEO Premium'
-			) . '</span>';
+					__( 'Required by %s', 'wordpress-seo' ),
+					'Yoast SEO Premium'
+				) . '</span>';
 
 			array_unshift( $links, $no_deactivation_explanation );
 
@@ -331,7 +342,7 @@ class WPSEO_Admin {
 			[
 				'isRtl'                   => is_rtl(),
 				'variable_warning'        => sprintf(
-					/* translators: %1$s: '%%term_title%%' variable used in titles and meta's template that's not compatible with the given template, %2$s: expands to 'HelpScout beacon' */
+				/* translators: %1$s: '%%term_title%%' variable used in titles and meta's template that's not compatible with the given template, %2$s: expands to 'HelpScout beacon' */
 					__( 'Warning: the variable %1$s cannot be used in this template. See the %2$s for more info.', 'wordpress-seo' ),
 					'<code>%s</code>',
 					'HelpScout beacon'

--- a/src/helpers/first-time-configuration-notice-helper.php
+++ b/src/helpers/first-time-configuration-notice-helper.php
@@ -59,10 +59,20 @@ class First_Time_Configuration_Notice_Helper {
 		return $this->first_time_configuration_not_finished();
 	}
 
+	/**
+	 * Gets the first time configuration title based on the show_alternate_message boolean
+	 *
+	 * @return string
+	 */
 	public function get_first_time_configuration_title() {
 		return ( ! $this->show_alternate_message ) ? \__( 'First-time SEO configuration', 'wordpress-seo' ) : \__( 'SEO configuration', 'wordpress-seo' );
 	}
 
+	/**
+	 * Determines if the first time configuration is completely finished.
+	 *
+	 * @return bool
+	 */
 	public function first_time_configuration_not_finished() {
 		if ( ! $this->user_can_do_first_time_configuration() ) {
 			return false;
@@ -152,15 +162,15 @@ class First_Time_Configuration_Notice_Helper {
 		}
 
 		if ( $company_or_person === 'company' ) {
-			return ! empty( $this->options_helper->get( 'company_name' ) )
-				   && ! empty( $this->options_helper->get( 'company_logo', '' ) );
+			return ! empty( $this->options_helper->get( 'company_name' ) ) && ! empty( $this->options_helper->get( 'company_logo', '' ) );
 		}
 
-		return ! empty( $this->options_helper->get( 'company_or_person_user_id' ) )
-			   && ! empty( $this->options_helper->get( 'person_logo', '' ) );
+		return ! empty( $this->options_helper->get( 'company_or_person_user_id' ) ) && ! empty( $this->options_helper->get( 'person_logo', '' ) );
 	}
 
 	/**
+	 * Getter for the show alternate message boolean.
+	 *
 	 * @return bool
 	 */
 	public function should_show_alternate_message() {

--- a/src/helpers/first-time-configuration-notice-helper.php
+++ b/src/helpers/first-time-configuration-notice-helper.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace Yoast\WP\SEO\Helpers;
+
+/**
+ * A helper to determine the status of ftc and front-end related configuration.
+ */
+class First_Time_Configuration_Notice_Helper {
+
+	/**
+	 * The options' helper.
+	 *
+	 * @var Options_Helper
+	 */
+	private $options_helper;
+
+	/**
+	 * The indexing helper.
+	 *
+	 * @var Indexing_Helper
+	 */
+	private $indexing_helper;
+
+	/**
+	 * Whether we show the alternate mesage.
+	 *
+	 * @var bool
+	 */
+	private $show_alternate_message;
+
+	/**
+	 * First_Time_Configuration_Notice_Integration constructor.
+	 *
+	 * @param Options_Helper  $options_helper  The options helper.
+	 * @param Indexing_Helper $indexing_helper The indexing helper.
+	 */
+	public function __construct(
+		Options_Helper $options_helper,
+		Indexing_Helper $indexing_helper
+	) {
+		$this->options_helper         = $options_helper;
+		$this->indexing_helper        = $indexing_helper;
+		$this->show_alternate_message = false;
+	}
+
+	/**
+	 * Determines whether and where the "First-time SEO Configuration" admin notice should be displayed.
+	 *
+	 * @return bool Whether the "First-time SEO Configuration" admin notice should be displayed.
+	 */
+	public function should_display_first_time_configuration_notice() {
+		if ( ! $this->options_helper->get( 'dismiss_configuration_workout_notice', false ) === false ) {
+			return false;
+		}
+		if ( ! $this->on_wpseo_admin_page_or_dashboard() ) {
+			return false;
+		}
+
+		return $this->first_time_configuration_not_finished();
+	}
+
+	public function get_first_time_configuration_title() {
+		return ( ! $this->show_alternate_message ) ? \__( 'First-time SEO configuration', 'wordpress-seo' ) : \__( 'SEO configuration', 'wordpress-seo' );
+	}
+
+	public function first_time_configuration_not_finished() {
+		if ( ! $this->user_can_do_first_time_configuration() ) {
+			return false;
+		}
+
+		if ( $this->is_first_time_configuration_finished() ) {
+			return false;
+		}
+
+		if ( $this->options_helper->get( 'first_time_install', false ) !== false ) {
+			return ! $this->are_site_representation_name_and_logo_set() || $this->indexing_helper->get_unindexed_count() > 0;
+		}
+
+		if ( $this->indexing_helper->is_initial_indexing() === false ) {
+			return false;
+		}
+
+		if ( $this->indexing_helper->is_finished_indexables_indexing() === true ) {
+			return false;
+		}
+
+		$this->show_alternate_message = true;
+
+		return ! $this->are_site_representation_name_and_logo_set();
+	}
+
+	/**
+	 * Whether the user can do the first-time configuration.
+	 *
+	 * @return bool Whether the current user can do the first-time configuration.
+	 */
+	private function user_can_do_first_time_configuration() {
+		return \current_user_can( 'wpseo_manage_options' );
+	}
+
+	/**
+	 * Whether the user is currently visiting one of our admin pages or the WordPress dashboard.
+	 *
+	 * @return bool Whether the current page is a Yoast SEO admin page
+	 */
+	private function on_wpseo_admin_page_or_dashboard() {
+		$pagenow = $GLOBALS['pagenow'];
+
+		// Show on the WP Dashboard.
+		if ( $pagenow === 'index.php' ) {
+			return true;
+		}
+
+		$page_from_get = \filter_input( \INPUT_GET, 'page' );
+
+		// Show on Yoast SEO pages, with some exceptions.
+		if ( $pagenow === 'admin.php' && \strpos( $page_from_get, 'wpseo' ) === 0 ) {
+			$exceptions = [
+				'wpseo_installation_successful',
+				'wpseo_installation_successful_free',
+			];
+
+			if ( ! \in_array( $page_from_get, $exceptions, true ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Whether all steps of the first-time configuration have been finished.
+	 *
+	 * @return bool Whether the first-time configuration has been finished.
+	 */
+	private function is_first_time_configuration_finished() {
+		$configuration_finished_steps = $this->options_helper->get( 'configuration_finished_steps', [] );
+
+		return \count( $configuration_finished_steps ) === 3;
+	}
+
+	/**
+	 * Whether the site representation name and logo have been set.
+	 *
+	 * @return bool  Whether the site representation name and logo have been set.
+	 */
+	private function are_site_representation_name_and_logo_set() {
+		$company_or_person = $this->options_helper->get( 'company_or_person', '' );
+
+		if ( $company_or_person === '' ) {
+			return false;
+		}
+
+		if ( $company_or_person === 'company' ) {
+			return ! empty( $this->options_helper->get( 'company_name' ) )
+				   && ! empty( $this->options_helper->get( 'company_logo', '' ) );
+		}
+
+		return ! empty( $this->options_helper->get( 'company_or_person_user_id' ) )
+			   && ! empty( $this->options_helper->get( 'person_logo', '' ) );
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function should_show_alternate_message() {
+		return $this->show_alternate_message;
+	}
+}

--- a/src/integrations/admin/first-time-configuration-notice-integration.php
+++ b/src/integrations/admin/first-time-configuration-notice-integration.php
@@ -30,6 +30,8 @@ class First_Time_Configuration_Notice_Integration implements Integration_Interfa
 	private $admin_asset_manager;
 
 	/**
+	 * The first time configuration notice helper.
+	 *
 	 * @var \Yoast\WP\SEO\Helpers\First_Time_Configuration_Notice_Helper
 	 */
 	private $first_time_configuration_notice_helper;
@@ -44,8 +46,9 @@ class First_Time_Configuration_Notice_Integration implements Integration_Interfa
 	/**
 	 * First_Time_Configuration_Notice_Integration constructor.
 	 *
-	 * @param Options_Helper            $options_helper      The options helper.
-	 * @param WPSEO_Admin_Asset_Manager $admin_asset_manager The admin asset manager.
+	 * @param Options_Helper                         $options_helper      The options helper.
+	 * @param First_Time_Configuration_Notice_Helper $first_time_configuration_notice_helper      The first time configuration notice helper.
+	 * @param WPSEO_Admin_Asset_Manager              $admin_asset_manager The admin asset manager.
 	 */
 	public function __construct(
 		Options_Helper $options_helper,

--- a/src/integrations/admin/first-time-configuration-notice-integration.php
+++ b/src/integrations/admin/first-time-configuration-notice-integration.php
@@ -8,6 +8,7 @@ use Yoast\WP\SEO\Helpers\Indexing_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
 use Yoast\WP\SEO\Presenters\Admin\Notice_Presenter;
+use Yoast\WP\SEO\Helpers\First_Time_Configuration_Notice_Helper;
 
 /**
  * First_Time_Configuration_Notice_Integration class
@@ -22,13 +23,6 @@ class First_Time_Configuration_Notice_Integration implements Integration_Interfa
 	private $options_helper;
 
 	/**
-	 * The indexing helper.
-	 *
-	 * @var Indexing_Helper
-	 */
-	private $indexing_helper;
-
-	/**
 	 * The admin asset manager.
 	 *
 	 * @var WPSEO_Admin_Asset_Manager
@@ -36,11 +30,9 @@ class First_Time_Configuration_Notice_Integration implements Integration_Interfa
 	private $admin_asset_manager;
 
 	/**
-	 * Whether we show the alternate mesage.
-	 *
-	 * @var bool
+	 * @var \Yoast\WP\SEO\Helpers\First_Time_Configuration_Notice_Helper
 	 */
-	private $show_alternate_message;
+	private $first_time_configuration_notice_helper;
 
 	/**
 	 * {@inheritDoc}
@@ -53,18 +45,16 @@ class First_Time_Configuration_Notice_Integration implements Integration_Interfa
 	 * First_Time_Configuration_Notice_Integration constructor.
 	 *
 	 * @param Options_Helper            $options_helper      The options helper.
-	 * @param Indexing_Helper           $indexing_helper     The indexing helper.
 	 * @param WPSEO_Admin_Asset_Manager $admin_asset_manager The admin asset manager.
 	 */
 	public function __construct(
 		Options_Helper $options_helper,
-		Indexing_Helper $indexing_helper,
+		First_Time_Configuration_Notice_Helper $first_time_configuration_notice_helper,
 		WPSEO_Admin_Asset_Manager $admin_asset_manager
 	) {
-		$this->options_helper         = $options_helper;
-		$this->indexing_helper        = $indexing_helper;
-		$this->admin_asset_manager    = $admin_asset_manager;
-		$this->show_alternate_message = false;
+		$this->options_helper                         = $options_helper;
+		$this->admin_asset_manager                    = $admin_asset_manager;
+		$this->first_time_configuration_notice_helper = $first_time_configuration_notice_helper;
 	}
 
 	/**
@@ -90,37 +80,7 @@ class First_Time_Configuration_Notice_Integration implements Integration_Interfa
 	 * @return bool Whether the "First-time SEO Configuration" admin notice should be displayed.
 	 */
 	public function should_display_first_time_configuration_notice() {
-		if ( ! $this->options_helper->get( 'dismiss_configuration_workout_notice', false ) === false ) {
-			return false;
-		}
-
-		if ( ! $this->user_can_do_first_time_configuration() ) {
-			return false;
-		}
-
-		if ( ! $this->on_wpseo_admin_page_or_dashboard() ) {
-			return false;
-		}
-
-		if ( $this->is_first_time_configuration_finished() ) {
-			return false;
-		}
-
-		if ( $this->options_helper->get( 'first_time_install', false ) !== false ) {
-			return ! $this->are_site_representation_name_and_logo_set() || $this->indexing_helper->get_unindexed_count() > 0;
-		}
-
-		if ( $this->indexing_helper->is_initial_indexing() === false ) {
-			return false;
-		}
-
-		if ( $this->indexing_helper->is_finished_indexables_indexing() === true ) {
-			return false;
-		}
-
-		$this->show_alternate_message = true;
-
-		return ! $this->are_site_representation_name_and_logo_set();
+		return $this->first_time_configuration_notice_helper->should_display_first_time_configuration_notice();
 	}
 
 	/**
@@ -135,8 +95,8 @@ class First_Time_Configuration_Notice_Integration implements Integration_Interfa
 
 		$this->admin_asset_manager->enqueue_style( 'monorepo' );
 
-		$title = ( ! $this->show_alternate_message ) ? \__( 'First-time SEO configuration', 'wordpress-seo' ) : \__( 'SEO configuration', 'wordpress-seo' );
-		if ( ! $this->show_alternate_message ) {
+		$title = $this->first_time_configuration_notice_helper->get_first_time_configuration_title();
+		if ( ! $this->first_time_configuration_notice_helper->should_show_alternate_message() ) {
 			$content = \sprintf(
 				/* translators: 1: Link start tag to the first-time configuration, 2: Yoast SEO, 3: Link closing tag. */
 				\__( 'Get started quickly with the %1$s%2$s First-time configuration%3$s and configure Yoast SEO with the optimal SEO settings for your site!', 'wordpress-seo' ),
@@ -184,76 +144,5 @@ class First_Time_Configuration_Notice_Integration implements Integration_Interfa
 				} );
 			} );
 			</script>";
-	}
-
-	/**
-	 * Whether the user can do the first-time configuration.
-	 *
-	 * @return bool Whether the current user can do the first-time configuration.
-	 */
-	private function user_can_do_first_time_configuration() {
-		return \current_user_can( 'wpseo_manage_options' );
-	}
-
-	/**
-	 * Whether the user is currently visiting one of our admin pages or the WordPress dashboard.
-	 *
-	 * @return bool Whether the current page is a Yoast SEO admin page
-	 */
-	private function on_wpseo_admin_page_or_dashboard() {
-		$pagenow = $GLOBALS['pagenow'];
-
-		// Show on the WP Dashboard.
-		if ( $pagenow === 'index.php' ) {
-			return true;
-		}
-
-		$page_from_get = \filter_input( \INPUT_GET, 'page' );
-
-		// Show on Yoast SEO pages, with some exceptions.
-		if ( $pagenow === 'admin.php' && \strpos( $page_from_get, 'wpseo' ) === 0 ) {
-			$exceptions = [
-				'wpseo_installation_successful',
-				'wpseo_installation_successful_free',
-			];
-
-			if ( ! \in_array( $page_from_get, $exceptions, true ) ) {
-				return true;
-			}
-		}
-
-		return false;
-	}
-
-	/**
-	 * Whether all steps of the first-time configuration have been finished.
-	 *
-	 * @return bool Whether the first-time configuration has been finished.
-	 */
-	private function is_first_time_configuration_finished() {
-		$configuration_finished_steps = $this->options_helper->get( 'configuration_finished_steps', [] );
-
-		return \count( $configuration_finished_steps ) === 3;
-	}
-
-	/**
-	 * Whether the site representation name and logo have been set.
-	 *
-	 * @return bool  Whether the site representation name and logo have been set.
-	 */
-	private function are_site_representation_name_and_logo_set() {
-		$company_or_person = $this->options_helper->get( 'company_or_person', '' );
-
-		if ( $company_or_person === '' ) {
-			return false;
-		}
-
-		if ( $company_or_person === 'company' ) {
-			return ! empty( $this->options_helper->get( 'company_name' ) )
-					&& ! empty( $this->options_helper->get( 'company_logo', '' ) );
-		}
-
-		return ! empty( $this->options_helper->get( 'company_or_person_user_id' ) )
-				&& ! empty( $this->options_helper->get( 'person_logo', '' ) );
 	}
 }

--- a/src/surfaces/helpers-surface.php
+++ b/src/surfaces/helpers-surface.php
@@ -11,40 +11,41 @@ use YoastSEO_Vendor\Symfony\Component\DependencyInjection\ContainerInterface;
  *
  * Surface for the indexables.
  *
- * @property Helpers\Asset_Helper          $asset
- * @property Helpers\Author_Archive_Helper $author_archive
- * @property Helpers\Blocks_Helper         $blocks
- * @property Helpers\Capability_Helper     $capability
- * @property Helpers\Current_Page_Helper   $current_page
- * @property Helpers\Date_Helper           $date
- * @property Helpers\Environment_Helper    $environment
- * @property Helpers\Home_Url_Helper       $home_url
- * @property Helpers\Image_Helper          $image
- * @property Helpers\Indexable_Helper      $indexable
- * @property Helpers\Indexing_Helper       $indexing
- * @property Helpers\Input_Helper          $input
- * @property Helpers\Language_Helper       $language
- * @property Helpers\Meta_Helper           $meta
- * @property Helpers\Notification_Helper   $notification
- * @property Helpers\Options_Helper        $options
- * @property Helpers\Pagination_Helper     $pagination
- * @property Helpers\Permalink_Helper      $permalink
- * @property Helpers\Post_Helper           $post
- * @property Helpers\Post_Type_Helper      $post_type
- * @property Helpers\Primary_Term_Helper   $primary_term
- * @property Helpers\Product_Helper        $product
- * @property Helpers\Redirect_Helper       $redirect
- * @property Helpers\Request_Helper      $request
- * @property Helpers\Require_File_Helper $require_file
- * @property Helpers\Robots_Helper       $robots
- * @property Helpers\Short_Link_Helper   $short_link
- * @property Helpers\Site_Helper         $site
- * @property Helpers\String_Helper       $string
- * @property Helpers\Taxonomy_Helper     $taxonomy
- * @property Helpers\Url_Helper          $url
- * @property Helpers\User_Helper         $user
- * @property Helpers\Woocommerce_Helper  $woocommerce
- * @property Helpers\Wordpress_Helper    $wordpress
+ * @property Helpers\Asset_Helper                           $asset
+ * @property Helpers\Author_Archive_Helper                  $author_archive
+ * @property Helpers\Blocks_Helper                          $blocks
+ * @property Helpers\Capability_Helper                      $capability
+ * @property Helpers\Current_Page_Helper                    $current_page
+ * @property Helpers\Date_Helper                            $date
+ * @property Helpers\Environment_Helper                     $environment
+ * @property Helpers\First_Time_Configuration_Notice_Helper $first_time_configuration_notice
+ * @property Helpers\Home_Url_Helper                        $home_url
+ * @property Helpers\Image_Helper                           $image
+ * @property Helpers\Indexable_Helper                       $indexable
+ * @property Helpers\Indexing_Helper                        $indexing
+ * @property Helpers\Input_Helper                           $input
+ * @property Helpers\Language_Helper                        $language
+ * @property Helpers\Meta_Helper                            $meta
+ * @property Helpers\Notification_Helper                    $notification
+ * @property Helpers\Options_Helper                         $options
+ * @property Helpers\Pagination_Helper                      $pagination
+ * @property Helpers\Permalink_Helper                       $permalink
+ * @property Helpers\Post_Helper                            $post
+ * @property Helpers\Post_Type_Helper                       $post_type
+ * @property Helpers\Primary_Term_Helper                    $primary_term
+ * @property Helpers\Product_Helper                         $product
+ * @property Helpers\Redirect_Helper                        $redirect
+ * @property Helpers\Request_Helper                         $request
+ * @property Helpers\Require_File_Helper                    $require_file
+ * @property Helpers\Robots_Helper                          $robots
+ * @property Helpers\Short_Link_Helper                      $short_link
+ * @property Helpers\Site_Helper                            $site
+ * @property Helpers\String_Helper                          $string
+ * @property Helpers\Taxonomy_Helper                        $taxonomy
+ * @property Helpers\Url_Helper                             $url
+ * @property Helpers\User_Helper                            $user
+ * @property Helpers\Woocommerce_Helper                     $woocommerce
+ * @property Helpers\Wordpress_Helper                       $wordpress
  */
 class Helpers_Surface {
 
@@ -156,6 +157,7 @@ class Helpers_Surface {
 	 */
 	protected function get_helper_class( $helper ) {
 		$helper = \implode( '_', \array_map( 'ucfirst', \explode( '_', $helper ) ) );
+
 		return "Yoast\WP\SEO\Helpers\\{$helper}_Helper";
 	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to add a CTA link to finish the SEO configuration in the plugin overview page. This only gets registered when the FTC is not finished yet.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds a link to the first time configuration in the plugin overview when this is not completed yet.

## Relevant technical choices:

* I extracted some code from the FTC integration into a helper so I could re-use it in the plugin overview class.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Reset FTC progress and your indexables via the Test helper.
* Go to /wp-admin/plugins.php and make sure `Required by Yoast SEO Premium | [Finish your SEO configuration] | [FAQ] | [Settings]` is shown in the `Yoast SEO` plugin 
* Open the FTC via the link and run the optimization. When completed go back to /wp-admin/plugins.php. The notice should now be gone. Verify there is also no banner to go to the FTC in /wp-admin/admin.php?page=wpseo_dashboard
* Reset FTC progress and your indexables via the Test helper.
* Open the FTC and skip the optimization step. Save the `SITE REPRESENTATION` and make sure the FTC banner and link still show up.
* Fill in the `SOCIAL PROFILES` step with data and save. Make sure the FTC banner and link still show up.
* Fill in the `PERSONAL PREFERENCES` step and save. The banner and link should now be gone, because you finished the FTC.
* Reset FTC progress and your indexables via de Test helper.
* Disable and enable Free. underneath the plugin it should now show: 

Get Premium \| Finish your first-time configuration \| FAQ \| Settings \| Deactivate


* Start up a multisite and make sure that the 'Finish your first-time configuration' does not show up in the network admin and only in the subsite plugin view.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [X] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* There are no code changes that should impact the showing of the FTC banner, but it would be good to double check all scenario's when it should show up.

## UI changes

* [X] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes https://github.com/Yoast/wordpress-seo/issues/19465
