### PR TITLE
DUPP-865-settings-ui-catch-a-11-y-skip-to-links-before-they-break-hash-routing

### DIFF
--- a/packages/js/src/settings/app.js
+++ b/packages/js/src/settings/app.js
@@ -233,7 +233,7 @@ const App = () => {
 			const WpToolbar = document.querySelector( '[href="#wp-toolbar"]' );
 			WpToolbar.addEventListener( "click", function( e ) {
 				e.preventDefault();
-				document.getElementById( "yst-search-button" ).focus();
+				document.querySelector( "#wp-admin-bar-wp-logo a" ).focus();
 			}
 			);
 		}

--- a/packages/js/src/settings/app.js
+++ b/packages/js/src/settings/app.js
@@ -223,14 +223,17 @@ const App = () => {
 	useRouterScrollRestore();
 
 	useEffect( () => {
+		// WordPress skip links disable the default behavior of the links and redirect to active tab.
 		if ( document ) {
 			const WpcontentBody = document.querySelector( '[href="#wpbody-content"]' );
 			WpcontentBody.addEventListener( "click", function( e ) {
 				e.preventDefault();
+				document.getElementById( "yst-search-button" ).focus();
 			} );
 			const WpToolbar = document.querySelector( '[href="#wp-toolbar"]' );
 			WpToolbar.addEventListener( "click", function( e ) {
 				e.preventDefault();
+				document.getElementById( "yst-search-button" ).focus();
 			}
 			);
 		}

--- a/packages/js/src/settings/app.js
+++ b/packages/js/src/settings/app.js
@@ -1,4 +1,5 @@
 import { Transition } from "@headlessui/react";
+import { useEffect } from "@wordpress/element";
 import {
 	AdjustmentsIcon,
 	ArrowNarrowRightIcon,
@@ -219,8 +220,21 @@ const App = () => {
 	const postTypes = useSelectSettings( "selectPostTypes" );
 	const taxonomies = useSelectSettings( "selectTaxonomies" );
 	const isPremium = useSelectSettings( "selectPreference", [], "isPremium" );
-
 	useRouterScrollRestore();
+
+	useEffect( () => {
+		if ( document ) {
+			const WpcontentBody = document.querySelector( '[href="#wpbody-content"]' );
+			WpcontentBody.addEventListener( "click", function( e ) {
+				e.preventDefault();
+			} );
+			const WpToolbar = document.querySelector( '[href="#wp-toolbar"]' );
+			WpToolbar.addEventListener( "click", function( e ) {
+				e.preventDefault();
+			}
+			);
+		}
+	}, [] );
 
 	const { dirty } = useFormikContext();
 	useBeforeUnload(

--- a/packages/js/src/settings/app.js
+++ b/packages/js/src/settings/app.js
@@ -1,5 +1,4 @@
 import { Transition } from "@headlessui/react";
-import { useEffect } from "@wordpress/element";
 import {
 	AdjustmentsIcon,
 	ArrowNarrowRightIcon,
@@ -221,23 +220,6 @@ const App = () => {
 	const taxonomies = useSelectSettings( "selectTaxonomies" );
 	const isPremium = useSelectSettings( "selectPreference", [], "isPremium" );
 	useRouterScrollRestore();
-
-	useEffect( () => {
-		// WordPress skip links disable the default behavior of the links and redirect to active tab.
-		if ( document ) {
-			const WpcontentBody = document.querySelector( '[href="#wpbody-content"]' );
-			WpcontentBody.addEventListener( "click", function( e ) {
-				e.preventDefault();
-				document.getElementById( "yst-search-button" ).focus();
-			} );
-			const WpToolbar = document.querySelector( '[href="#wp-toolbar"]' );
-			WpToolbar.addEventListener( "click", function( e ) {
-				e.preventDefault();
-				document.querySelector( "#wp-admin-bar-wp-logo a" ).focus();
-			}
-			);
-		}
-	}, [] );
 
 	const { dirty } = useFormikContext();
 	useBeforeUnload(

--- a/packages/js/src/settings/components/search.js
+++ b/packages/js/src/settings/components/search.js
@@ -165,6 +165,7 @@ const Search = () => {
 
 	return <>
 		<button
+			id="yst-search-button"
 			type="button"
 			className="yst-w-full yst-flex yst-items-center yst-bg-white yst-text-sm yst-leading-6 yst-text-slate-500 yst-rounded-md yst-border yst-border-slate-300 yst-shadow-sm yst-py-1.5 yst-pl-2 yst-pr-3 focus:yst-outline-none focus:yst-ring-2 focus:yst-ring-offset-2 focus:yst-ring-primary-500"
 			onClick={ setOpen }

--- a/packages/js/src/settings/initialize.js
+++ b/packages/js/src/settings/initialize.js
@@ -45,6 +45,26 @@ const preloadUsers = async( { settings } ) => {
 	}
 };
 
+/**
+ * Fixes the WordPress skip links.
+ *
+ * By disabling the default behavior of the links and focusing the elements.
+ *
+ * @returns {void}
+ */
+const fixFocusLinkCompatibility = () => {
+	const wpContentBody = document.querySelector( "[href=\"#wpbody-content\"]" );
+	wpContentBody.addEventListener( "click", e => {
+		e.preventDefault();
+		document.getElementById( "yst-search-button" ).focus();
+	} );
+	const wpToolbar = document.querySelector( "[href=\"#wp-toolbar\"]" );
+	wpToolbar.addEventListener( "click", e => {
+		e.preventDefault();
+		document.querySelector( "#wp-admin-bar-wp-logo a" ).focus();
+	} );
+};
+
 domReady( () => {
 	const root = document.getElementById( "yoast-seo-settings" );
 	if ( ! root ) {
@@ -64,6 +84,7 @@ domReady( () => {
 	registerStore();
 	preloadMedia( { settings, fallbacks } );
 	preloadUsers( { settings } );
+	fixFocusLinkCompatibility();
 
 	const isRtl = select( STORE_NAME ).selectPreference( "isRtl", false );
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Disable WordPress `skip links` for `Skip to content` and `Skip to toolbar` to prevent adding hash to url, which results in an empty tab in settings UI.
* Repurpose `Skip to content` link to focus on search button in the settings UI menu.
* Reset `Skip to toolbar` to focus on toolbar without adding hash to url.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Disable WordPress `skip links` for `Skip to content` and `Skip to toolbar` to prevent adding hash to url, which results in an empty tab in settings UI.
* Repurpose `Skip to content` link to focus on search button in the settings UI menu.
* Reset `Skip to toolbar` to focus on toolbar without adding hash to url.

## Relevant technical choices:

* Added ID to the search button for targeting.


## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Go to `Yoast SEO` -> `Settings` 
* For `Skip to content`:
  * Click on `Tab` key until you find the `Skip to Content` button appearing on the top left corner of the screen.
  * Check that after clicking `Tab` once again, focus will move the to the search field in the settings UI.
* For `Skip to toolbar`
  * Click on `Tab` key until you find the `Skip to toolbar` button appearing on the top left corner of the screen.
  * Check that after clicking `Tab` once again, focus will move the to the first option in the tool bar.

<img width="884" alt="image" src="https://user-images.githubusercontent.com/65466507/209138210-a5c43e78-9f41-4859-bf07-d78873c5a4a5.png">


#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The `Search` component, I added id to the search button.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes https://github.com/Yoast/wordpress-seo/issues/19441 
Jira [DUPP-865](https://yoast.atlassian.net/browse/DUPP-865)
