### PR TITLE
19665 new public post types taxonomies notifications cannot be dismissed

### DIFF
--- a/admin/views/tabs/metas/post-types.php
+++ b/admin/views/tabs/metas/post-types.php
@@ -11,9 +11,6 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 	exit();
 }
 
-WPSEO_Post_Type::remove_post_types_made_public_notification();
-WPSEO_Post_Type::remove_taxonomies_made_public_notification();
-
 /*
  * WPSEO_Post_Type::get_accessible_post_types() should *not* be used here.
  * Otherwise setting a post-type to `noindex` will remove it from the list,

--- a/inc/class-post-type.php
+++ b/inc/class-post-type.php
@@ -98,4 +98,24 @@ class WPSEO_Post_Type {
 	public static function has_metabox_enabled( $post_type ) {
 		return WPSEO_Options::get( 'display-metabox-pt-' . $post_type, false );
 	}
+
+	/**
+	 * Removes the notification related to the post types which have been made public.
+	 *
+	 * @return void
+	 */
+	public static function remove_post_types_made_public_notification() {
+		$notification_center = Yoast_Notification_Center::get();
+		$notification_center->remove_notification_by_id( 'post-types-made-public' );
+	}
+
+	/**
+	 * Removes the notification related to the taxonomies which have been made public.
+	 *
+	 * @return void
+	 */
+	public static function remove_taxonomies_made_public_notification() {
+		$notification_center = Yoast_Notification_Center::get();
+		$notification_center->remove_notification_by_id( 'taxonomies-made-public' );
+	}
 }

--- a/inc/class-post-type.php
+++ b/inc/class-post-type.php
@@ -98,24 +98,4 @@ class WPSEO_Post_Type {
 	public static function has_metabox_enabled( $post_type ) {
 		return WPSEO_Options::get( 'display-metabox-pt-' . $post_type, false );
 	}
-
-	/**
-	 * Removes the notification related to the post types which have been made public.
-	 *
-	 * @return void
-	 */
-	public static function remove_post_types_made_public_notification() {
-		$notification_center = Yoast_Notification_Center::get();
-		$notification_center->remove_notification_by_id( 'post-types-made-public' );
-	}
-
-	/**
-	 * Removes the notification related to the taxonomies which have been made public.
-	 *
-	 * @return void
-	 */
-	public static function remove_taxonomies_made_public_notification() {
-		$notification_center = Yoast_Notification_Center::get();
-		$notification_center->remove_notification_by_id( 'taxonomies-made-public' );
-	}
 }

--- a/src/integrations/settings-integration.php
+++ b/src/integrations/settings-integration.php
@@ -13,6 +13,7 @@ use WPSEO_Options;
 use WPSEO_Replace_Vars;
 use WPSEO_Shortlinker;
 use WPSEO_Sitemaps_Router;
+use Yoast_Notification_Center;
 use Yoast\WP\SEO\Actions\Settings_Introduction_Action;
 use Yoast\WP\SEO\Conditionals\Settings_Conditional;
 use Yoast\WP\SEO\Config\Schema_Types;
@@ -255,6 +256,10 @@ class Settings_Integration implements Integration_Interface {
 			\add_action( 'admin_init', [ $this, 'register_setting' ] );
 			\add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_assets' ] );
 			\add_action( 'in_admin_header', [ $this, 'remove_notices' ], \PHP_INT_MAX );
+
+			// Remove the post types and taxonomies made public notifications (if any).
+			$this->remove_post_types_made_public_notification();
+			$this->remove_taxonomies_made_public_notification();
 		}
 	}
 
@@ -820,5 +825,25 @@ class Settings_Integration implements Integration_Interface {
 		return [
 			'siteLogoId' => $site_logo_id,
 		];
+	}
+
+	/**
+	 * Removes the notification related to the post types which have been made public.
+	 *
+	 * @return void
+	 */
+	private function remove_post_types_made_public_notification() {
+		$notification_center = Yoast_Notification_Center::get();
+		$notification_center->remove_notification_by_id( 'post-types-made-public' );
+	}
+
+	/**
+	 * Removes the notification related to the taxonomies which have been made public.
+	 *
+	 * @return void
+	 */
+	private function remove_taxonomies_made_public_notification() {
+		$notification_center = Yoast_Notification_Center::get();
+		$notification_center->remove_notification_by_id( 'taxonomies-made-public' );
 	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Fix an unreleased bug where notifications related to new public post types/taxonomies are never dismissed

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where notifications related to new public post types/taxonomies are never dismissed.

## Relevant technical choices:

* N/A

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install and activate `Yoast Test Helper`
  * If you have it already active, make sure  the `Enable post types & taxonomies` checkbox is not checked **before testing this PR**
* Go to `Tools` -> `Yoast Test`, check  the `Enable post types & taxonomies` checkbox and click `Save`
* Go to `Yoast SEO` -> `General` and verify you have the two notifications in the picture below:

<img width="1497" alt="Screenshot 2023-01-19 at 15 58 03" src="https://user-images.githubusercontent.com/68744851/213475914-f17bbe3f-e518-4ffd-9509-b0d1c3a04b83.png">

* Click on one of the two `Settings` link
* Verify the `Settings` page opens
* Verify the two notifications are gone

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* No additional aspects of the plugin are interested by the changes: I trigger already-existing (and tested) code upon entering the new `Settings` page. the same code was used in the previous version of the settings.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes https://github.com/Yoast/wordpress-seo/issues/19665
