### PR TITLE
Settings UI: mirror arrows in rtl language #295

### DIFF
--- a/css/src/admin-global.css
+++ b/css/src/admin-global.css
@@ -1,6 +1,10 @@
 @import url(../src/icons.css);
 @import "../src/tooltips.css";
 
+.rtl .yst-icon-rtl {
+	@apply yst-rotate-180;
+}
+
 .wpseo-premium-indicator {
   width: 1px;
   height: 1px;

--- a/css/src/new-settings.css
+++ b/css/src/new-settings.css
@@ -222,5 +222,8 @@
 		.yst-root .yst-replacevar .emoji-select-popover {
 			@apply yst-left-0 yst-right-auto;
 		}
+		.icon-rtl {
+			@apply yst-rotate-180;
+		}
 	}
 }

--- a/css/src/new-settings.css
+++ b/css/src/new-settings.css
@@ -222,8 +222,5 @@
 		.yst-root .yst-replacevar .emoji-select-popover {
 			@apply yst-left-0 yst-right-auto;
 		}
-		.icon-rtl {
-			@apply yst-rotate-180;
-		}
 	}
 }

--- a/packages/js/src/indexables-page/components/suggested-links-modal.js
+++ b/packages/js/src/indexables-page/components/suggested-links-modal.js
@@ -143,7 +143,7 @@ const SuggestedLinksModal = ( { isLinkSuggestionsEnabled, isPremium, suggestedLi
 							}
 						</span>
 						<ArrowNarrowRightIcon
-							className="yst-ml-2 yst-h-5 yst-w-5 yst-text-yellow-900"
+							className="yst-ml-2 yst-h-5 yst-w-5 yst-text-yellow-900 yst-icon-rtl"
 						/>
 					</Button>
 				</div>

--- a/packages/js/src/integrations-page/algolia-integration.js
+++ b/packages/js/src/integrations-page/algolia-integration.js
@@ -101,7 +101,7 @@ export const AlgoliaIntegration = ( {
 									__( "(Opens in a new browser tab)", "wordpress-seo" )
 								}
 							</span>
-							<ArrowSmRightIcon className="yst-h-4 yst-w-4 yst-ml-1 icon-rtl" />
+							<ArrowSmRightIcon className="yst-h-4 yst-w-4 yst-ml-1 yst-icon-rtl" />
 						</Link> }
 					</p>
 				</div>

--- a/packages/js/src/integrations-page/algolia-integration.js
+++ b/packages/js/src/integrations-page/algolia-integration.js
@@ -101,7 +101,7 @@ export const AlgoliaIntegration = ( {
 									__( "(Opens in a new browser tab)", "wordpress-seo" )
 								}
 							</span>
-							<ArrowSmRightIcon className="yst-h-4 yst-w-4 yst-ml-1" />
+							<ArrowSmRightIcon className="yst-h-4 yst-w-4 yst-ml-1 icon-rtl" />
 						</Link> }
 					</p>
 				</div>

--- a/packages/js/src/integrations-page/simple-integration.js
+++ b/packages/js/src/integrations-page/simple-integration.js
@@ -62,7 +62,7 @@ export const SimpleIntegration = ( { integration, isActive, children } ) => {
 								__( "(Opens in a new browser tab)", "wordpress-seo" )
 							}
 						</span>
-						<ArrowSmRightIcon className="yst-h-4 yst-w-4 yst-ml-1 icon-rtl" />
+						<ArrowSmRightIcon className="yst-h-4 yst-w-4 yst-ml-1 yst-icon-rtl" />
 					</Link> }
 				</div>
 			</Card.Content>

--- a/packages/js/src/integrations-page/simple-integration.js
+++ b/packages/js/src/integrations-page/simple-integration.js
@@ -62,7 +62,7 @@ export const SimpleIntegration = ( { integration, isActive, children } ) => {
 								__( "(Opens in a new browser tab)", "wordpress-seo" )
 							}
 						</span>
-						<ArrowSmRightIcon className="yst-h-4 yst-w-4 yst-ml-1" />
+						<ArrowSmRightIcon className="yst-h-4 yst-w-4 yst-ml-1 icon-rtl" />
 					</Link> }
 				</div>
 			</Card.Content>

--- a/packages/js/src/integrations-page/toggleable-integration.js
+++ b/packages/js/src/integrations-page/toggleable-integration.js
@@ -98,7 +98,7 @@ export const ToggleableIntegration = ( {
 									__( "(Opens in a new browser tab)", "wordpress-seo" )
 								}
 							</span>
-							<ArrowSmRightIcon className="yst-h-4 yst-w-4 yst-ml-1" />
+							<ArrowSmRightIcon className="yst-h-4 yst-w-4 yst-ml-1 icon-rtl" />
 						</Link> }
 					</p>
 				</div>

