### PR TITLE
Settings: optional vertical scroll for notifications

### DIFF
--- a/css/src/new-settings.css
+++ b/css/src/new-settings.css
@@ -105,6 +105,14 @@
 	}
 
 	.yst-root {
+		.yst-notifications {
+			max-height: calc(100% - 4rem - 32px); /* Extra 32px for the height of the WP admin bar. */
+
+			@media (max-width: 782px) {
+				max-height: calc(100% - 4rem - 48px); /* Extra 48px for the height of the mobile WP admin bar. */
+			}
+		}
+
 		.yst-notifications--bottom-left {
 			z-index: 9991; /* 1 above admin menu */
 

--- a/packages/ui-library/src/components/notifications/style.css
+++ b/packages/ui-library/src/components/notifications/style.css
@@ -3,6 +3,7 @@
 
         .yst-notifications {
             max-width: calc(100% - 4rem); /* 100% - top and left of 2rem = 4rem. */
+            max-height: calc(100% - 4rem); /* 100% - ( top of 2rem * 2 )  = 4rem. */
             @apply yst-fixed yst-w-full yst-z-20 yst-pointer-events-none yst-flex yst-flex-col yst-space-y-4;
         }
 
@@ -19,7 +20,7 @@
         }
 
         .yst-notification {
-            @apply yst-w-80 yst-max-w-full yst-p-4 yst-bg-white yst-shadow-lg yst-rounded-lg yst-ring-1 yst-ring-black yst-ring-opacity-5 yst-z-20 yst-pointer-events-auto;
+            @apply yst-w-80 yst-max-w-full yst-overflow-y-auto yst-p-4 yst-bg-white yst-shadow-lg yst-rounded-lg yst-ring-1 yst-ring-black yst-ring-opacity-5 yst-z-20 yst-pointer-events-auto;
         }
 
         .yst-notification--large {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Fix notifications content being unreadable.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where the Settings notifications content could be to become unreadable due to it not fitting on the screen, now there will be a vertical scrollbar.
* [@yoast/ui-library] Notifications will now provide vertical scrolling if the content does not fit.

## Relevant technical choices:

* 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Go to Settings > General > Site representation
* Set it to organization and start adding way too many other profiles that all have invalid data, e.g. `a`
  * You can also try just making your screen height awfully small, and it will scroll the default save notification too. But that is not really real world.
* Click on save and the validation notification shows up
* Verify that it now has a vertical scrollbar, where before you where unable to get to all the content (see issue)
  * <img width="439" alt="image" src="https://user-images.githubusercontent.com/35524806/213215323-0cfaedbc-c0b4-44a9-84d6-c360f174deea.png">
* Make the screen 782px or less wide
* Verify that the notification is still the same amount away from the top as before (it made room for the taller WP admin bar)

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The notifications in the UI library, which should only be used in the Settings at this point.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes https://github.com/Yoast/plugins-automated-testing/issues/303
