### PR TITLE
Add location context to synonyms upsell.

### DIFF
--- a/packages/js/src/components/contentAnalysis/SeoAnalysis.js
+++ b/packages/js/src/components/contentAnalysis/SeoAnalysis.js
@@ -36,10 +36,11 @@ class SeoAnalysis extends Component {
 	 * Renders the keyword synonyms upsell modal.
 	 *
 	 * @param {string} location The location of the upsell component. Used to determine the shortlinks in the component.
+	 * @param {string} locationContext In which editor this component is rendered.
 	 *
 	 * @returns {wp.Element} A modalButtonContainer component with the modal for a keyword synonyms upsell.
 	 */
-	renderSynonymsUpsell( location ) {
+	renderSynonymsUpsell( location, locationContext ) {
 		const modalProps = {
 			classes: {
 				openButton: "wpseo-keyword-synonyms button-link",
@@ -67,6 +68,8 @@ class SeoAnalysis extends Component {
 			link = wpseoAdminL10n[ "shortlinks.upsell.sidebar.focus_keyword_synonyms_link" ];
 			buyLink = wpseoAdminL10n[ "shortlinks.upsell.sidebar.focus_keyword_synonyms_button" ];
 		}
+		link = addQueryArgs( link, { context: locationContext } );
+		buyLink = addQueryArgs( buyLink, { context: locationContext } );
 
 		return (
 			<Modal { ...modalProps }>
@@ -265,7 +268,7 @@ class SeoAnalysis extends Component {
 										>
 											<SynonymSlot location={ location } />
 											{ this.props.shouldUpsell && <Fragment>
-												{ this.renderSynonymsUpsell( location ) }
+												{ this.renderSynonymsUpsell( location, locationContext ) }
 												{ this.renderMultipleKeywordsUpsell( location ) }
 											</Fragment> }
 											{ this.props.shouldUpsellWordFormRecognition && this.renderWordFormsUpsell( location, locationContext ) }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We missed one upsell link where want to add a context variable to the url.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a not released bug where the context get parameter was not added to two upsell links.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Disable premium and build this RC/pr for free.
* Make sure every upsell link still works and ends up on: https://yoast.com/reasons-to-upgrade-keywords

* Open a post in the Gutenberg editor. 
* In the metabox open the `SEO analysis` tab and click on the `+ Add synonyms` button. In the modal make sure the `Yoast SEO Premium` link and the buy button both have a context parameter that is `block-metabox`.
* Do the same for the sidebar and make sure the context parameter is `block-sidebar`.

*Open a post in the classic editor.
* In the metabox open the `SEO analysis` tab and click on the `+ Add synonyms` button. In the modal make sure the `Yoast SEO Premium` link and the but button both have a context parameter that is `classic-metabox`.

* Open a post in Elementor.
* In the sidebar open the `SEO analysis` tab and click on the `+ Add synonyms` button. In the modal make sure the `Yoast SEO Premium` link and the but button both have a context parameter that is `elementor-sidebar`.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [X] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
