### PR TITLE
Settings: add search keywords

### DIFF
--- a/packages/js/src/settings/helpers/search.js
+++ b/packages/js/src/settings/helpers/search.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 import { __, sprintf } from "@wordpress/i18n";
-import { omit, reduce, times, filter, includes, isEmpty } from "lodash";
+import { filter, includes, isEmpty, omit, reduce, times } from "lodash";
 import { safeToLocaleLower } from "./i18n";
 
 /**
@@ -332,7 +332,9 @@ export const createSearchIndex = ( postTypes, taxonomies, { userLocale } = {} ) 
 			routeLabel: __( "Site features", "wordpress-seo" ),
 			fieldId: "card-wpseo-enable_index_now",
 			fieldLabel: __( "IndexNow", "wordpress-seo" ),
-			keywords: [],
+			keywords: [
+				__( "Index Now", "wordpress-seo" ),
+			],
 		},
 		disableadvanced_meta: {
 			route: "/site-basics",
@@ -364,6 +366,8 @@ export const createSearchIndex = ( postTypes, taxonomies, { userLocale } = {} ) 
 			fieldLabel: __( "Google", "wordpress-seo" ),
 			keywords: [
 				__( "Webmaster", "wordpress-seo" ),
+				__( "Google search console", "wordpress-seo" ),
+				"gsc",
 			],
 		},
 		msverify: {
@@ -617,7 +621,10 @@ export const createSearchIndex = ( postTypes, taxonomies, { userLocale } = {} ) 
 			routeLabel: __( "Site representation", "wordpress-seo" ),
 			fieldId: "input-wpseo_titles-company_or_person-company",
 			fieldLabel: __( "Organization/person", "wordpress-seo" ),
-			keywords: [],
+			keywords: [
+				__( "Schema", "wordpress-seo" ),
+				__( "Structured data", "wordpress-seo" ),
+			],
 		},
 		company_name: {
 			route: "/site-representation",
@@ -638,7 +645,9 @@ export const createSearchIndex = ( postTypes, taxonomies, { userLocale } = {} ) 
 			routeLabel: __( "Site representation", "wordpress-seo" ),
 			fieldId: "button-wpseo_titles-company_logo-preview",
 			fieldLabel: __( "Organization logo", "wordpress-seo" ),
-			keywords: [],
+			keywords: [
+				__( "Image", "wordpress-seo" ),
+			],
 		},
 		company_or_person_user_id: {
 			route: "/site-representation",
@@ -652,7 +661,9 @@ export const createSearchIndex = ( postTypes, taxonomies, { userLocale } = {} ) 
 			routeLabel: __( "Site representation", "wordpress-seo" ),
 			fieldId: "button-wpseo_titles-person_logo-preview",
 			fieldLabel: __( "Personal logo or avatar", "wordpress-seo" ),
-			keywords: [],
+			keywords: [
+				__( "Image", "wordpress-seo" ),
+			],
 		},
 		"title-home-wpseo": {
 			route: "/homepage",
@@ -694,7 +705,10 @@ export const createSearchIndex = ( postTypes, taxonomies, { userLocale } = {} ) 
 			routeLabel: __( "Breadcrumbs", "wordpress-seo" ),
 			fieldId: "input-wpseo_titles-breadcrumbs-sep",
 			fieldLabel: __( "Separator between breadcrumbs", "wordpress-seo" ),
-			keywords: [],
+			keywords: [
+				__( "Divider", "wordpress-seo" ),
+				__( "Separator", "wordpress-seo" ),
+			],
 		},
 		"breadcrumbs-home": {
 			route: "/breadcrumbs",
@@ -1075,6 +1089,8 @@ export const createSearchIndex = ( postTypes, taxonomies, { userLocale } = {} ) 
 			keywords: [
 				__( "Social", "wordpress-seo" ),
 				__( "OpenGraph", "wordpress-seo" ),
+				__( "Facebook", "wordpress-seo" ),
+				__( "Share", "wordpress-seo" ),
 			],
 		},
 		twitter: {
@@ -1084,6 +1100,8 @@ export const createSearchIndex = ( postTypes, taxonomies, { userLocale } = {} ) 
 			fieldLabel: __( "Twitter card data", "wordpress-seo" ),
 			keywords: [
 				__( "Social", "wordpress-seo" ),
+				__( "Share", "wordpress-seo" ),
+				__( "Tweet", "wordpress-seo" ),
 			],
 		},
 		og_default_image_id: {
@@ -1111,6 +1129,7 @@ export const createSearchIndex = ( postTypes, taxonomies, { userLocale } = {} ) 
 				__( "Social", "wordpress-seo" ),
 				__( "Open Graph", "wordpress-seo" ),
 				__( "OpenGraph", "wordpress-seo" ),
+				__( "Share", "wordpress-seo" ),
 			],
 		},
 		twitter_site: {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to improve the search in the settings by adding keywords.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves the search keywords in the Settings.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Go to Settings
* Search results for:
  * `index` and `now` should include Site features > IndexNow
  * `search` and `console` should include Site connections > Google
  * `schema` and `structured data` should include Site representation > Organization/person
  * `image` should include Site representation > Organization logo and Personal logo or avatar
  * `divider` and `separator` should include Breadcrumbs > Separator between breadcrumbs
  * `facebook` and `share` should include Site features > Open graph data
    * Note that `og` was requested here, but we have a minimum of 3 characters, so that won't work
  * `share` and `tweet` should include Site features > Twitter
  * `share` should include Site representation > Organization Facebook 

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The search in the Settings.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes Yoast/wordpress-seo#19619
