### PR TITLE
Settings: Add redirect search pretty URLs

### DIFF
--- a/packages/js/src/settings/helpers/search.js
+++ b/packages/js/src/settings/helpers/search.js
@@ -545,6 +545,13 @@ export const createSearchIndex = ( postTypes, taxonomies, { userLocale } = {} ) 
 			fieldLabel: __( "Filter searches with common spam patterns", "wordpress-seo" ),
 			keywords: [],
 		},
+		redirect_search_pretty_urls: {
+			route: "/crawl-optimization",
+			routeLabel: __( "Crawl optimization", "wordpress-seo" ),
+			fieldId: "input-wpseo-redirect_search_pretty_urls",
+			fieldLabel: __( "Redirect pretty URLs to ‘raw’ formats", "wordpress-seo" ),
+			keywords: [],
+		},
 		deny_search_crawling: {
 			route: "/crawl-optimization",
 			routeLabel: __( "Crawl optimization", "wordpress-seo" ),

--- a/packages/js/src/settings/routes/crawl-optimization.js
+++ b/packages/js/src/settings/routes/crawl-optimization.js
@@ -162,6 +162,20 @@ const CrawlOptimization = () => {
 		} ),
 
 		// Internal site search cleanup.
+		redirectSearchPrettyUrls: createInterpolateElement(
+			sprintf(
+				/* translators: %1$s, %2$s and %3$s expand to example parts of a URL, surrounded by <code> tags. */
+				__( "Consolidates WordPress' multiple site search URL formats into the %1$s syntax. E.g., %2$s will redirect to %3$s", "wordpress-seo" ),
+				"<code1/>",
+				"<code2/>",
+				"<code3/>"
+			),
+			{
+				code1: <Code>?s=</Code>,
+				code2: <Code variant="block">https://www.example.com/search/cats</Code>,
+				code3: <Code variant="block">https://www.example.com/?s=cats</Code>,
+			}
+		),
 		denySearchCrawling: createInterpolateElement(
 			sprintf(
 				/* translators: %1$s and %2$s expand to example parts of a URL, surrounded by <code> tags. */
@@ -595,6 +609,16 @@ const CrawlOptimization = () => {
 							description={ __( "Block internal site searches which match the patterns of known spam attacks.", "wordpress-seo" ) }
 							disabled={ ! searchCleanup }
 							checked={ searchCleanup && searchCleanupPatterns }
+							isDummy={ ! isPremium }
+							className="yst-max-w-2xl"
+						/>
+						<FormikValueChangeFieldWithDummy
+							as={ ToggleField }
+							type="checkbox"
+							name="wpseo.redirect_search_pretty_urls"
+							id="input-wpseo-redirect_search_pretty_urls"
+							label={ __( "Redirect pretty URLs to ‘raw’ formats", "wordpress-seo" ) }
+							description={ descriptions.redirectSearchPrettyUrls }
 							isDummy={ ! isPremium }
 							className="yst-max-w-2xl"
 						/>


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Add missing crawl optimization toggle.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where the crawl optimization in the settings would miss the `Redirect pretty URLs to ‘raw’ formats` toggle. 

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Enable Premium, latest 20.0 (at the time of writing RC2)
* Go to Settings
* Search for `redirect`.
* Verify:
  * search suggests `Redirect pretty URLs to ‘raw’ formats`
  * going there puts focus on: Settings  > Advanced > Crawl optimization > Internal site search cleanup > Redirect pretty URLs to ‘raw’ formats
* Verify the `Redirect pretty URLs to ‘raw’ formats` toggle:
  * has the same text as the original issue https://yoast.atlassian.net/browse/PC-390
  * looks like (screenshot of implementation): ![image](https://user-images.githubusercontent.com/35524806/209642954-6ff3fc7a-5f81-4995-ae93-1d7d584e8976.png)
* Ensure the toggle is turned off and save if needed
* Go to a frontend search URL in the pretty URL form. For example: `https://basic.wordpress.test/search/hello`
* Verify it does _not_ redirect to the raw URL, e.g. `https://basic.wordpress.test/?s=hello`
* Go back to the setting, turn it on and save
* Go to a frontend search URL in the pretty URL form. For example: `https://basic.wordpress.test/search/hello`
* Verify it redirects to the raw URL, e.g. `https://basic.wordpress.test/?s=hello`
* Turn off Premium
* Verify the toggle is now disabled and can not be interacted with
* Go to a frontend search URL in the pretty URL form. For example: `https://basic.wordpress.test/search/hello`
* Verify it does _not_ redirect to the raw URL, e.g. `https://basic.wordpress.test/?s=hello`

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [x] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes Yoast/plugins-automated-testing#294
