### PR TITLE
fix upsell title on general page

### DIFF
--- a/css/src/yst_plugin_tools.css
+++ b/css/src/yst_plugin_tools.css
@@ -572,7 +572,6 @@ body.toplevel_page_wpseo_dashboard .wp-badge {
 }
 .yoast-get-premium-title{
   line-height: 27px;
-  text-align:center;
 }
 
 .yoast-sidebar__product .product-image {

--- a/css/src/yst_plugin_tools.css
+++ b/css/src/yst_plugin_tools.css
@@ -575,6 +575,10 @@ body.toplevel_page_wpseo_dashboard .wp-badge {
   line-height: 27px;
 }
 
+.yoast-get-premium-title span {
+  white-space: nowrap;
+}
+
 .yoast-sidebar__product .product-image {
 	position: relative;
 	z-index: 2;

--- a/css/src/yst_plugin_tools.css
+++ b/css/src/yst_plugin_tools.css
@@ -570,7 +570,8 @@ body.toplevel_page_wpseo_dashboard .wp-badge {
 	font-size: 22px;
 	font-weight: bold;
 }
-.yoast-get-premium-title{
+
+.yoast-get-premium-title {
   line-height: 27px;
 }
 

--- a/src/presenters/admin/sidebar-presenter.php
+++ b/src/presenters/admin/sidebar-presenter.php
@@ -45,7 +45,12 @@ class Sidebar_Presenter extends Abstract_Presenter {
 						<h2 class="yoast-get-premium-title">
 							<?php
 							/* translators: %s expands to <br>Yoast SEO Premium */
-							\printf( \esc_html__( 'Get %s', 'wordpress-seo' ), '<br>Yoast SEO Premium' );
+							\printf(
+								\esc_html__( '%1$sGet%2$s %3$s', 'wordpress-seo' ),
+								'<nowrap>',
+								'</nowrap>',
+								'Yoast SEO Premium'
+							);
 							?>
 						</h2>
 						<p>

--- a/src/presenters/admin/sidebar-presenter.php
+++ b/src/presenters/admin/sidebar-presenter.php
@@ -45,12 +45,7 @@ class Sidebar_Presenter extends Abstract_Presenter {
 						<h2 class="yoast-get-premium-title">
 							<?php
 							/* translators: %1$s and %2$s expand to a span wrap to avoid linebreaks. %3$s expands to "Yoast SEO Premium". */
-							\printf(
-								\esc_html__( '%1$sGet%2$s %3$s', 'wordpress-seo' ),
-								'<nowrap>',
-								'</nowrap>',
-								'Yoast SEO Premium'
-							);
+							\printf( \esc_html__( '%1$sGet%2$s %3$s', 'wordpress-seo' ), '<nowrap>', '</nowrap>', 'Yoast SEO Premium' );
 							?>
 						</h2>
 						<p>

--- a/src/presenters/admin/sidebar-presenter.php
+++ b/src/presenters/admin/sidebar-presenter.php
@@ -45,8 +45,7 @@ class Sidebar_Presenter extends Abstract_Presenter {
 						<h2 class="yoast-get-premium-title">
 							<?php
 							/* translators: %1$s and %2$s expand to a span wrap to avoid linebreaks. %3$s expands to "Yoast SEO Premium". */
-							\printf(
-								\esc_html__( '%1$sGet%2$s %3$s', 'wordpress-seo' ),
+							\printf( \esc_html__( '%1$sGet%2$s %3$s', 'wordpress-seo' ),
 								'<nowrap>',
 								'</nowrap>',
 								'Yoast SEO Premium'

--- a/src/presenters/admin/sidebar-presenter.php
+++ b/src/presenters/admin/sidebar-presenter.php
@@ -45,7 +45,8 @@ class Sidebar_Presenter extends Abstract_Presenter {
 						<h2 class="yoast-get-premium-title">
 							<?php
 							/* translators: %1$s and %2$s expand to a span wrap to avoid linebreaks. %3$s expands to "Yoast SEO Premium". */
-							\printf( \esc_html__( '%1$sGet%2$s %3$s', 'wordpress-seo' ),
+							\printf(
+								\esc_html__( '%1$sGet%2$s %3$s', 'wordpress-seo' ),
 								'<nowrap>',
 								'</nowrap>',
 								'Yoast SEO Premium'

--- a/src/presenters/admin/sidebar-presenter.php
+++ b/src/presenters/admin/sidebar-presenter.php
@@ -44,7 +44,7 @@ class Sidebar_Presenter extends Abstract_Presenter {
 						</figure>
 						<h2 class="yoast-get-premium-title">
 							<?php
-							/* translators: %s expands to <br>Yoast SEO Premium */
+							/* translators: %1$s and %2$s expand to a span wrap to avoid linebreaks. %3$s expands to "Yoast SEO Premium". */
 							\printf(
 								\esc_html__( '%1$sGet%2$s %3$s', 'wordpress-seo' ),
 								'<nowrap>',

--- a/src/presenters/admin/sidebar-presenter.php
+++ b/src/presenters/admin/sidebar-presenter.php
@@ -45,7 +45,7 @@ class Sidebar_Presenter extends Abstract_Presenter {
 						<h2 class="yoast-get-premium-title">
 							<?php
 							/* translators: %1$s and %2$s expand to a span wrap to avoid linebreaks. %3$s expands to "Yoast SEO Premium". */
-							\printf( \esc_html__( '%1$sGet%2$s %3$s', 'wordpress-seo' ), '<nowrap>', '</nowrap>', 'Yoast SEO Premium' );
+							\printf( \esc_html__( '%1$sGet%2$s %3$s', 'wordpress-seo' ), '<span>', '</span>', 'Yoast SEO Premium' );
 							?>
 						</h2>
 						<p>


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Alternate approach to the solution of https://github.com/Yoast/plugins-automated-testing/issues/301 and fix to https://github.com/Yoast/wordpress-seo/pull/19601

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves the sidebar upsell in the General page when viewed in languages that do _not_ need a line break.
* Tweaked the sidebar upsell styling in the General page: title is no longer center aligned.

## Relevant technical choices:

* Change the translation to incorporate the tags around _Get_
* Add `white-space: nowrap` around _Get_ to ensure there can only be a linebreak in there. This happened in Japanese.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Prepare environment
* Depending on whether the new translation has already been done or not, you'd need to alter the translations yourself in order to test this
* The used translation changed from `Get %s` to `%1$sGet%2$s %3$s`
* Repeat for each language you want to test. Suggested: English (US), Japanese (JA), Ukrainian (UK) and Dutch (NL)
  * Switch your site language to one language and update the languages (this downloads them)
  * Go to your WordPress install folder > wp-content > languages > plugins
  * Search for `"Get %s" in the files
  * Open the ones that start with `wordpress-seo-` and then the locale code for the language, e.g. `nl_NL`
    * Note that you can skip English because that is the default
  * Add a translation for `"%1$sGet%2$s %3$s` that is similar to the Get one, just changes the replacement variables. For your convenience:
    * Japanese: `"%1$sGet%2$s %3$s":["%3$s %1$s\u3092\u5165\u624b%2$s"]`
    * Ukrainian: `"%1$sGet%2$s %3$s":["%1$s\u041e\u0442\u0440\u0438\u043c\u0430\u0439\u0442\u0435%2$s %3$s"]`
    * Dutch: `"%1$sGet%2$s %3$s":["%1$sKoop%2$s %3$s"]`

#### Check the sidebar upsell' style changes
* Disable Premium plugin if you have it on
* Go to General and look at the sidebar upsell
* Verify the title is no longer center aligned
* Verify, for each specified language, that the text in the upsell in the sidebar looks okay:
  * English
![image](https://user-images.githubusercontent.com/35524806/211534837-5a03baa3-0c4f-4c8d-9a59-ef1c6ad09888.png)
  * Japanese
![image](https://user-images.githubusercontent.com/35524806/211534789-6e1d10f4-3a5e-43ef-8f28-f7c830b2aea2.png)
  * Ukrainian
![image](https://user-images.githubusercontent.com/35524806/211535048-39892ebe-643e-4f51-a3f1-23d2f7c4255a.png)
  * Dutch
![image](https://user-images.githubusercontent.com/35524806/211535090-db6a1620-4d24-4968-88f7-0d9ef27fe60f.png)

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Sidebar upsell in the Settings

## UI changes

* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes [[Minor] Upsell title on General page should be in one line#387](https://github.com/Yoast/plugins-automated-testing/issues/387)
