### PR TITLE
Settings UI: Mobile view: Fix detected mobile view issues

### DIFF
--- a/css/src/new-settings.css
+++ b/css/src/new-settings.css
@@ -50,10 +50,43 @@
 }
 
 @layer components {
+	body.sticky-menu {
+		.yst-root .yst-notifications--bottom-left {
+			@media (min-width: 783px) and (max-width: 962px) {
+				left: calc(160px + 2rem); /* Next to admin menu. 160px is the admin menu width. */
+			}
+		}
+
+		&.folded, &.auto-fold {
+			.yst-root .yst-notifications--bottom-left {
+				@media (min-width: 783px) and (max-width: 963px) {
+					left: calc(32px + 2rem); /* Next to admin menu. 32px is the collapsed admin menu width. */
+				}
+			}
+		}
+
+		&.folded {
+			.yst-root .yst-notifications--bottom-left {
+				@media (min-width: 962px) {
+					left: calc(32px + 2rem); /* Next to admin menu. 32px is the collapsed admin menu width. */
+				}
+			}
+		}
+	}
+
+	body:not(.sticky-menu) .wp-responsive-open .yst-root {
+		.yst-notifications--bottom-left {
+			left: calc(190px + 2rem); /* Next to admin menu. 190px is the responsive admin menu width. */
+		}
+	}
+
 	.yst-root {
 		.yst-notifications--bottom-left {
-			left: calc(160px + 2rem); /* Next to admin menu. 160px is admin menu width */
 			z-index: 9991; /* 1 above admin menu */
+
+			@media (min-width: 783px) {
+				left: calc(160px + 2rem); /* Next to admin menu. 160px is the admin menu width. */
+			}
 		}
 
 		.yst-mobile-navigation__top {

--- a/css/src/new-settings.css
+++ b/css/src/new-settings.css
@@ -23,6 +23,12 @@
 			padding-left: 17rem;
 		}
 	}
+
+	.wp-responsive-open #wpbody {
+		@media screen and (max-width: 782px) {
+			right: -190px; /* Override to not leave space between the mobile menu and the content. */
+		}
+	}
 }
 
 @layer base {
@@ -76,7 +82,9 @@
 
 	body:not(.sticky-menu) .wp-responsive-open .yst-root {
 		.yst-notifications--bottom-left {
-			left: calc(190px + 2rem); /* Next to admin menu. 190px is the responsive admin menu width. */
+			@media (max-width: 783px) {
+				left: calc(190px + 2rem); /* Next to admin menu. 190px is the responsive admin menu width. */
+			}
 		}
 	}
 

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@draft-js-plugins/mention": "^5.0.0",
-    "@headlessui/react": "^1.7.1",
+    "@headlessui/react": "^1.7.7",
     "@heroicons/react": "^1.0.6",
     "@wordpress/api-fetch": "^6.13.0",
     "@wordpress/blocks": "^11.1.2",

--- a/packages/js/src/settings/app.js
+++ b/packages/js/src/settings/app.js
@@ -66,7 +66,7 @@ const Menu = ( { postTypes, taxonomies, idSuffix = "" } ) => {
 			<Link to="/" className="yst-inline-block">
 				<YoastLogo className="yst-w-40" { ...svgAriaProps } />
 			</Link>
-			<Search />
+			<Search buttonId={ `button-search${ idSuffix }` } />
 		</header>
 		<div className="yst-px-0.5 yst-space-y-6">
 			<SidebarNavigation.MenuItem

--- a/packages/js/src/settings/app.js
+++ b/packages/js/src/settings/app.js
@@ -70,7 +70,7 @@ const Menu = ( { postTypes, taxonomies, idSuffix = "" } ) => {
 		</header>
 		<div className="yst-px-0.5 yst-space-y-6">
 			<SidebarNavigation.MenuItem
-				id={ `menu-general${ idSuffix && `-${ idSuffix }` }` }
+				id={ `menu-general${ idSuffix }` }
 				icon={ DesktopComputerIcon }
 				label={ __( "General", "wordpress-seo" ) }
 			>
@@ -84,7 +84,7 @@ const Menu = ( { postTypes, taxonomies, idSuffix = "" } ) => {
 				<SidebarNavigation.SubmenuItem to="/site-connections" label={ __( "Site connections", "wordpress-seo" ) } idSuffix={ idSuffix } />
 			</SidebarNavigation.MenuItem>
 			<SidebarNavigation.MenuItem
-				id={ `menu-content-types${ idSuffix && `-${ idSuffix }` }` }
+				id={ `menu-content-types${ idSuffix }` }
 				icon={ NewspaperIcon }
 				label={ __( "Content types", "wordpress-seo" ) }
 			>
@@ -101,7 +101,7 @@ const Menu = ( { postTypes, taxonomies, idSuffix = "" } ) => {
 				</ChildrenLimiter>
 			</SidebarNavigation.MenuItem>
 			<SidebarNavigation.MenuItem
-				id={ `menu-categories-and-tags${ idSuffix && `-${ idSuffix }` }` }
+				id={ `menu-categories-and-tags${ idSuffix }` }
 				icon={ ColorSwatchIcon }
 				label={ __( "Categories & tags", "wordpress-seo" ) }
 			>
@@ -116,7 +116,7 @@ const Menu = ( { postTypes, taxonomies, idSuffix = "" } ) => {
 				</ChildrenLimiter>
 			</SidebarNavigation.MenuItem>
 			<SidebarNavigation.MenuItem
-				id={ `menu-advanced${ idSuffix && `-${ idSuffix }` }` }
+				id={ `menu-advanced${ idSuffix }` }
 				icon={ AdjustmentsIcon }
 				label={ __( "Advanced", "wordpress-seo" ) }
 				defaultOpen={ false }
@@ -231,7 +231,7 @@ const App = () => {
 					openButtonScreenReaderText={ __( "Open sidebar", "wordpress-seo" ) }
 					closeButtonScreenReaderText={ __( "Close sidebar", "wordpress-seo" ) }
 				>
-					<Menu idSuffix="mobile" postTypes={ postTypes } taxonomies={ taxonomies } />
+					<Menu idSuffix="-mobile" postTypes={ postTypes } taxonomies={ taxonomies } />
 				</SidebarNavigation.Mobile>
 				<div className="yst-p-4 min-[783px]:yst-p-8 yst-flex yst-gap-4">
 					<aside className="yst-sidebar yst-sidebar-nav yst-shrink-0 yst-hidden min-[783px]:yst-block yst-pb-6 yst-bottom-0 yst-w-56">

--- a/packages/js/src/settings/app.js
+++ b/packages/js/src/settings/app.js
@@ -1,14 +1,7 @@
 /* eslint-disable react/jsx-max-depth */
 import { Transition } from "@headlessui/react";
-import {
-	AdjustmentsIcon,
-	ArrowNarrowRightIcon,
-	ChevronDownIcon,
-	ChevronUpIcon,
-	ColorSwatchIcon,
-	DesktopComputerIcon,
-	NewspaperIcon,
-} from "@heroicons/react/outline";
+import { AdjustmentsIcon, ArrowNarrowRightIcon, ColorSwatchIcon, DesktopComputerIcon, NewspaperIcon } from "@heroicons/react/outline";
+import { ChevronDownIcon, ChevronUpIcon } from "@heroicons/react/solid";
 import { useCallback, useMemo } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
 import { Badge, Button, ChildrenLimiter, ErrorBoundary, Title, useBeforeUnload, useSvgAria } from "@yoast/ui-library";
@@ -54,7 +47,7 @@ const Menu = ( { postTypes, taxonomies, idSuffix = "" } ) => {
 			<div className="yst-relative">
 				<hr className="yst-absolute yst-inset-x-0 yst-top-1/2 yst-bg-slate-200" />
 				<button
-					className="yst-relative yst-flex yst-items-center yst-gap-2 yst-px-2.5 yst-py-1 yst-mx-auto yst-text-xs yst-font-medium yst-text-slate-700 yst-bg-slate-50 yst-rounded-full yst-border yst-border-slate-300 hover:yst-bg-white hover:yst-text-slate-800 focus:yst-outline-none focus:yst-ring-2 focus:yst-ring-primary-500 focus:yst-ring-offset-2"
+					className="yst-relative yst-flex yst-items-center yst-gap-1.5 yst-px-2.5 yst-py-1 yst-mx-auto yst-text-xs yst-font-medium yst-text-slate-700 yst-bg-slate-50 yst-rounded-full yst-border yst-border-slate-300 hover:yst-bg-white hover:yst-text-slate-800 focus:yst-outline-none focus:yst-ring-2 focus:yst-ring-primary-500 focus:yst-ring-offset-2"
 					onClick={ toggle }
 					{ ...ariaProps }
 				>

--- a/packages/js/src/settings/components/search.js
+++ b/packages/js/src/settings/components/search.js
@@ -1,9 +1,9 @@
 /* eslint-disable complexity */
 import { Combobox } from "@headlessui/react";
 import { SearchIcon } from "@heroicons/react/outline";
-import { useCallback, useRef, useState, useMemo } from "@wordpress/element";
+import { useCallback, useMemo, useRef, useState } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
-import { Modal, Title, useSvgAria, useToggleState, Code } from "@yoast/ui-library";
+import { Code, Modal, Title, useNavigationContext, useSvgAria, useToggleState } from "@yoast/ui-library";
 import classNames from "classnames";
 import { debounce, first, groupBy, includes, isEmpty, map, max, reduce, split, trim, values } from "lodash";
 import PropTypes from "prop-types";
@@ -80,6 +80,7 @@ const Search = ( { buttonId = "button-search" } ) => {
 	const navigate = useNavigate();
 	const inputRef = useRef( null );
 	const { platform, os } = useParsedUserAgent();
+	const { isMobileMenuOpen, setMobileMenuOpen } = useNavigationContext();
 
 	// Determines the minimum characters to start a search, based on the user locale.
 	const queryMinChars = useMemo( () => {
@@ -103,7 +104,7 @@ const Search = ( { buttonId = "button-search" } ) => {
 		event => {
 			event.preventDefault();
 			// Only bind hotkeys when platform type is desktop.
-			if ( platform?.type === "desktop" && ! isOpen ) {
+			if ( platform?.type === "desktop" && ! isOpen && ! isMobileMenuOpen ) {
 				setOpen();
 			}
 		},
@@ -111,15 +112,16 @@ const Search = ( { buttonId = "button-search" } ) => {
 			enableOnFormTags: true,
 			enableOnContentEditable: true,
 		},
-		[ isOpen, setOpen, platform ]
+		[ isOpen, setOpen, platform, isMobileMenuOpen ]
 	);
 
 	const handleNavigate = useCallback( ( { route, fieldId } ) => {
+		setMobileMenuOpen( false );
 		setClose();
 		setQuery( "" );
 		setResults( [] );
 		navigate( `${ route }#${ fieldId }` );
-	}, [ setClose, setQuery ] );
+	}, [ setClose, setQuery, setMobileMenuOpen ] );
 
 	const debouncedSearch = useCallback( debounce( newQuery => {
 		const trimmedQuery = trim( newQuery );

--- a/packages/js/src/settings/components/search.js
+++ b/packages/js/src/settings/components/search.js
@@ -67,10 +67,10 @@ SearchNoResultsContent.propTypes = {
 };
 
 /**
+ * @param {string} [buttonId] The ID for the search button.
  * @returns {JSX.Element} The element.
  */
-const Search = () => {
-	// eslint-disable-next-line no-unused-vars
+const Search = ( { buttonId = "button-search" } ) => {
 	const [ isOpen, , , setOpen, setClose ] = useToggleState( false );
 	const [ query, setQuery ] = useState( "" );
 	const userLocale = useSelectSettings( "selectPreference", [], "userLocale" );
@@ -181,7 +181,7 @@ const Search = () => {
 
 	return <>
 		<button
-			id="yst-search-button"
+			id={ buttonId }
 			type="button"
 			className="yst-w-full yst-flex yst-items-center yst-bg-white yst-text-sm yst-leading-6 yst-text-slate-500 yst-rounded-md yst-border yst-border-slate-300 yst-shadow-sm yst-py-1.5 yst-pl-2 yst-pr-3 focus:yst-outline-none focus:yst-ring-2 focus:yst-ring-offset-2 focus:yst-ring-primary-500"
 			onClick={ setOpen }
@@ -258,6 +258,10 @@ const Search = () => {
 			</Modal.Panel>
 		</Modal>
 	</>;
+};
+
+Search.propTypes = {
+	buttonId: PropTypes.string,
 };
 
 export default Search;

--- a/packages/js/src/settings/components/sidebar-navigation.js
+++ b/packages/js/src/settings/components/sidebar-navigation.js
@@ -1,7 +1,7 @@
-import { SidebarNavigation } from "@yoast/ui-library";
-import PropTypes from "prop-types";
-import { replace } from "lodash";
 import { useMemo } from "@wordpress/element";
+import { SidebarNavigation } from "@yoast/ui-library";
+import { replace } from "lodash";
+import PropTypes from "prop-types";
 import { Link } from "react-router-dom";
 
 const PureSubmenuItem = SidebarNavigation.SubmenuItem;
@@ -13,8 +13,8 @@ const PureSubmenuItem = SidebarNavigation.SubmenuItem;
  * @returns {JSX.Element} The submenu item element.
  */
 const SubmenuItem = ( { to, idSuffix = "", ...props } ) => {
-	const id = useMemo( () => replace( replace( `link-${to}`, "/", "-" ), "--", "-" ), [ to ] );
-	return <PureSubmenuItem as={ Link } pathProp="to" id={ `${ id }${ idSuffix && `-${ idSuffix }` }` } to={ to } { ...props } />;
+	const id = useMemo( () => replace( replace( `link-${ to }`, "/", "-" ), "--", "-" ), [ to ] );
+	return <PureSubmenuItem as={ Link } pathProp="to" id={ `${ id }${ idSuffix }` } to={ to } { ...props } />;
 };
 
 SubmenuItem.propTypes = {

--- a/packages/js/src/settings/initialize.js
+++ b/packages/js/src/settings/initialize.js
@@ -56,12 +56,16 @@ const fixFocusLinkCompatibility = () => {
 	const wpContentBody = document.querySelector( "[href=\"#wpbody-content\"]" );
 	wpContentBody.addEventListener( "click", e => {
 		e.preventDefault();
-		document.getElementById( "yst-search-button" ).focus();
+		let searchButton = document.getElementById( "yst-search-button-mobile" );
+		if ( ! searchButton ) {
+			searchButton = document.getElementById( "yst-search-button" )?.focus();
+		}
+		searchButton?.focus();
 	} );
 	const wpToolbar = document.querySelector( "[href=\"#wp-toolbar\"]" );
 	wpToolbar.addEventListener( "click", e => {
 		e.preventDefault();
-		document.querySelector( "#wp-admin-bar-wp-logo a" ).focus();
+		document.querySelector( "#wp-admin-bar-wp-logo a" )?.focus();
 	} );
 };
 

--- a/packages/ui-library/package.json
+++ b/packages/ui-library/package.json
@@ -60,7 +60,7 @@
     "tailwindcss": "^3.2.0"
   },
   "dependencies": {
-    "@headlessui/react": "^1.7.1",
+    "@headlessui/react": "^1.7.7",
     "@heroicons/react": "^1.0.6",
     "classnames": "^2.3.1",
     "lodash": "^4.17.21",

--- a/packages/ui-library/src/components/notifications/style.css
+++ b/packages/ui-library/src/components/notifications/style.css
@@ -2,6 +2,7 @@
     .yst-root {
 
         .yst-notifications {
+            max-width: calc(100% - 4rem); /* 100% - top and left of 2rem = 4rem. */
             @apply yst-fixed yst-w-full yst-z-20 yst-pointer-events-none yst-flex yst-flex-col yst-space-y-4;
         }
 
@@ -18,7 +19,7 @@
         }
 
         .yst-notification {
-            @apply yst-w-80 yst-p-4 yst-bg-white yst-shadow-lg yst-rounded-lg yst-ring-1 yst-ring-black yst-ring-opacity-5 yst-z-20 yst-pointer-events-auto;
+            @apply yst-w-80 yst-max-w-full yst-p-4 yst-bg-white yst-shadow-lg yst-rounded-lg yst-ring-1 yst-ring-black yst-ring-opacity-5 yst-z-20 yst-pointer-events-auto;
         }
 
         .yst-notification--large {

--- a/packages/ui-library/src/components/sidebar-navigation/index.js
+++ b/packages/ui-library/src/components/sidebar-navigation/index.js
@@ -1,28 +1,36 @@
-import { createContext, useContext } from "@wordpress/element";
+import { createContext, useContext, useState } from "@wordpress/element";
+import { noop } from "lodash";
 import PropTypes from "prop-types";
 import MenuItem from "./menu-item";
 import Mobile from "./mobile";
 import Sidebar from "./sidebar";
 import SubmenuItem from "./submenu-item";
 
-const NavigationContext = createContext( { activePath: "" } );
+export const NavigationContext = createContext( {
+	activePath: "",
+	isMobileMenuOpen: false,
+	setMobileMenuOpen: noop,
+} );
 
 /**
  * @returns {Object} The navigation context.
  */
 export const useNavigationContext = () => useContext( NavigationContext );
 
-
 /**
  * @param {string} activePath The path of the active menu item.
  * @param {JSX.node} children The menu(s).
  * @returns {JSX.Element} The navigation element.
  */
-const SidebarNavigation = ( { activePath = "", children } ) => (
-	<NavigationContext.Provider value={ { activePath } }>
-		{ children }
-	</NavigationContext.Provider>
-);
+const SidebarNavigation = ( { activePath = "", children } ) => {
+	const [ isMobileMenuOpen, setMobileMenuOpen ] = useState( false );
+
+	return (
+		<NavigationContext.Provider value={ { activePath, isMobileMenuOpen, setMobileMenuOpen } }>
+			{ children }
+		</NavigationContext.Provider>
+	);
+};
 
 SidebarNavigation.propTypes = {
 	activePath: PropTypes.string,

--- a/packages/ui-library/src/components/sidebar-navigation/mobile.js
+++ b/packages/ui-library/src/components/sidebar-navigation/mobile.js
@@ -1,37 +1,29 @@
 import { Dialog } from "@headlessui/react";
 import { MenuAlt2Icon, XIcon } from "@heroicons/react/outline";
-import { useEffect } from "@wordpress/element";
+import { useCallback } from "@wordpress/element";
 import PropTypes from "prop-types";
-import { usePrevious, useToggleState } from "../../hooks";
 import { useNavigationContext } from "./index";
 
 /**
  * @param {JSX.node} children The menu items.
  * @param {string} [openButtonScreenReaderText] The open button screen reader text.
  * @param {string} [closeButtonScreenReaderText] The close button screen reader text.
- * @param {boolean} [closeOnNavigate] Whether to close the mobile navigation when the active path changed.
  * @returns {JSX.Element} The mobile element.
  */
-const Mobile = ( { children, openButtonScreenReaderText = "Open", closeButtonScreenReaderText = "Close", closeOnNavigate = true } ) => {
-	const { activePath } = useNavigationContext();
-	const previousPath = usePrevious( activePath );
-	const [ isOpen, toggleOpen, setOpen ] = useToggleState( false );
-
-	useEffect( () => {
-		if ( closeOnNavigate && isOpen && activePath !== previousPath ) {
-			setOpen( false );
-		}
-	}, [ closeOnNavigate, activePath, previousPath, isOpen, setOpen ] );
+const Mobile = ( { children, openButtonScreenReaderText = "Open", closeButtonScreenReaderText = "Close" } ) => {
+	const { isMobileMenuOpen, setMobileMenuOpen } = useNavigationContext();
+	const openMobileMenu = useCallback( () => setMobileMenuOpen( true ), [ setMobileMenuOpen ] );
+	const closeMobileMenu = useCallback( () => setMobileMenuOpen( false ), [ setMobileMenuOpen ] );
 
 	return <>
-		<Dialog className="yst-root" open={ isOpen } onClose={ toggleOpen }>
+		<Dialog className="yst-root" open={ isMobileMenuOpen } onClose={ closeMobileMenu }>
 			<div className="yst-mobile-navigation__dialog">
 				<div className="yst-fixed yst-inset-0 yst-bg-slate-600 yst-bg-opacity-75 yst-z-30" aria-hidden="true" />
 				<Dialog.Panel className="yst-relative yst-flex yst-flex-1 yst-flex-col yst-max-w-xs yst-w-full yst-z-40 yst-bg-slate-100">
 					<div className="yst-absolute yst-top-0 yst-right-0 yst--mr-14 yst-p-1">
 						<button
 							className="yst-flex yst-h-12 yst-w-12 yst-items-center yst-justify-center yst-rounded-full focus:yst-outline-none focus:yst-bg-slate-600"
-							onClick={ toggleOpen }
+							onClick={ closeMobileMenu }
 						>
 							<span className="yst-sr-only">{ closeButtonScreenReaderText }</span>
 							<XIcon className="yst-h-6 yst-w-6 yst-text-white" />
@@ -49,7 +41,7 @@ const Mobile = ( { children, openButtonScreenReaderText = "Open", closeButtonScr
 			<div className="yst-flex yst-relative yst-flex-shrink-0 yst-h-16 yst-z-10 yst-bg-white yst-border-b yst-border-slate-200">
 				<button
 					className="yst-px-4 yst-border-r yst-border-slate-200 yst-text-slate-400 focus:yst-outline-none focus:yst-ring-2 focus:yst-ring-inset focus:yst-ring-primary-500"
-					onClick={ toggleOpen }
+					onClick={ openMobileMenu }
 				>
 					<span className="yst-sr-only">{ openButtonScreenReaderText }</span>
 					<MenuAlt2Icon className="yst-w-6 yst-h-6" />
@@ -63,7 +55,6 @@ Mobile.propTypes = {
 	children: PropTypes.node.isRequired,
 	openButtonScreenReaderText: PropTypes.string,
 	closeButtonScreenReaderText: PropTypes.string,
-	closeOnNavigate: PropTypes.bool,
 };
 
 export default Mobile;

--- a/packages/ui-library/src/components/sidebar-navigation/stories.js
+++ b/packages/ui-library/src/components/sidebar-navigation/stories.js
@@ -1,11 +1,6 @@
+import { AdjustmentsIcon, ColorSwatchIcon, DesktopComputerIcon, NewspaperIcon } from "@heroicons/react/outline";
 import SidebarNavigation from ".";
-import {
-	AdjustmentsIcon,
-	ColorSwatchIcon,
-	DesktopComputerIcon,
-	NewspaperIcon,
-} from "@heroicons/react/outline";
-
+import Table from "../../elements/table";
 
 export default {
 	title: "2. Components/Sidebar Navigation",
@@ -19,52 +14,55 @@ export default {
 			table: {
 				type: { summary: "string" },
 			},
-		 },
+		},
 		label: {
 			control: "text",
 			description: "Available for `MenuItem` and `SubmenuItem`",
 			table: {
 				type: { summary: "string" },
 			},
-		 },
+		},
 		defaultOpen: {
 			control: "boolean",
 			description: "Available for `MenuItem`",
 			table: {
 				type: { summary: "boolean" },
-			} },
+			},
+		},
 		icon: {
 			control: "object",
 			description: "Available for `MenuItem`",
 			table: {
 				type: { summary: "JSX Element" },
 			},
-		 },
+		},
 		id: {
 			control: "text",
 			description: "Available for `MenuItem`",
 			table: {
 				type: { summary: "string" },
 			},
-		 },
+		},
 		openButtonScreenReaderText: {
 			control: "text",
 			description: "Accesability for `Mobile`",
 			table: {
 				type: { summary: "string" },
-			} },
+			},
+		},
 		closeButtonScreenReaderText: {
 			control: "text",
 			description: "Accesability for `Mobile`",
 			table: {
 				type: { summary: "string" },
-			} },
+			},
+		},
 
 	},
 	parameters: {
 		docs: {
 			description: {
-				component: "A sidebar navigation component. Contains the subcomponents `Sidebar`, `Mobile`, `MenuItem` and `SubmenuItem`.",
+				component: "A sidebar navigation component. Contains the subcomponents `Sidebar`, `Mobile`, `MenuItem` and `SubmenuItem` and contains the hook `useNavigationContext`.",
 			},
 		},
 	},
@@ -198,4 +196,41 @@ Mobile.args = {
 
 		</SidebarNavigation.MenuItem>
 	</SidebarNavigation.Mobile> ),
+};
+
+
+export const NavigationContext = Template.bind( {} );
+
+NavigationContext.parameters = {
+	docs: {
+		description: {
+			story: "The `useNavigationContext` hook is exported. The context contains: `activePath`, `isMobileMenuOpen` and `setMobileMenuOpen` for if you need more control or create your own `SubmenuItem`.",
+		},
+		transformSource: () => "import { useNavigationContext } from \"@yoast/ui-library\";\n\n" +
+			"const { activePath, isMobileMenuOpen, setMobileMenuOpen } = useNavigationContext();",
+	},
+};
+NavigationContext.args = {
+	children: <Table>
+		<Table.Head>
+			<Table.Row>
+				<Table.Header>Key</Table.Header>
+				<Table.Header>Description</Table.Header>
+			</Table.Row>
+		</Table.Head>
+		<Table.Body>
+			<Table.Row>
+				<Table.Cell>activePath</Table.Cell>
+				<Table.Cell>Represents what path is active. Used to determine which SubmenuItem is active.</Table.Cell>
+			</Table.Row>
+			<Table.Row>
+				<Table.Cell>isMobileMenuOpen</Table.Cell>
+				<Table.Cell>Represents whether the mobile menu is currently open.</Table.Cell>
+			</Table.Row>
+			<Table.Row>
+				<Table.Cell>setMobileMenuOpen</Table.Cell>
+				<Table.Cell>Controls the mobile menu.</Table.Cell>
+			</Table.Row>
+		</Table.Body>
+	</Table>,
 };

--- a/packages/ui-library/src/components/sidebar-navigation/submenu-item.js
+++ b/packages/ui-library/src/components/sidebar-navigation/submenu-item.js
@@ -1,3 +1,4 @@
+import { useCallback } from "@wordpress/element";
 import classNames from "classnames";
 import PropTypes from "prop-types";
 import { useNavigationContext } from "./index";
@@ -10,7 +11,9 @@ import { useNavigationContext } from "./index";
  * @returns {JSX.Element} The submenu item element.
  */
 const SubmenuItem = ( { as: Component = "a", pathProp = "href", label, ...props } ) => {
-	const { activePath } = useNavigationContext();
+	const { activePath, setMobileMenuOpen } = useNavigationContext();
+
+	const handleClick = useCallback( () => setMobileMenuOpen( false ), [ setMobileMenuOpen ] );
 
 	return (
 		<li className="yst-m-0 yst-pb-1">
@@ -22,6 +25,7 @@ const SubmenuItem = ( { as: Component = "a", pathProp = "href", label, ...props 
 						: "yst-text-slate-600 hover:yst-text-slate-900 hover:yst-bg-slate-50",
 				) }
 				aria-current={ activePath === props[ pathProp ] ? "page" : null }
+				onClick={ handleClick }
 				{ ...props }
 			>
 				{ label }

--- a/packages/ui-library/src/index.js
+++ b/packages/ui-library/src/index.js
@@ -29,7 +29,7 @@ export { default as Notifications } from "./components/notifications";
 export { default as RadioGroup } from "./components/radio-group";
 export { default as Root } from "./components/root";
 export { default as SelectField } from "./components/select-field";
-export { default as SidebarNavigation } from "./components/sidebar-navigation";
+export { default as SidebarNavigation, useNavigationContext } from "./components/sidebar-navigation";
 export { default as TagField } from "./components/tag-field";
 export { default as TextField } from "./components/text-field";
 export { default as TextareaField } from "./components/textarea-field";

--- a/yarn.lock
+++ b/yarn.lock
@@ -2251,10 +2251,12 @@
   dependencies:
     "@hapi/hoek" "^9.0.0"
 
-"@headlessui/react@^1.7.1":
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/@headlessui/react/-/react-1.7.1.tgz#39c1b14b2e92d2edb32dd07722a8783a12d0d0be"
-  integrity sha512-vnRlB71kvEr3y26Lm1WpCiMML8n5JcJ7jK5+vaF0hGTZFArW206j61meVemXkTOuGLhmyWe6yj3OETzsxHoryQ==
+"@headlessui/react@^1.7.7":
+  version "1.7.7"
+  resolved "https://registry.yarnpkg.com/@headlessui/react/-/react-1.7.7.tgz#d6f8708d8943ae8ebb1a6929108234e4515ac7e8"
+  integrity sha512-BqDOd/tB9u2tA0T3Z0fn18ktw+KbVwMnkxxsGPIH2hzssrQhKB5n/6StZOyvLYP/FsYtvuXfi9I0YowKPv2c1w==
+  dependencies:
+    client-only "^0.0.1"
 
 "@heroicons/react@^1.0.6":
   version "1.0.6"
@@ -10422,6 +10424,11 @@ cli-width@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-3.0.0.tgz#a2f48437a2caa9a22436e794bf071ec9e61cedf6"
   integrity sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==
+
+client-only@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/client-only/-/client-only-0.0.1.tgz#38bba5d403c41ab150bff64a95c85013cf73bca1"
+  integrity sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==
 
 clipboard@^1.5.15:
   version "1.7.1"


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Strife to be compatible with a mobile viewport.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where the Settings notifications where would not appear next to the WordPress menu on mobile.
* Fixes an unreleased bug where opening the WordPress menu on mobile would push our content a bit too far to the right.
* Fixes an unreleased bug where the (Settings) notifications could be wider than the screen.
* Fixes an unreleased bug where the mobile menu would not close when navigating to the same page or when going to a search result on the same page.
* Fixes an unreleased bug where the Show more/less icon in the Settings menu would be bigger than designed.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Notifications [#309](https://github.com/Yoast/plugins-automated-testing/issues/309)
* Go to Settings > Site representation
* Enter something invalid in an other profile field and save so you get the error/validation notification
* Combinations of screen widths to check if the notification are okay:
  * \>= 961px wide
    * Collapse the WP menu
  * < 961px wide (but > 782px)
    * Uncollapse the WP menu
  * <= 782px wide
    * Open the WP menu
    * Keeping the WP menu open, then recheck the other sizes to verify they still work.
* In a screen size from 400 to about 500px wide
  * Verify the validation notification becomes smaller and never pokes out of the screen

#### Miscellaneous mobile view
* In <= 782px wide, with the WP menu open
  * Verify our content starts right next to the menu
![image](https://user-images.githubusercontent.com/35524806/209977178-1b18997d-8ca6-4c43-a226-3f96a745dba2.png)
  * Before this fix it was like this:
![image](https://user-images.githubusercontent.com/35524806/209977284-40342433-8820-4c22-b12e-2e9491e7f5a1.png)

#### Menu icon [#320](https://github.com/Yoast/plugins-automated-testing/issues/320)
* Ensure you have more than 5 posts or taxonomies/tags so you get the show more button in the menu
* Verify the show more icon is now smaller
![image](https://user-images.githubusercontent.com/35524806/210214646-97b08de2-6f07-4f33-bc4f-ba52da8325c3.png)
* Click on show more
* Verify the show less icon is similar

#### Mobile menu and search [#311](https://github.com/Yoast/plugins-automated-testing/issues/311)
* In a mobile viewport
* Go to Settings > Site features
* Open the mobile menu
* Click on search
* Search for `ana` and select the SEO analysis
* Verify the mobile menu closes
* Open the mobile menu
* Click on SEO analysis
* Verify the mobile menu closes

##### Edge case: desktop -> mobile
* Switch to a desktop viewport and refresh the page
* Verify the search shortcode (cmd+k or ctrl+k) works, and close the search modal
* Switch to a mobile viewport
* Verify the search shortcode (cmd+k or ctrl+k) works, and close the search modal
* Open the mobile menu
* Verify the search shortcode does not work when the mobile menu is open (it actually never works when you land on the page in mobile; note the difference between mobile and mobile viewport here)

#### Quick sanity check
* Since this PR updates the Headless UI minor version
* Please do a quick check if the First Time Configuration still functions. Specifically the transitions and the combobox (site represents)
* As well as a quick sanity check in the settings. Specifically any toggle and select (site represents). The modal and autocomplete should be tested already via the search modal.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The settings UI, should be covered with the test instructions. 

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [x] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes https://github.com/Yoast/plugins-automated-testing/issues/311
Fixes https://github.com/Yoast/plugins-automated-testing/issues/309
Fixes https://github.com/Yoast/plugins-automated-testing/issues/320