### PR TITLE
Fix translations settings

### DIFF
--- a/packages/js/src/settings/components/route-layout.js
+++ b/packages/js/src/settings/components/route-layout.js
@@ -19,10 +19,9 @@ const RouteLayout = ( {
 } ) => {
 	const documentTitle = useDocumentTitle( { prefix: `${ title } ‹ ` } );
 	const ariaLiveTitle = sprintf(
-		/* translators: 1: Settings' section title, 2: Settings, 3: Yoast SEO */
-		__( "%1$s %2$s - %3$s", "wordpress-seo" ),
+		/* translators: 1: Settings' section title, 2: Yoast SEO */
+		__( "%1$s Settings - %2$s", "wordpress-seo" ),
 		title,
-		"Settings",
 		"Yoast SEO"
 	);
 	return (

--- a/packages/js/src/settings/routes/site-connections.js
+++ b/packages/js/src/settings/routes/site-connections.js
@@ -47,6 +47,7 @@ const SiteConnections = () => {
 							label={ __( "Baidu", "wordpress-seo" ) }
 							description={ addLinkToString(
 								sprintf(
+									// translators: %1$s and %2$s are replaced by opening and closing <a> tags.
 									__( "Get your verification code in %1$sBaidu Webmaster tools%2$s.", "wordpress-seo" ),
 									"<a>",
 									"</a>"
@@ -65,6 +66,7 @@ const SiteConnections = () => {
 							label={ __( "Bing", "wordpress-seo" ) }
 							description={ addLinkToString(
 								sprintf(
+									// translators: %1$s and %2$s are replaced by opening and closing <a> tags.
 									__( "Get your verification code in %1$sBing Webmaster tools%2$s.", "wordpress-seo" ),
 									"<a>",
 									"</a>"
@@ -83,6 +85,7 @@ const SiteConnections = () => {
 							label={ __( "Google", "wordpress-seo" ) }
 							description={ addLinkToString(
 								sprintf(
+									// translators: %1$s and %2$s are replaced by opening and closing <a> tags.
 									__( "Get your verification code in %1$sGoogle Search console%2$s.", "wordpress-seo" ),
 									"<a>",
 									"</a>"
@@ -101,6 +104,7 @@ const SiteConnections = () => {
 							label={ __( "Pinterest", "wordpress-seo" ) }
 							description={ addLinkToString(
 								sprintf(
+									// translators: %1$s and %2$s are replaced by opening and closing <a> tags.
 									__( "Claim your site over at %1$sPinterest%2$s.", "wordpress-seo" ),
 									"<a>",
 									"</a>"
@@ -119,6 +123,7 @@ const SiteConnections = () => {
 							label={ __( "Yandex", "wordpress-seo" ) }
 							description={ addLinkToString(
 								sprintf(
+									// translators: %1$s and %2$s are replaced by opening and closing <a> tags.
 									__( "Get your verification code in %1$sYandex Webmaster tools%2$s.", "wordpress-seo" ),
 									"<a>",
 									"</a>"

--- a/packages/js/src/settings/routes/site-connections.js
+++ b/packages/js/src/settings/routes/site-connections.js
@@ -47,7 +47,7 @@ const SiteConnections = () => {
 							label={ __( "Baidu", "wordpress-seo" ) }
 							description={ addLinkToString(
 								sprintf(
-									// translators: %1$s and %2$s are replaced by opening and closing <a> tags.
+									// translators: %1$s and %2$s are replaced by opening and closing <a> tags, respectively.
 									__( "Get your verification code in %1$sBaidu Webmaster tools%2$s.", "wordpress-seo" ),
 									"<a>",
 									"</a>"
@@ -66,7 +66,7 @@ const SiteConnections = () => {
 							label={ __( "Bing", "wordpress-seo" ) }
 							description={ addLinkToString(
 								sprintf(
-									// translators: %1$s and %2$s are replaced by opening and closing <a> tags.
+									// translators: %1$s and %2$s are replaced by opening and closing <a> tags, respectively.
 									__( "Get your verification code in %1$sBing Webmaster tools%2$s.", "wordpress-seo" ),
 									"<a>",
 									"</a>"
@@ -85,7 +85,7 @@ const SiteConnections = () => {
 							label={ __( "Google", "wordpress-seo" ) }
 							description={ addLinkToString(
 								sprintf(
-									// translators: %1$s and %2$s are replaced by opening and closing <a> tags.
+									// translators: %1$s and %2$s are replaced by opening and closing <a> tags, respectively.
 									__( "Get your verification code in %1$sGoogle Search console%2$s.", "wordpress-seo" ),
 									"<a>",
 									"</a>"
@@ -104,7 +104,7 @@ const SiteConnections = () => {
 							label={ __( "Pinterest", "wordpress-seo" ) }
 							description={ addLinkToString(
 								sprintf(
-									// translators: %1$s and %2$s are replaced by opening and closing <a> tags.
+									// translators: %1$s and %2$s are replaced by opening and closing <a> tags, respectively.
 									__( "Claim your site over at %1$sPinterest%2$s.", "wordpress-seo" ),
 									"<a>",
 									"</a>"
@@ -123,7 +123,7 @@ const SiteConnections = () => {
 							label={ __( "Yandex", "wordpress-seo" ) }
 							description={ addLinkToString(
 								sprintf(
-									// translators: %1$s and %2$s are replaced by opening and closing <a> tags.
+									// translators: %1$s and %2$s are replaced by opening and closing <a> tags, respectively.
 									__( "Get your verification code in %1$sYandex Webmaster tools%2$s.", "wordpress-seo" ),
 									"<a>",
 									"</a>"


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to properly inform translators about some translatable strings
* We also want to improve the copy of a translatable string

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves the translations comments in _Settings > Site connections_ and a translatable string used by screen readers.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* visit e.g. Settings > Homepage and see **with the inspector** that in the code you can see  a div like:
```
<div style="border: 0px none; clip: rect(0px, 0px, 0px, 0px); height: 1px; margin: -1px; overflow: hidden; white-space: nowrap; padding: 0px; width: 1px; position: absolute;" role="log" aria-live="polite">Homepage Settings - Yoast SEO</div>
```
(the important part is `Homepage Settings - Yoast SEO`)

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Quickly smoke test that with English(UK) as a site language, all settings pages work properly without console errors. 

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #19702 
