### PR TITLE
Fix Fatal Error when trying to create breadcrumbs with unindexable items

### DIFF
--- a/src/generators/breadcrumbs-generator.php
+++ b/src/generators/breadcrumbs-generator.php
@@ -146,6 +146,7 @@ class Breadcrumbs_Generator implements Generator_Interface {
 		}
 
 		$indexables = \apply_filters( 'wpseo_breadcrumb_indexables', $indexables, $context );
+		$indexables = \is_array( $indexables ) ? $indexables : [];
 		$indexables = \array_filter(
 			$indexables,
 			function ( $indexable ) {

--- a/src/generators/breadcrumbs-generator.php
+++ b/src/generators/breadcrumbs-generator.php
@@ -97,11 +97,14 @@ class Breadcrumbs_Generator implements Generator_Interface {
 		if ( $breadcrumbs_home !== '' && ! \in_array( $this->current_page_helper->get_page_type(), [ 'Home_Page', 'Static_Home_Page' ], true ) ) {
 			$front_page_id = $this->current_page_helper->get_front_page_id();
 			if ( $front_page_id === 0 ) {
-				$static_ancestors[] = $this->repository->find_for_home_page();
+				$home_page_ancestor = $this->repository->find_for_home_page();
+				if ( \is_a( $home_page_ancestor, Indexable::class ) ) {
+					$static_ancestors[] = $home_page_ancestor;
+				}
 			}
 			else {
 				$static_ancestor = $this->repository->find_by_id_and_type( $front_page_id, 'post' );
-				if ( $static_ancestor->post_status !== 'unindexed' ) {
+				if ( \is_a( $static_ancestor, Indexable::class ) && $static_ancestor->post_status !== 'unindexed' ) {
 					$static_ancestors[] = $static_ancestor;
 				}
 			}
@@ -109,7 +112,7 @@ class Breadcrumbs_Generator implements Generator_Interface {
 		$page_for_posts = \get_option( 'page_for_posts' );
 		if ( $this->should_have_blog_crumb( $page_for_posts, $context ) ) {
 			$static_ancestor = $this->repository->find_by_id_and_type( $page_for_posts, 'post' );
-			if ( $static_ancestor->post_status !== 'unindexed' ) {
+			if ( \is_a( $static_ancestor, Indexable::class ) && $static_ancestor->post_status !== 'unindexed' ) {
 				$static_ancestors[] = $static_ancestor;
 			}
 		}
@@ -119,12 +122,18 @@ class Breadcrumbs_Generator implements Generator_Interface {
 			&& $context->indexable->object_sub_type !== 'page'
 			&& $this->post_type_helper->has_archive( $context->indexable->object_sub_type )
 		) {
-			$static_ancestors[] = $this->repository->find_for_post_type_archive( $context->indexable->object_sub_type );
+			$static_ancestor = $this->repository->find_for_post_type_archive( $context->indexable->object_sub_type );
+			if ( \is_a( $static_ancestor, Indexable::class ) ) {
+				$static_ancestors[] = $static_ancestor;
+			}
 		}
 		if ( $context->indexable->object_type === 'term' ) {
 			$parent = $this->get_taxonomy_post_type_parent( $context->indexable->object_sub_type );
 			if ( $parent && $parent !== 'post' && $this->post_type_helper->has_archive( $parent ) ) {
-				$static_ancestors[] = $this->repository->find_for_post_type_archive( $parent );
+				$static_ancestor = $this->repository->find_for_post_type_archive( $parent );
+				if ( \is_a( $static_ancestor, Indexable::class ) ) {
+					$static_ancestors[] = $static_ancestor;
+				}
 			}
 		}
 
@@ -137,6 +146,12 @@ class Breadcrumbs_Generator implements Generator_Interface {
 		}
 
 		$indexables = \apply_filters( 'wpseo_breadcrumb_indexables', $indexables, $context );
+		$indexables = \array_filter(
+			$indexables,
+			function ( $indexable ) {
+				return \is_a( $indexable, Indexable::class );
+			}
+		);
 
 		$callback = function ( Indexable $ancestor ) {
 			$crumb = [

--- a/src/integrations/third-party/woocommerce.php
+++ b/src/integrations/third-party/woocommerce.php
@@ -178,7 +178,10 @@ class WooCommerce implements Integration_Interface {
 
 		foreach ( $indexables as $index => $indexable ) {
 			if ( $indexable->object_type === 'post-type-archive' && $indexable->object_sub_type === 'product' ) {
-				$indexables[ $index ] = $this->repository->find_by_id_and_type( $shop_page_id, 'post' );
+				$shop_page_indexable = $this->repository->find_by_id_and_type( $shop_page_id, 'post' );
+				if ( \is_a( $shop_page_indexable, Indexable::class ) ) {
+					$indexables[ $index ] = $shop_page_indexable;
+				}
 			}
 		}
 

--- a/tests/unit/integrations/third-party/woocommerce-test.php
+++ b/tests/unit/integrations/third-party/woocommerce-test.php
@@ -12,6 +12,7 @@ use Yoast\WP\SEO\Helpers\Pagination_Helper;
 use Yoast\WP\SEO\Helpers\Woocommerce_Helper;
 use Yoast\WP\SEO\Integrations\Third_Party\WooCommerce;
 use Yoast\WP\SEO\Memoizers\Meta_Tags_Context_Memoizer;
+use Yoast\WP\SEO\Models\Indexable;
 use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
 use Yoast\WP\SEO\Tests\Unit\Doubles\Models\Indexable_Mock;
@@ -185,9 +186,33 @@ class WooCommerce_Test extends TestCase {
 			->once()
 			->andReturn( 707 );
 
-		$this->repository->expects( 'find_by_id_and_type' )->once()->with( 707, 'post' )->andReturn( 'shop' );
+		$indexable_mock = Mockery::mock( Indexable::class );
 
-		$this->assertEquals( [ 'shop' ], $this->instance->add_shop_to_breadcrumbs( $indexables ) );
+		$this->repository->expects( 'find_by_id_and_type' )->once()->with( 707, 'post' )->andReturn( $indexable_mock );
+
+		$this->assertEquals( [ $indexable_mock ], $this->instance->add_shop_to_breadcrumbs( $indexables ) );
+	}
+
+	/**
+	 * Tests the add shop to breadcrumbs function when finding no indexable for the shop page.
+	 *
+	 * @covers ::add_shop_to_breadcrumbs
+	 */
+	public function test_add_shop_to_breadcrumbs_no_indexable_shop_page() {
+		$indexables = [
+			(object) [
+				'object_type'     => 'post-type-archive',
+				'object_sub_type' => 'product',
+			],
+		];
+
+		$this->woocommerce_helper->expects( 'get_shop_page_id' )
+			->once()
+			->andReturn( 707 );
+
+		$this->repository->expects( 'find_by_id_and_type' )->once()->with( 707, 'post' )->andReturn( false );
+
+		$this->assertEquals( $indexables, $this->instance->add_shop_to_breadcrumbs( $indexables ) );
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where a fatal error would be thrown when trying to create breadcrumbs from unindexable items.

## Relevant technical choices:

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:


* Add this filter in your functions.php:
```
add_filter( 'wpseo_indexable_excluded_post_types', function( $post_types ) { 
    $post_types[] = 'page'; 
    return $post_types;
} );
```
* Activate Yoast SEO (or if you had it active before, clean up indexables)
* Activate WooCommerce
* Create a product and visit its frontend

_Without this PR:_
* You would get this Fatal Error:
```
PHP Fatal error:  Uncaught TypeError: Yoast\WP\SEO\Generators\Breadcrumbs_Generator::Yoast\WP\SEO\Generators\{closure}(): Argument #1 ($ancestor) must be of type Yoast\WP\SEO\Models\Indexable, bool given in ...\wordpress-seo\src\generators\breadcrumbs-generator.php:141
```
_With this PR:_
* No fatal error would show

**Second way of replicating**

* In Settings->Reading, set a static page as your Home Page
* Add this filter in your functions.php:
```
add_filter( 'wpseo_indexable_excluded_post_types', function( $post_types ) { 
    $post_types[] = 'page'; 
    return $post_types;
} );
```
* Activate Yoast SEO (or if you had it active before, clean up indexables)
* Create a post and visit its frontend

_Without this PR:_
* You would get this Fatal Error:
```
PHP Fatal error:  Uncaught TypeError: Yoast\WP\SEO\Generators\Breadcrumbs_Generator::Yoast\WP\SEO\Generators\{closure}(): Argument #1 ($ancestor) must be of type Yoast\WP\SEO\Models\Indexable, bool given in ...\wordpress-seo\src\generators\breadcrumbs-generator.php:141
```
_With this PR:_
* No fatal error would show

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Breadcrumb creation

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes # [DUPP-848](https://yoast.atlassian.net/browse/DUPP-848)
