### PR TITLE
[PT][ES] Optimizes participle detection for Portuguese and Spanish

### DIFF
--- a/packages/yoastseo/src/languageProcessing/languages/es/config/internal/passiveVoiceParticiples.js
+++ b/packages/yoastseo/src/languageProcessing/languages/es/config/internal/passiveVoiceParticiples.js
@@ -4279,7 +4279,6 @@ export default [
 	"hurtad",
 	"husmad",
 	"husmead",
-	"id",
 	"idead",
 	"idealizad",
 	"identificad",

--- a/packages/yoastseo/src/languageProcessing/languages/es/helpers/internal/getParticiples.js
+++ b/packages/yoastseo/src/languageProcessing/languages/es/helpers/internal/getParticiples.js
@@ -12,7 +12,7 @@ function isParticiple( word ) {
 	const participleSuffixes = [ "a", "o", "as", "os" ];
 	// For each participle suffixes, check if the word ends in one of them.
 	return participleSuffixes.some( suffix => {
-		if ( word.endsWith( suffix ) ) {
+		if ( word.length > 3 && word.endsWith( suffix ) ) {
 			// If the word ends with one of the suffixes, retrieve the stem.
 			const stem = word.slice( 0, -( suffix.length ) );
 			// Check if the stem is in the list of participles: return true if it is, otherwise return false.

--- a/packages/yoastseo/src/languageProcessing/languages/es/helpers/internal/getParticiples.js
+++ b/packages/yoastseo/src/languageProcessing/languages/es/helpers/internal/getParticiples.js
@@ -16,7 +16,7 @@ function isParticiple( word ) {
 		if ( word.length > 3 && word.endsWith( suffix ) ) {
 			// If the word ends with one of the suffixes, retrieve the stem.
 			const stem = word.slice( 0, -( suffix.length ) );
-			// Check if the stem is in the list of participles: return true if it is, otherwise return false.
+			// Check if the stem is in the list of participle stems: return true if it is, otherwise return false.
 			return participleStems.includes( stem );
 		}
 	} );

--- a/packages/yoastseo/src/languageProcessing/languages/es/helpers/internal/getParticiples.js
+++ b/packages/yoastseo/src/languageProcessing/languages/es/helpers/internal/getParticiples.js
@@ -12,6 +12,7 @@ function isParticiple( word ) {
 	const participleSuffixes = [ "a", "o", "as", "os" ];
 	// For each participle suffixes, check if the word ends in one of them.
 	return participleSuffixes.some( suffix => {
+		// Make sure only possible participles are targeted (minimum length being "> 3")
 		if ( word.length > 3 && word.endsWith( suffix ) ) {
 			// If the word ends with one of the suffixes, retrieve the stem.
 			const stem = word.slice( 0, -( suffix.length ) );

--- a/packages/yoastseo/src/languageProcessing/languages/it/helpers/internal/getParticiples.js
+++ b/packages/yoastseo/src/languageProcessing/languages/it/helpers/internal/getParticiples.js
@@ -12,6 +12,7 @@ function isParticiple( word ) {
 	const participleSuffixes = [ "a", "o", "e", "i" ];
 	// For each participle suffixes, check if the word ends in one of them.
 	return participleSuffixes.some( suffix => {
+		// Make sure only possible participles are targeted (minimum length being "> 3")
 		if ( word.length > 3 && word.endsWith( suffix ) ) {
 			// If the word ends with one of the suffixes, retrieve the stem.
 			const stem = word.slice( 0, -1 );

--- a/packages/yoastseo/src/languageProcessing/languages/it/helpers/internal/getParticiples.js
+++ b/packages/yoastseo/src/languageProcessing/languages/it/helpers/internal/getParticiples.js
@@ -16,7 +16,7 @@ function isParticiple( word ) {
 		if ( word.length > 3 && word.endsWith( suffix ) ) {
 			// If the word ends with one of the suffixes, retrieve the stem.
 			const stem = word.slice( 0, -1 );
-			// Check if the stem is in the list of participles: return true if it is, otherwise return false.
+			// Check if the stem is in the list of participle stems: return true if it is, otherwise return false.
 			return participleStems.includes( stem );
 		}
 	} );

--- a/packages/yoastseo/src/languageProcessing/languages/pt/config/internal/passiveVoiceParticiples.js
+++ b/packages/yoastseo/src/languageProcessing/languages/pt/config/internal/passiveVoiceParticiples.js
@@ -2451,7 +2451,6 @@ export default [
 	"idealizad",
 	"identificad",
 	"ideologizad",
-	"id",
 	"idolatrad",
 	"ignorad",
 	"igualad",

--- a/packages/yoastseo/src/languageProcessing/languages/pt/helpers/internal/getParticiples.js
+++ b/packages/yoastseo/src/languageProcessing/languages/pt/helpers/internal/getParticiples.js
@@ -12,7 +12,7 @@ function isParticiple( word ) {
 	const participleSuffixes = [ "a", "o", "as", "os" ];
 	// For each participle suffixes, check if the word ends in one of them.
 	return participleSuffixes.some( suffix => {
-		if ( word.endsWith( suffix ) ) {
+		if ( word.length > 3 && word.endsWith( suffix ) ) {
 			// If the word ends with one of the suffixes, retrieve the stem.
 			const stem = word.slice( 0, -( suffix.length ) );
 			// Check if the stem is in the list of participles: return true if it is, otherwise return false.

--- a/packages/yoastseo/src/languageProcessing/languages/pt/helpers/internal/getParticiples.js
+++ b/packages/yoastseo/src/languageProcessing/languages/pt/helpers/internal/getParticiples.js
@@ -16,7 +16,7 @@ function isParticiple( word ) {
 		if ( word.length > 3 && word.endsWith( suffix ) ) {
 			// If the word ends with one of the suffixes, retrieve the stem.
 			const stem = word.slice( 0, -( suffix.length ) );
-			// Check if the stem is in the list of participles: return true if it is, otherwise return false.
+			// Check if the stem is in the list of participle stems: return true if it is, otherwise return false.
 			return participleStems.includes( stem );
 		}
 	} );

--- a/packages/yoastseo/src/languageProcessing/languages/pt/helpers/internal/getParticiples.js
+++ b/packages/yoastseo/src/languageProcessing/languages/pt/helpers/internal/getParticiples.js
@@ -12,6 +12,7 @@ function isParticiple( word ) {
 	const participleSuffixes = [ "a", "o", "as", "os" ];
 	// For each participle suffixes, check if the word ends in one of them.
 	return participleSuffixes.some( suffix => {
+		// Make sure only possible participles are targeted (minimum length being "> 3")
 		if ( word.length > 3 && word.endsWith( suffix ) ) {
 			// If the word ends with one of the suffixes, retrieve the stem.
 			const stem = word.slice( 0, -( suffix.length ) );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The current code for participle detection in Portuguese and Spanish scans the whole text in search for participle forms, but only words of more than 3 characters are possible. Using the same conditional as in [this improvement for Italian](https://github.com/Yoast/wordpress-seo/pull/19610), we can make the scanning for participles more effective.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Optimizes participle detection for Portuguese and Spanish
* [shopify-seo] Optimizes participle detection for Portuguese and Spanish

## Relevant technical choices:

* There was one participle stem `id` (_to go_) which was removed from both language directories (in `passiveVoiceParticiples.js`). Intransitive verbs cannot be passivized.
* The conditional with `length > 3` works in all three languages. Although it is generally bad practice to assign "magic numbers", I checked for every possible case to make sure this change is future-proof and new additions to `passiveVoiceParticiples.js` will not be affected. Participles in IT, PT and ES have predictable endings (e.g., `-do, -to , -so` etc.) and if `length > 2` were to be true, the preceding letter would have to be a vowel (in order to not violate the phonotactic rules of each language). After checking for each vowel + participle ending (e.g. `edo, odo, udo`, etc.), I could only find non-words.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
_**NOTE:** when you open a post that was created in Classic editor with Block editor or Elementor, the percentage of passive sentences will be different from the percentage in Classic editor. This is a pre-existing issue. An IM-issue was made [here](https://github.com/Yoast/wordpress-seo/issues/19674). This issue can be resolved in Block editor by “Converting to blocks” and in Elementor by directly pasting the text in Elementor. In both cases it shows the same result as in Classic editor. This behaviour was observed for Spanish._

This PR can be acceptance tested by following these steps:

### For Portuguese:
* Follow the test instructions in [ this PR](https://github.com/Yoast/wordpress-seo/pull/19498).

### For Spanish:
* Follow the test instructions in [this PR](https://github.com/Yoast/wordpress-seo/pull/19527).

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [x] Changes should be tested on different editors (Block/Classic/Elementor/other)*
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* This PR changes the list of participles in `passiveVoiceParticiples.js`, and the code in `getParticiples.js` for Portuguese and Spanish. As such, the PR only affects the _passive voice_ assessment for these languages.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [x] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes [#19670](https://github.com/Yoast/wordpress-seo/issues/19670)
