### PR TITLE
Expands list of transition words for Portuguese

### DIFF
--- a/packages/yoastseo/src/languageProcessing/languages/pt/config/transitionWords.js
+++ b/packages/yoastseo/src/languageProcessing/languages/pt/config/transitionWords.js
@@ -1,7 +1,7 @@
 export const singleWords = [
-	"ademais", "afinal", "aliás", "analogamente", "anteriormente", "assim", "certamente", "conforme",
+	"ademais", "afinal", "aliás", "analogamente", "anteriormente", "assim", "atualmente", "certamente", "conforme",
 	"conquanto", "contudo", "decerto", "embora", "enfim", "enquanto", "então", "entretanto", "eventualmente",
-	"igualmente", "inegavelmente", "inesperadamente", "mas", "outrossim", "pois", "porquanto", "porque", "portanto",
+	"igualmente", "inegavelmente", "inesperadamente", "mas", "ocasionalmente", "outrossim", "pois", "porquanto", "porque", "portanto",
 	"posteriormente", "precipuamente", "primeiramente", "primordialmente", "principalmente", "salvo",
 	"semelhantemente", "similarmente", "sobretudo", "surpreendentemente", "todavia",
 ];
@@ -9,17 +9,17 @@ export const singleWords = [
 export const multipleWords = [
 	"a fim de", "a fim de que", "a menos que", "a princípio", "a saber", "acima de tudo", "ainda assim", "ainda mais", "ainda que",
 	"além disso", "antes de mais nada", "antes de tudo", "antes que", "ao mesmo tempo", "ao passo que", "ao propósito",
-	"apesar de", "às vezes", "assim como", "assim que", "assim sendo", "assim também", "bem como", "com a finalidade de",
+	"apesar de", "apesar disso", "às vezes", "assim como", "assim que", "assim sendo", "assim também", "bem como", "com a finalidade de",
 	"com efeito", "com o fim de", "com o intuito de", "com o propósito de", "com toda a certeza", "como resultado", "como se",
 	"da mesma forma", "de acordo com", "de conformidade com", "de fato", "de maneira idêntica", "de tal forma que", "de tal sorte que",
 	"depois que", "desde que", "dessa forma", "dessa maneira", "desse modo", "do mesmo modo", "é provável", "em conclusão",
 	"em contrapartida", "em contraste com", "em outras palavras", "em primeiro lugar", "em princípio", "em resumo", "em seguida",
-	"em segundo lugar", "em síntese", "em suma", "em terceiro lugar", "em virtude de", "finalmente agora atualmente", "isto é",
-	"já que", "logo após", "logo depois", "logo que", "mesmo que", "não apenas", "nesse hiato", "nesse ínterim", "nesse meio tempo",
+	"em segundo lugar", "em síntese", "em suma", "em terceiro lugar", "em virtude de", "finalmente", "isto é",
+	"já que", "juntamente com", "logo após", "logo depois", "logo que", "mesmo que", "não apenas", "nesse hiato", "nesse ínterim", "nesse meio tempo",
 	"nesse sentido", "no entanto", "no momento em que", "ou por outra", "ou seja", "para que", "pelo contrário", "por analogia",
-	"por causa de", "por certo", "por conseguinte", "por conseqüência", "por exemplo", "por fim", "por isso", "por mais que",
-	"por menos que", "por outro lado", "posto que", "se acaso", "se bem que", "seja como for", "sem dúvida", "só para exemplificar",
-	"só para ilustrar", "só que", "sob o mesmo ponto de vista", "talvez provavelmente", "tanto quanto", "uma vez que", "visto que",
+	"por causa de", "por certo", "por conseguinte", "por conseqüência", "porém", "por exemplo", "por fim", "por isso", "por mais que",
+	"por menos que", "por outro lado", "por vezes", "posto que", "se acaso", "se bem que", "seja como for", "sem dúvida", "sempre que", "só para exemplificar",
+	"só para ilustrar", "só que", "sob o mesmo ponto de vista", "talvez provavelmente", "tanto quanto", "todas as vezes que", "todas as vezes em que", "uma vez que", "visto que",
 ];
 
 export const allWords = singleWords.concat( multipleWords );

--- a/packages/yoastseo/src/languageProcessing/languages/pt/config/transitionWords.js
+++ b/packages/yoastseo/src/languageProcessing/languages/pt/config/transitionWords.js
@@ -18,8 +18,9 @@ export const multipleWords = [
 	"já que", "juntamente com", "logo após", "logo depois", "logo que", "mesmo que", "não apenas", "nesse hiato", "nesse ínterim", "nesse meio tempo",
 	"nesse sentido", "no entanto", "no momento em que", "ou por outra", "ou seja", "para que", "pelo contrário", "por analogia",
 	"por causa de", "por certo", "por conseguinte", "por conseqüência", "porém", "por exemplo", "por fim", "por isso", "por mais que",
-	"por menos que", "por outro lado", "por vezes", "posto que", "se acaso", "se bem que", "seja como for", "sem dúvida", "sempre que", "só para exemplificar",
-	"só para ilustrar", "só que", "sob o mesmo ponto de vista", "talvez provavelmente", "tanto quanto", "todas as vezes que", "todas as vezes em que", "uma vez que", "visto que",
+	"por menos que", "por outro lado", "por vezes", "posto que", "se acaso", "se bem que", "seja como for", "sem dúvida", "sempre que",
+	"só para exemplificar", "só para ilustrar", "só que", "sob o mesmo ponto de vista", "talvez provavelmente", "tanto quanto",
+	"todas as vezes que", "todas as vezes em que", "uma vez que", "visto que",
 ];
 
 export const allWords = singleWords.concat( multipleWords );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We have received user feedback on [missing transition words for Portuguese](https://wordpress.org/support/topic/transition-words/). After reviewing the suggestions (as a native speaker of Portuguese), there are a few which are common enough to be worth adding.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves the  _transition words_ assessment for Portuguese by adding new transition words.
* [shopify-seo] Improves the  _transition words_ assessment for Portuguese by adding new transition words.

## Relevant technical choices:

* Words added include: `atualmente, ocasionalmente, apesar disso, juntamente com`
* There was an odd entry with `finalmente agora atualmente`. This was corrected to `finalmente`
* Since many of the user suggestions involve ambiguous words (i.e., not always used as transition words), I decided not to include those at this time to prevent false positives. As a basis, I used the list of transition words for English in `packages/yoastseo/src/languageProcessing/languages/en/config/transitionWords.js`

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install and activate Yoast SEO Free.
* Go to **Settings** > **General** > Set **Site Language** to `Português`.
* Create a post/page/cpt (_Artigos > Novo artigo_).
* Paste this [sample](https://github.com/Yoast/wordpress-seo/files/10287831/pt-TransitionWords.txt).
* Open the Readability assessment (_Legibilidade_).
* Under Transition words (_Palavras de transição_) click on the highlight/eye toggle.
* The following sentences are expected to be highlighted for transition words:
1. `Afirmou, em relatório sobre o caso datado de agosto de 2002, o então procurador-geral de Justiça José Muiños Pinheiro Filho. `
2. `Ele é atualmente desembargador de o TJRJ (Tribunal de Justiça de o Rio de Janeiro).`
3. `Ele foi professor na Universidade de Artes de Berlim e ainda ocasionalmente dá cursos lá.`
4. `Apesar disso, o exame não teria confirmado o tipo e, por isso, seriam necessários novos testes para uma confirmação.`
5. `Alegadamente, Amanda terá entrado no prédio para pegar numa faca de cozinha e, logo após Anna ter sido esfaqueada no lado esquerdo do peito, a testemunha desceu as escadas do prédio para a socorrer.`
6. `Duas horas antes do incidente, Anna tinha publicado uma foto na rede social Facebook, que mostrava as duas irmãs a sorrir, juntamente com dois amigos.`

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [x] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* This PR changes the list of transition words in Portuguese. As such, the PR only affects the _transition words_ assessment for Portuguese.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [x] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes https://yoast.atlassian.net/browse/PC-1064
Fixes #19476
