### PR TITLE
settings ui 19521 improve the feature cards accessibility

### DIFF
--- a/packages/js/src/settings/components/form-layout.js
+++ b/packages/js/src/settings/components/form-layout.js
@@ -55,7 +55,7 @@ const FormLayout = ( { children } ) => {
 							>
 								{ __( "Discard changes", "wordpress-seo" ) }
 							</Button>
-							<Modal onClose={ unsetRequestUndo } isOpen={ isRequestUndo }>
+							<Modal onClose={ unsetRequestUndo } isOpen={ isRequestUndo } ariaLabelledby="discard-all-changes-title">
 								<Modal.Panel closeButtonScreenReaderText={ __( "Close", "wordpress-seo" ) }>
 									<div className="sm:yst-flex sm:yst-items-start">
 										<div
@@ -64,7 +64,7 @@ const FormLayout = ( { children } ) => {
 											<ExclamationIcon className="yst-h-6 yst-w-6 yst-text-red-600" { ...svgAriaProps } />
 										</div>
 										<div className="yst-mt-3 yst-text-center sm:yst-mt-0 sm:yst-ml-4 sm:yst-text-left">
-											<Modal.Title as="h3" className="yst-text-lg yst-leading-6 yst-font-medium yst-text-slate-900">
+											<Modal.Title as="h1" className="yst-text-lg yst-leading-6 yst-font-medium yst-text-slate-900" id="discard-all-changes-title">
 												{ __( "Discard all changes", "wordpress-seo" ) }
 											</Modal.Title>
 											<Modal.Description className="yst-text-sm yst-text-slate-500">

--- a/packages/js/src/settings/components/form-layout.js
+++ b/packages/js/src/settings/components/form-layout.js
@@ -64,7 +64,7 @@ const FormLayout = ( { children } ) => {
 											<ExclamationIcon className="yst-h-6 yst-w-6 yst-text-red-600" { ...svgAriaProps } />
 										</div>
 										<div className="yst-mt-3 yst-text-center sm:yst-mt-0 sm:yst-ml-4 sm:yst-text-left">
-											<Modal.Title as="h1" className="yst-text-lg yst-leading-6 yst-font-medium yst-text-slate-900">
+											<Modal.Title className="yst-text-lg yst-leading-6 yst-font-medium yst-text-slate-900">
 												{ __( "Discard all changes", "wordpress-seo" ) }
 											</Modal.Title>
 											<Modal.Description className="yst-text-sm yst-text-slate-500">

--- a/packages/js/src/settings/components/form-layout.js
+++ b/packages/js/src/settings/components/form-layout.js
@@ -55,7 +55,7 @@ const FormLayout = ( { children } ) => {
 							>
 								{ __( "Discard changes", "wordpress-seo" ) }
 							</Button>
-							<Modal onClose={ unsetRequestUndo } isOpen={ isRequestUndo } ariaLabelledby="discard-all-changes-title">
+							<Modal onClose={ unsetRequestUndo } isOpen={ isRequestUndo }>
 								<Modal.Panel closeButtonScreenReaderText={ __( "Close", "wordpress-seo" ) }>
 									<div className="sm:yst-flex sm:yst-items-start">
 										<div
@@ -64,7 +64,7 @@ const FormLayout = ( { children } ) => {
 											<ExclamationIcon className="yst-h-6 yst-w-6 yst-text-red-600" { ...svgAriaProps } />
 										</div>
 										<div className="yst-mt-3 yst-text-center sm:yst-mt-0 sm:yst-ml-4 sm:yst-text-left">
-											<Modal.Title as="h1" className="yst-text-lg yst-leading-6 yst-font-medium yst-text-slate-900" id="discard-all-changes-title">
+											<Modal.Title as="h1" className="yst-text-lg yst-leading-6 yst-font-medium yst-text-slate-900">
 												{ __( "Discard all changes", "wordpress-seo" ) }
 											</Modal.Title>
 											<Modal.Description className="yst-text-sm yst-text-slate-500">

--- a/packages/js/src/settings/components/introduction.js
+++ b/packages/js/src/settings/components/introduction.js
@@ -233,9 +233,9 @@ const Introduction = () => {
 									index === stepIndex ? "yst-opacity-100" : "yst-opacity-0"
 								) }
 							>
-								<Title as="h2" size="2">
+								<Modal.Title as="h2" className="yst-text-lg">
 									{ step.title }
-								</Title>
+								</Modal.Title>
 								<Modal.Description className="yst-max-w-xs yst-mx-auto yst-mt-2">
 									{ step.description }
 								</Modal.Description>

--- a/packages/js/src/settings/components/introduction.js
+++ b/packages/js/src/settings/components/introduction.js
@@ -2,7 +2,7 @@
 import { ArrowLeftIcon as PureArrowLeftIcon, ArrowRightIcon as PureArrowRightIcon } from "@heroicons/react/outline";
 import { useCallback, useEffect, useMemo, useState } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
-import { Button, Modal, Spinner, Title, useRootContext, useSvgAria, useToggleState } from "@yoast/ui-library";
+import { Button, Modal, Spinner, useRootContext, useSvgAria, useToggleState } from "@yoast/ui-library";
 import classNames from "classnames";
 import { times } from "lodash";
 import { Helmet } from "react-helmet";
@@ -233,7 +233,7 @@ const Introduction = () => {
 									index === stepIndex ? "yst-opacity-100" : "yst-opacity-0"
 								) }
 							>
-								<Modal.Title as="h2" className="yst-text-lg">
+								<Modal.Title as="h2" size="2">
 									{ step.title }
 								</Modal.Title>
 								<Modal.Description className="yst-max-w-xs yst-mx-auto yst-mt-2">

--- a/packages/js/src/settings/components/introduction.js
+++ b/packages/js/src/settings/components/introduction.js
@@ -2,7 +2,7 @@
 import { ArrowLeftIcon as PureArrowLeftIcon, ArrowRightIcon as PureArrowRightIcon } from "@heroicons/react/outline";
 import { useCallback, useEffect, useMemo, useState } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
-import { Button, Modal, Spinner, useRootContext, useSvgAria, useToggleState } from "@yoast/ui-library";
+import { Button, Modal, Title, Spinner, useRootContext, useSvgAria, useToggleState } from "@yoast/ui-library";
 import classNames from "classnames";
 import { times } from "lodash";
 import { Helmet } from "react-helmet";
@@ -133,7 +133,7 @@ const Introduction = () => {
 	return (
 
 		// handleClose function is closing the modal and setting the user meta to not show introduction again
-		<Modal onClose={ handleClose } isOpen={ isOpen }>
+		<Modal onClose={ handleClose } isOpen={ isOpen } aria-label={ __( "Introduction to settings", "wordpress-seo" ) }>
 			<div className="yst-modal__panel yst-max-w-[37rem] yst-p-0 yst-rounded-2xl sm:yst-rounded-3xl">
 
 				{ /* //checks ther is permission from wista to add video and add js script, Helmet component adds the script tp the head */ }
@@ -233,12 +233,12 @@ const Introduction = () => {
 									index === stepIndex ? "yst-opacity-100" : "yst-opacity-0"
 								) }
 							>
-								<Modal.Title as="h2" size="2">
+								<Title as="h2" size="2">
 									{ step.title }
-								</Modal.Title>
-								<Modal.Description className="yst-max-w-xs yst-mx-auto yst-mt-2">
+								</Title>
+								<p className="yst-max-w-xs yst-mx-auto yst-mt-2">
 									{ step.description }
-								</Modal.Description>
+								</p>
 							</div>
 						) ) }
 					</div>

--- a/packages/js/src/settings/components/introduction.js
+++ b/packages/js/src/settings/components/introduction.js
@@ -2,7 +2,7 @@
 import { ArrowLeftIcon as PureArrowLeftIcon, ArrowRightIcon as PureArrowRightIcon } from "@heroicons/react/outline";
 import { useCallback, useEffect, useMemo, useState } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
-import { Button, Modal, Title, Spinner, useRootContext, useSvgAria, useToggleState } from "@yoast/ui-library";
+import { Button, Modal, Spinner, Title, useRootContext, useSvgAria, useToggleState } from "@yoast/ui-library";
 import classNames from "classnames";
 import { times } from "lodash";
 import { Helmet } from "react-helmet";

--- a/packages/js/src/settings/components/search.js
+++ b/packages/js/src/settings/components/search.js
@@ -56,7 +56,7 @@ SearchResultLabel.propTypes = {
  */
 const SearchNoResultsContent = ( { title, children } ) => (
 	<div className="yst-border-t yst-border-slate-100 yst-p-6 yst-py-12 yst-space-3 yst-text-center yst-text-sm">
-		<span className="yst-block yst-font-semibold yst-text-slate-900">{ title }</span>
+		<Modal.Title className="yst-block yst-font-semibold yst-text-slate-900 yst-text-sm">{ title }</Modal.Title>
 		{ children }
 	</div>
 );

--- a/packages/js/src/settings/components/search.js
+++ b/packages/js/src/settings/components/search.js
@@ -56,7 +56,7 @@ SearchResultLabel.propTypes = {
  */
 const SearchNoResultsContent = ( { title, children } ) => (
 	<div className="yst-border-t yst-border-slate-100 yst-p-6 yst-py-12 yst-space-3 yst-text-center yst-text-sm">
-		<Modal.Title className="yst-block yst-font-semibold yst-text-slate-900 yst-text-sm">{ title }</Modal.Title>
+		<Modal.Title className="yst-block yst-font-semibold yst-text-slate-900" size="5">{ title }</Modal.Title>
 		{ children }
 	</div>
 );

--- a/packages/js/src/settings/components/search.js
+++ b/packages/js/src/settings/components/search.js
@@ -56,7 +56,7 @@ SearchResultLabel.propTypes = {
  */
 const SearchNoResultsContent = ( { title, children } ) => (
 	<div className="yst-border-t yst-border-slate-100 yst-p-6 yst-py-12 yst-space-3 yst-text-center yst-text-sm">
-		<Modal.Title className="yst-block yst-font-semibold yst-text-slate-900" size="5">{ title }</Modal.Title>
+		<span className="yst-block yst-font-semibold yst-text-slate-900">{ title }</span>
 		{ children }
 	</div>
 );
@@ -204,6 +204,7 @@ const Search = ( { buttonId = "button-search" } ) => {
 			isOpen={ isOpen }
 			initialFocus={ inputRef }
 			position="top-center"
+			aria-label={ __( "Search", "wordpress-seo" ) }
 		>
 			<Modal.Panel closeButtonScreenReaderText={ __( "Close", "wordpress-seo" ) }>
 				<Combobox as="div" className="yst--m-6 yst--mt-5" onChange={ handleNavigate }>

--- a/packages/js/src/settings/routes/site-features.js
+++ b/packages/js/src/settings/routes/site-features.js
@@ -73,7 +73,7 @@ const FeatureCard = ( {
 				) }
 			</Card.Header>
 			<Card.Content className="yst-flex yst-flex-col yst-gap-3">
-				{ title && 	<Title as="h3">{ title } </Title> }
+				<Title as="h3">{ title }</Title>
 				{ children }
 			</Card.Content>
 			<Card.Footer>

--- a/packages/js/src/settings/routes/site-features.js
+++ b/packages/js/src/settings/routes/site-features.js
@@ -151,7 +151,7 @@ const LearnMoreLink = ( { id, link, ariaLabel, ...props } ) => {
 LearnMoreLink.propTypes = {
 	id: PropTypes.string.isRequired,
 	link: PropTypes.string.isRequired,
-	ariaLabel: PropTypes.string,
+	ariaLabel: PropTypes.string.isRequired,
 };
 
 /**

--- a/packages/js/src/settings/routes/site-features.js
+++ b/packages/js/src/settings/routes/site-features.js
@@ -32,6 +32,7 @@ const FeatureCard = ( {
 	isPremiumFeature = false,
 	isPremiumLink = "",
 	isBetaFeature = false,
+	title,
 } ) => {
 	const isPremium = useSelectSettings( "selectPreference", [], "isPremium" );
 	const imageSrc = useSelectSettings( "selectPluginUrl", [ rawImageSrc ], rawImageSrc );
@@ -57,7 +58,7 @@ const FeatureCard = ( {
 						shouldDimHeaderImage && "yst-opacity-50 yst-filter yst-grayscale"
 					) }
 					src={ imageSrc }
-					alt={ imageAlt }
+					alt={ imageAlt ? imageAlt : "" }
 					width={ 500 }
 					height={ 250 }
 					loading="lazy"
@@ -72,6 +73,7 @@ const FeatureCard = ( {
 				) }
 			</Card.Header>
 			<Card.Content className="yst-flex yst-flex-col yst-gap-3">
+				{ title && 	<Title as="h3">{ title } </Title> }
 				{ children }
 			</Card.Content>
 			<Card.Footer>
@@ -80,6 +82,7 @@ const FeatureCard = ( {
 					type="checkbox"
 					name={ name }
 					id={ inputId }
+					aria-label={ `${ __( "Enable feature", "wordpress-seo" )} ${title}` }
 					label={ __( "Enable feature", "wordpress-seo" ) }
 					disabled={ isDisabled }
 					checked={ disabledSetting === "language" ? false : value }
@@ -113,10 +116,11 @@ FeatureCard.propTypes = {
 	inputId: PropTypes.string.isRequired,
 	children: PropTypes.node.isRequired,
 	imageSrc: PropTypes.string.isRequired,
-	imageAlt: PropTypes.string.isRequired,
+	imageAlt: PropTypes.string,
 	isPremiumFeature: PropTypes.bool,
 	isBetaFeature: PropTypes.bool,
 	isPremiumLink: PropTypes.string,
+	title: PropTypes.string.isRequired,
 };
 
 /**
@@ -124,7 +128,7 @@ FeatureCard.propTypes = {
  * @param {string} href The link.
  * @returns {JSX.Element} The learn more link.
  */
-const LearnMoreLink = ( { id, link } ) => {
+const LearnMoreLink = ( { id, link, ariaLabel, ... props } ) => {
 	const href = useSelectSettings( "selectLink", [ link ], link );
 
 	return (
@@ -135,6 +139,8 @@ const LearnMoreLink = ( { id, link } ) => {
 			className="yst-flex yst-items-center yst-gap-1 yst-no-underline yst-font-medium yst-text-primary-500 hover:yst-text-primary-400"
 			target="_blank"
 			rel="noopener"
+			aria-label={ `Learn more about ${ ariaLabel }, opens in a new tab` }
+			{ ...props }
 		>
 			{ __( "Learn more", "wordpress-seo" ) }
 			<ArrowNarrowRightIcon className="yst-w-4 yst-h-4 yst-icon-rtl" />
@@ -145,6 +151,7 @@ const LearnMoreLink = ( { id, link } ) => {
 LearnMoreLink.propTypes = {
 	id: PropTypes.string.isRequired,
 	link: PropTypes.string.isRequired,
+	ariaLabel: PropTypes.string,
 };
 
 /**
@@ -186,53 +193,41 @@ const SiteFeatures = () => {
 								cardId="card-wpseo-keyword_analysis_active"
 								inputId="input-wpseo-keyword_analysis_active"
 								imageSrc="/images/seo_analysis.png"
-								imageAlt={ __( "SEO analysis", "wordpress-seo" ) }
+								title={ __( "SEO analysis", "wordpress-seo" ) }
 							>
-								<Title as="h3">
-									{ __( "SEO analysis", "wordpress-seo" ) }
-								</Title>
 								<p>{ __( "The SEO analysis offers suggestions to improve the findability of your text and makes sure that your content meets best practices.", "wordpress-seo" ) }</p>
-								<LearnMoreLink id="link-seo-analysis" link="https://yoa.st/2ak" />
+								<LearnMoreLink id="link-seo-analysis" link="https://yoa.st/2ak" ariaLabel={ __( "SEO analysis", "wordpress-seo" ) } />
 							</FeatureCard>
 							<FeatureCard
 								name="wpseo.content_analysis_active"
 								cardId="card-wpseo-content_analysis_active"
 								inputId="input-wpseo-content_analysis_active"
 								imageSrc="/images/readability_analysis.png"
-								imageAlt={ __( "Readability analysis", "wordpress-seo" ) }
+								title={ __( "Readability analysis", "wordpress-seo" ) }
 							>
-								<Title as="h3">
-									{ __( "Readability analysis", "wordpress-seo" ) }
-								</Title>
 								<p>{ __( "The readability analysis offers suggestions to improve the structure and style of your text.", "wordpress-seo" ) }</p>
-								<LearnMoreLink id="link-readability-analysis" link="https://yoa.st/2ao" />
+								<LearnMoreLink id="link-readability-analysis" link="https://yoa.st/2ao" ariaLabel={ __( "Readability analysis", "wordpress-seo" ) } />
 							</FeatureCard>
 							<FeatureCard
 								name="wpseo.inclusive_language_analysis_active"
 								cardId="card-wpseo-inclusive_language_analysis_active"
 								inputId="input-wpseo-inclusive_language_analysis_active"
 								imageSrc="/images/inclusive_language_analysis.png"
-								imageAlt={ __( "Inclusive language analysis", "wordpress-seo" ) }
 								isBetaFeature={ true }
+								title={ __( "Inclusive language analysis", "wordpress-seo" ) }
 							>
-								<Title as="h3">
-									{ __( "Inclusive language analysis", "wordpress-seo" ) }
-								</Title>
 								<p>{ __( "The inclusive language analysis offers suggestions to write more inclusive copy, so more people will be able to relate to your content.", "wordpress-seo" ) }</p>
-								<LearnMoreLink id="link-inclusive-language-analysis" link="https://yoa.st/inclusive-language-features-free" />
+								<LearnMoreLink id="link-inclusive-language-analysis" link="https://yoa.st/inclusive-language-features-free" ariaLabel={  __( "Inclusive language analysis", "wordpress-seo" ) } />
 							</FeatureCard>
 							<FeatureCard
 								name="wpseo.enable_metabox_insights"
 								cardId="card-wpseo-enable_metabox_insights"
 								inputId="input-wpseo-enable_metabox_insights"
 								imageSrc="/images/insights.png"
-								imageAlt={ __( "Insights", "wordpress-seo" ) }
+								title={ __( "Insights", "wordpress-seo" ) }
 							>
-								<Title as="h3">
-									{ __( "Insights", "wordpress-seo" ) }
-								</Title>
 								<p>{ __( "Get more insights into what you are writing. What words do you use most often? How much time does it take to read your text? Is your text easy to read?", "wordpress-seo" ) }</p>
-								<LearnMoreLink id="link-insights" link="https://yoa.st/4ew" />
+								<LearnMoreLink id="link-insights" link="https://yoa.st/4ew" aria-label={ __( "Insights", "wordpress-seo" ) } />
 							</FeatureCard>
 						</div>
 					</fieldset>
@@ -250,41 +245,32 @@ const SiteFeatures = () => {
 								cardId="card-wpseo-enable_cornerstone_content"
 								inputId="input-wpseo-enable_cornerstone_content"
 								imageSrc="/images/cornerstone_content.png"
-								imageAlt={ __( "Cornerstone content", "wordpress-seo" ) }
+								title={ __( "Cornerstone content", "wordpress-seo" ) }
 							>
-								<Title as="h3">
-									{ __( "Cornerstone content", "wordpress-seo" ) }
-								</Title>
 								<p>{ __( "Mark and filter your cornerstone content to make sure your most important articles get the attention they deserve. To help you write excellent copy, we’ll assess your text more strictly.", "wordpress-seo" ) }</p>
-								<LearnMoreLink id="link-cornerstone-content" link="https://yoa.st/dashboard-help-cornerstone" />
+								<LearnMoreLink id="link-cornerstone-content" link="https://yoa.st/dashboard-help-cornerstone" ariaLabel={  __( "Cornerstone content", "wordpress-seo" ) } />
 							</FeatureCard>
 							<FeatureCard
 								name="wpseo.enable_text_link_counter"
 								cardId="card-wpseo-enable_text_link_counter"
 								inputId="input-wpseo-enable_text_link_counter"
 								imageSrc="/images/text_link_counter.png"
-								imageAlt={ __( "Text link counter", "wordpress-seo" ) }
+								title={ __( "Text link counter", "wordpress-seo" ) }
 							>
-								<Title as="h3">
-									{ __( "Text link counter", "wordpress-seo" ) }
-								</Title>
 								<p>{ __( "Count the number of internal links from and to your posts to improve your site structure.", "wordpress-seo" ) }</p>
-								<LearnMoreLink id="link-text-link-counter" link="https://yoa.st/2aj" />
+								<LearnMoreLink id="link-text-link-counter" link="https://yoa.st/2aj" ariaLabel={ __( "Text link counter", "wordpress-seo" ) } />
 							</FeatureCard>
 							<FeatureCard
 								name="wpseo.enable_link_suggestions"
 								cardId="card-wpseo-enable_link_suggestions"
 								inputId="input-wpseo-enable_link_suggestions"
 								imageSrc="/images/link_suggestions.png"
-								imageAlt={ __( "Link suggestions", "wordpress-seo" ) }
 								isPremiumFeature={ true }
 								isPremiumLink="https://yoa.st/get-link-suggestions"
+								title={ __( "Link suggestions", "wordpress-seo" ) }
 							>
-								<Title as="h3">
-									{ __( "Link suggestions", "wordpress-seo" ) }
-								</Title>
 								<p>{ __( "Get recommendations for relevant posts to link to and set up a great internal linking structure by connecting related content.", "wordpress-seo" ) }</p>
-								<LearnMoreLink id="link-suggestions-link" link={ isPremium ? "https://yoa.st/17g" : "https://yoa.st/4ev" } />
+								<LearnMoreLink id="link-suggestions-link" link={ isPremium ? "https://yoa.st/17g" : "https://yoa.st/4ev" } ariaLabel={ __( "Link suggestions", "wordpress-seo" ) } />
 							</FeatureCard>
 						</div>
 					</fieldset>
@@ -302,41 +288,32 @@ const SiteFeatures = () => {
 								cardId="card-wpseo_social-opengraph"
 								inputId="input-wpseo_social-opengraph"
 								imageSrc="/images/open_graph.png"
-								imageAlt={ __( "Open Graph data", "wordpress-seo" ) }
+								title={ __( "Open Graph data", "wordpress-seo" ) }
 							>
-								<Title as="h3">
-									{ __( "Open Graph data", "wordpress-seo" ) }
-								</Title>
 								<p>
 									{ __( "Allows for Facebook and other social media to display a preview with images and a text excerpt when a link to your site is shared. Keep this feature enabled to optimize your site for social media.", "wordpress-seo" ) }
 								</p>
-								<LearnMoreLink id="link-open-graph-data" link="https://yoa.st/site-features-open-graph-data" />
+								<LearnMoreLink id="link-open-graph-data" link="https://yoa.st/site-features-open-graph-data" ariaLabel={ __( "Open Graph data", "wordpress-seo" ) } />
 							</FeatureCard>
 							<FeatureCard
 								name="wpseo_social.twitter"
 								cardId="card-wpseo_social-twitter"
 								inputId="input-wpseo_social-twitter"
 								imageSrc="/images/twitter_card.png"
-								imageAlt={ __( "Twitter card data", "wordpress-seo" ) }
+								title={ __( "Twitter card data", "wordpress-seo" ) }
 							>
-								<Title as="h3">
-									{ __( "Twitter card data", "wordpress-seo" ) }
-								</Title>
 								<p>{ __( "Allows for Twitter to display a preview with images and a text excerpt when a link to your site is shared.", "wordpress-seo" ) }</p>
-								<LearnMoreLink id="link-twitter-card-data" link="https://yoa.st/site-features-twitter-card-data" />
+								<LearnMoreLink id="link-twitter-card-data" link="https://yoa.st/site-features-twitter-card-data" ariaLabel={ __( "Twitter card data", "wordpress-seo" ) } />
 							</FeatureCard>
 							<FeatureCard
 								name="wpseo.enable_enhanced_slack_sharing"
 								cardId="card-wpseo-enable_enhanced_slack_sharing"
 								inputId="input-wpseo-enable_enhanced_slack_sharing"
 								imageSrc="/images/slack_sharing.png"
-								imageAlt={ __( "Slack sharing", "wordpress-seo" ) }
+								title={ __( "Slack sharing", "wordpress-seo" ) }
 							>
-								<Title as="h3">
-									{ __( "Slack sharing", "wordpress-seo" ) }
-								</Title>
 								<p>{ __( "This adds an author byline and reading time estimate to the article’s snippet when shared on Slack.", "wordpress-seo" ) }</p>
-								<LearnMoreLink id="link-slack-sharing" link="https://yoa.st/help-slack-share" />
+								<LearnMoreLink id="link-slack-sharing" link="https://yoa.st/help-slack-share" ariaLabel={ __( "Slack sharing", "wordpress-seo" ) } />
 							</FeatureCard>
 						</div>
 					</fieldset>
@@ -354,11 +331,8 @@ const SiteFeatures = () => {
 								cardId="card-wpseo-enable_admin_bar_menu"
 								inputId="input-wpseo-enable_admin_bar_menu"
 								imageSrc="/images/admin_bar.png"
-								imageAlt={ __( "Admin bar menu", "wordpress-seo" ) }
+								title={ __( "Admin bar menu", "wordpress-seo" ) }
 							>
-								<Title as="h3">
-									{ __( "Admin bar menu", "wordpress-seo" ) }
-								</Title>
 								<p>
 									{ sprintf(
 										// translators: %1$s expands to Yoast.
@@ -366,7 +340,7 @@ const SiteFeatures = () => {
 										"Yoast"
 									) }
 								</p>
-								<LearnMoreLink id="link-admin-bar" link="https://yoa.st/site-features-admin-bar" />
+								<LearnMoreLink id="link-admin-bar" link="https://yoa.st/site-features-admin-bar" ariaLabel={ __( "Admin bar menu", "wordpress-seo" ) } />
 							</FeatureCard>
 						</div>
 					</fieldset>
@@ -384,24 +358,18 @@ const SiteFeatures = () => {
 								cardId="card-wpseo-enable_headless_rest_endpoints"
 								inputId="input-wpseo-enable_headless_rest_endpoints"
 								imageSrc="/images/rest_api.png"
-								imageAlt={ __( "REST API endpoint", "wordpress-seo" ) }
+								title={ __( "REST API endpoint", "wordpress-seo" ) }
 							>
-								<Title as="h3">
-									{ __( "REST API endpoint", "wordpress-seo" ) }
-								</Title>
 								<p>{ __( "This Yoast SEO REST API endpoint gives you all the metadata you need for a specific URL. This will make it very easy for headless WordPress sites to use Yoast SEO for all their SEO meta output.", "wordpress-seo" ) }</p>
-								<LearnMoreLink id="link-rest-api-endpoint" link="https://yoa.st/site-features-rest-api-endpoint" />
+								<LearnMoreLink id="link-rest-api-endpoint" link="https://yoa.st/site-features-rest-api-endpoint" ariaLabel={ __( "REST API endpoint", "wordpress-seo" ) } />
 							</FeatureCard>
 							<FeatureCard
 								name="wpseo.enable_xml_sitemap"
 								cardId="card-wpseo-enable_xml_sitemap"
 								inputId="input-wpseo-enable_xml_sitemap"
 								imageSrc="/images/xml_sitemaps.png"
-								imageAlt={ __( "XML sitemaps", "wordpress-seo" ) }
+								title={ __( "XML sitemaps", "wordpress-seo" ) }
 							>
-								<Title as="h3">
-									{ __( "XML sitemaps", "wordpress-seo" ) }
-								</Title>
 								<p>
 									{ sprintf(
 										// translators: %1$s expands to "Yoast SEO".
@@ -421,22 +389,19 @@ const SiteFeatures = () => {
 									{ __( "View the XML sitemap", "wordpress-seo" ) }
 									<ExternalLinkIcon className="yst--mr-1 yst-ml-1 yst-h-5 yst-w-5 yst-text-slate-400" />
 								</Button> }
-								<LearnMoreLink id="link-xml-sitemaps" link="https://yoa.st/2a-" />
+								<LearnMoreLink id="link-xml-sitemaps-learn-more" link="https://yoa.st/2a-" ariaLabel={ __( "XML sitemaps", "wordpress-seo" ) } />
 							</FeatureCard>
 							<FeatureCard
 								name="wpseo.enable_index_now"
 								cardId="card-wpseo-enable_index_now"
 								inputId="input-wpseo-enable_index_now"
 								imageSrc="/images/indexnow.png"
-								imageAlt={ __( "IndexNow", "wordpress-seo" ) }
 								isPremiumFeature={ true }
 								isPremiumLink="https://yoa.st/get-indexnow"
+								title={ __( "IndexNow", "wordpress-seo" ) }
 							>
-								<Title as="h3">
-									{ __( "IndexNow", "wordpress-seo" ) }
-								</Title>
 								<p>{ __( "Automatically ping search engines like Bing and Yandex whenever you publish, update or delete a post.", "wordpress-seo" ) }</p>
-								<LearnMoreLink id="link-index-now" link="https://yoa.st/index-now-feature" />
+								<LearnMoreLink id="link-index-now" link="https://yoa.st/index-now-feature" ariaLabel={ __( "IndexNow", "wordpress-seo" ) } />
 							</FeatureCard>
 						</div>
 					</fieldset>

--- a/packages/js/src/settings/routes/site-features.js
+++ b/packages/js/src/settings/routes/site-features.js
@@ -227,7 +227,7 @@ const SiteFeatures = () => {
 								title={ __( "Insights", "wordpress-seo" ) }
 							>
 								<p>{ __( "Get more insights into what you are writing. What words do you use most often? How much time does it take to read your text? Is your text easy to read?", "wordpress-seo" ) }</p>
-								<LearnMoreLink id="link-insights" link="https://yoa.st/4ew" aria-label={ __( "Insights", "wordpress-seo" ) } />
+								<LearnMoreLink id="link-insights" link="https://yoa.st/4ew" ariaLabel={ __( "Insights", "wordpress-seo" ) } />
 							</FeatureCard>
 						</div>
 					</fieldset>

--- a/packages/js/src/settings/routes/site-features.js
+++ b/packages/js/src/settings/routes/site-features.js
@@ -58,7 +58,7 @@ const FeatureCard = ( {
 						shouldDimHeaderImage && "yst-opacity-50 yst-filter yst-grayscale"
 					) }
 					src={ imageSrc }
-					alt={ imageAlt ? imageAlt : "" }
+					alt={ imageAlt ?? "" }
 					width={ 500 }
 					height={ 250 }
 					loading="lazy"

--- a/packages/js/src/settings/routes/site-features.js
+++ b/packages/js/src/settings/routes/site-features.js
@@ -82,7 +82,7 @@ const FeatureCard = ( {
 					type="checkbox"
 					name={ name }
 					id={ inputId }
-					aria-label={ `${ __( "Enable feature", "wordpress-seo" )} ${title}` }
+					aria-label={ `${ __( "Enable feature", "wordpress-seo" ) } ${ title }` }
 					label={ __( "Enable feature", "wordpress-seo" ) }
 					disabled={ isDisabled }
 					checked={ disabledSetting === "language" ? false : value }

--- a/packages/js/src/settings/routes/site-features.js
+++ b/packages/js/src/settings/routes/site-features.js
@@ -128,7 +128,7 @@ FeatureCard.propTypes = {
  * @param {string} href The link.
  * @returns {JSX.Element} The learn more link.
  */
-const LearnMoreLink = ( { id, link, ariaLabel, ... props } ) => {
+const LearnMoreLink = ( { id, link, ariaLabel, ...props } ) => {
 	const href = useSelectSettings( "selectLink", [ link ], link );
 
 	return (

--- a/packages/js/src/settings/routes/site-features.js
+++ b/packages/js/src/settings/routes/site-features.js
@@ -140,7 +140,7 @@ const LearnMoreLink = ( { id, link, ariaLabel, ...props } ) => {
 			className="yst-flex yst-items-center yst-gap-1 yst-no-underline yst-font-medium"
 			target="_blank"
 			rel="noopener"
-			aria-label={ `Learn more about ${ ariaLabel }, opens in a new tab` }
+			aria-label={ `Learn more about ${ ariaLabel } (Opens in a new browser tab)` }
 			{ ...props }
 		>
 			{ __( "Learn more", "wordpress-seo" ) }

--- a/packages/ui-library/src/components/card/index.js
+++ b/packages/ui-library/src/components/card/index.js
@@ -8,7 +8,7 @@ import { forwardRef } from "@wordpress/element";
  * @param {string} className The className.
  * @returns {WPElement} The card header.
  */
-const Header = ( { as: Component = "header", children, className = "", ...props } ) => (
+const Header = ( { as: Component = "div", children, className = "", ...props } ) => (
 	<Component { ...props } className={ classNames( "yst-card__header", className ) }>
 		{ children }
 	</Component>
@@ -45,7 +45,7 @@ Content.propTypes = {
  * @param {string} className The className.
  * @returns  {WPElement} The card footer.
  */
-const Footer = ( { as: Component = "footer", children, className = "", ...props } ) => (
+const Footer = ( { as: Component = "div", children, className = "", ...props } ) => (
 	<Component { ...props } className={ classNames( "yst-card__footer", className ) }>
 		{ children }
 	</Component>

--- a/packages/ui-library/src/components/modal/index.js
+++ b/packages/ui-library/src/components/modal/index.js
@@ -38,6 +38,7 @@ Title.propTypes = {
 	size: PropTypes.oneOf( Object.keys( titleClassNameMap.size ) ),
 	className: PropTypes.string,
 	children: PropTypes.node.isRequired,
+	as: PropTypes.elementType,
 };
 
 /**

--- a/packages/ui-library/src/components/modal/index.js
+++ b/packages/ui-library/src/components/modal/index.js
@@ -5,6 +5,7 @@ import classNames from "classnames";
 import PropTypes from "prop-types";
 import { useSvgAria } from "../../hooks";
 import { ModalContext, useModalContext } from "./hooks";
+import { classNameMap as titleClassNameMap } from "../../elements/title";
 
 /**
  * @param {JSX.node} children Title text.
@@ -12,11 +13,14 @@ import { ModalContext, useModalContext } from "./hooks";
  * @param {Object} [props] Additional props.
  * @returns {JSX.Element} The panel.
  */
-const Title = forwardRef( ( { children, className = "", ...props }, ref ) => {
+const Title = forwardRef( ( { children, size, className, ...props }, ref ) => {
 	return (
 		<Dialog.Title
 			ref={ ref }
-			className={  classNames( "yst-title", className ) }
+			className={  classNames(
+				"yst-title",
+				size ? titleClassNameMap.size[ size ] : "",
+				className ) }
 			{ ...props }
 		>
 			{ children }
@@ -24,7 +28,13 @@ const Title = forwardRef( ( { children, className = "", ...props }, ref ) => {
 	);
 } );
 
+Title.defaultProps = {
+	className: "",
+	as: "h1",
+};
+
 Title.propTypes = {
+	size: PropTypes.oneOf( Object.keys( titleClassNameMap.size ) ),
 	className: PropTypes.string,
 	children: PropTypes.node.isRequired,
 };

--- a/packages/ui-library/src/components/modal/index.js
+++ b/packages/ui-library/src/components/modal/index.js
@@ -29,7 +29,6 @@ Title.propTypes = {
 	children: PropTypes.node.isRequired,
 };
 
-
 /**
  * @param {JSX.node} children Contents of the modal.
  * @param {string} [className] Additional class names.
@@ -129,7 +128,6 @@ Modal.propTypes = {
 	className: PropTypes.string,
 	position: PropTypes.oneOf( Object.keys( classNameMap.position ) ),
 };
-
 
 Modal.Panel = Panel;
 Modal.Panel.displayName = "Modal.Panel";

--- a/packages/ui-library/src/components/modal/index.js
+++ b/packages/ui-library/src/components/modal/index.js
@@ -10,7 +10,7 @@ import { classNameMap as titleClassNameMap } from "../../elements/title";
 /**
  * @param {JSX.node} children Title text.
  * @param {string} [className] Additional class names.
- * @param {string} [as] Html tag.
+ * @param {string|JSX.Element} [as="h1"] Base component.
  * @param {string} [size] Size of title.
  * @param {Object} [props] Additional props.
  * @returns {JSX.Element} The title.

--- a/packages/ui-library/src/components/modal/index.js
+++ b/packages/ui-library/src/components/modal/index.js
@@ -20,7 +20,7 @@ const Title = forwardRef( ( { children, size, className, as, ...props }, ref ) =
 		<Dialog.Title
 			as={ as }
 			ref={ ref }
-			className={  classNames(
+			className={ classNames(
 				"yst-title",
 				size ? titleClassNameMap.size[ size ] : "",
 				className ) }

--- a/packages/ui-library/src/components/modal/index.js
+++ b/packages/ui-library/src/components/modal/index.js
@@ -13,7 +13,7 @@ import { classNameMap as titleClassNameMap } from "../../elements/title";
  * @param {string} [as] Html tag.
  * @param {string} [size] Size of title.
  * @param {Object} [props] Additional props.
- * @returns {JSX.Element} The panel.
+ * @returns {JSX.Element} The title.
  */
 const Title = forwardRef( ( { children, size, className, as, ...props }, ref ) => {
 	return (

--- a/packages/ui-library/src/components/modal/index.js
+++ b/packages/ui-library/src/components/modal/index.js
@@ -3,9 +3,33 @@ import { XIcon } from "@heroicons/react/outline";
 import { forwardRef, Fragment } from "@wordpress/element";
 import classNames from "classnames";
 import PropTypes from "prop-types";
-import Title from "../../elements/title";
+// import Title from "../../elements/title";
 import { useSvgAria } from "../../hooks";
 import { ModalContext, useModalContext } from "./hooks";
+
+/**
+ * @param {JSX.node} children Title text.
+ * @param {string} [className] Additional class names.
+ * @param {Object} [props] Additional props.
+ * @returns {JSX.Element} The panel.
+ */
+const ModalTitle = forwardRef( ( { children, className = "", ...props }, ref ) => {
+	return (
+		<Dialog.Title
+			ref={ ref }
+			className={ `yst-title ${ className }` }
+			{ ...props }
+		>
+			{ children }
+		</Dialog.Title>
+	);
+} );
+
+ModalTitle.propTypes = {
+	className: PropTypes.string,
+	children: PropTypes.node.isRequired,
+};
+
 
 /**
  * @param {JSX.node} children Contents of the modal.
@@ -107,9 +131,10 @@ Modal.propTypes = {
 	position: PropTypes.oneOf( Object.keys( classNameMap.position ) ),
 };
 
+
 Modal.Panel = Panel;
 Modal.Panel.displayName = "Modal.Panel";
-Modal.Title = Title;
+Modal.Title = ModalTitle;
 Modal.Title.displayName = "Modal.Title";
 Modal.Description = Dialog.Description;
 Modal.Description.displayName = "Modal.Description";

--- a/packages/ui-library/src/components/modal/index.js
+++ b/packages/ui-library/src/components/modal/index.js
@@ -13,9 +13,10 @@ import { classNameMap as titleClassNameMap } from "../../elements/title";
  * @param {Object} [props] Additional props.
  * @returns {JSX.Element} The panel.
  */
-const Title = forwardRef( ( { children, size, className, ...props }, ref ) => {
+const Title = forwardRef( ( { children, size, className, as, ...props }, ref ) => {
 	return (
 		<Dialog.Title
+			as={ as }
 			ref={ ref }
 			className={  classNames(
 				"yst-title",

--- a/packages/ui-library/src/components/modal/index.js
+++ b/packages/ui-library/src/components/modal/index.js
@@ -3,7 +3,6 @@ import { XIcon } from "@heroicons/react/outline";
 import { forwardRef, Fragment } from "@wordpress/element";
 import classNames from "classnames";
 import PropTypes from "prop-types";
-// import Title from "../../elements/title";
 import { useSvgAria } from "../../hooks";
 import { ModalContext, useModalContext } from "./hooks";
 
@@ -13,7 +12,7 @@ import { ModalContext, useModalContext } from "./hooks";
  * @param {Object} [props] Additional props.
  * @returns {JSX.Element} The panel.
  */
-const ModalTitle = forwardRef( ( { children, className = "", ...props }, ref ) => {
+const Title = forwardRef( ( { children, className = "", ...props }, ref ) => {
 	return (
 		<Dialog.Title
 			ref={ ref }
@@ -25,7 +24,7 @@ const ModalTitle = forwardRef( ( { children, className = "", ...props }, ref ) =
 	);
 } );
 
-ModalTitle.propTypes = {
+Title.propTypes = {
 	className: PropTypes.string,
 	children: PropTypes.node.isRequired,
 };
@@ -134,7 +133,7 @@ Modal.propTypes = {
 
 Modal.Panel = Panel;
 Modal.Panel.displayName = "Modal.Panel";
-Modal.Title = ModalTitle;
+Modal.Title = Title;
 Modal.Title.displayName = "Modal.Title";
 Modal.Description = Dialog.Description;
 Modal.Description.displayName = "Modal.Description";

--- a/packages/ui-library/src/components/modal/index.js
+++ b/packages/ui-library/src/components/modal/index.js
@@ -10,6 +10,8 @@ import { classNameMap as titleClassNameMap } from "../../elements/title";
 /**
  * @param {JSX.node} children Title text.
  * @param {string} [className] Additional class names.
+ * @param {string} [as] Html tag.
+ * @param {string} [size] Size of title.
  * @param {Object} [props] Additional props.
  * @returns {JSX.Element} The panel.
  */

--- a/packages/ui-library/src/components/modal/index.js
+++ b/packages/ui-library/src/components/modal/index.js
@@ -17,7 +17,7 @@ const ModalTitle = forwardRef( ( { children, className = "", ...props }, ref ) =
 	return (
 		<Dialog.Title
 			ref={ ref }
-			className={ `yst-title ${ className }` }
+			className={  classNames( "yst-title", className ) }
 			{ ...props }
 		>
 			{ children }

--- a/packages/ui-library/src/components/modal/stories.js
+++ b/packages/ui-library/src/components/modal/stories.js
@@ -113,7 +113,7 @@ export const WithTitleAndDescription = {
 	parameters: {
 		docs: {
 			description: {
-				story: "Using the `Modal.Title` and `Modal.Description` components.",
+				story: "Using the `Modal.Title` and `Modal.Description` components will add `aria-labelledby` and `aria-describedby` to the Modal with matching IDrefs.",
 			},
 		},
 	},

--- a/packages/ui-library/src/components/modal/stories.js
+++ b/packages/ui-library/src/components/modal/stories.js
@@ -3,6 +3,7 @@ import { noop } from "lodash";
 import PropTypes from "prop-types";
 import RawModal, { classNameMap } from ".";
 import Button from "../../elements/button";
+import TextInput from "../../elements/text-input";
 import { classNameMap as titleClassNameMap } from "../../elements/title";
 
 const Modal = ( { isOpen: initialIsOpen, onClose: _, children, ...props } ) => {

--- a/packages/ui-library/src/components/modal/stories.js
+++ b/packages/ui-library/src/components/modal/stories.js
@@ -3,7 +3,7 @@ import { noop } from "lodash";
 import PropTypes from "prop-types";
 import RawModal, { classNameMap } from ".";
 import Button from "../../elements/button";
-import TextInput from "../../elements/text-input";
+import { classNameMap as titleClassNameMap } from "../../elements/title";
 
 const Modal = ( { isOpen: initialIsOpen, onClose: _, children, ...props } ) => {
 	const [ isOpen, setIsOpen ] = useState( initialIsOpen );
@@ -61,6 +61,12 @@ export default {
 				defaultValue: { summary: "center" },
 			},
 			options: Object.keys( classNameMap.position ),
+		},
+		size: {
+			control: "select",
+			description: "Prop for the `Model.Title` component.",
+			type: { summary: Object.keys( titleClassNameMap.size ).join( "|" ) },
+			options: Object.keys( titleClassNameMap.size ),
 		},
 	},
 	parameters: {

--- a/packages/ui-library/src/components/toggle-field/index.js
+++ b/packages/ui-library/src/components/toggle-field/index.js
@@ -31,11 +31,12 @@ const ToggleField = forwardRef( ( {
 }, ref ) => (
 	<Switch.Group
 		as="div"
+
 		className={ classNames( "yst-toggle-field", disabled && "yst-toggle-field--disabled", className ) }
 	>
 		<div className="yst-toggle-field__header">
 			{ label && <div className="yst-toggle-field__label-wrapper">
-				<Label as={ Switch.Label } className="yst-toggle-field__label" label={ label } />
+				<Label as={ Switch.Label } className="yst-toggle-field__label" label={ label } aria-label={ props[ "aria-label" ] } />
 				{ labelSuffix }
 			</div> }
 			<Toggle

--- a/packages/ui-library/src/components/toggle-field/index.js
+++ b/packages/ui-library/src/components/toggle-field/index.js
@@ -31,7 +31,6 @@ const ToggleField = forwardRef( ( {
 }, ref ) => (
 	<Switch.Group
 		as="div"
-
 		className={ classNames( "yst-toggle-field", disabled && "yst-toggle-field--disabled", className ) }
 	>
 		<div className="yst-toggle-field__header">

--- a/packages/ui-library/src/components/toggle-field/index.js
+++ b/packages/ui-library/src/components/toggle-field/index.js
@@ -67,7 +67,7 @@ const propTypes = {
 	disabled: PropTypes.bool,
 	onChange: PropTypes.func.isRequired,
 	className: PropTypes.string,
-	ariaLabel: PropTypes.string,
+	"aria-label": PropTypes.string,
 };
 
 ToggleField.propTypes = propTypes;

--- a/packages/ui-library/src/components/toggle-field/index.js
+++ b/packages/ui-library/src/components/toggle-field/index.js
@@ -27,6 +27,7 @@ const ToggleField = forwardRef( ( {
 	disabled,
 	onChange,
 	className,
+	"aria-label": ariaLabel,
 	...props
 }, ref ) => (
 	<Switch.Group
@@ -35,7 +36,7 @@ const ToggleField = forwardRef( ( {
 	>
 		<div className="yst-toggle-field__header">
 			{ label && <div className="yst-toggle-field__label-wrapper">
-				<Label as={ Switch.Label } className="yst-toggle-field__label" label={ label } aria-label={ props[ "aria-label" ] } />
+				<Label as={ Switch.Label } className="yst-toggle-field__label" label={ label } aria-label={ ariaLabel } />
 				{ labelSuffix }
 			</div> }
 			<Toggle
@@ -66,6 +67,7 @@ const propTypes = {
 	disabled: PropTypes.bool,
 	onChange: PropTypes.func.isRequired,
 	className: PropTypes.string,
+	ariaLabel: PropTypes.string,
 };
 
 ToggleField.propTypes = propTypes;

--- a/packages/ui-library/src/elements/link/stories.js
+++ b/packages/ui-library/src/elements/link/stories.js
@@ -38,7 +38,7 @@ export const Anchor = {
 		},
 	},
 	args: {
-		children: <><span className="yst-sr-only">(opens in a new tab)</span>yoast.com</>,
+		children: <><span className="yst-sr-only">(Opens in a new browser tab)</span>yoast.com</>,
 		href: "https://yoast.com",
 		target: "_blank",
 		rel: "noopener noreferrer",

--- a/packages/ui-library/src/elements/title/index.js
+++ b/packages/ui-library/src/elements/title/index.js
@@ -9,6 +9,7 @@ export const classNameMap = {
 		2: "yst-title--2",
 		3: "yst-title--3",
 		4: "yst-title--4",
+		5: "yst-title--5",
 	},
 };
 

--- a/packages/ui-library/src/elements/title/index.js
+++ b/packages/ui-library/src/elements/title/index.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import classNames from "classnames";
 import { forwardRef } from "@wordpress/element";
 
-const classNameMap = {
+export const classNameMap = {
 	size: {
 		1: "yst-title--1",
 		2: "yst-title--2",

--- a/packages/ui-library/src/elements/title/style.css
+++ b/packages/ui-library/src/elements/title/style.css
@@ -19,6 +19,7 @@
 		.yst-title--4 {
 			@apply yst-text-base;
 		}
+		
 		.yst-title--5 {
 			@apply yst-text-sm;
 		}

--- a/packages/ui-library/src/elements/title/style.css
+++ b/packages/ui-library/src/elements/title/style.css
@@ -16,8 +16,8 @@
 			@apply yst-text-tiny;
 		}
 
-		.yst-title--4 {
-			@apply yst-text-base;
+		.yst-title--5 {
+			@apply yst-text-sm;
 		}
 	}
 }

--- a/packages/ui-library/src/elements/title/style.css
+++ b/packages/ui-library/src/elements/title/style.css
@@ -16,6 +16,9 @@
 			@apply yst-text-tiny;
 		}
 
+		.yst-title--4 {
+			@apply yst-text-base;
+		}
 		.yst-title--5 {
 			@apply yst-text-sm;
 		}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Improves accessibility for feature card in `Site features`:
  * Adds screen reader support for `Learn more` 
  * Adds screen reader support for `Enable feature`    
  *  Adds empty alt for feature Image
 * Improves accessibility for `Introduction` modal
 * Improves accessibility for `Search` modal
 *  Improves accessibility for `Discard changes` modal

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves accessibility for `Learn more` links and `Enable feature` switches on page `Site features`
* Improves accessibility for features' images.

## Relevant technical choices:

* Added `aria-label` support for `label` in `ToggleField` component in `Ui library`
* Refactored title in to the `FeatureCard` component
* Refactor `LearnMore` component to accept the title in an `ariaLabel` prop and adds text to it: `Learn more about...`.
* Fixed duplicate `id` for `XML sitemaps` feature, changed the `id` of `Learn more` link in this feature to: `link-xml-sitemaps-learn-more`

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:


* Open Safari browser
* Login as new user to enable introduction modal to appear.
* Turn on screen reader, on mac its command + f5
* Open `YoastSEO`->`Settings`
* Check screen reader doesn't read the steps subtext (e.g. `Welcome to your new Yoast SEO settings!
`) when focusing on the modal
*  Check that screen reader identify introduction modal as "Introduction to settings" before switching to the modal content
* Open `YoastSEO`->`Settings`->`Site features`
* Tab to `Learn more` links and check if the screen reader gets the description of the link. `Learn more about <name of feature>, opens in a new tab`
* Tab or click on `Enable feature` and check if screen reader gets the description of the switch. `Enable feature <name of feature>`
* Click on `Search` and verify the screen reader identifies the modal as `Search, Dialog`
* Inspect a feature's image: verify the `alt` attribute is set to `""`
* Enable a feature and click `Discard changes`
* Inspect the title of the modal: verify the title is an `h1` element


---
**Ony for devs: UI library storybook**
* Check `ToggleField` has `aria-label` that goes to the label of that field.
* Check `Card.Header` is of `div` tag and not `header` tag.
* Check `Card.Footer` is of `div` tag and not `footer` tag.

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [X] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes [Improve the feature cards accessibility#19521](https://github.com/Yoast/wordpress-seo/issues/19521)