### PR TITLE
Recognize self-closing break tags (</br>)

### DIFF
--- a/packages/yoastseo/spec/fullTextTests/testTexts/ar/arabicPaper.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/ar/arabicPaper.js
@@ -118,9 +118,8 @@ const expectedResults = {
 	},
 	textTransitionWords: {
 		isApplicable: true,
-		score: 6,
-		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 23.5% of the sentences contain transition words, " +
-			"which is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more of them</a>.",
+		score: 9,
+		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Well done!",
 	},
 	passiveVoice: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/fullTextTests/testTexts/pt/portuguesePaper.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/pt/portuguesePaper.js
@@ -127,7 +127,7 @@ const expectedResults = {
 	textTransitionWords: {
 		isApplicable: true,
 		score: 3,
-		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 7.8% of the sentences contain transition words," +
+		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 9.2% of the sentences contain transition words," +
 			" which is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more of them</a>.",
 	},
 	passiveVoice: {

--- a/packages/yoastseo/spec/languageProcessing/helpers/sentence/SentenceTokenizerSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/helpers/sentence/SentenceTokenizerSpec.js
@@ -419,3 +419,17 @@ describe( "A test for tokenizing a (html) text into sentences", function() {
 	} );
 } );
 
+describe( "Tests for isBreakTag", () => {
+	it( "returns true for a break tag", () => {
+		expect( mockTokenizer.isBreakTag( "<br" ) ).toBe( true );
+	} );
+	it( "returns false for a non-break tag", () => {
+		expect( mockTokenizer.isBreakTag( "<p" ) ).toBe( false );
+	} );
+	it( "returns true for a self-closing break tag", () => {
+		expect( mockTokenizer.isBreakTag( "<br/>" ) ).toBe( true );
+	} );
+	it( "returns true for a closing break tag", () => {
+		expect( mockTokenizer.isBreakTag( "</br>" ) ).toBe( true );
+	} );
+} );

--- a/packages/yoastseo/src/languageProcessing/helpers/sentence/SentenceTokenizer.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/sentence/SentenceTokenizer.js
@@ -416,8 +416,6 @@ export default class SentenceTokenizer {
 		} while ( sliced && tokenArray.length > 1 );
 
 		tokenArray.forEach( ( token, i ) => {
-			// print token
-			console.log( token, "TEST4" );
 
 			let hasNextSentence, nextCharacters, tokenizeResults;
 			const nextToken = tokenArray[ i + 1 ];
@@ -432,7 +430,6 @@ export default class SentenceTokenizer {
 			switch ( token.type ) {
 				case "html-start":
 				case "html-end":
-					console.log( "html start", token.src, this.isBreakTag( token.src ), token.type, "TEST6" );
 					if ( this.isBreakTag( token.src ) ) {
 						tokenSentences.push( currentSentence );
 						currentSentence = "";

--- a/packages/yoastseo/src/languageProcessing/helpers/sentence/SentenceTokenizer.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/sentence/SentenceTokenizer.js
@@ -416,7 +416,6 @@ export default class SentenceTokenizer {
 		} while ( sliced && tokenArray.length > 1 );
 
 		tokenArray.forEach( ( token, i ) => {
-
 			let hasNextSentence, nextCharacters, tokenizeResults;
 			const nextToken = tokenArray[ i + 1 ];
 			const previousToken = tokenArray[ i - 1 ];

--- a/packages/yoastseo/src/languageProcessing/helpers/sentence/SentenceTokenizer.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/sentence/SentenceTokenizer.js
@@ -71,7 +71,7 @@ export default class SentenceTokenizer {
 	 * @returns {boolean} Whether or not the given HTML tag is a break tag.
 	 */
 	isBreakTag( htmlTag ) {
-		return /<br/.test( htmlTag );
+		return /<\/?br/.test( htmlTag );
 	}
 
 	/**
@@ -416,6 +416,9 @@ export default class SentenceTokenizer {
 		} while ( sliced && tokenArray.length > 1 );
 
 		tokenArray.forEach( ( token, i ) => {
+			// print token
+			console.log( token, "TEST4" );
+
 			let hasNextSentence, nextCharacters, tokenizeResults;
 			const nextToken = tokenArray[ i + 1 ];
 			const previousToken = tokenArray[ i - 1 ];
@@ -429,6 +432,7 @@ export default class SentenceTokenizer {
 			switch ( token.type ) {
 				case "html-start":
 				case "html-end":
+					console.log( "html start", token.src, this.isBreakTag( token.src ), token.type, "TEST6" );
 					if ( this.isBreakTag( token.src ) ) {
 						tokenSentences.push( currentSentence );
 						currentSentence = "";


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* There was a bug in the sentence tokenizer that a closing break tag (`</br>`) was not sanitized. This lead to problems with marking in the classic editor when a text was copied from a third party source (word or other text editors). This would introduce closing break tags. If such break tags were present in a sentence, words in this sentence could not be marked.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where self-closing break tags (`</br>`) would not be removed when analyzing content.

## Relevant technical choices:

* There is still a bug present that a break tag is seen as a sentence delimiter, which is not necessarily true. But for now, this does not lead to visible problems, so a separate issue will be made for this.
* While this PR does touch code that is used in Shopify, it's impossible to add a self-closing break tag in their editor (see comment below), so we've removed the "Shopify" label and did not add a Shopify-specific changelog item.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install and activate yoastSEO Free
* Install and activate YoastSEO premium. Don't forget to require `recognize-self-closing-break-tags` if you are building from a checked out branch. As long as the newest trunk (that contains 20.0) is not merged in `feature/lingo-fixes` it is best to use the `release/19.7`-branch for premium. Since premium trunk requires at least free 20.0.
* Install classic editor.
* Create a post/page/cpt using the default editor
* Paste [this text](https://github.com/Yoast/wordpress-seo/files/10336583/alice_sample_short.txt)
* Save the post, then activate Classic editor and re-open the post
* Check the HTML of the post and confirm that it contains <br /> tags 

##### Scenario 1: word complexity
* Toggle the highlighting for complex words.
* Make sure the following **8** words are highlighted: `containing`, `wheresoever`, `waistcoat-pocket`, `waistcoat-pocket`, `curiosity`, `fortunately`, `rabbit-hole`, `rabbit-hole`. **NOTE**: once  #19390 is merged, only **7** words will be marked: the previous list minus `wheresoever`

##### Scenario 2: Keyphrase marking.
* Set `rabbit` as the focus keyphrase.
* Toggle highlighting for keyphrase distribution. 
* Make sure that `rabbit` is marked 5 times in the text.
* Repeat scenario 2 for keyphrase density.

##### Scenario 3: smoke test marking of full sentence.
* Add the sentence `The cat was greeted by the dog`.
* Toggle highlighting for passive sentences
* Make sure that the sentence is highlighted.

##### Scenario 4:
* Toggle highlighting for transition words.
* You will notice that some sentences are not highlighted entirely. This is due to the abovementioned bug.

##### Misc

* Repeat scenarios 1-3 for block editor.
* Reoeat scenarios 1-3 for shopify. Do note that the editor there actually prevents the use of self-closing break tags. 
* Elementor does not have highlighting. But smoke test with the console open whether anything fishy happens.
* Content types such as taxonomies do not have highlighting. But smoke test the readability analyses for taxonomies

* This PR touches the sentence tokenizer. So be creative and try to come up with ways to break/test this.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [x] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* This PR affects the sentence tokenizer. Theoretically all cases are covered by the testing scenarion. But it is good to be extra creative when testing to see if you can find something.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #https://github.com/Yoast/wordpress-seo-premium/issues/3776
