### PR TITLE
19618 revisit new taxonomies and post types indexables notice

### DIFF
--- a/packages/js/src/settings/routes/templates/post-type.js
+++ b/packages/js/src/settings/routes/templates/post-type.js
@@ -1,10 +1,9 @@
 /* eslint-disable complexity */
-import apiFetch from "@wordpress/api-fetch";
+/* eslint-disable max-statements */
 import { createInterpolateElement, useEffect, useMemo } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
 import { Badge, FeatureUpsell, Link, SelectField, TextField, Title, ToggleField } from "@yoast/ui-library";
 import { Field, useFormikContext } from "formik";
-import { get, remove, set } from "lodash";
 import PropTypes from "prop-types";
 import { addLinkToString } from "../../../helpers/stringHelpers";
 import {

--- a/packages/js/src/settings/routes/templates/post-type.js
+++ b/packages/js/src/settings/routes/templates/post-type.js
@@ -133,7 +133,7 @@ const PostType = ( { name, label, route, singularLabel, hasArchive, hasSchemaArt
 
 		if ( newPostTypeNotifications.includes( notificationId ) ) {
 			await apiFetch( {
-				path: "yoast/v1/settings_introduction/remove_post_type_notification",
+				path: "yoast/v1/settings_introduction/remove_notification",
 				method: "POST",
 				data: { id: notificationId },
 			} ).then( response => {

--- a/packages/js/src/settings/store/index.js
+++ b/packages/js/src/settings/store/index.js
@@ -11,6 +11,12 @@ import fallbacks, { createInitialFallbacksState, fallbacksActions, fallbacksSele
 import introduction, { createInitialIntroductionState, introductionActions, introductionControls, introductionSelectors } from "./introduction";
 import linkParams, { createInitialLinkParamsState, linkParamsActions, linkParamsSelectors } from "./link-params";
 import media, { createInitialMediaState, mediaActions, mediaControls, mediaSelectors } from "./media";
+import newPostTypeNotifications, {
+	createInitialNewPostTypeNotificationsState,
+	newPostTypeNotificationsActions,
+	newPostTypeNotificationsControls,
+	newPostTypeNotificationsSelectors,
+} from "./new-post-type-notifications";
 import notifications, { createInitialNotificationsState, notificationsActions, notificationsSelectors } from "./notifications";
 import postTypes, { createInitialPostTypesState, postTypesActions, postTypesSelectors } from "./post-types";
 import preferences, { createInitialPreferencesState, preferencesActions, preferencesSelectors } from "./preferences";
@@ -38,6 +44,7 @@ const createStore = ( { initialState } ) => {
 			...introductionActions,
 			...linkParamsActions,
 			...mediaActions,
+			...newPostTypeNotificationsActions,
 			...notificationsActions,
 			...postTypesActions,
 			...preferencesActions,
@@ -54,6 +61,7 @@ const createStore = ( { initialState } ) => {
 			...introductionSelectors,
 			...linkParamsSelectors,
 			...mediaSelectors,
+			...newPostTypeNotificationsSelectors,
 			...notificationsSelectors,
 			...postTypesSelectors,
 			...preferencesSelectors,
@@ -71,6 +79,7 @@ const createStore = ( { initialState } ) => {
 				introduction: createInitialIntroductionState(),
 				linkParams: createInitialLinkParamsState(),
 				media: createInitialMediaState(),
+				newPostTypeNotifications: createInitialNewPostTypeNotificationsState(),
 				notifications: createInitialNotificationsState(),
 				postTypes: createInitialPostTypesState(),
 				preferences: createInitialPreferencesState(),
@@ -88,6 +97,7 @@ const createStore = ( { initialState } ) => {
 			introduction,
 			linkParams,
 			media,
+			newPostTypeNotifications,
 			notifications,
 			postTypes,
 			preferences,
@@ -101,6 +111,7 @@ const createStore = ( { initialState } ) => {
 			...mediaControls,
 			...usersControls,
 			...introductionControls,
+			...newPostTypeNotificationsControls,
 		},
 	} );
 };

--- a/packages/js/src/settings/store/index.js
+++ b/packages/js/src/settings/store/index.js
@@ -17,6 +17,12 @@ import newPostTypeNotifications, {
 	newPostTypeNotificationsControls,
 	newPostTypeNotificationsSelectors,
 } from "./new-post-type-notifications";
+import newTaxonomyNotifications, {
+	createInitialNewTaxonomyNotificationsState,
+	newTaxonomyNotificationsActions,
+	newTaxonomyNotificationsControls,
+	newTaxonomyNotificationsSelectors,
+} from "./new-taxonomy-notifications";
 import notifications, { createInitialNotificationsState, notificationsActions, notificationsSelectors } from "./notifications";
 import postTypes, { createInitialPostTypesState, postTypesActions, postTypesSelectors } from "./post-types";
 import preferences, { createInitialPreferencesState, preferencesActions, preferencesSelectors } from "./preferences";
@@ -45,6 +51,7 @@ const createStore = ( { initialState } ) => {
 			...linkParamsActions,
 			...mediaActions,
 			...newPostTypeNotificationsActions,
+			...newTaxonomyNotificationsActions,
 			...notificationsActions,
 			...postTypesActions,
 			...preferencesActions,
@@ -62,6 +69,7 @@ const createStore = ( { initialState } ) => {
 			...linkParamsSelectors,
 			...mediaSelectors,
 			...newPostTypeNotificationsSelectors,
+			...newTaxonomyNotificationsSelectors,
 			...notificationsSelectors,
 			...postTypesSelectors,
 			...preferencesSelectors,
@@ -80,6 +88,7 @@ const createStore = ( { initialState } ) => {
 				linkParams: createInitialLinkParamsState(),
 				media: createInitialMediaState(),
 				newPostTypeNotifications: createInitialNewPostTypeNotificationsState(),
+				newTaxonomyNotifications: createInitialNewTaxonomyNotificationsState(),
 				notifications: createInitialNotificationsState(),
 				postTypes: createInitialPostTypesState(),
 				preferences: createInitialPreferencesState(),
@@ -98,6 +107,7 @@ const createStore = ( { initialState } ) => {
 			linkParams,
 			media,
 			newPostTypeNotifications,
+			newTaxonomyNotifications,
 			notifications,
 			postTypes,
 			preferences,
@@ -112,6 +122,7 @@ const createStore = ( { initialState } ) => {
 			...usersControls,
 			...introductionControls,
 			...newPostTypeNotificationsControls,
+			...newTaxonomyNotificationsControls,
 		},
 	} );
 };

--- a/packages/js/src/settings/store/new-post-type-notifications.js
+++ b/packages/js/src/settings/store/new-post-type-notifications.js
@@ -1,0 +1,79 @@
+import { createSelector, createSlice } from "@reduxjs/toolkit";
+import apiFetch from "@wordpress/api-fetch";
+import { get } from "lodash";
+import { ASYNC_ACTION_NAMES, ASYNC_ACTION_STATUS } from "../constants";
+
+export const REMOVE_NEW_POST_TYPE_NOTIFICATION = "removeNewPostTypeNotification";
+
+/**
+ * @param {string} id The notification ID.
+ * @returns {Object} Success or error action object.
+ */
+export function* removeNewPostTypeNotification( id ) {
+	yield{ type: `${ REMOVE_NEW_POST_TYPE_NOTIFICATION }/${ ASYNC_ACTION_NAMES.request }` };
+	try {
+		// Trigger the control flow.
+		yield{
+			type: REMOVE_NEW_POST_TYPE_NOTIFICATION,
+			payload: id,
+		};
+		return { type: `${ REMOVE_NEW_POST_TYPE_NOTIFICATION }/${ ASYNC_ACTION_NAMES.success }`, payload: id };
+	} catch ( error ) {
+		console.error( error );
+		return { type: `${ REMOVE_NEW_POST_TYPE_NOTIFICATION }/${ ASYNC_ACTION_NAMES.error }`, payload: error };
+	}
+}
+
+/**
+ * @returns {Object} The initial state.
+ */
+export const createInitialNewPostTypeNotificationsState = () => ( {
+	ids: [ ...get( window, "wpseoScriptData.newPostTypeNotifications", [] ) ],
+	status: ASYNC_ACTION_STATUS.idle,
+	error: "",
+} );
+
+const slice = createSlice( {
+	name: "newPostTypeNotifications",
+	initialState: createInitialNewPostTypeNotificationsState(),
+	reducers: {},
+	extraReducers: ( builder ) => {
+		builder.addCase( `${ REMOVE_NEW_POST_TYPE_NOTIFICATION }/${ ASYNC_ACTION_NAMES.request }`, ( state ) => {
+			state.status = ASYNC_ACTION_STATUS.loading;
+		} );
+		builder.addCase( `${ REMOVE_NEW_POST_TYPE_NOTIFICATION }/${ ASYNC_ACTION_NAMES.success }`, ( state, { payload } ) => {
+			state.status = ASYNC_ACTION_STATUS.success;
+			state.ids = state.ids.filter( id => id !== payload );
+		} );
+		builder.addCase( `${ REMOVE_NEW_POST_TYPE_NOTIFICATION }/${ ASYNC_ACTION_NAMES.error }`, ( state, { payload } ) => {
+			state.status = ASYNC_ACTION_STATUS.error;
+			state.error = payload;
+		} );
+	},
+} );
+
+export const newPostTypeNotificationsSelectors = {
+	selectNewPostTypeNotifications: state => get( state, "newPostTypeNotifications.ids", [] ),
+};
+newPostTypeNotificationsSelectors.selectHasNewPostTypeNotification = createSelector(
+	[
+		newPostTypeNotificationsSelectors.selectNewPostTypeNotifications,
+		( state, notificationId ) => notificationId,
+	],
+	( newPostTypeNotifications, notificationId ) => newPostTypeNotifications.includes( notificationId )
+);
+
+export const newPostTypeNotificationsActions = {
+	...slice.actions,
+	removeNewPostTypeNotification,
+};
+
+export const newPostTypeNotificationsControls = {
+	[ REMOVE_NEW_POST_TYPE_NOTIFICATION ]: async( { payload } ) => apiFetch( {
+		path: "yoast/v1/settings_introduction/remove_notification",
+		method: "POST",
+		data: { id: payload },
+	} ),
+};
+
+export default slice.reducer;

--- a/packages/js/src/settings/store/new-taxonomy-notifications.js
+++ b/packages/js/src/settings/store/new-taxonomy-notifications.js
@@ -1,0 +1,79 @@
+import { createSelector, createSlice } from "@reduxjs/toolkit";
+import apiFetch from "@wordpress/api-fetch";
+import { get } from "lodash";
+import { ASYNC_ACTION_NAMES, ASYNC_ACTION_STATUS } from "../constants";
+
+export const REMOVE_NEW_TAXONOMY_NOTIFICATION = "removeNewTaxonomyNotification";
+
+/**
+ * @param {string} id The notification ID.
+ * @returns {Object} Success or error action object.
+ */
+export function* removeNewTaxonomyNotification( id ) {
+	yield{ type: `${ REMOVE_NEW_TAXONOMY_NOTIFICATION }/${ ASYNC_ACTION_NAMES.request }` };
+	try {
+		// Trigger the control flow.
+		yield{
+			type: REMOVE_NEW_TAXONOMY_NOTIFICATION,
+			payload: id,
+		};
+		return { type: `${ REMOVE_NEW_TAXONOMY_NOTIFICATION }/${ ASYNC_ACTION_NAMES.success }`, payload: id };
+	} catch ( error ) {
+		console.error( error );
+		return { type: `${ REMOVE_NEW_TAXONOMY_NOTIFICATION }/${ ASYNC_ACTION_NAMES.error }`, payload: error };
+	}
+}
+
+/**
+ * @returns {Object} The initial state.
+ */
+export const createInitialNewTaxonomyNotificationsState = () => ( {
+	ids: [ ...get( window, "wpseoScriptData.newTaxonomyNotifications", [] ) ],
+	status: ASYNC_ACTION_STATUS.idle,
+	error: "",
+} );
+
+const slice = createSlice( {
+	name: "newTaxonomyNotifications",
+	initialState: createInitialNewTaxonomyNotificationsState(),
+	reducers: {},
+	extraReducers: ( builder ) => {
+		builder.addCase( `${ REMOVE_NEW_TAXONOMY_NOTIFICATION }/${ ASYNC_ACTION_NAMES.request }`, ( state ) => {
+			state.status = ASYNC_ACTION_STATUS.loading;
+		} );
+		builder.addCase( `${ REMOVE_NEW_TAXONOMY_NOTIFICATION }/${ ASYNC_ACTION_NAMES.success }`, ( state, { payload } ) => {
+			state.status = ASYNC_ACTION_STATUS.success;
+			state.ids = state.ids.filter( id => id !== payload );
+		} );
+		builder.addCase( `${ REMOVE_NEW_TAXONOMY_NOTIFICATION }/${ ASYNC_ACTION_NAMES.error }`, ( state, { payload } ) => {
+			state.status = ASYNC_ACTION_STATUS.error;
+			state.error = payload;
+		} );
+	},
+} );
+
+export const newTaxonomyNotificationsSelectors = {
+	selectNewTaxonomyNotifications: state => get( state, "newTaxonomyNotifications.ids", [] ),
+};
+newTaxonomyNotificationsSelectors.selectHasNewTaxonomyNotification = createSelector(
+	[
+		newTaxonomyNotificationsSelectors.selectNewTaxonomyNotifications,
+		( state, notificationId ) => notificationId,
+	],
+	( newTaxonomyNotifications, notificationId ) => newTaxonomyNotifications.includes( notificationId )
+);
+
+export const newTaxonomyNotificationsActions = {
+	...slice.actions,
+	removeNewTaxonomyNotification,
+};
+
+export const newTaxonomyNotificationsControls = {
+	[ REMOVE_NEW_TAXONOMY_NOTIFICATION ]: async( { payload } ) => apiFetch( {
+		path: "yoast/v1/settings_introduction/remove_notification",
+		method: "POST",
+		data: { id: payload },
+	} ),
+};
+
+export default slice.reducer;

--- a/src/actions/settings-introduction-action.php
+++ b/src/actions/settings-introduction-action.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\SEO\Actions;
 
 use Exception;
 use Yoast\WP\SEO\Helpers\User_Helper;
+use Yoast_Notification_Center;
 
 /**
  * Settings_Introduction_Action class.
@@ -25,12 +26,24 @@ class Settings_Introduction_Action {
 	private $user_helper;
 
 	/**
+	 * The notifications center.
+	 *
+	 * @var Yoast_Notification_Center
+	 */
+	private $notification_center;
+
+	/**
 	 * Constructs Settings_Introduction_Action.
 	 *
-	 * @param User_Helper $user_helper The User_Helper.
+	 * @param User_Helper               $user_helper         The User_Helper.
+	 * @param Yoast_Notification_Center $notification_center The notification center.
 	 */
-	public function __construct( User_Helper $user_helper ) {
-		$this->user_helper = $user_helper;
+	public function __construct( 
+		User_Helper $user_helper,
+		Yoast_Notification_Center $notification_center
+	) {
+		$this->user_helper         = $user_helper;
+		$this->notification_center = $notification_center;
 	}
 
 	/**
@@ -105,6 +118,25 @@ class Settings_Introduction_Action {
 		$values['show'] = $value;
 
 		return $this->user_helper->update_meta( $user_id, self::USER_META_KEY, $values ) !== false;
+	}
+
+	/**
+	 * Removes a notification related to a post type.
+	 *
+	 * @param string $notification_id The id of the notification to be removed.
+	 *
+	 * @return bool Whether the notification has been removed.
+	 */
+	public function remove_post_type_notification( $notification_id ) {
+		$previous_notifications_count = $this->notification_center->get_notification_count();
+
+		$this->notification_center->remove_notification_by_id( $notification_id );
+
+		if ( $this->notification_center->get_notification_count() < $previous_notifications_count ) {
+			return true;
+		}
+
+		return false;
 	}
 
 	/**

--- a/src/actions/settings-introduction-action.php
+++ b/src/actions/settings-introduction-action.php
@@ -121,13 +121,13 @@ class Settings_Introduction_Action {
 	}
 
 	/**
-	 * Removes a notification related to a post type.
+	 * Removes a notification.
 	 *
 	 * @param string $notification_id The id of the notification to be removed.
 	 *
 	 * @return bool Whether the notification has been removed.
 	 */
-	public function remove_post_type_notification( $notification_id ) {
+	public function remove_notification( $notification_id ) {
 		$previous_notifications_count = $this->notification_center->get_notification_count();
 
 		$this->notification_center->remove_notification_by_id( $notification_id );

--- a/src/actions/settings-introduction-action.php
+++ b/src/actions/settings-introduction-action.php
@@ -38,7 +38,7 @@ class Settings_Introduction_Action {
 	 * @param User_Helper               $user_helper         The User_Helper.
 	 * @param Yoast_Notification_Center $notification_center The notification center.
 	 */
-	public function __construct( 
+	public function __construct(
 		User_Helper $user_helper,
 		Yoast_Notification_Center $notification_center
 	) {

--- a/src/helpers/post-type-helper.php
+++ b/src/helpers/post-type-helper.php
@@ -17,12 +17,21 @@ class Post_Type_Helper {
 	protected $options_helper;
 
 	/**
+	 * The settings helper.
+	 *
+	 * @var Settings_Helper
+	 */
+	protected $settings_helper;
+
+	/**
 	 * Post_Type_Helper constructor.
 	 *
-	 * @param Options_Helper $options_helper The options helper.
+	 * @param Options_Helper  $options_helper  The options helper.
+	 * @param Settings_Helper $settings_helper The settings helper.
 	 */
-	public function __construct( Options_Helper $options_helper ) {
-		$this->options_helper = $options_helper;
+	public function __construct( Options_Helper $options_helper, Settings_Helper $settings_helper ) {
+		$this->options_helper  = $options_helper;
+		$this->settings_helper = $settings_helper;
 	}
 
 	/**
@@ -170,22 +179,12 @@ class Post_Type_Helper {
 	}
 
 	/**
-	 * Gets the passed post type's slug.
+	 * Gets the passed post type's label.
 	 *
 	 * @param string $post_type The name of the post type.
 	 *
-	 * @return string The slug for the post_type. Returns the post type's name if no slug could be found.
+	 * @return string The label for the post_type. Returns the post type's name if no label could be found.
 	 */
-	public function get_post_type_slug( $post_type ) {
-		$post_type_object = \get_post_type_object( $post_type );
-
-		if ( $post_type_object && \property_exists( $post_type_object, 'rewrite' ) && \is_array( $post_type_object->rewrite ) && isset( $post_type_object->rewrite['slug'] ) ) {
-			return $post_type_object->rewrite['slug'];
-		}
-
-		return \strtolower( $post_type_object->name );
-	}
-	
 	public function get_post_type_label( $post_type ) {
 		$post_type_object = \get_post_type_object( $post_type );
 
@@ -194,5 +193,18 @@ class Post_Type_Helper {
 		}
 
 		return $post_type_object->name;
+	}
+
+	/**
+	 * Gets the post type's route used in the settings.
+	 *
+	 * @param string $post_type The name of the post type.
+	 *
+	 * @return string The route for the post_type.
+	 */
+	public function get_post_type_route( $post_type ) {
+		$post_type_object = \get_post_type_object( $post_type );
+
+		return $this->settings_helper->get_route( $post_type_object->name, $post_type_object->rewrite, $post_type_object->rest_base );
 	}
 }

--- a/src/helpers/post-type-helper.php
+++ b/src/helpers/post-type-helper.php
@@ -168,4 +168,21 @@ class Post_Type_Helper {
 
 		return $post_type_objects;
 	}
+
+	/**
+	 * Gets the passed post type's slug.
+	 *
+	 * @param string $post_type The name of the post type.
+	 *
+	 * @return string The slug for the post_type. Returns the post type's name if no slug could be found.
+	 */
+	public function get_post_type_slug( $post_type ) {
+		$post_type_object = \get_post_type_object( $post_type );
+
+		if ( $post_type_object && \property_exists( $post_type_object, 'rewrite' ) && \is_array( $post_type_object->rewrite ) && isset( $post_type_object->rewrite['slug'] ) ) {
+			return $post_type_object->rewrite['slug'];
+		}
+
+		return \strtolower( $post_type_object->name );
+	}
 }

--- a/src/helpers/post-type-helper.php
+++ b/src/helpers/post-type-helper.php
@@ -185,4 +185,14 @@ class Post_Type_Helper {
 
 		return \strtolower( $post_type_object->name );
 	}
+	
+	public function get_post_type_label( $post_type ) {
+		$post_type_object = \get_post_type_object( $post_type );
+
+		if ( $post_type_object && \property_exists( $post_type_object, 'label' ) ) {
+			return $post_type_object->label;
+		}
+
+		return $post_type_object->name;
+	}
 }

--- a/src/helpers/settings-helper.php
+++ b/src/helpers/settings-helper.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Yoast\WP\SEO\Helpers;
+
+/**
+ * A helper object for settings.
+ */
+class Settings_Helper {
+
+	/**
+	 * Gets the route from a name, rewrite and rest_base.
+	 *
+	 * @param string $name      The name.
+	 * @param array  $rewrite   The rewrite data.
+	 * @param string $rest_base The rest base.
+	 *
+	 * @return string The route.
+	 */
+	public function get_route( $name, $rewrite, $rest_base ) {
+		$route = $name;
+		if ( isset( $rewrite['slug'] ) ) {
+			$route = $rewrite['slug'];
+		}
+		if ( ! empty( $rest_base ) ) {
+			$route = $rest_base;
+		}
+		// Always strip leading slashes.
+		while ( \substr( $route, 0, 1 ) === '/' ) {
+			$route = \substr( $route, 1 );
+		}
+
+		return $route;
+	}
+}

--- a/src/helpers/taxonomy-helper.php
+++ b/src/helpers/taxonomy-helper.php
@@ -176,4 +176,14 @@ class Taxonomy_Helper {
 
 		return $taxonomy_objects;
 	}
+
+	public function get_taxonomy_label( $taxonomy ) {
+		$taxonomy_object = \get_taxonomy( $taxonomy );
+
+		if ( $taxonomy_object && \property_exists( $taxonomy_object, 'label' ) ) {
+			return $taxonomy_object->label;
+		}
+
+		return $taxonomy_object->name;
+	}
 }

--- a/src/helpers/taxonomy-helper.php
+++ b/src/helpers/taxonomy-helper.php
@@ -19,6 +19,13 @@ class Taxonomy_Helper {
 	private $options;
 
 	/**
+	 * The settings helper.
+	 *
+	 * @var Settings_Helper
+	 */
+	protected $settings_helper;
+
+	/**
 	 * The string helper.
 	 *
 	 * @var String_Helper
@@ -30,12 +37,14 @@ class Taxonomy_Helper {
 	 *
 	 * @codeCoverageIgnore It only sets dependencies.
 	 *
-	 * @param Options_Helper $options       The options helper.
-	 * @param String_Helper  $string_helper The string helper.
+	 * @param Options_Helper  $options         The options helper.
+	 * @param Settings_Helper $settings_helper The settings helper.
+	 * @param String_Helper   $string_helper   The string helper.
 	 */
-	public function __construct( Options_Helper $options, String_Helper $string_helper ) {
-		$this->options = $options;
-		$this->string  = $string_helper;
+	public function __construct( Options_Helper $options, Settings_Helper $settings_helper, String_Helper $string_helper ) {
+		$this->options         = $options;
+		$this->settings_helper = $settings_helper;
+		$this->string          = $string_helper;
 	}
 
 	/**
@@ -177,6 +186,13 @@ class Taxonomy_Helper {
 		return $taxonomy_objects;
 	}
 
+	/**
+	 * Gets the passed taxonomy's label.
+	 *
+	 * @param string $taxonomy The name of the taxonomy.
+	 *
+	 * @return string The label for the taxonomy. Returns the taxonomy's name if no label could be found.
+	 */
 	public function get_taxonomy_label( $taxonomy ) {
 		$taxonomy_object = \get_taxonomy( $taxonomy );
 
@@ -185,5 +201,18 @@ class Taxonomy_Helper {
 		}
 
 		return $taxonomy_object->name;
+	}
+
+	/**
+	 * Gets the taxonomy's route used in the settings.
+	 *
+	 * @param string $taxonomy The name of the tacxonomy.
+	 *
+	 * @return string The route for the taxonomy.
+	 */
+	public function get_taxonomy_route( $taxonomy ) {
+		$taxonomy_object = \get_taxonomy( $taxonomy );
+
+		return $this->settings_helper->get_route( $taxonomy_object->name, $taxonomy_object->rewrite, $taxonomy_object->rest_base );
 	}
 }

--- a/src/integrations/settings-integration.php
+++ b/src/integrations/settings-integration.php
@@ -404,11 +404,12 @@ class Settings_Integration implements Integration_Interface {
 			'fallbacks'                => $this->get_fallbacks(),
 			'introduction'             => $this->get_introduction_data(),
 			'newPostTypeNotifications' => $this->get_new_post_type_notifications(),
+			'newTaxonomyNotifications' => $this->get_new_taxonomy_notifications(),
 		];
 	}
 
 	/**
-	 * Retrieves the post types that have been recently added as public.
+	 * Retrieves the notification ids related to post types that have been recently added as public.
 	 *
 	 * @return array The notifications ids.
 	 */
@@ -416,10 +417,30 @@ class Settings_Integration implements Integration_Interface {
 		$notifications    = $this->notification_center->get_notifications_for_user( $this->user_helper->get_current_user_id() );
 		$notifications_id = [];
 
-		// We search notifications related to a newly-introduced post type.
+		// We look for notifications related to a newly-introduced post type.
 		foreach ( $notifications as $notification ) {
 			$notification_id = $notification->get_id();
 			if ( str_contains( $notification_id, 'post-type-made-public-' ) ) {
+				$notifications_id[] = $notification_id;
+			}
+		}
+
+		return $notifications_id;
+	}
+
+	/**
+	 * Retrieves the notification ids related to taxonomies that have been recently added as public.
+	 *
+	 * @return array The notifications ids.
+	 */
+	protected function get_new_taxonomy_notifications() {
+		$notifications    = $this->notification_center->get_notifications_for_user( $this->user_helper->get_current_user_id() );
+		$notifications_id = [];
+
+		// We look for notifications related to a newly-introduced taxonomy.
+		foreach ( $notifications as $notification ) {
+			$notification_id = $notification->get_id();
+			if ( str_contains( $notification_id, 'taxonomy-made-public-' ) ) {
 				$notifications_id[] = $notification_id;
 			}
 		}

--- a/src/integrations/settings-integration.php
+++ b/src/integrations/settings-integration.php
@@ -20,6 +20,7 @@ use Yoast\WP\SEO\Helpers\Current_Page_Helper;
 use Yoast\WP\SEO\Helpers\Language_Helper;
 use Yoast\WP\SEO\Helpers\Post_Type_Helper;
 use Yoast\WP\SEO\Helpers\Product_Helper;
+use Yoast\WP\SEO\Helpers\Settings_Helper;
 use Yoast\WP\SEO\Helpers\Schema\Article_Helper;
 use Yoast\WP\SEO\Helpers\Taxonomy_Helper;
 use Yoast\WP\SEO\Helpers\User_Helper;
@@ -144,6 +145,13 @@ class Settings_Integration implements Integration_Interface {
 	protected $product_helper;
 
 	/**
+	 * Holds the Settings_Helper.
+	 *
+	 * @var Settings_Helper
+	 */
+	protected $settings_helper;
+
+	/**
 	 * Holds the Woocommerce_Helper.
 	 *
 	 * @var Woocommerce_Helper
@@ -189,6 +197,7 @@ class Settings_Integration implements Integration_Interface {
 	 * @param Language_Helper              $language_helper              The Language_Helper.
 	 * @param Taxonomy_Helper              $taxonomy_helper              The Taxonomy_Helper.
 	 * @param Product_Helper               $product_helper               The Product_Helper.
+	 * @param Settings_Helper              $settings_helper              The Settings_Helper.
 	 * @param Woocommerce_Helper           $woocommerce_helper           The Woocommerce_Helper.
 	 * @param Article_Helper               $article_helper               The Article_Helper.
 	 * @param User_Helper                  $user_helper                  The User_Helper.
@@ -204,6 +213,7 @@ class Settings_Integration implements Integration_Interface {
 		Language_Helper $language_helper,
 		Taxonomy_Helper $taxonomy_helper,
 		Product_Helper $product_helper,
+		Settings_Helper $settings_helper,
 		Woocommerce_Helper $woocommerce_helper,
 		Article_Helper $article_helper,
 		User_Helper $user_helper,
@@ -218,6 +228,7 @@ class Settings_Integration implements Integration_Interface {
 		$this->post_type_helper             = $post_type_helper;
 		$this->language_helper              = $language_helper;
 		$this->product_helper               = $product_helper;
+		$this->settings_helper              = $settings_helper;
 		$this->woocommerce_helper           = $woocommerce_helper;
 		$this->article_helper               = $article_helper;
 		$this->user_helper                  = $user_helper;
@@ -417,7 +428,7 @@ class Settings_Integration implements Integration_Interface {
 		$notifications    = $this->notification_center->get_notifications_for_user( $this->user_helper->get_current_user_id() );
 		$notifications_id = [];
 
-		// We look for notifications related to a newly-introduced post type.
+		// We look notifications related to a newly-introduced post type.
 		foreach ( $notifications as $notification ) {
 			$notification_id = $notification->get_id();
 			if ( str_contains( $notification_id, 'post-type-made-public-' ) ) {
@@ -758,7 +769,7 @@ class Settings_Integration implements Integration_Interface {
 		foreach ( $post_types as $index => $post_type ) {
 			$transformed[ $post_type->name ] = [
 				'name'                 => $post_type->name,
-				'route'                => $this->get_route( $post_type->name, $post_type->rewrite, $post_type->rest_base ),
+				'route'                => $this->settings_helper->get_route( $post_type->name, $post_type->rewrite, $post_type->rest_base ),
 				'label'                => $post_type->label,
 				'singularLabel'        => $post_type->labels->singular_name,
 				'hasArchive'           => $this->post_type_helper->has_archive( $post_type ),
@@ -809,7 +820,7 @@ class Settings_Integration implements Integration_Interface {
 		foreach ( $taxonomies as $index => $taxonomy ) {
 			$transformed[ $taxonomy->name ] = [
 				'name'          => $taxonomy->name,
-				'route'         => $this->get_route( $taxonomy->name, $taxonomy->rewrite, $taxonomy->rest_base ),
+				'route'         => $this->settings_helper->get_route( $taxonomy->name, $taxonomy->rewrite, $taxonomy->rest_base ),
 				'label'         => $taxonomy->label,
 				'singularLabel' => $taxonomy->labels->singular_name,
 				'postTypes'     => \array_filter(
@@ -829,31 +840,6 @@ class Settings_Integration implements Integration_Interface {
 		);
 
 		return $transformed;
-	}
-
-	/**
-	 * Gets the route from a name, rewrite and rest_base.
-	 *
-	 * @param string $name      The name.
-	 * @param array  $rewrite   The rewrite data.
-	 * @param string $rest_base The rest base.
-	 *
-	 * @return string The route.
-	 */
-	protected function get_route( $name, $rewrite, $rest_base ) {
-		$route = $name;
-		if ( isset( $rewrite['slug'] ) ) {
-			$route = $rewrite['slug'];
-		}
-		if ( ! empty( $rest_base ) ) {
-			$route = $rest_base;
-		}
-		// Always strip leading slashes.
-		while ( \substr( $route, 0, 1 ) === '/' ) {
-			$route = \substr( $route, 1 );
-		}
-
-		return $route;
 	}
 
 	/**

--- a/src/integrations/watchers/indexable-post-type-change-watcher.php
+++ b/src/integrations/watchers/indexable-post-type-change-watcher.php
@@ -154,7 +154,7 @@ class Indexable_Post_Type_Change_Watcher implements Integration_Interface {
 				\wp_schedule_single_event( ( \time() + ( \MINUTE_IN_SECONDS * 5 ) ), Cleanup_Integration::START_HOOK );
 			}
 			// Remove also the notifications issued when the post types have been made public.
-			foreach( $newly_made_non_public_post_types as $post_type_slug ) {
+			foreach ( $newly_made_non_public_post_types as $post_type_slug ) {
 				$this->notification_center->remove_notification_by_id( self::POST_TYPE_ID_PREFIX . "-$post_type_slug" );
 			}
 		}
@@ -162,13 +162,13 @@ class Indexable_Post_Type_Change_Watcher implements Integration_Interface {
 
 	/**
 	 * Decides if a notification should be added in the notification center.
-	 * 
-	 * @param array $newly_made_public_post_types The array of names of newly made public post types. 
+	 *
+	 * @param array $newly_made_public_post_types The array of names of newly made public post types.
 	 *
 	 * @return void
 	 */
 	private function maybe_add_notification( $newly_made_public_post_types ) {
-		foreach( $newly_made_public_post_types as $post_type_slug ) {
+		foreach ( $newly_made_public_post_types as $post_type_slug ) {
 			$post_type_object = \get_post_type_object( $post_type_slug );
 
 			$notification = $this->notification_center->get_notification_by_id( self::POST_TYPE_ID_PREFIX . "-$post_type_slug" );
@@ -183,7 +183,7 @@ class Indexable_Post_Type_Change_Watcher implements Integration_Interface {
 	 *
 	 * @param string $post_type_label The label used for the post type.
 	 * @param string $post_type_slug  The post type slug.
-	 * 
+	 *
 	 * @return void
 	 */
 	private function add_notification( $post_type_label, $post_type_slug ) {

--- a/src/integrations/watchers/indexable-post-type-change-watcher.php
+++ b/src/integrations/watchers/indexable-post-type-change-watcher.php
@@ -106,25 +106,20 @@ class Indexable_Post_Type_Change_Watcher implements Integration_Interface {
 			return;
 		}
 
-		$public_post_types_names = \array_keys( $this->post_type_helper->get_public_post_types() );
-		$public_post_types_slugs = [];
-
-		foreach ( $public_post_types_names as $post_type ) {
-			$public_post_types_slugs[] = $this->post_type_helper->get_post_type_slug( $post_type );
-		}
+		$public_post_types = \array_keys( $this->post_type_helper->get_public_post_types() );
 
 		$last_known_public_post_types = $this->options->get( 'last_known_public_post_types', [] );
 
 		// Initializing the option on the first run.
 		if ( empty( $last_known_public_post_types ) ) {
-			$this->options->set( 'last_known_public_post_types', $public_post_types_slugs );
+			$this->options->set( 'last_known_public_post_types', $public_post_types );
 			return;
 		}
 
 		// We look for new public post types.
-		$newly_made_public_post_types = \array_diff( $public_post_types_slugs, $last_known_public_post_types );
+		$newly_made_public_post_types = \array_diff( $public_post_types, $last_known_public_post_types );
 		// We look for post types that from public have been made private.
-		$newly_made_non_public_post_types = \array_diff( $last_known_public_post_types, $public_post_types_slugs );
+		$newly_made_non_public_post_types = \array_diff( $last_known_public_post_types, $public_post_types );
 
 		// Nothing to be done if no changes has been made to post types.
 		if ( empty( $newly_made_public_post_types ) && ( empty( $newly_made_non_public_post_types ) ) ) {
@@ -132,7 +127,7 @@ class Indexable_Post_Type_Change_Watcher implements Integration_Interface {
 		}
 
 		// Update the list of last known public post types in the database.
-		$this->options->set( 'last_known_public_post_types', $public_post_types_slugs );
+		$this->options->set( 'last_known_public_post_types', $public_post_types );
 
 		// There are new post types that have been made public.
 		if ( ! empty( $newly_made_public_post_types ) ) {
@@ -154,8 +149,8 @@ class Indexable_Post_Type_Change_Watcher implements Integration_Interface {
 				\wp_schedule_single_event( ( \time() + ( \MINUTE_IN_SECONDS * 5 ) ), Cleanup_Integration::START_HOOK );
 			}
 			// Remove also the notifications issued when the post types have been made public.
-			foreach ( $newly_made_non_public_post_types as $post_type_slug ) {
-				$this->notification_center->remove_notification_by_id( self::POST_TYPE_ID_PREFIX . "-$post_type_slug" );
+			foreach ( $newly_made_non_public_post_types as $post_type ) {
+				$this->remove_notification($post_type );
 			}
 		}
 	}
@@ -168,12 +163,13 @@ class Indexable_Post_Type_Change_Watcher implements Integration_Interface {
 	 * @return void
 	 */
 	private function maybe_add_notification( $newly_made_public_post_types ) {
-		foreach ( $newly_made_public_post_types as $post_type_slug ) {
-			$post_type_object = \get_post_type_object( $post_type_slug );
+		foreach ( $newly_made_public_post_types as $post_type ) {
+			$post_type_label = $this->post_type_helper->get_post_type_label( $post_type );
+			$post_type_slug  = $this->post_type_helper->get_post_type_slug( $post_type );
+			$notification    = $this->notification_center->get_notification_by_id( self::POST_TYPE_ID_PREFIX . "-$post_type_slug" );
 
-			$notification = $this->notification_center->get_notification_by_id( self::POST_TYPE_ID_PREFIX . "-$post_type_slug" );
 			if ( \is_null( $notification ) ) {
-				$this->add_notification( $post_type_object->label, $post_type_slug );
+				$this->add_notification( $post_type_label, $post_type_slug );
 			}
 		}
 	}
@@ -206,5 +202,10 @@ class Indexable_Post_Type_Change_Watcher implements Integration_Interface {
 		);
 
 		$this->notification_center->add_notification( $notification );
+	}
+
+	private function remove_notification( $post_type ) {
+		$post_type_slug = $this->post_type_helper->get_post_type_slug( $post_type );
+		$this->notification_center->remove_notification_by_id( self::POST_TYPE_ID_PREFIX . "-$post_type_slug" );
 	}
 }

--- a/src/integrations/watchers/indexable-post-type-change-watcher.php
+++ b/src/integrations/watchers/indexable-post-type-change-watcher.php
@@ -19,6 +19,12 @@ use Yoast_Notification_Center;
  * Post type change watcher.
  */
 class Indexable_Post_Type_Change_Watcher implements Integration_Interface {
+	/**
+	 * Represents the notification id prefix.
+	 *
+	 * @var string
+	 */
+	const POST_TYPE_ID_PREFIX = 'post-type-made-public';
 
 	/**
 	 * The indexing helper.
@@ -154,7 +160,7 @@ class Indexable_Post_Type_Change_Watcher implements Integration_Interface {
 			$post_type_object = \get_post_type_object( $post_type );
 			$post_type_slug = $post_type_object->rewrite !== false ? $post_type_object->rewrite['slug'] : $post_type_object->name;
 
-			$notification = $this->notification_center->get_notification_by_id( "post-types-made-public-$post_type_slug" );
+			$notification = $this->notification_center->get_notification_by_id( self::POST_TYPE_ID_PREFIX . "-$post_type_slug" );
 			if ( \is_null( $notification ) ) {
 				$this->add_notification( $post_type_object->label, $post_type_slug );
 			}
@@ -168,7 +174,7 @@ class Indexable_Post_Type_Change_Watcher implements Integration_Interface {
 	 */
 	private function add_notification( $post_type_label, $post_type_slug ) {
 		$message = \sprintf(
-			/* translators:  1: Opening tag of the link to the Search appearance settings page, 2: Post type name (plural), 3: Link closing tag. */
+			/* translators:  1: Opening tag of the link to the post type search appearance settings page, 2: Post type name (plural), 3: Link closing tag. */
 			\esc_html__( 'It looks like you\'ve added a new type of content to your website. We recommend that you review your search appearance settings for %1$s%2$s%3$s.', 'wordpress-seo' ),
 			'<a href="' . \esc_url( \admin_url( "admin.php?page=wpseo_page_settings#/post-type/$post_type_slug" ) ) . '">',
 			$post_type_label,
@@ -179,7 +185,7 @@ class Indexable_Post_Type_Change_Watcher implements Integration_Interface {
 			$message,
 			[
 				'type'         => Yoast_Notification::WARNING,
-				'id'           => "post-type-made-public-$post_type_slug",
+				'id'           => self::POST_TYPE_ID_PREFIX . "-$post_type_slug",
 				'capabilities' => 'wpseo_manage_options',
 				'priority'     => 0.8,
 			]

--- a/src/integrations/watchers/indexable-post-type-change-watcher.php
+++ b/src/integrations/watchers/indexable-post-type-change-watcher.php
@@ -106,7 +106,7 @@ class Indexable_Post_Type_Change_Watcher implements Integration_Interface {
 			return;
 		}
 
-		$public_post_types = \array_keys( $this->post_type_helper->get_public_post_types() );
+		$public_post_types = $this->post_type_helper->get_indexable_post_types();
 
 		$last_known_public_post_types = $this->options->get( 'last_known_public_post_types', [] );
 
@@ -165,11 +165,11 @@ class Indexable_Post_Type_Change_Watcher implements Integration_Interface {
 	private function maybe_add_notification( $newly_made_public_post_types ) {
 		foreach ( $newly_made_public_post_types as $post_type ) {
 			$post_type_label = $this->post_type_helper->get_post_type_label( $post_type );
-			$post_type_slug  = $this->post_type_helper->get_post_type_slug( $post_type );
-			$notification    = $this->notification_center->get_notification_by_id( self::POST_TYPE_ID_PREFIX . "-$post_type_slug" );
+			$post_type_route  = $this->post_type_helper->get_post_type_route( $post_type );
+			$notification    = $this->notification_center->get_notification_by_id( self::POST_TYPE_ID_PREFIX . "-$post_type_route" );
 
 			if ( \is_null( $notification ) ) {
-				$this->add_notification( $post_type_label, $post_type_slug );
+				$this->add_notification( $post_type_label, $post_type_route );
 			}
 		}
 	}
@@ -178,15 +178,15 @@ class Indexable_Post_Type_Change_Watcher implements Integration_Interface {
 	 * Adds a notification to be shown on the next page request since posts are updated in an ajax request.
 	 *
 	 * @param string $post_type_label The label used for the post type.
-	 * @param string $post_type_slug  The post type slug.
+	 * @param string $post_type_route  The post type slug.
 	 *
 	 * @return void
 	 */
-	private function add_notification( $post_type_label, $post_type_slug ) {
+	private function add_notification( $post_type_label, $post_type_route ) {
 		$message = \sprintf(
 			/* translators:  1: Opening tag of the link to the post type search appearance settings page, 2: Post type name (plural), 3: Link closing tag. */
 			\esc_html__( 'It looks like you\'ve added a new type of content to your website. We recommend that you review your search appearance settings for %1$s%2$s%3$s.', 'wordpress-seo' ),
-			'<a href="' . \esc_url( \admin_url( "admin.php?page=wpseo_page_settings#/post-type/$post_type_slug" ) ) . '">',
+			'<a href="' . \esc_url( \admin_url( "admin.php?page=wpseo_page_settings#/post-type/$post_type_route" ) ) . '">',
 			$post_type_label,
 			'</a>'
 		);
@@ -195,7 +195,7 @@ class Indexable_Post_Type_Change_Watcher implements Integration_Interface {
 			$message,
 			[
 				'type'         => Yoast_Notification::WARNING,
-				'id'           => self::POST_TYPE_ID_PREFIX . "-$post_type_slug",
+				'id'           => self::POST_TYPE_ID_PREFIX . "-$post_type_route",
 				'capabilities' => 'wpseo_manage_options',
 				'priority'     => 0.8,
 			]
@@ -205,7 +205,7 @@ class Indexable_Post_Type_Change_Watcher implements Integration_Interface {
 	}
 
 	private function remove_notification( $post_type ) {
-		$post_type_slug = $this->post_type_helper->get_post_type_slug( $post_type );
-		$this->notification_center->remove_notification_by_id( self::POST_TYPE_ID_PREFIX . "-$post_type_slug" );
+		$post_type_route = $this->post_type_helper->get_post_type_route( $post_type );
+		$this->notification_center->remove_notification_by_id( self::POST_TYPE_ID_PREFIX . "-$post_type_route" );
 	}
 }

--- a/src/integrations/watchers/indexable-taxonomy-change-watcher.php
+++ b/src/integrations/watchers/indexable-taxonomy-change-watcher.php
@@ -165,12 +165,14 @@ class Indexable_Taxonomy_Change_Watcher implements Integration_Interface {
 	/**
 	 * Decides if a notification should be added in the notification center.
 	 *
+	 * @param array $newly_made_public_taxonomies The array of names of newly made public taxonomies.
+	 *
 	 * @return void
 	 */
 	private function maybe_add_notification( $newly_made_public_taxonomies ) {
-		foreach( $newly_made_public_taxonomies as $taxonomy_slug ) {
+		foreach ( $newly_made_public_taxonomies as $taxonomy_slug ) {
 			$taxonomy_object = \get_taxonomy( $taxonomy_slug );
-			$notification = $this->notification_center->get_notification_by_id( self::TAXONOMY_ID_PREFIX . "-$taxonomy_slug" );
+			$notification    = $this->notification_center->get_notification_by_id( self::TAXONOMY_ID_PREFIX . "-$taxonomy_slug" );
 			if ( \is_null( $notification ) ) {
 				$this->add_notification( $taxonomy_object->label, $taxonomy_slug );
 			}
@@ -179,6 +181,9 @@ class Indexable_Taxonomy_Change_Watcher implements Integration_Interface {
 
 	/**
 	 * Adds a notification to be shown on the next page request since posts are updated in an ajax request.
+	 *
+	 * @param string $taxonomy_label The label used for the taxonomy.
+	 * @param string $taxonomy_slug  The taxonomy slug.
 	 *
 	 * @return void
 	 */
@@ -202,19 +207,5 @@ class Indexable_Taxonomy_Change_Watcher implements Integration_Interface {
 		);
 
 		$this->notification_center->add_notification( $notification );
-	}
-
-	/**
-	 * Removes the notification related to a taxonomy.
-	 * 
-	 * @param string $post_type The name of the taxonomy related to the notification to be removed. 
-	 *
-	 * @return void
-	 */
-	private function remove_notification( $taxonomy_slug ) {
-		$taxonomy_object = \get_taxonomy( $taxonomy );
-		$taxonomy_slug = $taxonomy_object->rewrite !== false ? $taxonomy_object->rewrite['slug'] : $taxonomy_object->name;
-		// No check needed, if the notification does not exist, remove_notification_by_id silently returns.
-		$this->notification_center->remove_notification_by_id( self::TAXONOMY_ID_PREFIX . "-$taxonomy_slug" );
 	}
 }

--- a/src/integrations/watchers/indexable-taxonomy-change-watcher.php
+++ b/src/integrations/watchers/indexable-taxonomy-change-watcher.php
@@ -108,19 +108,25 @@ class Indexable_Taxonomy_Change_Watcher implements Integration_Interface {
 			return;
 		}
 
-		$public_taxonomies            = \array_keys( $this->taxonomy_helper->get_public_taxonomies() );
+		$public_taxonomies_names = \array_keys( $this->taxonomy_helper->get_public_taxonomies() );
+		$public_taxonomies_slugs = [];
+
+		foreach ( $public_taxonomies_names as $taxonomy ) {
+			$public_taxonomies_slugs[] = $this->taxonomy_helper->get_taxonomy_slug( $taxonomy );
+		}
+
 		$last_known_public_taxonomies = $this->options->get( 'last_known_public_taxonomies', [] );
 
 		// Initializing the option on the first run.
 		if ( empty( $last_known_public_taxonomies ) ) {
-			$this->options->set( 'last_known_public_taxonomies', $public_taxonomies );
+			$this->options->set( 'last_known_public_taxonomies', $public_taxonomies_slugs );
 			return;
 		}
 
 		// We look for new public taxonomies.
-		$newly_made_public_taxonomies = \array_diff( $public_taxonomies, $last_known_public_taxonomies );
+		$newly_made_public_taxonomies = \array_diff( $public_taxonomies_slugs, $last_known_public_taxonomies );
 		// We look fortaxonomies that from public have been made private.
-		$newly_made_non_public_taxonomies = \array_diff( $last_known_public_taxonomies, $public_taxonomies );
+		$newly_made_non_public_taxonomies = \array_diff( $last_known_public_taxonomies, $public_taxonomies_slugs );
 
 		// Nothing to be done if no changes has been made to taxonomies.
 		if ( empty( $newly_made_public_taxonomies ) && ( empty( $newly_made_non_public_taxonomies ) ) ) {
@@ -128,7 +134,7 @@ class Indexable_Taxonomy_Change_Watcher implements Integration_Interface {
 		}
 
 		// Update the list of last known public taxonomies in the database.
-		$this->options->set( 'last_known_public_taxonomies', $public_taxonomies );
+		$this->options->set( 'last_known_public_taxonomies', $public_taxonomies_slugs );
 
 		// There are new taxonomies that have been made public.
 		if ( ! empty( $newly_made_public_taxonomies ) ) {
@@ -149,6 +155,10 @@ class Indexable_Taxonomy_Change_Watcher implements Integration_Interface {
 			if ( $cleanup_not_yet_scheduled ) {
 				\wp_schedule_single_event( ( \time() + ( \MINUTE_IN_SECONDS * 5 ) ), Cleanup_Integration::START_HOOK );
 			}
+			// Remove also the notifications issued when the taxonomies have been made public.
+			foreach ( $newly_made_non_public_taxonomies as $taxonomy_slug ) {
+				$this->notification_center->remove_notification_by_id( self::TAXONOMY_ID_PREFIX . "-$taxonomy_slug" );
+			}
 		}
 	}
 
@@ -158,10 +168,8 @@ class Indexable_Taxonomy_Change_Watcher implements Integration_Interface {
 	 * @return void
 	 */
 	private function maybe_add_notification( $newly_made_public_taxonomies ) {
-		foreach( $newly_made_public_taxonomies as $taxonomy ) {
-			$taxonomy_object = \get_taxonomy( $taxonomy );
-			$taxonomy_slug = $taxonomy_object->rewrite !== false ? $taxonomy_object->rewrite['slug'] : $taxonomy_object->name;
-
+		foreach( $newly_made_public_taxonomies as $taxonomy_slug ) {
+			$taxonomy_object = \get_taxonomy( $taxonomy_slug );
 			$notification = $this->notification_center->get_notification_by_id( self::TAXONOMY_ID_PREFIX . "-$taxonomy_slug" );
 			if ( \is_null( $notification ) ) {
 				$this->add_notification( $taxonomy_object->label, $taxonomy_slug );
@@ -194,5 +202,19 @@ class Indexable_Taxonomy_Change_Watcher implements Integration_Interface {
 		);
 
 		$this->notification_center->add_notification( $notification );
+	}
+
+	/**
+	 * Removes the notification related to a taxonomy.
+	 * 
+	 * @param string $post_type The name of the taxonomy related to the notification to be removed. 
+	 *
+	 * @return void
+	 */
+	private function remove_notification( $taxonomy_slug ) {
+		$taxonomy_object = \get_taxonomy( $taxonomy );
+		$taxonomy_slug = $taxonomy_object->rewrite !== false ? $taxonomy_object->rewrite['slug'] : $taxonomy_object->name;
+		// No check needed, if the notification does not exist, remove_notification_by_id silently returns.
+		$this->notification_center->remove_notification_by_id( self::TAXONOMY_ID_PREFIX . "-$taxonomy_slug" );
 	}
 }

--- a/src/routes/settings-introduction-route.php
+++ b/src/routes/settings-introduction-route.php
@@ -37,6 +37,13 @@ class Settings_Introduction_Route implements Route_Interface {
 	const SHOW = self::ROUTE_PREFIX . '/show';
 
 	/**
+	 * Represents removing a notification related to a new post type
+	 *
+	 * @var string
+	 */
+	const REMOVE_POST_TYPE_NOTIFICATION = self::ROUTE_PREFIX . '/remove_post_type_notification';
+
+	/**
 	 * Holds the Settings_Introduction_Action.
 	 *
 	 * @var Settings_Introduction_Action
@@ -114,6 +121,24 @@ class Settings_Introduction_Route implements Route_Interface {
 						'value' => [
 							'required' => true,
 							'type'     => 'bool',
+						],
+					],
+				],
+			]
+		);
+
+		\register_rest_route(
+			Main::API_V1_NAMESPACE,
+			self::REMOVE_POST_TYPE_NOTIFICATION,
+			[
+				[
+					'methods'             => 'POST',
+					'callback'            => [ $this, 'remove_post_type_notification' ],
+					'permission_callback' => [ $this, 'permission_manage_options' ],
+					'args'                => [
+						'id' => [
+							'required' => true,
+							'type'     => 'string',
 						],
 					],
 				],
@@ -215,6 +240,37 @@ class Settings_Introduction_Route implements Route_Interface {
 
 		try {
 			$result = $this->settings_introduction_action->set_show( $value );
+		} catch ( Exception $exception ) {
+			return new WP_Error(
+				'wpseo_settings_introduction_error',
+				$exception->getMessage(),
+				(object) []
+			);
+		}
+
+		return new WP_REST_Response(
+			[
+				'json' => (object) [
+					'success' => $result,
+				],
+			],
+			( $result ) ? 200 : 400
+		);
+	}
+
+	/**
+	 * Removes a notification related to a new post type
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 *
+	 * @return WP_REST_Response|WP_Error The success or failure response.
+	 */
+	public function remove_post_type_notification( WP_REST_Request $request ) {
+		$params          = $request->get_json_params();
+		$notification_id = $params['id'];
+
+		try {
+			$result = $this->settings_introduction_action->remove_post_type_notification( $notification_id );
 		} catch ( Exception $exception ) {
 			return new WP_Error(
 				'wpseo_settings_introduction_error',

--- a/src/routes/settings-introduction-route.php
+++ b/src/routes/settings-introduction-route.php
@@ -41,7 +41,7 @@ class Settings_Introduction_Route implements Route_Interface {
 	 *
 	 * @var string
 	 */
-	const REMOVE_POST_TYPE_NOTIFICATION = self::ROUTE_PREFIX . '/remove_post_type_notification';
+	const REMOVE_NOTIFICATION = self::ROUTE_PREFIX . '/remove_notification';
 
 	/**
 	 * Holds the Settings_Introduction_Action.
@@ -129,11 +129,11 @@ class Settings_Introduction_Route implements Route_Interface {
 
 		\register_rest_route(
 			Main::API_V1_NAMESPACE,
-			self::REMOVE_POST_TYPE_NOTIFICATION,
+			self::REMOVE_NOTIFICATION,
 			[
 				[
 					'methods'             => 'POST',
-					'callback'            => [ $this, 'remove_post_type_notification' ],
+					'callback'            => [ $this, 'remove_notification' ],
 					'permission_callback' => [ $this, 'permission_manage_options' ],
 					'args'                => [
 						'id' => [
@@ -259,18 +259,18 @@ class Settings_Introduction_Route implements Route_Interface {
 	}
 
 	/**
-	 * Removes a notification related to a new post type
+	 * Removes a notification.
 	 *
 	 * @param WP_REST_Request $request The request object.
 	 *
 	 * @return WP_REST_Response|WP_Error The success or failure response.
 	 */
-	public function remove_post_type_notification( WP_REST_Request $request ) {
+	public function remove_notification( WP_REST_Request $request ) {
 		$params          = $request->get_json_params();
 		$notification_id = $params['id'];
 
 		try {
-			$result = $this->settings_introduction_action->remove_post_type_notification( $notification_id );
+			$result = $this->settings_introduction_action->remove_notification( $notification_id );
 		} catch ( Exception $exception ) {
 			return new WP_Error(
 				'wpseo_settings_introduction_error',

--- a/src/routes/settings-introduction-route.php
+++ b/src/routes/settings-introduction-route.php
@@ -269,15 +269,7 @@ class Settings_Introduction_Route implements Route_Interface {
 		$params          = $request->get_json_params();
 		$notification_id = $params['id'];
 
-		try {
-			$result = $this->settings_introduction_action->remove_notification( $notification_id );
-		} catch ( Exception $exception ) {
-			return new WP_Error(
-				'wpseo_settings_introduction_error',
-				$exception->getMessage(),
-				(object) []
-			);
-		}
+		$result = $this->settings_introduction_action->remove_notification( $notification_id );
 
 		return new WP_REST_Response(
 			[

--- a/src/surfaces/helpers-surface.php
+++ b/src/surfaces/helpers-surface.php
@@ -38,6 +38,7 @@ use YoastSEO_Vendor\Symfony\Component\DependencyInjection\ContainerInterface;
  * @property Helpers\Require_File_Helper $require_file
  * @property Helpers\Robots_Helper       $robots
  * @property Helpers\Short_Link_Helper   $short_link
+ * @property Helpers\Settings_Helper     $settings
  * @property Helpers\Site_Helper         $site
  * @property Helpers\String_Helper       $string
  * @property Helpers\Taxonomy_Helper     $taxonomy

--- a/tests/unit/actions/settings-introduction-action-test.php
+++ b/tests/unit/actions/settings-introduction-action-test.php
@@ -52,10 +52,10 @@ class Settings_Introduction_Action_Test extends TestCase {
 		parent::set_up();
 
 		$this->user_helper = Mockery::mock( User_Helper::class );
-		
+
 		$this->notification_center = Mockery::mock( Yoast_Notification_Center::class );
 
-		$this->instance = new Settings_Introduction_Action( 
+		$this->instance = new Settings_Introduction_Action(
 			$this->user_helper,
 			$this->notification_center
 		);
@@ -290,24 +290,24 @@ class Settings_Introduction_Action_Test extends TestCase {
 	 * @param int  $second_count The number of notifications after the removal.
 	 * @param bool $expected     The expected result.
 	 */
-	public function test_remove_notification(  $first_count, $second_count, $expected ) {
+	public function test_remove_notification( $first_count, $second_count, $expected ) {
 
 		$this->notification_center
 			->expects( 'get_notification_count' )
 			->once()
 			->andReturn( $first_count );
-		
+
 		$this->notification_center
 			->expects( 'remove_notification_by_id' )
 			->once()
 			->andReturns();
-		
-			$this->notification_center
-			->expects( 'get_notification_count' )
-			->once()
-			->andReturn( $second_count );
 
-		$this->assertEquals( $expected, $this->instance->remove_notification('test-id') );
+			$this->notification_center
+				->expects( 'get_notification_count' )
+				->once()
+				->andReturn( $second_count );
+
+		$this->assertEquals( $expected, $this->instance->remove_notification( 'test-id' ) );
 	}
 
 	/**

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -56,9 +56,11 @@ Yoast\WPTestUtils\BrainMonkey\makeDoublesForUnavailableClasses(
 	[
 		'WP',
 		'WP_Post',
+		'WP_Post_Type',
 		'WP_Query',
 		'WP_Rewrite',
 		'WP_Roles',
+		'WP_Taxonomy',
 		'WP_Term',
 		'WP_User',
 		'wpdb',

--- a/tests/unit/helpers/settings-helper-test.php
+++ b/tests/unit/helpers/settings-helper-test.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Helpers;
+
+use Brain\Monkey;
+use Mockery;
+use WP_Query;
+use WP_Rewrite;
+use Yoast\WP\SEO\Helpers\Settings_Helper;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+use Yoast\WP\SEO\Wrappers\WP_Query_Wrapper;
+use Yoast\WP\SEO\Wrappers\WP_Rewrite_Wrapper;
+
+/**
+ * Class Settings_Helper_Test.
+ *
+ * @group helpers
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Helpers\Settings_Helper
+ */
+class Settings_Helper_Test extends TestCase {
+
+	/**
+	 * Class instance to use for the test.
+	 *
+	 * @var Settings_Helper
+	 */
+	protected $instance;
+
+	/**
+	 * Sets up the test class.
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->instance = new Settings_Helper();
+	}
+
+	/**
+	 * Tests the get_route method.
+	 *
+	 * @covers ::get_route
+	 *
+	 * @dataProvider get_route_provider
+	 *
+	 * @param string $name      The name.
+	 * @param array  $rewrite   The rewrite data.
+	 * @param string $rest_base The rest base.
+	 * @param string $expected  The expected route.
+	 */
+	public function test_get_route( $name, $rewrite, $rest_base, $expected ) {
+		$this->assertEquals( $this->instance->get_route( $name, $rewrite, $rest_base ), $expected );
+	}
+
+	/**
+	 * Data provider for tet_get_route.
+	 *
+	 * @covers ::get_route
+	 *
+	 * @return array
+	 */
+	public function get_route_provider() {
+		return [
+			[
+				'name',
+				[ 'slug' => 'slug' ],
+				'rest_base',
+				'rest_base',
+			],
+			[
+				'name',
+				[ 'slug' => 'slug' ],
+				null,
+				'slug',
+			],
+			[
+				'name',
+				null,
+				null,
+				'name',
+			],
+			[
+				'name',
+				null,
+				'rest_base',
+				'rest_base',
+			],
+		];
+	}
+}

--- a/tests/unit/helpers/taxonomy-helper-test.php
+++ b/tests/unit/helpers/taxonomy-helper-test.php
@@ -5,6 +5,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Helpers;
 use Brain\Monkey\Functions;
 use Mockery;
 use Yoast\WP\SEO\Helpers\Options_Helper;
+use Yoast\WP\SEO\Helpers\Settings_Helper;
 use Yoast\WP\SEO\Helpers\String_Helper;
 use Yoast\WP\SEO\Helpers\Taxonomy_Helper;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
@@ -33,6 +34,13 @@ class Taxonomy_Helper_Test extends TestCase {
 	private $options;
 
 	/**
+	 * The settings helper.
+	 *
+	 * @var Mockery\MockInterface|Settings_Helper
+	 */
+	protected $settings_helper;
+
+	/**
 	 * Represents the string helper.
 	 *
 	 * @var Mockery\MockInterface|String_Helper
@@ -45,9 +53,10 @@ class Taxonomy_Helper_Test extends TestCase {
 	protected function set_up() {
 		parent::set_up();
 
-		$this->options  = Mockery::mock( Options_Helper::class );
-		$this->string   = Mockery::mock( String_Helper::class );
-		$this->instance = Mockery::mock( Taxonomy_Helper::class, [ $this->options, $this->string ] )->makePartial();
+		$this->options         = Mockery::mock( Options_Helper::class );
+		$this->settings_helper = Mockery::mock( Settings_Helper::class );
+		$this->string          = Mockery::mock( String_Helper::class );
+		$this->instance        = Mockery::mock( Taxonomy_Helper::class, [ $this->options, $this->settings_helper, $this->string ] )->makePartial();
 	}
 
 	/**

--- a/tests/unit/integrations/settings-integration-test.php
+++ b/tests/unit/integrations/settings-integration-test.php
@@ -19,6 +19,7 @@ use Yoast\WP\SEO\Helpers\User_Helper;
 use Yoast\WP\SEO\Helpers\Woocommerce_Helper;
 use Yoast\WP\SEO\Integrations\Settings_Integration;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
+use Yoast_Notification_Center;
 
 /**
  * Class Settings_Integration_Test.
@@ -52,6 +53,7 @@ class Settings_Integration_Test extends TestCase {
 		$article_helper               = Mockery::mock( Article_Helper::class );
 		$user_helper                  = Mockery::mock( User_Helper::class );
 		$settings_introduction_action = Mockery::mock( Settings_Introduction_Action::class );
+		$notification_center          = Mockery::mock( Yoast_Notification_Center::class );
 
 		$this->instance = new Settings_Integration(
 			$asset_manager,
@@ -65,7 +67,8 @@ class Settings_Integration_Test extends TestCase {
 			$woocommerce_helper,
 			$article_helper,
 			$user_helper,
-			$settings_introduction_action
+			$settings_introduction_action,
+			$notification_center
 		);
 	}
 

--- a/tests/unit/integrations/settings-integration-test.php
+++ b/tests/unit/integrations/settings-integration-test.php
@@ -50,7 +50,7 @@ class Settings_Integration_Test extends TestCase {
 		$language_helper              = Mockery::mock( Language_Helper::class );
 		$taxonomy_helper              = Mockery::mock( Taxonomy_Helper::class );
 		$product_helper               = Mockery::mock( Product_Helper::class );
-		$settings_helper			  = Mockery::mock( Settings_Helper::class );
+		$settings_helper              = Mockery::mock( Settings_Helper::class );
 		$woocommerce_helper           = Mockery::mock( Woocommerce_Helper::class );
 		$article_helper               = Mockery::mock( Article_Helper::class );
 		$user_helper                  = Mockery::mock( User_Helper::class );

--- a/tests/unit/integrations/settings-integration-test.php
+++ b/tests/unit/integrations/settings-integration-test.php
@@ -13,6 +13,7 @@ use Yoast\WP\SEO\Helpers\Current_Page_Helper;
 use Yoast\WP\SEO\Helpers\Language_Helper;
 use Yoast\WP\SEO\Helpers\Post_Type_Helper;
 use Yoast\WP\SEO\Helpers\Product_Helper;
+use Yoast\WP\SEO\Helpers\Settings_Helper;
 use Yoast\WP\SEO\Helpers\Schema\Article_Helper;
 use Yoast\WP\SEO\Helpers\Taxonomy_Helper;
 use Yoast\WP\SEO\Helpers\User_Helper;
@@ -49,6 +50,7 @@ class Settings_Integration_Test extends TestCase {
 		$language_helper              = Mockery::mock( Language_Helper::class );
 		$taxonomy_helper              = Mockery::mock( Taxonomy_Helper::class );
 		$product_helper               = Mockery::mock( Product_Helper::class );
+		$settings_helper			  = Mockery::mock( Settings_Helper::class );
 		$woocommerce_helper           = Mockery::mock( Woocommerce_Helper::class );
 		$article_helper               = Mockery::mock( Article_Helper::class );
 		$user_helper                  = Mockery::mock( User_Helper::class );
@@ -64,6 +66,7 @@ class Settings_Integration_Test extends TestCase {
 			$language_helper,
 			$taxonomy_helper,
 			$product_helper,
+			$settings_helper,
 			$woocommerce_helper,
 			$article_helper,
 			$user_helper,

--- a/tests/unit/integrations/watchers/indexable-post-type-change-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-post-type-change-watcher-test.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Integrations\Watchers;
 
 use Brain\Monkey\Functions;
 use Mockery;
+use WP_Post_Type;
 use Yoast\WP\SEO\Actions\Indexing\Indexable_Post_Indexation_Action;
 use Yoast\WP\SEO\Conditionals\Admin_Conditional;
 use Yoast\WP\SEO\Conditionals\Migrations_Conditional;
@@ -16,8 +17,6 @@ use Yoast\WP\SEO\Integrations\Cleanup_Integration;
 use Yoast\WP\SEO\Integrations\Watchers\Indexable_Post_Type_Change_Watcher;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 use Yoast_Notification_Center;
-
-use WP_Post_Type;
 /**
  * Class Indexable_Post_Type_Change_Watcher_Test.
  *
@@ -68,6 +67,13 @@ class Indexable_Post_Type_Change_Watcher_Test extends TestCase {
 	private $instance;
 
 	/**
+	 * Holds the post type objects.
+	 *
+	 * @var WP_Post_Type[]
+	 */
+	private $post_type_objects_array;
+
+	/**
 	 * Sets up the test fixtures.
 	 */
 	protected function set_up() {
@@ -84,6 +90,20 @@ class Indexable_Post_Type_Change_Watcher_Test extends TestCase {
 			$this->post_type_helper,
 			$this->notification_center
 		);
+
+		$post_type            = Mockery::mock( WP_Post_Type::class );
+		$post_type->name      = 'test';
+		$post_type->rewrite   = [ 'slug' => 'test_rewrite' ];
+		$post_type->rest_base = 'test_route';
+
+		$this->post_type_objects_array[] = $post_type;
+
+		$post_type            = Mockery::mock( WP_Post_Type::class );
+		$post_type->name      = 'test2';
+		$post_type->rewrite   = [ 'slug' => 'test_rewrite2' ];
+		$post_type->rest_base = 'test_route2';
+
+		$this->post_type_objects_array[] = $post_type;
 	}
 
 	/**
@@ -119,20 +139,6 @@ class Indexable_Post_Type_Change_Watcher_Test extends TestCase {
 	 * @covers ::check_post_types_public_availability
 	 */
 	public function test_check_post_types_public_availability_new_post_type_added() {
-		$post_type            = Mockery::mock( WP_Post_Type::class )->makePartial();
-		$post_type->name      = 'test';
-		$post_type->rewrite   = 'test_rewrite';
-		$post_type->rest_base = 'test_route';
-
-		$indexable_post_type_objects[] = $post_type;
-
-		$post_type            = Mockery::mock( WP_Post_Type::class )->makePartial();
-		$post_type->name      = 'test2';
-		$post_type->rewrite   = 'test_rewrite2';
-		$post_type->rest_base = 'test_route2';
-
-		$indexable_post_type_objects[] = $post_type;
-
 		Functions\expect( 'wp_is_json_request' )
 			->once()
 			->andReturn( false );
@@ -140,7 +146,7 @@ class Indexable_Post_Type_Change_Watcher_Test extends TestCase {
 		$this->post_type_helper
 			->expects( 'get_indexable_post_type_objects' )
 			->once()
-			->andReturn( $indexable_post_type_objects );
+			->andReturn( $this->post_type_objects_array );
 
 		$this->post_type_helper
 			->expects( 'get_post_type_route' )
@@ -197,13 +203,6 @@ class Indexable_Post_Type_Change_Watcher_Test extends TestCase {
 	 * @covers ::check_post_types_public_availability
 	 */
 	public function test_check_post_types_public_availability_post_type_removed() {
-		$post_type            = Mockery::mock( WP_Post_Type::class )->makePartial();
-		$post_type->name      = 'test';
-		$post_type->rewrite   = 'test_rewrite';
-		$post_type->rest_base = 'test_route';
-
-		$indexable_post_type_objects[] = $post_type;
-
 		Functions\expect( 'wp_is_json_request' )
 			->once()
 			->andReturn( false );
@@ -211,7 +210,7 @@ class Indexable_Post_Type_Change_Watcher_Test extends TestCase {
 		$this->post_type_helper
 			->expects( 'get_indexable_post_type_objects' )
 			->once()
-			->andReturn( $indexable_post_type_objects );
+			->andReturn( \array_slice( $this->post_type_objects_array, 0, 1 ) );
 
 		$this->post_type_helper
 			->expects( 'get_post_type_route' )

--- a/tests/unit/integrations/watchers/indexable-taxonomy-change-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-taxonomy-change-watcher-test.php
@@ -67,6 +67,13 @@ class Indexable_Taxonomy_Change_Watcher_Test extends TestCase {
 	 */
 	private $instance;
 
+	/*
+	 * Holds the taxonomies array.
+	 *
+	 * @var array
+	 */
+	private $taxonomies_array;
+
 	/**
 	 * Sets up the test fixtures.
 	 */
@@ -84,6 +91,20 @@ class Indexable_Taxonomy_Change_Watcher_Test extends TestCase {
 			$this->taxonomy_helper,
 			$this->notification_center
 		);
+
+		$taxonomy            = Mockery::mock( WP_Taxonomy::class );
+		$taxonomy->name      = 'test';
+		$taxonomy->rewrite   = 'test_rewrite';
+		$taxonomy->rest_base = 'test_route';
+
+		$this->taxonomies_array[] = $taxonomy;
+
+		$taxonomy            = Mockery::mock( WP_Taxonomy::class );
+		$taxonomy->name      = 'test2';
+		$taxonomy->rewrite   = 'test_rewrite2';
+		$taxonomy->rest_base = 'test_route2';
+
+		$this->taxonomies_array[] = $taxonomy;
 	}
 
 	/**
@@ -119,20 +140,6 @@ class Indexable_Taxonomy_Change_Watcher_Test extends TestCase {
 	 * @covers ::check_taxonomy_public_availability
 	 */
 	public function test_check_taxonomy_public_availability_new_taxonomy_added() {
-		$taxonomy            = Mockery::mock( WP_Taxonomy::class );
-		$taxonomy->name      = 'test';
-		$taxonomy->rewrite   = 'test_rewrite';
-		$taxonomy->rest_base = 'test_route';
-
-		$indexable_taxonomy_objects[] = $taxonomy;
-
-		$taxonomy            = Mockery::mock( WP_Taxonomy::class );
-		$taxonomy->name      = 'test2';
-		$taxonomy->rewrite   = 'test_rewrite2';
-		$taxonomy->rest_base = 'test_route2';
-
-		$indexable_taxonomy_objects[] = $taxonomy;
-
 		Functions\expect( 'wp_is_json_request' )
 			->once()
 			->andReturn( false );
@@ -140,7 +147,7 @@ class Indexable_Taxonomy_Change_Watcher_Test extends TestCase {
 		$this->taxonomy_helper
 			->expects( 'get_indexable_taxonomy_objects' )
 			->once()
-			->andReturn( $indexable_taxonomy_objects );
+			->andReturn( $this->taxonomies_array );
 
 		$this->taxonomy_helper
 			->expects( 'get_taxonomy_route' )
@@ -197,13 +204,6 @@ class Indexable_Taxonomy_Change_Watcher_Test extends TestCase {
 		 * @covers ::check_taxonomy_public_availability
 		 */
 	public function test_check_taxonomy_public_availability_taxonomy_removed() {
-		$taxonomy = Mockery::mock( WP_Taxonomy::class );
-		$taxonomy->name      = 'test';
-		$taxonomy->rewrite   = 'test_rewrite';
-		$taxonomy->rest_base = 'test_route';
-
-		$indexable_taxonomy_objects[] = $taxonomy;
-
 		Functions\expect( 'wp_is_json_request' )
 			->once()
 			->andReturn( false );
@@ -211,7 +211,7 @@ class Indexable_Taxonomy_Change_Watcher_Test extends TestCase {
 		$this->taxonomy_helper
 			->expects( 'get_indexable_taxonomy_objects' )
 			->once()
-			->andReturn( $indexable_taxonomy_objects );
+			->andReturn( \array_slice( $this->taxonomies_array, 0, 1 ) );
 
 		$this->taxonomy_helper
 			->expects( 'get_taxonomy_route' )

--- a/tests/unit/integrations/watchers/indexable-taxonomy-change-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-taxonomy-change-watcher-test.php
@@ -4,7 +4,6 @@ namespace Yoast\WP\SEO\Tests\Unit\Integrations\Watchers;
 
 use Brain\Monkey\Functions;
 use Mockery;
-use WP_Taxonomy;
 use Yoast_Notification_Center;
 use Yoast\WP\SEO\Actions\Indexing\Indexable_Term_Indexation_Action;
 use Yoast\WP\SEO\Conditionals\Admin_Conditional;
@@ -67,7 +66,7 @@ class Indexable_Taxonomy_Change_Watcher_Test extends TestCase {
 	 */
 	private $instance;
 
-	/*
+	/**
 	 * Holds the taxonomies array.
 	 *
 	 * @var array
@@ -92,14 +91,14 @@ class Indexable_Taxonomy_Change_Watcher_Test extends TestCase {
 			$this->notification_center
 		);
 
-		$taxonomy            = Mockery::mock( WP_Taxonomy::class );
+		$taxonomy            = Mockery::mock( \WP_Taxonomy::class );
 		$taxonomy->name      = 'test';
 		$taxonomy->rewrite   = 'test_rewrite';
 		$taxonomy->rest_base = 'test_route';
 
 		$this->taxonomies_array[] = $taxonomy;
 
-		$taxonomy            = Mockery::mock( WP_Taxonomy::class );
+		$taxonomy            = Mockery::mock( \WP_Taxonomy::class );
 		$taxonomy->name      = 'test2';
 		$taxonomy->rewrite   = 'test_rewrite2';
 		$taxonomy->rest_base = 'test_route2';

--- a/tests/unit/integrations/watchers/indexable-taxonomy-change-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-taxonomy-change-watcher-test.php
@@ -119,14 +119,14 @@ class Indexable_Taxonomy_Change_Watcher_Test extends TestCase {
 	 * @covers ::check_taxonomy_public_availability
 	 */
 	public function test_check_taxonomy_public_availability_new_taxonomy_added() {
-		$taxonomy            = Mockery::mock( WP_Taxonomy::class )->makePartial();
+		$taxonomy            = Mockery::mock( WP_Taxonomy::class );
 		$taxonomy->name      = 'test';
 		$taxonomy->rewrite   = 'test_rewrite';
 		$taxonomy->rest_base = 'test_route';
 
 		$indexable_taxonomy_objects[] = $taxonomy;
 
-		$taxonomy            = Mockery::mock( WP_Taxonomy::class )->makePartial();
+		$taxonomy            = Mockery::mock( WP_Taxonomy::class );
 		$taxonomy->name      = 'test2';
 		$taxonomy->rewrite   = 'test_rewrite2';
 		$taxonomy->rest_base = 'test_route2';
@@ -197,7 +197,7 @@ class Indexable_Taxonomy_Change_Watcher_Test extends TestCase {
 		 * @covers ::check_taxonomy_public_availability
 		 */
 	public function test_check_taxonomy_public_availability_taxonomy_removed() {
-		$taxonomy            = Mockery::mock( WP_Taxonomy::class )->makePartial();
+		$taxonomy = Mockery::mock( WP_Taxonomy::class );
 		$taxonomy->name      = 'test';
 		$taxonomy->rewrite   = 'test_rewrite';
 		$taxonomy->rest_base = 'test_route';

--- a/tests/unit/integrations/watchers/indexable-taxonomy-change-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-taxonomy-change-watcher-test.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Integrations\Watchers;
 
 use Brain\Monkey\Functions;
 use Mockery;
+use WP_Taxonomy;
 use Yoast_Notification_Center;
 use Yoast\WP\SEO\Actions\Indexing\Indexable_Term_Indexation_Action;
 use Yoast\WP\SEO\Conditionals\Admin_Conditional;
@@ -67,9 +68,9 @@ class Indexable_Taxonomy_Change_Watcher_Test extends TestCase {
 	private $instance;
 
 	/**
-	 * Holds the taxonomies array.
+	 * Holds the taxonomy objects array.
 	 *
-	 * @var array
+	 * @var WP_Taxonomy[]
 	 */
 	private $taxonomies_array;
 
@@ -91,16 +92,16 @@ class Indexable_Taxonomy_Change_Watcher_Test extends TestCase {
 			$this->notification_center
 		);
 
-		$taxonomy            = Mockery::mock( \WP_Taxonomy::class );
+		$taxonomy            = Mockery::mock( WP_Taxonomy::class );
 		$taxonomy->name      = 'test';
-		$taxonomy->rewrite   = 'test_rewrite';
+		$taxonomy->rewrite   = [ 'slug' => 'test_rewrite' ];
 		$taxonomy->rest_base = 'test_route';
 
 		$this->taxonomies_array[] = $taxonomy;
 
-		$taxonomy            = Mockery::mock( \WP_Taxonomy::class );
+		$taxonomy            = Mockery::mock( WP_Taxonomy::class );
 		$taxonomy->name      = 'test2';
-		$taxonomy->rewrite   = 'test_rewrite2';
+		$taxonomy->rewrite   = [ 'slug' => 'test_rewrite2' ];
 		$taxonomy->rest_base = 'test_route2';
 
 		$this->taxonomies_array[] = $taxonomy;

--- a/tests/unit/routes/settings-introduction-route-test.php
+++ b/tests/unit/routes/settings-introduction-route-test.php
@@ -137,23 +137,23 @@ class Settings_Introduction_Route_Test extends TestCase {
 			);
 
 			Monkey\Functions\expect( 'register_rest_route' )
-			->with(
-				'yoast/v1',
-				'/settings_introduction/remove_notification',
-				[
+				->with(
+					'yoast/v1',
+					'/settings_introduction/remove_notification',
 					[
-						'methods'             => 'POST',
-						'callback'            => [ $this->instance, 'remove_notification' ],
-						'permission_callback' => [ $this->instance, 'permission_manage_options' ],
-						'args'                => [
-							'id' => [
-								'required' => true,
-								'type'     => 'string',
+						[
+							'methods'             => 'POST',
+							'callback'            => [ $this->instance, 'remove_notification' ],
+							'permission_callback' => [ $this->instance, 'permission_manage_options' ],
+							'args'                => [
+								'id' => [
+									'required' => true,
+									'type'     => 'string',
+								],
 							],
 						],
-					],
-				]
-			);
+					]
+				);
 
 		$this->instance->register_routes();
 	}
@@ -454,14 +454,14 @@ class Settings_Introduction_Route_Test extends TestCase {
 	 * Tests the remove_notification route.
 	 *
 	 * @dataProvider remove_notification_dataprovider
-	 * 
+	 *
 	 * @covers ::remove_notification
-	 * 
+	 *
 	 * @param bool $return_value The return value of the remove_notification method.
 	 * @param bool $success      The expected success value.
 	 * @param int  $code         The expected code value.
 	 */
-	public function test_remove_notification_failed( $return_value, $success, $code) {
+	public function test_remove_notification( $return_value, $success, $code ) {
 		$this->settings_introduction_action
 			->expects( 'remove_notification' )
 			->with( 'dummy-id' )
@@ -493,6 +493,11 @@ class Settings_Introduction_Route_Test extends TestCase {
 		);
 	}
 
+	/**
+	 * Dataprovider for test_remove_notification.
+	 *
+	 * @covers ::remove_notification
+	 */
 	public function remove_notification_dataprovider() {
 		return [
 			[ true, true, 200 ],

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -262,6 +262,9 @@ function _wpseo_deactivate() {
 	// Clear cache so the changes are obvious.
 	WPSEO_Utils::clear_cache();
 
+	WPSEO_Options::set( 'last_known_public_post_types', [] );
+	WPSEO_Options::set( 'last_known_public_taxonomies', [] );
+
 	do_action( 'wpseo_deactivate' );
 }
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to make more clear the notifications we issue in relation to newly-introduced post types and taxonomies.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Refactors notifications related to new public post types and taxonomies to be more specific.

## Relevant technical choices:

* N/A

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

**Prerequisites**
* Install and activate `Yoast Test Helper`
  * If you have it already active, make sure  the `Enable post types & taxonomies` checkbox is not checked **before testing this PR**
* install and activate [WP Crontrol](https://wordpress.org/plugins/wp-crontrol/)
* Add the following code to your WordPress theme:
```
add_filter( 'wpseo_shutdown_indexation_limit', 'custom_limit', 1 );
function custom_limit() {
  return 1;
}
```
* Go to `Tools` -> `Cron Events`
* Click on `Custom events` and verify `wpseo_start_cleanup_indexables` is not in the list of the scheduled hooks; if it is, delete it
---
**Test that each change in content visibility gets its notification**
* Go to `Tools` -> `Yoast Test`, check  the `Enable post types & taxonomies` checkbox and click `Save`
* Go to `Yoast SEO` -> `General` and verify your notifications look like the picture below:
<img width="1356" alt="Screenshot 2023-01-17 at 12 39 06" src="https://user-images.githubusercontent.com/68744851/212889863-4fe907ef-47fb-41d6-9ea1-25ffd0d7c27a.png">

---

**Test  post type-related notifications go away when the corresponding settings page is visited**
* Click on `Books` in the `It looks like you've added a new type of content to your website. We recommend that you review your search appearance settings for Books.` notification
  * Verify the link opens the Settings section related to `Books` content type ( wp-admin/admin.php?page=wpseo_page_settings#/post-type/yoast-test-books )
* Go back to  `Yoast SEO` -> `General`
  * Verify the above notification is not displayed anymore

---

**Test  taxonomy-related notifications go away when the corresponding settings page is visited**
* Click on  `Categories` in the first `It looks like you've added a new taxonomy to your website. We recommend that you review your search appearance settings for Categories.` notification
  * Verify the link opens the Settings section related to `Categories` for `Books ` ( wp-admin/admin.php?page=wpseo_page_settings#/taxonomy/yoast-test-book-category )
* Go back to  `Yoast SEO` -> `General`
  * Verify the above notification is not displayed anymore

---

**Test notifications go away when plugin is deactivated**
 * Go to `Plugins` and deactivate `Yoast SEO`
 *  Activate it again and verify all the notifications starting with `It looks like` are gone

---

**Test the cleanup job is scheduled correctly**
* Go to `Tools` -> `Yoast Test`
  * Uncheck  the `Enable post types & taxonomies` checkbox and click `Save`
  * Press `Reset Notifications`
  * Check  the `Enable post types & taxonomies` checkbox again and click `Save`
  * Uncheck it one last time and click `Save`
* Go to `Tools` -> `Cron Events`
  * Verify `wpseo_start_cleanup_indexables` is in the list of the scheduled hooks

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [X] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* This PR involves the mechanism we use to detect when a post type or a taxonomy changes in visibility (i.e. gets added/removed or is sets as public/non public). To do so I have updated also the new `Settings UI`, and specifically the code  related to the sections `Content Types` and `Categories and Tags`. Regression test should be performed in order to ensure the two sections are displayed and work correctly.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [X] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes https://github.com/Yoast/wordpress-seo/issues/19618
