### PR TITLE
Make an ability to clear tags.

### DIFF
--- a/packages/js/src/settings/components/formik-tag-field.js
+++ b/packages/js/src/settings/components/formik-tag-field.js
@@ -28,13 +28,17 @@ const FormikTagField = props => {
 		setTouched( true, false );
 		setValue( [ ...tags.slice( 0, index ), ...tags.slice( index + 1 ) ].join( "," ) );
 	}, [ setTouched, setValue, tags ] );
-
+	const handleSetTags = useCallback( tagValue => {
+		setTouched( true, false );
+		setValue( tagValue.join( "," )  );
+	}, [ setTouched, setValue ] );
 	return (
 		<TagField
 			{ ...field }
 			tags={ tags }
 			onAddTag={ handleAddTag }
 			onRemoveTag={ handleRemoveTag }
+			onSetTags={ handleSetTags }
 			{ ...props }
 		/>
 	);

--- a/packages/ui-library/src/elements/tag-input/index.js
+++ b/packages/ui-library/src/elements/tag-input/index.js
@@ -67,6 +67,7 @@ Tag.propTypes = {
  * @param {boolean} [disabled] Whether the input is disabled.
  * @param {function} [onAddTag] Add tag handler.
  * @param {function} [onRemoveTag] Remove tag handler.
+ * @param {function} [onSetTags] Set tag handler.
  * @param {function} [onBlur] Blur handler.
  * @param {string} [screenReaderRemoveTag] Screen reader text for the remove tag button.
  * @param {object} [props] Extra properties.
@@ -79,6 +80,7 @@ const TagInput = forwardRef( ( {
 	disabled,
 	onAddTag,
 	onRemoveTag,
+	onSetTags,
 	onBlur,
 	screenReaderRemoveTag,
 	...props
@@ -103,7 +105,11 @@ const TagInput = forwardRef( ( {
 				if ( text.length !== 0 || tags.length === 0 ) {
 					break;
 				}
-				onRemoveTag( tags.length - 1 );
+				onRemoveTag( tags.length - 1  );
+				if ( event.ctrlKey ) {
+					onSetTags( [] );
+				}
+
 				event.preventDefault();
 				return true;
 		}
@@ -152,6 +158,7 @@ const propTypes = {
 	disabled: PropTypes.bool,
 	onAddTag: PropTypes.func,
 	onRemoveTag: PropTypes.func,
+	onSetTags: PropTypes.func,
 	onBlur: PropTypes.func,
 	screenReaderRemoveTag: PropTypes.string,
 };
@@ -168,6 +175,7 @@ TagInput.defaultProps = {
 	disabled: false,
 	onAddTag: noop,
 	onRemoveTag: noop,
+	onSetTags: noop,
 	onBlur: noop,
 	screenReaderRemoveTag: "Remove tag",
 };

--- a/packages/ui-library/src/elements/tag-input/stories.js
+++ b/packages/ui-library/src/elements/tag-input/stories.js
@@ -38,6 +38,11 @@ export default {
 			description: "`TagInput.Tag` prop",
 			table: { type: { required: true, summary: "function"  } },
 		},
+		onSetTags: {
+			control: "function",
+			description: "Sets the tags to the given array.",
+			table: { type: { required: true, summary: "function"  } },
+		},
 		screenReaderRemoveTag: {
 			description: "`TagInput.Tag` prop",
 			control: "text",
@@ -71,9 +76,8 @@ const Template = args => {
 	const removeTag = useCallback( index => {
 		setTags( [ ...tags.slice( 0, index ), ...tags.slice( index + 1 ) ] );
 	}, [ tags, setTags ] );
-
 	return (
-		<StoryComponent { ...args } tags={ tags } onAddTag={ addTag } onRemoveTag={ removeTag } />
+		<StoryComponent { ...args } tags={ tags } onAddTag={ addTag } onRemoveTag={ removeTag } onSetTags={ setTags } />
 	);
 };
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We wanted an easy way to clear an tag input field mostly for automated tests

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds the ability to clear a tag input field by using the `ctrl + backspace` keyboard shortcut.

## Relevant technical choices:

* We decided to go for a combination shortcut, because tripple clicking was technically really complex because the tag field is not just 1 input field it is a combination of inputs. We also did not go for an UI element because all the best places for a X marker are already occupied by validation states.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Make sure premium is enabled and the new ui library is also build ( can be done with `grunt build:dev`) This is already done in the RC.
* Browse to wp-admin/admin.php?page=wpseo_page_settings#/crawl-optimization and scroll all the way down.
* Enable `Remove unregistered URL parameters`.

* Fill in a couple of tags and hit save. Make sure they are still there after a refresh.
* Remove a tag by just pressing backspace and save. Make sure they are gone after a refresh.
* Remove another tag by just pressing backspace and hit discard changes. Make sure there are no changes after a refresh.

* Add some more tags and save. Make sure they are still there after a refresh.
* Hit `ctrl + backspace` to remove all tags in one go and save. Make sure they are gone after a refresh.
* Add new tags and save.
* Hit `ctrl + backsapce` to remove all tags and hit discard changes. Make sure there are no changes after a refresh.

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
[Make id="input-wpseo-clean_permalinks_extra_variables" support clickMultipleTimes#342](https://github.com/Yoast/plugins-automated-testing/issues/342)