### PR TITLE
DUPP-884-improve-the-discard-all-changes-dialog-a-11-y

### DIFF
--- a/packages/js/src/settings/components/form-layout.js
+++ b/packages/js/src/settings/components/form-layout.js
@@ -55,7 +55,7 @@ const FormLayout = ( { children } ) => {
 							>
 								{ __( "Discard changes", "wordpress-seo" ) }
 							</Button>
-							<Modal onClose={ unsetRequestUndo } isOpen={ isRequestUndo }>
+							<Modal onClose={ unsetRequestUndo } isOpen={ isRequestUndo } ariaLabelledby="discard-all-changes-title">
 								<Modal.Panel closeButtonScreenReaderText={ __( "Close", "wordpress-seo" ) }>
 									<div className="sm:yst-flex sm:yst-items-start">
 										<div
@@ -64,7 +64,7 @@ const FormLayout = ( { children } ) => {
 											<ExclamationIcon className="yst-h-6 yst-w-6 yst-text-red-600" { ...svgAriaProps } />
 										</div>
 										<div className="yst-mt-3 yst-text-center sm:yst-mt-0 sm:yst-ml-4 sm:yst-text-left">
-											<Modal.Title as="h3" className="yst-text-lg yst-leading-6 yst-font-medium yst-text-slate-900">
+											<Modal.Title as="h1" className="yst-text-lg yst-leading-6 yst-font-medium yst-text-slate-900" id="discard-all-changes-title">
 												{ __( "Discard all changes", "wordpress-seo" ) }
 											</Modal.Title>
 											<Modal.Description className="yst-text-sm yst-text-slate-500">

--- a/packages/js/src/settings/components/form-layout.js
+++ b/packages/js/src/settings/components/form-layout.js
@@ -55,7 +55,7 @@ const FormLayout = ( { children } ) => {
 							>
 								{ __( "Discard changes", "wordpress-seo" ) }
 							</Button>
-							<Modal onClose={ unsetRequestUndo } isOpen={ isRequestUndo } ariaLabelledby="discard-all-changes-title">
+							<Modal onClose={ unsetRequestUndo } isOpen={ isRequestUndo }>
 								<Modal.Panel closeButtonScreenReaderText={ __( "Close", "wordpress-seo" ) }>
 									<div className="sm:yst-flex sm:yst-items-start">
 										<div
@@ -64,7 +64,7 @@ const FormLayout = ( { children } ) => {
 											<ExclamationIcon className="yst-h-6 yst-w-6 yst-text-red-600" { ...svgAriaProps } />
 										</div>
 										<div className="yst-mt-3 yst-text-center sm:yst-mt-0 sm:yst-ml-4 sm:yst-text-left">
-											<Modal.Title as="h1" className="yst-text-lg yst-leading-6 yst-font-medium yst-text-slate-900" id="discard-all-changes-title">
+											<Modal.Title as="h1" className="yst-text-lg yst-leading-6 yst-font-medium yst-text-slate-900">
 												{ __( "Discard all changes", "wordpress-seo" ) }
 											</Modal.Title>
 											<Modal.Description className="yst-text-sm yst-text-slate-500">

--- a/packages/js/src/settings/components/introduction.js
+++ b/packages/js/src/settings/components/introduction.js
@@ -233,9 +233,9 @@ const Introduction = () => {
 									index === stepIndex ? "yst-opacity-100" : "yst-opacity-0"
 								) }
 							>
-								<Title as="h2" size="2">
+								<Modal.Title as="h2" className="yst-text-lg">
 									{ step.title }
-								</Title>
+								</Modal.Title>
 								<Modal.Description className="yst-max-w-xs yst-mx-auto yst-mt-2">
 									{ step.description }
 								</Modal.Description>

--- a/packages/js/src/settings/components/introduction.js
+++ b/packages/js/src/settings/components/introduction.js
@@ -2,7 +2,7 @@
 import { ArrowLeftIcon as PureArrowLeftIcon, ArrowRightIcon as PureArrowRightIcon } from "@heroicons/react/outline";
 import { useCallback, useEffect, useMemo, useState } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
-import { Button, Modal, Spinner, Title, useRootContext, useSvgAria, useToggleState } from "@yoast/ui-library";
+import { Button, Modal, Spinner, useRootContext, useSvgAria, useToggleState } from "@yoast/ui-library";
 import classNames from "classnames";
 import { times } from "lodash";
 import { Helmet } from "react-helmet";
@@ -233,7 +233,7 @@ const Introduction = () => {
 									index === stepIndex ? "yst-opacity-100" : "yst-opacity-0"
 								) }
 							>
-								<Modal.Title as="h2" className="yst-text-lg">
+								<Modal.Title as="h2" size="2">
 									{ step.title }
 								</Modal.Title>
 								<Modal.Description className="yst-max-w-xs yst-mx-auto yst-mt-2">

--- a/packages/js/src/settings/components/introduction.js
+++ b/packages/js/src/settings/components/introduction.js
@@ -2,7 +2,7 @@
 import { ArrowLeftIcon as PureArrowLeftIcon, ArrowRightIcon as PureArrowRightIcon } from "@heroicons/react/outline";
 import { useCallback, useEffect, useMemo, useState } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
-import { Button, Modal, Spinner, useRootContext, useSvgAria, useToggleState } from "@yoast/ui-library";
+import { Button, Modal, Title, Spinner, useRootContext, useSvgAria, useToggleState } from "@yoast/ui-library";
 import classNames from "classnames";
 import { times } from "lodash";
 import { Helmet } from "react-helmet";
@@ -133,7 +133,7 @@ const Introduction = () => {
 	return (
 
 		// handleClose function is closing the modal and setting the user meta to not show introduction again
-		<Modal onClose={ handleClose } isOpen={ isOpen }>
+		<Modal onClose={ handleClose } isOpen={ isOpen } aria-label={ __( "Introduction to settings", "wordpress-seo" ) }>
 			<div className="yst-modal__panel yst-max-w-[37rem] yst-p-0 yst-rounded-2xl sm:yst-rounded-3xl">
 
 				{ /* //checks ther is permission from wista to add video and add js script, Helmet component adds the script tp the head */ }
@@ -233,12 +233,12 @@ const Introduction = () => {
 									index === stepIndex ? "yst-opacity-100" : "yst-opacity-0"
 								) }
 							>
-								<Modal.Title as="h2" size="2">
+								<Title as="h2" size="2">
 									{ step.title }
-								</Modal.Title>
-								<Modal.Description className="yst-max-w-xs yst-mx-auto yst-mt-2">
+								</Title>
+								<p className="yst-max-w-xs yst-mx-auto yst-mt-2">
 									{ step.description }
-								</Modal.Description>
+								</p>
 							</div>
 						) ) }
 					</div>

