### PR TITLE
#301 get premium title formating

### DIFF
--- a/css/src/yst_plugin_tools.css
+++ b/css/src/yst_plugin_tools.css
@@ -570,6 +570,10 @@ body.toplevel_page_wpseo_dashboard .wp-badge {
 	font-size: 22px;
 	font-weight: bold;
 }
+.yoast-get-premium-title{
+  line-height: 27px;
+  text-align:center;
+}
 
 .yoast-sidebar__product .product-image {
 	position: relative;

--- a/packages/js/src/settings/components/sidebar-recommendations.js
+++ b/packages/js/src/settings/components/sidebar-recommendations.js
@@ -39,8 +39,10 @@ const PremiumUpsellCard = () => {
 			>
 				<YoastSeoLogo />
 			</figure>
-			<Title as="h2" className="yst-mt-6 yst-text-base yst-font-extrabold yst-text-white">
-				{ getPremium }
+			<Title as="h2" className="yst-mt-6 yst-text-base yst-font-extrabold yst-text-white yst-text-center">
+				{ __( "Get", "wordpress-seo" ) }
+				<br />
+				Yoast SEO Premium
 			</Title>
 			<p className="yst-mt-2">{ info }</p>
 			<Button

--- a/src/presenters/admin/sidebar-presenter.php
+++ b/src/presenters/admin/sidebar-presenter.php
@@ -56,10 +56,10 @@ class Sidebar_Presenter extends Abstract_Presenter {
 								</div>
 							</div>
 						<?php endif; ?>
-						<h2>
+						<h2 class="yoast-get-premium-title">
 							<?php
 							/* translators: %s expands to Yoast SEO Premium */
-							\printf( \esc_html__( 'Get %s', 'wordpress-seo' ), 'Yoast SEO Premium' );
+							\printf( \esc_html__( 'Get %s', 'wordpress-seo' ), '<br>Yoast SEO Premium' );
 							?>
 						</h2>
 						<p>

--- a/src/presenters/admin/sidebar-presenter.php
+++ b/src/presenters/admin/sidebar-presenter.php
@@ -58,7 +58,7 @@ class Sidebar_Presenter extends Abstract_Presenter {
 						<?php endif; ?>
 						<h2 class="yoast-get-premium-title">
 							<?php
-							/* translators: %s expands to Yoast SEO Premium */
+							/* translators: %s expands to <br>Yoast SEO Premium */
 							\printf( \esc_html__( 'Get %s', 'wordpress-seo' ), '<br>Yoast SEO Premium' );
 							?>
 						</h2>


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Fixes `Get Yoast SEO Premium` formatting to be optimal for all languages.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes `Get Yoast SEO Premium` formatting to be optimal for all languages.

## Relevant technical choices:

* 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Turn off premium plugin
* Open `Yoast SEO` -> `General` 
* Check sidebar title `Get Yoast SEO Premium` is centered and `Get` and `Yoast SEO Premium` are in separate lines and centered.
* Open `Yoast SEO` -> `Settings` 
* Check sidebar title `Get Yoast SEO Premium` is centered and `Get` and `Yoast SEO Premium` are in separate lines and centered.

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [X] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes [Trivial: "Get Yoast SEO Premium" formatting is not optimal for many languages#301](https://github.com/Yoast/plugins-automated-testing/issues/301)
