### PR TITLE
Add ariaLabel to logo and focus style

### DIFF
--- a/packages/js/src/settings/app.js
+++ b/packages/js/src/settings/app.js
@@ -71,8 +71,8 @@ const Menu = ( { postTypes, taxonomies, idSuffix = "" } ) => {
 
 	return <>
 		<header className="yst-px-3 yst-mb-6 yst-space-y-6">
-			<Link to="/" className="yst-inline-block yst-rounded-md focus:yst-ring-2 focus:yst-ring-offset-2 focus:yst-ring-primary-500"  tabindex={ 0 }>
-				<YoastLogo className="yst-w-40" { ...svgAriaProps } ariaLabel={ `Yoast SEO ${isPremium ? "Premium " : "" }settings` } />
+			<Link to="/" className="yst-inline-block yst-rounded-md focus:yst-ring-2 focus:yst-ring-offset-2 focus:yst-ring-primary-500" aria-label={ `Yoast SEO${ isPremium ? " Premium" : "" }` }>
+				<YoastLogo className="yst-w-40" { ...svgAriaProps } />
 			</Link>
 			<Search />
 		</header>

--- a/packages/js/src/settings/app.js
+++ b/packages/js/src/settings/app.js
@@ -71,7 +71,7 @@ const Menu = ( { postTypes, taxonomies, idSuffix = "" } ) => {
 
 	return <>
 		<header className="yst-px-3 yst-mb-6 yst-space-y-6">
-			<Link to="/" className="yst-inline-block yst-rounded-md focus:yst-border focus:yst-outline-none focus:yst-ring-2 focus:yst-ring-offset-2 focus:yst-ring-primary-500"  tabindex={ 0 }>
+			<Link to="/" className="yst-inline-block yst-rounded-md focus:yst-ring-2 focus:yst-ring-offset-2 focus:yst-ring-primary-500"  tabindex={ 0 }>
 				<YoastLogo className="yst-w-40" { ...svgAriaProps } ariaLabel={ `Yoast SEO ${isPremium ? "Premium " : "" }settings` } />
 			</Link>
 			<Search />

--- a/packages/js/src/settings/app.js
+++ b/packages/js/src/settings/app.js
@@ -46,6 +46,7 @@ import {
  */
 const Menu = ( { postTypes, taxonomies, idSuffix = "" } ) => {
 	const svgAriaProps = useSvgAria();
+	const isPremium = useSelectSettings( "selectPreference", [], "isPremium" );
 
 	const renderMoreOrLessButton = useCallback( ( { show, toggle, ariaProps } ) => {
 		const ChevronIcon = useMemo( () => show ? ChevronUpIcon : ChevronDownIcon, [ show ] );
@@ -70,8 +71,8 @@ const Menu = ( { postTypes, taxonomies, idSuffix = "" } ) => {
 
 	return <>
 		<header className="yst-px-3 yst-mb-6 yst-space-y-6">
-			<Link to="/" className="yst-inline-block">
-				<YoastLogo className="yst-w-40" { ...svgAriaProps } />
+			<Link to="/" className="yst-inline-block yst-rounded-md focus:yst-border focus:yst-outline-none focus:yst-ring-2 focus:yst-ring-offset-2 focus:yst-ring-primary-500"  tabindex={ 0 }>
+				<YoastLogo className="yst-w-40" { ...svgAriaProps } ariaLabel={ `Yoast SEO ${isPremium ? "Premium " : "" }settings` } />
 			</Link>
 			<Search />
 		</header>


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Adds aria-label to Yoast logo link in `settings UI` with different label for premium.
* Adds focus style to logo's link

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves the accessibility of the `Yoast SEO` logo in settings.

## Relevant technical choices:

* 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Open `YoastSeo`-> `settings`
* Click on tab key and see if focus is on logo
* Turn off premium and inspect page and check if logo has aria-label and if it is "Yoast SEO".
* Turn on Premium and inspect page and check if logo has aria-label and if it is "Yoast SEO Premium".
* Inspect logo's link and check if it has `aria-label` prop.
* Open in Safari, enable voiceover (cmd+f5) and verify the label gets read.

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [X] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes [Improve Yoast SEO logo link accessibility#19434](https://github.com/Yoast/wordpress-seo/issues/19434)
