### PR TITLE
Punctuation centralization

### DIFF
--- a/packages/yoastseo/spec/languageProcessing/helpers/match/matchTextWithArraySpec.js
+++ b/packages/yoastseo/spec/languageProcessing/helpers/match/matchTextWithArraySpec.js
@@ -1,6 +1,7 @@
 import arrayMatch from "../../../../src/languageProcessing/helpers/match/matchTextWithArray.js";
 import matchWordCustomHelper from "../../../../src/languageProcessing/languages/ja/helpers/matchTextWithWord";
 
+
 describe( "a test matching strings in an array", function() {
 	it( "returns the matches in the array", function() {
 		expect( arrayMatch( "this is a test with words.", [ "test", "string", "words" ] ) ).toEqual(

--- a/packages/yoastseo/spec/languageProcessing/helpers/match/matchTextWithWordSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/helpers/match/matchTextWithWordSpec.js
@@ -166,9 +166,13 @@ describe( "Counts the occurences of a word in a string", function() {
 		expect( wordMatch( "(keyword)", "keyword", "es_ES" ).count ).toBe( 1 );
 		expect( wordMatch( "(keyword)", "keyword", "es_ES" ).matches ).toEqual( [ "keyword" ] );
 
-		expect( wordMatch( "-keyword", "keyword", "es_ES" ).count ).toBe( 1 );
-		expect( wordMatch( "keyword-", "keyword", "es_ES" ).count ).toBe( 1 );
-		expect( wordMatch( "-keyword-", "keyword", "es_ES" ).count ).toBe( 1 );
+		expect( wordMatch( "『keyword", "keyword", "es_ES" ).count ).toBe( 1 );
+		expect( wordMatch( "keyword』", "keyword", "es_ES" ).count ).toBe( 1 );
+		expect( wordMatch( "『keyword』", "keyword", "es_ES" ).count ).toBe( 1 );
+
+		// expect( wordMatch( "-keyword", "keyword", "es_ES" ).count ).toBe( 0 );
+		// expect( wordMatch( "keyword-", "keyword", "es_ES" ).count ).toBe( 0 );
+		// expect( wordMatch( "-keyword-", "keyword", "es_ES" ).count ).toBe( 0 );
 	} );
 
 	it( "should not match words preceded/followed by a - in Indonesian", function() {

--- a/packages/yoastseo/spec/languageProcessing/helpers/word/addWordBoundarySpec.js
+++ b/packages/yoastseo/spec/languageProcessing/helpers/word/addWordBoundarySpec.js
@@ -1,42 +1,43 @@
 import addWordBoundary from "../../../../src/languageProcessing/helpers/word/addWordboundary";
+import { wordBoundariesStringForRegex } from "../../../../src/config/punctuation";
 
 describe( "a test adding word boundaries to a string", function() {
-	const wordBoundary = " \\u00a0\\u2014\\u06d4\\u061f\\u060C\\u061B\\n\\r\\t.,()”“〝〞〟‟„\"+\\-;!¡?¿:/»«‹›";
-
+	// const wordBoundary = "(^|[\\ \\\\    \\\\ \\\"\\»\\«\\”\\“\\〝\\〞\\〟\\‟\\„\\『\\』\\‘\\’\\‛\\`\\.\\,\\(\\)\\+\\;\\!\\?\\:\\/\\<\\>\\¡\\¿\\—\\۔\\؟\\،\\؛\\ '‘’‛`])keyword($|([\\ \\\\    \\\\ \\\"\\»\\«\\”\\“\\〝\\〞\\〟\\‟\\„\\『\\』\\‘\\’\\‛\\`\\.\\,\\(\\)\\+\\;\\!\\?\\:\\/\\<\\>\\¡\\¿\\—\\۔\\؟\\،\\؛\\ ])|((['‘’‛`])([\\ \\\\    \\\\ \\\"\\»\\«\\”\\“\\〝\\〞\\〟\\‟\\„\\『\\』\\‘\\’\\‛\\`\\.\\,\\(\\)\\+\\;\\!\\?\\:\\/\\<\\>\\¡\\¿\\—\\۔\\؟\\،\\؛\\
+	const wordBoundary = wordBoundariesStringForRegex;
 	it( "adds start and end boundaries", function() {
 		expect( addWordBoundary( "keyword" ) ).toEqual(
-			"(^|[" + wordBoundary + "<>'‘’‛`])" +
-			"keyword($|([" + wordBoundary + "<>])|((['‘’‛`])" +
-			"([" + wordBoundary + "<>])))"
+			"(^|[" + wordBoundary + "'‘’‛`])" +
+			"keyword($|([" + wordBoundary + "])|((['‘’‛`])" +
+			"([" + wordBoundary + "])))"
 		);
 	} );
 	it( "adds start and end boundaries and an extra boundary", function() {
 		expect( addWordBoundary( "keyword", false, "#" ) ).toEqual(
-			"(^|[" + wordBoundary + "#<>'‘’‛`])" +
-			"keyword($|([" + wordBoundary + "#<>])|((['‘’‛`])" +
-			"([" + wordBoundary + "#<>])))"
+			"(^|[" + wordBoundary + "#'‘’‛`])" +
+			"keyword($|([" + wordBoundary + "#])|((['‘’‛`])" +
+			"([" + wordBoundary + "#])))"
 		);
 	} );
 	it( "adds start boundaries, and end boundaries with positive lookahead", function() {
 		expect( addWordBoundary( "keyword", true, "" ) ).toEqual(
-			"(^|[" + wordBoundary + "<>'‘’‛`])" +
-			"keyword($|((?=[" + wordBoundary + "<>]))|((['‘’‛`])" +
-			"([" + wordBoundary + "<>])))"
+			"(^|[" + wordBoundary + "'‘’‛`])" +
+			"keyword($|((?=[" + wordBoundary + "]))|((['‘’‛`])" +
+			"([" + wordBoundary + "])))"
 		);
 	} );
 	it( "adds start boundaries with an extra boundary, and end boundaries with positive lookahead and an extra boundary", function() {
 		expect( addWordBoundary( "keyword", true, "#" ) ).toEqual(
-			"(^|[" + wordBoundary + "#<>'‘’‛`])" +
-			"keyword($|((?=[" + wordBoundary + "#<>]))|((['‘’‛`])" +
-			"([" + wordBoundary + "#<>])))"
+			"(^|[" + wordBoundary + "#'‘’‛`])" +
+			"keyword($|((?=[" + wordBoundary + "#]))|((['‘’‛`])" +
+			"([" + wordBoundary + "#])))"
 		);
 	} );
 	it( "uses a word boundary excluding - when the locale is Indonesian", function() {
-		const idWordBoundary = " \\u00a0\\n\\r\\t.,()”“〝〞〟‟„\"+;!¡?¿:/»«‹›";
+		const idWordBoundary = wordBoundariesStringForRegex;
 		expect( addWordBoundary( "keyword", false, "", "id_ID" ) ).toEqual(
-			"(^|[" + idWordBoundary + "<>'‘’‛`])" +
-			"keyword($|([" + idWordBoundary + "<>])|((['‘’‛`])" +
-			"([" + idWordBoundary + "<>])))"
+			"(^|[" + idWordBoundary + "'‘’‛`])" +
+			"keyword($|([" + idWordBoundary + "])|((['‘’‛`])" +
+			"([" + idWordBoundary + "])))"
 		);
 	} );
 } );

--- a/packages/yoastseo/spec/languageProcessing/researches/getKeywordDensitySpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/getKeywordDensitySpec.js
@@ -46,7 +46,7 @@ describe( "Test for counting the keyword density in a text", function() {
 		expect( getKeywordDensity( mockPaper, new EnglishResearcher( mockPaper ) ) ).toBe( 7.6923076923076925 );
 		mockPaper = new Paper( "a string of text with the key_word in it, density should be 0.0%", { keyword: "key word" } );
 		expect( getKeywordDensity( mockPaper, new EnglishResearcher( mockPaper ) ) ).toBe( 0 );
-		mockPaper = new Paper( "a string of text with the key-word in it, density should be 7.7%", { keyword: "key word" } );
+		mockPaper = new Paper( "a string of text with the key>word in it, density should be 7.7%", { keyword: "key word" } );
 		// This behavior might change in the future.
 		expect( getKeywordDensity( mockPaper, new EnglishResearcher( mockPaper ) ) ).toBe( 7.6923076923076925 );
 		mockPaper = new Paper( "a string of text with the key&word in it, density should be 7.7%", { keyword: "key&word" } );

--- a/packages/yoastseo/src/config/punctuation.js
+++ b/packages/yoastseo/src/config/punctuation.js
@@ -1,0 +1,36 @@
+
+// "\u00a0" = NBSP
+// Whitespace is always a word boundary.
+const whitespaces = [ " ", "\\n", "\\r", "\\t", "\u00a0" ];
+
+export const doubleQuotes = [ "\"", "»", "«", "”", "“", "〝", "〞", "〟", "‟", "„", "『", "』" ];
+
+// ‘’‛`‹›
+export const singleQuotes = [ "‘",  "’", "‛", "`", "‹", "›", "'" ];
+export const singleQuotesForRegex = singleQuotes.map( ( boundary ) => "\\" + boundary ).join( "" );
+
+const genericPunctuation = [ ".", ",", "(", ")", "+", ";", "!", "?", ":", "/", "<", ">", "¡", "¿", "\\",
+//   \u2014 - em dash
+	"\u2014" ];
+
+const hyphen = [ "-" ];
+
+
+const misc = [
+
+	// \u06d4 - Urdu full stop
+	"\u06d4",
+	// \u061f - Arabic question mark
+	"\u061f",
+	// \u060C - Arabic comma
+	"\u060C",
+	// \u061B - Arabic semicolon
+	"\u061B",
+	" " ];
+
+const quotes = [].concat( doubleQuotes, singleQuotes );
+
+export const wordBoundaries = [].concat( whitespaces, quotes, genericPunctuation, misc );
+export const wordBoundariesStringForRegex = wordBoundaries.map( ( boundary ) => "\\" + boundary ).join( "" );
+
+//\\u00a0\\u2014\\u06d4\\u061f\\u060C\\u061B\\n\\r\\t\.,\(\)”“〝〞〟‟„\"\+\\-;!¡\?¿:\/»«‹›<>

--- a/packages/yoastseo/src/config/punctuation.js
+++ b/packages/yoastseo/src/config/punctuation.js
@@ -1,15 +1,16 @@
 
 // "\u00a0" = NBSP
 // Whitespace is always a word boundary.
-const whitespaces = [ " ", "\\n", "\\r", "\\t", "\u00a0" ];
+const whitespaces = [ " ", "\n", "\r", "\t", "\u00a0" ];
 
 export const doubleQuotes = [ "\"", "»", "«", "”", "“", "〝", "〞", "〟", "‟", "„", "『", "』" ];
+export const doubleQuotesForRegex = doubleQuotes.map( ( boundary ) => "\\" + boundary ).join( "" )
 
 // ‘’‛`‹›
-export const singleQuotes = [ "‘",  "’", "‛", "`", "‹", "›", "'" ];
+export const singleQuotes = [ "‘",  "’", "‛", "`" ]; //, "'" "‹", "›"
 export const singleQuotesForRegex = singleQuotes.map( ( boundary ) => "\\" + boundary ).join( "" );
 
-const genericPunctuation = [ ".", ",", "(", ")", "+", ";", "!", "?", ":", "/", "<", ">", "¡", "¿", "\\",
+const genericPunctuation = [ ".", ",", "(", ")", "+", ";", "!", "?", ":", "/", "<", ">", "¡", "¿",
 //   \u2014 - em dash
 	"\u2014" ];
 

--- a/packages/yoastseo/src/languageProcessing/helpers/sanitize/quotes.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/sanitize/quotes.js
@@ -1,5 +1,4 @@
-import { doubleQuotes } from "../../../config/punctuation";
-
+import { singleQuotesForRegex, doubleQuotesForRegex } from "../../../config/punctuation";
 /**
  * Normalizes single quotes to 'regular' quotes.
  *
@@ -8,6 +7,7 @@ import { doubleQuotes } from "../../../config/punctuation";
  */
 function normalizeSingleQuotes( text ) {
 	return text.replace( /[‘’‛`‹›]/g, "'" );
+	// return text.replace( new RegExp( `[${singleQuotesForRegex}]`, "g" ), "'" );
 }
 
 /**
@@ -18,6 +18,7 @@ function normalizeSingleQuotes( text ) {
  */
 function normalizeDoubleQuotes( text ) {
 	return text.replace( /[“”〝〞〟‟„『』«»]/g, "\"" );
+	// return text.replace( new RegExp( `[${doubleQuotesForRegex}]`, "g" ), "\"" );
 }
 
 /**

--- a/packages/yoastseo/src/languageProcessing/helpers/sanitize/quotes.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/sanitize/quotes.js
@@ -1,3 +1,5 @@
+import { doubleQuotes } from "../../../config/punctuation";
+
 /**
  * Normalizes single quotes to 'regular' quotes.
  *

--- a/packages/yoastseo/src/languageProcessing/helpers/word/addWordboundary.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/word/addWordboundary.js
@@ -2,7 +2,6 @@
 /* eslint-disable no-useless-escape */
 
 import { wordBoundariesStringForRegex, singleQuotesForRegex } from "../../../config/punctuation";
-console.log(wordBoundariesStringForRegex)
 
 /**
  * Returns a string that can be used in a regex to match a matchString with word boundaries.
@@ -29,14 +28,14 @@ export default function( matchString, positiveLookAhead = false, extraWordBounda
 		* \u060C - Arabic comma
 		* \u061B - Arabic semicolon
 		*/
-	wordBoundary = `[${wordBoundariesStringForRegex}`;
+	wordBoundary = `[${wordBoundariesStringForRegex}${extraWordBoundary}`;
 	// }
 
-	const wordBoundaryStart = `(^|${wordBoundary}${singleQuotesForRegex}])`;
+	const wordBoundaryStart = `(^|${wordBoundary}'‘’‛\`])`;
 	if ( positiveLookAhead ) {
-		wordBoundaryEnd = `($|((?=${wordBoundary}]))|(([${singleQuotesForRegex}])(${wordBoundary}])))`;
+		wordBoundaryEnd = `($|((?=${wordBoundary}]))|((['‘’‛\`])(${wordBoundary}])))`;
 	} else {
-		wordBoundaryEnd = `($|(${wordBoundary}])|(([${singleQuotesForRegex}])(${wordBoundary}])))`;
+		wordBoundaryEnd = `($|(${wordBoundary}])|((['‘’‛\`])(${wordBoundary}])))`;
 	}
 
 	return wordBoundaryStart + matchString + wordBoundaryEnd;

--- a/packages/yoastseo/src/languageProcessing/helpers/word/addWordboundary.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/word/addWordboundary.js
@@ -1,6 +1,9 @@
 /** @module stringProcessing/addWordboundary */
 /* eslint-disable no-useless-escape */
 
+import { wordBoundariesStringForRegex, singleQuotesForRegex } from "../../../config/punctuation";
+console.log(wordBoundariesStringForRegex)
+
 /**
  * Returns a string that can be used in a regex to match a matchString with word boundaries.
  *
@@ -12,28 +15,28 @@
  *
  * @returns {string} A regex string that matches the matchString with word boundaries.
  */
-export default function( matchString, positiveLookAhead = false, extraWordBoundary = "", locale = "" ) {
+export default function( matchString, positiveLookAhead = false, extraWordBoundary="", locale = "" ) {
 	let wordBoundary, wordBoundaryEnd;
 
-	if ( locale === "id_ID" ) {
-		wordBoundary = "[ \\u00a0\\n\\r\\t\.,\(\)”“〝〞〟‟„\"\+;!¡\?¿:\/»«‹›" + extraWordBoundary + "<>";
-	} else {
-		/*
-		 * \u00a0 - no-break space
-		 * \u2014 - em dash
-         * \u06d4 - Urdu full stop
-         * \u061f - Arabic question mark
-         * \u060C - Arabic comma
-         * \u061B - Arabic semicolon
-         */
-		wordBoundary = "[ \\u00a0\\u2014\\u06d4\\u061f\\u060C\\u061B\\n\\r\\t\.,\(\)”“〝〞〟‟„\"\+\\-;!¡\?¿:\/»«‹›" + extraWordBoundary + "<>";
-	}
+	// if ( locale === "id_ID" ) {
+	// 	wordBoundary = "[ \\u00a0\\n\\r\\t\.,\(\)”“〝〞〟‟„\"\+;!¡\?¿:\/»«‹›" + "<>";
+	// } else {
+	/*
+		* \u00a0 - no-break space
+		* \u2014 - em dash
+		* \u06d4 - Urdu full stop
+		* \u061f - Arabic question mark
+		* \u060C - Arabic comma
+		* \u061B - Arabic semicolon
+		*/
+	wordBoundary = `[${wordBoundariesStringForRegex}`;
+	// }
 
-	const wordBoundaryStart = "(^|" + wordBoundary + "'‘’‛`])";
+	const wordBoundaryStart = `(^|${wordBoundary}${singleQuotesForRegex}])`;
 	if ( positiveLookAhead ) {
-		wordBoundaryEnd = "($|((?=" + wordBoundary + "]))|((['‘’‛`])(" + wordBoundary + "])))";
+		wordBoundaryEnd = `($|((?=${wordBoundary}]))|(([${singleQuotesForRegex}])(${wordBoundary}])))`;
 	} else {
-		wordBoundaryEnd = "($|(" + wordBoundary + "])|((['‘’‛`])(" + wordBoundary + "])))";
+		wordBoundaryEnd = `($|(${wordBoundary}])|(([${singleQuotesForRegex}])(${wordBoundary}])))`;
 	}
 
 	return wordBoundaryStart + matchString + wordBoundaryEnd;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

*

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

*

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
