### PR TITLE
[IM] Highlighting feature: Enable highlighting text containing html tags in Classic editor and make sure yoastmark doesn't corrupt anchor tags in Shopify

### DIFF
--- a/packages/js/src/decorator/tinyMCE.js
+++ b/packages/js/src/decorator/tinyMCE.js
@@ -1,6 +1,5 @@
-import { markers } from "yoastseo";
+import { markers, languageProcessing } from "yoastseo";
 import { forEach } from "lodash-es";
-import { languageProcessing } from "yoastseo";
 
 var MARK_TAG = "yoastmark";
 
@@ -36,11 +35,30 @@ function markTinyMCE( editor, paper, marks ) {
 	let html = editor.getContent();
 	html = markers.removeMarks( html );
 
+	/*
+	 * Get the information whether we want to mark a specific part of the HTML. If we do, `fieldsToMark` should return an array with that information.
+	 * For example, [ "heading" ] means that we want to apply the markings in subheadings only, and not the other parts.
+	 * `selectedHTML` is an array of the HTML parts that we want to apply the marking to.
+	 */
 	const { fieldsToMark, selectedHTML } = languageProcessing.getFieldsToMark( marks, html );
 
 	// Generate marked HTML.
 	forEach( marks, function( mark ) {
+		/*
+		 * Classic editor uses double quotes for HTML attribute values. However, Block editor uses single quotes for HTML tag attributes,
+		 * and that's why in `yoastseo`, we use single quotes for the attribute values when we create the marked object. As a result,
+		 * the replacement did not work, as the marks passed by `yoastseo` did not match anything in the original text.
+		 * This step is replacing the single quotes in the marked object output by `yoastseo` with double quotes.
+		 * This way, we make sure that the replacement can find a match between the original text of the marked object and the text in the page.
+		 */
+		if ( editor.id !== "acf_content" ) {
+			mark._properties.marked = languageProcessing.normalizeHTML( mark._properties.marked );
+			mark._properties.original = languageProcessing.normalizeHTML( mark._properties.original );
+		}
+
+		// Check if we want to mark only specific part of the HTML.
 		if ( fieldsToMark.length > 0 ) {
+			// Apply the marking to the selected HTML parts.
 			selectedHTML.forEach( element => {
 				const markedElement = mark.applyWithReplace( element );
 				html = html.replace( element, markedElement );

--- a/packages/yoastseo/spec/fullTextTests/testTexts/ar/arabicPaper.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/ar/arabicPaper.js
@@ -119,7 +119,7 @@ const expectedResults = {
 	textTransitionWords: {
 		isApplicable: true,
 		score: 6,
-		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 23.5% of the sentences contain transition words, " +
+		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 23.1% of the sentences contain transition words, " +
 			"which is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more of them</a>.",
 	},
 	passiveVoice: {

--- a/packages/yoastseo/spec/fullTextTests/testTexts/de/germanPaper.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/de/germanPaper.js
@@ -127,13 +127,13 @@ const expectedResults = {
 	textTransitionWords: {
 		isApplicable: true,
 		score: 6,
-		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 27.1% of the sentences contain " +
+		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 25.5% of the sentences contain " +
 			"transition words, which is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more of them</a>.",
 	},
 	passiveVoice: {
 		isApplicable: true,
 		score: 3,
-		resultText: "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: 16.7% of the sentences contain passive voice, " +
+		resultText: "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: 15.7% of the sentences contain passive voice, " +
 			"which is more than the recommended maximum of 10%. <a href='https://yoa.st/34u' target='_blank'>" +
 			"Try to use their active counterparts</a>.",
 	},

--- a/packages/yoastseo/spec/fullTextTests/testTexts/el/greekPaper.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/el/greekPaper.js
@@ -126,13 +126,13 @@ const expectedResults = {
 	textTransitionWords: {
 		isApplicable: true,
 		score: 3,
-		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 19.7% of the sentences contain" +
+		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 19.4% of the sentences contain" +
 			" transition words, which is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more of them</a>.",
 	},
 	passiveVoice: {
 		isApplicable: true,
 		score: 3,
-		resultText: "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: 25.9% of the sentences contain passive voice, " +
+		resultText: "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: 25.5% of the sentences contain passive voice, " +
 			"which is more than the recommended maximum of 10%. <a href='https://yoa.st/34u' target='_blank'>" +
 			"Try to use their active counterparts</a>.",
 	},

--- a/packages/yoastseo/spec/fullTextTests/testTexts/en/englishPaperForPerformanceTest.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/en/englishPaperForPerformanceTest.js
@@ -126,7 +126,7 @@ const expectedResults = {
 	textTransitionWords: {
 		isApplicable: true,
 		score: 3,
-		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 5.6% of the sentences contain transition words, " +
+		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 5.5% of the sentences contain transition words, " +
 			"which is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more of them</a>.",
 	},
 	passiveVoice: {

--- a/packages/yoastseo/spec/fullTextTests/testTexts/fa/farsiPaper.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/fa/farsiPaper.js
@@ -135,7 +135,7 @@ const expectedResults = {
 	passiveVoice: {
 		isApplicable: true,
 		score: 6,
-		resultText: "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: 11.8% of the sentences contain passive voice, " +
+		resultText: "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: 11.5% of the sentences contain passive voice, " +
 			"which is more than the recommended maximum of 10%. <a href='https://yoa.st/34u' target='_blank'>" +
 			"Try to use their active counterparts</a>.",
 	},

--- a/packages/yoastseo/spec/fullTextTests/testTexts/hu/hungarianPaper.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/hu/hungarianPaper.js
@@ -112,7 +112,7 @@ const expectedResults = {
 	textTransitionWords: {
 		isApplicable: true,
 		score: 3,
-		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 13.1% of the sentences contain transition words, which is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more of them</a>.",
+		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 12.5% of the sentences contain transition words, which is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more of them</a>.",
 	},
 	passiveVoice: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/fullTextTests/testTexts/id/indonesianPaper.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/id/indonesianPaper.js
@@ -119,7 +119,7 @@ const expectedResults = {
 	passiveVoice: {
 		isApplicable: true,
 		score: 3,
-		resultText: "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: 25.3% of the sentences contain passive voice, which is more than the recommended maximum of 10%. <a href='https://yoa.st/34u' target='_blank'>Try to use their active counterparts</a>.",
+		resultText: "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: 24.7% of the sentences contain passive voice, which is more than the recommended maximum of 10%. <a href='https://yoa.st/34u' target='_blank'>Try to use their active counterparts</a>.",
 	},
 	textPresence: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/fullTextTests/testTexts/nb/norwegianPaper.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/nb/norwegianPaper.js
@@ -126,10 +126,8 @@ const expectedResults = {
 	},
 	passiveVoice: {
 		isApplicable: true,
-		score: 6,
-		resultText: "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: 10.6% of the sentences contain passive voice, " +
-			"which is more than the recommended maximum of 10%. <a href='https://yoa.st/34u' target='_blank'>" +
-			"Try to use their active counterparts</a>.",
+		score: 9,
+		resultText: "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: You're using enough active voice. That's great!",
 	},
 	textPresence: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/fullTextTests/testTexts/pt/portuguesePaper.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/pt/portuguesePaper.js
@@ -127,13 +127,13 @@ const expectedResults = {
 	textTransitionWords: {
 		isApplicable: true,
 		score: 3,
-		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 7.8% of the sentences contain transition words," +
+		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 9% of the sentences contain transition words," +
 			" which is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more of them</a>.",
 	},
 	passiveVoice: {
 		isApplicable: true,
 		score: 6,
-		resultText: "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: 10.6% of the sentences contain passive voice, " +
+		resultText: "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: 15.3% of the sentences contain passive voice, " +
 			"which is more than the recommended maximum of 10%. <a href='https://yoa.st/34u' target='_blank'>" +
 			"Try to use their active counterparts</a>.",
 	},

--- a/packages/yoastseo/spec/fullTextTests/testTexts/pt/portuguesePaper.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/pt/portuguesePaper.js
@@ -127,13 +127,13 @@ const expectedResults = {
 	textTransitionWords: {
 		isApplicable: true,
 		score: 3,
-		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 9% of the sentences contain transition words," +
+		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 7.6% of the sentences contain transition words," +
 			" which is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more of them</a>.",
 	},
 	passiveVoice: {
 		isApplicable: true,
 		score: 6,
-		resultText: "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: 15.3% of the sentences contain passive voice, " +
+		resultText: "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: 10.4% of the sentences contain passive voice, " +
 			"which is more than the recommended maximum of 10%. <a href='https://yoa.st/34u' target='_blank'>" +
 			"Try to use their active counterparts</a>.",
 	},

--- a/packages/yoastseo/spec/fullTextTests/testTexts/sk/slovakPaper.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/sk/slovakPaper.js
@@ -121,7 +121,7 @@ const expectedResults = {
 	textTransitionWords: {
 		isApplicable: true,
 		score: 3,
-		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 12.9% of the sentences contain transition words," +
+		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 12.8% of the sentences contain transition words," +
 			" which is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more of them</a>.",
 	},
 	passiveVoice: {

--- a/packages/yoastseo/spec/fullTextTests/testTexts/tr/turkishPaper.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/tr/turkishPaper.js
@@ -90,8 +90,10 @@ const expectedResults = {
 		isApplicable: false,
 	},
 	keyphraseDistribution: {
-		// The text doesnt contain more than 15 sentences.
-		isApplicable: false,
+		isApplicable: true,
+		score: 6,
+		resultText: "<a href='https://yoa.st/33q' target='_blank'>Keyphrase distribution</a>: Uneven. Some parts of your text do not " +
+			"contain the keyphrase or its synonyms. <a href='https://yoa.st/33u' target='_blank'>Distribute them more evenly</a>.",
 	},
 	subheadingsTooLong: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/languageProcessing/helpers/html/normalizeHTMLSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/helpers/html/normalizeHTMLSpec.js
@@ -1,0 +1,38 @@
+import normalizeHTML from "../../../../src/languageProcessing/helpers/html/normalizeHTML";
+
+describe( "normalizeHTML", function() {
+	it( "should return the same string when no single quotes are present", function() {
+		expect( normalizeHTML( "This is a test" ) )
+			.toEqual( "This is a test" );
+	} );
+
+	it( "should return the same string when only double quotes in HTML attribute values are present", function() {
+		expect( normalizeHTML( "<yoastmark class=\"yoast-text-mark\">This is a test</yoastmark>" ) )
+			.toEqual( "<yoastmark class=\"yoast-text-mark\">This is a test</yoastmark>" );
+	} );
+
+	it( "should return the same string when a string contains non breaking spaces.", function() {
+		expect( normalizeHTML( "<yoastmark class=\"yoast-text-mark\">This\u{00a0}is a\u{00a0}test</yoastmark>" ) )
+			.toEqual( "<yoastmark class=\"yoast-text-mark\">This\u{00a0}is a\u{00a0}test</yoastmark>" );
+	} );
+
+	it( "should not replace single quotes (or apostrophes) outside HTML tags", function() {
+		expect( normalizeHTML( "This is a test, let's go!" ) )
+			.toEqual( "This is a test, let's go!" );
+	} );
+
+	it( "should replace the outer single quotes in HTML attribute values with double quotes", function() {
+		expect( normalizeHTML( "<span style='color: red'>This</span> is a test" ) )
+			.toEqual( "<span style=\"color: red\">This</span> is a test" );
+	} );
+
+	it( "should not replace any inner single quotes in HTML attribute values", function() {
+		expect( normalizeHTML( "<span data-attr=\"let's go, time's up\">This</span> is a test" ) )
+			.toEqual( "<span data-attr=\"let's go, time's up\">This</span> is a test" );
+	} );
+
+	it( "should replace the outer single quotes in multiple HTML attribute values with double quotes", function() {
+		expect( normalizeHTML( "<yoastmark class='yoast-text-mark' style='color: blue'>This is a test</yoastmark>" ) )
+			.toEqual( "<yoastmark class=\"yoast-text-mark\" style=\"color: blue\">This is a test</yoastmark>" );
+	} );
+} );

--- a/packages/yoastseo/spec/languageProcessing/helpers/sentence/SentenceTokenizerSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/helpers/sentence/SentenceTokenizerSpec.js
@@ -419,3 +419,34 @@ describe( "A test for tokenizing a (html) text into sentences", function() {
 	} );
 } );
 
+describe( "testing the isValidTagPair helper method", function() {
+	it( "returns true if the tags are of the same type and the correct type", function() {
+		[ "p", "div", "h1", "h2", "h3", "h4", "h5", "h6", "span" ].forEach( function( tagType ) {
+			const mockOpenTag = { src: `<${tagType}>` };
+			const mockCloseTag = { src: `</${tagType}>` };
+			expect( mockTokenizer.isValidTagPair( mockOpenTag, mockCloseTag ) ).toBe( true );
+		} );
+	} );
+	it( "returns true if the tags are of the same type and the correct type and the have attributes", function() {
+		[ "p", "div", "h1", "h2", "h3", "h4", "h5", "h6", "span" ].forEach( function( tagType ) {
+			const mockOpenTag = { src: `<${tagType} class="onzin" messy="1">` };
+			const mockCloseTag = { src: `</${tagType}>` };
+			expect( mockTokenizer.isValidTagPair( mockOpenTag, mockCloseTag ) ).toBe( true );
+		} );
+	} );
+	it( "returns false if the tags are of the same type but not of the correct type", function() {
+		const mockOpenTag = { src: "<i>" };
+		const mockCloseTag = { src: "</i>" };
+		expect( mockTokenizer.isValidTagPair( mockOpenTag, mockCloseTag ) ).toBe( false );
+	} );
+	it( "returns false if the tags are of te correct type but not of the same type", function() {
+		const mockOpenTag = { src: "<div>" };
+		const mockCloseTag = { src: "</span>" };
+		expect( mockTokenizer.isValidTagPair( mockOpenTag, mockCloseTag ) ).toBe( false );
+	} );
+	it( "returns false if the tags are of te wrong type and not of the same type", function() {
+		const mockOpenTag = { src: "<i>" };
+		const mockCloseTag = { src: "</b>" };
+		expect( mockTokenizer.isValidTagPair( mockOpenTag, mockCloseTag ) ).toBe( false );
+	} );
+} );

--- a/packages/yoastseo/spec/languageProcessing/helpers/word/markWordsInSentenceSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/helpers/word/markWordsInSentenceSpec.js
@@ -1,8 +1,50 @@
-import { markWordsInSentences } from "../../../../src/languageProcessing/helpers/word/markWordsInSentences";
+import { deConstructAnchor, markWordsInSentences, reConstructAnchor } from "../../../../src/languageProcessing/helpers/word/markWordsInSentences";
 import Mark from "../../../../src/values/Mark";
 import matchWordCustomHelper from "../../../../src/languageProcessing/languages/ja/helpers/matchTextWithWord";
 
 describe( "Adds Yoast marks to specific words in a sentence", function() {
+	it( "should add Yoast marks to all instances of specified words in a sentence, except when there is an anchor," +
+		" the marking should not be applied to the anchor tag attribute", function() {
+		expect( markWordsInSentences(
+			[ "picket", "tile" ],
+			[ "Introducing Palisades Ceramic Picket Tile — the latest trend in <a href=\"https://www.tileclub.com/collections/ceramic-tile\"" +
+			" target=\"_blank\" rel=\"noopener\">ceramic tile</a>!" ],
+			"en_EN"
+		) ).toEqual( [
+			new Mark( {
+				marked: "Introducing Palisades Ceramic <yoastmark class='yoast-text-mark'>Picket Tile</yoastmark> — the latest trend in " +
+						"<a href=\"https://www.tileclub.com/" +
+						"collections/ceramic-tile\" target=\"_blank\" rel=\"noopener\">ceramic " +
+						"<yoastmark class='yoast-text-mark'>tile</yoastmark></a>!",
+				original: "Introducing Palisades Ceramic Picket Tile — the latest trend in " +
+						"<a href=\"https://www.tileclub.com/collections/ceramic-tile\"" +
+						" target=\"_blank\" rel=\"noopener\">ceramic tile</a>!" } ),
+		]
+		);
+	} );
+
+	it( "should add Yoast marks to all instances of specified words in a sentence, except when there are multiple anchors," +
+		" the marking should not be applied to the anchor tag attribute", function() {
+		expect( markWordsInSentences(
+			[ "picket", "tile" ],
+			[ "Introducing Palisades Ceramic <a href=\"https://www.tileclub.com/ceramic-tile\">Picket Tile</a> — " +
+			"the latest trend in <a href=\"https://www.tileclub.com/collections/ceramic-tile\"" +
+			" target=\"_blank\" rel=\"noopener\">ceramic tile</a>!" ],
+			"en_EN"
+		) ).toEqual( [
+			new Mark( {
+				marked: "Introducing Palisades Ceramic <a href=\"https://www.tileclub.com/ceramic-tile\"><yoastmark class='yoast-text-mark'>" +
+						"Picket Tile</yoastmark></a> — the latest trend in " +
+						"<a href=\"https://www.tileclub.com/" +
+						"collections/ceramic-tile\" target=\"_blank\" rel=\"noopener\">ceramic " +
+						"<yoastmark class='yoast-text-mark'>tile</yoastmark></a>!",
+				original: "Introducing Palisades Ceramic <a href=\"https://www.tileclub.com/ceramic-tile\">Picket Tile</a> — " +
+						"the latest trend in <a href=\"https://www.tileclub.com/collections/ceramic-tile\"" +
+						" target=\"_blank\" rel=\"noopener\">ceramic tile</a>!" } ),
+		]
+		);
+	} );
+
 	it( "should add Yoast marks to all instances of specified words in a sentence", function() {
 		expect( markWordsInSentences(
 			[ "turtle", "hamster" ],
@@ -101,4 +143,63 @@ describe( "Adds Yoast marks to specific words in a sentence for languages with c
 		) ).toEqual( [] );
 	} );
 } );
+
+describe( "test the deconstructAnchor and reconstructAnchor helper", () => {
+	it( "correctly deconstructs and reconstructs an anchor", () => {
+		const testAnchor = "<a href=\"https://yoast.com\">This is yoast.</a>";
+		const deconstructedAnchor = deConstructAnchor( testAnchor );
+
+		expect( deconstructedAnchor ).toEqual( {
+			openTag: "<a href=\"https://yoast.com\">",
+			content: "This is yoast.",
+		} );
+
+		const reconstructedAnchor = reConstructAnchor( deconstructedAnchor.openTag, deconstructedAnchor.content );
+		expect( reconstructedAnchor ).toEqual( testAnchor );
+	} );
+
+	it( "correctly deconstructs and reconstructs an anchor that contains html elements itself", () => {
+		const testAnchor = "<a href=\"https://yoast.com\">This <i>is</i> <b>yoast</b>.</a>";
+		const deconstructedAnchor = deConstructAnchor( testAnchor );
+
+		expect( deconstructedAnchor ).toEqual( {
+			openTag: "<a href=\"https://yoast.com\">",
+			content: "This <i>is</i> <b>yoast</b>.",
+		} );
+
+		const reconstructedAnchor = reConstructAnchor( deconstructedAnchor.openTag, deconstructedAnchor.content );
+		expect( reconstructedAnchor ).toEqual( testAnchor );
+	} );
+
+	it( "correctly deconstructs and reconstructs an anchor if does not contain content", () => {
+		// Unrealistic Scenario. But protects against the bug that is solved in this PR:
+		// https://github.com/Yoast/wordpress-seo/pull/19373
+		const testAnchor = "<a href=\"https://yoast.com\"></a>";
+		const deconstructedAnchor = deConstructAnchor( testAnchor );
+
+		expect( deconstructedAnchor ).toEqual( {
+			openTag: "<a href=\"https://yoast.com\">",
+			content: "",
+		} );
+
+		const reconstructedAnchor = reConstructAnchor( deconstructedAnchor.openTag, deconstructedAnchor.content );
+		expect( reconstructedAnchor ).toEqual( testAnchor );
+	} );
+
+	it( "correctly deconstructs and reconstructs an anchor if content contains a newline", () => {
+		// Unrealistic Scenario. But protects against the bug that is solved in this PR:
+		// https://github.com/Yoast/wordpress-seo/pull/19373
+		const testAnchor = "<a href=\"https://yoast.com\">This is a line.\nAnd this is a line.</a>";
+		const deconstructedAnchor = deConstructAnchor( testAnchor );
+
+		expect( deconstructedAnchor ).toEqual( {
+			openTag: "<a href=\"https://yoast.com\">",
+			content: "This is a line.\nAnd this is a line.",
+		} );
+
+		const reconstructedAnchor = reConstructAnchor( deconstructedAnchor.openTag, deconstructedAnchor.content );
+		expect( reconstructedAnchor ).toEqual( testAnchor );
+	} );
+} );
+
 

--- a/packages/yoastseo/spec/scoring/productPages/fullTextTests/testTexts/en/englishPaper3.js
+++ b/packages/yoastseo/spec/scoring/productPages/fullTextTests/testTexts/en/englishPaper3.js
@@ -160,7 +160,7 @@ const expectedResults = {
 	passiveVoice: {
 		isApplicable: true,
 		score: 3,
-		resultText: "<a href='https://yoa.st/shopify42' target='_blank'>Passive voice</a>: 21.1% of the sentences contain passive voice, " +
+		resultText: "<a href='https://yoa.st/shopify42' target='_blank'>Passive voice</a>: 19% of the sentences contain passive voice, " +
 			"which is more than the recommended maximum of 10%. <a href='https://yoa.st/shopify43' target='_blank'>" +
 			"Try to use their active counterparts</a>.",
 	},

--- a/packages/yoastseo/src/languageProcessing/helpers/html/getFieldsToMark.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/html/getFieldsToMark.js
@@ -7,7 +7,7 @@ import { getSubheadings } from "./getSubheadings";
  * @param {array}   marks  The array of mark objects.
  * @param {string}  html   The html of the page where we want to apply the marking to.
  *
- * @returns {{selectedHTML: *[], fieldsToMark: *}} The selected part of the html we want to apply the marking tp.
+ * @returns {{selectedHTML: *[], fieldsToMark: *}} The selected part of the html we want to apply the marking to.
  */
 export function getFieldsToMark( marks, html ) {
 	const fieldsToMark = uniq( flatten( marks.map( mark => {

--- a/packages/yoastseo/src/languageProcessing/helpers/html/normalizeHTML.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/html/normalizeHTML.js
@@ -1,0 +1,17 @@
+/**
+ * Replaces single quotes around HTML attribute values with double quotes.
+ * Double quotes are the standard, but we convert these to single quotes when parsing the HTML in `yoastseo` package.
+ * Here, we change them back to double quotes so by parsing the HTML and then outputting it again.
+ * Note that this function does more than just replacing single quotes with double quotes. It also restores corrupted HTML.
+ * @param {string} str The input string.
+ *
+ * @returns {string} The string with single quotes around HTML attributes replaced with double quotes.
+ */
+export default function( str ) {
+	const element = document.createElement( "body" );
+	element.innerHTML = str;
+	const normalizedHTML = element.innerHTML;
+
+	// Replace `&nbsp;` with an actual non breaking space (U+00A0).
+	return normalizedHTML.replace( /&nbsp;/g, "\u00A0" );
+}

--- a/packages/yoastseo/src/languageProcessing/helpers/word/markWordsInSentences.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/word/markWordsInSentences.js
@@ -3,6 +3,66 @@ import arrayToRegex from "../regex/createRegexFromArray";
 import addMark from "../../../markers/addMarkSingleWord";
 import Mark from "../../../values/Mark";
 import { escapeRegExp } from "lodash-es";
+import getAnchorsFromText from "../link/getAnchorsFromText";
+
+// Regex to deconstruct an anchor into open tag, content and close tag.
+const anchorDeconstructionRegex = /(<a[\s]+[^>]+>)([^]*?)(<\/a>)/;
+
+/**
+ * Deconstructs an anchor to the opening tag and the content. The content is the anchor text.
+ * We don't return the closing tag since the value would always be the same, i.e. </a>.
+ *
+ * @param {string} anchor An anchor of the shape <a ...>...</a>.
+ *
+ * @returns {object} An object containing the opening tag and the content.
+ */
+export const deConstructAnchor = function( anchor ) {
+	// The const array mirrors the anchorDeconstructionRegex, using a comma to access the first element without a name.
+	const [ , openTag, content ] = anchor.match( anchorDeconstructionRegex );
+	return {
+		openTag: openTag,
+		content: content,
+	};
+};
+
+/**
+ * Reconstructs an anchor from an openTag, the content, and the closing tag.
+ *
+ * @param {string} openTag The opening tag of the anchor. Must be of the shape <a ...>.
+ * @param {string} content The text of the anchor.
+ *
+ * @returns {string} An anchor.
+ */
+export const reConstructAnchor = function( openTag, content ) {
+	return `${openTag}${content}</a>`;
+};
+
+
+/**
+ * Gets the anchors and marks the anchors' text if the words are found in it.
+ *
+ * @param {string} sentence The sentence to retrieve the anchors from.
+ * @param {RegExp} wordsRegex The regex of the words.
+ *
+ * @returns {Object} The anchors and the marked anchors.
+ */
+const getMarkedAnchors = function( sentence, wordsRegex ) {
+	// Retrieve the anchors.
+	const anchors = getAnchorsFromText( sentence );
+	// For every anchor, apply the markings only to the anchor tag.
+	const markedAnchors = anchors.map( anchor => {
+		// Retrieve the open tag and the content/anchor text.
+		const { openTag, content } = deConstructAnchor( anchor );
+
+		// Apply the marking to the anchor text if there is a match.
+		const markedAnchorText = content.replace( wordsRegex, ( x ) => addMark( x ) );
+
+		// Create a new anchor tag with a (marked) anchor text.
+		return reConstructAnchor( openTag, markedAnchorText );
+	} );
+
+	return { anchors, markedAnchors };
+};
 
 /**
  * Adds marks to a sentence and merges marks if those are only separated by a space
@@ -10,19 +70,40 @@ import { escapeRegExp } from "lodash-es";
  * the marks will be put around "ballet shoes" together, not "`ballet` `shoes`".)
  *
  * @param {string}    sentence               The sentence to mark words in.
- * @param {[string]}  topicFoundInSentence   The words to mark in the sentence.
+ * @param {[string]}  wordsFoundInSentence   The words to mark in the sentence.
  * @param {function}  matchWordCustomHelper  The language-specific helper function to match word in text.
  *
  * @returns {string} The sentence with marks.
  */
-export const collectMarkingsInSentence = function( sentence, topicFoundInSentence, matchWordCustomHelper ) {
-	topicFoundInSentence = topicFoundInSentence.map( word => escapeRegExp( word ) );
+export const collectMarkingsInSentence = function( sentence, wordsFoundInSentence, matchWordCustomHelper ) {
+	wordsFoundInSentence = wordsFoundInSentence.map( word => escapeRegExp( word ) );
 	// If a language has a custom helper to match words, we disable the word boundary when creating the regex.
-	const topicRegex = matchWordCustomHelper ? arrayToRegex( topicFoundInSentence, true ) : arrayToRegex( topicFoundInSentence );
-	const markup = sentence.replace( topicRegex, function( x ) {
+	const wordsRegex = matchWordCustomHelper ? arrayToRegex( wordsFoundInSentence, true ) : arrayToRegex( wordsFoundInSentence );
+
+	// Retrieve the anchors and mark the anchors' text if the words are found in the anchors' text.
+	const { anchors, markedAnchors } = getMarkedAnchors( sentence, wordsRegex );
+
+	let markup = sentence.replace( wordsRegex, function( x ) {
 		return addMark( x );
 	} );
 
+	/**
+	 * In 'markup', we apply the markings also inside the anchor's attribute if there is a match, on top of
+	 * marking the anchor's text.
+	 * The step below is to replace the incorrectly marked anchors with the marked anchors that we want:
+	 * where the markings are only applied in the anchor's text.
+	 */
+	if ( anchors.length > 0 ) {
+		const markupAnchors = getAnchorsFromText( markup );
+		for ( let i = 0; i < markupAnchors.length; i++ ) {
+			markup = markup.replace( markupAnchors[ i ], markedAnchors[ i ] );
+		}
+	}
+
+	/*
+	 * If two marks are separated by only a space, remove the closing tag of the first mark and the opening tag of the
+	 * second mark so that the two marks can be combined into one.
+	 */
 	return ( markup.replace( new RegExp( "</yoastmark> <yoastmark class='yoast-text-mark'>", "ig" ), " " ) );
 };
 
@@ -37,16 +118,16 @@ export const collectMarkingsInSentence = function( sentence, topicFoundInSentenc
  * @returns {[string]} The sentences with marks.
  */
 export function markWordsInSentences( wordsToMark, sentences, locale, matchWordCustomHelper ) {
-	let topicFoundInSentence = [];
+	let wordsFoundInSentence = [];
 	let markings = [];
 
 	sentences.forEach( function( sentence ) {
-		topicFoundInSentence = matchWords( sentence, wordsToMark, locale, matchWordCustomHelper ).matches;
+		wordsFoundInSentence = matchWords( sentence, wordsToMark, locale, matchWordCustomHelper ).matches;
 
-		if ( topicFoundInSentence.length > 0 ) {
+		if ( wordsFoundInSentence.length > 0 ) {
 			markings = markings.concat( new Mark( {
 				original: sentence,
-				marked: collectMarkingsInSentence( sentence, topicFoundInSentence, matchWordCustomHelper ),
+				marked: collectMarkingsInSentence( sentence, wordsFoundInSentence, matchWordCustomHelper ),
 			} ) );
 		}
 	} );

--- a/packages/yoastseo/src/languageProcessing/index.js
+++ b/packages/yoastseo/src/languageProcessing/index.js
@@ -26,6 +26,7 @@ import { stripFullTags as stripHTMLTags } from "./helpers/sanitize/stripHTMLTags
 import sanitizeString from "./helpers/sanitize/sanitizeString";
 import { unifyAllSpaces } from "./helpers/sanitize/unifyWhitespace";
 import removePunctuation from "./helpers/sanitize/removePunctuation";
+import normalizeHTML from "./helpers/html/normalizeHTML";
 import countMetaDescriptionLength from "./helpers/word/countMetaDescriptionLength";
 import getLanguage from "./helpers/language/getLanguage";
 import getSentences from "./helpers/sentence/getSentences";
@@ -65,4 +66,5 @@ export {
 	getSentences,
 	getFieldsToMark,
 	unifyAllSpaces,
+	normalizeHTML,
 };


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Highlighting that used the "markWordsInSentences" strategy (such as keyphrase highlighting) did not work when there was an anchor in the text that contained the string that should be marked (e.g. the keyphrase `catnip` also occurred in the url in the anchor). 
* This problem was solved previously in the following PR. This was reverted as it caused a problem with classic blocks in the block editor. https://github.com/Yoast/wordpress-seo/pull/19162
* Another attempt was made in this PR. https://github.com/Yoast/wordpress-seo/pull/19499 . This attempt is theoretically more simple, but also elicited a lot more problems that could not be solved.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the highlighting feature in the Classic editor would not work when inline HTML tags were present.
* [shopify-seo] Fixes a bug where the `yoastmark` tags broke the HTML when applied to inline HTML attributes. 
* [yoastseo] Excludes applying `yoastmark` to anchor tag attributes.

## Relevant technical choices:

* in `getSentencesFromTokens`, a check was added. Previously, if there was an opening tag on the beginning of the text, and a closing tag at the end, both would be removed, regardless of whether they belonged together. In this PR a check is added that does a rudimentary (and not watertight) check whether they belong together. Once we have the html parser, this should be replaced.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

**NOTE:** while testing, you might note that there are different results for the same text between post and page in default editor. This is reproducible on `trunk`. And [this IM issue](https://github.com/Yoast/wordpress-seo/issues/19643) was created for it

This testing plan is quite extensive. The reason is that this PR touches A lot of different marking

#### WordPress
* Install and activate Yoast SEO
* Set the site language to English
* Create a post in Classic editor and add this text:
[catnip.txt](https://github.com/Yoast/wordpress-seo/files/10003094/catnip.txt)

NOTE: Add the text in `Text` editor mode in Classic editor, and in Code editor mode in Block editor

##### Keyword density assessment
* Set the word catnip as the focus keyphrase
* Confirm that the keyphrase density assessment detects 8 occurrences of the keyphrase in the text
* Embed this link below to the phrase "alternative plants exist" (the link contains the focus keyphrase):

> https://en.wikipedia.org/wiki/Catnip#Felines_not_affected_by_catnip
* Confirm that the keyword density assessment still detects 8 occurrences of the keyphrase in the text
* Click the eye icon of keyword density assessment
* Confirm that the "alternative plants exist" is not highlighted
* Check the anchor link of the phrase and confirm that the `href` value doesn't contain yoast mark tags, e.g. `"<yoastmark class='yoast-text-mark'>"` or `"</yoastmark>"`
* Embed this link below to the phrase "catnip flowers" (the link contains the focus keyphrase)

> https://hort.extension.wisc.edu/articles/catnip-nepeta-cataria/
* Confirm that the keyword density assessment still detects 8 occurrences of the keyphrase in the text
* Click the eye icon of keyword density assessment
* Confirm that the "catnip" in "catnip flowers" is highlighted
* Check the anchor link of the phrase and confirm that the `href` value doesn't contain yoast mark tags, e.g. `"<yoastmark class='yoast-text-mark'>"` or `"</yoastmark>"`

##### Keyphrase distribution assessment
* Install and activate Yoast SEO premium
   * When building the Premium plugin, run `composer require yoast/wordpress-seo:dev-19477-attempt-3-yoast-markers-break-html-of-content-in-shopify-and-classic@dev` before building it
* Go to the previous post
* Set the word catnip as the focus keyphrase
* Embed this link below to the phrase "alternative plants exist" (the link contains the focus keyphrase):

> https://en.wikipedia.org/wiki/Catnip#Felines_not_affected_by_catnip

* Click the eye icon of keyphrase distribution assessment
* Confirm that the "alternative plants exist" is not highlighted
* Check the anchor link of the phrase and confirm that the `href` value doesn't contain yoast mark tags, e.g. `"<yoastmark class='yoast-text-mark'>"` or `"</yoastmark>"`
* Embed this link below to the phrase "catnip flowers":

> https://hort.extension.wisc.edu/articles/catnip-nepeta-cataria/

* Click the eye icon of keyphrase distribution assessment
* Confirm that the "catnip" in "catnip flowers" is highlighted
* Check the anchor link of the phrase and confirm that the `href` value doesn't contain yoast mark tags, e.g. `"<yoastmark class='yoast-text-mark'>"` or `"</yoastmark>"`

##### Synonyms:
* add `catmint` as a keyphrase synonym.
* toggle the highlighting button for keyphrase density
* Make sure all occurrences of `catnip` are marked
* toggle the highlighting button for the keyphrase distribution
* Make sure all occurrences of `catnip` as well as all occurrences of `catmint` are marked
* embed the url below to one of the occurrences of `catmint`

> https://en.wikipedia.org/wiki/Catmint

* Highlight keyphrase distribution
* Make sure that all occurrences of `catmint` are properly highlighted.
* Undo the highlighting
* Make sure that all occurrences of `catmint` are still there. (there should be 3 occurrences)

##### Word complexity assessment
* Install and activate Yoast SEO premium
* Go to the previous post
* Go to the Readability analysis tab
* Embed this link below to the word "hereditary" in the text:

> https://en.wikipedia.org/wiki/hereditary-defects

* Click the eye icon on the Word complexity assessment
* Confirm that the word "hereditary" is highlighted
* Check the anchor link of the phrase and confirm that the `href` value doesn't contain yoast mark tags, e.g. `"<yoastmark class='yoast-text-mark'>"` or `"</yoastmark>"`

##### Sentence length, Passive voice, and Transition words assessment
* Go to the previous post
* Add this sentence to the post (in text editing mode as opposed to visual editing):

`However, the compounds were found to repel <a href="https://en.wikipedia.org/wiki/Mosquito" rel="nofollow">mosquitos</a>, and it is hypothesized that rubbing against the plants provides the cats with a chemical coat that protects them against mosquito bites.`

NOTE: Add the text in `Text` editor mode in Classic editor, and in Code editor mode in Block editor

* Click on the eye icon of the sentence length assessment
* Confirm that the sentence above is highlighted
* Click on the eye icon of the passive sentence assessment
* Confirm that the sentence above is highlighted
* Click on the eye icon of the transition words assessments
* Confirm that the sentence above is highlighted

##### Consecutive sentences assessment
* (Assessment not available for E-commerce content types)
* Go to the previous post
* Add these three sentences containing anchor links that start with the same words:

`<a href="https://en.wikipedia.org/wiki/Cat">Cats</a> detect nepetalactone through their <a href="https://en.wikipedia.org/wiki/Olfactory_epithelium">olfactory epithelium</a>, not through their vomeronasal organ. <a href="https://en.wikipedia.org/wiki/Cat">Cats</a> detect nepetalactone through their <a href="https://en.wikipedia.org/wiki/Olfactory_epithelium">olfactory epithelium</a>, not through their vomeronasal organ. <a href="https://en.wikipedia.org/wiki/Cat">Cats</a> detect nepetalactone through their <a href="https://en.wikipedia.org/wiki/Olfactory_epithelium">olfactory epithelium</a>, not through their vomeronasal organ.`

NOTE: Add the text in `Text` editor mode in Classic editor, and in Code editor mode in Block editor

* Click on the eye icon of the consecutive sentences assessment
* Confirm that the three sentences above are highlighted

##### Paragraph length assessment
* Go to the previous post
* Make one of the paragraphs that contain links longer than 150 words
* Click on the paragraph length assessment
* Confirm that the long paragraph that contains links is highlighted

##### Paragraph length assessment
* Combine the 2nd, 3rd and 4th paragraph to 1 paragraph.
* Activate highlighting for paragraph length assessment
* Make sure the newly combined paragraph is highlighted.

##### Inclusive language analysis
* Go to the previous post
* In one of the sentences that contain links, add a non-inclusive word like, "seniors", "policemen" etc.
* Click on the eye icon of the feedback
* Confirm that sentence that contains the non-inclusive word is highlighted

#### Upgrade routine
* Install and activate the previous version of Yoast SEO
* Set the site language to English
* Create a post in Classic editor and add this text:
[catnip.txt](https://github.com/Yoast/wordpress-seo/files/10003099/catnip.txt)
NOTE: Add the text in `Text` editor mode in Classic editor

* Set "catnip" as the focus keyphrase
* Embed this link below to the phrase "catnip flowers":

> https://hort.extension.wisc.edu/articles/catnip-nepeta-cataria/

* Click the eye icon of keyphrase distribution assessment or keyphrase density
* Confirm that the "catnip" in "catnip flower" is NOT highlighted
* Upgrade Yoast SEO version to the one that includes this fix
* Go to the previous post
* Click the eye icon of keyphrase distribution assessment or keyphrase density
* Confirm that the "catnip" in "catnip flower" is highlighted

##### Smoke test Advanced custom fields
* Install and activate the [Advanced Custom Fields](https://wordpress.org/plugins/advanced-custom-fields/) plugin.
* Install and activate [ACF Content Analysis for Yoast SEO](https://wordpress.org/plugins/acf-content-analysis-for-yoast-seo/) .
* Open a post/page/cpt/... and add text
* Smoke test all highlighting

##### Smoke classic editor block in block editor
* Install and activate the classic editor.
* Create a post and add text and save the post.
* Deactivate the classic editor.
* Open the post in the block editor or gutenberg. Do NOT try block recovery.
* Smoke test all highlighting.
* Do block recovery.
* Smoke test all highlighting
* Add a single `/classic` block (create a new block and type `/classic`), and add some text to it that contains the words `catnip` and `catmint`. 
* Make sure that with keyphrase distribution all occurrences of `catnip` and `catmint` are highlighted.
* Make sure that with keyphrase density all occurrences of `catnip` are highlighted.

#### Test in Shopify
* Install and activate Yoast SEO for Shopify
   * If building the app:
      * Build the app from  `main` in `shopify-seo`
      * Link the `wordpress-seo` before building
* Set the store language to English
* Create a product and add this text:
[catnip.txt](https://github.com/Yoast/wordpress-seo/files/10003101/catnip.txt)

* NOTE: the test instruction below should be repeated in all content types in Shopify

##### Keyword density and Keyphrase distribution assessment
* Set the word catnip as the focus keyphrase
* Confirm that the keyword density assessment detects 8 occurrences of the keyphrase in the text
* Embed this link below to the phrase "alternative plants exist":

> https://en.wikipedia.org/wiki/Catnip#Felines_not_affected_by_catnip
* Confirm that the keyword density assessment still detects 8 occurrences of the keyphrase in the text
* Click the eye icon of keyword density assessment
* Confirm that the "alternative plants exist" is not highlighted
* Check the anchor link of the phrase and confirm that the `href` value doesn't contain yoast mark tags, e.g. `"<yoastmark class='yoast-text-mark'>"` or `"</yoastmark>"`
* Click the eye icon of keyphrase distribution assessment
* Confirm that the "alternative plants exist" is not highlighted
* Check the anchor link of the phrase and confirm that the `href` value doesn't contain yoast mark tags, e.g. `"<yoastmark class='yoast-text-mark'>"` or `"</yoastmark>"`
* Embed this link below to the phrase "catnip flowers": 

> https://hort.extension.wisc.edu/articles/catnip-nepeta-cataria/
* Confirm that the keyword density assessment still detects 8 occurrences of the keyphrase in the text
* Click the eye icon of keyword density assessment
* Confirm that the "catnip" in "catnip flower" is highlighted
* Check the anchor link of the phrase and confirm that the `href` value doesn't contain yoast mark tags, e.g. `"<yoastmark class='yoast-text-mark'>"` or `"</yoastmark>"`

* Click the eye icon of keyphrase distribution assessment
* Confirm that the "catnip" in "catnip flowers" is highlighted
* Check the anchor link of the phrase and confirm that the `href` value doesn't contain yoast mark tags, e.g. `"<yoastmark class='yoast-text-mark'>"` or `"</yoastmark>"`

##### Word complexity assessment
* Go to the Readability analysis tab
* Embed this link below to the word "hereditary" in the text:

> https://en.wikipedia.org/wiki/hereditary-defects

* Click the eye icon on the Word complexity assessment
* Confirm that the word "hereditary" is highlighted
* Check the anchor link of the phrase and confirm that the `href` value doesn't contain yoast mark tags, e.g. `"<yoastmark class='yoast-text-mark'>"` or `"</yoastmark>"`

##### (Smoke) Test impact by sentence tokenizer
* Add the following sentence as a separate paragraph (use text editing mode (as opposed to visual editing mode)): `<i>The cat</i> was greeted by <i>the dog</i>`.
* Toggle highlighting for passive voice analysis. Make sure that the above-mentioned sentence is properly highlighted. 
  * **properly** = 
  * The sentence is fully highlighted. 
  * The previous sentence and past sentence are not highlighted (unless they are passive voice as well)
  * When highlighting 'the cat' and 'the dog' are still in _italics_.
  * After undoing the highlighting 'the cat' and 'the dog' are still in _italics_.
* Add the following sentence as a separate paragraph (use text editing mode (as opposed to visual editing mode)): `<div>The cat was greeted by the dog</div>`.
* Toggle highlighting for passive voice analysis. Make sure that the above-mentioned sentence is properly highlighted.
* Add the word `midget` to a few random sentences in the post. This should trigger the inclusive language assessment for `midget`.
* Toggle highlighting for `midget`.
* Make sure that all sentences containing midget are properly highlighted.


#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [x] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* This PR impacts all assessments that use highlighting. Tests are added for this.
* This PR impacts classic editor and shopify. Block editor and Elementor need to be smoke tested.
* This PR impacts the sentence tokenizer. An acceptance testing scenario was added to cover this.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [x] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unit tests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #19477 
