### PR TITLE
Defensive coding to fix some errors when using SQLite

### DIFF
--- a/lib/orm.php
+++ b/lib/orm.php
@@ -1967,6 +1967,9 @@ class ORM implements \ArrayAccess {
 		}
 
 		$rows = [];
+		if ( ! \is_array( $wpdb->last_result ) ) {
+			return $rows;
+		}
 		foreach ( $wpdb->last_result as $row ) {
 			$rows[] = \get_object_vars( $row );
 		}

--- a/src/actions/indexing/post-link-indexing-action.php
+++ b/src/actions/indexing/post-link-indexing-action.php
@@ -55,6 +55,10 @@ class Post_Link_Indexing_Action extends Abstract_Link_Indexing_Action {
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Function get_select_query returns a prepared query.
 		$posts = $this->wpdb->get_results( $query );
 
+		if ( empty( $posts ) ) {
+			return [];
+		}
+
 		return \array_map(
 			static function ( $post ) {
 				return (object) [


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->
In a few days, the next release of the Performance Lab plugin will be released. This version will include an SQLite implementation which is a proposal for WP-Core (at some point in the distant future).

When testing this implementation with the Yoast SEO plugin, I was getting some PHP warnings in my log:
```
PHP Warning:  array_map(): Expected parameter 2 to be an array, null given in wordpress-seo/src/actions/indexing/post-link-indexing-action.php on line 66
PHP Warning:  Invalid argument supplied for foreach() in wordpress-seo/src/actions/indexing/abstract-link-indexing-action.php on line 62
PHP Warning:  Invalid argument supplied for foreach() in wordpress-seo/lib/orm.php on line 1970
```

## Summary

This PR adds some defensive coding to avoid errors in case a query returns `null` or is empty.

This PR can be summarized in the following changelog entry:

* Proactively add checks to avoid warnings when a database query returns invalid results.

## Relevant technical choices:

* Added a couple of simple PHP checks, to ensure that variables are actually arrays before running functions like `array_map` or `foreach` loops.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install and activate the Performance Lab plugin. If v1.8.0 is not officially released yet, then this can be tested using the GitHub version from https://github.com/WordPress/performance
* Go to the plugin's settings and activate the SQLite module
* Once SQLite is active, the site is using an SQLite db. Activate the Yoast plugin, and ensure there are no errors/warnings triggered from the plugin in the PHP error log.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
