### PR TITLE
added link to organisation/person radio button description

### DIFF
--- a/packages/js/src/settings/routes/site-representation.js
+++ b/packages/js/src/settings/routes/site-representation.js
@@ -58,12 +58,12 @@ const SiteRepresentation = () => {
 						description={ addLinkToString(
 							sprintf(
 								// translators: %1$s and %2$s are replaced by opening and closing <a> tags.
-								__( "Choose whether your site represents an organization or a person. %1$sLearn more about the differences and choosing between Organization and Person.%2$s.", "wordpress-seo" ),
+								__( "Choose whether your site represents an organization or a person. %1$sLearn more about the differences and choosing between Organization and Person%2$s.", "wordpress-seo" ),
 								"<a>",
 								"</a>"
 							),
 							organizationPersonLink,
-							"site-representation-organization-person"
+							"link-site-representation-organization-person"
 						) }
 					>
 						{ isLocalSeoActive && (

--- a/packages/js/src/settings/routes/site-representation.js
+++ b/packages/js/src/settings/routes/site-representation.js
@@ -30,6 +30,7 @@ const SiteRepresentation = () => {
 	const personUser = useSelectSettings( "selectUserById", [ companyOrPersonId ], companyOrPersonId );
 	const googleKnowledgeGraphLink = useSelectSettings( "selectLink", [], "https://yoa.st/1-p" );
 	const structuredDataLink = useSelectSettings( "selectLink", [], "https://yoa.st/3r3" );
+	const organizationPersonLink = useSelectSettings( "selectLink", [], "https://yoa.st/site-representation-organization-person" );
 	const editUserUrl = useSelectSettings( "selectPreference", [], "editUserUrl" );
 	const isLocalSeoActive = useSelectSettings( "selectPreference", [], "isLocalSeoActive" );
 	const companyOrPersonMessage = useSelectSettings( "selectPreference", [], "companyOrPersonMessage" );
@@ -54,7 +55,16 @@ const SiteRepresentation = () => {
 				<div className="yst-max-w-5xl">
 					<FieldsetLayout
 						title={ __( "Organization/person", "wordpress-seo" ) }
-						description={ __( "Choose whether your site represents an organization or a person.", "wordpress-seo" ) }
+						description={ addLinkToString(
+							sprintf(
+								// translators: %1$s and %2$s are replaced by opening and closing <a> tags.
+								__( "Choose whether your site represents an organization or a person. %1$sLearn more about the differences and choosing between Organization and Person.%2$s.", "wordpress-seo" ),
+								"<a>",
+								"</a>"
+							),
+							organizationPersonLink,
+							"site-representation-organization-person"
+						) }
 					>
 						{ isLocalSeoActive && (
 							<Alert id="alert-local-seo-company-or-person" variant="info">


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The Organization / Person choice is one of the most important ones when initially configuring Yoast SEO. To make sure our users will make good choice we linked a help article about this. 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds a link to a help article for Organization / Person choice.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Open `YoastSEO`->`Settings`
* In the sidebar navigation go to `Site representation`->`Organization/person`
* Check that description has a link [Learn more about the differences and choosing between Organization and Person.](https://yoa.st/site-representation-organization-person)\
* The short-link should be yoa.st/site-representation-organization-person (yet to be created) @marijnyoast 
* The short-link should redirect to https://yoast.com/help/search-appearance-organization-or-person/.

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
