### PR TITLE
Avoid duplicate unindexed entries in indexable table

### DIFF
--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -85,7 +85,7 @@ class WPSEO_Upgrade {
 			'19.3-RC0'   => 'upgrade_193',
 			'19.6-RC0'   => 'upgrade_196',
 			'19.11-RC0'  => 'upgrade_1911',
-			'19.12-RC0'  => 'upgrade_1912',
+			'20.0-RC0'   => 'upgrade_200',
 		];
 
 		array_walk( $routines, [ $this, 'run_upgrade_routine' ], $version );
@@ -965,13 +965,17 @@ class WPSEO_Upgrade {
 	}
 
 	/**
-	 * Performs the 19.12 upgrade routine.
-	 * This just schedules the cleanup routine cron again, since in combination of premium cleans up the prominent words table.
+	 * Performs the 20.0 upgrade routine.
+	 *
+	 * @TODO: Update with the correct version number when the time comes.
 	 */
-	private function upgrade_1912() {
+	private function upgrade_200() {
 		if ( ! \wp_next_scheduled( Cleanup_Integration::START_HOOK ) ) {
+			// This just schedules the cleanup routine cron again, since in combination of premium cleans up the prominent words table.
 			\wp_schedule_single_event( ( time() + ( MINUTE_IN_SECONDS * 5 ) ), Cleanup_Integration::START_HOOK );
 		}
+
+		$this->clean_unindexed_indexable_rows_with_no_object_id();
 	}
 
 	/**
@@ -1513,6 +1517,34 @@ class WPSEO_Upgrade {
 				// phpcs:enable
 			}
 		}
+
+		$wpdb->show_errors = $show_errors;
+	}
+
+	/**
+	 * Cleans up "unindexed" indexable rows when appropriate, aka when there's no object ID even though it should.
+	 *
+	 * @return void
+	 */
+	private function clean_unindexed_indexable_rows_with_no_object_id() {
+		global $wpdb;
+
+		// If migrations haven't been completed successfully the following may give false errors. So suppress them.
+		$show_errors       = $wpdb->show_errors;
+		$wpdb->show_errors = false;
+
+		$indexable_table = Model::get_table_name( 'Indexable' );
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Reason: No user input, just a table name.
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery -- Reason: Most performant way.
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching -- Reason: No relevant caches.
+		$delete_query = $wpdb->query(
+			"DELETE FROM $indexable_table
+			WHERE post_status = 'unindexed'
+			AND object_type NOT IN ( 'home-page', 'date-archive', 'post-type-archive', 'system-page' )
+			AND object_id IS NULL"
+		);
+		// phpcs:enable
 
 		$wpdb->show_errors = $show_errors;
 	}

--- a/src/builders/indexable-builder.php
+++ b/src/builders/indexable-builder.php
@@ -403,6 +403,9 @@ class Indexable_Builder {
 			return $this->save_indexable( $indexable, $indexable_before );
 		}
 		catch ( Source_Exception $exception ) {
+			if ( \is_null( $indexable->object_id ) ) {
+				return false;
+			}
 			/**
 			 * The current indexable could not be indexed. Create a placeholder indexable, so we can
 			 * skip this indexable in future indexing runs.

--- a/src/builders/indexable-builder.php
+++ b/src/builders/indexable-builder.php
@@ -324,6 +324,17 @@ class Indexable_Builder {
 		return $author_indexable;
 	}
 
+	/**
+	 * Checks if the indexable type is one that is not supposed to have object ID for.
+	 *
+	 * @param string $type The type of the indexable.
+	 *
+	 * @return bool Whether the indexable type is one that is not supposed to have object ID for.
+	 */
+	private function is_type_with_no_id( $type ) {
+		return \in_array( $type, [ 'home-page', 'date-archive', 'post-type-archive', 'system-page' ], true );
+	}
+
 	// phpcs:disable Squiz.Commenting.FunctionCommentThrowTag.Missing -- Exceptions are handled by the catch statement in the method.
 
 	/**
@@ -403,7 +414,7 @@ class Indexable_Builder {
 			return $this->save_indexable( $indexable, $indexable_before );
 		}
 		catch ( Source_Exception $exception ) {
-			if ( \is_null( $indexable->object_id ) ) {
+			if ( ! $this->is_type_with_no_id( $indexable->object_type ) && ( ! isset( $indexable->object_id ) || \is_null( $indexable->object_id ) ) ) {
 				return false;
 			}
 			/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to protect the indexable creation from needlessly creating `unindexed` entries when invalid IDs are passed for posts and terms

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves the indexables creation mechanism by avoiding duplicate `unindexed` entries when multiple invalid posts and terms are being used.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

**For the improvement**:
* Clean up indexables
* We have to artificially pass invalid terms to create indexables for. One way to do so, is to add some code in src\builders\indexable-builder.php, in the `build()` function. Add the following to the beginning of that function, so that it becomes:
```
public function build( $indexable, $defaults = null ) {
	if ( $defaults['object_type'] === 'term' ) { // This is new.
		$defaults['object_id'] = null;  // This is new.
	}  // This is new.
	// Backup the previous Indexable, if there was one.
```
* Go on to create a new category.
* Check in the db, in the indexable table. There shouldn't have been created an entry for that new category. Without this PR, it would be created a row with `post_status = unindexed` and `object_id = NULL`

For the upgrade cleanup routine:
* Without this PR (or with a previous plugin version if you're QA), add the code above again and create 4-5 categories
* In the indexable table, you should get 4-5 rows with `post_status = unindexed` and `object_id = NULL`
* Remove the above code and again in the src\builders\indexable-builder.php file, add a `throw new Source_Exception();` line in the `build()` function, inside the `case 'post':`. So like this:
```
case 'term':
	throw new Source_Exception(); // This is the new line that we are adding.
	$indexable = $this->term_builder->build( $indexable->object_id, $indexable );
```
* Create another category. This time you will get a row with `post_status = unindexed` but now the object_id won't be NULL
* Use the upgrade routine
* Check the database and confirm that the rows with the `object_id = NULL` have now been deleted, but the row with the `object_id != NULL` hasnt been cleaned up.


#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* This PR should still work as expected: https://github.com/Yoast/wordpress-seo/pull/19079
* Also this PR: https://github.com/Yoast/wordpress-seo/pull/19087 (the **Removing duplicates - Cleanup** section)

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
