### PR TITLE
19436 make sure all links do have a focus style

### DIFF
--- a/packages/js/src/settings/app.js
+++ b/packages/js/src/settings/app.js
@@ -64,7 +64,7 @@ const Menu = ( { postTypes, taxonomies, idSuffix = "" } ) => {
 
 	return <>
 		<header className="yst-px-3 yst-mb-6 yst-space-y-6">
-			<Link to="/" className="yst-inline-block yst-rounded-md focus:yst-ring-2 focus:yst-ring-offset-2 focus:yst-ring-primary-500" aria-label={ `Yoast SEO${ isPremium ? " Premium" : "" }` }>
+			<Link to="/" className="yst-inline-block yst-rounded-md focus:yst-ring-primary-500" aria-label={ `Yoast SEO${ isPremium ? " Premium" : "" }` }>
 				<YoastLogo className="yst-w-40" { ...svgAriaProps } />
 			</Link>
 			<Search buttonId={ `button-search${ idSuffix }` } />

--- a/packages/js/src/settings/components/formik-media-select-field.js
+++ b/packages/js/src/settings/components/formik-media-select-field.js
@@ -196,7 +196,7 @@ const FormikMediaSelectField = ( {
 					</div>
 				) }
 			</button>
-			<div className="yst-flex yst-gap-4">
+			<div className="yst-flex yst-gap-1">
 				{ ! isDummy && ( mediaId > 0 ) ? (
 					<Button
 						id={ `button-${ id }-replace` }
@@ -221,7 +221,10 @@ const FormikMediaSelectField = ( {
 						type="button"
 						variant="error"
 						onClick={ handleRemoveMediaClick }
-						className={ classNames( disabled && "yst-opacity-50 yst-cursor-not-allowed" ) }
+						className={ classNames(
+							"yst-px-3 yst-py-2 yst-rounded-md",
+							disabled && "yst-opacity-50 yst-cursor-not-allowed"
+						) }
 						disabled={ disabled }
 					>
 						{ removeLabel }

--- a/packages/js/src/settings/components/sidebar-recommendations.js
+++ b/packages/js/src/settings/components/sidebar-recommendations.js
@@ -51,7 +51,7 @@ const PremiumUpsellCard = () => {
 				href={ premiumLink }
 				target="_blank"
 				rel="noopener"
-				className="yst-flex yst-justify-center yst-gap-2 yst-mt-4 yst-px-4 sm:yst-px-0"
+				className="yst-flex yst-justify-center yst-gap-2 yst-mt-4 yst-px-4 sm:yst-px-0 focus:yst-ring-offset-primary-500"
 				{ ...premiumUpsellConfig }
 			>
 				{ getPremium }

--- a/packages/js/src/settings/routes/site-features.js
+++ b/packages/js/src/settings/routes/site-features.js
@@ -1,8 +1,8 @@
 /* eslint-disable complexity */
-import { ArrowNarrowRightIcon, LockOpenIcon, ExternalLinkIcon } from "@heroicons/react/outline";
+import { ArrowNarrowRightIcon, ExternalLinkIcon, LockOpenIcon } from "@heroicons/react/outline";
 import { useMemo } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
-import { Badge, Button, Card, Title, ToggleField, useSvgAria } from "@yoast/ui-library";
+import { Badge, Button, Card, Link, Title, ToggleField, useSvgAria } from "@yoast/ui-library";
 import classNames from "classnames";
 import { useFormikContext } from "formik";
 import { get } from "lodash";
@@ -129,16 +129,17 @@ const LearnMoreLink = ( { id, link } ) => {
 
 	return (
 		// eslint-disable-next-line react/jsx-no-target-blank
-		<a
+		<Link
 			id={ id }
 			href={ href }
-			className="yst-flex yst-items-center yst-gap-1 yst-no-underline yst-font-medium yst-text-primary-500 hover:yst-text-primary-400"
+			variant="primary"
+			className="yst-flex yst-items-center yst-gap-1 yst-no-underline yst-font-medium"
 			target="_blank"
 			rel="noopener"
 		>
 			{ __( "Learn more", "wordpress-seo" ) }
 			<ArrowNarrowRightIcon className="yst-w-4 yst-h-4 yst-icon-rtl" />
-		</a>
+		</Link>
 	);
 };
 

--- a/packages/ui-library/src/components/root/style.css
+++ b/packages/ui-library/src/components/root/style.css
@@ -425,10 +425,15 @@
 			@apply
 			yst-underline
 			yst-text-indigo-600
-			
+
 			hover:yst-text-indigo-500
 			focus:yst-text-indigo-500
 			focus:yst-outline-none
+			focus:yst-ring-1
+			focus:yst-ring-offset-1
+			focus:yst-ring-offset-transparent
+			focus:yst-ring-indigo-600
+			focus:yst-rounded-sm
 			visited:yst-text-primary-500
 			visited:hover:yst-text-primary-400;
 		}

--- a/packages/ui-library/src/components/sidebar-navigation/submenu-item.js
+++ b/packages/ui-library/src/components/sidebar-navigation/submenu-item.js
@@ -19,7 +19,7 @@ const SubmenuItem = ( { as: Component = "a", pathProp = "href", label, ...props 
 		<li className="yst-m-0 yst-pb-1">
 			<Component
 				className={ classNames(
-					"yst-group yst-flex yst-items-center yst-px-3 yst-py-2 yst-text-sm yst-font-medium yst-rounded-md yst-no-underline focus:yst-outline-none focus:yst-ring-2 focus:yst-ring-primary-500",
+					"yst-group yst-flex yst-items-center yst-px-3 yst-py-2 yst-text-sm yst-font-medium yst-rounded-md yst-no-underline focus:yst-outline-none focus:yst-ring-1 focus:yst-ring-offset-1 focus:yst-ring-offset-transparent focus:yst-ring-primary-500",
 					activePath === props[ pathProp ]
 						? "yst-bg-slate-200 yst-text-slate-900"
 						: "yst-text-slate-600 hover:yst-text-slate-900 hover:yst-bg-slate-50",

--- a/packages/ui-library/src/elements/button/style.css
+++ b/packages/ui-library/src/elements/button/style.css
@@ -20,7 +20,14 @@
 			focus:yst-outline-none
 			focus:yst-ring-2
 			focus:yst-ring-offset-2
-			focus:yst-ring-primary-500
+			focus:yst-ring-primary-500;
+		}
+
+		/* Special styling for buttons rendered `as` "a" (to override anchor defaults). */
+		a.yst-button {
+			@apply
+			focus:yst-ring-offset-white
+			focus:yst-rounded-md;
 		}
 
 		/* Variants */
@@ -33,6 +40,8 @@
 
 			hover:yst-text-white
 			hover:yst-bg-primary-700
+			focus:yst-text-white
+			focus:yst-ring-primary-700
 			visited:yst-text-white
 			visited:hover:yst-text-white;
 		}
@@ -45,6 +54,8 @@
 
 			hover:yst-text-slate-800
 			hover:yst-bg-slate-50
+			focus:yst-text-slate-800
+			focus:yst-ring-primary-700
 			visited:yst-text-slate-800
 			visited:hover:yst-text-slate-800;
 		}
@@ -57,6 +68,7 @@
 
 			hover:yst-text-white
 			hover:yst-bg-red-700
+			focus:yst-text-white
 			focus:yst-ring-red-600
 			visited:yst-text-white
 			visited:hover:yst-text-white;
@@ -70,6 +82,7 @@
 
 			hover:yst-text-amber-900
 			hover:yst-bg-amber-400
+			focus:yst-text-amber-900
 			focus:yst-ring-amber-400
 			visited:yst-text-amber-900
 			visited:hover:yst-text-amber-900;

--- a/packages/ui-library/src/elements/link/style.css
+++ b/packages/ui-library/src/elements/link/style.css
@@ -9,6 +9,11 @@
 			hover:yst-text-indigo-500
 			focus:yst-text-indigo-500
 			focus:yst-outline-none
+			focus:yst-ring-1
+			focus:yst-ring-offset-1
+			focus:yst-ring-offset-transparent
+			focus:yst-ring-indigo-600
+			focus:yst-rounded-sm
 			visited:yst-text-primary-500
 			visited:hover:yst-text-primary-400;
 		}
@@ -18,11 +23,11 @@
 		}
 
 		.yst-link--primary {
-			@apply yst-text-primary-600 hover:yst-text-primary-500 focus:yst-text-primary-500;
+			@apply yst-text-primary-600 hover:yst-text-primary-500 focus:yst-text-primary-500 focus:yst-ring-primary-600;
 		}
 
 		.yst-link--error {
-			@apply yst-text-red-600 hover:yst-text-red-500 focus:yst-text-red-500;
+			@apply yst-text-red-600 hover:yst-text-red-500 focus:yst-text-red-500 focus:yst-ring-red-600;
 		}
 	}
 }

--- a/packages/ui-library/src/elements/tag-input/index.js
+++ b/packages/ui-library/src/elements/tag-input/index.js
@@ -124,7 +124,6 @@ const TagInput = forwardRef( ( {
 					tag={ tag }
 					index={ index }
 					disabled={ disabled }
-					tabIndex="2"
 					onRemoveTag={ onRemoveTag }
 					screenReaderRemoveTag={ screenReaderRemoveTag }
 				/>
@@ -134,7 +133,6 @@ const TagInput = forwardRef( ( {
 				type="text"
 				disabled={ disabled }
 				className="yst-tag-input__input"
-				tabIndex="1"
 				onKeyDown={ handleKeyDown }
 				{ ...props }
 				onChange={ handleChange }

--- a/packages/ui-library/src/elements/validation/style.css
+++ b/packages/ui-library/src/elements/validation/style.css
@@ -88,7 +88,11 @@
 
 		.yst-validation-message {
 			a {
-				@apply yst-font-medium yst-text-inherit hover:visited:yst-text-inherit;
+				@apply
+				yst-font-medium
+				yst-text-inherit
+				focus:yst-ring-current
+				hover:visited:yst-text-inherit;
 			}
 		}
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Make sure all links do have a (clear) focus style

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves the link focus styles in the first time configuration.
* Fixes an unreleased bug where the focus styles of links in the Settings where non-existent or incorrect.
* [@yoast/ui-library] Improves the focus style of anchors by making it more pronounced. This affects: all anchors within the `yst-root` and `yst-validation-message` classes as well as the `Link` and `SidebarNavigation.SubmenuItem` components. And lastly, the `Button` element, if rendered `as` an anchor.
* [@yoast/ui-library] Removes the `TagInput`' _tabindex_ override.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Enable Premium
* Go to the Settings
* Check the style and specifically the focus style of:
  * Yoast SEO logo: visual change. Note that [this was fixed already](https://github.com/Yoast/wordpress-seo/issues/19434) but now changed due to the link focus style.
  * Submenu items: no visual change
  * Site features > Learn more: visual change. Also, the color is slightly adjusted, now inline with other links
  * Site features > XML sitemap > View the XML sitemap ("button" appears when saved as enabled): style change, now more like a button (it is an HTML anchor tag)
  * Site basics > Site info's `replacement variables` link: focus style. Note this is an example of the general link style change, I won't note all of them in the test instructions. Others fall under the tab through instruction at the end.
  * Site basics > Site image: focus style of the `Remove image` button. Note this is similar to the XML sitemap, a button rendered as an anchor
  * Site representation > Person > Link in the info alert: focus style
  * Content types > Posts > Additional settings > Add custom fields to page analysis
    * Verify tabbing to that TagInput works when there are _no_ tags specified
    * Verify tabbing to that TagInput works when there tags specified
    * What changed? Previously it specified a `tabindex` to try and change the tab order to be first on the text input, then on any tags. But that does not work properly.
  * Crawl optimization > Advanced: URL cleanup > The read more link in the warning alert: focus style. Note that the color is in warning style too. Otherwise the same as the other alert.
* Disable Premium
* Check the style and specifically the focus style of:
  * The right sidebar's Get Premium button and Read review link

#### Extra safety
* Tab through the whole settings and verify the focus style is clearly visible.
  * Note that I created [an issue to fix the focus style](https://github.com/Yoast/wordpress-seo/issues/19533) of the Settings > Site basics > Title separator
* Go to the First time configuration
  * Tab through the steps (if done before, edit them)
  * Most things now have a focus style. Technically this duplicated some things instead of using the UI library. For example, the image remove button does not have the same focus style now.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Settings UI, UI library and anything that uses the UI library like the First Time Configuration.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #19436