--- a/packages/js/src/integrations-page/toggleable-integration.js
+++ b/packages/js/src/integrations-page/toggleable-integration.js
@@ -98,7 +98,7 @@ export const ToggleableIntegration = ( {
 									__( "(Opens in a new browser tab)", "wordpress-seo" )
 								}
 							</span>
-							<ArrowSmRightIcon className="yst-h-4 yst-w-4 yst-ml-1 icon-rtl" />
+							<ArrowSmRightIcon className="yst-h-4 yst-w-4 yst-ml-1 yst-icon-rtl" />
 						</Link> }
 					</p>
 				</div>

--- a/packages/js/src/settings/app.js
+++ b/packages/js/src/settings/app.js
@@ -207,7 +207,7 @@ const PremiumUpsellList = () => {
 					__( "Get %s", "wordpress-seo" ),
 					"Yoast SEO Premium"
 				) }
-				<ArrowNarrowRightIcon className="yst-w-4 yst-h-4" />
+				<ArrowNarrowRightIcon className="yst-w-4 yst-h-4 icon-rtl" />
 			</Button>
 		</div>
 	);

--- a/packages/js/src/settings/app.js
+++ b/packages/js/src/settings/app.js
@@ -207,7 +207,7 @@ const PremiumUpsellList = () => {
 					__( "Get %s", "wordpress-seo" ),
 					"Yoast SEO Premium"
 				) }
-				<ArrowNarrowRightIcon className="yst-w-4 yst-h-4 icon-rtl" />
+				<ArrowNarrowRightIcon className="yst-w-4 yst-h-4 yst-icon-rtl" />
 			</Button>
 		</div>
 	);

--- a/packages/js/src/settings/components/sidebar-recommendations.js
+++ b/packages/js/src/settings/components/sidebar-recommendations.js
@@ -53,7 +53,7 @@ const PremiumUpsellCard = () => {
 				{ ...premiumUpsellConfig }
 			>
 				{ getPremium }
-				<ArrowNarrowRightIcon className="yst-w-4 yst-h-4" />
+				<ArrowNarrowRightIcon className="yst-w-4 yst-h-4 icon-rtl" />
 			</Button>
 			<a
 				className="yst-block yst-mt-4 yst-no-underline"

--- a/packages/js/src/settings/components/sidebar-recommendations.js
+++ b/packages/js/src/settings/components/sidebar-recommendations.js
@@ -53,7 +53,7 @@ const PremiumUpsellCard = () => {
 				{ ...premiumUpsellConfig }
 			>
 				{ getPremium }
-				<ArrowNarrowRightIcon className="yst-w-4 yst-h-4 icon-rtl" />
+				<ArrowNarrowRightIcon className="yst-w-4 yst-h-4 yst-icon-rtl" />
 			</Button>
 			<a
 				className="yst-block yst-mt-4 yst-no-underline"

--- a/packages/js/src/settings/routes/site-features.js
+++ b/packages/js/src/settings/routes/site-features.js
@@ -137,7 +137,7 @@ const LearnMoreLink = ( { id, link } ) => {
 			rel="noopener"
 		>
 			{ __( "Learn more", "wordpress-seo" ) }
-			<ArrowNarrowRightIcon className="yst-w-4 yst-h-4" />
+			<ArrowNarrowRightIcon className="yst-w-4 yst-h-4 icon-rtl" />
 		</a>
 	);
 };

--- a/packages/js/src/settings/routes/site-features.js
+++ b/packages/js/src/settings/routes/site-features.js
@@ -137,7 +137,7 @@ const LearnMoreLink = ( { id, link } ) => {
 			rel="noopener"
 		>
 			{ __( "Learn more", "wordpress-seo" ) }
-			<ArrowNarrowRightIcon className="yst-w-4 yst-h-4 icon-rtl" />
+			<ArrowNarrowRightIcon className="yst-w-4 yst-h-4 yst-icon-rtl" />
 		</a>
 	);
 };


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Fixes arrows direction on `rtl` languages in settings ui and integrations.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where arrows in settings ui and integration would point to the right when site language direction is `rtl`.

## Relevant technical choices:

* Added class `yst-icon-rtl` to the `admin-global.css` so it would be applied in the settings ui and the integration page.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Change site language to one of the `rtl` languages.
* Turn off `Premium`
  * Open `Yoast SEO`->`Settings`->`Site features`
  * Check the arrow next to `Learn more` is pointing to the left.
  * On the sidebar check the recommendation to get premium has arrow that is pointing to the left.
  * On the bottom check the recommendation to get premium has arrow that is pointing to the left.

* Change site language back to. `ltr` languages.
* Turn off `Premium`
  * Open `Yoast SEO`->`Settings`->`Site features`
  * Check the arrow next to `Learn more` is pointing to the right.
  * On the sidebar check the recommendation to get premium has arrow that is pointing to the right.
  * On the bottom check the recommendation to get premium has arrow that is pointing to the right.

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [X] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes [Trivial: arrows in RTL language should be mirrored#295](https://github.com/Yoast/plugins-automated-testing/issues/295)
