### PR TITLE
19453 fix notice in the block editor for faq and how to blocks

### DIFF
--- a/packages/js/src/structured-data-blocks/convertValueToStringRichText.js
+++ b/packages/js/src/structured-data-blocks/convertValueToStringRichText.js
@@ -1,5 +1,5 @@
 /**
- * Convert content to string due to depracation of toHTML in RichText.Content for nested attributes.
+ * Convert content to string due to deprecation of toHTML in RichText.Content for nested attributes.
  * See https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/components/rich-text/index.js line 175
  * @param {Array|String} content As an array of objects (type: html tag, props: html atttributes, children: content).
  * @returns {string} The html content as a string.

--- a/packages/js/src/structured-data-blocks/convertValueToStringRichText.js
+++ b/packages/js/src/structured-data-blocks/convertValueToStringRichText.js
@@ -1,0 +1,23 @@
+/**
+ * Convert content to string due to depracation of toHTML in RichText.Content.
+ * See https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/components/rich-text/index.js line 175
+ * @param {Array|String} content .
+ * @returns {string} The Question component.
+ */
+export default function convertValueToStringRichText( content ) {
+	if ( typeof content === "string" ) {
+		return content;
+	}
+	return content.map( ( item ) => {
+		if ( typeof item === "string" ) {
+			return item;
+		}
+		if ( item.type === "br" ) {
+			return `<${item.type}>`;
+		}
+		if ( item.type === "img" ) {
+			return `<${item.type} src="${item.props.src}" alt="${item.props.alt}" style="${item.props.style}" class="${item.props.class}" />`;
+		}
+	 return `<${item.type} >${convertValueToStringRichText( item.props.children )}</${item.type}>`;
+	} ).join( "" );
+}

