### PR TITLE
Settings UI: Introduce a notification urging for upgrade Premium if < 20.0

### DIFF
--- a/inc/options/class-wpseo-option-wpseo.php
+++ b/inc/options/class-wpseo-option-wpseo.php
@@ -87,6 +87,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 		'configuration_finished_steps'             => [],
 		'dismiss_configuration_workout_notice'     => false,
 		'dismiss_premium_deactivated_notice'       => false,
+		'dismiss_old_premium_notice'               => false,
 		'importing_completed'                      => [],
 		'wincher_integration_active'               => true,
 		'wincher_tokens'                           => [],

--- a/src/integrations/admin/old-premium-integration.php
+++ b/src/integrations/admin/old-premium-integration.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace Yoast\WP\SEO\Integrations\Admin;
+
+use WPSEO_Admin_Asset_Manager;
+use Yoast\WP\SEO\Conditionals\Admin_Conditional;
+use Yoast\WP\SEO\Helpers\Capability_Helper;
+use Yoast\WP\SEO\Helpers\Options_Helper;
+use Yoast\WP\SEO\Helpers\Product_Helper;
+use Yoast\WP\SEO\Integrations\Integration_Interface;
+use Yoast\WP\SEO\Presenters\Admin\Notice_Presenter;
+
+/**
+ * Old_Premium_Integration class
+ */
+class Old_Premium_Integration implements Integration_Interface {
+
+	/**
+	 * The options' helper.
+	 *
+	 * @var Options_Helper
+	 */
+	private $options_helper;
+
+	/**
+	 * The product helper.
+	 *
+	 * @var Product_Helper
+	 */
+	private $product_helper;
+
+	/**
+	 * The capability helper.
+	 *
+	 * @var Capability_Helper
+	 */
+	private $capability_helper;
+
+	/**
+	 * The admin asset manager.
+	 *
+	 * @var WPSEO_Admin_Asset_Manager
+	 */
+	private $admin_asset_manager;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_conditionals() {
+		return [ Admin_Conditional::class ];
+	}
+
+	/**
+	 * First_Time_Configuration_Notice_Integration constructor.
+	 *
+	 * @param Options_Helper            $options_helper      The options helper.
+	 * @param Product_Helper            $product_helper      The product helper.
+	 * @param Capability_Helper         $capability_helper   The capability helper.
+	 * @param WPSEO_Admin_Asset_Manager $admin_asset_manager The admin asset manager.
+	 */
+	public function __construct(
+		Options_Helper $options_helper,
+		Product_Helper $product_helper,
+		Capability_Helper $capability_helper,
+		WPSEO_Admin_Asset_Manager $admin_asset_manager
+	) {
+		$this->options_helper      = $options_helper;
+		$this->product_helper      = $product_helper;
+		$this->capability_helper   = $capability_helper;
+		$this->admin_asset_manager = $admin_asset_manager;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function register_hooks() {
+		\add_action( 'admin_notices', [ $this, 'old_premium_notice' ] );
+		\add_action( 'wp_ajax_dismiss_old_premium_notice', [ $this, 'dismiss_old_premium_notice' ] );
+	}
+
+	/**
+	 * Shows a notice if Premium is older than 20.0-RC1 so Settings might be missing from the UI.
+	 *
+	 * @return void
+	 */
+	public function old_premium_notice() {
+		global $pagenow;
+		if ( $pagenow === 'update.php' ) {
+			return;
+		}
+
+		if ( $this->options_helper->get( 'dismiss_old_premium_notice', false ) === true ) {
+			return;
+		}
+
+		if ( ! $this->capability_helper->current_user_can( 'wpseo_manage_options' ) ) {
+			return;
+		}
+
+		if ( $this->premium_is_old() ) {
+			$this->admin_asset_manager->enqueue_style( 'monorepo' );
+
+			$content = \sprintf(
+				/* translators: 1: Yoast SEO Premium */
+				\__( 'Please update %1$s to the latest version to ensure you can fully use all Premium settings and features.', 'wordpress-seo' ),
+				'Yoast SEO Premium'
+			);
+            // phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped -- Output escaped above.
+			echo new Notice_Presenter(
+				/* translators: 1: Yoast SEO Premium */
+				\sprintf( \__( 'Update to the latest version of %1$s!', 'wordpress-seo' ), 'Yoast SEO Premium' ),
+				$content,
+				null,
+				null,
+				true,
+				'yoast-old-deactivated-notice'
+			);
+            // phpcs:enable
+
+			// Enable permanently dismissing the notice.
+			echo "<script>
+                function dismiss_old_premium_notice(){
+                    var data = {
+                    'action': 'dismiss_old_premium_notice',
+                    };
+
+                    jQuery.post( ajaxurl, data, function( response ) {
+                        jQuery( '#yoast-old-premium-notice' ).hide();
+                    });
+                }
+
+                jQuery( document ).ready( function() {
+                    jQuery( 'body' ).on( 'click', '#yoast-old-premium-notice .notice-dismiss', function() {
+                        dismiss_old_premium_notice();
+                    } );
+                } );
+            </script>";
+		}
+	}
+
+	/**
+	 * Dismisses the old premium notice.
+	 *
+	 * @return bool
+	 */
+	public function dismiss_old_premium_notice() {
+		return $this->options_helper->set( 'dismiss_old_premium_notice', true );
+	}
+
+	/**
+	 * Returns whether Premium is installed but older than 20.0.
+	 *
+	 * @return bool Whether premium is installed but older than 20.0.
+	 */
+	protected function premium_is_old() {
+		$premium_version = $this->product_helper->get_premium_version();
+		if ( ! \is_null( $premium_version ) ) {
+			return \version_compare( $premium_version, '20.0-RC0', '<' );
+		}
+
+		return false;
+	}
+}

--- a/src/integrations/admin/old-premium-integration.php
+++ b/src/integrations/admin/old-premium-integration.php
@@ -113,7 +113,7 @@ class Old_Premium_Integration implements Integration_Interface {
 				null,
 				null,
 				true,
-				'yoast-old-deactivated-notice'
+				'yoast-old-premium-notice'
 			);
             // phpcs:enable
 

--- a/tests/unit/integrations/admin/old-premium-integration-test.php
+++ b/tests/unit/integrations/admin/old-premium-integration-test.php
@@ -1,0 +1,288 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Integrations\Admin;
+
+use Brain\Monkey;
+use Mockery;
+use WPSEO_Admin_Asset_Manager;
+use Yoast\WP\SEO\Conditionals\Admin_Conditional;
+use Yoast\WP\SEO\Conditionals\Indexables_Page_Conditional;
+use Yoast\WP\SEO\Helpers\Capability_Helper;
+use Yoast\WP\SEO\Helpers\Options_Helper;
+use Yoast\WP\SEO\Helpers\Product_Helper;
+use Yoast\WP\SEO\Integrations\Admin\Old_Premium_Integration;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Class Old_Premium_Integration_Test.
+ *
+ * @group integrations
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Integrations\Admin\Old_Premium_Integration
+ */
+class Old_Premium_Integration_Test extends TestCase {
+
+	/**
+	 * Mock of the options helper.
+	 *
+	 * @var Mockery\MockInterface|Options_Helper
+	 */
+	protected $options_helper;
+
+	/**
+	 * Mock of the product helper.
+	 *
+	 * @var Mockery\MockInterface|Product_Helper
+	 */
+	protected $product_helper;
+
+	/**
+	 * Mock of the capability helper.
+	 *
+	 * @var Mockery\MockInterface|Capability_Helper
+	 */
+	protected $capability_helper;
+
+	/**
+	 * Mock of the asset manager.
+	 *
+	 * @var Mockery\MockInterface|WPSEO_Admin_Asset_Manager
+	 */
+	protected $asset_manager;
+
+	/**
+	 * Mock of the instance.
+	 *
+	 * @var Mockery\MockInterface|Old_Premium_Integration
+	 */
+	protected $instance;
+
+	/**
+	 * Sets up the test fixtures.
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->stubTranslationFunctions();
+		$this->stubEscapeFunctions();
+
+		$this->options_helper    = Mockery::mock( Options_Helper::class );
+		$this->product_helper    = Mockery::mock( Product_Helper::class );
+		$this->capability_helper = Mockery::mock( Capability_Helper::class );
+		$this->asset_manager     = Mockery::mock( WPSEO_Admin_Asset_Manager::class );
+		$this->instance          = new Old_Premium_Integration(
+			$this->options_helper,
+			$this->product_helper,
+			$this->capability_helper,
+			$this->asset_manager
+		);
+	}
+
+	/**
+	 * Tests the constructor.
+	 *
+	 * @covers ::__construct
+	 */
+	public function test_constructor() {
+		self::assertInstanceOf(
+			Options_Helper::class,
+			$this->getPropertyValue( $this->instance, 'options_helper' )
+		);
+
+		self::assertInstanceOf(
+			Product_Helper::class,
+			$this->getPropertyValue( $this->instance, 'product_helper' )
+		);
+
+		self::assertInstanceOf(
+			Capability_Helper::class,
+			$this->getPropertyValue( $this->instance, 'capability_helper' )
+		);
+
+		self::assertInstanceOf(
+			WPSEO_Admin_Asset_Manager::class,
+			$this->getPropertyValue( $this->instance, 'admin_asset_manager' )
+		);
+	}
+
+	/**
+	 * Tests if the expected conditionals are given.
+	 *
+	 * @covers ::get_conditionals
+	 */
+	public function test_get_conditionals() {
+		$this->assertEquals( [ Admin_Conditional::class ], Old_Premium_Integration::get_conditionals() );
+	}
+
+	/**
+	 * Tests the registration of the hooks.
+	 *
+	 * @covers ::register_hooks
+	 */
+	public function test_register_hooks() {
+		$this->instance->register_hooks();
+
+		$this->assertNotFalse( \has_action( 'admin_notices', [ $this->instance, 'old_premium_notice' ] ) );
+		$this->assertNotFalse( \has_action( 'wp_ajax_dismiss_old_premium_notice', [ $this->instance, 'dismiss_old_premium_notice' ] ) );
+	}
+
+	/**
+	 * Tests showing the notice when all the conditions are true.
+	 *
+	 * @covers ::old_premium_notice
+	 * @covers ::premium_is_old
+	 */
+	public function test_old_premium_notice() {
+		$this->options_helper
+			->expects( 'get' )
+			->with( 'dismiss_old_premium_notice', false )
+			->andReturnFalse();
+
+		$this->capability_helper
+			->expects( 'current_user_can' )
+			->with( 'wpseo_manage_options' )
+			->andReturnTrue();
+
+		$this->product_helper
+			->expects( 'get_premium_version' )
+			->andReturn( '19.7' );
+
+		$this->asset_manager
+			->expects( 'enqueue_style' )
+			->with( 'monorepo' );
+
+		Monkey\Functions\expect( 'wp_enqueue_style' )->with( 'yoast-seo-notifications' );
+		Monkey\Functions\expect( 'plugin_dir_url' )->andReturn( 'https://example.org/wp-content/plugins/' );
+
+		$conditional = Mockery::mock( Indexables_Page_Conditional::class );
+		$conditional->expects( 'is_met' )->once()->andReturnFalse();
+
+		$container = $this->create_container_with( [ Indexables_Page_Conditional::class => $conditional ] );
+
+		Monkey\Functions\expect( 'YoastSEO' )
+			->once()
+			->andReturn( (object) [ 'classes' => $this->create_classes_surface( $container ) ] );
+
+		// Output should contain the ajax action script.
+		$this->expectOutputContains(
+			"<script>
+                function dismiss_old_premium_notice(){
+                    var data = {
+                    'action': 'dismiss_old_premium_notice',
+                    };
+
+                    jQuery.post( ajaxurl, data, function( response ) {
+                        jQuery( '#yoast-old-premium-notice' ).hide();
+                    });
+                }
+
+                jQuery( document ).ready( function() {
+                    jQuery( 'body' ).on( 'click', '#yoast-old-premium-notice .notice-dismiss', function() {
+                        dismiss_old_premium_notice();
+                    } );
+                } );
+            </script>"
+		);
+
+		$this->instance->old_premium_notice();
+	}
+
+	/**
+	 * Tests showing the notice when we're on the wrong page.
+	 *
+	 * @covers ::old_premium_notice
+	 */
+	public function test_old_premium_notice_if_on_update_page() {
+		global $pagenow;
+		$pagenow = 'update.php';
+
+		// Nothing should be output.
+		$this->expectOutputString( '' );
+		$this->instance->old_premium_notice();
+	}
+
+	/**
+	 * Tests showing the notice when the notice has been dismissed.
+	 *
+	 * @covers ::old_premium_notice
+	 */
+	public function test_old_premium_notice_if_dismissed() {
+		global $pagenow;
+		$pagenow = 'admin.php';
+
+		$this->options_helper
+			->expects( 'get' )
+			->with( 'dismiss_old_premium_notice', false )
+			->andReturnTrue();
+
+		// Nothing should be output.
+		$this->expectOutputString( '' );
+		$this->instance->old_premium_notice();
+	}
+
+	/**
+	 * Tests showing the notice when the user doesn't have the right capability.
+	 *
+	 * @covers ::old_premium_notice
+	 */
+	public function test_old_premium_notice_if_no_capabilities() {
+		global $pagenow;
+		$pagenow = 'admin.php';
+
+		$this->options_helper
+			->expects( 'get' )
+			->with( 'dismiss_old_premium_notice', false )
+			->andReturnFalse();
+
+		$this->capability_helper
+			->expects( 'current_user_can' )
+			->with( 'wpseo_manage_options' )
+			->andReturnFalse();
+
+		// Nothing should be output.
+		$this->expectOutputString( '' );
+		$this->instance->old_premium_notice();
+	}
+
+	/**
+	 * Tests showing the notice when Premium is not active.
+	 *
+	 * @covers ::old_premium_notice
+	 * @covers ::premium_is_old
+	 */
+	public function test_old_premium_notice_if_no_premium_active() {
+		global $pagenow;
+		$pagenow = 'admin.php';
+
+		$this->options_helper
+			->expects( 'get' )
+			->with( 'dismiss_old_premium_notice', false )
+			->andReturnFalse();
+
+		$this->capability_helper
+			->expects( 'current_user_can' )
+			->with( 'wpseo_manage_options' )
+			->andReturnTrue();
+
+		$this->product_helper
+			->expects( 'get_premium_version' )
+			->andReturnNull();
+
+		// Nothing should be output.
+		$this->expectOutputString( '' );
+		$this->instance->old_premium_notice();
+	}
+
+	/**
+	 * Tests dismissing the notice.
+	 *
+	 * @covers ::dismiss_old_premium_notice
+	 */
+	public function test_dismiss_premium_deactivated_notice() {
+		$this->options_helper
+			->expects( 'set' )
+			->with( 'dismiss_old_premium_notice', true );
+
+		$this->instance->dismiss_old_premium_notice();
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to display a notification urging to upgrade Premium if it's active and its version is < 20.0 because some settings might be missing from the new UI.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Displays a notification urging to upgrade Premium if the version is below 20.0, since some settings might be missing from the new user interface.

## Relevant technical choices:

* The notification is displayed only to users with the `wpseo_manage_options` capability, since other users cannot see the settings.
* Includes a unit test with 100% line coverage.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install together  with Premium < 20.0-RC1
* See that on any admin page you can see a notification such as:
![Screenshot 2022-12-19 at 16-21-11 Plugins ‹ debug — WordPress](https://user-images.githubusercontent.com/15989132/208459512-81e39da9-a072-4e1c-b9e5-36e6edb13947.png)
* switch to a different user role and check if you can still see the notification: only admins and SEO managers should be able to.
* deactivate Premium and see that the notification goes away.
* activate premium back
* install any plugin by uploading its zip file
  * verify that when the installation process reaches the `update.php` page the notification is not visible 
* upgrade Premium to 20.0-RC* and see that the notification goes away.
  * if Premium 20.0 is not yet available, you can test by changing the version check in `src/integrations/admin/old-premium-integration.php#L158` from `20.0-RC0` to e.g. `19.5-RC0`
  * don't forget to change the code back to the right value
* make sure you can see the notification and dismiss it
  * check that it stays dismissed

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [x] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes [DUPP-858]


[DUPP-858]: https://yoast.atlassian.net/browse/DUPP-858?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