### PR TITLE
Settings UI: Change minimum query characters depending on the user locale

### DIFF
--- a/packages/js/src/settings/components/search.js
+++ b/packages/js/src/settings/components/search.js
@@ -81,12 +81,13 @@ const Search = () => {
 	const inputRef = useRef( null );
 	const { platform, os } = useParsedUserAgent();
 
-	// For Korean, Chinese, and Chinese (Hong Kong), Chinese (Taiwan), we need to search with 1 character.
-	// For Japanese, we need to search with 2 characters. (ja is the language code for Japanese.)
+	// Determines the minimum characters to start a search, based on the user locale.
 	const queryMinChars = useMemo( () => {
 		switch ( userLocale ) {
+			// Japanese.
 			case "ja":
 				return 2;
+			// Korean, Chinese, Chinese (Hong Kong), Chinese (Taiwan).
 			case "ko-KR":
 			case "zh-CN":
 			case "zh-HK":

--- a/packages/js/src/settings/components/search.js
+++ b/packages/js/src/settings/components/search.js
@@ -1,9 +1,9 @@
 /* eslint-disable complexity */
 import { Combobox } from "@headlessui/react";
 import { SearchIcon } from "@heroicons/react/outline";
-import { useCallback, useMemo, useRef, useState } from "@wordpress/element";
+import { useCallback, useRef, useState, useMemo } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
-import { Code, Modal, Title, useSvgAria, useToggleState } from "@yoast/ui-library";
+import { Modal, Title, useSvgAria, useToggleState, Code } from "@yoast/ui-library";
 import classNames from "classnames";
 import { debounce, first, groupBy, includes, isEmpty, map, max, reduce, split, trim, values } from "lodash";
 import PropTypes from "prop-types";
@@ -80,6 +80,9 @@ const Search = () => {
 	const navigate = useNavigate();
 	const inputRef = useRef( null );
 	const { platform, os } = useParsedUserAgent();
+
+	// For Japanese, Korean, Chinese, and Chinese (Hong Kong) we need to search with 1 character.
+	// For Chinese (Taiwan) we need to search with 2 characters.
 	const queryMinChars = useMemo( () => {
 		switch ( userLocale ) {
 			case "ja":

--- a/packages/js/src/settings/components/search.js
+++ b/packages/js/src/settings/components/search.js
@@ -1,9 +1,9 @@
 /* eslint-disable complexity */
 import { Combobox } from "@headlessui/react";
 import { SearchIcon } from "@heroicons/react/outline";
-import { useCallback, useRef, useState, useMemo } from "@wordpress/element";
+import { useCallback, useMemo, useRef, useState } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
-import { Modal, Title, useSvgAria, useToggleState, Code } from "@yoast/ui-library";
+import { Code, Modal, Title, useSvgAria, useToggleState } from "@yoast/ui-library";
 import classNames from "classnames";
 import { debounce, first, groupBy, includes, isEmpty, map, max, reduce, split, trim, values } from "lodash";
 import PropTypes from "prop-types";
@@ -12,7 +12,6 @@ import { useNavigate } from "react-router-dom";
 import { safeToLocaleLower } from "../helpers";
 import { useParsedUserAgent, useSelectSettings } from "../hooks";
 
-const QUERY_MIN_CHARS = 3;
 const POST_TYPE_OR_TAXONOMY_BREADCRUMB_SETTING_REGEXP = new RegExp( /^input-wpseo_titles-(post_types|taxonomy)-(?<name>\S+)-(maintax|ptparent)$/is );
 
 /**
@@ -21,7 +20,7 @@ const POST_TYPE_OR_TAXONOMY_BREADCRUMB_SETTING_REGEXP = new RegExp( /^input-wpse
  * @returns {JSX.Element} The SearchResultLabel element.
  */
 const SearchResultLabel = ( { fieldId, fieldLabel } ) => {
-	// Deduce wether field is a breadcrumb option for post type or taxonomy.
+	// Deduce whether field is a breadcrumb option for post type or taxonomy.
 	const { isPostTypeOrTaxonomyBreadcrumbSetting, postTypeOrTaxonomyName } = useMemo( () => {
 		const matches = POST_TYPE_OR_TAXONOMY_BREADCRUMB_SETTING_REGEXP.exec( fieldId );
 		return {
@@ -81,6 +80,19 @@ const Search = () => {
 	const navigate = useNavigate();
 	const inputRef = useRef( null );
 	const { platform, os } = useParsedUserAgent();
+	const queryMinChars = useMemo( () => {
+		switch ( userLocale ) {
+			case "ja":
+				return 2;
+			case "ko-KR":
+			case "zh-CN":
+			case "zh-HK":
+			case "zh-TW":
+				return 1;
+			default:
+				return 3;
+		}
+	}, [ userLocale ] );
 
 	useHotkeys(
 		"meta+k",
@@ -109,7 +121,7 @@ const Search = () => {
 		const trimmedQuery = trim( newQuery );
 
 		// Bail if query is too short.
-		if ( trimmedQuery.length < QUERY_MIN_CHARS ) {
+		if ( trimmedQuery.length < queryMinChars ) {
 			return false;
 		}
 
@@ -203,16 +215,18 @@ const Search = () => {
 							className="yst-h-12 yst-w-full yst-border-0 yst-bg-transparent yst-px-11 yst-text-slate-800 yst-placeholder-slate-400 focus:yst-ring-0 sm:yst-text-sm"
 						/>
 					</div>
-					{ query.length >= QUERY_MIN_CHARS && ! isEmpty( results ) && (
+					{ query.length >= queryMinChars && ! isEmpty( results ) && (
 						<Combobox.Options
 							static={ true }
 							className="yst-max-h-[calc(90vh-10rem)] yst-scroll-pt-11 yst-scroll-pb-2 yst-space-y-2 yst-overflow-y-auto yst-pb-2"
 						>
 							{ map( results, ( groupedItems, index ) => (
 								<li key={ groupedItems?.[ 0 ]?.route || `group-${ index }` }>
-									<Title as="h4" size="3" className="yst-bg-slate-100 yst-py-3 yst-px-4">{ first( groupedItems ).routeLabel }</Title>
+									<Title as="h4" size="3" className="yst-bg-slate-100 yst-py-3 yst-px-4">
+										{ first( groupedItems ).routeLabel }
+									</Title>
 									<ul>
-										{ map( groupedItems, ( item ) =>  (
+										{ map( groupedItems, ( item ) => (
 											<Combobox.Option
 												key={ item.fieldId }
 												value={ item }
@@ -226,12 +240,12 @@ const Search = () => {
 							) ) }
 						</Combobox.Options>
 					) }
-					{ query.length < QUERY_MIN_CHARS && (
+					{ query.length < queryMinChars && (
 						<SearchNoResultsContent title={ __( "Search", "wordpress-seo" ) }>
 							<p className="yst-text-slate-500">{ __( "Please enter a search term with at least 3 characters.", "wordpress-seo" ) }</p>
 						</SearchNoResultsContent>
 					) }
-					{ query.length >= QUERY_MIN_CHARS && isEmpty( results ) && (
+					{ query.length >= queryMinChars && isEmpty( results ) && (
 						<SearchNoResultsContent title={ __( "No results found", "wordpress-seo" ) }>
 							<p className="yst-text-slate-500">{ __( "We couldn’t find anything with that term.", "wordpress-seo" ) }</p>
 						</SearchNoResultsContent>

--- a/packages/js/src/settings/components/search.js
+++ b/packages/js/src/settings/components/search.js
@@ -81,8 +81,8 @@ const Search = () => {
 	const inputRef = useRef( null );
 	const { platform, os } = useParsedUserAgent();
 
-	// For Japanese, Korean, Chinese, and Chinese (Hong Kong) we need to search with 1 character.
-	// For Chinese (Taiwan) we need to search with 2 characters.
+	// For Korean, Chinese, and Chinese (Hong Kong), Chinese (Taiwan), we need to search with 1 character.
+	// For Japanese, we need to search with 2 characters. (ja is the language code for Japanese.)
 	const queryMinChars = useMemo( () => {
 		switch ( userLocale ) {
 			case "ja":


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Improve searching in other locales.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where certain terms would not be searchable in certain locales due to the minimum length of the query.

## Relevant technical choices:

* Mapping user locale to minimum query lengths to gain more precision.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Verify the user language is set to site default.
* Switch the site language to Japanese and download the translations.
* Go to the Settings > Content types > Posts (to help with languages: `https://basic.wordpress.test/wp-admin/admin.php?page=wpseo_page_settings#/post-type/posts`)
* Copy the translation of `Posts`, i.e. the title of the page. In Japanese this is `設定`.
* Search for that term
* Verify you get results (where before this you would not, see issue)
* Repeat the above steps for: Korean and Chinese. You can use the user language instead of the site language (that is what is checked).

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [x] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes https://github.com/Yoast/plugins-automated-testing/issues/302
