### PR TITLE
Settings-UI: DUPP-864-settings-ui-inclusive-language-issues

### DIFF
--- a/inc/options/class-wpseo-option-wpseo.php
+++ b/inc/options/class-wpseo-option-wpseo.php
@@ -51,7 +51,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 		'environment_type'                         => '',
 		'content_analysis_active'                  => true,
 		'keyword_analysis_active'                  => true,
-		'inclusive_language_analysis_active'       => true,
+		'inclusive_language_analysis_active'       => false,
 		'enable_admin_bar_menu'                    => true,
 		'enable_cornerstone_content'               => true,
 		'enable_xml_sitemap'                       => true,

--- a/inc/options/class-wpseo-option-wpseo.php
+++ b/inc/options/class-wpseo-option-wpseo.php
@@ -51,7 +51,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 		'environment_type'                         => '',
 		'content_analysis_active'                  => true,
 		'keyword_analysis_active'                  => true,
-		'inclusive_language_analysis_active'       => false,
+		'inclusive_language_analysis_active'       => true,
 		'enable_admin_bar_menu'                    => true,
 		'enable_cornerstone_content'               => true,
 		'enable_xml_sitemap'                       => true,

--- a/packages/js/src/settings/hooks/use-disabled-message.js
+++ b/packages/js/src/settings/hooks/use-disabled-message.js
@@ -24,7 +24,7 @@ const useDisabledMessage = ( { name } ) => {
 			return __( "Unavailable for sub-sites", "wordpress-seo" );
 		}
 		if ( isDisabledInclusiveLanguageAnalysis ) {
-			return __( "Unavailable for non-English sites", "wordpress-seo" );
+			return __( "Only available for English sites", "wordpress-seo" );
 		}
 		switch ( disabledSetting ) {
 			case "multisite":

--- a/packages/js/src/settings/hooks/use-disabled-message.js
+++ b/packages/js/src/settings/hooks/use-disabled-message.js
@@ -14,23 +14,19 @@ const useDisabledMessage = ( { name } ) => {
 		() => name === "wpseo.tracking" && ! isNetworkAdmin && ! isMainSite,
 		[ name, isNetworkAdmin, isMainSite ]
 	);
-	const isDisabledInclusiveLanguageAnalysis = useMemo(
-		() => name === "wpseo.inclusive_language_analysis_active" && Boolean( window.wpseoScriptData.hasInclusiveLanguageSupport ) === false,
-		[ name, window.wpseoScriptData.hasInclusiveLanguageSupport ]
-	);
 	const disabledSetting = useMemo( () => get( window, `wpseoScriptData.disabledSettings.${ name }`, "" ), [] );
+
 	const message = useMemo( () => {
 		if ( isDisabledTracking ) {
 			return __( "Unavailable for sub-sites", "wordpress-seo" );
-		}
-		if ( isDisabledInclusiveLanguageAnalysis ) {
-			return __( "Only available for English sites", "wordpress-seo" );
 		}
 		switch ( disabledSetting ) {
 			case "multisite":
 				return __( "Unavailable for multisites", "wordpress-seo" );
 			case "network":
 				return __( "Network disabled", "wordpress-seo" );
+			case "language":
+				return __( "Only available for English sites", "wordpress-seo" );
 			default:
 				return "";
 		}
@@ -40,6 +36,7 @@ const useDisabledMessage = ( { name } ) => {
 	return {
 		isDisabled,
 		message,
+		disabledSetting,
 	};
 };
 

--- a/packages/js/src/settings/hooks/use-disabled-message.js
+++ b/packages/js/src/settings/hooks/use-disabled-message.js
@@ -14,10 +14,17 @@ const useDisabledMessage = ( { name } ) => {
 		() => name === "wpseo.tracking" && ! isNetworkAdmin && ! isMainSite,
 		[ name, isNetworkAdmin, isMainSite ]
 	);
+	const isDisabledInclusiveLanguageAnalysis = useMemo(
+		() => name === "wpseo.inclusive_language_analysis_active" && window.wpseoScriptData.userLanguageCode !== "en",
+		[ name, isNetworkAdmin, isMainSite ]
+	);
 	const disabledSetting = useMemo( () => get( window, `wpseoScriptData.disabledSettings.${ name }`, "" ), [] );
 	const message = useMemo( () => {
 		if ( isDisabledTracking ) {
 			return __( "Unavailable for sub-sites", "wordpress-seo" );
+		}
+		if ( isDisabledInclusiveLanguageAnalysis ) {
+			return __( "Unavailable for non-English sites", "wordpress-seo" );
 		}
 		switch ( disabledSetting ) {
 			case "multisite":

--- a/packages/js/src/settings/hooks/use-disabled-message.js
+++ b/packages/js/src/settings/hooks/use-disabled-message.js
@@ -16,7 +16,7 @@ const useDisabledMessage = ( { name } ) => {
 	);
 	const isDisabledInclusiveLanguageAnalysis = useMemo(
 		() => name === "wpseo.inclusive_language_analysis_active" && window.wpseoScriptData.userLanguageCode !== "en",
-		[ name, isNetworkAdmin, isMainSite ]
+		[ name ]
 	);
 	const disabledSetting = useMemo( () => get( window, `wpseoScriptData.disabledSettings.${ name }`, "" ), [] );
 	const message = useMemo( () => {

--- a/packages/js/src/settings/hooks/use-disabled-message.js
+++ b/packages/js/src/settings/hooks/use-disabled-message.js
@@ -15,8 +15,8 @@ const useDisabledMessage = ( { name } ) => {
 		[ name, isNetworkAdmin, isMainSite ]
 	);
 	const isDisabledInclusiveLanguageAnalysis = useMemo(
-		() => name === "wpseo.inclusive_language_analysis_active" && window.wpseoScriptData.userLanguageCode !== "en",
-		[ name ]
+		() => name === "wpseo.inclusive_language_analysis_active" && Boolean( window.wpseoScriptData.hasInclusiveLanguageSupport ) === false,
+		[ name, window.wpseoScriptData.hasInclusiveLanguageSupport ]
 	);
 	const disabledSetting = useMemo( () => get( window, `wpseoScriptData.disabledSettings.${ name }`, "" ), [] );
 	const message = useMemo( () => {

--- a/packages/js/src/settings/routes/site-features.js
+++ b/packages/js/src/settings/routes/site-features.js
@@ -212,15 +212,13 @@ const SiteFeatures = () => {
 								inputId="input-wpseo-inclusive_language_analysis_active"
 								imageSrc="/images/inclusive_language_analysis.png"
 								imageAlt={ __( "Inclusive language analysis", "wordpress-seo" ) }
-								isPremiumFeature={ true }
-								isPremiumLink="https://yoa.st/get-inclusive-language"
 								isBetaFeature={ true }
 							>
 								<Title as="h3">
 									{ __( "Inclusive language analysis", "wordpress-seo" ) }
 								</Title>
 								<p>{ __( "The inclusive language analysis offers suggestions to write more inclusive copy, so more people will be able to relate to your content.", "wordpress-seo" ) }</p>
-								<LearnMoreLink id="link-inclusive-language-analysis" link="https://yoa.st/inclusive-language-analysis" />
+								<LearnMoreLink id="link-inclusive-language-analysis" link="https://yoa.st/inclusive-language-features-free" />
 							</FeatureCard>
 							<FeatureCard
 								name="wpseo.enable_metabox_insights"

--- a/packages/js/src/settings/routes/site-features.js
+++ b/packages/js/src/settings/routes/site-features.js
@@ -35,7 +35,7 @@ const FeatureCard = ( {
 } ) => {
 	const isPremium = useSelectSettings( "selectPreference", [], "isPremium" );
 	const imageSrc = useSelectSettings( "selectPluginUrl", [ rawImageSrc ], rawImageSrc );
-	const { isDisabled, message } = useDisabledMessage( { name } );
+	const { isDisabled, message, disabledSetting } = useDisabledMessage( { name } );
 	const { values } = useFormikContext();
 	const isPremiumHref = useSelectSettings( "selectLink", [ isPremiumLink ], isPremiumLink );
 	const premiumUpsellConfig = useSelectSettings( "selectUpsellSettingsAsProps" );
@@ -82,6 +82,7 @@ const FeatureCard = ( {
 					id={ inputId }
 					label={ __( "Enable feature", "wordpress-seo" ) }
 					disabled={ isDisabled }
+					checked={ disabledSetting === "language" ? false : value }
 				/> }
 				{ shouldUpsell && (
 					<Button

--- a/src/helpers/language-helper.php
+++ b/src/helpers/language-helper.php
@@ -70,4 +70,14 @@ class Language_Helper {
 		}
 		return $researcher_language;
 	}
+
+	/**
+	 * Returns The site language code without region
+	 * (e.g. 'en' for 'en_US' or 'en_GB').
+	 *
+	 * @return string The site language code without region.
+	 */
+	public function get_language() {
+		return WPSEO_Language_Utils::get_language( \get_locale() );
+	}
 }

--- a/src/integrations/settings-integration.php
+++ b/src/integrations/settings-integration.php
@@ -16,6 +16,7 @@ use Yoast\WP\SEO\Conditionals\Settings_Conditional;
 use Yoast\WP\SEO\Config\Schema_Types;
 use Yoast\WP\SEO\Helpers\Current_Page_Helper;
 use Yoast\WP\SEO\Helpers\Post_Type_Helper;
+use Yoast\WP\SEO\Helpers\Language_Helper;
 use Yoast\WP\SEO\Helpers\Product_Helper;
 use Yoast\WP\SEO\Helpers\Schema\Article_Helper;
 use Yoast\WP\SEO\Helpers\Taxonomy_Helper;
@@ -119,6 +120,14 @@ class Settings_Integration implements Integration_Interface {
 	protected $post_type_helper;
 
 	/**
+	 * Holds the Language_Helper.
+	 *
+	 * @var Language_Helper
+	 */
+	protected $language_helper;
+
+
+	/**
 	 * Holds the Taxonomy_Helper.
 	 *
 	 * @var Taxonomy_Helper
@@ -161,6 +170,7 @@ class Settings_Integration implements Integration_Interface {
 	 * @param Schema_Types              $schema_types           The Schema_Types.
 	 * @param Current_Page_Helper       $current_page_helper    The Current_Page_Helper.
 	 * @param Post_Type_Helper          $post_type_helper       The Post_Type_Helper.
+	 * @param Language_Helper           $language_helper        The Language_Helper.
 	 * @param Taxonomy_Helper           $taxonomy_helper        The Taxonomy_Helper.
 	 * @param Product_Helper            $product_helper         The Product_Helper.
 	 * @param Woocommerce_Helper        $woocommerce_helper     The Woocommerce_Helper.
@@ -173,6 +183,7 @@ class Settings_Integration implements Integration_Interface {
 		Schema_Types $schema_types,
 		Current_Page_Helper $current_page_helper,
 		Post_Type_Helper $post_type_helper,
+		Language_Helper $language_helper,
 		Taxonomy_Helper $taxonomy_helper,
 		Product_Helper $product_helper,
 		Woocommerce_Helper $woocommerce_helper,
@@ -185,6 +196,7 @@ class Settings_Integration implements Integration_Interface {
 		$this->current_page_helper    = $current_page_helper;
 		$this->taxonomy_helper        = $taxonomy_helper;
 		$this->post_type_helper       = $post_type_helper;
+		$this->language_helper        = $language_helper;
 		$this->product_helper         = $product_helper;
 		$this->woocommerce_helper     = $woocommerce_helper;
 		$this->article_helper         = $article_helper;
@@ -353,6 +365,7 @@ class Settings_Integration implements Integration_Interface {
 		$transformed_post_types = $this->transform_post_types( $post_types );
 
 		return [
+			'userLanguageCode'     => $this->language_helper->get_researcher_language(),
 			'settings'             => $this->transform_settings( $settings ),
 			'defaultSettingValues' => $default_setting_values,
 			'disabledSettings'     => $this->get_disabled_settings( $settings ),

--- a/src/integrations/settings-integration.php
+++ b/src/integrations/settings-integration.php
@@ -126,7 +126,6 @@ class Settings_Integration implements Integration_Interface {
 	 */
 	protected $language_helper;
 
-
 	/**
 	 * Holds the Taxonomy_Helper.
 	 *

--- a/src/integrations/settings-integration.php
+++ b/src/integrations/settings-integration.php
@@ -362,22 +362,23 @@ class Settings_Integration implements Integration_Interface {
 		$post_types             = $this->post_type_helper->get_public_post_types( 'objects' );
 		$taxonomies             = $this->taxonomy_helper->get_public_taxonomies( 'objects' );
 		$transformed_post_types = $this->transform_post_types( $post_types );
+		$site_language 		    = $this->language_helper->get_language();
 
 		return [
-			'userLanguageCode'     => $this->language_helper->get_researcher_language(),
-			'settings'             => $this->transform_settings( $settings ),
-			'defaultSettingValues' => $default_setting_values,
-			'disabledSettings'     => $this->get_disabled_settings( $settings ),
-			'endpoint'             => \admin_url( 'options.php' ),
-			'nonce'                => \wp_create_nonce( self::PAGE . '-options' ),
-			'separators'           => WPSEO_Option_Titles::get_instance()->get_separator_options_for_display(),
-			'replacementVariables' => $this->get_replacement_variables(),
-			'schema'               => $this->get_schema( $transformed_post_types ),
-			'preferences'          => $this->get_preferences(),
-			'linkParams'           => WPSEO_Shortlinker::get_query_params(),
-			'postTypes'            => $transformed_post_types,
-			'taxonomies'           => $this->transform_taxonomies( $taxonomies, \array_keys( $transformed_post_types ) ),
-			'fallbacks'            => $this->get_fallbacks(),
+			'hasInclusiveLanguageSupport' => $this->language_helper->has_inclusive_language_support( $site_language ),
+			'settings'                    => $this->transform_settings( $settings ),
+			'defaultSettingValues'        => $default_setting_values,
+			'disabledSettings'            => $this->get_disabled_settings( $settings ),
+			'endpoint'                    => \admin_url( 'options.php' ),
+			'nonce'                       => \wp_create_nonce( self::PAGE . '-options' ),
+			'separators'                  => WPSEO_Option_Titles::get_instance()->get_separator_options_for_display(),
+			'replacementVariables'        => $this->get_replacement_variables(),
+			'schema'                      => $this->get_schema( $transformed_post_types ),
+			'preferences'                 => $this->get_preferences(),
+			'linkParams'                  => WPSEO_Shortlinker::get_query_params(),
+			'postTypes'                   => $transformed_post_types,
+			'taxonomies'                  => $this->transform_taxonomies( $taxonomies, \array_keys( $transformed_post_types ) ),
+			'fallbacks'                   => $this->get_fallbacks(),
 		];
 	}
 

--- a/src/integrations/settings-integration.php
+++ b/src/integrations/settings-integration.php
@@ -362,7 +362,7 @@ class Settings_Integration implements Integration_Interface {
 		$post_types             = $this->post_type_helper->get_public_post_types( 'objects' );
 		$taxonomies             = $this->taxonomy_helper->get_public_taxonomies( 'objects' );
 		$transformed_post_types = $this->transform_post_types( $post_types );
-		$site_language 		    = $this->language_helper->get_language();
+		$site_language          = $this->language_helper->get_language();
 
 		return [
 			'hasInclusiveLanguageSupport' => $this->language_helper->has_inclusive_language_support( $site_language ),

--- a/src/integrations/settings-integration.php
+++ b/src/integrations/settings-integration.php
@@ -579,10 +579,8 @@ class Settings_Integration implements Integration_Interface {
 			}
 		}
 
-		
-		
-		if( \array_key_exists( 'wpseo', $disabled_settings ) && !$this->language_helper->has_inclusive_language_support( $site_language )){
-			$disabled_settings[ 'wpseo' ]['inclusive_language_analysis_active'] = 'language';
+		if ( \array_key_exists( 'wpseo', $disabled_settings ) && ! $this->language_helper->has_inclusive_language_support( $site_language ) ) {
+			$disabled_settings['wpseo']['inclusive_language_analysis_active'] = 'language';
 		}
 
 		return $disabled_settings;

--- a/src/integrations/settings-integration.php
+++ b/src/integrations/settings-integration.php
@@ -362,10 +362,8 @@ class Settings_Integration implements Integration_Interface {
 		$post_types             = $this->post_type_helper->get_public_post_types( 'objects' );
 		$taxonomies             = $this->taxonomy_helper->get_public_taxonomies( 'objects' );
 		$transformed_post_types = $this->transform_post_types( $post_types );
-		$site_language          = $this->language_helper->get_language();
 
 		return [
-			'hasInclusiveLanguageSupport' => $this->language_helper->has_inclusive_language_support( $site_language ),
 			'settings'                    => $this->transform_settings( $settings ),
 			'defaultSettingValues'        => $default_setting_values,
 			'disabledSettings'            => $this->get_disabled_settings( $settings ),
@@ -551,6 +549,7 @@ class Settings_Integration implements Integration_Interface {
 	 */
 	protected function get_disabled_settings( $settings ) {
 		$disabled_settings = [];
+		$site_language     = $this->language_helper->get_language();
 
 		foreach ( WPSEO_Options::$options as $option_name => $instance ) {
 			if ( ! \in_array( $option_name, self::ALLOWED_OPTION_GROUPS, true ) ) {
@@ -578,6 +577,12 @@ class Settings_Integration implements Integration_Interface {
 					}
 				}
 			}
+		}
+
+		
+		
+		if( \array_key_exists( 'wpseo', $disabled_settings ) && !$this->language_helper->has_inclusive_language_support( $site_language )){
+			$disabled_settings[ 'wpseo' ]['inclusive_language_analysis_active'] = 'language';
 		}
 
 		return $disabled_settings;

--- a/tests/unit/integrations/settings-integration-test.php
+++ b/tests/unit/integrations/settings-integration-test.php
@@ -44,7 +44,7 @@ class Settings_Integration_Test extends TestCase {
 		$schema_types           = Mockery::mock( Schema_Types::class );
 		$current_page_helper    = Mockery::mock( Current_Page_Helper::class );
 		$post_type_helper       = Mockery::mock( Post_Type_Helper::class );
-		$language_helper       = Mockery::mock( Language_Helper::class );
+		$language_helper        = Mockery::mock( Language_Helper::class );
 		$taxonomy_helper        = Mockery::mock( Taxonomy_Helper::class );
 		$product_helper         = Mockery::mock( Product_Helper::class );
 		$woocommerce_helper     = Mockery::mock( Woocommerce_Helper::class );

--- a/tests/unit/integrations/settings-integration-test.php
+++ b/tests/unit/integrations/settings-integration-test.php
@@ -9,6 +9,7 @@ use Mockery;
 use Yoast\WP\SEO\Config\Schema_Types;
 use Yoast\WP\SEO\Helpers\Current_Page_Helper;
 use Yoast\WP\SEO\Helpers\Post_Type_Helper;
+use Yoast\WP\SEO\Helpers\Language_Helper;
 use Yoast\WP\SEO\Helpers\Taxonomy_Helper;
 use Yoast\WP\SEO\Helpers\Product_Helper;
 use Yoast\WP\SEO\Helpers\Woocommerce_Helper;
@@ -43,6 +44,7 @@ class Settings_Integration_Test extends TestCase {
 		$schema_types           = Mockery::mock( Schema_Types::class );
 		$current_page_helper    = Mockery::mock( Current_Page_Helper::class );
 		$post_type_helper       = Mockery::mock( Post_Type_Helper::class );
+		$language_helper       = Mockery::mock( Language_Helper::class );
 		$taxonomy_helper        = Mockery::mock( Taxonomy_Helper::class );
 		$product_helper         = Mockery::mock( Product_Helper::class );
 		$woocommerce_helper     = Mockery::mock( Woocommerce_Helper::class );
@@ -55,6 +57,7 @@ class Settings_Integration_Test extends TestCase {
 			$schema_types,
 			$current_page_helper,
 			$post_type_helper,
+			$language_helper,
 			$taxonomy_helper,
 			$product_helper,
 			$woocommerce_helper,


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Changed link to the correct link https://yoa.st/inclusive-language-features-free in `Inclusive language analysis` feature.
* Feature available for Free users. No upsell or premium badge.
* Feature is disabled for non-english sites.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Changes link for the Inclusive Language post to the correct link.
* Removes Premium/Upsell badges for the Inclusive Language setting.
* Disables the Inclusive Language setting for non-english sites.

## Relevant technical choices:

* Added a function to the `Language_Helper` class which is a wrapper to the function `WPSEO_Language_Utils::get_language( \get_locale() )`.
* Added the `hasInclusiveLanguageSupport` to the global `window.wpseo.ScriptData`. 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Go to `Settings` -> `General`
*  Make sure the selected language is English (no matter the region).
* Go to `Yoast SEO` -> `Settings` -> `Site features`
* In the `writing` section verify: 
  * The `Inclusive language analysis` feature is disabled
  * No premium badge is displayed.
  * The `Learn more` link has the following URL  `https://yoa.st/inclusive-language-features-free`
* Verify you can turn on the `Inclusive language analysis` feature by clicking on the `Enable feature` toggle on the bottom of the card, no matter if Premium is enabled or not.

---

**Check non-English website behaviour.**
* Go to `Settings` -> `General`
*  Select a language other than English.
* Go to `Yoast SEO` -> `Settings` -> `Site features`
* In the `writing` section verify: 
  * The `Inclusive language analysis` feature is disabled with a message `Only available for English sites`.
* Verify you can not turn on the `Inclusive language analysis` feature by clicking on the `Enable feature` toggle on the bottom of the card, it should always be turned off even if it was turned on when site language was English.


<img width="708" alt="image" src="https://user-images.githubusercontent.com/65466507/208920858-ba474e51-7883-4026-9fe5-dff8588119ac.png">


#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* This PR alters the logic used to check if a feature in settings UI is disabled.  Verify that enable and disable features works as expected.

## UI changes

* [X] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes [Jira DUPP-864](https://yoast.atlassian.net/browse/DUPP-864)
Fixes [#19444](https://github.com/Yoast/wordpress-seo/issues/19444)