--- a/packages/js/src/structured-data-blocks/convertValueToStringRichText.js
+++ b/packages/js/src/structured-data-blocks/convertValueToStringRichText.js
@@ -1,8 +1,8 @@
 /**
- * Convert content to string due to depracation of toHTML in RichText.Content.
+ * Convert content to string due to depracation of toHTML in RichText.Content for nested attributes.
  * See https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/components/rich-text/index.js line 175
- * @param {Array|String} content .
- * @returns {string} The Question component.
+ * @param {Array|String} content As an array of objects (type: html tag, props: html atttributes, children: content).
+ * @returns {string} The html content as a string.
  */
 export default function convertValueToStringRichText( content ) {
 	if ( typeof content === "string" ) {

--- a/packages/js/src/structured-data-blocks/faq/components/Question.js
+++ b/packages/js/src/structured-data-blocks/faq/components/Question.js
@@ -2,7 +2,7 @@
 import PropTypes from "prop-types";
 import { __ } from "@wordpress/i18n";
 import { isShallowEqualObjects } from "@wordpress/is-shallow-equal";
-
+import convertValueToStringRichText from "../../convertValueToStringRichText";
 import { Component } from "@wordpress/element";
 import { Button } from "@wordpress/components";
 import { RichText, MediaUpload } from "@wordpress/block-editor";
@@ -290,13 +290,13 @@ export default class Question extends Component {
 					tagName="strong"
 					className="schema-faq-question"
 					key={ question.id + "-question" }
-					value={ question.question }
+					value={ convertValueToStringRichText( question.question ) }
 				/>
 				<RichTextWithAppendedSpace
 					tagName="p"
 					className="schema-faq-answer"
 					key={ question.id + "-answer" }
-					value={ question.answer }
+					value={ convertValueToStringRichText( question.answer ) }
 				/>
 			</div>
 		);
@@ -333,13 +333,14 @@ export default class Question extends Component {
 			answer,
 		} = attributes;
 
+
 		return (
 			<div className="schema-faq-section" key={ id }>
 				<RichText
 					className="schema-faq-question"
 					tagName="p"
 					key={ id + "-question" }
-					value={ question }
+					value={ convertValueToStringRichText( question ) }
 					onChange={ this.onChangeQuestion }
 					unstableOnFocus={ this.onFocusQuestion }
 					placeholder={ __( "Enter a question", "wordpress-seo" ) }
@@ -349,7 +350,7 @@ export default class Question extends Component {
 					className="schema-faq-answer"
 					tagName="p"
 					key={ id + "-answer" }
-					value={ answer }
+					value={ convertValueToStringRichText( answer ) }
 					onChange={ this.onChangeAnswer }
 					unstableOnFocus={ this.onFocusAnswer }
 					placeholder={ __( "Enter the answer to the question", "wordpress-seo" ) }

--- a/packages/js/src/structured-data-blocks/how-to/block.js
+++ b/packages/js/src/structured-data-blocks/how-to/block.js
@@ -20,8 +20,8 @@ const attributes = {
 		type: "string",
 	},
 	description: {
-		type: "array",
-		source: "children",
+		type: "string",
+		source: "html",
 		selector: ".schema-how-to-description",
 	},
 	jsonDescription: {

--- a/packages/js/src/structured-data-blocks/how-to/components/HowTo.js
+++ b/packages/js/src/structured-data-blocks/how-to/components/HowTo.js
@@ -13,6 +13,7 @@ import appendSpace from "../../../components/higherorder/appendSpace";
 import { RichText, InspectorControls } from "@wordpress/block-editor";
 import { Button, PanelBody, TextControl, ToggleControl } from "@wordpress/components";
 import { Component, renderToString, createRef } from "@wordpress/element";
+import convertValueToStringRichText from "../../convertValueToStringRichText";
 
 const RichTextWithAppendedSpace = appendSpace( RichText.Content );
 
@@ -732,7 +733,7 @@ export default class HowTo extends Component {
 				<RichText
 					tagName="p"
 					className="schema-how-to-description"
-					value={ attributes.description }
+					value={ convertValueToStringRichText( attributes.description ) }
 					unstableOnFocus={ this.focusDescription }
 					onChange={ this.onChangeDescription }
 					placeholder={ __( "Enter a description", "wordpress-seo" ) }

--- a/packages/js/src/structured-data-blocks/how-to/components/HowTo.js
+++ b/packages/js/src/structured-data-blocks/how-to/components/HowTo.js
@@ -13,7 +13,6 @@ import appendSpace from "../../../components/higherorder/appendSpace";
 import { RichText, InspectorControls } from "@wordpress/block-editor";
 import { Button, PanelBody, TextControl, ToggleControl } from "@wordpress/components";
 import { Component, renderToString, createRef } from "@wordpress/element";
-import convertValueToStringRichText from "../../convertValueToStringRichText";
 
 const RichTextWithAppendedSpace = appendSpace( RichText.Content );
 
@@ -733,7 +732,7 @@ export default class HowTo extends Component {
 				<RichText
 					tagName="p"
 					className="schema-how-to-description"
-					value={ convertValueToStringRichText( attributes.description ) }
+					value={ attributes.description }
 					unstableOnFocus={ this.focusDescription }
 					onChange={ this.onChangeDescription }
 					placeholder={ __( "Enter a description", "wordpress-seo" ) }

--- a/packages/js/src/structured-data-blocks/how-to/components/HowToStep.js
+++ b/packages/js/src/structured-data-blocks/how-to/components/HowToStep.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import { __ } from "@wordpress/i18n";
 import appendSpace from "../../../components/higherorder/appendSpace";
 import { isShallowEqualObjects } from "@wordpress/is-shallow-equal";
-
+import convertValueToStringRichText from "../../convertValueToStringRichText";
 import { Component } from "@wordpress/element";
 import { Button } from "@wordpress/components";
 import { RichText, MediaUpload } from "@wordpress/block-editor";
@@ -289,13 +289,13 @@ export default class HowToStep extends Component {
 					tagName="strong"
 					className="schema-how-to-step-name"
 					key={ step.id + "-name" }
-					value={ step.name }
+					value={ convertValueToStringRichText( step.name ) }
 				/>
 				<RichTextContentWithAppendedSpace
 					tagName="p"
 					className="schema-how-to-step-text"
 					key={ step.id + "-text" }
-					value={ step.text }
+					value={ convertValueToStringRichText( step.text ) }
 				/>
 			</li>
 		);
@@ -315,7 +315,6 @@ export default class HowToStep extends Component {
 		} = this.props;
 
 		const { id, name, text } = step;
-
 		return (
 			<li className="schema-how-to-step" key={ id }>
 				<span className="schema-how-to-step-number">
@@ -328,7 +327,7 @@ export default class HowToStep extends Component {
 					className="schema-how-to-step-name"
 					tagName="p"
 					key={ `${ id }-name` }
-					value={ name }
+					value={ convertValueToStringRichText( name )  }
 					onChange={ this.onChangeTitle }
 					placeholder={ __( "Enter a step title", "wordpress-seo" ) }
 					unstableOnFocus={ this.onFocusTitle }
@@ -338,7 +337,7 @@ export default class HowToStep extends Component {
 					className="schema-how-to-step-text"
 					tagName="p"
 					key={ `${ id }-text` }
-					value={ text }
+					value={ convertValueToStringRichText( text ) }
 					onChange={ this.onChangeText }
 					placeholder={ __( "Enter a step description", "wordpress-seo" ) }
 					unstableOnFocus={ this.onFocusText }

--- a/src/generators/schema/howto.php
+++ b/src/generators/schema/howto.php
@@ -130,7 +130,7 @@ class HowTo extends Abstract_Schema_Piece {
 	 * @param array $step        The step block data.
 	 */
 	private function add_step_image( &$schema_step, $step ) {
-		if(isset($step['text']) && is_array($step['text'])){
+		if ( isset( $step['text'] ) && is_array( $step['text'] ) ) {
 			foreach ( $step['text'] as $line ) {
 				if ( \is_array( $line ) && isset( $line['type'] ) && $line['type'] === 'img' ) {
 					$schema_step['image'] = $this->get_image_schema( \esc_url( $line['props']['src'] ) );

--- a/src/generators/schema/howto.php
+++ b/src/generators/schema/howto.php
@@ -130,9 +130,11 @@ class HowTo extends Abstract_Schema_Piece {
 	 * @param array $step        The step block data.
 	 */
 	private function add_step_image( &$schema_step, $step ) {
-		foreach ( $step['text'] as $line ) {
-			if ( \is_array( $line ) && isset( $line['type'] ) && $line['type'] === 'img' ) {
-				$schema_step['image'] = $this->get_image_schema( \esc_url( $line['props']['src'] ) );
+		if(isset($step['text']) && is_array($step['text'])){
+			foreach ( $step['text'] as $line ) {
+				if ( \is_array( $line ) && isset( $line['type'] ) && $line['type'] === 'img' ) {
+					$schema_step['image'] = $this->get_image_schema( \esc_url( $line['props']['src'] ) );
+				}
 			}
 		}
 	}

--- a/src/integrations/blocks/structured-data-blocks.php
+++ b/src/integrations/blocks/structured-data-blocks.php
@@ -346,16 +346,18 @@ class Structured_Data_Blocks implements Integration_Interface {
 			if ( ! isset( $element[ $key ] ) ) {
 				continue;
 			}
-			foreach ( $element[ $key ] as $part ) {
-				if ( ! \is_array( $part ) || ! isset( $part['type'] ) || $part['type'] !== 'img' ) {
-					continue;
-				}
+			if(isset($element[ $key ]) && is_array($element[ $key ])){
+				foreach ( $element[ $key ] as $part ) {
+					if ( ! \is_array( $part ) || ! isset( $part['type'] ) || $part['type'] !== 'img' ) {
+						continue;
+					}
 
-				if ( ! isset( $part['key'] ) || ! isset( $part['props']['src'] ) ) {
-					continue;
-				}
+					if ( ! isset( $part['key'] ) || ! isset( $part['props']['src'] ) ) {
+						continue;
+					}
 
-				$images[ $part['props']['src'] ] = (int) $part['key'];
+					$images[ $part['props']['src'] ] = (int) $part['key'];
+				}
 			}
 		}
 

--- a/src/integrations/blocks/structured-data-blocks.php
+++ b/src/integrations/blocks/structured-data-blocks.php
@@ -346,7 +346,7 @@ class Structured_Data_Blocks implements Integration_Interface {
 			if ( ! isset( $element[ $key ] ) ) {
 				continue;
 			}
-			if(isset($element[ $key ]) && is_array($element[ $key ])){
+			if ( isset( $element[ $key ] ) && is_array( $element[ $key ] ) ) {
 				foreach ( $element[ $key ] as $part ) {
 					if ( ! \is_array( $part ) || ! isset( $part['type'] ) || $part['type'] !== 'img' ) {
 						continue;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Fix console notices when editing `FAQ` and `How To` blocks.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes deprecation notices when editing `FAQ` and `How to` blocks.
* Adds defensive code around php function for images in `FAQ` and `How to`.

## Relevant technical choices:

* I chose to create custom function `convertValueToStringRichText.js`

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Edit a page or a post with the block editor.
* Add FAQ block ( After you click the blue + on the top left side of the screen, scroll all the way down in the list of the blocks until you reach Yoast blocks)
* Add few questions and answers.
* Change some questions or answers to `bold`,`italic`,`strikethrough`, add a link, image or line break.
* Save changes.
* Open console and see if you are getting deprecation messages.
* View page and see if your changes are visible as expected. 
* Go back to edit the page and add `How To` block.
* Add few steps. description and time to complete.
* Change some steps to `bold`,`italic`, `strikethrough`, add a link, image or line break.
* Save changes
* Open console and see if you are getting deprecation messages.
* View page and see if your changes are visible as expected. 

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes [Notice in the block editor: wp.blockEditor.RichText, wp.blocks.children.toHTML, wp.blocks.children.matcher, wp.blocks.children.fromDOM and wp.blocks.node.fromDOM will be removed in version 6.3.#19453](https://github.com/Yoast/wordpress-seo/issues/19453)