--- a/packages/js/src/settings/components/search.js
+++ b/packages/js/src/settings/components/search.js
@@ -57,7 +57,7 @@ SearchResultLabel.propTypes = {
  */
 const SearchNoResultsContent = ( { title, children } ) => (
 	<div className="yst-border-t yst-border-slate-100 yst-p-6 yst-py-12 yst-space-3 yst-text-center yst-text-sm">
-		<span className="yst-block yst-font-semibold yst-text-slate-900">{ title }</span>
+		<Modal.Title className="yst-block yst-font-semibold yst-text-slate-900 yst-text-sm">{ title }</Modal.Title>
 		{ children }
 	</div>
 );

--- a/packages/js/src/settings/components/search.js
+++ b/packages/js/src/settings/components/search.js
@@ -57,7 +57,7 @@ SearchResultLabel.propTypes = {
  */
 const SearchNoResultsContent = ( { title, children } ) => (
 	<div className="yst-border-t yst-border-slate-100 yst-p-6 yst-py-12 yst-space-3 yst-text-center yst-text-sm">
-		<Modal.Title className="yst-block yst-font-semibold yst-text-slate-900" size="5">{ title }</Modal.Title>
+		<span className="yst-block yst-font-semibold yst-text-slate-900">{ title }</span>
 		{ children }
 	</div>
 );
@@ -186,6 +186,7 @@ const Search = () => {
 			isOpen={ isOpen }
 			initialFocus={ inputRef }
 			position="top-center"
+			aria-label={ __( "Search", "wordpress-seo" ) }
 		>
 			<Modal.Panel closeButtonScreenReaderText={ __( "Close", "wordpress-seo" ) }>
 				<Combobox as="div" className="yst--m-6 yst--mt-5" onChange={ handleNavigate }>

--- a/packages/js/src/settings/components/search.js
+++ b/packages/js/src/settings/components/search.js
@@ -57,7 +57,7 @@ SearchResultLabel.propTypes = {
  */
 const SearchNoResultsContent = ( { title, children } ) => (
 	<div className="yst-border-t yst-border-slate-100 yst-p-6 yst-py-12 yst-space-3 yst-text-center yst-text-sm">
-		<Modal.Title className="yst-block yst-font-semibold yst-text-slate-900 yst-text-sm">{ title }</Modal.Title>
+		<Modal.Title className="yst-block yst-font-semibold yst-text-slate-900" size="5">{ title }</Modal.Title>
 		{ children }
 	</div>
 );

--- a/packages/ui-library/src/components/modal/index.js
+++ b/packages/ui-library/src/components/modal/index.js
@@ -38,6 +38,7 @@ Title.propTypes = {
 	size: PropTypes.oneOf( Object.keys( titleClassNameMap.size ) ),
 	className: PropTypes.string,
 	children: PropTypes.node.isRequired,
+	as: PropTypes.elementType,
 };
 
 /**

--- a/packages/ui-library/src/components/modal/index.js
+++ b/packages/ui-library/src/components/modal/index.js
@@ -5,6 +5,7 @@ import classNames from "classnames";
 import PropTypes from "prop-types";
 import { useSvgAria } from "../../hooks";
 import { ModalContext, useModalContext } from "./hooks";
+import { classNameMap as titleClassNameMap } from "../../elements/title";
 
 /**
  * @param {JSX.node} children Title text.
@@ -12,11 +13,14 @@ import { ModalContext, useModalContext } from "./hooks";
  * @param {Object} [props] Additional props.
  * @returns {JSX.Element} The panel.
  */
-const Title = forwardRef( ( { children, className = "", ...props }, ref ) => {
+const Title = forwardRef( ( { children, size, className, ...props }, ref ) => {
 	return (
 		<Dialog.Title
 			ref={ ref }
-			className={  classNames( "yst-title", className ) }
+			className={  classNames(
+				"yst-title",
+				size ? titleClassNameMap.size[ size ] : "",
+				className ) }
 			{ ...props }
 		>
 			{ children }
@@ -24,7 +28,13 @@ const Title = forwardRef( ( { children, className = "", ...props }, ref ) => {
 	);
 } );
 
+Title.defaultProps = {
+	className: "",
+	as: "h1",
+};
+
 Title.propTypes = {
+	size: PropTypes.oneOf( Object.keys( titleClassNameMap.size ) ),
 	className: PropTypes.string,
 	children: PropTypes.node.isRequired,
 };

--- a/packages/ui-library/src/components/modal/index.js
+++ b/packages/ui-library/src/components/modal/index.js
@@ -29,7 +29,6 @@ Title.propTypes = {
 	children: PropTypes.node.isRequired,
 };
 
-
 /**
  * @param {JSX.node} children Contents of the modal.
  * @param {string} [className] Additional class names.
@@ -129,7 +128,6 @@ Modal.propTypes = {
 	className: PropTypes.string,
 	position: PropTypes.oneOf( Object.keys( classNameMap.position ) ),
 };
-
 
 Modal.Panel = Panel;
 Modal.Panel.displayName = "Modal.Panel";

--- a/packages/ui-library/src/components/modal/index.js
+++ b/packages/ui-library/src/components/modal/index.js
@@ -3,9 +3,33 @@ import { XIcon } from "@heroicons/react/outline";
 import { forwardRef, Fragment } from "@wordpress/element";
 import classNames from "classnames";
 import PropTypes from "prop-types";
-import Title from "../../elements/title";
+// import Title from "../../elements/title";
 import { useSvgAria } from "../../hooks";
 import { ModalContext, useModalContext } from "./hooks";
+
+/**
+ * @param {JSX.node} children Title text.
+ * @param {string} [className] Additional class names.
+ * @param {Object} [props] Additional props.
+ * @returns {JSX.Element} The panel.
+ */
+const ModalTitle = forwardRef( ( { children, className = "", ...props }, ref ) => {
+	return (
+		<Dialog.Title
+			ref={ ref }
+			className={ `yst-title ${ className }` }
+			{ ...props }
+		>
+			{ children }
+		</Dialog.Title>
+	);
+} );
+
+ModalTitle.propTypes = {
+	className: PropTypes.string,
+	children: PropTypes.node.isRequired,
+};
+
 
 /**
  * @param {JSX.node} children Contents of the modal.
@@ -107,9 +131,10 @@ Modal.propTypes = {
 	position: PropTypes.oneOf( Object.keys( classNameMap.position ) ),
 };
 
+
 Modal.Panel = Panel;
 Modal.Panel.displayName = "Modal.Panel";
-Modal.Title = Title;
+Modal.Title = ModalTitle;
 Modal.Title.displayName = "Modal.Title";
 Modal.Description = Dialog.Description;
 Modal.Description.displayName = "Modal.Description";

--- a/packages/ui-library/src/components/modal/index.js
+++ b/packages/ui-library/src/components/modal/index.js
@@ -13,9 +13,10 @@ import { classNameMap as titleClassNameMap } from "../../elements/title";
  * @param {Object} [props] Additional props.
  * @returns {JSX.Element} The panel.
  */
-const Title = forwardRef( ( { children, size, className, ...props }, ref ) => {
+const Title = forwardRef( ( { children, size, className, as, ...props }, ref ) => {
 	return (
 		<Dialog.Title
+			as={ as }
 			ref={ ref }
 			className={  classNames(
 				"yst-title",

--- a/packages/ui-library/src/components/modal/index.js
+++ b/packages/ui-library/src/components/modal/index.js
@@ -3,7 +3,6 @@ import { XIcon } from "@heroicons/react/outline";
 import { forwardRef, Fragment } from "@wordpress/element";
 import classNames from "classnames";
 import PropTypes from "prop-types";
-// import Title from "../../elements/title";
 import { useSvgAria } from "../../hooks";
 import { ModalContext, useModalContext } from "./hooks";
 
@@ -13,7 +12,7 @@ import { ModalContext, useModalContext } from "./hooks";
  * @param {Object} [props] Additional props.
  * @returns {JSX.Element} The panel.
  */
-const ModalTitle = forwardRef( ( { children, className = "", ...props }, ref ) => {
+const Title = forwardRef( ( { children, className = "", ...props }, ref ) => {
 	return (
 		<Dialog.Title
 			ref={ ref }
@@ -25,7 +24,7 @@ const ModalTitle = forwardRef( ( { children, className = "", ...props }, ref ) =
 	);
 } );
 
-ModalTitle.propTypes = {
+Title.propTypes = {
 	className: PropTypes.string,
 	children: PropTypes.node.isRequired,
 };
@@ -134,7 +133,7 @@ Modal.propTypes = {
 
 Modal.Panel = Panel;
 Modal.Panel.displayName = "Modal.Panel";
-Modal.Title = ModalTitle;
+Modal.Title = Title;
 Modal.Title.displayName = "Modal.Title";
 Modal.Description = Dialog.Description;
 Modal.Description.displayName = "Modal.Description";

--- a/packages/ui-library/src/components/modal/index.js
+++ b/packages/ui-library/src/components/modal/index.js
@@ -10,6 +10,8 @@ import { classNameMap as titleClassNameMap } from "../../elements/title";
 /**
  * @param {JSX.node} children Title text.
  * @param {string} [className] Additional class names.
+ * @param {string} [as] Html tag.
+ * @param {string} [size] Size of title.
  * @param {Object} [props] Additional props.
  * @returns {JSX.Element} The panel.
  */

--- a/packages/ui-library/src/components/modal/index.js
+++ b/packages/ui-library/src/components/modal/index.js
@@ -17,7 +17,7 @@ const ModalTitle = forwardRef( ( { children, className = "", ...props }, ref ) =
 	return (
 		<Dialog.Title
 			ref={ ref }
-			className={ `yst-title ${ className }` }
+			className={  classNames( "yst-title", className ) }
 			{ ...props }
 		>
 			{ children }

--- a/packages/ui-library/src/components/modal/stories.js
+++ b/packages/ui-library/src/components/modal/stories.js
@@ -3,6 +3,7 @@ import { noop } from "lodash";
 import PropTypes from "prop-types";
 import RawModal, { classNameMap } from ".";
 import Button from "../../elements/button";
+import { classNameMap as titleClassNameMap } from "../../elements/title";
 
 const Modal = ( { isOpen: initialIsOpen, onClose: _, children, ...props } ) => {
 	const [ isOpen, setIsOpen ] = useState( initialIsOpen );
@@ -60,6 +61,12 @@ export default {
 				defaultValue: { summary: "center" },
 			},
 			options: Object.keys( classNameMap.position ),
+		},
+		size: {
+			control: "select",
+			description: "Prop for the `Model.Title` component.",
+			type: { summary: Object.keys( titleClassNameMap.size ).join( "|" ) },
+			options: Object.keys( titleClassNameMap.size ),
 		},
 	},
 	parameters: {

--- a/packages/ui-library/src/components/modal/stories.js
+++ b/packages/ui-library/src/components/modal/stories.js
@@ -112,7 +112,7 @@ export const WithTitleAndDescription = {
 	parameters: {
 		docs: {
 			description: {
-				story: "Using the `Modal.Title` and `Modal.Description` components.",
+				story: "Using the `Modal.Title` and `Modal.Description` components will add `aria-labelledby` and `aria-describedby` to the Modal with matching IDrefs.",
 			},
 		},
 	},

--- a/packages/ui-library/src/elements/title/index.js
+++ b/packages/ui-library/src/elements/title/index.js
@@ -8,6 +8,7 @@ export const classNameMap = {
 		2: "yst-title--2",
 		3: "yst-title--3",
 		4: "yst-title--4",
+		5: "yst-title--5",
 	},
 };
 

--- a/packages/ui-library/src/elements/title/index.js
+++ b/packages/ui-library/src/elements/title/index.js
@@ -2,7 +2,7 @@
 import PropTypes from "prop-types";
 import classNames from "classnames";
 
-const classNameMap = {
+export const classNameMap = {
 	size: {
 		1: "yst-title--1",
 		2: "yst-title--2",

--- a/packages/ui-library/src/elements/title/style.css
+++ b/packages/ui-library/src/elements/title/style.css
@@ -19,6 +19,7 @@
 		.yst-title--4 {
 			@apply yst-text-base;
 		}
+		
 		.yst-title--5 {
 			@apply yst-text-sm;
 		}

--- a/packages/ui-library/src/elements/title/style.css
+++ b/packages/ui-library/src/elements/title/style.css
@@ -16,8 +16,8 @@
 			@apply yst-text-tiny;
 		}
 
-		.yst-title--4 {
-			@apply yst-text-base;
+		.yst-title--5 {
+			@apply yst-text-sm;
 		}
 	}
 }

--- a/packages/ui-library/src/elements/title/style.css
+++ b/packages/ui-library/src/elements/title/style.css
@@ -16,6 +16,9 @@
 			@apply yst-text-tiny;
 		}
 
+		.yst-title--4 {
+			@apply yst-text-base;
+		}
 		.yst-title--5 {
 			@apply yst-text-sm;
 		}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Changes `Modal.Title` tag from `h3` to default `h1`.
* Adds `aria-labelledby` support to `Modal` with `Modal.Title` component in `ui-library`.
* Updates `Modal.Title` in `Discard changes`, 
* Adds `aria-label` to `Indroduction` and `Search` modals.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves modal title accessibility in the `Discard changes`,`Search` and `Introduction` modals.

## Relevant technical choices:

* Replaces the `Modal.Title` from `Title` (from the `ui-library`) to `Dialog.Title` (from `headless-ui`) to automatically add `aria-labelledby` tag to modal.
* `Modal.Title` component in `ui-library` now has:
  * `yst-title` class by default.
  * `size` support as `Title` Element.
  * `ref` support as in the original component `Dialog.Title`.
  * Default `as` is `h1`
* Adding documentation in the Modal stories.
*  Updates the `aria-label` in `Introduction` and `Search` modals.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

For `Discard changes` modal:
* Open `YoastSeo`->`settings`
* Change something and click on `Discard changes` in the bottom of the screen.
* Inspect dialog box and check if dialog div where it has `role="dialog"` has `aria-labelledby` prop
* Inspect title in dialog box and check if:
  * If the title tag is `h1`.
  * If it has `id` that matches the `aria-labelledby` value. 
* Open in Safari, enable voiceover (cmd+f5) and verify the title gets read.

For `Search` modal:
* Open `YoastSeo`->`settings`
* Click on the search.
* Inspect dialog box and check if dialog div where it has `role="dialog"` has `aria-label` prop.
* Open in Safari, enable voiceover (cmd+f5) and verify the title gets read.

For `Intoduction` modal:
* Open `YoastSeo`->`settings`
* The `Introduction modal should open, if it doesn't then update entry in database to enable or switch to a different or new user.
* Inspect dialog box and check if dialog div where it has `role="dialog"` has `aria-label` prop.
* Open in Safari, enable voiceover (cmd+f5) and verify the title gets read.

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [X] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* UI library

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [X] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes [Improve the 'Discard all changes' dialog a11y#19488](https://github.com/Yoast/wordpress-seo/issues/19488)
[DUPP-884](https://yoast.atlassian.net/browse/DUPP-884)
