### PR TITLE
Minor: [Search functionality] Fix the font styles in the search results box.

### DIFF
--- a/packages/js/src/settings/components/search.js
+++ b/packages/js/src/settings/components/search.js
@@ -228,7 +228,7 @@ const Search = ( { buttonId = "button-search" } ) => {
 						>
 							{ map( results, ( groupedItems, index ) => (
 								<li key={ groupedItems?.[ 0 ]?.route || `group-${ index }` }>
-									<Title as="h4" size="3" className="yst-bg-slate-100 yst-py-3 yst-px-4">
+									<Title as="h4" size="5" className="yst-bg-slate-100 yst-font-semibold yst-py-3 yst-px-4">
 										{ first( groupedItems ).routeLabel }
 									</Title>
 									<ul>

--- a/packages/ui-library/src/elements/title/index.js
+++ b/packages/ui-library/src/elements/title/index.js
@@ -9,6 +9,7 @@ const classNameMap = {
 		2: "yst-title--2",
 		3: "yst-title--3",
 		4: "yst-title--4",
+		5: "yst-title--5",
 	},
 };
 

--- a/packages/ui-library/src/elements/title/style.css
+++ b/packages/ui-library/src/elements/title/style.css
@@ -19,5 +19,8 @@
 		.yst-title--4 {
 			@apply yst-text-base;
 		}
+		.yst-title--5 {
+			@apply yst-text-xs;
+		}
 	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We wanted to align our styling with the tailwind ui component.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Reduces the font size of the group header in the search results.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Open the new settings
* Click Quick Search... field/button
* Type in a search term like `open` for example.
* You can see the search results with group categories and clickable search results.
* The group category text should be `xs` so .75rem and the font-weight should be semibold `600`.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [X] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
[Minor: [Search functionality] Fix the font styles in the search results box.#313](https://github.com/Yoast/plugins-automated-testing/issues/313)