### PR TITLE
PC-1029-anchors-containing-square-brackets-in-content-lead-to-errors-with-classic-editor

### DIFF
--- a/packages/yoastseo/spec/languageProcessing/helpers/word/markWordsInSentenceSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/helpers/word/markWordsInSentenceSpec.js
@@ -168,4 +168,19 @@ describe( "test the deconstructAnchor and reconstructAnchor helper", () => {
 		const reconstructedAnchor = reConstructAnchor( deconstructedAnchor.openTag, deconstructedAnchor.content );
 		expect( reconstructedAnchor ).toEqual( testAnchor );
 	} );
+
+	it( "correctly deconstructs and reconstructs an anchor if does not contain content", () => {
+		// Unrealistic Scenario. But protects against the bug that is solved in this PR:
+		// https://github.com/Yoast/wordpress-seo/pull/19373
+		const testAnchor = "<a href=\"https://yoast.com\"></a>";
+		const deconstructedAnchor = deConstructAnchor( testAnchor );
+
+		expect( deconstructedAnchor ).toEqual( {
+			openTag: "<a href=\"https://yoast.com\">",
+			content: "",
+		} );
+
+		const reconstructedAnchor = reConstructAnchor( deconstructedAnchor.openTag, deconstructedAnchor.content );
+		expect( reconstructedAnchor ).toEqual( testAnchor );
+	} );
 } );

--- a/packages/yoastseo/spec/languageProcessing/helpers/word/markWordsInSentenceSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/helpers/word/markWordsInSentenceSpec.js
@@ -183,4 +183,19 @@ describe( "test the deconstructAnchor and reconstructAnchor helper", () => {
 		const reconstructedAnchor = reConstructAnchor( deconstructedAnchor.openTag, deconstructedAnchor.content );
 		expect( reconstructedAnchor ).toEqual( testAnchor );
 	} );
+
+	it( "correctly deconstructs and reconstructs an anchor if content contains a newline", () => {
+		// Unrealistic Scenario. But protects against the bug that is solved in this PR:
+		// https://github.com/Yoast/wordpress-seo/pull/19373
+		const testAnchor = "<a href=\"https://yoast.com\">This is a line.\nAnd this is a line.</a>";
+		const deconstructedAnchor = deConstructAnchor( testAnchor );
+
+		expect( deconstructedAnchor ).toEqual( {
+			openTag: "<a href=\"https://yoast.com\">",
+			content: "This is a line.\nAnd this is a line.",
+		} );
+
+		const reconstructedAnchor = reConstructAnchor( deconstructedAnchor.openTag, deconstructedAnchor.content );
+		expect( reconstructedAnchor ).toEqual( testAnchor );
+	} );
 } );

--- a/packages/yoastseo/src/languageProcessing/helpers/word/markWordsInSentences.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/word/markWordsInSentences.js
@@ -6,8 +6,8 @@ import matchWords from "../match/matchTextWithArray";
 import arrayToRegex from "../regex/createRegexFromArray";
 
 // Regex to deconstruct an anchor into open tag, content and close tag.
