### PR TITLE
19531 add link to plugin overview to premium update notice

### DIFF
--- a/src/integrations/admin/old-premium-integration.php
+++ b/src/integrations/admin/old-premium-integration.php
@@ -5,6 +5,7 @@ namespace Yoast\WP\SEO\Integrations\Admin;
 use WPSEO_Admin_Asset_Manager;
 use Yoast\WP\SEO\Conditionals\Admin_Conditional;
 use Yoast\WP\SEO\Helpers\Capability_Helper;
+use Yoast\WP\SEO\Helpers\Current_Page_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Product_Helper;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
@@ -44,6 +45,13 @@ class Old_Premium_Integration implements Integration_Interface {
 	private $admin_asset_manager;
 
 	/**
+	 * The Current_Page_Helper.
+	 *
+	 * @var Current_Page_Helper
+	 */
+	private $current_page_helper;
+
+	/**
 	 * {@inheritDoc}
 	 */
 	public static function get_conditionals() {
@@ -57,17 +65,20 @@ class Old_Premium_Integration implements Integration_Interface {
 	 * @param Product_Helper            $product_helper      The product helper.
 	 * @param Capability_Helper         $capability_helper   The capability helper.
 	 * @param WPSEO_Admin_Asset_Manager $admin_asset_manager The admin asset manager.
+	 * @param Current_Page_Helper       $current_page_helper The Current_Page_Helper.
 	 */
 	public function __construct(
 		Options_Helper $options_helper,
 		Product_Helper $product_helper,
 		Capability_Helper $capability_helper,
-		WPSEO_Admin_Asset_Manager $admin_asset_manager
+		WPSEO_Admin_Asset_Manager $admin_asset_manager,
+		Current_Page_Helper $current_page_helper
 	) {
 		$this->options_helper      = $options_helper;
 		$this->product_helper      = $product_helper;
 		$this->capability_helper   = $capability_helper;
 		$this->admin_asset_manager = $admin_asset_manager;
+		$this->current_page_helper = $current_page_helper;
 	}
 
 	/**
@@ -100,12 +111,13 @@ class Old_Premium_Integration implements Integration_Interface {
 		if ( $this->premium_is_old() ) {
 			$this->admin_asset_manager->enqueue_style( 'monorepo' );
 
-			$content = \sprintf(
+			$is_plugins_page = $this->current_page_helper->get_current_admin_page() === 'plugins.php';
+			$content         = \sprintf(
 				/* translators: 1: Yoast SEO Premium, 2 and 3: opening and closing anchor tag. */
 				\esc_html__( 'Please %2$supdate %1$s to the latest version%3$s to ensure you can fully use all Premium settings and features.', 'wordpress-seo' ),
 				'Yoast SEO Premium',
-				'<a href="' . \esc_url( \self_admin_url( 'plugins.php' ) ) . '">',
-				'</a>'
+				( $is_plugins_page ) ? '' : '<a href="' . \esc_url( \self_admin_url( 'plugins.php' ) ) . '">',
+				( $is_plugins_page ) ? '' : '</a>'
 			);
 			// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped -- Output of the title escaped in the Notice_Presenter.
 			echo new Notice_Presenter(

--- a/src/integrations/admin/old-premium-integration.php
+++ b/src/integrations/admin/old-premium-integration.php
@@ -101,11 +101,13 @@ class Old_Premium_Integration implements Integration_Interface {
 			$this->admin_asset_manager->enqueue_style( 'monorepo' );
 
 			$content = \sprintf(
-				/* translators: 1: Yoast SEO Premium */
-				\__( 'Please update %1$s to the latest version to ensure you can fully use all Premium settings and features.', 'wordpress-seo' ),
-				'Yoast SEO Premium'
+				/* translators: 1: Yoast SEO Premium, 2 and 3: opening and closing anchor tag. */
+				\esc_html__( 'Please %2$supdate %1$s to the latest version%3$s to ensure you can fully use all Premium settings and features.', 'wordpress-seo' ),
+				'Yoast SEO Premium',
+				'<a href="' . \esc_url( \self_admin_url( 'plugins.php' ) ) . '">',
+				'</a>'
 			);
-            // phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped -- Output escaped above.
+			// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped -- Output of the title escaped in the Notice_Presenter.
 			echo new Notice_Presenter(
 				/* translators: 1: Yoast SEO Premium */
 				\sprintf( \__( 'Update to the latest version of %1$s!', 'wordpress-seo' ), 'Yoast SEO Premium' ),

--- a/src/integrations/admin/old-premium-integration.php
+++ b/src/integrations/admin/old-premium-integration.php
@@ -59,7 +59,7 @@ class Old_Premium_Integration implements Integration_Interface {
 	}
 
 	/**
-	 * First_Time_Configuration_Notice_Integration constructor.
+	 * Old_Premium_Integration constructor.
 	 *
 	 * @param Options_Helper            $options_helper      The options helper.
 	 * @param Product_Helper            $product_helper      The product helper.
@@ -129,7 +129,7 @@ class Old_Premium_Integration implements Integration_Interface {
 				true,
 				'yoast-old-premium-notice'
 			);
-            // phpcs:enable
+			// phpcs:enable
 
 			// Enable permanently dismissing the notice.
 			echo "<script>

--- a/tests/unit/integrations/admin/old-premium-integration-test.php
+++ b/tests/unit/integrations/admin/old-premium-integration-test.php
@@ -8,6 +8,7 @@ use WPSEO_Admin_Asset_Manager;
 use Yoast\WP\SEO\Conditionals\Admin_Conditional;
 use Yoast\WP\SEO\Conditionals\Indexables_Page_Conditional;
 use Yoast\WP\SEO\Helpers\Capability_Helper;
+use Yoast\WP\SEO\Helpers\Current_Page_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Product_Helper;
 use Yoast\WP\SEO\Integrations\Admin\Old_Premium_Integration;
@@ -51,6 +52,13 @@ class Old_Premium_Integration_Test extends TestCase {
 	protected $asset_manager;
 
 	/**
+	 * Mock of the Current_Page_Helper.
+	 *
+	 * @var Mockery\MockInterface|Current_Page_Helper
+	 */
+	protected $current_page_helper;
+
+	/**
 	 * Mock of the instance.
 	 *
 	 * @var Mockery\MockInterface|Old_Premium_Integration
@@ -66,15 +74,17 @@ class Old_Premium_Integration_Test extends TestCase {
 		$this->stubTranslationFunctions();
 		$this->stubEscapeFunctions();
 
-		$this->options_helper    = Mockery::mock( Options_Helper::class );
-		$this->product_helper    = Mockery::mock( Product_Helper::class );
-		$this->capability_helper = Mockery::mock( Capability_Helper::class );
-		$this->asset_manager     = Mockery::mock( WPSEO_Admin_Asset_Manager::class );
-		$this->instance          = new Old_Premium_Integration(
+		$this->options_helper      = Mockery::mock( Options_Helper::class );
+		$this->product_helper      = Mockery::mock( Product_Helper::class );
+		$this->capability_helper   = Mockery::mock( Capability_Helper::class );
+		$this->asset_manager       = Mockery::mock( WPSEO_Admin_Asset_Manager::class );
+		$this->current_page_helper = Mockery::mock( Current_Page_Helper::class );
+		$this->instance            = new Old_Premium_Integration(
 			$this->options_helper,
 			$this->product_helper,
 			$this->capability_helper,
-			$this->asset_manager
+			$this->asset_manager,
+			$this->current_page_helper
 		);
 	}
 
@@ -102,6 +112,11 @@ class Old_Premium_Integration_Test extends TestCase {
 		self::assertInstanceOf(
 			WPSEO_Admin_Asset_Manager::class,
 			$this->getPropertyValue( $this->instance, 'admin_asset_manager' )
+		);
+
+		self::assertInstanceOf(
+			Current_Page_Helper::class,
+			$this->getPropertyValue( $this->instance, 'current_page_helper' )
 		);
 	}
 
@@ -150,6 +165,10 @@ class Old_Premium_Integration_Test extends TestCase {
 		$this->asset_manager
 			->expects( 'enqueue_style' )
 			->with( 'monorepo' );
+
+		$this->current_page_helper
+			->expects( 'get_current_admin_page' )
+			->andReturn( 'admin.php' );
 
 		Monkey\Functions\expect( 'wp_enqueue_style' )->with( 'yoast-seo-notifications' );
 		Monkey\Functions\expect( 'plugin_dir_url' )->andReturn( 'https://example.org/wp-content/plugins/' );

--- a/tests/unit/integrations/admin/old-premium-integration-test.php
+++ b/tests/unit/integrations/admin/old-premium-integration-test.php
@@ -153,6 +153,9 @@ class Old_Premium_Integration_Test extends TestCase {
 
 		Monkey\Functions\expect( 'wp_enqueue_style' )->with( 'yoast-seo-notifications' );
 		Monkey\Functions\expect( 'plugin_dir_url' )->andReturn( 'https://example.org/wp-content/plugins/' );
+		Monkey\Functions\expect( 'self_admin_url' )
+			->with( 'plugins.php' )
+			->andReturn( 'https://example.org/wp-admin/plugins/' );
 
 		$conditional = Mockery::mock( Indexables_Page_Conditional::class );
 		$conditional->expects( 'is_met' )->once()->andReturnFalse();

--- a/tests/unit/integrations/admin/old-premium-integration-test.php
+++ b/tests/unit/integrations/admin/old-premium-integration-test.php
@@ -138,7 +138,15 @@ class Old_Premium_Integration_Test extends TestCase {
 		$this->instance->register_hooks();
 
 		$this->assertNotFalse( \has_action( 'admin_notices', [ $this->instance, 'old_premium_notice' ] ) );
-		$this->assertNotFalse( \has_action( 'wp_ajax_dismiss_old_premium_notice', [ $this->instance, 'dismiss_old_premium_notice' ] ) );
+		$this->assertNotFalse(
+			\has_action(
+				'wp_ajax_dismiss_old_premium_notice',
+				[
+					$this->instance,
+					'dismiss_old_premium_notice',
+				]
+			)
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Add a link to the plugin overview in the "old Premium" notice. [Original PR](https://github.com/Yoast/wordpress-seo/pull/19401)

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds a link to the plugin overview in the "old Premium" notice.

## Relevant technical choices:

* Added a check to see if not already on the plugins overview, as linking to the same page is a bit unstylish.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Have a Premium version < 20.0-RC1
* Verify you get the notification:
  * <img width="620" alt="image" src="https://user-images.githubusercontent.com/35524806/213152516-8a20d02c-ecf0-4fc5-b90c-e31215462cec.png">
* Verify it includes a link that takes you to your plugins overview page
* Verify that on the plugins overview page, there is no link:
  * <img width="628" alt="image" src="https://user-images.githubusercontent.com/35524806/213152689-d21b2351-8b73-4d4b-8635-ae20b26697e2.png">
* You can check the above on multisite, to verify the URL points to the site you are on

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [x] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The notification when Premium < 20.0

## UI changes

* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes https://github.com/Yoast/wordpress-seo/issues/19531
