### PR TITLE
settings-ui: 19523 improve mobile navigation a11y

### DIFF
--- a/packages/js/src/settings/app.js
+++ b/packages/js/src/settings/app.js
@@ -229,8 +229,9 @@ const App = () => {
 			<Notifications />
 			<SidebarNavigation activePath={ pathname }>
 				<SidebarNavigation.Mobile
-					openButtonScreenReaderText={ __( "Open sidebar", "wordpress-seo" ) }
-					closeButtonScreenReaderText={ __( "Close sidebar", "wordpress-seo" ) }
+					openButtonScreenReaderText={ __( "Open settings navigation", "wordpress-seo" ) }
+					closeButtonScreenReaderText={ __( "Close settings navigation", "wordpress-seo" ) }
+					aria-label={ __( "Settings navigation", "wordpress-seo" ) }
 				>
 					<Menu idSuffix="-mobile" postTypes={ postTypes } taxonomies={ taxonomies } />
 				</SidebarNavigation.Mobile>

--- a/packages/ui-library/src/components/sidebar-navigation/mobile.js
+++ b/packages/ui-library/src/components/sidebar-navigation/mobile.js
@@ -10,7 +10,7 @@ import { useNavigationContext } from "./index";
  * @param {string} [closeButtonScreenReaderText] The close button screen reader text.
  * @returns {JSX.Element} The mobile element.
  */
-const Mobile = ( { children, openButtonScreenReaderText = "Open", closeButtonScreenReaderText = "Close" } ) => {
+const Mobile = ( { children, openButtonScreenReaderText = "Opens a menu", closeButtonScreenReaderText = "Closes a menu" } ) => {
 	const { isMobileMenuOpen, setMobileMenuOpen } = useNavigationContext();
 	const openMobileMenu = useCallback( () => setMobileMenuOpen( true ), [ setMobileMenuOpen ] );
 	const closeMobileMenu = useCallback( () => setMobileMenuOpen( false ), [ setMobileMenuOpen ] );

--- a/packages/ui-library/src/components/sidebar-navigation/mobile.js
+++ b/packages/ui-library/src/components/sidebar-navigation/mobile.js
@@ -10,7 +10,7 @@ import { useNavigationContext } from "./index";
  * @param {string} [closeButtonScreenReaderText] The close button screen reader text.
  * @returns {JSX.Element} The mobile element.
  */
-const Mobile = ( { children, openButtonScreenReaderText = "Opens a menu", closeButtonScreenReaderText = "Closes a menu" } ) => {
+const Mobile = ( { children, openButtonScreenReaderText, closeButtonScreenReaderText } ) => {
 	const { isMobileMenuOpen, setMobileMenuOpen } = useNavigationContext();
 	const openMobileMenu = useCallback( () => setMobileMenuOpen( true ), [ setMobileMenuOpen ] );
 	const closeMobileMenu = useCallback( () => setMobileMenuOpen( false ), [ setMobileMenuOpen ] );
@@ -53,8 +53,8 @@ const Mobile = ( { children, openButtonScreenReaderText = "Opens a menu", closeB
 
 Mobile.propTypes = {
 	children: PropTypes.node.isRequired,
-	openButtonScreenReaderText: PropTypes.string,
-	closeButtonScreenReaderText: PropTypes.string,
+	openButtonScreenReaderText: PropTypes.string.isRequired,
+	closeButtonScreenReaderText: PropTypes.string.isRequired,
 };
 
 export default Mobile;

--- a/packages/ui-library/src/components/sidebar-navigation/mobile.js
+++ b/packages/ui-library/src/components/sidebar-navigation/mobile.js
@@ -22,7 +22,7 @@ const Mobile = ( { children, openButtonScreenReaderText = "Open", closeButtonScr
 				<Dialog.Panel className="yst-relative yst-flex yst-flex-1 yst-flex-col yst-max-w-xs yst-w-full yst-z-40 yst-bg-slate-100">
 					<div className="yst-absolute yst-top-0 yst-right-0 yst--mr-14 yst-p-1">
 						<button
-							className="yst-flex yst-h-12 yst-w-12 yst-items-center yst-justify-center yst-rounded-full focus:yst-outline-none focus:yst-bg-slate-600"
+							className="yst-flex yst-h-12 yst-w-12 yst-items-center yst-justify-center yst-rounded-full focus:yst-outline-none yst-bg-slate-600 focus:yst-ring-2 focus:yst-ring-inset focus:yst-ring-primary-500"
 							onClick={ closeMobileMenu }
 						>
 							<span className="yst-sr-only">{ closeButtonScreenReaderText }</span>
@@ -40,7 +40,7 @@ const Mobile = ( { children, openButtonScreenReaderText = "Open", closeButtonScr
 		<div className="yst-mobile-navigation__top">
 			<div className="yst-flex yst-relative yst-flex-shrink-0 yst-h-16 yst-z-10 yst-bg-white yst-border-b yst-border-slate-200">
 				<button
-					className="yst-px-4 yst-border-r yst-border-slate-200 yst-text-slate-400 focus:yst-outline-none focus:yst-ring-2 focus:yst-ring-inset focus:yst-ring-primary-500"
+					className="yst-px-4 yst-border-r yst-border-slate-200 yst-text-slate-500 focus:yst-outline-none focus:yst-ring-2 focus:yst-ring-inset focus:yst-ring-primary-500"
 					onClick={ openMobileMenu }
 				>
 					<span className="yst-sr-only">{ openButtonScreenReaderText }</span>

--- a/packages/ui-library/src/components/sidebar-navigation/mobile.js
+++ b/packages/ui-library/src/components/sidebar-navigation/mobile.js
@@ -10,13 +10,18 @@ import { useNavigationContext } from "./index";
  * @param {string} [closeButtonScreenReaderText] The close button screen reader text.
  * @returns {JSX.Element} The mobile element.
  */
-const Mobile = ( { children, openButtonScreenReaderText, closeButtonScreenReaderText } ) => {
+const Mobile = ( {
+	children,
+	openButtonScreenReaderText = "Open",
+	closeButtonScreenReaderText = "Close",
+	"aria-label": ariaLabel,
+} ) => {
 	const { isMobileMenuOpen, setMobileMenuOpen } = useNavigationContext();
 	const openMobileMenu = useCallback( () => setMobileMenuOpen( true ), [ setMobileMenuOpen ] );
 	const closeMobileMenu = useCallback( () => setMobileMenuOpen( false ), [ setMobileMenuOpen ] );
 
 	return <>
-		<Dialog className="yst-root" open={ isMobileMenuOpen } onClose={ closeMobileMenu }>
+		<Dialog className="yst-root" open={ isMobileMenuOpen } onClose={ closeMobileMenu } aria-label={ ariaLabel }>
 			<div className="yst-mobile-navigation__dialog">
 				<div className="yst-fixed yst-inset-0 yst-bg-slate-600 yst-bg-opacity-75 yst-z-30" aria-hidden="true" />
 				<Dialog.Panel className="yst-relative yst-flex yst-flex-1 yst-flex-col yst-max-w-xs yst-w-full yst-z-40 yst-bg-slate-100">
@@ -53,8 +58,9 @@ const Mobile = ( { children, openButtonScreenReaderText, closeButtonScreenReader
 
 Mobile.propTypes = {
 	children: PropTypes.node.isRequired,
-	openButtonScreenReaderText: PropTypes.string.isRequired,
-	closeButtonScreenReaderText: PropTypes.string.isRequired,
+	openButtonScreenReaderText: PropTypes.string,
+	closeButtonScreenReaderText: PropTypes.string,
+	"aria-label": PropTypes.string,
 };
 
 export default Mobile;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Improves accessibility for mobile navigation.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves accessibility for mobile navigation by changing style of menu open and close button, and the default screen reader text of that component.

## Relevant technical choices:

* `aria-label` prop was added to `SidebarNavigation.Mobile` in `ui-library`.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Open `YoastSEO`->`Settings`
* Resize the screen to see the sidebar in mobile view.
* Check hamburger has style `yst-text-slate-500`
* Open menu and check `X` has background grey circle and when focus has ring border in the primary colour `primary-500` (The classes that should be there are `focus:yst-ring-2 focus:yst-ring-inset focus:yst-ring-primary-500`) 
* Enable voice over/screen reader and open the mobile settings menu.
* Check that screen reader reads the text for opening menu as "Open settings navigation" and close button reads as "Close settings navigation".
* When menu open check that screen reader reads the dialog as "Settings navigation" 

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes [Improve mobile navigation a11y#19523](https://github.com/Yoast/wordpress-seo/issues/19523)
