### PR TITLE
Make using the SEO Link table as optional, when generating schema for an image based on its URL

### DIFF
--- a/src/helpers/image-helper.php
+++ b/src/helpers/image-helper.php
@@ -297,11 +297,12 @@ class Image_Helper {
 	/**
 	 * Find an attachment ID for a given URL.
 	 *
-	 * @param string $url The URL to find the attachment for.
+	 * @param string $url             The URL to find the attachment for.
+	 * @param bool   $use_link_table  Whether the SEO Links table will be used to retrieve the id.
 	 *
 	 * @return int The found attachment ID, or 0 if none was found.
 	 */
-	public function get_attachment_by_url( $url ) {
+	public function get_attachment_by_url( $url, $use_link_table = true ) {
 		// Don't try to do this for external URLs.
 		if ( $this->url_helper->get_link_type( $url ) === SEO_Links::TYPE_EXTERNAL ) {
 			return 0;
@@ -325,6 +326,10 @@ class Image_Helper {
 			}
 
 			return $post_id;
+		}
+
+		if ( ! $use_link_table ) {
+			return WPSEO_Image_Utils::get_attachment_by_url( $url );
 		}
 
 		$link = $this->seo_links_repository->find_one_by_url( $url );

--- a/src/helpers/schema/image-helper.php
+++ b/src/helpers/schema/image-helper.php
@@ -48,15 +48,16 @@ class Image_Helper {
 	/**
 	 * Find an image based on its URL and generate a Schema object for it.
 	 *
-	 * @param string $schema_id The `@id` to use for the returned image.
-	 * @param string $url       The image URL to base our object on.
-	 * @param string $caption   An optional caption.
-	 * @param bool   $add_hash  Whether a hash will be added as a suffix in the @id.
+	 * @param string $schema_id       The `@id` to use for the returned image.
+	 * @param string $url             The image URL to base our object on.
+	 * @param string $caption         An optional caption.
+	 * @param bool   $add_hash        Whether a hash will be added as a suffix in the @id.
+	 * @param bool   $use_link_table  Whether the SEO Links table will be used to retrieve the id.
 	 *
 	 * @return array Schema ImageObject array.
 	 */
-	public function generate_from_url( $schema_id, $url, $caption = '', $add_hash = false ) {
-		$attachment_id = $this->image->get_attachment_by_url( $url );
+	public function generate_from_url( $schema_id, $url, $caption = '', $add_hash = false, $use_link_table = true ) {
+		$attachment_id = $this->image->get_attachment_by_url( $url, $use_link_table );
 		if ( $attachment_id > 0 ) {
 			return $this->generate_from_attachment_id( $schema_id, $attachment_id, $caption, $add_hash );
 		}

--- a/tests/unit/helpers/schema/image-helper-test.php
+++ b/tests/unit/helpers/schema/image-helper-test.php
@@ -69,7 +69,7 @@ class Image_Helper_Test extends TestCase {
 		$this->image
 			->expects( 'get_attachment_by_url' )
 			->once()
-			->with( 'https://example.org/image.jpg' )
+			->with( 'https://example.org/image.jpg', true )
 			->andReturn( 1337 );
 
 		$this->instance
@@ -93,7 +93,7 @@ class Image_Helper_Test extends TestCase {
 		$this->image
 			->expects( 'get_attachment_by_url' )
 			->once()
-			->with( 'https://example.org/image.jpg' )
+			->with( 'https://example.org/image.jpg', false )
 			->andReturn( 0 );
 
 		$this->instance
@@ -104,7 +104,7 @@ class Image_Helper_Test extends TestCase {
 
 		$this->assertEquals(
 			[],
-			$this->instance->generate_from_url( '#schema-image-ABC', 'https://example.org/image.jpg', 'caption' )
+			$this->instance->generate_from_url( '#schema-image-ABC', 'https://example.org/image.jpg', 'caption', false, false )
 		);
 	}
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* To be tested together with https://github.com/Yoast/wpseo-woocommerce/pull/874
* It enables Woo to not query the links table in vain for products with placeholder images (that are bound to not be in that table)

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Enables Woo SEO to not perform unnecessary queries

## Relevant technical choices:

* Adds additional non-required parameters in the `get_attachment_by_url()` & `generate_from_url()` methods to enable not using the SEO Links table from other plugins

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

For the case of using the SEO link table for the `attachment_src_to_id` change (this also covers the fact that this should have been tested for [the main PR](https://github.com/Yoast/wordpress-seo/pull/19297), but it wasn't):
* With indexables cleaned out and the `Enable media pages` setting disabled, create a new post and add a How-To block with an image in one of its steps, like this: Add a step with step title, and as step description add some text and after that an image.
* Save the post and visit the frontend. Make a note of the post schema *and* the HTML of the How To block (confirm that the How To schema has an image in its step.)
* Clean out indexables, delete cache (aka, delete all mentions of the `yoast-structured-data-blocks-images-cache` in the postmeta db table) and check out the main(production) branch.
* Save the post again and visit the frontend again. Confirm that the post schema and the HTML of the How To block have stayed the same
* Repeat the test, with the `Enable media pages` setting enabled. Again remove the cache from the postmeta table before re-checking)

For the case of not using the SEO Link table:
* Also perform the impact check for [the respective Woo PR](https://github.com/Yoast/wpseo-woocommerce/pull/874) to cover the case of not using the SEO Link table.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The impact check is basically the LINK BUILDING and FRONTEND IMPACT sections of [the main PR ](https://github.com/Yoast/wordpress-seo/pull/19297) for this phase, so if that has been checked, it covers this PR as well.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
