### PR TITLE
Dupp 729 validation variants

### DIFF
--- a/packages/js/src/settings/hocs/with-formik-error.js
+++ b/packages/js/src/settings/hocs/with-formik-error.js
@@ -14,7 +14,7 @@ const withFormikError = Component => {
 	 */
 	const ComponentWithFormikError = ( { name, ...props } ) => {
 		const { isTouched, error } = useFormikError( { name } );
-		return <Component name={ name } error={ isTouched && error } { ...props } />;
+		return <Component name={ name } validation={ { variant: "error", message: isTouched && error } } { ...props } />;
 	};
 
 	ComponentWithFormikError.propTypes = {

--- a/packages/ui-library/.storybook/style.css
+++ b/packages/ui-library/.storybook/style.css
@@ -15,6 +15,7 @@
 @import "../src/elements/toggle/style.css";
 @import "../src/elements/file-input/style.css";
 @import "../src/elements/autocomplete/style.css";
+@import "../src/elements/validation/style.css";
 
 @import "../src/components/autocomplete-field/style.css";
 @import "../src/components/card/style.css";

--- a/packages/ui-library/.storybook/theme.js
+++ b/packages/ui-library/.storybook/theme.js
@@ -5,7 +5,7 @@ const theme = tailwindConfig.presets[ 0 ].theme;
 
 export default create( {
 	base: "light",
-	brandTitle: "Yoast Storybook",
+	brandTitle: "Yoast UI library",
 	brandUrl: "https://yoast.com",
 	brandImage: "https://yoast.com/app/uploads/2021/01/yoast_logo_rgb_optm.svg",
 

--- a/packages/ui-library/src/components/autocomplete-field/index.js
+++ b/packages/ui-library/src/components/autocomplete-field/index.js
@@ -1,11 +1,12 @@
 import classNames from "classnames";
 import PropTypes from "prop-types";
 import Autocomplete from "../../elements/autocomplete";
+import { ValidationMessage, validationPropType } from "../../elements/validation";
 import { useDescribedBy } from "../../hooks";
 
 /**
  * @param {string} id Identifier.
- * @param {JSX.Element} error Error node.
+ * @param {Object} validation The validation state.
  * @param {string} [className] Optional CSS class.
  * @param {string} label Label.
  * @param {JSX.node} [description] Optional description.
@@ -16,11 +17,11 @@ const AutocompleteField = ( {
 	id,
 	label,
 	description,
-	error = null,
+	validation = {},
 	className = "",
 	...props
 } ) => {
-	const { ids, describedBy } = useDescribedBy( id, { error, description } );
+	const { ids, describedBy } = useDescribedBy( id, { validation: validation?.message, description } );
 
 	return (
 		<div className={ classNames( "yst-autocomplete-field", className ) }>
@@ -31,12 +32,14 @@ const AutocompleteField = ( {
 					as: "label",
 					className: "yst-label yst-autocomplete-field__label",
 				} }
-				isError={ Boolean( error ) }
+				validation={ validation }
 				className="yst-autocomplete-field__select"
 				buttonProps={ { "aria-describedby": describedBy } }
 				{ ...props }
 			/>
-			{ error && <p id={ ids.error } className="yst-autocomplete-field__error">{ error }</p> }
+			{ validation?.message && (
+				<ValidationMessage variant={ validation?.variant } id={ ids.validation } className="yst-autocomplete-field__validation">{ validation.message }</ValidationMessage>
+			) }
 			{ description && <div id={ ids.description } className="yst-autocomplete-field__description">{ description }</div> }
 		</div>
 	);
@@ -47,7 +50,7 @@ AutocompleteField.propTypes = {
 	name: PropTypes.string.isRequired,
 	label: PropTypes.string.isRequired,
 	description: PropTypes.node,
-	error: PropTypes.node,
+	validation: validationPropType,
 	className: PropTypes.string,
 };
 

--- a/packages/ui-library/src/components/autocomplete-field/index.js
+++ b/packages/ui-library/src/components/autocomplete-field/index.js
@@ -1,7 +1,7 @@
 import classNames from "classnames";
 import PropTypes from "prop-types";
 import Autocomplete from "../../elements/autocomplete";
-import { ValidationMessage, validationPropType } from "../../elements/validation";
+import { ValidationMessage } from "../../elements/validation";
 import { useDescribedBy } from "../../hooks";
 
 /**
@@ -50,7 +50,10 @@ AutocompleteField.propTypes = {
 	name: PropTypes.string.isRequired,
 	label: PropTypes.string.isRequired,
 	description: PropTypes.node,
-	validation: validationPropType,
+	validation: PropTypes.shape( {
+		variant: PropTypes.string,
+		message: PropTypes.node,
+	} ),
 	className: PropTypes.string,
 };
 

--- a/packages/ui-library/src/components/autocomplete-field/stories.js
+++ b/packages/ui-library/src/components/autocomplete-field/stories.js
@@ -1,13 +1,13 @@
 import AutocompleteField from ".";
 import { useCallback, useMemo, useState } from "@wordpress/element";
-import { filter, find, includes, toLower } from "lodash";
+import { filter, find, includes, toLower, noop, map } from "lodash";
+import { VALIDATION_VARIANTS } from "../../constants";
 
 export default {
 	title: "2) Components/Autocomplete Field",
 	component: AutocompleteField,
 	argTypes: {
 		description: { control: "text" },
-		error: { control: "text" },
 	},
 	parameters: {
 		docs: {
@@ -75,22 +75,6 @@ Factory.args = {
 	placeholder: "Search an option...",
 };
 
-export const WithError = Template.bind( {} );
-
-WithError.parameters = {
-	controls: { disable: false },
-	docs: { description: { story: "An exampe with error message using `error` prop." } },
-};
-
-WithError.args = {
-	id: "with-error",
-	name: "with-error",
-	label: "Example label",
-	labelProps: { className: "yoast-field-group__label" },
-	isError: true,
-	error: "This is an error message",
-};
-
 export const WithDescription = Template.bind( {} );
 
 WithDescription.parameters = {
@@ -151,4 +135,34 @@ ChildrenProp.args = {
 
 ChildrenProp.parameters = { docs: { description: { story: "The `children` prop can be used to render custom content. The options are rendered using the sub component `Option` (`AutocompleteField.Option` is equal to `Autocomplete` element). Default values should be set inside the child component and not the `selectedLabel` prop." } } };
 
-
+export const Validation = () => (
+	<div className="yst-space-y-8">
+		{ map( VALIDATION_VARIANTS, variant => (
+			<AutocompleteField
+				key={ variant }
+				id={ `validation-${ variant }` }
+				name={ `validation-${ variant }` }
+				label={ `With validation of variant ${ variant }` }
+				value="1"
+				selectedLabel="The quick brown fox jumps over the lazy dog"
+				onChange={ noop }
+				onQueryChange={ noop }
+				options={ [
+					{ value: "1", label: "Option 1" },
+					{ value: "2", label: "Option 2" },
+					{ value: "3", label: "Option 3" },
+					{ value: "4", label: "Option 4" },
+				] }
+				validation={ {
+					variant,
+					message: {
+						success: "Looks like you are nailing it!",
+						warning: "Looks like you could do better!",
+						info: <>Looks like you could use some <a href="https://yoast.com" target="_blank" rel="noreferrer">more info</a>!</>,
+						error: "Looks like you are doing it wrong!",
+					}[ variant ],
+				} }
+			/>
+		) ) }
+	</div>
+);

--- a/packages/ui-library/src/components/autocomplete-field/style.css
+++ b/packages/ui-library/src/components/autocomplete-field/style.css
@@ -4,8 +4,8 @@
 			@apply yst-mt-2;
 		}
 
-		.yst-autocomplete-field__error {
-			@apply yst-mt-2 yst-text-red-600;
+		.yst-autocomplete-field__validation {
+			@apply yst-mt-2;
 		}
 	}
 }

--- a/packages/ui-library/src/components/file-import/index.js
+++ b/packages/ui-library/src/components/file-import/index.js
@@ -1,7 +1,6 @@
 import { useCallback, useContext, createContext, useMemo } from "@wordpress/element";
 import { values, includes, isEmpty, isNull, capitalize } from "lodash";
 import { DocumentTextIcon, XIcon } from "@heroicons/react/outline";
-import { CheckCircleIcon, ExclamationCircleIcon, ExclamationIcon, InformationCircleIcon } from "@heroicons/react/solid";
 import PropTypes from "prop-types";
 import { Transition } from "@headlessui/react";
 

--- a/packages/ui-library/src/components/file-import/index.js
+++ b/packages/ui-library/src/components/file-import/index.js
@@ -7,6 +7,7 @@ import { Transition } from "@headlessui/react";
 
 import FileInput from "../../elements/file-input";
 import ProgressBar from "../../elements/progress-bar";
+import { ValidationIcon } from "../../elements/validation";
 
 export const FILE_IMPORT_STATUS = {
 	idle: "idle",
@@ -155,7 +156,7 @@ const FileImport = ( {
 							</div>
 							<div className="yst-relative yst-h-5 yst-w-5">
 								<Transition show={ isSelected } { ...statusIconTransitionProps }>
-									<InformationCircleIcon className="yst-h-5 yst-w-5 yst-text-blue-500" />
+									<ValidationIcon variant="info" className="yst-w-5 yst-h-5" />
 								</Transition>
 								<Transition show={ isLoading } { ...statusIconTransitionProps }>
 									<button onClick={ onAbort } className="yst-file-import__abort-button">
@@ -164,13 +165,13 @@ const FileImport = ( {
 									</button>
 								</Transition>
 								<Transition show={ isSuccess } { ...statusIconTransitionProps }>
-									<CheckCircleIcon className="yst-h-5 yst-w-5 yst-text-green-500" />
+									<ValidationIcon variant="success" className="yst-w-5 yst-h-5" />
 								</Transition>
 								<Transition show={ isAborted } { ...statusIconTransitionProps }>
-									<ExclamationIcon className="yst-h-5 yst-w-5 yst-text-amber-500" />
+									<ValidationIcon variant="warning" className="yst-w-5 yst-h-5" />
 								</Transition>
 								<Transition show={ isError } { ...statusIconTransitionProps }>
-									<ExclamationCircleIcon className="yst-h-5 yst-w-5 yst-text-red-500" />
+									<ValidationIcon variant="error" className="yst-w-5 yst-h-5" />
 								</Transition>
 							</div>
 						</header>

--- a/packages/ui-library/src/components/notifications/index.js
+++ b/packages/ui-library/src/components/notifications/index.js
@@ -2,10 +2,10 @@
 import { Transition } from "@headlessui/react";
 import PropTypes from "prop-types";
 import { useState, useCallback, useEffect, useContext, createContext } from "@wordpress/element";
-import { CheckCircleIcon, ExclamationIcon, XIcon, InformationCircleIcon } from "@heroicons/react/outline";
-import { ExclamationCircleIcon } from "@heroicons/react/solid";
+import { XIcon } from "@heroicons/react/outline";
 import { isArray, keys } from "lodash";
 import classNames from "classnames";
+import { ValidationIcon } from "../../elements/validation";
 
 const NotificationsContext = createContext( { position: "bottom-left" } );
 
@@ -30,13 +30,6 @@ export const notificationClassNameMap = {
 		"default": "",
 		large: "yst-notification--large",
 	},
-};
-
-export const notificationsIconMap = {
-	info: InformationCircleIcon,
-	warning: ExclamationIcon,
-	success: CheckCircleIcon,
-	error: ExclamationCircleIcon,
 };
 
 /**
@@ -64,7 +57,6 @@ export const Notification = ( {
 } ) => {
 	const { position } = useNotificationsContext();
 	const [ isVisible, setIsVisible ] = useState( false );
-	const Icon = notificationsIconMap[ variant ];
 
 	const handleDismiss = useCallback( () => {
 		// Disable visibility on dismiss to trigger transition.
@@ -107,7 +99,7 @@ export const Notification = ( {
 		>
 			<div className="yst-flex yst-items-start yst-gap-3">
 				<div className="yst-flex-shrink-0">
-					<Icon className="yst-notification__icon" />
+					<ValidationIcon variant={ variant } className="yst-notification__icon" />
 				</div>
 				<div className="yst-w-0 yst-flex-1">
 					<p className="yst-text-sm yst-font-medium yst-text-slate-800">

--- a/packages/ui-library/src/components/notifications/style.css
+++ b/packages/ui-library/src/components/notifications/style.css
@@ -25,22 +25,6 @@
             @apply yst-w-96;
         }
 
-        .yst-notification--info .yst-notification__icon {
-            @apply yst-text-blue-500;
-        }
-
-        .yst-notification--warning .yst-notification__icon {
-            @apply yst-text-amber-500;
-        }
-
-        .yst-notification--success .yst-notification__icon {
-            @apply yst-text-green-500;
-        }
-
-        .yst-notification--error .yst-notification__icon {
-            @apply yst-text-red-500;
-        }
-
         .yst-notification__icon {
             @apply yst-w-5 yst-h-5;
         }

--- a/packages/ui-library/src/components/select-field/index.js
+++ b/packages/ui-library/src/components/select-field/index.js
@@ -1,7 +1,7 @@
 import classNames from "classnames";
 import PropTypes from "prop-types";
 import Select from "../../elements/select";
-import { ValidationMessage, validationPropType } from "../../elements/validation";
+import { ValidationMessage } from "../../elements/validation";
 import { useDescribedBy } from "../../hooks";
 
 /**
@@ -56,7 +56,10 @@ SelectField.propTypes = {
 	label: PropTypes.string.isRequired,
 	description: PropTypes.node,
 	disabled: PropTypes.bool,
-	validation: validationPropType,
+	validation: PropTypes.shape( {
+		variant: PropTypes.string,
+		message: PropTypes.node,
+	} ),
 	className: PropTypes.string,
 };
 

--- a/packages/ui-library/src/components/select-field/index.js
+++ b/packages/ui-library/src/components/select-field/index.js
@@ -1,6 +1,7 @@
 import classNames from "classnames";
 import PropTypes from "prop-types";
 import Select from "../../elements/select";
+import { ValidationMessage, validationPropType } from "../../elements/validation";
 import { useDescribedBy } from "../../hooks";
 
 /**
@@ -18,11 +19,11 @@ const SelectField = ( {
 	label,
 	description,
 	disabled = false,
-	error = null,
+	validation = {},
 	className = "",
 	...props
 } ) => {
-	const { ids, describedBy } = useDescribedBy( id, { error, description } );
+	const { ids, describedBy } = useDescribedBy( id, { validation: validation?.message, description } );
 
 	return (
 		<div className={ classNames( "yst-select-field", disabled && "yst-select-field--disabled", className ) }>
@@ -34,12 +35,16 @@ const SelectField = ( {
 					className: "yst-label yst-select-field__label",
 				} }
 				disabled={ disabled }
-				isError={ Boolean( error ) }
+				validation={ validation }
 				className="yst-select-field__select"
 				buttonProps={ { "aria-describedby": describedBy } }
 				{ ...props }
 			/>
-			{ error && <p id={ ids.error } className="yst-select-field__error">{ error }</p> }
+			{ validation?.message && (
+				<ValidationMessage variant={ validation?.variant } id={ ids.validation } className="yst-select-field__validation">
+					{ validation.message }
+				</ValidationMessage>
+			) }
 			{ description && <div id={ ids.description } className="yst-select-field__description">{ description }</div> }
 		</div>
 	);
@@ -51,7 +56,7 @@ SelectField.propTypes = {
 	label: PropTypes.string.isRequired,
 	description: PropTypes.node,
 	disabled: PropTypes.bool,
-	error: PropTypes.node,
+	validation: validationPropType,
 	className: PropTypes.string,
 };
 

--- a/packages/ui-library/src/components/select-field/stories.js
+++ b/packages/ui-library/src/components/select-field/stories.js
@@ -1,4 +1,6 @@
 import { useCallback, useState } from "@wordpress/element";
+import { noop, map } from "lodash";
+import { VALIDATION_VARIANTS } from "../../constants";
 import { Badge, SelectField } from "../../index";
 
 const options = [
@@ -113,3 +115,33 @@ SelectFieldOption.args = {
 SelectFieldOption.parameters = {
 	docs: { description: { story: "Add options as an array of React components with `children` prop, using the exposed option component `SelectField.Option`. In this case changing the `selectedLabel` should be done manually in the handleChange function." } },
 };
+
+export const Validation = () => (
+	<div className="yst-space-y-8">
+		{ map( VALIDATION_VARIANTS, variant => (
+			<SelectField
+				key={ variant }
+				id={ `validation-${ variant }` }
+				name={ `validation-${ variant }` }
+				label={ `With validation of variant ${ variant }` }
+				value="The quick brown fox jumps over the lazy dog"
+				onChange={ noop }
+				options={ [
+					{ value: "1", label: "Option 1" },
+					{ value: "2", label: "Option 2" },
+					{ value: "3", label: "Option 3" },
+					{ value: "4", label: "Option 4" },
+				] }
+				validation={ {
+					variant,
+					message: {
+						success: "Looks like you are nailing it!",
+						warning: "Looks like you could do better!",
+						info: <>Looks like you could use some <a href="https://yoast.com" target="_blank" rel="noreferrer">more info</a>!</>,
+						error: "Looks like you are doing it wrong!",
+					}[ variant ],
+				} }
+			/>
+		) ) }
+	</div>
+);

--- a/packages/ui-library/src/components/select-field/style.css
+++ b/packages/ui-library/src/components/select-field/style.css
@@ -20,8 +20,8 @@
 			@apply yst-mt-2;
 		}
 
-		.yst-select-field__error {
-			@apply yst-mt-2 yst-text-red-600;
+		.yst-select-field__validation {
+			@apply yst-mt-2;
 		}
 	}
 }

--- a/packages/ui-library/src/components/tag-field/index.js
+++ b/packages/ui-library/src/components/tag-field/index.js
@@ -1,9 +1,9 @@
-import { ExclamationCircleIcon } from "@heroicons/react/solid";
 import classNames from "classnames";
 import PropTypes from "prop-types";
 import Label from "../../elements/label";
 import TagInput from "../../elements/tag-input";
-import { useDescribedBy, useSvgAria } from "../../hooks";
+import { validationPropType, ValidationInput, ValidationMessage } from "../../elements/validation";
+import { useDescribedBy } from "../../hooks";
 
 /**
  * @param {string} id The ID of the input.
@@ -12,7 +12,7 @@ import { useDescribedBy, useSvgAria } from "../../hooks";
  * @param {string} [className] The HTML class.
  * @param {JSX.node} [description] A description.
  * @param {boolean} [disabled] The disabled state.
- * @param {JSX.node} [error] An error "message".
+ * @param {Object} [validation] The validation state.
  * @param {Object} [props] Any extra properties for the TagInput.
  * @returns {JSX.Element} The tag field.
  */
@@ -23,11 +23,10 @@ const TagField = ( {
 	disabled = false,
 	className = "",
 	description = null,
-	error = null,
+	validation = {},
 	...props
 } ) => {
-	const { ids, describedBy } = useDescribedBy( id, { error, description } );
-	const svgAriaProps = useSvgAria();
+	const { ids, describedBy } = useDescribedBy( id, { validation: validation?.message, description } );
 
 	return (
 		<div className={ classNames( "yst-tag-field", disabled && "yst-tag-field--disabled", className ) }>
@@ -35,22 +34,20 @@ const TagField = ( {
 				<Label className="yst-tag-field__label" htmlFor={ id } label={ label } />
 				{ labelSuffix }
 			</div>
-			<div className="yst-relative">
-				<TagInput
-					id={ id }
-					disabled={ disabled }
-					className={ classNames(
-						"yst-tag-field__input",
-						error && "yst-tag-field__input--error",
-					) }
-					aria-describedby={ describedBy }
-					{ ...props }
-				/>
-				{ error && <div className="yst-tag-field__error-icon">
-					<ExclamationCircleIcon { ...svgAriaProps } />
-				</div> }
-			</div>
-			{ error && <p id={ ids.error } className="yst-tag-field__error">{ error }</p> }
+			<ValidationInput
+				as={ TagInput }
+				id={ id }
+				disabled={ disabled }
+				className="yst-tag-field__input"
+				aria-describedby={ describedBy }
+				validation={ validation }
+				{ ...props }
+			/>
+			{ validation?.message && (
+				<ValidationMessage variant={ validation?.variant } id={ ids.validation } className="yst-tag-field__validation">
+					{ validation.message }
+				</ValidationMessage>
+			) }
 			{ description && <p id={ ids.description } className="yst-tag-field__description">{ description }</p> }
 		</div>
 	);
@@ -63,7 +60,7 @@ TagField.propTypes = {
 	disabled: PropTypes.bool,
 	className: PropTypes.string,
 	description: PropTypes.node,
-	error: PropTypes.node,
+	validation: validationPropType,
 };
 
 export default TagField;

--- a/packages/ui-library/src/components/tag-field/index.js
+++ b/packages/ui-library/src/components/tag-field/index.js
@@ -2,7 +2,7 @@ import classNames from "classnames";
 import PropTypes from "prop-types";
 import Label from "../../elements/label";
 import TagInput from "../../elements/tag-input";
-import { validationPropType, ValidationInput, ValidationMessage } from "../../elements/validation";
+import { ValidationInput, ValidationMessage } from "../../elements/validation";
 import { useDescribedBy } from "../../hooks";
 
 /**
@@ -60,7 +60,10 @@ TagField.propTypes = {
 	disabled: PropTypes.bool,
 	className: PropTypes.string,
 	description: PropTypes.node,
-	validation: validationPropType,
+	validation: PropTypes.shape( {
+		variant: PropTypes.string,
+		message: PropTypes.node,
+	} ),
 };
 
 export default TagField;

--- a/packages/ui-library/src/components/tag-field/stories.js
+++ b/packages/ui-library/src/components/tag-field/stories.js
@@ -1,4 +1,6 @@
 import { useCallback, useState } from "@wordpress/element";
+import { noop, map } from "lodash";
+import { VALIDATION_VARIANTS } from "../../constants";
 import TagField from ".";
 
 export default {
@@ -49,10 +51,26 @@ WithLabelAndDescription.args = {
 	description: "Tag field with a description.",
 };
 
-export const WithError = Template.bind( {} );
-WithError.args = {
-	id: "tag-field-2",
-	label: "Tag field with a label",
-	description: "Tag field with a description.",
-	error: "This is what the error message looks like!",
-};
+export const Validation = () => (
+	<div className="yst-space-y-8">
+		{ map( VALIDATION_VARIANTS, variant => (
+			<TagField
+				key={ variant }
+				id={ `validation-${ variant }` }
+				name={ `validation-${ variant }` }
+				label={ `With validation of variant ${ variant }` }
+				value="The quick brown fox jumps over the lazy dog"
+				onChange={ noop }
+				validation={ {
+					variant,
+					message: {
+						success: "Looks like you are nailing it!",
+						warning: "Looks like you could do better!",
+						info: <>Looks like you could use some <a href="https://yoast.com" target="_blank" rel="noreferrer">more info</a>!</>,
+						error: "Looks like you are doing it wrong!",
+					}[ variant ],
+				} }
+			/>
+		) ) }
+	</div>
+);

--- a/packages/ui-library/src/components/tag-field/style.css
+++ b/packages/ui-library/src/components/tag-field/style.css
@@ -1,33 +1,18 @@
 @layer components {
 	.yst-root {
 		.yst-tag-field--disabled {
-			.yst-tag-field__label, .yst-tag-field__description {
+			.yst-tag-field__label,
+			.yst-tag-field__description {
 				@apply yst-opacity-50 yst-cursor-not-allowed;
 			}
-		}
-
-		.yst-tag-field__input--error {
-			@apply yst-pr-9 yst-border-red-300 focus:yst-ring-red-500 focus:yst-border-red-500;
-		}
-
-		.yst-tag-field__label {
-			@apply yst-items-center;
 		}
 
 		.yst-tag-field__description {
 			@apply yst-mt-2;
 		}
 
-		.yst-tag-field__error-icon {
-			@apply yst-flex yst-shrink-0 yst-grow-0 yst-items-center yst-absolute yst-inset-y-0 yst-right-0 yst-mr-3;
-		}
-
-		.yst-tag-field__error-icon > svg {
-			@apply yst-pointer-events-none yst-h-5 yst-w-5 yst-text-red-500;
-		}
-
-		.yst-tag-field__error {
-			@apply yst-mt-2 yst-text-sm yst-text-red-600;
+		.yst-tag-field__validation {
+			@apply yst-mt-2;
 		}
 	}
 }

--- a/packages/ui-library/src/components/text-field/index.js
+++ b/packages/ui-library/src/components/text-field/index.js
@@ -1,9 +1,9 @@
-import { ExclamationCircleIcon } from "@heroicons/react/solid";
 import classNames from "classnames";
 import PropTypes from "prop-types";
 import Label from "../../elements/label";
 import TextInput from "../../elements/text-input";
-import { useDescribedBy, useSvgAria } from "../../hooks";
+import { validationPropType, ValidationInput, ValidationMessage } from "../../elements/validation";
+import { useDescribedBy } from "../../hooks";
 
 /**
  * @param {string} id The ID of the input.
@@ -14,7 +14,7 @@ import { useDescribedBy, useSvgAria } from "../../hooks";
  * @param {JSX.node} [description] A description.
  * @param {boolean} [disabled] The disabled state.
  * @param {boolean} [readOnly] The read-only state.
- * @param {JSX.node} [error] An error "message".
+ * @param {JSX.node} [validation] The validation state.
  * @param {Object} [props] Any extra properties for the TextInput.
  * @returns {JSX.Element} The input field.
  */
@@ -27,11 +27,10 @@ const TextField = ( {
 	readOnly = false,
 	className = "",
 	description = null,
-	error = null,
+	validation = {},
 	...props
 } ) => {
-	const { ids, describedBy } = useDescribedBy( id, { error, description } );
-	const svgAriaProps = useSvgAria();
+	const { ids, describedBy } = useDescribedBy( id, { validation: validation?.message, description } );
 
 	return (
 		<div
@@ -43,27 +42,25 @@ const TextField = ( {
 			) }
 		>
 			<div className="yst-flex yst-items-center yst-mb-2">
-				<Label className="yst-text-field__label" htmlFor={ id } label={ label } />
+				<Label className="yst-text-field__label" htmlFor={ id }>{ label }</Label>
 				{ labelSuffix }
 			</div>
-			<div className="yst-relative">
-				<TextInput
-					id={ id }
-					onChange={ onChange }
-					disabled={ disabled }
-					readOnly={ readOnly }
-					className={ classNames(
-						"yst-text-field__input",
-						error && "yst-text-field__input--error",
-					) }
-					aria-describedby={ describedBy }
-					{ ...props }
-				/>
-				{ error && <div className="yst-text-field__error-icon">
-					<ExclamationCircleIcon { ...svgAriaProps } />
-				</div> }
-			</div>
-			{ error && <p id={ ids.error } className="yst-text-field__error">{ error }</p> }
+			<ValidationInput
+				as={ TextInput }
+				id={ id }
+				onChange={ onChange }
+				disabled={ disabled }
+				readOnly={ readOnly }
+				className="yst-text-field__input"
+				aria-describedby={ describedBy }
+				validation={ validation }
+				{ ...props }
+			/>
+			{ validation?.message && (
+				<ValidationMessage variant={ validation?.variant } id={ ids.validation } className="yst-text-field__validation">
+					{ validation.message }
+				</ValidationMessage>
+			) }
 			{ description && <p id={ ids.description } className="yst-text-field__description">{ description }</p> }
 		</div>
 	);
@@ -78,7 +75,7 @@ TextField.propTypes = {
 	readOnly: PropTypes.bool,
 	className: PropTypes.string,
 	description: PropTypes.node,
-	error: PropTypes.node,
+	validation: validationPropType,
 };
 
 export default TextField;

--- a/packages/ui-library/src/components/text-field/index.js
+++ b/packages/ui-library/src/components/text-field/index.js
@@ -14,7 +14,7 @@ import { useDescribedBy } from "../../hooks";
  * @param {JSX.node} [description] A description.
  * @param {boolean} [disabled] The disabled state.
  * @param {boolean} [readOnly] The read-only state.
- * @param {JSX.node} [validation] The validation state.
+ * @param {Object} [validation] The validation state.
  * @param {Object} [props] Any extra properties for the TextInput.
  * @returns {JSX.Element} The input field.
  */

--- a/packages/ui-library/src/components/text-field/index.js
+++ b/packages/ui-library/src/components/text-field/index.js
@@ -2,7 +2,7 @@ import classNames from "classnames";
 import PropTypes from "prop-types";
 import Label from "../../elements/label";
 import TextInput from "../../elements/text-input";
-import { validationPropType, ValidationInput, ValidationMessage } from "../../elements/validation";
+import { ValidationInput, ValidationMessage } from "../../elements/validation";
 import { useDescribedBy } from "../../hooks";
 
 /**
@@ -75,7 +75,10 @@ TextField.propTypes = {
 	readOnly: PropTypes.bool,
 	className: PropTypes.string,
 	description: PropTypes.node,
-	validation: validationPropType,
+	validation: PropTypes.shape( {
+		variant: PropTypes.string,
+		message: PropTypes.node,
+	} ),
 };
 
 export default TextField;

--- a/packages/ui-library/src/components/text-field/stories.js
+++ b/packages/ui-library/src/components/text-field/stories.js
@@ -1,10 +1,11 @@
 import { useCallback, useState } from "@wordpress/element";
-import { noop } from "lodash";
-import InputField from ".";
+import { noop, map } from "lodash";
+import TextField from ".";
+import { VALIDATION_VARIANTS } from "../../constants";
 
 export default {
 	title: "2) Components/Text Field",
-	component: InputField,
+	component: TextField,
 	argTypes: {
 		description: { control: "text" },
 		error: { control: "text" },
@@ -30,7 +31,7 @@ export const Factory = {
 		const handleChange = useCallback( setValue, [ setValue ] );
 
 		return (
-			<InputField { ...args } value={ value } onChange={ handleChange } />
+			<TextField { ...args } value={ value } onChange={ handleChange } />
 		);
 	},
 	parameters: {
@@ -47,13 +48,26 @@ export const WithLabelAndDescription = {
 	},
 };
 
-export const WithError = {
-	component: Factory.component.bind( {} ),
-	args: {
-		id: "input-field-2",
-		label: "Input field with a label",
-		description: "Input field with a description.",
-		type: "email",
-		error: "Please enter a valid email address.",
-	},
-};
+export const Validation = () => (
+	<div className="yst-space-y-8">
+		{ map( VALIDATION_VARIANTS, variant => (
+			<TextField
+				key={ variant }
+				id={ `validation-${ variant }` }
+				name={ `validation-${ variant }` }
+				label={ `With validation of variant ${ variant }` }
+				value="The quick brown fox jumps over the lazy dog"
+				onChange={ noop }
+				validation={ {
+					variant,
+					message: {
+						success: "Looks like you are nailing it!",
+						warning: "Looks like you could do better!",
+						info: <>Looks like you could use some <a href="https://yoast.com" target="_blank" rel="noreferrer">more info</a>!</>,
+						error: "Looks like you are doing it wrong!",
+					}[ variant ],
+				} }
+			/>
+		) ) }
+	</div>
+);

--- a/packages/ui-library/src/components/text-field/style.css
+++ b/packages/ui-library/src/components/text-field/style.css
@@ -17,28 +17,12 @@
 			}
 		}
 
-		.yst-text-field__input--error {
-			@apply yst-pr-9 yst-border-red-300 focus:yst-ring-red-500 focus:yst-border-red-500;
-		}
-
-		.yst-text-field__label {
-			@apply yst-items-center;
-		}
-
 		.yst-text-field__description {
 			@apply yst-mt-2;
 		}
 
-		.yst-text-field__error-icon {
-			@apply yst-flex yst-shrink-0 yst-grow-0 yst-items-center yst-absolute yst-inset-y-0 yst-right-0 yst-mr-3;
-		}
-
-		.yst-text-field__error-icon > svg {
-			@apply yst-pointer-events-none yst-h-5 yst-w-5 yst-text-red-500;
-		}
-
-		.yst-text-field__error {
-			@apply yst-mt-2 yst-text-sm yst-text-red-600;
+		.yst-text-field__validation {
+			@apply yst-mt-2;
 		}
 	}
 }

--- a/packages/ui-library/src/components/textarea-field/index.js
+++ b/packages/ui-library/src/components/textarea-field/index.js
@@ -2,7 +2,7 @@ import classNames from "classnames";
 import PropTypes from "prop-types";
 import Label from "../../elements/label";
 import Textarea from "../../elements/textarea";
-import { validationPropType, ValidationInput, ValidationMessage } from "../../elements/validation";
+import { ValidationInput, ValidationMessage } from "../../elements/validation";
 import { useDescribedBy } from "../../hooks";
 
 /**
@@ -53,7 +53,10 @@ TextareaField.propTypes = {
 	label: PropTypes.string.isRequired,
 	className: PropTypes.string,
 	description: PropTypes.node,
-	validation: validationPropType,
+	validation: PropTypes.shape( {
+		variant: PropTypes.string,
+		message: PropTypes.node,
+	} ),
 };
 
 export default TextareaField;

--- a/packages/ui-library/src/components/textarea-field/index.js
+++ b/packages/ui-library/src/components/textarea-field/index.js
@@ -1,9 +1,9 @@
-import { ExclamationCircleIcon } from "@heroicons/react/solid";
 import classNames from "classnames";
 import PropTypes from "prop-types";
 import Label from "../../elements/label";
 import Textarea from "../../elements/textarea";
-import { useDescribedBy, useSvgAria } from "../../hooks";
+import { validationPropType, ValidationInput, ValidationMessage } from "../../elements/validation";
+import { useDescribedBy } from "../../hooks";
 
 /**
  * @param {string} id The ID of the input.
@@ -11,39 +11,38 @@ import { useDescribedBy, useSvgAria } from "../../hooks";
  * @param {string} label The label.
  * @param {string} [className] The HTML class.
  * @param {JSX.node} [description] A description.
- * @param {JSX.node} [error] An error "message".
+ * @param {Object} [error] The validation state.
  * @param {Object} [props] Any extra properties for the Textarea.
  * @returns {JSX.Element} The textarea field.
  */
 const TextareaField = ( {
 	id,
 	label,
-	className,
-	description,
-	error,
+	className = "",
+	description = "",
+	validation = {},
 	...props
 } ) => {
-	const { ids, describedBy } = useDescribedBy( id, { error, description } );
-	const svgAriaProps = useSvgAria();
+	const { ids, describedBy } = useDescribedBy( id, { validation: validation?.message, description } );
 
 	return (
 		<div className={ classNames( "yst-textarea-field", className ) }>
-			<Label className="yst-textarea-field__label" htmlFor={ id } label={ label } />
-			<div className="yst-relative">
-				<Textarea
-					id={ id }
-					className={ classNames(
-						"yst-textarea-field__input",
-						error && "yst-textarea-field__input--error",
-					) }
-					aria-describedby={ describedBy }
-					{ ...props }
-				/>
-				{ error && <div className="yst-textarea-field__error-icon">
-					<ExclamationCircleIcon { ...svgAriaProps } />
-				</div> }
+			<div className="yst-flex yst-items-center yst-mb-2">
+				<Label className="yst-textarea-field__label" htmlFor={ id }>{ label }</Label>
 			</div>
-			{ error && <p id={ ids.error } className="yst-textarea-field__error">{ error }</p> }
+			<ValidationInput
+				as={ Textarea }
+				id={ id }
+				className="yst-textarea-field__input"
+				aria-describedby={ describedBy }
+				validation={ validation }
+				{ ...props }
+			/>
+			{ validation?.message && (
+				<ValidationMessage variant={ validation?.variant } id={ ids.validation } className="yst-textarea-field__validation">
+					{ validation.message }
+				</ValidationMessage>
+			) }
 			{ description && <p id={ ids.description } className="yst-textarea-field__description">{ description }</p> }
 		</div>
 	);
@@ -54,13 +53,7 @@ TextareaField.propTypes = {
 	label: PropTypes.string.isRequired,
 	className: PropTypes.string,
 	description: PropTypes.node,
-	error: PropTypes.node,
-};
-
-TextareaField.defaultProps = {
-	className: "",
-	description: null,
-	error: null,
+	validation: validationPropType,
 };
 
 export default TextareaField;

--- a/packages/ui-library/src/components/textarea-field/stories.js
+++ b/packages/ui-library/src/components/textarea-field/stories.js
@@ -1,4 +1,6 @@
+import { noop, map } from "lodash";
 import TextareaField from ".";
+import { VALIDATION_VARIANTS } from "../../constants";
 
 export default {
 	title: "2) Components/Textarea Field",
@@ -36,15 +38,26 @@ export const WithLabelAndDescription = {
 	},
 };
 
-export const WithError = {
-	component: Factory.component.bind( {} ),
-	parameters: {
-		controls: { disable: false },
-	},
-	args: {
-		id: "textarea-field-2",
-		label: "Textarea field with a label",
-		description: "Textarea field with a description.",
-		error: "Please enter a valid text.",
-	},
-};
+export const Validation = () => (
+	<div className="yst-space-y-8">
+		{ map( VALIDATION_VARIANTS, variant => (
+			<TextareaField
+				key={ variant }
+				id={ `validation-${ variant }` }
+				name={ `validation-${ variant }` }
+				label={ `With validation of variant ${ variant }` }
+				value="The quick brown fox jumps over the lazy dog"
+				onChange={ noop }
+				validation={ {
+					variant,
+					message: {
+						success: "Looks like you are nailing it!",
+						warning: "Looks like you could do better!",
+						info: <>Looks like you could use some <a href="https://yoast.com" target="_blank" rel="noreferrer">more info</a>!</>,
+						error: "Looks like you are doing it wrong!",
+					}[ variant ],
+				} }
+			/>
+		) ) }
+	</div>
+);

--- a/packages/ui-library/src/components/textarea-field/style.css
+++ b/packages/ui-library/src/components/textarea-field/style.css
@@ -1,27 +1,14 @@
 @layer components {
 	.yst-root {
-		.yst-textarea-field__input--error {
-			@apply yst-border-red-300 focus:yst-ring-red-500 focus:yst-border-red-500;
-		}
 
-		.yst-textarea-field__label {
-			@apply yst-flex yst-items-center yst-mb-2;
-		}
+		.yst-textarea-field__label {}
 
 		.yst-textarea-field__description {
 			@apply yst-mt-2;
 		}
 
-		.yst-textarea-field__error-icon {
-			@apply yst-absolute yst-top-1 yst-right-1 yst-bottom-0 yst-pointer-events-none;
-		}
-
-		.yst-textarea-field__error-icon > svg {
-			@apply yst-h-5 yst-w-5 yst-text-red-500;
-		}
-
-		.yst-textarea-field__error {
-			@apply yst-mt-2 yst-text-sm yst-text-red-600;
+		.yst-textarea-field__validation {
+			@apply yst-mt-2;
 		}
 	}
 }

--- a/packages/ui-library/src/constants/index.js
+++ b/packages/ui-library/src/constants/index.js
@@ -1,1 +1,2 @@
 export { FILE_IMPORT_STATUS } from "../components/file-import";
+export { VALIDATION_VARIANTS, VALIDATION_ICON_MAP } from "../elements/validation/constants";

--- a/packages/ui-library/src/elements/alert/index.js
+++ b/packages/ui-library/src/elements/alert/index.js
@@ -1,7 +1,6 @@
-import { CheckCircleIcon, ExclamationIcon, InformationCircleIcon, ExclamationCircleIcon } from "@heroicons/react/solid";
 import classNames from "classnames";
 import PropTypes from "prop-types";
-import { useSvgAria } from "../../hooks";
+import { ValidationIcon, ValidationMessage } from "../validation";
 
 const classNameMap = {
 	variant: {
@@ -10,13 +9,6 @@ const classNameMap = {
 		success: "yst-alert--success",
 		error: "yst-alert--error",
 	},
-};
-
-const iconMap = {
-	success: CheckCircleIcon,
-	warning: ExclamationIcon,
-	info: InformationCircleIcon,
-	error: ExclamationCircleIcon,
 };
 
 const roleMap = {
@@ -34,32 +26,27 @@ const roleMap = {
  */
 const Alert = ( {
 	children,
-	role,
-	as: Component,
-	variant,
-	className,
+	role = "status",
+	as: Component = "span",
+	variant = "info",
+	className = "",
 	...props
-} ) => {
-	const Icon = iconMap[ variant ];
-	const svgAriaProps = useSvgAria();
-
-	return (
-		<Component
-			className={ classNames(
-				"yst-alert",
-				classNameMap.variant[ variant ],
-				className,
-			) }
-			role={ roleMap[ role ] }
-			{ ...props }
-		>
-			<Icon className="yst-alert__icon" { ...svgAriaProps } />
-			<div>
-				{ children }
-			</div>
-		</Component>
-	);
-};
+} ) => (
+	<Component
+		className={ classNames(
+			"yst-alert",
+			classNameMap.variant[ variant ],
+			className,
+		) }
+		role={ roleMap[ role ] }
+		{ ...props }
+	>
+		<ValidationIcon variant={ variant } className="yst-alert__icon" />
+		<ValidationMessage as="div" variant={ variant }>
+			{ children }
+		</ValidationMessage>
+	</Component>
+);
 
 Alert.propTypes = {
 	children: PropTypes.node.isRequired,
@@ -67,13 +54,6 @@ Alert.propTypes = {
 	variant: PropTypes.oneOf( Object.keys( classNameMap.variant ) ),
 	className: PropTypes.string,
 	role: PropTypes.oneOf( Object.keys( roleMap ) ),
-};
-
-Alert.defaultProps = {
-	as: "span",
-	variant: "info",
-	className: "",
-	role: "status",
 };
 
 export default Alert;

--- a/packages/ui-library/src/elements/alert/index.js
+++ b/packages/ui-library/src/elements/alert/index.js
@@ -42,7 +42,7 @@ const Alert = ( {
 		{ ...props }
 	>
 		<ValidationIcon variant={ variant } className="yst-alert__icon" />
-		<ValidationMessage as="div" variant={ variant }>
+		<ValidationMessage as="div" variant={ variant } className="yst-alert__message">
 			{ children }
 		</ValidationMessage>
 	</Component>

--- a/packages/ui-library/src/elements/alert/style.css
+++ b/packages/ui-library/src/elements/alert/style.css
@@ -6,10 +6,6 @@
 			yst-gap-3
 			yst-rounded-md
 			yst-p-4;
-
-			a {
-				@apply yst-text-inherit hover:visited:yst-text-inherit yst-font-medium;
-			}
 		}
 
 		/* Variants */

--- a/packages/ui-library/src/elements/alert/style.css
+++ b/packages/ui-library/src/elements/alert/style.css
@@ -13,46 +13,20 @@
 		}
 
 		/* Variants */
-
 		.yst-alert--info {
-			@apply
-			yst-bg-blue-100
-			yst-text-blue-800;
-
-			.yst-alert__icon {
-				@apply yst-text-blue-500;
-			}
+			@apply yst-bg-blue-100;
 		}
 
 		.yst-alert--warning {
-			@apply
-			yst-bg-amber-100
-			yst-text-amber-800;
-
-			.yst-alert__icon {
-				@apply yst-text-amber-500;
-			}
+			@apply yst-bg-amber-100;
 		}
 
 		.yst-alert--success {
-			@apply
-			yst-bg-green-100
-			yst-text-green-800;
-
-			.yst-alert__icon {
-				@apply yst-text-green-500;
-			}
-
+			@apply yst-bg-green-100;
 		}
 
 		.yst-alert--error {
-			@apply
-			yst-bg-red-100
-			yst-text-red-800;
-
-			.yst-alert__icon {
-				@apply yst-text-red-500;
-			}
+			@apply yst-bg-red-100;
 		}
 
 		/* Elements */

--- a/packages/ui-library/src/elements/alert/style.css
+++ b/packages/ui-library/src/elements/alert/style.css
@@ -15,18 +15,34 @@
 		/* Variants */
 		.yst-alert--info {
 			@apply yst-bg-blue-100;
+
+			.yst-alert__message {
+				@apply yst-text-blue-800;
+			}
 		}
 
 		.yst-alert--warning {
 			@apply yst-bg-amber-100;
+
+			.yst-alert__message {
+				@apply yst-text-amber-800;
+			}
 		}
 
 		.yst-alert--success {
 			@apply yst-bg-green-100;
+
+			.yst-alert__message {
+				@apply yst-text-green-800;
+			}
 		}
 
 		.yst-alert--error {
 			@apply yst-bg-red-100;
+
+			.yst-alert__message {
+				@apply yst-text-red-800;
+			}
 		}
 
 		/* Elements */

--- a/packages/ui-library/src/elements/autocomplete/index.js
+++ b/packages/ui-library/src/elements/autocomplete/index.js
@@ -1,11 +1,15 @@
 /* eslint-disable require-jsdoc */
 import PropTypes from "prop-types";
-import { Fragment, useCallback } from "@wordpress/element";
+import { forwardRef, Fragment, useCallback } from "@wordpress/element";
 import { Combobox, Transition } from "@headlessui/react";
-import { SelectorIcon, CheckIcon, ExclamationCircleIcon } from "@heroicons/react/solid";
+import { SelectorIcon, CheckIcon } from "@heroicons/react/solid";
 import classNames from "classnames";
 import { constant } from "lodash";
 import { useSvgAria } from "../../hooks";
+import { ValidationInput, validationPropType } from "../validation";
+
+// Render Combobox.Button as a div always.
+const AutocompleteButton = forwardRef( ( props, ref ) => <Combobox.Button as="div" ref={ ref } { ...props } /> );
 
 const Option = ( {
 	children,
@@ -52,7 +56,7 @@ Option.propTypes = optionPropType;
  * @param {JSX.node} [labelSuffix] Optional label suffix.
  * @param {Function} onChange Change callback.
  * @param {Function} onQueryChange Query change callback.
- * @param {boolean} [isError] Error message.
+ * @param {Object} [validation] The validation state.
  * @param {string} [placeholder] Input placeholder.
  * @param {string} [className] CSS class.
  * @param {Object} [buttonProps] Any extra props for the button.
@@ -69,7 +73,7 @@ const Autocomplete = ( {
 	labelSuffix = null,
 	onChange,
 	onQueryChange,
-	isError = false,
+	validation = {},
 	placeholder = "",
 	className = "",
 	buttonProps = {},
@@ -83,11 +87,7 @@ const Autocomplete = ( {
 			as="div"
 			value={ value }
 			onChange={ onChange }
-			className={ classNames(
-				"yst-autocomplete",
-				isError && "yst-autocomplete--error",
-				className,
-			) }
+			className={ classNames( "yst-autocomplete", className ) }
 			{ ...props }
 		>
 			{ label && <div className="yst-flex yst-items-center yst-mb-2">
@@ -95,26 +95,23 @@ const Autocomplete = ( {
 				{ labelSuffix }
 			</div> }
 			<div className="yst-relative">
-				<div className="yst-relative">
-					<Combobox.Button
-						data-id={ id }
-						className="yst-autocomplete__button"
-						{ ...buttonProps }
-						as="div"
-					>
-						<Combobox.Input
-							className="yst-autocomplete__input"
-							placeholder={ placeholder }
-							displayValue={ getDisplayValue }
-							onChange={ onQueryChange }
-						/>
-						{ isError ? (
-							<ExclamationCircleIcon className="yst-autocomplete__button-icon yst-text-red-500" { ...svgAriaProps } />
-						) : (
-							<SelectorIcon className="yst-autocomplete__button-icon" { ...svgAriaProps } />
-						) }
-					</Combobox.Button>
-				</div>
+				<ValidationInput
+					as={ AutocompleteButton }
+					data-id={ id }
+					validation={ validation }
+					className="yst-autocomplete__button"
+					{ ...buttonProps }
+				>
+					<Combobox.Input
+						className="yst-autocomplete__input"
+						placeholder={ placeholder }
+						displayValue={ getDisplayValue }
+						onChange={ onQueryChange }
+					/>
+					{ ! validation?.message && (
+						<SelectorIcon className="yst-autocomplete__button-icon" { ...svgAriaProps } />
+					) }
+				</ValidationInput>
 				<Transition
 					as={ Fragment }
 					enter="yst-transition yst-duration-100 yst-ease-out"
@@ -143,7 +140,7 @@ Autocomplete.propTypes = {
 	labelSuffix: PropTypes.node,
 	onChange: PropTypes.func.isRequired,
 	onQueryChange: PropTypes.func.isRequired,
-	isError: PropTypes.bool,
+	validation: validationPropType,
 	placeholder: PropTypes.string,
 	className: PropTypes.string,
 	buttonProps: PropTypes.object,

--- a/packages/ui-library/src/elements/autocomplete/index.js
+++ b/packages/ui-library/src/elements/autocomplete/index.js
@@ -6,7 +6,7 @@ import { SelectorIcon, CheckIcon } from "@heroicons/react/solid";
 import classNames from "classnames";
 import { constant } from "lodash";
 import { useSvgAria } from "../../hooks";
-import { ValidationInput, validationPropType } from "../validation";
+import { ValidationInput } from "../validation";
 
 // Render Combobox.Button as a div always.
 const AutocompleteButton = forwardRef( ( props, ref ) => <Combobox.Button as="div" ref={ ref } { ...props } /> );
@@ -140,7 +140,10 @@ Autocomplete.propTypes = {
 	labelSuffix: PropTypes.node,
 	onChange: PropTypes.func.isRequired,
 	onQueryChange: PropTypes.func.isRequired,
-	validation: validationPropType,
+	validation: PropTypes.shape( {
+		variant: PropTypes.string,
+		message: PropTypes.node,
+	} ),
 	placeholder: PropTypes.string,
 	className: PropTypes.string,
 	buttonProps: PropTypes.object,

--- a/packages/ui-library/src/elements/autocomplete/stories.js
+++ b/packages/ui-library/src/elements/autocomplete/stories.js
@@ -1,6 +1,7 @@
 import { useCallback, useMemo, useState } from "@wordpress/element";
-import { filter, find, includes, toLower } from "lodash";
+import { filter, find, includes, toLower, noop, map } from "lodash";
 import Autocomplete from ".";
+import { VALIDATION_VARIANTS } from "../../constants";
 
 export default {
 	title: "1) Elements/Autocomplete",
@@ -85,20 +86,6 @@ WithLabel.args = {
 	label: "Example label",
 };
 
-export const WithError = Template.bind( {} );
-
-WithError.parameters = {
-	controls: { disable: false },
-	docs: { description: { story: "An exampe with error using `isError` prop." } },
-};
-WithError.args = {
-	id: "with-error",
-	value: "",
-	label: "Example label",
-	labelProps: { className: "yoast-field-group__label" },
-	isError: true,
-};
-
 export const WithPlaceholder = Template.bind( {} );
 
 WithPlaceholder.parameters = {
@@ -124,3 +111,35 @@ WithSelectedLabel.args = {
 	id: "selected-label",
 	selectedLabel: "Option 1",
 };
+
+export const Validation = () => (
+	<div className="yst-space-y-8">
+		{ map( VALIDATION_VARIANTS, variant => (
+			<Autocomplete
+				key={ variant }
+				id={ `validation-${ variant }` }
+				name={ `validation-${ variant }` }
+				label={ `With validation of variant ${ variant }` }
+				value="1"
+				selectedLabel="The quick brown fox jumps over the lazy dog"
+				onChange={ noop }
+				onQueryChange={ noop }
+				options={ [
+					{ value: "1", label: "Option 1" },
+					{ value: "2", label: "Option 2" },
+					{ value: "3", label: "Option 3" },
+					{ value: "4", label: "Option 4" },
+				] }
+				validation={ {
+					variant,
+					message: {
+						success: "Looks like you are nailing it!",
+						warning: "Looks like you could do better!",
+						info: <>Looks like you could use some <a href="https://yoast.com" target="_blank" rel="noreferrer">more info</a>!</>,
+						error: "Looks like you are doing it wrong!",
+					}[ variant ],
+				} }
+			/>
+		) ) }
+	</div>
+);

--- a/packages/ui-library/src/elements/autocomplete/style.css
+++ b/packages/ui-library/src/elements/autocomplete/style.css
@@ -36,12 +36,7 @@
 		}
 
 		.yst-autocomplete__button-icon {
-			@apply
-			yst-h-5
-			yst-w-5
-			yst-text-slate-400
-			yst-inset-y-0
-			yst-right-0;
+			@apply yst-absolute yst-top-[0.6875rem] yst-right-2.5 yst-text-slate-400 yst-pointer-events-none yst-w-5 yst-h-5;
 		}
 
 		.yst-autocomplete__input {

--- a/packages/ui-library/src/elements/label/index.js
+++ b/packages/ui-library/src/elements/label/index.js
@@ -1,3 +1,4 @@
+import { forwardRef } from "@wordpress/element";
 import classNames from "classnames";
 import PropTypes from "prop-types";
 
@@ -8,20 +9,21 @@ import PropTypes from "prop-types";
  * @param {string} [className] CSS class.
  * @returns {JSX.Element} Label component.
  */
-const Label = ( {
+const Label = forwardRef( ( {
 	as: Component = "label",
 	className = "",
 	label = "",
 	children = "",
 	...props
-} ) => (
+}, ref ) => (
 	<Component
+		ref={ ref }
 		className={ classNames( "yst-label", className ) }
 		{ ...props }
 	>
 		{ label || children || null }
 	</Component>
-);
+) );
 
 Label.propTypes = {
 	label: PropTypes.string,

--- a/packages/ui-library/src/elements/select/index.js
+++ b/packages/ui-library/src/elements/select/index.js
@@ -4,7 +4,7 @@ import { Fragment, useCallback, useMemo } from "@wordpress/element";
 import classNames from "classnames";
 import PropTypes from "prop-types";
 import { useSvgAria } from "../../hooks";
-import { validationPropType, ValidationInput } from "../validation";
+import { ValidationInput } from "../validation";
 import Label from "../label";
 
 const optionPropType = {
@@ -137,7 +137,10 @@ Select.propTypes = {
 	labelSuffix: PropTypes.node,
 	onChange: PropTypes.func.isRequired,
 	disabled: PropTypes.bool,
-	validation: validationPropType,
+	validation: PropTypes.shape( {
+		variant: PropTypes.string,
+		message: PropTypes.node,
+	} ),
 	className: PropTypes.string,
 	buttonProps: PropTypes.object,
 };

--- a/packages/ui-library/src/elements/select/index.js
+++ b/packages/ui-library/src/elements/select/index.js
@@ -1,9 +1,11 @@
 import { Listbox, Transition } from "@headlessui/react";
-import { CheckIcon, ExclamationCircleIcon, SelectorIcon } from "@heroicons/react/solid";
+import { CheckIcon, SelectorIcon } from "@heroicons/react/solid";
 import { Fragment, useCallback, useMemo } from "@wordpress/element";
 import classNames from "classnames";
 import PropTypes from "prop-types";
 import { useSvgAria } from "../../hooks";
+import { validationPropType, ValidationInput } from "../validation";
+import Label from "../label";
 
 const optionPropType = {
 	value: PropTypes.oneOfType( [ PropTypes.string, PropTypes.number, PropTypes.bool ] ).isRequired,
@@ -50,7 +52,7 @@ Option.propTypes = optionPropType;
  * @param {JSX.node} [labelSuffix] Optional label suffix.
  * @param {Function} onChange Change callback.
  * @param {boolean} [disabled] Disabled state.
- * @param {boolean} [isError] Error message.
+ * @param {Object} [validation] The validation state.
  * @param {string} [className] CSS class.
  * @param {Object} [buttonProps] Any extra props for the button.
  * @param {Object} [props] Any extra props.
@@ -67,7 +69,7 @@ const Select = ( {
 	labelSuffix = null,
 	onChange,
 	disabled = false,
-	isError = false,
+	validation = {},
 	className = "",
 	buttonProps,
 	...props
@@ -87,23 +89,26 @@ const Select = ( {
 			className={ classNames(
 				"yst-select",
 				disabled && "yst-select--disabled",
-				isError && "yst-select--error",
 				className,
 			) }
 			{ ...props }
 		>
 			{ label && <div className="yst-flex yst-items-center yst-mb-2">
-				<Listbox.Label { ...labelProps }>{ label }</Listbox.Label>
+				<Listbox.Label as={ Label } { ...labelProps }>{ label }</Listbox.Label>
 				{ labelSuffix }
 			</div> }
-			<Listbox.Button data-id={ id } className="yst-select__button" { ...buttonProps }>
+			<ValidationInput
+				as={ Listbox.Button }
+				data-id={ id }
+				className="yst-select__button"
+				validation={ validation }
+				{ ...buttonProps }
+			>
 				<span className="yst-select__button-label">{ selectedLabel || selectedOption?.label || "" }</span>
-				{ isError ? (
-					<ExclamationCircleIcon className="yst-select__button-icon yst-select__button-icon--error" { ...svgAriaProps } />
-				) : (
+				{ ! validation?.message && (
 					<SelectorIcon className="yst-select__button-icon" { ...svgAriaProps } />
 				) }
-			</Listbox.Button>
+			</ValidationInput>
 			<Transition
 				as={ Fragment }
 				enter="yst-transition yst-duration-100 yst-ease-out"
@@ -132,7 +137,7 @@ Select.propTypes = {
 	labelSuffix: PropTypes.node,
 	onChange: PropTypes.func.isRequired,
 	disabled: PropTypes.bool,
-	isError: PropTypes.bool,
+	validation: validationPropType,
 	className: PropTypes.string,
 	buttonProps: PropTypes.object,
 };

--- a/packages/ui-library/src/elements/select/stories.js
+++ b/packages/ui-library/src/elements/select/stories.js
@@ -1,5 +1,7 @@
 import { useCallback, useState } from "@wordpress/element";
+import { noop, map } from "lodash";
 import Select from ".";
+import { VALIDATION_VARIANTS } from "../validation/constants";
 
 export default {
 	title: "1) Elements/Select",
@@ -54,14 +56,6 @@ Factory.args = {
 
 };
 
-export const States = Template.bind( {} );
-States.args = {
-	id: "select",
-	value: "1",
-	isError: true,
-	children: options.map( option => <Select.Option key={ option.value } { ...option } /> ),
-};
-
 export const OptionsProp = Template.bind( {} );
 OptionsProp.args = {
 	id: "select-field-4",
@@ -92,3 +86,33 @@ ChildrenProp.args = {
 ChildrenProp.parameters = {
 	docs: { description: { story: "Add options as an array of React components with `children` prop, using the exposed option component `Select.Option`. In this case changing the `selectedLabel` should be done manually in the handleChange function" } },
 };
+
+export const Validation = () => (
+	<div className="yst-space-y-8">
+		{ map( VALIDATION_VARIANTS, variant => (
+			<Select
+				key={ variant }
+				id={ `validation-${ variant }` }
+				name={ `validation-${ variant }` }
+				label={ `With validation of variant ${ variant }` }
+				value="The quick brown fox jumps over the lazy dog"
+				onChange={ noop }
+				options={ [
+					{ value: "1", label: "Option 1" },
+					{ value: "2", label: "Option 2" },
+					{ value: "3", label: "Option 3" },
+					{ value: "4", label: "Option 4" },
+				] }
+				validation={ {
+					variant,
+					message: {
+						success: "Looks like you are nailing it!",
+						warning: "Looks like you could do better!",
+						info: <>Looks like you could use some <a href="https://yoast.com" target="_blank" rel="noreferrer">more info</a>!</>,
+						error: "Looks like you are doing it wrong!",
+					}[ variant ],
+				} }
+			/>
+		) ) }
+	</div>
+);

--- a/packages/ui-library/src/elements/select/style.css
+++ b/packages/ui-library/src/elements/select/style.css
@@ -11,19 +11,6 @@
 			}
 		}
 
-		.yst-select--error {
-			.yst-select__button {
-				@apply
-				yst-border-red-300
-				yst-placeholder-red-300
-
-
-				focus:yst-outline-none
-				focus:yst-ring-red-500
-				focus:yst-border-red-500;
-			}
-		}
-
 		.yst-select__button {
 			@apply
 			yst-relative
@@ -50,17 +37,7 @@
 		}
 
 		.yst-select__button-icon {
-			@apply
-			yst-w-5
-			yst-h-5
-			yst-shrink-0
-			yst-grow-0
-			yst-text-slate-400
-			yst-pointer-events-none;
-		}
-
-		.yst-select__button-icon--error {
-			@apply yst-text-red-500;
+			@apply yst-absolute yst-top-2.5 yst-right-2.5 yst-text-slate-400 yst-pointer-events-none yst-w-5 yst-h-5;
 		}
 
 		.yst-select__options {

--- a/packages/ui-library/src/elements/validation/constants.js
+++ b/packages/ui-library/src/elements/validation/constants.js
@@ -1,0 +1,15 @@
+import { CheckCircleIcon, ExclamationIcon, InformationCircleIcon, ExclamationCircleIcon } from "@heroicons/react/solid";
+
+export const VALIDATION_VARIANTS = {
+	success: "success",
+	warning: "warning",
+	info: "info",
+	error: "error",
+};
+
+export const VALIDATION_ICON_MAP = {
+	success: CheckCircleIcon,
+	warning: ExclamationIcon,
+	info: InformationCircleIcon,
+	error: ExclamationCircleIcon,
+};

--- a/packages/ui-library/src/elements/validation/index.js
+++ b/packages/ui-library/src/elements/validation/index.js
@@ -1,2 +1,10 @@
+import PropTypes from "prop-types";
+
 export { default as ValidationIcon } from "./validation-icon";
+export { default as ValidationInput } from "./validation-input";
 export { default as ValidationMessage } from "./validation-message";
+
+export const validationPropType = PropTypes.shape( {
+	variant: PropTypes.string,
+	message: PropTypes.node,
+} );

--- a/packages/ui-library/src/elements/validation/index.js
+++ b/packages/ui-library/src/elements/validation/index.js
@@ -1,0 +1,2 @@
+export { default as ValidationIcon } from "./validation-icon";
+export { default as ValidationMessage } from "./validation-message";

--- a/packages/ui-library/src/elements/validation/index.js
+++ b/packages/ui-library/src/elements/validation/index.js
@@ -1,10 +1,3 @@
-import PropTypes from "prop-types";
-
 export { default as ValidationIcon } from "./validation-icon";
 export { default as ValidationInput } from "./validation-input";
 export { default as ValidationMessage } from "./validation-message";
-
-export const validationPropType = PropTypes.shape( {
-	variant: PropTypes.string,
-	message: PropTypes.node,
-} );

--- a/packages/ui-library/src/elements/validation/style.css
+++ b/packages/ui-library/src/elements/validation/style.css
@@ -83,16 +83,16 @@
         }
 
         .yst-validation-message--success {
-            @apply yst-text-green-800;
+            @apply yst-text-green-600;
         }
         .yst-validation-message--info {
-            @apply yst-text-blue-800;
+            @apply yst-text-blue-600;
         }
         .yst-validation-message--warning {
-            @apply yst-text-amber-800;
+            @apply yst-text-amber-600;
         }
         .yst-validation-message--error {
-            @apply yst-text-red-800;
+            @apply yst-text-red-600;
         }
     }
 }

--- a/packages/ui-library/src/elements/validation/style.css
+++ b/packages/ui-library/src/elements/validation/style.css
@@ -1,98 +1,111 @@
 @layer components {
-    .yst-root {
+	.yst-root {
 
-        /* Validation icon */
-        .yst-validation-icon {
-            @apply yst-pointer-events-none;
-        }
+		/* Validation icon */
 
-        .yst-validation-icon--success {
-            @apply yst-text-green-500;
-        }
-        .yst-validation-icon--info {
-            @apply yst-text-blue-500;
-        }
-        .yst-validation-icon--warning {
-            @apply yst-text-amber-500;
-        }
-        .yst-validation-icon--error {
-            @apply yst-text-red-500;
-        }
+		.yst-validation-icon {
+			@apply yst-pointer-events-none;
+		}
 
-        /* Validation input */
-        .yst-validation-input {
-            @apply yst-relative;
-        }
+		.yst-validation-icon--success {
+			@apply yst-text-green-500;
+		}
 
-        .yst-validation-input--success {
-            .yst-validation-input__input {
-                @apply
-                yst-pr-10
-                yst-border-green-300
-                focus:yst-ring-green-500
-                focus:yst-border-green-500
-                focus-within:yst-ring-green-500
-                focus-within:yst-border-green-500;
-            }
-        }
-        .yst-validation-input--info {
-            .yst-validation-input__input {
-                @apply
-                yst-pr-10
-                yst-border-blue-300
-                focus:yst-ring-blue-500
-                focus:yst-border-blue-500
-                focus-within:yst-ring-blue-500
-                focus-within:yst-border-blue-500;
-            }
-        }
-        .yst-validation-input--warning {
-            .yst-validation-input__input {
-                @apply
-                yst-pr-10
-                yst-border-amber-300
-                focus:yst-ring-amber-500
-                focus:yst-border-amber-500
-                focus-within:yst-ring-amber-500
-                focus-within:yst-border-amber-500;
-            }
-        }
-        .yst-validation-input--error {
-            .yst-validation-input__input {
-                @apply
-                yst-pr-10
-                yst-border-red-300
-                focus:yst-ring-red-500
-                focus:yst-border-red-500
-                focus-within:yst-ring-red-500
-                focus-within:yst-border-red-500;
-            }
-        }
+		.yst-validation-icon--info {
+			@apply yst-text-blue-500;
+		}
 
-        .yst-validation-input__input {}
+		.yst-validation-icon--warning {
+			@apply yst-text-amber-500;
+		}
 
-        .yst-validation-input__icon {
-            @apply yst-absolute yst-top-[0.6875rem] yst-right-2.5 yst-w-5 yst-h-5;
-        }
+		.yst-validation-icon--error {
+			@apply yst-text-red-500;
+		}
 
-        /* Validation message */
-        .yst-validation-message {
-            a {
+		/* Validation input */
+
+		.yst-validation-input {
+			@apply yst-relative;
+		}
+
+		.yst-validation-input--success {
+			.yst-validation-input__input {
+				@apply
+				yst-pr-10
+				yst-border-green-300
+				focus:yst-ring-green-500
+				focus:yst-border-green-500
+				focus-within:yst-ring-green-500
+				focus-within:yst-border-green-500;
+			}
+		}
+
+		.yst-validation-input--info {
+			.yst-validation-input__input {
+				@apply
+				yst-pr-10
+				yst-border-blue-300
+				focus:yst-ring-blue-500
+				focus:yst-border-blue-500
+				focus-within:yst-ring-blue-500
+				focus-within:yst-border-blue-500;
+			}
+		}
+
+		.yst-validation-input--warning {
+			.yst-validation-input__input {
+				@apply
+				yst-pr-10
+				yst-border-amber-300
+				focus:yst-ring-amber-500
+				focus:yst-border-amber-500
+				focus-within:yst-ring-amber-500
+				focus-within:yst-border-amber-500;
+			}
+		}
+
+		.yst-validation-input--error {
+			.yst-validation-input__input {
+				@apply
+				yst-pr-10
+				yst-border-red-300
+				focus:yst-ring-red-500
+				focus:yst-border-red-500
+				focus-within:yst-ring-red-500
+				focus-within:yst-border-red-500;
+			}
+		}
+
+		.yst-validation-input__input {
+		}
+
+		.yst-validation-input__icon {
+			@apply yst-absolute yst-top-[0.6875rem] yst-right-2.5 yst-w-5 yst-h-5;
+		}
+
+		/* Validation message */
+
+		.yst-validation-message {
+			a {
 				@apply yst-font-medium yst-text-inherit hover:visited:yst-text-inherit;
 			}
-        }
+		}
 
-        .yst-validation-message--success {
-            @apply yst-text-green-600;
-        }
-        .yst-validation-message--info {
-            @apply yst-text-blue-600;
-        }
-        .yst-validation-message--warning {
-            @apply yst-text-amber-600;
-        }
-        .yst-validation-message--error {
-            @apply yst-text-red-600;
-        }
-    }
+		.yst-validation-message--success {
+			@apply yst-text-green-600;
+		}
+
+		.yst-validation-message--info {
+			@apply yst-text-blue-600;
+		}
+
+		.yst-validation-message--warning {
+			@apply yst-text-amber-600;
+		}
+
+		.yst-validation-message--error {
+			@apply yst-text-red-600;
+		}
+	}
 }

--- a/packages/ui-library/src/elements/validation/style.css
+++ b/packages/ui-library/src/elements/validation/style.css
@@ -1,0 +1,41 @@
+@layer components {
+    .yst-root {
+
+        /* Validation icon */
+        .yst-validation-icon {}
+
+        .yst-validation-icon--success {
+            @apply yst-text-green-500;
+        }
+        .yst-validation-icon--info {
+            @apply yst-text-blue-500;
+        }
+        .yst-validation-icon--warning {
+            @apply yst-text-amber-500;
+        }
+        .yst-validation-icon--error {
+            @apply yst-text-red-500;
+        }
+
+        /* Validation message */
+        .yst-validation-message {
+
+            a {
+				@apply yst-font-medium yst-text-inherit hover:visited:yst-text-inherit;
+			}
+        }
+
+        .yst-validation-message--success {
+            @apply yst-bg-green-100 yst-text-green-800;
+        }
+        .yst-validation-message--info {
+            @apply yst-bg-blue-100 yst-text-blue-800;
+        }
+        .yst-validation-message--warning {
+            @apply yst-bg-amber-100 yst-text-amber-800;
+        }
+        .yst-validation-message--error {
+            @apply yst-bg-red-100 yst-text-red-800;
+        }
+    }
+}

--- a/packages/ui-library/src/elements/validation/style.css
+++ b/packages/ui-library/src/elements/validation/style.css
@@ -2,7 +2,9 @@
     .yst-root {
 
         /* Validation icon */
-        .yst-validation-icon {}
+        .yst-validation-icon {
+            @apply yst-pointer-events-none;
+        }
 
         .yst-validation-icon--success {
             @apply yst-text-green-500;
@@ -17,25 +19,80 @@
             @apply yst-text-red-500;
         }
 
+        /* Validation input */
+        .yst-validation-input {
+            @apply yst-relative;
+        }
+
+        .yst-validation-input--success {
+            .yst-validation-input__input {
+                @apply
+                yst-pr-10
+                yst-border-green-300
+                focus:yst-ring-green-500
+                focus:yst-border-green-500
+                focus-within:yst-ring-green-500
+                focus-within:yst-border-green-500;
+            }
+        }
+        .yst-validation-input--info {
+            .yst-validation-input__input {
+                @apply
+                yst-pr-10
+                yst-border-blue-300
+                focus:yst-ring-blue-500
+                focus:yst-border-blue-500
+                focus-within:yst-ring-blue-500
+                focus-within:yst-border-blue-500;
+            }
+        }
+        .yst-validation-input--warning {
+            .yst-validation-input__input {
+                @apply
+                yst-pr-10
+                yst-border-amber-300
+                focus:yst-ring-amber-500
+                focus:yst-border-amber-500
+                focus-within:yst-ring-amber-500
+                focus-within:yst-border-amber-500;
+            }
+        }
+        .yst-validation-input--error {
+            .yst-validation-input__input {
+                @apply
+                yst-pr-10
+                yst-border-red-300
+                focus:yst-ring-red-500
+                focus:yst-border-red-500
+                focus-within:yst-ring-red-500
+                focus-within:yst-border-red-500;
+            }
+        }
+
+        .yst-validation-input__input {}
+
+        .yst-validation-input__icon {
+            @apply yst-absolute yst-top-[0.6875rem] yst-right-2.5 yst-w-5 yst-h-5;
+        }
+
         /* Validation message */
         .yst-validation-message {
-
             a {
 				@apply yst-font-medium yst-text-inherit hover:visited:yst-text-inherit;
 			}
         }
 
         .yst-validation-message--success {
-            @apply yst-bg-green-100 yst-text-green-800;
+            @apply yst-text-green-800;
         }
         .yst-validation-message--info {
-            @apply yst-bg-blue-100 yst-text-blue-800;
+            @apply yst-text-blue-800;
         }
         .yst-validation-message--warning {
-            @apply yst-bg-amber-100 yst-text-amber-800;
+            @apply yst-text-amber-800;
         }
         .yst-validation-message--error {
-            @apply yst-bg-red-100 yst-text-red-800;
+            @apply yst-text-red-800;
         }
     }
 }

--- a/packages/ui-library/src/elements/validation/validation-icon.js
+++ b/packages/ui-library/src/elements/validation/validation-icon.js
@@ -16,6 +16,8 @@ const CLASSNAME_MAP = {
 
 /**
  * @param {string} variant The variant to render.
+ * @param {string} className The classname.
+ * @param {Object} [props] Any extra props.
  * @returns {JSX.Element} The ValidationIcon component.
  */
 const ValidationIcon = ( {

--- a/packages/ui-library/src/elements/validation/validation-icon.js
+++ b/packages/ui-library/src/elements/validation/validation-icon.js
@@ -1,0 +1,45 @@
+import PropTypes from "prop-types";
+import { keys } from "lodash";
+import { CheckCircleIcon, ExclamationIcon, InformationCircleIcon, ExclamationCircleIcon } from "@heroicons/react/solid";
+import classNames from "classnames";
+import { useSvgAria } from "../../hooks";
+
+const CLASSNAME_MAP = {
+	variant: {
+		success: "yst-validation-icon--success",
+		warning: "yst-validation-icon--warning",
+		info: "yst-validation-icon--info",
+		error: "yst-validation-icon--error",
+	},
+};
+
+const ICON_MAP = {
+	success: CheckCircleIcon,
+	warning: ExclamationIcon,
+	info: InformationCircleIcon,
+	error: ExclamationCircleIcon,
+};
+
+/**
+ * @param {string} variant The variant to render.
+ * @returns {JSX.Element} The ValidationIcon component.
+ */
+const ValidationIcon = ( {
+	variant = "info",
+	className = "",
+	...props
+} ) => {
+	const Component = ICON_MAP[ variant ];
+	const svgAriaProps = useSvgAria();
+
+	return Component ? (
+		<Component { ...svgAriaProps } { ...props } className={ classNames( "yst-validation-icon", CLASSNAME_MAP.variant[ variant ], className ) } />
+	) : null;
+};
+
+ValidationIcon.propTypes = {
+	variant: PropTypes.oneOf( keys( ICON_MAP ) ),
+	className: PropTypes.string,
+};
+
+export default ValidationIcon;

--- a/packages/ui-library/src/elements/validation/validation-icon.js
+++ b/packages/ui-library/src/elements/validation/validation-icon.js
@@ -1,8 +1,8 @@
 import PropTypes from "prop-types";
-import { keys } from "lodash";
-import { CheckCircleIcon, ExclamationIcon, InformationCircleIcon, ExclamationCircleIcon } from "@heroicons/react/solid";
+import { values } from "lodash";
 import classNames from "classnames";
 import { useSvgAria } from "../../hooks";
+import { VALIDATION_VARIANTS, VALIDATION_ICON_MAP } from "./constants";
 
 const CLASSNAME_MAP = {
 	variant: {
@@ -11,13 +11,6 @@ const CLASSNAME_MAP = {
 		info: "yst-validation-icon--info",
 		error: "yst-validation-icon--error",
 	},
-};
-
-const ICON_MAP = {
-	success: CheckCircleIcon,
-	warning: ExclamationIcon,
-	info: InformationCircleIcon,
-	error: ExclamationCircleIcon,
 };
 
 /**
@@ -29,7 +22,7 @@ const ValidationIcon = ( {
 	className = "",
 	...props
 } ) => {
-	const Component = ICON_MAP[ variant ];
+	const Component = VALIDATION_ICON_MAP[ variant ];
 	const svgAriaProps = useSvgAria();
 
 	return Component ? (
@@ -38,7 +31,7 @@ const ValidationIcon = ( {
 };
 
 ValidationIcon.propTypes = {
-	variant: PropTypes.oneOf( keys( ICON_MAP ) ),
+	variant: PropTypes.oneOf( values( VALIDATION_VARIANTS ) ),
 	className: PropTypes.string,
 };
 

--- a/packages/ui-library/src/elements/validation/validation-icon.js
+++ b/packages/ui-library/src/elements/validation/validation-icon.js
@@ -1,3 +1,4 @@
+import { useMemo } from "@wordpress/element";
 import PropTypes from "prop-types";
 import { values } from "lodash";
 import classNames from "classnames";
@@ -22,7 +23,7 @@ const ValidationIcon = ( {
 	className = "",
 	...props
 } ) => {
-	const Component = VALIDATION_ICON_MAP[ variant ];
+	const Component = useMemo( () => VALIDATION_ICON_MAP[ variant ], [ variant ] );
 	const svgAriaProps = useSvgAria();
 
 	return Component ? (

--- a/packages/ui-library/src/elements/validation/validation-input.js
+++ b/packages/ui-library/src/elements/validation/validation-input.js
@@ -14,6 +14,8 @@ const CLASSNAME_MAP = {
 
 /**
  * @param {string} variant The variant to render.
+ * @param {Object} [validation] The validation state.
+ * @param {string} [className] The classname.
  * @returns {JSX.Element} The ValidationInput component.
  */
 const ValidationInput = forwardRef( ( {

--- a/packages/ui-library/src/elements/validation/validation-input.js
+++ b/packages/ui-library/src/elements/validation/validation-input.js
@@ -2,7 +2,6 @@ import { forwardRef } from "@wordpress/element";
 import PropTypes from "prop-types";
 import classNames from "classnames";
 import ValidationIcon from "./validation-icon";
-import { validationPropType } from ".";
 
 const CLASSNAME_MAP = {
 	variant: {
@@ -39,7 +38,10 @@ const ValidationInput = forwardRef( ( {
 
 ValidationInput.propTypes = {
 	as: PropTypes.elementType.isRequired,
-	validation: validationPropType,
+	validation: PropTypes.shape( {
+		variant: PropTypes.string,
+		message: PropTypes.node,
+	} ),
 	className: PropTypes.string,
 };
 

--- a/packages/ui-library/src/elements/validation/validation-input.js
+++ b/packages/ui-library/src/elements/validation/validation-input.js
@@ -1,0 +1,46 @@
+import { forwardRef } from "@wordpress/element";
+import PropTypes from "prop-types";
+import classNames from "classnames";
+import ValidationIcon from "./validation-icon";
+import { validationPropType } from ".";
+
+const CLASSNAME_MAP = {
+	variant: {
+		success: "yst-validation-input--success",
+		warning: "yst-validation-input--warning",
+		info: "yst-validation-input--info",
+		error: "yst-validation-input--error",
+	},
+};
+
+/**
+ * @param {string} variant The variant to render.
+ * @returns {JSX.Element} The ValidationInput component.
+ */
+const ValidationInput = forwardRef( ( {
+	as: Component,
+	validation = {},
+	className = "",
+	...props
+}, ref ) => {
+	return (
+		<div className={ classNames( "yst-validation-input", validation?.message && CLASSNAME_MAP.variant[ validation?.variant ] ) }>
+			<Component
+				ref={ ref }
+				{ ...props }
+				className={ classNames( "yst-validation-input__input", className ) }
+			/>
+			{ validation?.message && (
+				<ValidationIcon variant={ validation?.variant } className="yst-validation-input__icon" />
+			) }
+		</div>
+	);
+} );
+
+ValidationInput.propTypes = {
+	as: PropTypes.elementType.isRequired,
+	validation: validationPropType,
+	className: PropTypes.string,
+};
+
+export default ValidationInput;

--- a/packages/ui-library/src/elements/validation/validation-message.js
+++ b/packages/ui-library/src/elements/validation/validation-message.js
@@ -12,9 +12,9 @@ const CLASSNAME_MAP = {
 };
 
 /**
- * @param {string|functione} [as="p"] The component to render as.
+ * @param {string|function} [as="p"] The component to render as.
  * @param {string} [variant="info"] The variant.
- * @param {JSX.node} [message=""] The validation message.
+ * @param {JSX.node} [children=""] The validation message.
  * @param {string} [className=""] The class name.
  * @returns {JSX.Element} The ValidationMessage component.
  */

--- a/packages/ui-library/src/elements/validation/validation-message.js
+++ b/packages/ui-library/src/elements/validation/validation-message.js
@@ -1,0 +1,41 @@
+import PropTypes from "prop-types";
+import { keys } from "lodash";
+import classNames from "classnames";
+
+const CLASSNAME_MAP = {
+	variant: {
+		success: "yst-validation-message--success",
+		warning: "yst-validation-message--warning",
+		info: "yst-validation-message--info",
+		error: "yst-validation-message--error",
+	},
+};
+
+/**
+ * @param {string|functione} [as="p"] The component to render as.
+ * @param {string} [variant="info"] The variant.
+ * @param {JSX.node} [message=""] The validation message.
+ * @param {string} [className=""] The class name.
+ * @returns {JSX.Element} The ValidationMessage component.
+ */
+const ValidationMessage = ( {
+	as: Component = "p",
+	variant = "info",
+	children,
+	className = "",
+	...props
+} ) =>  (
+	<Component { ...props } className={ classNames( "yst-validation-message", CLASSNAME_MAP.variant[ variant ], className ) }>
+		{ children }
+	</Component>
+);
+
+ValidationMessage.propTypes = {
+	as: PropTypes.elementType,
+	variant: PropTypes.oneOf( keys( CLASSNAME_MAP.variant ) ),
+	message: PropTypes.node,
+	className: PropTypes.string,
+	children: PropTypes.node.isRequired,
+};
+
+export default ValidationMessage;

--- a/packages/ui-library/src/index.js
+++ b/packages/ui-library/src/index.js
@@ -17,6 +17,7 @@ export { default as TextInput } from "./elements/text-input";
 export { default as Textarea } from "./elements/textarea";
 export { default as Title } from "./elements/title";
 export { default as Toggle } from "./elements/toggle";
+export { ValidationIcon, ValidationInput, ValidationMessage } from "./elements/validation";
 
 export { default as AutocompleteField } from "./components/autocomplete-field";
 export { default as Card } from "./components/card";


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Replace `error` API with more flexible `validation` API in all field type components.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Replace `error` API with more flexible `validation` API in all field type components.

## Relevant technical choices:

* Added some components for managing validation. Also touched `Alert`, `Notifications` and `File Import` because of this.
* Renamed Storybook to `Yoast UI library`
* Added validation stories to all field level components. This adds some duplications, but adding some general Storybook helpers seemed too scope increasing for now.
* Updated the `withFormikError` hoc in new settings UI to adhere to the new `validation` API.
* `Select`/`SelectField` and `Autocomplete`/`AutocompleteField` components have a slightly different implementation because of third-party components usage.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Start Storybook with `yarn storybook`
* Verify that all `Field` components have `Validation` stories and you see no console errors (except the already existing: `The pseudo class ":first-child"`).
* Verify that the `Select` and `Autocomplete` elements have `Validation` stories and you see no console errors.
* Verify that in the new settings UI, validation is still correctly rendered. Check by adding faulty values to ie. `Site connections -> Yandex` or `Site representation -> Facebook URL`. You could also trigger validation by uploading a non-image file to a image upload.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* No impact outside of new settings UI.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
