### PR TITLE
Settings: fix skip to main content

### DIFF
--- a/packages/js/src/settings/app.js
+++ b/packages/js/src/settings/app.js
@@ -64,7 +64,7 @@ const Menu = ( { postTypes, taxonomies, idSuffix = "" } ) => {
 
 	return <>
 		<header className="yst-px-3 yst-mb-6 yst-space-y-6">
-			<Link to="/" className="yst-inline-block yst-rounded-md focus:yst-ring-primary-500" aria-label={ `Yoast SEO${ isPremium ? " Premium" : "" }` }>
+			<Link id={ `link-yoast-logo${ idSuffix }` } to="/" className="yst-inline-block yst-rounded-md focus:yst-ring-primary-500" aria-label={ `Yoast SEO${ isPremium ? " Premium" : "" }` }>
 				<YoastLogo className="yst-w-40" { ...svgAriaProps } />
 			</Link>
 			<Search buttonId={ `button-search${ idSuffix }` } />
@@ -229,6 +229,8 @@ const App = () => {
 			<Notifications />
 			<SidebarNavigation activePath={ pathname }>
 				<SidebarNavigation.Mobile
+					openButtonId="button-open-settings-navigation-mobile"
+					closeButtonId="button-close-settings-navigation-mobile"
 					openButtonScreenReaderText={ __( "Open settings navigation", "wordpress-seo" ) }
 					closeButtonScreenReaderText={ __( "Close settings navigation", "wordpress-seo" ) }
 					aria-label={ __( "Settings navigation", "wordpress-seo" ) }

--- a/packages/js/src/settings/initialize.js
+++ b/packages/js/src/settings/initialize.js
@@ -56,11 +56,13 @@ const fixFocusLinkCompatibility = () => {
 	const wpContentBody = document.querySelector( "[href=\"#wpbody-content\"]" );
 	wpContentBody.addEventListener( "click", e => {
 		e.preventDefault();
-		let searchButton = document.getElementById( "yst-search-button-mobile" );
-		if ( ! searchButton ) {
-			searchButton = document.getElementById( "yst-search-button" )?.focus();
+		// Try to focus the Yoast logo if in "mobile" view.
+		if ( window.outerWidth > 782 ) {
+			document.getElementById( "link-yoast-logo" )?.focus();
+			return;
 		}
-		searchButton?.focus();
+		// Try to focus the open sidebar navigation button.
+		document.getElementById( "button-open-settings-navigation-mobile" )?.focus();
 	} );
 	const wpToolbar = document.querySelector( "[href=\"#wp-toolbar\"]" );
 	wpToolbar.addEventListener( "click", e => {

--- a/packages/ui-library/src/components/sidebar-navigation/mobile.js
+++ b/packages/ui-library/src/components/sidebar-navigation/mobile.js
@@ -6,12 +6,17 @@ import { useNavigationContext } from "./index";
 
 /**
  * @param {JSX.node} children The menu items.
+ * @param {string} [openButtonId] The ID of the open button.
+ * @param {string} [closeButtonId] The ID of the close button.
  * @param {string} [openButtonScreenReaderText] The open button screen reader text.
  * @param {string} [closeButtonScreenReaderText] The close button screen reader text.
+ * @param {string} [aria-label] The aria label for the Modal.
  * @returns {JSX.Element} The mobile element.
  */
 const Mobile = ( {
 	children,
+	openButtonId,
+	closeButtonId,
 	openButtonScreenReaderText = "Open",
 	closeButtonScreenReaderText = "Close",
 	"aria-label": ariaLabel,
@@ -27,6 +32,7 @@ const Mobile = ( {
 				<Dialog.Panel className="yst-relative yst-flex yst-flex-1 yst-flex-col yst-max-w-xs yst-w-full yst-z-40 yst-bg-slate-100">
 					<div className="yst-absolute yst-top-0 yst-right-0 yst--mr-14 yst-p-1">
 						<button
+							id={ closeButtonId }
 							className="yst-flex yst-h-12 yst-w-12 yst-items-center yst-justify-center yst-rounded-full focus:yst-outline-none yst-bg-slate-600 focus:yst-ring-2 focus:yst-ring-inset focus:yst-ring-primary-500"
 							onClick={ closeMobileMenu }
 						>
@@ -45,6 +51,7 @@ const Mobile = ( {
 		<div className="yst-mobile-navigation__top">
 			<div className="yst-flex yst-relative yst-flex-shrink-0 yst-h-16 yst-z-10 yst-bg-white yst-border-b yst-border-slate-200">
 				<button
+					id={ openButtonId }
 					className="yst-px-4 yst-border-r yst-border-slate-200 yst-text-slate-500 focus:yst-outline-none focus:yst-ring-2 focus:yst-ring-inset focus:yst-ring-primary-500"
 					onClick={ openMobileMenu }
 				>
@@ -58,6 +65,8 @@ const Mobile = ( {
 
 Mobile.propTypes = {
 	children: PropTypes.node.isRequired,
+	openButtonId: PropTypes.string,
+	closeButtonId: PropTypes.string,
 	openButtonScreenReaderText: PropTypes.string,
 	closeButtonScreenReaderText: PropTypes.string,
 	"aria-label": PropTypes.string,


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Fix the `Skip to main content` link. This got reported here: https://github.com/Yoast/wordpress-seo/pull/19472#issuecomment-1372315420

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where the `Skip to main content` link was not working.
* [@yoast/ui-library] Adds `openButtonId` and `closeButtonId` props to the _SidebarNavigation.Mobile_ component.

## Relevant technical choices:

* Added IDs to the Yoast logo link and the mobile sidebar navigation buttons
* Do a not-so-nice outerWidth check to see if we are in the "mobile" view or not

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Go to Settings
* Tab through the page until you get `Skip to main content` (hint: I put my focus in the console of the inspector, then tab)
  * ![image](https://user-images.githubusercontent.com/35524806/212882593-de53d622-fd85-4601-a15a-b03857e94dc8.png)
* Verify that "clicking" on that sets the focus on the Yoast logo
  * ![image](https://user-images.githubusercontent.com/35524806/212883349-ad9c02e4-5980-44b5-9520-10f4651cc2ac.png)
* Shrink the screen width to be 782 pixels wide (or smaller)
* Verify that "clicking" on the `Skip to main content` sets the focus on the open settings' navigation menu button
  * ![image](https://user-images.githubusercontent.com/35524806/212883269-c4e63aaf-c945-4ced-93fe-e50b7837632a.png)


#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Settings: Mobile menu button IDs, Yoast logo link ID  and the _Skip to main content_ functionality.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
