### PR TITLE
fix og:image for same size as custom size

### DIFF
--- a/inc/class-wpseo-image-utils.php
+++ b/inc/class-wpseo-image-utils.php
@@ -174,8 +174,8 @@ class WPSEO_Image_Utils {
 	/**
 	 * Find the right version of an image based on size.
 	 *
-	 * @param int    $attachment_id Attachment ID.
-	 * @param string $size          Size name.
+	 * @param int          $attachment_id Attachment ID.
+	 * @param string|array $size     Size name, or array of width and height in pixels (e.g [800,400]).
 	 *
 	 * @return array|false Returns an array with image data on success, false on failure.
 	 */
@@ -189,11 +189,24 @@ class WPSEO_Image_Utils {
 			$image = image_get_intermediate_size( $attachment_id, $size );
 		}
 
+		if ( ! is_array( $image ) ) {
+			$image_src = wp_get_attachment_image_src( $attachment_id, $size );
+			if ( is_array( $image_src ) && isset( $image_src[1] ) && isset( $image_src[2] ) ) {
+				$image           = [];
+				$image['url']    = $image_src[0];
+				$image['width']  = $image_src[1];
+				$image['height'] = $image_src[2];
+				$image['size']   = 'full';
+			}
+		}
+
 		if ( ! $image ) {
 			return false;
 		}
 
-		$image['size'] = $size;
+		if ( ! isset( $image['size'] ) ) {
+			$image['size'] = $size;
+		}
 
 		return self::get_data( $image, $attachment_id );
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to fix a bug that prevent featured image to appear in og:image when using `wpseo_opengraph_image_size` filter with custom size that is equal to image size. 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where `wpseo_opengraph_image_size' is used to set custom size to `og:image` but doesn't work when uploading an image with the same size as the custom size.

## Relevant technical choices:

* 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Add the following code to your active theme `functions.php`:
```
// Add custom image size for Yoast SEO socials
add_image_size( 'featured-full', 640, 480 );
add_filter( 'wpseo_opengraph_image_size', 'yoast_seo_opengraph_change_image_size' );
function yoast_seo_opengraph_change_image_size() {
return 'featured-full';
}
 ```
* Open site Dashboard
* Go to pages or posts
* Edit or create a page.
* Add feature image that has width:640px and height 480px.
* View page.
* View page source and make sure the image url, width and height appears in `og:image` meta tags like in the image bellow:
<img width="1123" alt="image" src="https://user-images.githubusercontent.com/65466507/214034628-4bdacf38-7017-468a-85e7-2ba4d330714a.png">


#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes [Using the wpseo_opengraph_image_size filter to select a specific image size does not output an og:image tag.#19448](https://github.com/Yoast/wordpress-seo/issues/19448)
