### PR TITLE
Settings: 19699 format archives settings page bug

### DIFF
--- a/src/helpers/post-type-helper.php
+++ b/src/helpers/post-type-helper.php
@@ -163,7 +163,10 @@ class Post_Type_Helper {
 		$post_type_objects    = [];
 		$indexable_post_types = $this->get_indexable_post_types();
 		foreach ( $indexable_post_types as $post_type ) {
-			$post_type_objects[ $post_type ] = \get_post_type_object( $post_type );
+			$post_type_object = \get_post_type_object( $post_type );
+			if ( ! empty( $post_type_object ) ) {
+				$post_type_objects[ $post_type ] = $post_type_object;
+			}
 		}
 
 		return $post_type_objects;

--- a/src/helpers/post-type-helper.php
+++ b/src/helpers/post-type-helper.php
@@ -163,7 +163,7 @@ class Post_Type_Helper {
 		$post_type_objects    = [];
 		$indexable_post_types = $this->get_indexable_post_types();
 		foreach ( $indexable_post_types as $post_type ) {
-			$post_type_objects[] = \get_post_type_object( $post_type );
+			$post_type_objects[ $post_type ] = \get_post_type_object( $post_type );
 		}
 
 		return $post_type_objects;

--- a/src/helpers/taxonomy-helper.php
+++ b/src/helpers/taxonomy-helper.php
@@ -171,7 +171,10 @@ class Taxonomy_Helper {
 		$taxonomy_objects     = [];
 		$indexable_taxonomies = $this->get_indexable_taxonomies();
 		foreach ( $indexable_taxonomies as $taxonomy ) {
-			$taxonomy_objects[ $taxonomy ] = \get_taxonomy( $taxonomy );
+			$taxonomy_object = \get_taxonomy( $taxonomy );
+			if ( ! empty( $taxonomy_object ) ) {
+				$taxonomy_objects[ $taxonomy ] = $taxonomy_object;
+			}
 		}
 
 		return $taxonomy_objects;

--- a/src/helpers/taxonomy-helper.php
+++ b/src/helpers/taxonomy-helper.php
@@ -171,7 +171,7 @@ class Taxonomy_Helper {
 		$taxonomy_objects     = [];
 		$indexable_taxonomies = $this->get_indexable_taxonomies();
 		foreach ( $indexable_taxonomies as $taxonomy ) {
-			$taxonomy_objects[] = \get_taxonomy( $taxonomy );
+			$taxonomy_objects[ $taxonomy ] = \get_taxonomy( $taxonomy );
 		}
 
 		return $taxonomy_objects;

--- a/src/integrations/settings-integration.php
+++ b/src/integrations/settings-integration.php
@@ -387,6 +387,14 @@ class Settings_Integration implements Integration_Interface {
 				$post_types['attachment'] = $attachment_object;
 			}
 		}
+		// Check if post formats are included in indexation.
+		if ( ! \array_key_exists( 'post_format', $taxonomies ) ) {
+			// Always include attachments in the settings, to let the user enable them again.
+			$post_format_object = \get_taxonomy( 'post_format' );
+			if ( ! empty( $post_format_object ) ) {
+				$taxonomies['post_format'] = $post_format_object;
+			}
+		}
 
 		$transformed_post_types = $this->transform_post_types( $post_types );
 		$transformed_taxonomies = $this->transform_taxonomies( $taxonomies, \array_keys( $transformed_post_types ) );

--- a/src/integrations/settings-integration.php
+++ b/src/integrations/settings-integration.php
@@ -382,7 +382,10 @@ class Settings_Integration implements Integration_Interface {
 		// Check if attachments are included in indexation.
 		if ( ! \array_key_exists( 'attachment', $post_types ) ) {
 			// Always include attachments in the settings, to let the user enable them again.
-			$post_types['attachment'] = \get_post_type_object( 'attachment' );
+			$attachment_object = \get_post_type_object( 'attachment' );
+			if ( ! empty( $attachment_object ) ) {
+				$post_types['attachment'] = $attachment_object;
+			}
 		}
 
 		$transformed_post_types = $this->transform_post_types( $post_types );

--- a/src/integrations/settings-integration.php
+++ b/src/integrations/settings-integration.php
@@ -389,7 +389,7 @@ class Settings_Integration implements Integration_Interface {
 		}
 		// Check if post formats are included in indexation.
 		if ( ! \array_key_exists( 'post_format', $taxonomies ) ) {
-			// Always include attachments in the settings, to let the user enable them again.
+			// Always include post_format in the settings, to let the user enable them again.
 			$post_format_object = \get_taxonomy( 'post_format' );
 			if ( ! empty( $post_format_object ) ) {
 				$taxonomies['post_format'] = $post_format_object;

--- a/src/integrations/settings-integration.php
+++ b/src/integrations/settings-integration.php
@@ -13,7 +13,6 @@ use WPSEO_Options;
 use WPSEO_Replace_Vars;
 use WPSEO_Shortlinker;
 use WPSEO_Sitemaps_Router;
-use Yoast_Notification_Center;
 use Yoast\WP\SEO\Actions\Settings_Introduction_Action;
 use Yoast\WP\SEO\Conditionals\Settings_Conditional;
 use Yoast\WP\SEO\Config\Schema_Types;
@@ -25,6 +24,7 @@ use Yoast\WP\SEO\Helpers\Schema\Article_Helper;
 use Yoast\WP\SEO\Helpers\Taxonomy_Helper;
 use Yoast\WP\SEO\Helpers\User_Helper;
 use Yoast\WP\SEO\Helpers\Woocommerce_Helper;
+use Yoast_Notification_Center;
 
 /**
  * Class Settings_Integration.
@@ -379,6 +379,12 @@ class Settings_Integration implements Integration_Interface {
 		$post_types             = $this->post_type_helper->get_indexable_post_type_objects();
 		$taxonomies             = $this->taxonomy_helper->get_indexable_taxonomy_objects();
 
+		// Check if attachments are included in indexation.
+		if ( ! \array_key_exists( 'attachment', $post_types ) ) {
+			// Always include attachments in the settings, to let the user enable them again.
+			$post_types['attachment'] = \get_post_type_object( 'attachment' );
+		}
+
 		$transformed_post_types = $this->transform_post_types( $post_types );
 		$transformed_taxonomies = $this->transform_taxonomies( $taxonomies, \array_keys( $transformed_post_types ) );
 
@@ -707,7 +713,7 @@ class Settings_Integration implements Integration_Interface {
 	 */
 	protected function transform_post_types( $post_types ) {
 		$transformed = [];
-		foreach ( $post_types as $index => $post_type ) {
+		foreach ( $post_types as $post_type ) {
 			$transformed[ $post_type->name ] = [
 				'name'                 => $post_type->name,
 				'route'                => $this->get_route( $post_type->name, $post_type->rewrite, $post_type->rest_base ),
@@ -758,7 +764,7 @@ class Settings_Integration implements Integration_Interface {
 	 */
 	protected function transform_taxonomies( $taxonomies, $post_type_names ) {
 		$transformed = [];
-		foreach ( $taxonomies as $index => $taxonomy ) {
+		foreach ( $taxonomies as $taxonomy ) {
 			$transformed[ $taxonomy->name ] = [
 				'name'          => $taxonomy->name,
 				'route'         => $this->get_route( $taxonomy->name, $taxonomy->rewrite, $taxonomy->rest_base ),


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Fix the Settings' Format archives.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the _Format archives_ settings would not work correctly when the `post_format` taxonomy is disabled.
* Fixes a bug where the _Media pages_ settings would not work correctly when the attachment post type is filtered out via `wpseo_indexable_excluded_post_types`.

## Relevant technical choices:

* Cherry picked the commits from https://github.com/Yoast/wordpress-seo/pull/19696 -- this code makes use of the keys that the taxonomy helper' `get_indexable_taxonomy_objects` got. Plus it is nice to ensure both fixes are present.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Go to Yoast SEO > Settings > Advanced > Format Archives
* Disable the _Enable format-based archives_ setting
* Save the settings and refresh the page
* Verify you no longer have any error mentioned in the issue:
  * With Yoast SEO Premium enabled you get:
    * _e is undefined_ (search for `undefined` on the page, as it was showing up as text too)
  * Without Yoast SEO Premium you get:
    * _t.split is not a function_ (this should be very visible as the whole page would be in error state)

Also the test instructions of https://github.com/Yoast/wordpress-seo/pull/19696
#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The Settings' Post archives page.
* Also the impact check of https://github.com/Yoast/wordpress-seo/pull/19696

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [x] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes https://github.com/Yoast/wordpress-seo/issues/19699
