### PR TITLE
19598 minor update upsell title design in settings

### DIFF
--- a/packages/js/src/settings/app.js
+++ b/packages/js/src/settings/app.js
@@ -241,7 +241,7 @@ const App = () => {
 						</SidebarNavigation.Sidebar>
 					</aside>
 					<div className={ classNames( "yst-flex yst-grow yst-flex-wrap", ! isPremium && "xl:yst-pr-[17.5rem]" ) }>
-						<div className="yst-grow yst-space-y-6 yst-mb-6 xl:yst-mb-0">
+						<div className="yst-grow yst-space-y-6 yst-mb-8 xl:yst-mb-0">
 							<main className="yst-rounded-lg yst-bg-white yst-shadow">
 								<ErrorBoundary FallbackComponent={ ErrorFallback }>
 									<Transition

--- a/packages/js/src/settings/components/sidebar-recommendations.js
+++ b/packages/js/src/settings/components/sidebar-recommendations.js
@@ -42,7 +42,7 @@ const PremiumUpsellCard = () => {
 	return (
 		<div className="yst-p-6 yst-rounded-lg yst-text-white yst-bg-primary-500 yst-shadow">
 			<figure
-				className="yst-logo-square yst-w-16 yst-h-16 yst-mt-[-2rem] yst-mx-auto yst-overflow-hidden yst-border yst-border-white yst-rounded-xl yst-rounded-br-none"
+				className="yst-logo-square yst-w-16 yst-h-16 yst-mt-[-2.6rem] yst-mx-auto yst-overflow-hidden yst-border yst-border-white yst-rounded-xl yst-rounded-br-none"
 			>
 				<YoastSeoLogo />
 			</figure>

--- a/packages/js/src/settings/components/sidebar-recommendations.js
+++ b/packages/js/src/settings/components/sidebar-recommendations.js
@@ -56,7 +56,7 @@ const PremiumUpsellCard = () => {
 				href={ premiumLink }
 				target="_blank"
 				rel="noopener"
-				className="yst-flex yst-justify-center yst-gap-2 yst-mt-4 yst-px-4 sm:yst-px-0 focus:yst-ring-offset-primary-500"
+				className="yst-flex yst-justify-center yst-gap-2 yst-mt-4 focus:yst-ring-offset-primary-500"
 				{ ...premiumUpsellConfig }
 			>
 				<span>{ getPremium }</span>

--- a/packages/js/src/settings/components/sidebar-recommendations.js
+++ b/packages/js/src/settings/components/sidebar-recommendations.js
@@ -46,7 +46,7 @@ const PremiumUpsellCard = () => {
 			>
 				<YoastSeoLogo />
 			</figure>
-			<Title as="h2" className="yst-mt-6 yst-text-base yst-font-extrabold yst-text-white yst-text-center">
+			<Title as="h2" className="yst-mt-6 yst-text-base yst-font-extrabold yst-text-white">
 				{ getPremium }
 			</Title>
 			<p className="yst-mt-2">{ info }</p>

--- a/packages/js/src/settings/components/sidebar-recommendations.js
+++ b/packages/js/src/settings/components/sidebar-recommendations.js
@@ -26,10 +26,17 @@ const PremiumUpsellCard = () => {
 			strong: <strong />,
 		}
 	), [] );
-	const getPremium = sprintf(
-		/* translators: %s expands to "Yoast SEO" Premium */
-		__( "Get %s", "wordpress-seo" ),
-		"Yoast SEO Premium"
+	const getPremium = createInterpolateElement(
+		sprintf(
+			/* translators: %1$s and %2$s expand to a span wrap to avoid linebreaks. %3$s expands to "Yoast SEO Premium". */
+			__( "%1$sGet%2$s %3$s", "wordpress-seo" ),
+			"<nowrap>",
+			"</nowrap>",
+			"Yoast SEO Premium"
+		),
+		{
+			nowrap: <span className="yst-whitespace-nowrap" />,
+		}
 	);
 
 	return (
@@ -40,9 +47,7 @@ const PremiumUpsellCard = () => {
 				<YoastSeoLogo />
 			</figure>
 			<Title as="h2" className="yst-mt-6 yst-text-base yst-font-extrabold yst-text-white yst-text-center">
-				{ __( "Get", "wordpress-seo" ) }
-				<br />
-				Yoast SEO Premium
+				{ getPremium }
 			</Title>
 			<p className="yst-mt-2">{ info }</p>
 			<Button
@@ -54,7 +59,7 @@ const PremiumUpsellCard = () => {
 				className="yst-flex yst-justify-center yst-gap-2 yst-mt-4 yst-px-4 sm:yst-px-0 focus:yst-ring-offset-primary-500"
 				{ ...premiumUpsellConfig }
 			>
-				{ getPremium }
+				<span>{ getPremium }</span>
 				<ArrowNarrowRightIcon className="yst-w-4 yst-h-4 yst-icon-rtl" />
 			</Button>
 			<a


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Alternate approach to the solution of https://github.com/Yoast/plugins-automated-testing/issues/301

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves the sidebar upsell in the settings when viewed in languages that do _not_ need a line break.
* Tweaked the sidebar upsell in the settings styling: logo up a bit more, title is no longer center aligned and the button now has the default horizontal spacing.

## Relevant technical choices:

* Change the translation to incorporate the tags around _Get_
* Add `white-space: nowrap` around both _Get_ to ensure there can only be a linebreak in there. This happened in Japanese
* The wrapper span in the button is because of the gap, otherwise it would put the gap between _Get_ and _Yoast SEO Premium_ too

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Prepare environment
* Depending on whether the new translation has already been done or not, you'd need to alter the translations yourself in order to test this
* The used translation changed from `Get %s` to `%1$sGet%2$s %3$s`
* Repeat for each language you want to test. Suggested: English (US), Japanese (JA), Ukrainian (UK) and Dutch (NL)
  * Switch your site language to one language and update the languages (this downloads them)
  * Go to your WordPress install folder > wp-content > languages > plugins
  * Search for `"Get %s" in the files
  * Open the ones that start with `wordpress-seo-` and then the locale code for the language, e.g. `nl_NL`
    * Note that you can skip English because that is the default
  * Add a translation for `"%1$sGet%2$s %3$s` that is similar to the Get one, just changes the replacement variables. For your convenience:
    * Japanese: `"%1$sGet%2$s %3$s":["%3$s %1$s\u3092\u5165\u624b%2$s"]`
    * Ukrainian: `"%1$sGet%2$s %3$s":["%1$s\u041e\u0442\u0440\u0438\u043c\u0430\u0439\u0442\u0435%2$s %3$s"]`
    * Dutch: `"%1$sGet%2$s %3$s":["%1$sKoop%2$s %3$s"]`

#### Check the sidebar upsell' style changes
* Disable Premium plugin if you have it on
* Go to Settings and look at the sidebar upsell
* Verify the Yoast logo is up a bit more than it was (now 16px from the admin bar)
  * When on mobile, and the sidebar is below the content: verify that the room above the upsell is not too close to the other card
* Verify the title is no longer center aligned
* Verify the button' horizontal spacing is never none: on some combinations the arrow was right next to the edge of the button
* Verify, for each specified language, that the text in the upsell in the sidebar looks okay:
  * English
![image](https://user-images.githubusercontent.com/35524806/211534837-5a03baa3-0c4f-4c8d-9a59-ef1c6ad09888.png)
  * Japanese
![image](https://user-images.githubusercontent.com/35524806/211534789-6e1d10f4-3a5e-43ef-8f28-f7c830b2aea2.png)
  * Ukrainian
![image](https://user-images.githubusercontent.com/35524806/211535048-39892ebe-643e-4f51-a3f1-23d2f7c4255a.png)
  * Dutch
![image](https://user-images.githubusercontent.com/35524806/211535090-db6a1620-4d24-4968-88f7-0d9ef27fe60f.png)

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Sidebar upsell in the Settings

## UI changes

* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes https://github.com/Yoast/wordpress-seo/issues/19598
