### PR TITLE
Settings UI missing text for rtl languages in introduction modal

### DIFF
--- a/packages/js/src/settings/app.js
+++ b/packages/js/src/settings/app.js
@@ -77,7 +77,7 @@ const Menu = ( { postTypes, taxonomies, idSuffix = "" } ) => {
 		</header>
 		<div className="yst-px-0.5 yst-space-y-6">
 			<SidebarNavigation.MenuItem
-				id={ `menu-site-settings${ idSuffix && `-${ idSuffix }` }` }
+				id={ `menu-general${ idSuffix && `-${ idSuffix }` }` }
 				icon={ DesktopComputerIcon }
 				label={ __( "General", "wordpress-seo" ) }
 			>
@@ -91,7 +91,7 @@ const Menu = ( { postTypes, taxonomies, idSuffix = "" } ) => {
 				<SidebarNavigation.SubmenuItem to="/site-connections" label={ __( "Site connections", "wordpress-seo" ) } idSuffix={ idSuffix } />
 			</SidebarNavigation.MenuItem>
 			<SidebarNavigation.MenuItem
-				id={ `menu-content-settings${ idSuffix && `-${ idSuffix }` }` }
+				id={ `menu-content-types${ idSuffix && `-${ idSuffix }` }` }
 				icon={ NewspaperIcon }
 				label={ __( "Content types", "wordpress-seo" ) }
 			>
@@ -108,7 +108,7 @@ const Menu = ( { postTypes, taxonomies, idSuffix = "" } ) => {
 				</ChildrenLimiter>
 			</SidebarNavigation.MenuItem>
 			<SidebarNavigation.MenuItem
-				id={ `menu-content-settings${ idSuffix && `-${ idSuffix }` }` }
+				id={ `menu-categories-and-tags${ idSuffix && `-${ idSuffix }` }` }
 				icon={ ColorSwatchIcon }
 				label={ __( "Categories & tags", "wordpress-seo" ) }
 			>
@@ -123,7 +123,7 @@ const Menu = ( { postTypes, taxonomies, idSuffix = "" } ) => {
 				</ChildrenLimiter>
 			</SidebarNavigation.MenuItem>
 			<SidebarNavigation.MenuItem
-				id={ `menu-advanced-settings${ idSuffix && `-${ idSuffix }` }` }
+				id={ `menu-advanced${ idSuffix && `-${ idSuffix }` }` }
 				icon={ AdjustmentsIcon }
 				label={ __( "Advanced", "wordpress-seo" ) }
 				defaultOpen={ false }

--- a/packages/js/src/settings/components/introduction.js
+++ b/packages/js/src/settings/components/introduction.js
@@ -215,6 +215,7 @@ const Introduction = () => {
 
 					{ /* // ----------------- Title and description section of each step -----------------*/ }
 					<div
+						style={ { direction: "ltr" } }
 						className={ classNames(
 							"yst-grid yst-transition-transform yst-duration-1000",
 							// Arrange a grid of 100% for each step.

--- a/packages/js/src/settings/components/search.js
+++ b/packages/js/src/settings/components/search.js
@@ -12,7 +12,6 @@ import { useNavigate } from "react-router-dom";
 import { safeToLocaleLower } from "../helpers";
 import { useParsedUserAgent, useSelectSettings } from "../hooks";
 
-const QUERY_MIN_CHARS = 3;
 const POST_TYPE_OR_TAXONOMY_BREADCRUMB_SETTING_REGEXP = new RegExp( /^input-wpseo_titles-(post_types|taxonomy)-(?<name>\S+)-(maintax|ptparent)$/is );
 
 /**
@@ -21,7 +20,7 @@ const POST_TYPE_OR_TAXONOMY_BREADCRUMB_SETTING_REGEXP = new RegExp( /^input-wpse
  * @returns {JSX.Element} The SearchResultLabel element.
  */
 const SearchResultLabel = ( { fieldId, fieldLabel } ) => {
-	// Deduce wether field is a breadcrumb option for post type or taxonomy.
+	// Deduce whether field is a breadcrumb option for post type or taxonomy.
 	const { isPostTypeOrTaxonomyBreadcrumbSetting, postTypeOrTaxonomyName } = useMemo( () => {
 		const matches = POST_TYPE_OR_TAXONOMY_BREADCRUMB_SETTING_REGEXP.exec( fieldId );
 		return {
@@ -82,6 +81,23 @@ const Search = () => {
 	const inputRef = useRef( null );
 	const { platform, os } = useParsedUserAgent();
 
+	// Determines the minimum characters to start a search, based on the user locale.
+	const queryMinChars = useMemo( () => {
+		switch ( userLocale ) {
+			// Japanese.
+			case "ja":
+				return 2;
+			// Korean, Chinese, Chinese (Hong Kong), Chinese (Taiwan).
+			case "ko-KR":
+			case "zh-CN":
+			case "zh-HK":
+			case "zh-TW":
+				return 1;
+			default:
+				return 3;
+		}
+	}, [ userLocale ] );
+
 	useHotkeys(
 		"meta+k",
 		event => {
@@ -109,7 +125,7 @@ const Search = () => {
 		const trimmedQuery = trim( newQuery );
 
 		// Bail if query is too short.
-		if ( trimmedQuery.length < QUERY_MIN_CHARS ) {
+		if ( trimmedQuery.length < queryMinChars ) {
 			return false;
 		}
 
@@ -203,16 +219,18 @@ const Search = () => {
 							className="yst-h-12 yst-w-full yst-border-0 yst-bg-transparent yst-px-11 yst-text-slate-800 yst-placeholder-slate-400 focus:yst-ring-0 sm:yst-text-sm"
 						/>
 					</div>
-					{ query.length >= QUERY_MIN_CHARS && ! isEmpty( results ) && (
+					{ query.length >= queryMinChars && ! isEmpty( results ) && (
 						<Combobox.Options
 							static={ true }
 							className="yst-max-h-[calc(90vh-10rem)] yst-scroll-pt-11 yst-scroll-pb-2 yst-space-y-2 yst-overflow-y-auto yst-pb-2"
 						>
 							{ map( results, ( groupedItems, index ) => (
 								<li key={ groupedItems?.[ 0 ]?.route || `group-${ index }` }>
-									<Title as="h4" size="3" className="yst-bg-slate-100 yst-py-3 yst-px-4">{ first( groupedItems ).routeLabel }</Title>
+									<Title as="h4" size="3" className="yst-bg-slate-100 yst-py-3 yst-px-4">
+										{ first( groupedItems ).routeLabel }
+									</Title>
 									<ul>
-										{ map( groupedItems, ( item ) =>  (
+										{ map( groupedItems, ( item ) => (
 											<Combobox.Option
 												key={ item.fieldId }
 												value={ item }
@@ -226,12 +244,12 @@ const Search = () => {
 							) ) }
 						</Combobox.Options>
 					) }
-					{ query.length < QUERY_MIN_CHARS && (
+					{ query.length < queryMinChars && (
 						<SearchNoResultsContent title={ __( "Search", "wordpress-seo" ) }>
 							<p className="yst-text-slate-500">{ __( "Please enter a search term with at least 3 characters.", "wordpress-seo" ) }</p>
 						</SearchNoResultsContent>
 					) }
-					{ query.length >= QUERY_MIN_CHARS && isEmpty( results ) && (
+					{ query.length >= queryMinChars && isEmpty( results ) && (
 						<SearchNoResultsContent title={ __( "No results found", "wordpress-seo" ) }>
 							<p className="yst-text-slate-500">{ __( "We couldn’t find anything with that term.", "wordpress-seo" ) }</p>
 						</SearchNoResultsContent>

--- a/packages/ui-library/.storybook/style.css
+++ b/packages/ui-library/.storybook/style.css
@@ -26,6 +26,7 @@
 @import "../src/components/radio-group/style.css";
 @import "../src/components/root/style.css";
 @import "../src/components/select-field/style.css";
+@import "../src/components/sidebar-navigation/style.css";
 @import "../src/components/tag-field/style.css";
 @import "../src/components/text-field/style.css";
 @import "../src/components/textarea-field/style.css";

--- a/packages/ui-library/src/components/children-limiter/index.js
+++ b/packages/ui-library/src/components/children-limiter/index.js
@@ -20,7 +20,7 @@ const ChildrenLimiter = ( { limit, children, renderButton, initialShow = false, 
 	const after = useMemo( () => slice( flattened, limit ), [ flattened ] );
 	const id = useMemo( () => requestedId || `yst-animate-height-${ nanoid() }`, [ requestedId ] );
 	const ariaProps = useMemo( () => ( {
-		"aria-expanded": ! show,
+		"aria-expanded": show,
 		"aria-controls": id,
 	} ), [ show, id ] );
 

--- a/packages/ui-library/src/components/sidebar-navigation/index.js
+++ b/packages/ui-library/src/components/sidebar-navigation/index.js
@@ -1,9 +1,9 @@
-import { Dialog } from "@headlessui/react";
-import { ChevronDownIcon, ChevronUpIcon, MenuAlt2Icon, XIcon } from "@heroicons/react/outline";
-import { createContext, useContext, useEffect } from "@wordpress/element";
-import classNames from "classnames";
+import { createContext, useContext } from "@wordpress/element";
 import PropTypes from "prop-types";
-import { usePrevious, useToggleState } from "../../hooks";
+import MenuItem from "./menu-item";
+import Mobile from "./mobile";
+import Sidebar from "./sidebar";
+import SubmenuItem from "./submenu-item";
 
 const NavigationContext = createContext( { activePath: "" } );
 
@@ -12,175 +12,26 @@ const NavigationContext = createContext( { activePath: "" } );
  */
 export const useNavigationContext = () => useContext( NavigationContext );
 
-/**
- * @param {JSX.node} label The label.
- * @param {JSX.ElementClass} [as] The field component.
- * @param {string} [pathProp] The key of the path in the props. Defaults to `href`.
- * @param {Object} [props] Extra props.
- * @returns {JSX.Element} The submenu item element.
- */
-const SubmenuItem = ( { as: Component = "a", pathProp = "href", label, ...props } ) => {
-	const { activePath } = useNavigationContext();
-
-	return (
-		<li className="yst-m-0 yst-pb-1">
-			<Component
-				className={ classNames(
-					"yst-group yst-flex yst-items-center yst-px-3 yst-py-2 yst-text-sm yst-font-medium yst-rounded-md yst-no-underline focus:yst-outline-none focus:yst-ring-2 focus:yst-ring-primary-500",
-					activePath === props[ pathProp ]
-						? "yst-bg-slate-200 yst-text-slate-900"
-						: "yst-text-slate-600 hover:yst-text-slate-900 hover:yst-bg-slate-50",
-				) }
-				{ ...props }
-			>
-				{ label }
-			</Component>
-		</li>
-	);
-};
-
-SubmenuItem.propTypes = {
-	as: PropTypes.elementType,
-	pathProp: PropTypes.string,
-	label: PropTypes.node.isRequired,
-	isActive: PropTypes.bool,
-};
-
-/**
- * @param {string} label The label.
- * @param {JSX.Element} [icon] Optional icon to put before the label.
- * @param {JSX.node} [children] Optional sub menu.
- * @param {boolean} [defaultOpen] Whether the sub menu starts opened.
- * @param {Object} [props] Extra props.
- * @returns {JSX.Element} The menu item element.
- */
-const MenuItem = ( { label, icon: Icon = null, children = null, defaultOpen = true, ...props } ) => {
-	const [ isOpen, toggleOpen ] = useToggleState( defaultOpen );
-	const ChevronIcon = isOpen ? ChevronUpIcon : ChevronDownIcon;
-
-	return (
-		<div>
-			<button
-				className="yst-group yst-flex yst-w-full yst-items-center yst-justify-between yst-gap-3 yst-px-3 yst-py-2 yst-text-sm yst-font-medium yst-text-slate-800 yst-rounded-md yst-no-underline hover:yst-text-slate-900 hover:yst-bg-slate-50 focus:yst-outline-none focus:yst-ring-2 focus:yst-ring-primary-500"
-				onClick={ toggleOpen }
-				{ ...props }
-			>
-				<span className="yst-flex yst-items-center yst-gap-3">
-					{ Icon &&
-						<Icon className="yst-flex-shrink-0 yst--ml-1 yst-h-6 yst-w-6 yst-text-slate-400 group-hover:yst-text-slate-500" />
-					}
-					{ label }
-				</span>
-				<ChevronIcon className="yst-h-4 yst-w-4 yst-text-slate-400 group-hover:yst-text-slate-500 yst-stroke-3" />
-			</button>
-			{ isOpen && children && <ul className="yst-ml-8 yst-mt-1 yst-space-y-1">
-				{ children }
-			</ul> }
-		</div>
-	);
-};
-
-MenuItem.propTypes = {
-	label: PropTypes.string.isRequired,
-	icon: PropTypes.elementType,
-	defaultOpen: PropTypes.bool,
-	children: PropTypes.node,
-};
-
-/**
- * @param {JSX.node} children The menu items.
- * @param {string} [openButtonScreenReaderText] The open button screen reader text.
- * @param {string} [closeButtonScreenReaderText] The close button screen reader text.
- * @param {boolean} [closeOnNavigate] Whether to close the mobile navigation when the active path changed.
- * @returns {JSX.Element} The mobile element.
- */
-const Mobile = ( { children, openButtonScreenReaderText = "Open", closeButtonScreenReaderText = "Close", closeOnNavigate = true } ) => {
-	const { activePath } = useNavigationContext();
-	const previousPath = usePrevious( activePath );
-	const [ isOpen, toggleOpen, setOpen ] = useToggleState( false );
-
-	useEffect( () => {
-		if ( closeOnNavigate && isOpen && activePath !== previousPath ) {
-			setOpen( false );
-		}
-	}, [ closeOnNavigate, activePath, previousPath, isOpen, setOpen ] );
-
-	return <>
-		<Dialog className="yst-root" open={ isOpen } onClose={ toggleOpen }>
-			<div className="yst-mobile-navigation__dialog">
-				<div className="yst-fixed yst-inset-0 yst-bg-slate-600 yst-bg-opacity-75 yst-z-30" aria-hidden="true" />
-				<Dialog.Panel className="yst-relative yst-flex yst-flex-1 yst-flex-col yst-max-w-xs yst-w-full yst-z-40 yst-bg-slate-100">
-					<div className="yst-absolute yst-top-0 yst-right-0 yst--mr-14 yst-p-1">
-						<button
-							className="yst-flex yst-h-12 yst-w-12 yst-items-center yst-justify-center yst-rounded-full focus:yst-outline-none focus:yst-bg-slate-600"
-							onClick={ toggleOpen }
-						>
-							<span className="yst-sr-only">{ closeButtonScreenReaderText }</span>
-							<XIcon className="yst-h-6 yst-w-6 yst-text-white" />
-						</button>
-					</div>
-					<div className="yst-flex-1 yst-h-0 yst-overflow-y-auto">
-						<nav className="yst-h-full yst-flex yst-flex-col yst-py-6 yst-px-2">
-							{ children }
-						</nav>
-					</div>
-				</Dialog.Panel>
-			</div>
-		</Dialog>
-		<div className="yst-mobile-navigation__top">
-			<div className="yst-flex yst-relative yst-flex-shrink-0 yst-h-16 yst-z-10 yst-bg-white yst-border-b yst-border-slate-200">
-				<button
-					className="yst-px-4 yst-border-r yst-border-slate-200 yst-text-slate-400 focus:yst-outline-none focus:yst-ring-2 focus:yst-ring-inset focus:yst-ring-primary-500"
-					onClick={ toggleOpen }
-				>
-					<span className="yst-sr-only">{ openButtonScreenReaderText }</span>
-					<MenuAlt2Icon className="yst-w-6 yst-h-6" />
-				</button>
-			</div>
-		</div>
-	</>;
-};
-
-Mobile.propTypes = {
-	children: PropTypes.node.isRequired,
-	openButtonScreenReaderText: PropTypes.string,
-	closeButtonScreenReaderText: PropTypes.string,
-	closeOnNavigate: PropTypes.bool,
-};
-
-/**
- * @param {JSX.node} children The menu items.
- * @param {string} className The CSS classname.
- * @returns {JSX.Element} The sidebar element.
- */
-const Sidebar = ( { children, className = "" } ) => (
-	<nav className={ className }>{ children }</nav>
-);
-
-Sidebar.propTypes = {
-	children: PropTypes.node.isRequired,
-	className: PropTypes.string,
-};
 
 /**
  * @param {string} activePath The path of the active menu item.
  * @param {JSX.node} children The menu(s).
  * @returns {JSX.Element} The navigation element.
  */
-const Navigation = ( { activePath = "", children } ) => (
+const SidebarNavigation = ( { activePath = "", children } ) => (
 	<NavigationContext.Provider value={ { activePath } }>
 		{ children }
 	</NavigationContext.Provider>
 );
 
-Navigation.propTypes = {
+SidebarNavigation.propTypes = {
 	activePath: PropTypes.string,
 	children: PropTypes.node.isRequired,
 };
 
-Navigation.Sidebar = Sidebar;
-Navigation.Mobile = Mobile;
-Navigation.MenuItem = MenuItem;
-Navigation.SubmenuItem = SubmenuItem;
+SidebarNavigation.Sidebar = Sidebar;
+SidebarNavigation.Mobile = Mobile;
+SidebarNavigation.MenuItem = MenuItem;
+SidebarNavigation.SubmenuItem = SubmenuItem;
 
-export default Navigation;
+export default SidebarNavigation;

--- a/packages/ui-library/src/components/sidebar-navigation/menu-item.js
+++ b/packages/ui-library/src/components/sidebar-navigation/menu-item.js
@@ -1,0 +1,47 @@
+import { ChevronDownIcon, ChevronUpIcon } from "@heroicons/react/outline";
+import PropTypes from "prop-types";
+import { useToggleState } from "../../hooks";
+
+/**
+ * @param {string} label The label.
+ * @param {JSX.Element} [icon] Optional icon to put before the label.
+ * @param {JSX.node} [children] Optional sub menu.
+ * @param {boolean} [defaultOpen] Whether the sub menu starts opened.
+ * @param {Object} [props] Extra props.
+ * @returns {JSX.Element} The menu item element.
+ */
+const MenuItem = ( { label, icon: Icon = null, children = null, defaultOpen = true, ...props } ) => {
+	const [ isOpen, toggleOpen ] = useToggleState( defaultOpen );
+	const ChevronIcon = isOpen ? ChevronUpIcon : ChevronDownIcon;
+
+	return (
+		<div>
+			<button
+				className="yst-group yst-flex yst-w-full yst-items-center yst-justify-between yst-gap-3 yst-px-3 yst-py-2 yst-text-sm yst-font-medium yst-text-slate-800 yst-rounded-md yst-no-underline hover:yst-text-slate-900 hover:yst-bg-slate-50 focus:yst-outline-none focus:yst-ring-2 focus:yst-ring-primary-500"
+				onClick={ toggleOpen }
+				aria-expanded={ isOpen }
+				{ ...props }
+			>
+				<span className="yst-flex yst-items-center yst-gap-3">
+					{ Icon &&
+						<Icon className="yst-flex-shrink-0 yst--ml-1 yst-h-6 yst-w-6 yst-text-slate-400 group-hover:yst-text-slate-500" />
+					}
+					{ label }
+				</span>
+				<ChevronIcon className="yst-h-4 yst-w-4 yst-text-slate-400 group-hover:yst-text-slate-500 yst-stroke-3" />
+			</button>
+			{ isOpen && children && <ul className="yst-ml-8 yst-mt-1 yst-space-y-1">
+				{ children }
+			</ul> }
+		</div>
+	);
+};
+
+MenuItem.propTypes = {
+	label: PropTypes.string.isRequired,
+	icon: PropTypes.elementType,
+	defaultOpen: PropTypes.bool,
+	children: PropTypes.node,
+};
+
+export default MenuItem;

--- a/packages/ui-library/src/components/sidebar-navigation/mobile.js
+++ b/packages/ui-library/src/components/sidebar-navigation/mobile.js
@@ -1,0 +1,69 @@
+import { Dialog } from "@headlessui/react";
+import { MenuAlt2Icon, XIcon } from "@heroicons/react/outline";
+import { useEffect } from "@wordpress/element";
+import PropTypes from "prop-types";
+import { usePrevious, useToggleState } from "../../hooks";
+import { useNavigationContext } from "./index";
+
+/**
+ * @param {JSX.node} children The menu items.
+ * @param {string} [openButtonScreenReaderText] The open button screen reader text.
+ * @param {string} [closeButtonScreenReaderText] The close button screen reader text.
+ * @param {boolean} [closeOnNavigate] Whether to close the mobile navigation when the active path changed.
+ * @returns {JSX.Element} The mobile element.
+ */
+const Mobile = ( { children, openButtonScreenReaderText = "Open", closeButtonScreenReaderText = "Close", closeOnNavigate = true } ) => {
+	const { activePath } = useNavigationContext();
+	const previousPath = usePrevious( activePath );
+	const [ isOpen, toggleOpen, setOpen ] = useToggleState( false );
+
+	useEffect( () => {
+		if ( closeOnNavigate && isOpen && activePath !== previousPath ) {
+			setOpen( false );
+		}
+	}, [ closeOnNavigate, activePath, previousPath, isOpen, setOpen ] );
+
+	return <>
+		<Dialog className="yst-root" open={ isOpen } onClose={ toggleOpen }>
+			<div className="yst-mobile-navigation__dialog">
+				<div className="yst-fixed yst-inset-0 yst-bg-slate-600 yst-bg-opacity-75 yst-z-30" aria-hidden="true" />
+				<Dialog.Panel className="yst-relative yst-flex yst-flex-1 yst-flex-col yst-max-w-xs yst-w-full yst-z-40 yst-bg-slate-100">
+					<div className="yst-absolute yst-top-0 yst-right-0 yst--mr-14 yst-p-1">
+						<button
+							className="yst-flex yst-h-12 yst-w-12 yst-items-center yst-justify-center yst-rounded-full focus:yst-outline-none focus:yst-bg-slate-600"
+							onClick={ toggleOpen }
+						>
+							<span className="yst-sr-only">{ closeButtonScreenReaderText }</span>
+							<XIcon className="yst-h-6 yst-w-6 yst-text-white" />
+						</button>
+					</div>
+					<div className="yst-flex-1 yst-h-0 yst-overflow-y-auto">
+						<nav className="yst-h-full yst-flex yst-flex-col yst-py-6 yst-px-2">
+							{ children }
+						</nav>
+					</div>
+				</Dialog.Panel>
+			</div>
+		</Dialog>
+		<div className="yst-mobile-navigation__top">
+			<div className="yst-flex yst-relative yst-flex-shrink-0 yst-h-16 yst-z-10 yst-bg-white yst-border-b yst-border-slate-200">
+				<button
+					className="yst-px-4 yst-border-r yst-border-slate-200 yst-text-slate-400 focus:yst-outline-none focus:yst-ring-2 focus:yst-ring-inset focus:yst-ring-primary-500"
+					onClick={ toggleOpen }
+				>
+					<span className="yst-sr-only">{ openButtonScreenReaderText }</span>
+					<MenuAlt2Icon className="yst-w-6 yst-h-6" />
+				</button>
+			</div>
+		</div>
+	</>;
+};
+
+Mobile.propTypes = {
+	children: PropTypes.node.isRequired,
+	openButtonScreenReaderText: PropTypes.string,
+	closeButtonScreenReaderText: PropTypes.string,
+	closeOnNavigate: PropTypes.bool,
+};
+
+export default Mobile;

--- a/packages/ui-library/src/components/sidebar-navigation/sidebar.js
+++ b/packages/ui-library/src/components/sidebar-navigation/sidebar.js
@@ -1,0 +1,17 @@
+import PropTypes from "prop-types";
+
+/**
+ * @param {JSX.node} children The menu items.
+ * @param {string} className The CSS classname.
+ * @returns {JSX.Element} The sidebar element.
+ */
+const Sidebar = ( { children, className = "" } ) => (
+	<nav className={ className }>{ children }</nav>
+);
+
+Sidebar.propTypes = {
+	children: PropTypes.node.isRequired,
+	className: PropTypes.string,
+};
+
+export default Sidebar;

--- a/packages/ui-library/src/components/sidebar-navigation/stories.js
+++ b/packages/ui-library/src/components/sidebar-navigation/stories.js
@@ -1,0 +1,201 @@
+import SidebarNavigation from ".";
+import {
+	AdjustmentsIcon,
+	ColorSwatchIcon,
+	DesktopComputerIcon,
+	NewspaperIcon,
+} from "@heroicons/react/outline";
+
+
+export default {
+	title: "2. Components/Sidebar Navigation",
+	component: SidebarNavigation,
+	argTypes: {
+		children: { control: "text" },
+		activePath: { control: "text" },
+		to: {
+			control: "text",
+			description: "Path, url for `SubmenuItem`",
+			table: {
+				type: { summary: "string" },
+			},
+		 },
+		label: {
+			control: "text",
+			description: "Available for `MenuItem` and `SubmenuItem`",
+			table: {
+				type: { summary: "string" },
+			},
+		 },
+		defaultOpen: {
+			control: "boolean",
+			description: "Available for `MenuItem`",
+			table: {
+				type: { summary: "boolean" },
+			} },
+		icon: {
+			control: "object",
+			description: "Available for `MenuItem`",
+			table: {
+				type: { summary: "JSX Element" },
+			},
+		 },
+		id: {
+			control: "text",
+			description: "Available for `MenuItem`",
+			table: {
+				type: { summary: "string" },
+			},
+		 },
+		openButtonScreenReaderText: {
+			control: "text",
+			description: "Accesability for `Mobile`",
+			table: {
+				type: { summary: "string" },
+			} },
+		closeButtonScreenReaderText: {
+			control: "text",
+			description: "Accesability for `Mobile`",
+			table: {
+				type: { summary: "string" },
+			} },
+
+	},
+	parameters: {
+		docs: {
+			description: {
+				component: "A sidebar navigation component. Contains the subcomponents `Sidebar`, `Mobile`, `MenuItem` and `SubmenuItem`.",
+			},
+		},
+	},
+	args: {
+		children: "test",
+	},
+};
+
+
+const Template = ( { children, activePath } ) => {
+	return (
+		<SidebarNavigation activePath={ activePath }>
+			{ children }
+		</SidebarNavigation> );
+};
+
+
+export const Factory = Template.bind( {} );
+
+Factory.args = {
+	children: <SidebarNavigation.Sidebar className="yst-w-1/3">
+
+		<SidebarNavigation.MenuItem
+			id={ "menu-item-default-1" }
+			icon={ DesktopComputerIcon }
+			label="MenuItem 1 label"
+		>
+			<SidebarNavigation.SubmenuItem to="#sub1" label="SubmenuItem 1 label" />
+			<SidebarNavigation.SubmenuItem to="#sub2" label="SubmenuItem 2 label" />
+			<SidebarNavigation.SubmenuItem to="#sub3" label="SubmenuItem 3 label" />
+		</SidebarNavigation.MenuItem>
+		<SidebarNavigation.MenuItem
+			id={ "menu-item-default-2" }
+			icon={ AdjustmentsIcon }
+			label="MenuItem 2 label"
+			defaultOpen={ false }
+		>
+			<SidebarNavigation.SubmenuItem to="#sub1" label="SubmenuItem 1 label" />
+			<SidebarNavigation.SubmenuItem to="#sub2" label="SubmenuItem 2 label" />
+			<SidebarNavigation.SubmenuItem to="#sub3" label="SubmenuItem 3 label" />
+
+		</SidebarNavigation.MenuItem>
+		<SidebarNavigation.MenuItem
+			id={ "menu-item-default-3" }
+			icon={ NewspaperIcon }
+			label="MenuItem 3 label"
+			defaultOpen={ false }
+		>
+			<SidebarNavigation.SubmenuItem to="#sub1" label="SubmenuItem 1 label" />
+			<SidebarNavigation.SubmenuItem to="#sub2" label="SubmenuItem 2 label" />
+			<SidebarNavigation.SubmenuItem to="#sub3" label="SubmenuItem 3 label" />
+
+		</SidebarNavigation.MenuItem>
+	</SidebarNavigation.Sidebar>,
+};
+
+export const MenuItem = Template.bind( {} );
+
+MenuItem.parameters = { docs: { description: { story: "The subcomponent `SidebarNavigation.MenuItem` accepts the subcomponents `SidebarNavigation.SubmenuItem` as children." } } };
+
+MenuItem.args = {
+	children: (
+		<SidebarNavigation.MenuItem
+			id={ "menuitem" }
+			icon={ ColorSwatchIcon }
+			label="MenuItem label"
+			defaultOpen={ true }
+		>
+			<SidebarNavigation.SubmenuItem to="#1" label="SubmenuItem 1" />
+			<SidebarNavigation.SubmenuItem to="#2" label="SubmenuItem 2" />
+			<SidebarNavigation.SubmenuItem to="#3" label="SubmenuItem 3" />
+
+		</SidebarNavigation.MenuItem>
+	),
+};
+
+
+export const Sidebar = Template.bind( {} );
+
+Sidebar.parameters = { docs: { description: { story: "The subcomponent `SidebarNavigation.Sidebar` is a `<nav>` wrapper component. It's props are `className` and `children` (`MenuItem` subomponents)." } } };
+
+Sidebar.args = {
+	children: (
+		<SidebarNavigation.Sidebar className="yst-w-1/3">
+			<SidebarNavigation.MenuItem
+				id={ "submenuitem-sidebar-1" }
+				icon={ NewspaperIcon }
+				label="MenuItem 1 label"
+				defaultOpen={ false }
+			>
+				<SidebarNavigation.SubmenuItem to="#1" label="SubmenuItem 1" />
+				<SidebarNavigation.SubmenuItem to="#2" label="SubmenuItem 2" />
+				<SidebarNavigation.SubmenuItem to="#3" label="SubmenuItem 3" />
+
+			</SidebarNavigation.MenuItem>
+			<SidebarNavigation.MenuItem
+				id={ "submenuitem-sidebar-2" }
+				icon={ ColorSwatchIcon }
+				label="MenuItem 2 label"
+				defaultOpen={ false }
+			>
+				<SidebarNavigation.SubmenuItem to="#1" label="SubmenuItem 1" />
+				<SidebarNavigation.SubmenuItem to="#2" label="SubmenuItem 2" />
+				<SidebarNavigation.SubmenuItem to="#3" label="SubmenuItem 3" />
+
+			</SidebarNavigation.MenuItem>
+		</SidebarNavigation.Sidebar>
+	),
+};
+
+
+export const Mobile = Template.bind( {} );
+
+Mobile.parameters = { docs: { description: { story: "The subcomponent `SidebarNavigation.Mobile` is a wrapper component over the `MenuItem` subcomponents for mobile view." } } };
+
+Mobile.args = {
+	children: ( <SidebarNavigation.Mobile
+		openButtonScreenReaderText="Open sidebar"
+		closeButtonScreenReaderText="Close sidebar"
+	>
+		<div className="yst-m-4">MobileMenu</div>
+		<SidebarNavigation.MenuItem
+			id={ "submenuitem-mobile" }
+			icon={ AdjustmentsIcon }
+			label="MenuItem label"
+			defaultOpen={ true }
+		>
+			<SidebarNavigation.SubmenuItem to="#1" label="SubmenuItem 1" />
+			<SidebarNavigation.SubmenuItem to="#2" label="SubmenuItem 2" />
+			<SidebarNavigation.SubmenuItem to="#3" label="SubmenuItem 3" />
+
+		</SidebarNavigation.MenuItem>
+	</SidebarNavigation.Mobile> ),
+};

--- a/packages/ui-library/src/components/sidebar-navigation/style.css
+++ b/packages/ui-library/src/components/sidebar-navigation/style.css
@@ -1,7 +1,11 @@
-.yst-mobile-navigation__top {
-	@apply yst-sticky yst-top-0 yst-w-full yst-z-50;
-}
+@layer components {
+	.yst-root {
+		.yst-mobile-navigation__top {
+			@apply yst-sticky yst-top-0 yst-w-full yst-z-50;
+		}
 
-.yst-mobile-navigation__dialog {
-	@apply yst-fixed yst-inset-0 yst-flex yst-z-50;
+		.yst-mobile-navigation__dialog {
+			@apply yst-fixed yst-inset-0 yst-flex yst-z-50;
+		}
+	}
 }

--- a/packages/ui-library/src/components/sidebar-navigation/submenu-item.js
+++ b/packages/ui-library/src/components/sidebar-navigation/submenu-item.js
@@ -1,0 +1,40 @@
+import classNames from "classnames";
+import PropTypes from "prop-types";
+import { useNavigationContext } from "./index";
+
+/**
+ * @param {JSX.node} label The label.
+ * @param {JSX.ElementClass} [as] The field component.
+ * @param {string} [pathProp] The key of the path in the props. Defaults to `href`.
+ * @param {Object} [props] Extra props.
+ * @returns {JSX.Element} The submenu item element.
+ */
+const SubmenuItem = ( { as: Component = "a", pathProp = "href", label, ...props } ) => {
+	const { activePath } = useNavigationContext();
+
+	return (
+		<li className="yst-m-0 yst-pb-1">
+			<Component
+				className={ classNames(
+					"yst-group yst-flex yst-items-center yst-px-3 yst-py-2 yst-text-sm yst-font-medium yst-rounded-md yst-no-underline focus:yst-outline-none focus:yst-ring-2 focus:yst-ring-primary-500",
+					activePath === props[ pathProp ]
+						? "yst-bg-slate-200 yst-text-slate-900"
+						: "yst-text-slate-600 hover:yst-text-slate-900 hover:yst-bg-slate-50",
+				) }
+				aria-current={ activePath === props[ pathProp ] ? "page" : null }
+				{ ...props }
+			>
+				{ label }
+			</Component>
+		</li>
+	);
+};
+
+SubmenuItem.propTypes = {
+	as: PropTypes.elementType,
+	pathProp: PropTypes.string,
+	label: PropTypes.node.isRequired,
+	isActive: PropTypes.bool,
+};
+
+export default SubmenuItem;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Fixes missing slides 2 and 3 on Introduction modal when language direction is `rtl`.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where slides 2 and 3 text on the settings UI Intoduction modal would disappear when language direction is `rtl`.

## Relevant technical choices:

* Enforced direction `ltr` on slider to preserve animation on `rtl`.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Log in as new user (so that the introduction modal will be displayed).
* Set your site language to an RTL language (e.g., Arabic or Hebrew).
* Open `Yoast SEO`->`Settings`.
* Confirm the introduction modal is opened, and the first step is rendered correctly.
* Move to the second and third step using the "Next" button.
* Check each step has title and text and the arrows and button are on `rtl` direction.

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [X] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes [Major: Missing text in Settings UI introduction modal (steps 2 and 3) for RTL languages#318](https://github.com/Yoast/plugins-automated-testing/issues/318)
