### PR TITLE
GH Actions: improve performance of the CS step

### DIFF
--- a/config/composer/actions.php
+++ b/config/composer/actions.php
@@ -227,7 +227,7 @@ class Actions {
 		 * The normal report will be shown in the actions output and ensures human readable (and colorized!) results there.
 		 * The checkstyle report is used to show the results inline in the GitHub code view.
 		 */
-		$extra_args = ( \getenv( 'CI' ) === false ) ? '' : ' --colors --report-full --report-checkstyle=./phpcs-report.xml';
+		$extra_args = ( \getenv( 'CI' ) === false ) ? '' : ' --colors --no-cache --report-full --report-checkstyle=./phpcs-report.xml';
 		$command    = \sprintf(
 			'composer check-cs-warnings -- %s %s',
 			\implode( ' ', \array_map( 'escapeshellarg', $php_files ) ),


### PR DESCRIPTION
## Context

* CI maintenance

## Summary

This PR can be summarized in the following changelog entry:

* CI maintenance

## Relevant technical choices:

All the repos in the Yoast organisation contain a `<arg name="cache" value="./.cache/phpcs.cache"/>` directive in the PHPCS ruleset. This directive makes running PHPCS faster by caching the run results in a file and only scanning changed files when running PHPCS again.

However, when there is no cache available, running with the `cache` option enabled will make PHPCS _slower_ as the cache needs to be created and the file read/write actions slow PHPCS down.

In GH Actions, we are not caching the PHPCS `cache` file, which means that there is cache file available and running with `cache` will be slower.

By adding the `--no-cache` option, the `cache` directive in the ruleset is ignored, which should result in a slightly faster runtime for the CS workflow.

Note: the alternative would be to _cache_ the cache file in GH Actions, but aside from the two very frequently changing repos, there's not much point doing that.


## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_