### PR TITLE
Revert "Revert "Fix Introduction modal dialog a11y.""

### DIFF
--- a/packages/js/src/settings/components/introduction.js
+++ b/packages/js/src/settings/components/introduction.js
@@ -1,6 +1,6 @@
 /* eslint-disable complexity */
 import { ArrowLeftIcon as PureArrowLeftIcon, ArrowRightIcon as PureArrowRightIcon } from "@heroicons/react/outline";
-import { useCallback, useEffect, useMemo, useState } from "@wordpress/element";
+import { useCallback, useEffect, useMemo, useState, useRef } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
 import { Button, Modal, Spinner, Title, useRootContext, useSvgAria, useToggleState } from "@yoast/ui-library";
 import classNames from "classnames";
@@ -25,6 +25,7 @@ const Introduction = () => {
 	const { isRtl } = useRootContext();
 	const ArrowLeftIcon = useMemo( () => isRtl ? PureArrowRightIcon : PureArrowLeftIcon, [ isRtl ] );
 	const ArrowRightIcon = useMemo( () => isRtl ? PureArrowLeftIcon : PureArrowRightIcon, [ isRtl ] );
+	const modalDialogRef = useRef( null );
 
 	// set the steps with the videos and thumbnails and memoize them for pluginUrl changes
 	const steps = useMemo( () => ( [
@@ -66,14 +67,7 @@ const Introduction = () => {
 	// check if is on last step and memoize it for stepIndex and steps changes
 	const isOnLastStep = useMemo( () => stepIndex === steps.length - 1, [ stepIndex, steps ] );
 
-
 	const playVideo = useCallback( () => setIntroductionVideoFlow( INTRODUCTION_VIDEO_FLOW.playing ), [ setIntroductionVideoFlow ] );
-
-	// move to next step and memoize it for stepIndex and steps changes
-	const handleNext = useCallback( () => setStepIndex( stepIndex + 1 ), [ stepIndex, setStepIndex ] );
-
-	// move to previous step and memoize it for stepIndex changes
-	const handlePrevious = useCallback( () => setStepIndex( stepIndex - 1 ), [ stepIndex, setStepIndex ] );
 
 	// handle the play button click and check permission from wistia else ask for permission
 	// memoize it for wistiaEmbedPermission, setIntroductionVideoFlow changes
@@ -87,11 +81,26 @@ const Introduction = () => {
 
 
 	 // if the videoFlow stage is equal to INTRODUCTION_VIDEO_FLOW.askPermission then show the permission modal
-	 // the next two handel functions are for the permission modal:
+	 // the next two handle functions are for the permission modal:
 
-	// handle the deny embed button click and memoize it for setIntroductionVideoFlow changes
-	// INTRODUCTION_VIDEO_FLOW.showPlay shows play button
-	const handleDenyEmbed = useCallback( () => setIntroductionVideoFlow( INTRODUCTION_VIDEO_FLOW.showPlay ), [ setIntroductionVideoFlow ] );
+	// Handle the deny embed button click and memoize it for setIntroductionVideoFlow changes.
+	// Also, set INTRODUCTION_VIDEO_FLOW.showPlay to show the play button and move focus to the modal.
+	const showPlayVideo = useCallback( () => {
+		setIntroductionVideoFlow( INTRODUCTION_VIDEO_FLOW.showPlay );
+		modalDialogRef.current.focus();
+	}, [ setIntroductionVideoFlow, modalDialogRef ] );
+
+	// move to next step and memoize it for stepIndex and steps changes
+	const handleNext = useCallback( () => {
+		setStepIndex( stepIndex + 1 );
+		showPlayVideo();
+	}, [ stepIndex, setStepIndex ] );
+
+	// move to previous step and memoize it for stepIndex changes
+	const handlePrevious = useCallback( () => {
+		setStepIndex( stepIndex - 1 );
+		showPlayVideo();
+	}, [ stepIndex, setStepIndex ] );
 
 	// when the user allows the embed:
 	// handle the allow embed button click and memoize it for setIntroductionVideoFlow, setIntroductionWistiaEmbedPermission changes
@@ -108,7 +117,6 @@ const Introduction = () => {
 		setIntroductionShow( false );
 		setClose();
 	}, [ setIntroductionShow, setClose ] );
-
 
 	useEffect( () => {
 		// exception-1: early return, if the videoFlow is not in the stage of playing then this useEffect should not run
@@ -131,9 +139,14 @@ const Introduction = () => {
 	}, [ videoFlow, stepIndex, steps, setVideo ] );
 
 	return (
-
 		// handleClose function is closing the modal and setting the user meta to not show introduction again
-		<Modal onClose={ handleClose } isOpen={ isOpen } aria-label={ __( "Introduction to settings", "wordpress-seo" ) }>
+		<Modal
+			onClose={ handleClose }
+			isOpen={ isOpen }
+			aria-label={ __( "Introduction to settings", "wordpress-seo" ) }
+			tabIndex="-1"
+			ref={ modalDialogRef }
+		>
 			<div className="yst-modal__panel yst-max-w-[37rem] yst-p-0 yst-rounded-2xl sm:yst-rounded-3xl">
 
 				{ /* //checks ther is permission from wista to add video and add js script, Helmet component adds the script tp the head */ }
@@ -144,7 +157,7 @@ const Introduction = () => {
 					<div className="yst-absolute yst-inset-0 yst-bg-gradient-to-b yst-from-primary-200" />
 					<div className="yst-relative yst-pt-6 sm:yst-pt-8 yst-pb-8 yst-px-4 sm:yst-px-8">
 						<div
-							className="yst-relative yst-w-full yst-h-0 yst-pt-[56.25%] yst-overflow-hidden yst-rounded-lg yst-shadow-md yst-bg-black"
+							className="yst-relative yst-w-full yst-h-0 yst-pt-[56.25%] yst-rounded-lg yst-shadow-md yst-bg-black"
 						>
 							{ /* // -------------------- Play button section, presents a thumbnail of the video enclosed in a button -------------*/ }
 							{ videoFlow === INTRODUCTION_VIDEO_FLOW.showPlay && steps.map( ( step, index ) => (
@@ -153,12 +166,12 @@ const Introduction = () => {
 									className={ classNames(
 										"yst-absolute yst-inset-0 yst-button yst-p-0 yst-border-none yst-bg-white",
 										"yst-transition-opacity yst-duration-1000",
-										index === stepIndex ? "yst-opacity-100" : "yst-opacity-0"
+										index === stepIndex ? "yst-opacity-100" : "yst-opacity-0",
+										index === stepIndex ? "yst-visible" : "yst-invisible"
 									) }
 									onClick={ handleRequestPlay }
 								>
-									{ /* eslint-disable-next-line jsx-a11y/alt-text */ }
-									<img className="yst-w-full yst-h-auto" { ...step.thumbnail } />
+									<img alt={ __( "Play video", "wordpress-seo" ) } className="yst-w-full yst-h-auto" { ...step.thumbnail } />
 								</button>
 							) ) }
 
@@ -180,7 +193,7 @@ const Introduction = () => {
 										<Button
 											type="button"
 											variant="secondary"
-											onClick={ handleDenyEmbed }
+											onClick={ showPlayVideo }
 											disabled={ wistiaEmbedPermission.status === ASYNC_ACTION_STATUS.loading }
 										>
 											{ __( "Deny", "wordpress-seo" ) }
@@ -225,27 +238,37 @@ const Introduction = () => {
 							stepIndex === 2 && "yst--translate-x-[200%] rtl:yst-translate-x-[200%]"
 						) }
 					>
-						{ steps.map( ( step, index ) => (
-							<div
-								key={ `step-copy-${ step.videoId }` }
-								className={ classNames(
-									"yst-transition-opacity yst-duration-1000 yst-delay-200",
-									index === stepIndex ? "yst-opacity-100" : "yst-opacity-0"
-								) }
-							>
-								<Title as="h2" size="2">
-									{ step.title }
-								</Title>
-								<p className="yst-max-w-xs yst-mx-auto yst-mt-2">
-									{ step.description }
-								</p>
-							</div>
-						) ) }
+						{ steps.map( ( step, index ) => {
+							// Modal.Description sets the aria-describedby on the Dialog.
+							// We want that to only happen for the description of the active slide.
+							const DescriptionComponent = index === stepIndex ? Modal.Description : "p";
+
+							return (
+								<div
+									key={ `step-copy-${ step.videoId }` }
+									className={ classNames(
+										"yst-transition-opacity yst-duration-1000 yst-delay-200",
+										index === stepIndex ? "yst-opacity-100" : "yst-opacity-0",
+										index === stepIndex ? "yst-visible" : "yst-invisible"
+									) }
+								>
+									<Title as="h1" size="2">
+										{ step.title }
+									</Title>
+									<DescriptionComponent className="yst-max-w-sm yst-mx-auto yst-mt-2">
+										{ step.description }
+									</DescriptionComponent>
+								</div>
+							);
+						} ) }
 					</div>
 
 
 					{ /* // -------------------- The navigation section ----------------*/ }
-					<ul className="yst-flex yst-mt-10 sm:yst-mt-8 yst-gap-5 yst-justify-center yst-items-center">
+					<ul
+						className="yst-flex yst-mt-10 sm:yst-mt-8 yst-gap-5 yst-justify-center yst-items-center"
+						aria-hidden="true"
+					>
 						{ times( steps.length ).map( ( index ) => (
 							<li
 								key={ `step-circle-${ index }` }

--- a/packages/js/tests/settings/__snapshots__/search.test.js.snap
+++ b/packages/js/tests/settings/__snapshots__/search.test.js.snap
@@ -2,13 +2,13 @@
 
 exports[`Search test should match search snapshot 1`] = `
 "<Fragment>
-  <button type=\\"button\\" className=\\"yst-w-full yst-flex yst-items-center yst-bg-white yst-text-sm yst-leading-6 yst-text-slate-500 yst-rounded-md yst-border yst-border-slate-300 yst-shadow-sm yst-py-1.5 yst-pl-2 yst-pr-3 focus:yst-outline-none focus:yst-ring-2 focus:yst-ring-offset-2 focus:yst-ring-primary-500\\" onClick={[Function (anonymous)]}>
+  <button id=\\"button-search\\" type=\\"button\\" className=\\"yst-w-full yst-flex yst-items-center yst-bg-white yst-text-sm yst-leading-6 yst-text-slate-500 yst-rounded-md yst-border yst-border-slate-300 yst-shadow-sm yst-py-1.5 yst-pl-2 yst-pr-3 focus:yst-outline-none focus:yst-ring-2 focus:yst-ring-offset-2 focus:yst-ring-primary-500\\" onClick={[Function (anonymous)]}>
     <ForwardRef(SearchIcon) className=\\"yst-flex-none yst-w-5 yst-h-5 yst-mr-3 yst-text-slate-400\\" role=\\"img\\" aria-hidden=\\"true\\" />
     <span className=\\"yst-overflow-hidden yst-whitespace-nowrap yst-text-ellipsis\\">
       Quick search...
     </span>
   </button>
-  <Modal onClose={[Function (anonymous)]} isOpen={false} initialFocus={{...}} position=\\"top-center\\">
+  <Modal onClose={[Function (anonymous)]} isOpen={false} initialFocus={{...}} position=\\"top-center\\" aria-label=\\"Search\\">
     <Modal.Panel closeButtonScreenReaderText=\\"Close\\">
       <ComboboxFn as=\\"div\\" className=\\"yst--m-6 yst--mt-5\\" onChange={[Function (anonymous)]}>
         <div className=\\"yst-relative\\">

--- a/packages/ui-library/src/components/modal/index.js
+++ b/packages/ui-library/src/components/modal/index.js
@@ -99,11 +99,18 @@ export const classNameMap = {
  * @param {Object} [props] Additional Dialog props.
  * @returns {JSX.Element} The modal.
  */
-const Modal = ( { isOpen, onClose, children, className = "", position = "center", ...props } ) => (
+const Modal = forwardRef( ( { isOpen, onClose, children, className = "", position = "center", ...props }, ref ) => (
 	<ModalContext.Provider value={ { isOpen, onClose } }>
 		<Transition.Root show={ isOpen } as={ Fragment }>
 			{ /* Using the `yst-root` class here to get our styling within the portal. */ }
-			<Dialog as="div" className="yst-root" open={ isOpen } onClose={ onClose } { ...props }>
+			<Dialog
+				as="div"
+				ref={ ref }
+				className="yst-root"
+				open={ isOpen }
+				onClose={ onClose }
+				{ ...props }
+			>
 				<div className={ classNames( "yst-modal", classNameMap.position[ position ], className ) }>
 					<Transition.Child
 						as={ Fragment }
@@ -133,7 +140,7 @@ const Modal = ( { isOpen, onClose, children, className = "", position = "center"
 			</Dialog>
 		</Transition.Root>
 	</ModalContext.Provider>
-);
+) );
 
 Modal.propTypes = {
 	isOpen: PropTypes.bool.isRequired,
@@ -143,6 +150,7 @@ Modal.propTypes = {
 	position: PropTypes.oneOf( Object.keys( classNameMap.position ) ),
 };
 
+Modal.displayName = "Modal";
 Modal.Panel = Panel;
 Modal.Panel.displayName = "Modal.Panel";
 Modal.Title = Title;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*  ⚠️ Reverts Yoast/wordpress-seo#19649 ⚠️ 
* Fixes the New Settings Introduction modal dialog accessibility.

Please note it's a while I'm not contributing to Yoast SEO, I'm not sure whether there's anything to do with stories and tests.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves accessibility of the Settings Introduction modal dialog.

## Relevant technical choices:

- Hides content of the 'out of view' slides so that assistive technologies don't perceive extraneous content. Also avoids invisible tab stops.
  - Note: this is done by setting `visibility: hidden` on the inactive slides so that their dimension is preserved and the animation still works as expected.
- Makes sure `aria-describedby` on the dialog only references one slide description at a time. Note: keeping `Modal.Description` is good as it automatically sets `aria-describedby`. We shouldn't remove it as done in https://github.com/Yoast/wordpress-seo/pull/19489. However, we should use it only for the active slide.
- Uses `forwardRef` on the Modal component to allow passing a ref to the actual DOM element.
- Avoids focus losses by moving focus to the modal dialog when pressing Deny, Next, and Back.
- Changes the h2 headings to h1: the modal is the only perceivable content in the page so it worths a h1.
- Hides the navigation three 'dots' from assistive technologies *this was read out as 'group', as it's a list with empty items).


## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

- Use a clean database or reset your user meta, specifically the one with meta key `_yoast_settings_introduction`
- Go to Yoast SEO > Settings.
- The introduction modal dialog opens.
- Check initial focus is on the Play button (the preview image) and that there is a visible focus style.
- Press Tab multiple times and check focus cycles only through visible elements in the current slide.
- Tab to the play button (the image) and press Enter: the Deny/Allow permission panel appears.
- Tab to Deny and press Enter: the Deny/Allow permission panel disappears and the Play button (image) appears again.
- Check keyboard focus is on the modal wrapper: just press Tab and check focus goes to the Play button (image).
- Press Enter: the Deny/Allow permission panel appears.
- Tab to Allow and press Enter: the video loads and starts playing.
- Tab to Next and press Enter: the next slide appears.
- Check the sliding animation works as expected.
- Check keyboard focus is on the modal wrapper: just press Tab and check focus goes to the Play button (image).
- Check the video does not play automatically and the play button (image) is shown instead.
- Play the video.
- Tab to Back and press Enter: the previous slide appears.
- Check the sliding animation works as expected.
- Check keyboard focus is on the modal wrapper: just press Tab and check focus goes to the Play button (image).
- Check the video does not play automatically and the play button (image) is shown instead.
- Check the 'Skip' and 'Got it' buttons work as expected. After this, you may need to reset your user meta to make the modal dialog appear again (after refreshing the page).

Specific a11y checks to be tested by inspecting the source with the browser dev tools:
- Check the modal dialog has an `aria-label="Introduction to settings"` attribute. Note: this was already fixed in https://github.com/Yoast/wordpress-seo/pull/19489
- Check the modal dialog `aria-describedby` attribute references only one description ID at a time. When navigating to the next slide, the `aria-describedby` value updates to the ID of the next slide description. 
- Check the images within the play button have an `alt="Play video"` attribute.
- Check the list with the 3 'dots' visually representing the navigation steps has an `aria-hidden="true"` attribute.


#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* UI library

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes https://yoast.atlassian.net/browse/DUPP-900
