### PR TITLE
Block editor: DUPP-850 fix error with gutenberg trunk

### DIFF
--- a/packages/js/src/initializers/block-editor-integration.js
+++ b/packages/js/src/initializers/block-editor-integration.js
@@ -43,6 +43,10 @@ import Root from "../components/contexts/root";
  */
 function registerFormats() {
 	if ( typeof get( window, "wp.blockEditor.__experimentalLinkControl" ) === "function" ) {
+		const unknownSettings = select( "core/rich-text" )
+			.getFormatType( "core/unknown" );
+
+		dispatch( "core/rich-text" ).removeFormatTypes( "core/unknown" );
 		[
 			link,
 		].forEach( ( { name, replaces, ...settings } ) => {
@@ -53,6 +57,7 @@ function registerFormats() {
 				registerFormatType( name, settings );
 			}
 		} );
+		registerFormatType( "core/unknown", unknownSettings );
 	} else {
 		console.warn(
 			__( "Marking links with nofollow/sponsored has been disabled for WordPress installs < 5.4.", "wordpress-seo" ) +

--- a/packages/js/src/initializers/block-editor-integration.js
+++ b/packages/js/src/initializers/block-editor-integration.js
@@ -46,7 +46,10 @@ function registerFormats() {
 		const unknownSettings = select( "core/rich-text" )
 			.getFormatType( "core/unknown" );
 
-		dispatch( "core/rich-text" ).removeFormatTypes( "core/unknown" );
+		if ( typeof( unknownSettings ) !== "undefined" ) {
+			dispatch( "core/rich-text" ).removeFormatTypes( "core/unknown" );
+		}
+
 		[
 			link,
 		].forEach( ( { name, replaces, ...settings } ) => {
@@ -57,7 +60,10 @@ function registerFormats() {
 				registerFormatType( name, settings );
 			}
 		} );
-		registerFormatType( "core/unknown", unknownSettings );
+
+		if ( typeof( unknownSettings ) !== "undefined" ) {
+			registerFormatType( "core/unknown", unknownSettings );
+		}
 	} else {
 		console.warn(
 			__( "Marking links with nofollow/sponsored has been disabled for WordPress installs < 5.4.", "wordpress-seo" ) +


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The next release of Gutenberg block editor will introduce a functionality to let users remove any unknown formatting tag to a rich-text snippent. It does so by adding a new `core/unknown` default formatting style which would break the `Link` functionality in the visual editor, making impossible for users to insert links through the GUI. 
We want to avoid this by updating in advance our code.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Avoids a future incompatibility with Gutenberg rich-formatting `core/unknown` formatting style.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Build Gutenberg trunk as plugin and activate it
* Open a post in the block editor
* Without this PR:
  * The `Link` functionality is missing when editing a text:
 <img width="428" alt="Screenshot 2022-12-13 at 12 35 01" src="https://user-images.githubusercontent.com/68744851/207307648-652ba897-d456-4fe2-ab2c-682f718cf5f0.png">

  * If you try to manually add a link by editing the block in HTML, the link is identified as `unknown formatting` style:
<img width="510" alt="Screenshot 2022-12-13 at 12 37 55" src="https://user-images.githubusercontent.com/68744851/207308099-8ed5d4e6-f13a-4292-b2cb-744d62d1efa3.png">

  * In the browser's console an error appears as follows:

`Format "core/unknown" is already registered to handle bare tag name "a". register-format-type.js:86:18`
* With this PR:
  * No console error is present
  * The `Yoast SEO` link functionality is present and  works as expected
<img width="527" alt="Screenshot 2022-12-13 at 12 51 18" src="https://user-images.githubusercontent.com/68744851/207310674-3e2ef192-52ba-4141-9ea9-48aad46382ed.png">

---
**Verify the correct behavior of the link functionality**
* Open a post in the block editor
* Click on a text paragraph and verify the `Link` functionality has the following appearance:

<img width="391" alt="Screenshot 2022-12-13 at 12 54 08" src="https://user-images.githubusercontent.com/68744851/207311317-fe543197-24e5-49d5-8f04-2764d67c567e.png">
instead of the default one:
<img width="421" alt="Screenshot 2022-12-13 at 12 54 45" src="https://user-images.githubusercontent.com/68744851/207311402-471ebcdb-5888-4995-a1e6-9e3191d35122.png">

* Now select a portion of text, click on the `Link` icon and:
  *  Specify a URL
  * Activate `Open in new tab` and `Search engine should ignore this link`  radio buttons
* Update the post
* Click on the paragraph containing the link you just created, click `Options` (three vertical dots) -> `Edit as HTML`
* Verify the link you have created contains  the following properties:`target="_blank" rel="noreferrer noopener nofollow"`
* Click on the link and verify that clicking on the `Unlink` button the link is removed
<img width="157" alt="Screenshot 2022-12-13 at 13 47 51" src="https://user-images.githubusercontent.com/68744851/207322486-cbfc4dea-29fa-4ae8-bbfb-d5cb919bda19.png">

---
**Verify that `clear unknown formatting` functionality is preserved**
* Open a post in the block editor
* Click on a text paragraph
* Click `Options` (three vertical dots) -> `Edit as HTML`
* Enclose a portion of text in a `<cite><\cite>` pair
<img width="686" alt="Screenshot 2022-12-13 at 13 50 58" src="https://user-images.githubusercontent.com/68744851/207323446-5f6876c9-dd46-4a5c-ad37-c546dc6ee9fd.png">

* Click `Edit Visually`
* Click on the portion of text modified and verify:
  * A new button `Clear Unknown Formatting` appears in the commands palette
  * Upon clicking it, the `cite` tags are removed from the text

---
**Verify compatibility with older Guntenberg versions**
* Disable the Gutenberg plugin built from trunk
* Open a post in the block editor
* Click on a text paragraph
* Click `Options` (three vertical dots) -> `Edit as HTML`
* Enclose a portion of text in a `<cite><\cite>` pair
* Click `Edit Visually`
* Click on the portion of text modified and verify:
  * No  `Clear Unknown Formatting` functionality is available
  * Yoast SEO `Link` functionality is present and works as expected

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [X] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->
* Test with console open to see the original error is not present anymore and we don't trigger additional messages
* Test with posts and pages as the block editor is present there

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* This PR changes the way we register our `core/link` rich-text format which is responsible of rendering the `link` functionality in the block editor.
Apart from checking simple links behavior as instructed in this PR, please perform a regression testing on data blocks, and specifically:
  * `Yoast Related Links`
    * Verify that links are created correctly and can be modified 
  * `Yoast Breadcrumbs`
    * Verify that links are created correctly
  * `Yoast FAQ` and `Yoast How-to`:
    * Verify you can add and modify links
* Please also check that you are still able to add links to a post in the block editor by:
  * Copy/pasting a URL directly inside a post (embedding)
  *  By typing `[[`
  * In any other way you can think about
* Please also verify this PR doesn't break any functionality in block editor for WordPress 5.9 and 6.1
## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes [https://yoast.atlassian.net/DUPP-850](DUPP-850)
