### PR TITLE
Disallow loading wp-polyfill-inert dependency in web worker.

### DIFF
--- a/packages/js/src/analysis-worker.js
+++ b/packages/js/src/analysis-worker.js
@@ -2,6 +2,26 @@
 self.window = self;
 
 /**
+ * These dependencies reference objects and methods that
+ * are not available inside a web worker, so we disallow
+ * loading them.
+ *
+ * We need to do that in this file, since we have no
+ * control over the dependencies of WordPress dependencies that we want to load.
+ *
+ * @type {string[]}
+ */
+const disallowedDependencies = [
+	/**
+	 * References `Element`, a DOM interface not available in web workers.
+	 *
+	 * Was renamed, hence the two variants.
+	 */
+	"wp-inert-polyfill",
+	"wp-polyfill-inert",
+];
+
+/**
  * Loads dependencies.
  *
  * @param {Object<string, string>} dependencies The dependencies.
@@ -14,7 +34,7 @@ function loadDependencies( dependencies ) {
 			continue;
 		}
 
-		if ( dependency === "wp-inert-polyfill" ) {
+		if ( disallowedDependencies.includes( dependency ) ) {
 			continue;
 		}
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Loading the WordPress SEO plugin within the nightly WordPress 6.2 build broke the SEO, Readability and Inclusive language analysis. A WordPress JavaScript library was inadvertently loaded inside of the Analysis Web Worker after it had been renamed from `wp-inert-polyfill` to `wp-polyfill-inert`.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the SEO, Readability and Inclusive language analysis would not load when using WordPress version 6.2-alpha.

## Relevant technical choices:

* Added a disallow list for dependencies that we do not want to load, to allow for future scripts we want to disallow.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install the latest nightly build of WordPress 6.2.
  * You can use [the WordPress Beta Tester plugin](https://wordpress.org/plugins/wordpress-beta-tester/ ) for this.
    * Install and activate it.
    * Select the right update channel and stream.
      * Go to the Beta Tester plugin settings (_Settings_ > _Beta Tester_).
      * Select the _Bleeding Edge_ option.
      * Save the settings.
      * Select the _Nightlies_ option under the heading titled **Select one of the stream options below**.
    * Update to the latest bleeding edge nightly build (which should be a WordPress 6.2-alpha version).
      * Go to _Dashboard_ > _Updates_.
      * Click the button titled _Update_.
* Open a post in the post editor.
* Check the SEO, Readability and Inclusive language analysis. They should all work as expected (do a quick smoke test).   

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
  * You should not see the following error in the browser console:
     ```
     wp-polyfill-inert.min.js?ver=3.1.2:1 Uncaught ReferenceError: Element is not defined
        at wp-polyfill-inert.min.js?ver=3.1.2:1:2400
        at wp-polyfill-inert.min.js?ver=3.1.2:1:107
        at wp-polyfill-inert.min.js?ver=3.1.2:1:129
        at analysis-worker.js?ver=551019cfeeb1666efc9b08aad1a76af4:1:1117
        at self.onmessage (analysis-worker.js?ver=551019cfeeb1666efc9b08aad1a76af4:1:1181)
     ``` 
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* SEO, Readability and Inclusive language analysis. Do a quick smoke test to see if they are still working as expected.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes https://github.com/Yoast/plugins-automated-testing/issues/392
