### PR TITLE
Inclusive language - Small typo fixes in feedback strings

### DIFF
--- a/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/cultureAssessmentsSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/cultureAssessmentsSpec.js
@@ -199,7 +199,7 @@ describe( "A test for Culture Assessments", () => {
 		const assessmentResult = assessor.getResult();
 		expect( assessmentResult.getScore() ).toEqual( 3 );
 		expect( assessmentResult.getText() ).toEqual(
-			"Avoid using <i>first-world</i> as it is overgeneralizing. Consider using specific name for the country or region instead.  " +
+			"Avoid using <i>first-world</i> as it is overgeneralizing. Consider using the specific name for the country or region instead.  " +
 			"<a href='https://yoa.st/inclusive-language-culture' target='_blank'>Learn more.</a>"
 		);
 		expect( assessmentResult.hasMarks() ).toBeTruthy();
@@ -207,6 +207,28 @@ describe( "A test for Culture Assessments", () => {
 			fieldsToMark: [],
 			marked: "<yoastmark class='yoast-text-mark'>This sentence contains first-world.</yoastmark>",
 			original: "This sentence contains first-world." } } ]
+		);
+	} );
+	it( "correctly identifies 'first world countries'", () => {
+		const mockPaper = new Paper( "Many first world countries adopted the policy." );
+		const mockResearcher = Factory.buildMockResearcher( [ "first world countries" ] );
+		const assessor = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "firstWorldCountries" ) );
+
+		const isApplicable = assessor.isApplicable( mockPaper, mockResearcher );
+
+		expect( isApplicable ).toBeTruthy();
+		const assessmentResult = assessor.getResult();
+		expect( assessmentResult.getScore() ).toEqual( 3 );
+		expect( assessmentResult.getText() ).toEqual(
+			"Avoid using <i>first world countries</i> as it is overgeneralizing. " +
+			"Consider using the specific name for the countries or regions instead.  " +
+			"<a href='https://yoa.st/inclusive-language-culture' target='_blank'>Learn more.</a>"
+		);
+		expect( assessmentResult.hasMarks() ).toBeTruthy();
+		expect( assessor.getMarks() ).toEqual(   [ { _properties: {
+			fieldsToMark: [],
+			marked: "<yoastmark class='yoast-text-mark'>first world countries</yoastmark>",
+			original: "first world countries" } } ]
 		);
 	} );
 	it( "correctly identifies 'third-world country'", () => {

--- a/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessmentsSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessmentsSpec.js
@@ -389,7 +389,7 @@ describe( "a test for targetting non-inclusive phrases in disability assessments
 		expect( assessment.isApplicable( mockPaper, mockResearcher ) ).toBe( true );
 		expect( assessment.getResult().score ).toBe( 6 );
 		expect( assessment.getResult().text ).toBe( "Be careful when using <i>daft</i> as it is potentially harmful. " +
-			"Consider using an alternative, such as <i>dense, uninformed, ignorant, foolish, inconsiderate, irrational, reckless</i>." +
+			"Consider using an alternative, such as <i>uninformed, ignorant, foolish, inconsiderate, irrational, reckless</i>." +
 			" <a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>" );
 	} );
 	it( "should return the appropriate score and feedback string for: 'imbecile'", () => {

--- a/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/sesAssessmentsSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/sesAssessmentsSpec.js
@@ -185,4 +185,27 @@ describe( "A test for SES assessments", function() {
 			original: "This sentence contains ex-offender." } } ]
 		);
 	} );
+
+	it( "gives the correct feedback for 'the undocumented'", () => {
+		const mockPaper = new Paper( "This sentence contains the undocumented." );
+		const mockResearcher = Factory.buildMockResearcher( [ "This sentence contains the undocumented." ] );
+		const assessor = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "theUndocumented" ) );
+
+		const isApplicable = assessor.isApplicable( mockPaper, mockResearcher );
+
+		expect( isApplicable ).toBeTruthy();
+		const assessmentResult = assessor.getResult();
+		expect( assessmentResult.getScore() ).toEqual( 3 );
+		expect( assessmentResult.getText() ).toEqual(
+			"Avoid using <i>the undocumented</i> as it is potentially overgeneralizing. " +
+			"Consider using <i>people who are undocumented, undocumented people, people without papers </i> instead. " +
+			"<a href='https://yoa.st/inclusive-language-ses' target='_blank'>Learn more.</a>"
+		);
+		expect( assessmentResult.hasMarks() ).toBeTruthy();
+		expect( assessor.getMarks() ).toEqual(   [ { _properties: {
+			fieldsToMark: [],
+			marked: "<yoastmark class='yoast-text-mark'>This sentence contains the undocumented.</yoastmark>",
+			original: "This sentence contains the undocumented." } } ]
+		);
+	} );
 } );