-const anchorDeconstructionRegex = /(<a[\s]+[^>]+>)((?:.|[\n\r\u2028\u2029])*?)(<\/a>)/;
-
+// [^] matches any character, including newline
+const anchorDeconstructionRegex = /(<a[\s]+[^>]+>)([^]*?)(<\/a>)/;
 
 /**
  * Deconstructs an anchor to the opening tag and the content. The content is the anchor text.
@@ -61,7 +61,6 @@ const getMarkedAnchors = function( sentence, wordsRegex ) {
 		// Create a new anchor tag with a (marked) anchor text.
 		return reConstructAnchor( openTag, markedAnchorText );
 	} );
-
 	return { anchors, markedAnchors };
 };
 
@@ -124,7 +123,6 @@ export function markWordsInSentences( wordsToMark, sentences, locale, matchWordC
 
 	sentences.forEach( function( sentence ) {
 		wordsFoundInSentence = matchWords( sentence, wordsToMark, locale, matchWordCustomHelper ).matches;
-
 		if ( wordsFoundInSentence.length > 0 ) {
 			markings = markings.concat( new Mark( {
 				original: sentence,

--- a/packages/yoastseo/src/languageProcessing/helpers/word/markWordsInSentences.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/word/markWordsInSentences.js
@@ -6,7 +6,8 @@ import matchWords from "../match/matchTextWithArray";
 import arrayToRegex from "../regex/createRegexFromArray";
 
 // Regex to deconstruct an anchor into open tag, content and close tag.
-const anchorDeconstructionRegex = /(<a[\s]+[^>]+>)(.*?)(<\/a>)/;
+const anchorDeconstructionRegex = /(<a[\s]+[^>]+>)((?:.|[\n\r\u2028\u2029])*?)(<\/a>)/;
+
 
 /**
  * Deconstructs an anchor to the opening tag and the content. The content is the anchor text.

--- a/packages/yoastseo/src/languageProcessing/helpers/word/markWordsInSentences.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/word/markWordsInSentences.js
@@ -6,7 +6,7 @@ import matchWords from "../match/matchTextWithArray";
 import arrayToRegex from "../regex/createRegexFromArray";
 
 // Regex to deconstruct an anchor into open tag, content and close tag.
-const anchorDeconstructionRegex = /(<a[\s]+[^>]+>)(.+?)(<\/a>)/;
+const anchorDeconstructionRegex = /(<a[\s]+[^>]+>)(.*?)(<\/a>)/;
 
 /**
  * Deconstructs an anchor to the opening tag and the content. The content is the anchor text.


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Fixes an unreleased bug where _keyword density_, _keyphrase distribution_ and _word complexity_ (which are all assessments that use `packages/yoastseo/src/languageProcessing/helpers/word/markWordsInSentences.js` for highlighting.) broke when there was an hyperlink on an item between square brackets. (`<a ...>[1]</a>`).
* The bug was introduced in this PR: https://github.com/Yoast/wordpress-seo/pull/19162
* In more detail: the bug was caused because, in classic editor, all items between square brackets are removed before the analysis as they are potential[ wordpress shortcodes](https://kinsta.com/blog/wordpress-shortcodes/).
* NOTE: There is still an issue: not all occurrences of `bread` are highlighted. This is due to a known issue regarding square brackets. This could not be solved within this issue without an enourmousscope creep. There are already two JIRA issue describing this bug. [PRODUCT-1041](https://yoast.atlassian.net/browse/PRODUCT-1041) and [IM-1089](https://yoast.atlassian.net/browse/IM-1089).

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug text items between square brackets that has an anchor tag breaks _keyword density_, _keyphrase distribution_ and _word complexity_.

## Relevant technical choices:

* None

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install and activate yoastSEO free and YoastSEO premium
* Install and activate Classic editor
* Have your console opened

##### Scenario 1: bug is not reproduced
* Create a new post (with classic editor)
* Paste [this text](https://github.com/Yoast/wordpress-seo/files/10193984/Bread.txt) in text edit mode. (see screenshot)
  <img width="604" alt="Screenshot 2022-12-09 at 11 43 42" src="https://user-images.githubusercontent.com/26040749/206684771-2b8590f1-6ac1-4af1-bf37-40b212ca5e37.png">
* Make sure the following error does not occur in the console: 
   ```
   yoastseo-woo-worker-154-RC1.js:1 TypeError: object null is not iterable (cannot read property Symbol(Symbol.iterator))
   ```
* Add _bread_ as your focus keyphrase.
* Make sure that the  _keyword density assessment_ works (located in the SEO analysis).
  * It should have a green bullet.
  * It should give the following feedback: `Keyphrase density: The focus keyphrase was found 3 times. This is great!`
  * If you click the highlighting toggle, it highlights 2 occurrences of "bread". NOTE: it does not highlight all 3 occurrences. See the comment in the context above.
* Make sure that the _keyphrase distribution assessment_ works (located in the SEO analysis).
  * It should have a red bullet.
  * It should give the following feedback `Keyphrase distribution: Very uneven. Large parts of your text do not contain the keyphrase or its synonyms. Distribute them more evenly.`
  * If you click the highlighting toggle, it highlights 2 occurrences of "bread". NOTE: it does not highlight all 3 occurrences. See the comment in the context above.
* Make sure that the _word complexity assessment_ works (located in the Readability analysis).
  * It should have n orange bullet.
  * It should give the following feedback `Word complexity: 17.54% of the words in your text are considered complex. Try to use shorter and more familiar words to improve readability.`
  * If you click the highlighting toggle, it should highlight a lot of words, the first three highlighted words are: `pounding`, `bread making`, `14,500-year-old`
* Repeat scenario 1 for all post types (Including woo product).
   * **Note**: highlighting buttons are not shown in tags and categories. 
* Block editor and Elementor should not be affected, but do repeat the test above to make sure. Highlighting in Elementor can be ignored, as we do not support that.

##### Scenario 2: Test other types of brackets
* Create a new post with classic editor
* Paste [this text](https://github.com/Yoast/wordpress-seo/files/10193984/Bread.txt) in **text edit mode**.
* Replace the square bracket pairs with parenthesis `()`.
* Smoke test _keyword density_, _keyphrase distribution_ and _word complexity_. You can use the tests from scenario 1 for this.
* Replace the parenthesis pairs with curly brackets `{}`.
* Smoke test _keyword density_, _keyphrase distribution_ and _word complexity_. You can use the tests from scenario 1 for this.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [x] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* This PR impacts all assessments that use the `markWordsInSentences.js` module. These are  _keyword density_, _keyphrase distribution_ and _word complexity_. Tests are included for all assessments.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes https://yoast.atlassian.net/browse/PC-1029?atlOrigin=eyJpIjoiOTU4OWUyMDI3ZmY4NDEzYmJkOTIxNzMzZDMyOGFkZDUiLCJwIjoiaiJ9
