### PR TITLE
Use shortlinks for Wincher links in popup

### DIFF
--- a/src/helpers/wincher-helper.php
+++ b/src/helpers/wincher-helper.php
@@ -82,8 +82,8 @@ class Wincher_Helper {
 	 */
 	public function get_admin_global_links() {
 		return [
-			'links.wincher.website' => 'https://www.wincher.com?utm_medium=plugin&utm_source=yoast&referer=yoast&partner=yoast',
-			'links.wincher.pricing' => 'https://www.wincher.com/pricing?utm_medium=plugin&utm_source=yoast&referer=yoast&partner=yoast',
+			'links.wincher.website' => \WPSEO_Shortlinker::get( 'https://yoa.st/wincher-popup' ),
+			'links.wincher.pricing' => \WPSEO_Shortlinker::get( 'https://yoa.st/wincher-popup-pricing' ),
 			'links.wincher.login'   => 'https://app.wincher.com/login?utm_medium=plugin&utm_source=yoast&referer=yoast&partner=yoast',
 		];
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Fix some links to be shortlinks

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* In the Yoast metabox, `Track SEO Performance` collapsible, check that URL of the page opened by the link highlighted in the following picture contains the parameters `referer=yoast&partner=yoast#utm_medium=plugin&utm_source=yoast`
<img width="770" alt="Screenshot 2023-01-11 at 14 20 19" src="https://user-images.githubusercontent.com/68744851/211818004-0eef2bd4-1e02-4138-a275-9d3e6fae634e.png">

* Track the number of keywords needed to reach the limit for your aubscription plan (5 keywords for free plans)
* Check that the URL of the page opened by clicking on the `upgrade your Wincher plan.`  contains the parameters mentioned above too
<img width="746" alt="Screenshot 2023-01-11 at 14 19 44" src="https://user-images.githubusercontent.com/68744851/211818066-c1433a4e-71a6-4419-ab7f-7349ada995f9.png">
