### PR TITLE
settings-ui: 341 update intro modal copy

### DIFF
--- a/packages/js/src/settings/components/introduction.js
+++ b/packages/js/src/settings/components/introduction.js
@@ -211,7 +211,7 @@ const Introduction = () => {
 						</div>
 					</div>
 				</div>
-				<div className="yst-relative yst-flex yst-flex-col yst-mt-2 yst-mb-8 yst-mx-4 sm:yst-mx-8 yst-text-center">
+				<div className="yst-relative yst-flex yst-flex-col yst-mt-2 yst-mb-6 sm:yst-mb-8 yst-mx-4 sm:yst-mx-8 yst-text-center">
 
 					{ /* // ----------------- Title and description section of each step -----------------*/ }
 					<div

--- a/packages/js/src/settings/components/introduction.js
+++ b/packages/js/src/settings/components/introduction.js
@@ -236,7 +236,7 @@ const Introduction = () => {
 								<Title as="h2" size="2">
 									{ step.title }
 								</Title>
-								<Modal.Description className="yst-max-w-xs yst-mx-auto yst-mt-2">
+								<Modal.Description className="yst-max-w-sm yst-mx-auto yst-mt-2">
 									{ step.description }
 								</Modal.Description>
 							</div>

--- a/packages/js/src/settings/components/introduction.js
+++ b/packages/js/src/settings/components/introduction.js
@@ -29,8 +29,8 @@ const Introduction = () => {
 	// set the steps with the videos and thumbnails and memoize them for pluginUrl changes
 	const steps = useMemo( () => ( [
 		{
-			title: __( "Welcome to your new Yoast SEO settings! There's lots to discover!", "wordpress-seo" ),
-			description: __( "There's a fresh new look, and now it's easier than ever to find and manage your site's SEO options.", "wordpress-seo" ),
+			title: __( "Welcome to your new Yoast SEO settings!", "wordpress-seo" ),
+			description: __( "There's a fresh new look, and it's easier than ever to find and manage your site's SEO options.", "wordpress-seo" ),
 			videoId: "c1fpikf45l",
 			thumbnail: {
 				src: `${ pluginUrl }/images/settings-intro_thumb0.jpg`,

--- a/packages/js/src/settings/components/introduction.js
+++ b/packages/js/src/settings/components/introduction.js
@@ -29,8 +29,8 @@ const Introduction = () => {
 	// set the steps with the videos and thumbnails and memoize them for pluginUrl changes
 	const steps = useMemo( () => ( [
 		{
-			title: __( "We gave our settings a new look!", "wordpress-seo" ),
-			description: __( "We've updated and comprehensively improved how our settings interface looks, feels, and behaves.", "wordpress-seo" ),
+			title: __( "Welcome to your new Yoast SEO settings! There's lots to discover!", "wordpress-seo" ),
+			description: __( "There's a fresh new look, and now it's easier than ever to find and manage your site's SEO options.", "wordpress-seo" ),
 			videoId: "c1fpikf45l",
 			thumbnail: {
 				src: `${ pluginUrl }/images/settings-intro_thumb0.jpg`,
@@ -39,8 +39,8 @@ const Introduction = () => {
 			},
 		},
 		{
-			title: __( "All your settings intuitively reorganized!", "wordpress-seo" ),
-			description: __( "We've added a new sidebar menu in which we carefully reorganized all settings.", "wordpress-seo" ),
+			title: __( "We've moved some things around!", "wordpress-seo" ),
+			description: __( "Now it's much easier to find the most important settings, or to dive straight into our advanced options.", "wordpress-seo" ),
 			videoId: "cxojwh5z3w",
 			thumbnail: {
 				src: `${ pluginUrl }/images/settings-intro_thumb1.jpg`,
@@ -49,8 +49,8 @@ const Introduction = () => {
 			},
 		},
 		{
-			title: __( "Easily find the setting you're looking for!", "wordpress-seo" ),
-			description: __( "We've added search functionality that lets you quickly find all settings and navigate directly to them.", "wordpress-seo" ),
+			title: __( "Not sure where to go? Try searching!", "wordpress-seo" ),
+			description: __( "Still feeling lost, or looking for something specific? Just type what you're looking for into our handy search tool.", "wordpress-seo" ),
 			videoId: "cq3yge9yjb",
 			thumbnail: {
 				src: `${ pluginUrl }/images/settings-intro_thumb2.jpg`,


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Fixes copy for introduction modal.
* Changes introduction description width.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes copy for the Settings' introduction modal.
* Changes the Settings' introduction description width.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Login as a new user to have the introduction modal enabled. 
* Open `YoastSEO`->`Settings`
* The modal should open.
* Check if the text in each matches:
Step 1. Title: `Welcome to your new Yoast SEO settings!`  Subtext: `There's a fresh new look, and it's easier than ever to find and manage your site's SEO options.`.
Step 2: Title: `We’ve moved some things around!` Subtex: `Now it’s much easier to find the most important settings, or to dive straight into our advanced options.`
Step 3. Title: `Not sure where to go? Try searching!` Subtext: `Still feeling lost, or looking for something specific? Just type what you’re looking for into our handy search tool.`
* Check that all subtext appears in 2 lines.
* check space under `Next` button is the same as space on top of video frame, on desktop and mobile.  

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes [Update intro modal copy#341](https://github.com/Yoast/plugins-automated-testing/issues/341)
