### PR TITLE
Adds a filter to allow developers the option to manipulate which post…

### DIFF
--- a/src/helpers/post-type-helper.php
+++ b/src/helpers/post-type-helper.php
@@ -151,6 +151,18 @@ class Post_Type_Helper {
 		$excluded_post_types = $this->get_excluded_post_types_for_indexables();
 
 		$included_post_types = \array_diff( $public_post_types, $excluded_post_types );
+
+		return $this->filter_included_post_types( $included_post_types );
+	}
+
+	/**
+	 * Filters the post types that are included to be indexed.
+	 *
+	 * @param array $included_post_types The post types that are included to be indexed.
+	 *
+	 * @return array The filtered post types that are included to be indexed.
+	 */
+	protected function filter_included_post_types( $included_post_types ) {
 		/**
 		 * Filter: 'wpseo_indexable_forced_included_post_types' - Allows force including posts of a certain post
 		 * type to be saved to the indexable table.

--- a/src/helpers/post-type-helper.php
+++ b/src/helpers/post-type-helper.php
@@ -100,10 +100,10 @@ class Post_Type_Helper {
 	 */
 	public function get_excluded_post_types_for_indexables() {
 		/**
-		 * Filter: 'wpseo_indexable_excluded_post_types' - Allow developers to prevent posts of a certain post
+		 * Filter: 'wpseo_indexable_excluded_post_types' - Allows excluding posts of a certain post
 		 * type from being saved to the indexable table.
 		 *
-		 * @param array $excluded_post_types The currently excluded post types.
+		 * @api array $excluded_post_types The currently excluded post types that indexables will not be created for.
 		 */
 		$excluded_post_types = \apply_filters( 'wpseo_indexable_excluded_post_types', [] );
 
@@ -152,20 +152,27 @@ class Post_Type_Helper {
 
 		$included_post_types = \array_diff( $public_post_types, $excluded_post_types );
 		/**
-		 * Filter: 'wpseo_indexable_force_post_type_indexable_creation' - Allow developers to make sure indexables get created for post types.
+		 * Filter: 'wpseo_indexable_forced_included_post_types' - Allows force including posts of a certain post
+		 * type to be saved to the indexable table.
 		 *
-		 * @param array $included_post_types The current post types where indexables will be created for.
+		 * @api array $included_post_types The currently included post types that indexables will be created for.
 		 */
-		$included_post_types = \apply_filters( 'wpseo_indexable_force_post_type_indexable_creation', $included_post_types );
+		$filtered_included_post_types = \apply_filters( 'wpseo_indexable_forced_included_post_types', $included_post_types );
+
+		if ( ! \is_array( $filtered_included_post_types ) ) {
+			// If the filter got misused, let's return the unfiltered array.
+			return \array_values( $included_post_types );
+		}
 
 		// Add sanity check to make sure everything is an actual post type.
-		foreach ( $included_post_types as $key => $post_type ) {
-			if ( ! post_type_exists( $post_type ) ) {
-				unset( $included_post_types[ $key ] );
+		foreach ( $filtered_included_post_types as $key => $post_type ) {
+			if ( ! \post_type_exists( $post_type ) ) {
+				unset( $filtered_included_post_types[ $key ] );
 			}
 		}
+
 		// `array_values`, to make sure that the keys are reset.
-		return \array_values( $included_post_types );
+		return \array_values( $filtered_included_post_types );
 	}
 
 	/**

--- a/src/helpers/post-type-helper.php
+++ b/src/helpers/post-type-helper.php
@@ -150,8 +150,22 @@ class Post_Type_Helper {
 		$public_post_types   = $this->get_public_post_types();
 		$excluded_post_types = $this->get_excluded_post_types_for_indexables();
 
+		$included_post_types = \array_diff( $public_post_types, $excluded_post_types );
+		/**
+		 * Filter: 'wpseo_indexable_force_post_type_indexable_creation' - Allow developers to make sure indexables get created for post types.
+		 *
+		 * @param array $included_post_types The current post types where indexables will be created for.
+		 */
+		$included_post_types = \apply_filters( 'wpseo_indexable_force_post_type_indexable_creation', $included_post_types );
+
+		// Add sanity check to make sure everything is an actual post type.
+		foreach ( $included_post_types as $key => $post_type ) {
+			if ( ! post_type_exists( $post_type ) ) {
+				unset( $included_post_types[ $key ] );
+			}
+		}
 		// `array_values`, to make sure that the keys are reset.
-		return \array_values( \array_diff( $public_post_types, $excluded_post_types ) );
+		return \array_values( $included_post_types );
 	}
 
 	/**

--- a/src/helpers/taxonomy-helper.php
+++ b/src/helpers/taxonomy-helper.php
@@ -123,10 +123,10 @@ class Taxonomy_Helper {
 	 */
 	public function get_excluded_taxonomies_for_indexables() {
 		/**
-		 * Filter: 'wpseo_indexable_excluded_taxonomies' - Allows excluding terms of a certain
-		 * taxonomy from being saved to the indexable table.
+		 * Filter: 'wpseo_indexable_excluded_taxonomies' - Allow developers to prevent a certain taxonomy
+		 * from being saved to the indexable table.
 		 *
-		 * @api array $excluded_taxonomies The currently excluded taxonomies that indexables will not be created for.
+		 * @param array $excluded_taxonomies The currently excluded taxonomies.
 		 */
 		$excluded_taxonomies = \apply_filters( 'wpseo_indexable_excluded_taxonomies', [] );
 
@@ -158,41 +158,8 @@ class Taxonomy_Helper {
 		$public_taxonomies   = $this->get_public_taxonomies();
 		$excluded_taxonomies = $this->get_excluded_taxonomies_for_indexables();
 
-		$included_taxonomies = \array_diff( $public_taxonomies, $excluded_taxonomies );
-
-		return $this->filter_included_taxonomies( $included_taxonomies );
-	}
-
-	/**
-	 * Filters the taxonomies that are included to be indexed.
-	 *
-	 * @param array $included_taxonomies The taxonomies that are included to be indexed.
-	 *
-	 * @return array The filtered taxonomies that are included to be indexed.
-	 */
-	protected function filter_included_taxonomies( $included_taxonomies ) {
-		/**
-		 * Filter: 'wpseo_indexable_forced_included_taxonomies' - Allows force including terms of a certain
-		 * taxonomy to be saved to the indexable table.
-		 *
-		 * @api array $included_taxonomies The currently included taxonomies that indexables will be created for.
-		 */
-		$filtered_included_taxonomies = \apply_filters( 'wpseo_indexable_forced_included_taxonomies', $included_taxonomies );
-
-		if ( ! \is_array( $filtered_included_taxonomies ) ) {
-			// If the filter got misused, let's return the unfiltered array.
-			return \array_values( $included_taxonomies );
-		}
-
-		// Add sanity check to make sure everything is an actual taxonomy.
-		foreach ( $filtered_included_taxonomies as $key => $taxonomy ) {
-			if ( ! \taxonomy_exists( $taxonomy ) ) {
-				unset( $filtered_included_taxonomies[ $key ] );
-			}
-		}
-
 		// `array_values`, to make sure that the keys are reset.
-		return \array_values( $filtered_included_taxonomies );
+		return \array_values( \array_diff( $public_taxonomies, $excluded_taxonomies ) );
 	}
 
 	/**

--- a/src/helpers/taxonomy-helper.php
+++ b/src/helpers/taxonomy-helper.php
@@ -164,7 +164,7 @@ class Taxonomy_Helper {
 	}
 
 	/**
-	 * Filters the taxonomies that are included be indexed.
+	 * Filters the taxonomies that are included to be indexed.
 	 *
 	 * @param array $included_taxonomies The taxonomies that are included to be indexed.
 	 *

--- a/src/helpers/taxonomy-helper.php
+++ b/src/helpers/taxonomy-helper.php
@@ -159,7 +159,7 @@ class Taxonomy_Helper {
 		$excluded_taxonomies = $this->get_excluded_taxonomies_for_indexables();
 
 		$included_taxonomies = \array_diff( $public_taxonomies, $excluded_taxonomies );
-		
+
 		return $this->filter_included_taxonomies( $included_taxonomies );
 	}
 

--- a/src/helpers/taxonomy-helper.php
+++ b/src/helpers/taxonomy-helper.php
@@ -123,10 +123,10 @@ class Taxonomy_Helper {
 	 */
 	public function get_excluded_taxonomies_for_indexables() {
 		/**
-		 * Filter: 'wpseo_indexable_excluded_taxonomies' - Allow developers to prevent a certain taxonomy
-		 * from being saved to the indexable table.
+		 * Filter: 'wpseo_indexable_excluded_taxonomies' - Allows excluding terms of a certain
+		 * taxonomy from being saved to the indexable table.
 		 *
-		 * @param array $excluded_taxonomies The currently excluded taxonomies.
+		 * @api array $excluded_taxonomies The currently excluded taxonomies that indexables will not be created for.
 		 */
 		$excluded_taxonomies = \apply_filters( 'wpseo_indexable_excluded_taxonomies', [] );
 
@@ -158,8 +158,41 @@ class Taxonomy_Helper {
 		$public_taxonomies   = $this->get_public_taxonomies();
 		$excluded_taxonomies = $this->get_excluded_taxonomies_for_indexables();
 
+		$included_taxonomies = \array_diff( $public_taxonomies, $excluded_taxonomies );
+		
+		return $this->filter_included_taxonomies( $included_taxonomies );
+	}
+
+	/**
+	 * Filters the taxonomies that are included be indexed.
+	 *
+	 * @param array $included_taxonomies The taxonomies that are included to be indexed.
+	 *
+	 * @return array The filtered taxonomies that are included to be indexed.
+	 */
+	protected function filter_included_taxonomies( $included_taxonomies ) {
+		/**
+		 * Filter: 'wpseo_indexable_forced_included_taxonomies' - Allows force including terms of a certain
+		 * taxonomy to be saved to the indexable table.
+		 *
+		 * @api array $included_taxonomies The currently included taxonomies that indexables will be created for.
+		 */
+		$filtered_included_taxonomies = \apply_filters( 'wpseo_indexable_forced_included_taxonomies', $included_taxonomies );
+
+		if ( ! \is_array( $filtered_included_taxonomies ) ) {
+			// If the filter got misused, let's return the unfiltered array.
+			return \array_values( $included_taxonomies );
+		}
+
+		// Add sanity check to make sure everything is an actual taxonomy.
+		foreach ( $filtered_included_taxonomies as $key => $taxonomy ) {
+			if ( ! \taxonomy_exists( $taxonomy ) ) {
+				unset( $filtered_included_taxonomies[ $key ] );
+			}
+		}
+
 		// `array_values`, to make sure that the keys are reset.
-		return \array_values( \array_diff( $public_taxonomies, $excluded_taxonomies ) );
+		return \array_values( $filtered_included_taxonomies );
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to give our users a little bit more flexibility to force creation of indexables in niche scenarios where a post type is not public but you still want an indexable.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds a `wpseo_indexable_forced_included_post_types` filter to force creation of indexables for post types.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Create a `non public` post type using a plugin like `CPT UI`.
* Add the following code to your functions.php files of your active theme

```
add_filter('wpseo_indexable_forced_included_post_types', 'yoast_post_types' );
function yoast_post_types($post_types) {
	$post_types[] = '{The slug of the post type you just added}';
	return $post_types;
}
```
* Create a post for this post type.
* Check in the database that an indexable record is created for this post.
* Remove the filter and repeat the test. Confirm that an indexable record did not get created this time.


#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* This also impacts overview pages for the post type. When there is no indexables there should not be stoplights in the overview. When indexables are created they should appear.
* Excluded post types. Make sure that excluded post types keep dont getting indexables created for them.
  * Also check that excluded post types don't get pages in the new settings, while included post types do.
* Non-public post types. Make sure that non-public post types keep dont getting indexables created for them.
  * Also check that non-public post types don't get pages in the new settings, while non-public post types do.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [X] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
