### PR TITLE
Settings: always require a value for the search character limit

### DIFF
--- a/packages/js/src/settings/helpers/validation.js
+++ b/packages/js/src/settings/helpers/validation.js
@@ -63,7 +63,10 @@ export const createValidationSchema = ( postTypes, taxonomies ) => {
 				.matches( ALPHA_NUMERIC_UNTIL_F_VERIFY_REGEXP, __( "The verification code is not valid. Please use only the letters A to F, numbers, underscores and dashes.", "wordpress-seo" ) ),
 			yandexverify: string()
 				.matches( ALPHA_NUMERIC_UNTIL_F_VERIFY_REGEXP, __( "The verification code is not valid. Please use only the letters A to F, numbers, underscores and dashes.", "wordpress-seo" ) ),
-			search_character_limit: number().min( 1, __( "The number you've entered is not between 1 and 50.", "wordpress-seo" ) ).max( 50, __( "The number you've entered is not between 1 and 50.", "wordpress-seo" ) ),
+			search_character_limit: number()
+				.required( __( "Please enter a number between 1 and 50.", "wordpress-seo" ) )
+				.min( 1, __( "The number you've entered is not between 1 and 50.", "wordpress-seo" ) )
+				.max( 50, __( "The number you've entered is not between 1 and 50.", "wordpress-seo" ) ),
 		} ),
 		wpseo_social: object().shape( {
 			og_default_image_id: number().isMediaTypeImage(),

--- a/packages/js/src/settings/routes/crawl-optimization.js
+++ b/packages/js/src/settings/routes/crawl-optimization.js
@@ -589,6 +589,8 @@ const CrawlOptimization = () => {
 							description={ __( "Limit the length of internal site search queries to reduce the impact of spam attacks and confusing URLs. Please enter a number between 1 and 50.", "wordpress-seo" ) }
 							disabled={ ! searchCleanup }
 							isDummy={ ! isPremium }
+							min={ 1 }
+							max={ 50 }
 						/>
 						<FormikValueChangeFieldWithDummy
 							as={ ToggleField }

--- a/packages/js/src/settings/routes/crawl-optimization.js
+++ b/packages/js/src/settings/routes/crawl-optimization.js
@@ -589,8 +589,6 @@ const CrawlOptimization = () => {
 							description={ __( "Limit the length of internal site search queries to reduce the impact of spam attacks and confusing URLs. Please enter a number between 1 and 50.", "wordpress-seo" ) }
 							disabled={ ! searchCleanup }
 							isDummy={ ! isPremium }
-							min={ 1 }
-							max={ 50 }
 						/>
 						<FormikValueChangeFieldWithDummy
 							as={ ToggleField }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

As you can see in the issue, it is not always clear what consequences it can have when you saved an empty field.
_What would happen?_
Empty values would result in a `0` value in the database due to our PHP, which would not be valid (between 1 and 50) in our settings and all the search characters would be stripped (instead of the expected `unlimited`).
_What happens now?_
This PR prevents saving empty values. Only a number between 1 and 50 is allowed to be saved in our settings.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Requires the search character limit to be a value (between 1 and 50).

## Relevant technical choices:

* Preventing empty values from being saved. Empty values would result in a `0` value in the database due to our PHP, which would not be valid (between 1 and 50) in our settings and all the search characters would be stripped instead of the expected `unlimited`.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Go to Settings > Advanced > Crawl optimization
* Enable _Filter search terms_
* Remove the value in _Max number of characters to allow in searches_
* Verify you get the validation error: `Please enter a number between 1 and 50.`
  * This happens like any other validation: when you tab away for the first time, or right away when already editing, or when trying to save

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The filter search terms' character limit input field in the settings.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes https://github.com/Yoast/wordpress-seo/issues/19621
