### PR TITLE
310 minor validation rest error may block new settings from saving

### DIFF
--- a/packages/js/src/settings/components/formik-media-select-field.js
+++ b/packages/js/src/settings/components/formik-media-select-field.js
@@ -59,10 +59,11 @@ const FormikMediaSelectField = ( {
 	const wpMedia = useMemo( () => get( window, "wp.media", null ), [] );
 	const mediaId = useMemo( () => get( values, mediaIdName, "" ), [ values, mediaIdName ] );
 	const media = useSelectSettings( "selectMediaById", [ mediaId ], mediaId );
+	const isMediaError = useSelectSettings( "selectIsMediaError" );
 	const fallbackMedia = useSelectSettings( "selectMediaById", [ fallbackMediaId ], fallbackMediaId );
 	const { fetchMedia, addOneMedia } = useDispatchSettings();
 	const error = useMemo( () => get( errors, mediaIdName, "" ), [ errors, mediaIdName ] );
-	const disabled = useMemo( () => isDisabled || isDummy, [ isDummy, isDisabled ] );
+	const disabled = useMemo( () => isDisabled || isDummy || isMediaError, [ isDummy, isDisabled, isMediaError ] );
 	const { ids: describedByIds, describedBy } = useDescribedBy( `field-${ id }-id`, { description, error } );
 	const previewMedia = useMemo( () => {
 		if ( mediaId > 0 ) {
@@ -232,6 +233,7 @@ const FormikMediaSelectField = ( {
 				) }
 			</div>
 			{ error && <p id={ describedByIds.error } className="yst-mt-2 yst-text-sm yst-text-red-600">{ error }</p> }
+			{ isMediaError && <p className="yst-mt-2 yst-text-sm yst-text-red-600">{ __( "Failed to retrieve media.", "wordpress-seo" ) }</p> }
 			{ description && (
 				<p id={ describedByIds.description } className={ classNames( "yst-mt-2", disabled && "yst-opacity-50 yst-cursor-not-allowed" ) }>
 					{ description }

--- a/packages/js/src/settings/helpers/validation.js
+++ b/packages/js/src/settings/helpers/validation.js
@@ -17,7 +17,13 @@ addMethod( number, "isMediaTypeImage", function() {
 			if ( ! input ) {
 				return true;
 			}
+
 			const media = select( STORE_NAME ).selectMediaById( input );
+			// No metadata to validate: default to valid.
+			if ( ! media ) {
+				return true;
+			}
+
 			return media?.type === "image";
 		}
 	);

--- a/packages/js/src/settings/store/media.js
+++ b/packages/js/src/settings/store/media.js
@@ -93,6 +93,7 @@ export const mediaSelectors = {
 	selectMediaIds: adapterSelectors.selectIds,
 	selectMediaById: adapterSelectors.selectById,
 	selectIsMediaLoading: state => get( state, "media.status", ASYNC_ACTION_STATUS.idle ) === ASYNC_ACTION_STATUS.loading,
+	selectIsMediaError: state => get( state, "media.status", ASYNC_ACTION_STATUS.idle ) === ASYNC_ACTION_STATUS.error,
 };
 
 export const mediaActions = {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Validates WP media rest error.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Validates WP media rest error in the Settings.

## Relevant technical choices:

* Rest api error validation is separate from the general form validation.
* Other fields can be saved except media fields which are disabled.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install the [Disable REST API](https://wordpress.org/plugins/disable-json-api/) plugin
* Set a valid image under `Yoast` -> `Settings` -> `Site basics` -> `Site image` and save the settings.
* Go to `Settings` -> `Disable REST API` -> `Rules for Administrator` and deactivate the following 4 routes:
```
/wp/v2/media
/wp/v2/media/(?P[\d]+)
/wp/v2/media/(?P[\d]+)/post-process
/wp/v2/media/(?P[\d]+)/edit
```
* Return to `YoastSEO`-> `Settings` and try to save anything that is unrelated to any media.
* Check that you are able to save.
* Go to `Yoast` -> `Settings` -> `Site basics` -> `Site image` and check that image is not there but there is an error `Failed to retrieve media.`
* Check that images buttons are disabled.

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* All the media/images in the Settings UI

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes [Minor: [Validation] REST error may block new settings from saving#310](https://github.com/Yoast/plugins-automated-testing/issues/310)
