### PR TITLE
19520 improve navigation experience a11y

### DIFF
--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -54,7 +54,8 @@
     "react-router-dom": "^6.3.0",
     "yup": "^0.32.11",
     "bowser": "^2.11.0",
-    "react-hotkeys-hook": "^4.0.5"
+    "react-hotkeys-hook": "^4.0.5",
+	"react-aria-live": "^2.0.5"
   },
   "devDependencies": {
     "@babel/core": "^7.17.9",

--- a/packages/js/src/settings/components/route-layout.js
+++ b/packages/js/src/settings/components/route-layout.js
@@ -1,6 +1,8 @@
+import { __, sprintf } from "@wordpress/i18n";
 import { Title } from "@yoast/ui-library";
 import PropTypes from "prop-types";
 import { Helmet } from "react-helmet";
+import { LiveAnnouncer, LiveMessage } from "react-aria-live";
 import { useDocumentTitle } from "../hooks";
 
 /**
@@ -16,9 +18,16 @@ const RouteLayout = ( {
 	description,
 } ) => {
 	const documentTitle = useDocumentTitle( { prefix: `${ title } ‹ ` } );
-
+	const ariaLiveTitle = sprintf(
+		/* translators: 1: Settings' section title, 2: Settings, 3: Yoast SEO */
+		__( "%1$s - %2$s - %3$s", "wordpress-seo" ),
+		title,
+		"Settings",
+		"Yoast SEO"
+	);
 	return (
-		<>
+		<LiveAnnouncer>
+			<LiveMessage message={ ariaLiveTitle } aria-live="polite" />
 			<Helmet>
 				<title>{ documentTitle }</title>
 			</Helmet>
@@ -29,7 +38,7 @@ const RouteLayout = ( {
 				</div>
 			</header>
 			{ children }
-		</>
+		</LiveAnnouncer>
 	);
 };
 

--- a/packages/js/src/settings/components/route-layout.js
+++ b/packages/js/src/settings/components/route-layout.js
@@ -20,7 +20,7 @@ const RouteLayout = ( {
 	const documentTitle = useDocumentTitle( { prefix: `${ title } ‹ ` } );
 	const ariaLiveTitle = sprintf(
 		/* translators: 1: Settings' section title, 2: Settings, 3: Yoast SEO */
-		__( "%1$s - %2$s - %3$s", "wordpress-seo" ),
+		__( "%1$s %2$s - %3$s", "wordpress-seo" ),
 		title,
 		"Settings",
 		"Yoast SEO"

--- a/yarn.lock
+++ b/yarn.lock
@@ -25934,6 +25934,13 @@ react-animate-height@^3.1.0:
   resolved "https://registry.yarnpkg.com/react-animate-height/-/react-animate-height-3.1.0.tgz#f7def40acfe857f936621fe9d7bad601467d0e31"
   integrity sha512-+0pW2OzB8PzVn10dpTB9q5jFI+GwQTnCDLbzyqPBUzKXJfpBrlWW954uud/59Mreo+laRN/fPzvckuA+WTptXA==
 
+react-aria-live@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/react-aria-live/-/react-aria-live-2.0.5.tgz#333480cb898d6963421bd86fe3cbd0ce54e37f08"
+  integrity sha512-rXiH1HNKJrr/UfVeGwA2aKY43r5WbjLs+AYB6/kJF1qny2hwxzQc1qewQmUpdQ5h8HAOTD8O/XlGcEHjqlCl0g==
+  dependencies:
+    uuid "^3.2.1"
+
 react-autosize-textarea@^7.0.0, react-autosize-textarea@^7.1.0:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/react-autosize-textarea/-/react-autosize-textarea-7.1.0.tgz#902c84fc395a689ca3a484dfb6bc2be9ba3694d1"
@@ -30747,7 +30754,7 @@ uuid-browser@^3.1.0:
   resolved "https://registry.yarnpkg.com/uuid-browser/-/uuid-browser-3.1.0.tgz#0f05a40aef74f9e5951e20efbf44b11871e56410"
   integrity sha1-DwWkCu90+eWVHiDvv0SxGHHlZBA=
 
-uuid@^3.0.1, uuid@^3.3.2, uuid@^3.4.0:
+uuid@^3.0.1, uuid@^3.2.1, uuid@^3.3.2, uuid@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to enhance the accessibility of our new `Settings UI` by allowing screen readers to notify users when they change section.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Allows screen readers to notify the user when s/he navigates to a new section in the `Settings` page.

## Relevant technical choices:

* The `react-aria-live` package has been favored over `@wordpress/a11y`  `speak` because it is implemented in a way which plays nicer with our `Settings UI` (i.e. by using React context takes care of reading things just once when it's needed). 
* When the screen reader encounters a section containing `info` or `warning` boxes will give precedence to their content before announcing the section. This is foreseen behavior.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Activate a screen reader
  * If you're on MacOS you can activate the `VoiceOver` screen reader by pressing (<kbd>fn</kbd>)+<kbd>Cmd</kbd>+<kbd>F5</kbd> 
  * Tip: by pressing <kbd>ctrl</kbd> you can interrupt the message that is currently being spoken
* Navigate to `Yoast SEO` -> `Settings`
* Navigate through some sections of the `Settings` page and verify that, at each section change, that section is being announced with the format: `section name` + `Settings` + `Yoast SEO`

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [X] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->
* Please verify which is the suggested browser supported by your OS for what concerns accessibility (for MacOS is Safari)
 
### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Nothing more needs to be tested.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes https://github.com/Yoast/wordpress-seo/issues/19520