--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/cultureAssessments.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/cultureAssessments.js
@@ -233,14 +233,14 @@ const cultureAssessments = [
 	{
 		identifier: "firstWorldCountries",
 		nonInclusivePhrases: [ "first world countries" ],
-		inclusiveAlternatives: "specific name for the countries or regions",
+		inclusiveAlternatives: "the specific name for the countries or regions",
 		score: SCORES.NON_INCLUSIVE,
 		feedbackFormat: overgeneralizing,
 	},
 	{
 		identifier: "firstWorldHyphen",
 		nonInclusivePhrases: [ "first-world" ],
-		inclusiveAlternatives: "specific name for the country or region",
+		inclusiveAlternatives: "the specific name for the country or region",
 		score: SCORES.NON_INCLUSIVE,
 		feedbackFormat: overgeneralizing,
 	},

--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessments.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessments.js
@@ -94,7 +94,7 @@ const disabilityAssessments =  [
 	{
 		identifier: "daft",
 		nonInclusivePhrases: [ "daft" ],
-		inclusiveAlternatives: "<i>dense, uninformed, ignorant, foolish, inconsiderate, irrational, reckless</i>",
+		inclusiveAlternatives: "<i>uninformed, ignorant, foolish, inconsiderate, irrational, reckless</i>",
 		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
 		feedbackFormat: potentiallyHarmfulCareful,
 	},

--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/sesAssessments.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/sesAssessments.js
@@ -68,7 +68,7 @@ const sesAssessments = [
 	{
 		identifier: "theUndocumented",
 		nonInclusivePhrases: [ "the undocumented" ],
-		inclusiveAlternatives: "<i>people who are undocumented/ undocumented people, people without papers </i>",
+		inclusiveAlternatives: "<i>people who are undocumented, undocumented people, people without papers </i>",
 		score: SCORES.NON_INCLUSIVE,
 		feedbackFormat: "Avoid using <i>%1$s</i> as it is potentially overgeneralizing. Consider using %2$s instead.",
 		rule: ( words, nonInclusivePhrase ) => {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Feedback strings for some _Inclusive language_ assessments contained typos. This PR fixes those types.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Removes the word "dense" as a possible inclusive alternative for the potentially non-inclusive phrase "daft".
* Replaces a forward slash ("/") with a comma (",") in the possible alternatives for the non-inclusive phrase "the undocumented".
* Adds a missing "the" to the possible alternatives for the non-inclusive phrases "first world countries" and "first-world".

## Relevant technical choices:

* 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:
* Make sure that the _Inclusive language_ feature is enabled within the Yoast SEO settings.

#### Removes the word "dense" as a possible inclusive alternative for the potentially non-inclusive phrase "daft".
* Create a post or open an existing one.
* Add a sentence to the post's content containing the phrase "daft".
* You should see an orange traffic light with the feedback:
   > Be careful when using _daft_ as it is potentially harmful. Consider using an alternative, such as _uninformed, ignorant, foolish, inconsiderate, irrational, reckless_, unless referring to someone who explicitly wants to be referred to with this term.

#### Replaces a forward slash ("/") with a comma (",") in the possible alternatives for the non-inclusive phrase "the undocumented".
* Create a post or open an existing one.
* Add a sentence to the post's content containing the phrase "the undocumented".
* You should see a red traffic light with the feedback:
   > Avoid using _the undocumented_ as it is potentially overgeneralizing. Consider using _people who are undocumented, undocumented people, people without papers_ instead.

#### Adds a missing "the" to the possible alternatives for the non-inclusive phrases "first world countries" and "first-world".
* Create a post or open an existing one.
* Add a sentence to the post's content containing the phrase "first world countries".
* You should see a red traffic light with the feedback:
   > Avoid using _first world countries_ as it is overgeneralizing. Consider using the specific name for the countries or regions instead. 
* Add a sentence to the post's content containing the phrase "first-world".
* You should see a red traffic light with the feedback:
   > Avoid using _first-world_ as it is overgeneralizing. Consider using the specific name for the country or region instead. 


#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Since this only changes the text of the feedback of some _Inclusive language_ assessments, no other impact (other than the assessments described in the test instructions) is expected.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes:
 * https://yoast.atlassian.net/browse/PC-1051
 * https://yoast.atlassian.net/browse/PC-1053
 * https://yoast.atlassian.net/browse/PC-1054
