### PR TITLE
19452 fix richtext notices in block editor

### DIFF
--- a/packages/js/src/structured-data-blocks/faq/components/FAQ.js
+++ b/packages/js/src/structured-data-blocks/faq/components/FAQ.js
@@ -7,7 +7,7 @@ import { speak } from "@wordpress/a11y";
 import Question from "./Question";
 import appendSpace from "../../../components/higherorder/appendSpace";
 
-import { IconButton } from "@wordpress/components";
+import { Button } from "@wordpress/components";
 import { Component, renderToString } from "@wordpress/element";
 
 const QuestionContentWithAppendedSpace = appendSpace( Question.Content );
@@ -229,13 +229,13 @@ export default class FAQ extends Component {
 	 */
 	getAddQuestionButton() {
 		return (
-			<IconButton
+			<Button
 				icon="insert"
 				onClick={ this.onAddQuestionButtonClick }
 				className="schema-faq-add-question"
 			>
 				{ __( "Add question", "wordpress-seo" ) }
-			</IconButton>
+			</Button>
 		);
 	}
 

--- a/packages/js/src/structured-data-blocks/faq/components/Question.js
+++ b/packages/js/src/structured-data-blocks/faq/components/Question.js
@@ -343,7 +343,7 @@ export default class Question extends Component {
 					onChange={ this.onChangeQuestion }
 					unstableOnFocus={ this.onFocusQuestion }
 					placeholder={ __( "Enter a question", "wordpress-seo" ) }
-					formattingControls={ [ "italic", "strikethrough", "link" ] }
+					allowedFormats={ [ "core/italic", "core/strikethrough", "core/link" ] }
 				/>
 				<RichText
 					className="schema-faq-answer"

--- a/packages/js/src/structured-data-blocks/faq/components/Question.js
+++ b/packages/js/src/structured-data-blocks/faq/components/Question.js
@@ -4,7 +4,7 @@ import { __ } from "@wordpress/i18n";
 import { isShallowEqualObjects } from "@wordpress/is-shallow-equal";
 
 import { Component } from "@wordpress/element";
-import { IconButton } from "@wordpress/components";
+import { Button } from "@wordpress/components";
 import { RichText, MediaUpload } from "@wordpress/block-editor";
 
 /* Internal dependencies */
@@ -47,13 +47,13 @@ export default class Question extends Component {
 	 */
 	getMediaUploadButton( props ) {
 		return (
-			<IconButton
+			<Button
 				className="schema-faq-section-button faq-section-add-media"
 				icon="insert"
 				onClick={ props.open }
 			>
 				{ __( "Add image", "wordpress-seo" ) }
-			</IconButton>
+			</Button>
 		);
 	}
 
@@ -187,13 +187,13 @@ export default class Question extends Component {
 				value={ attributes.id }
 				render={ this.getMediaUploadButton }
 			/>
-			<IconButton
+			<Button
 				className="schema-faq-section-button"
 				icon="trash"
 				label={ __( "Delete question", "wordpress-seo" ) }
 				onClick={ this.onRemoveQuestion }
 			/>
-			<IconButton
+			<Button
 				className="schema-faq-section-button"
 				icon="insert"
 				label={ __( "Insert question", "wordpress-seo" ) }
@@ -209,14 +209,14 @@ export default class Question extends Component {
 	 */
 	getMover() {
 		return <div className="schema-faq-section-mover">
-			<IconButton
+			<Button
 				className="editor-block-mover__control"
 				onClick={ this.onMoveUp }
 				icon="arrow-up-alt2"
 				label={ __( "Move question up", "wordpress-seo" ) }
 				aria-disabled={ this.props.isFirst }
 			/>
-			<IconButton
+			<Button
 				className="editor-block-mover__control"
 				onClick={ this.onMoveDown }
 				icon="arrow-down-alt2"

--- a/packages/js/src/structured-data-blocks/how-to/components/HowTo.js
+++ b/packages/js/src/structured-data-blocks/how-to/components/HowTo.js
@@ -11,7 +11,7 @@ import buildDurationString from "../utils/buildDurationString";
 import appendSpace from "../../../components/higherorder/appendSpace";
 
 import { RichText, InspectorControls } from "@wordpress/block-editor";
-import { IconButton, PanelBody, TextControl, ToggleControl } from "@wordpress/components";
+import { Button, PanelBody, TextControl, ToggleControl } from "@wordpress/components";
 import { Component, renderToString, createRef } from "@wordpress/element";
 
 const RichTextWithAppendedSpace = appendSpace( RichText.Content );
@@ -452,13 +452,13 @@ export default class HowTo extends Component {
 	 */
 	getAddStepButton() {
 		return (
-			<IconButton
+			<Button
 				icon="insert"
 				onClick={ this.onAddStepButtonClick }
 				className="schema-how-to-add-step"
 			>
 				{ __( "Add step", "wordpress-seo" ) }
-			</IconButton>
+			</Button>
 		);
 	}
 
@@ -600,14 +600,14 @@ export default class HowTo extends Component {
 
 		if ( ! attributes.hasDuration ) {
 			return (
-				<IconButton
+				<Button
 					onClick={ this.addDuration }
 					className="schema-how-to-duration-button"
 					ref={ this.addDurationButton }
 					icon="insert"
 				>
 					{ __( "Add total time", "wordpress-seo" ) }
-				</IconButton>
+				</Button>
 			);
 		}
 
@@ -664,7 +664,7 @@ export default class HowTo extends Component {
 							onChange={ this.onChangeMinutes }
 							placeholder="MM"
 						/>
-						<IconButton
+						<Button
 							className="schema-how-to-duration-delete-button"
 							icon="trash"
 							label={ __( "Delete total time", "wordpress-seo" ) }

--- a/packages/js/src/structured-data-blocks/how-to/components/HowToStep.js
+++ b/packages/js/src/structured-data-blocks/how-to/components/HowToStep.js
@@ -5,7 +5,7 @@ import appendSpace from "../../../components/higherorder/appendSpace";
 import { isShallowEqualObjects } from "@wordpress/is-shallow-equal";
 
 import { Component } from "@wordpress/element";
-import { IconButton } from "@wordpress/components";
+import { Button } from "@wordpress/components";
 import { RichText, MediaUpload } from "@wordpress/block-editor";
 
 const RichTextWithAppendedSpace = appendSpace( RichText );
@@ -146,13 +146,13 @@ export default class HowToStep extends Component {
 	 */
 	getMediaUploadButton( props ) {
 		return (
-			<IconButton
+			<Button
 				className="schema-how-to-step-button how-to-step-add-media"
 				icon="insert"
 				onClick={ props.open }
 			>
 				{ __( "Add image", "wordpress-seo" ) }
-			</IconButton>
+			</Button>
 		);
 	}
 
@@ -175,13 +175,13 @@ export default class HowToStep extends Component {
 				render={ this.getMediaUploadButton }
 			/>
 			}
-			<IconButton
+			<Button
 				className="schema-how-to-step-button"
 				icon="trash"
 				label={ __( "Delete step", "wordpress-seo" ) }
 				onClick={ this.onRemoveStep }
 			/>
-			<IconButton
+			<Button
 				className="schema-how-to-step-button"
 				icon="insert"
 				label={ __( "Insert step", "wordpress-seo" ) }
@@ -197,14 +197,14 @@ export default class HowToStep extends Component {
 	 */
 	getMover() {
 		return <div className="schema-how-to-step-mover">
-			<IconButton
+			<Button
 				className="editor-block-mover__control"
 				onClick={ this.onMoveStepUp }
 				icon="arrow-up-alt2"
 				label={ __( "Move step up", "wordpress-seo" ) }
 				aria-disabled={ this.props.isFirst }
 			/>
-			<IconButton
+			<Button
 				className="editor-block-mover__control"
 				onClick={ this.onMoveStepDown }
 				icon="arrow-down-alt2"

--- a/packages/js/src/structured-data-blocks/how-to/components/HowToStep.js
+++ b/packages/js/src/structured-data-blocks/how-to/components/HowToStep.js
@@ -332,7 +332,7 @@ export default class HowToStep extends Component {
 					onChange={ this.onChangeTitle }
 					placeholder={ __( "Enter a step title", "wordpress-seo" ) }
 					unstableOnFocus={ this.onFocusTitle }
-					formattingControls={ [ "italic", "strikethrough", "link" ] }
+					allowedFormats={ [ "core/italic", "core/strikethrough", "core/link" ] }
 				/>
 				<RichTextWithAppendedSpace
 					className="schema-how-to-step-text"


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to avoid some WordPress deprecation notices in our `How-to` and `FAQ` blocks

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Stops using deprecated WordPress components\props in `Yoast How-to` and `Yoast FAQ` blocks.

## Relevant technical choices:

* N/A

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:
**Test the Yoast FAQ block**
* Create a new post
* Insert a `Yoast FAQ` block
* Verify that:
  * All the buttons are present and function correctly
    <img width="460" alt="Screenshot 2023-01-20 at 15 00 23" src="https://user-images.githubusercontent.com/68744851/213715099-ab240dc8-9de6-4733-95ee-83e4857de464.png">
  * You can use the `Italic`, `Link` and `Strike-through` formatting buttons both in the question and in the answer
  * You get none of the following notice in the browser's console:
    * `wp.components.IconButton is deprecated since version 5.4 and will be removed in version 6.2. Please use wp.components.Button instead`
    * `wp.blockEditor.RichText formattingcontrols prop is deprecated since version 5.4 and will be removed in version 6.2. Please use allowedFormats instead`

---
**Test the Yoast How-to block**
* Insert a `Yoast How-to` block
* Verify that:
  * All the buttons are present and function correctly
    <img width="458" alt="Screenshot 2023-01-20 at 15 10 18" src="https://user-images.githubusercontent.com/68744851/213717215-028891c8-d08f-48a8-9ad5-bd8e7029db69.png">
  * You can use the `Italic`, `Link` and `Strike-through` formatting buttons in the how-to description, steps and steps description
  * You get none of the following notice in the browser's console:
    * `wp.components.IconButton is deprecated since version 5.4 and will be removed in version 6.2. Please use wp.components.Button instead`
    * `wp.blockEditor.RichText formattingcontrols prop is deprecated since version 5.4 and will be removed in version 6.2. Please use allowedFormats instead`

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* No other parts of the plugin are involved in this PR.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes https://github.com/Yoast/wordpress-seo/issues/19452
