### PR TITLE
Settings: 19706 improve modal on screens with small vertical height

### DIFF
--- a/css/src/new-settings.css
+++ b/css/src/new-settings.css
@@ -45,6 +45,16 @@
 	input[type=week] {
 		@apply yst-min-h-0;
 	}
+
+	#modal-introduction {
+		.yst-modal__close {
+			@apply yst-top-2 yst-right-2;
+
+			.yst-modal__close-button {
+				@apply yst-bg-transparent yst-text-white;
+			}
+		}
+	}
 }
 
 @layer base {

--- a/css/src/new-settings.css
+++ b/css/src/new-settings.css
@@ -47,6 +47,18 @@
 	}
 
 	#modal-introduction {
+		.yst-modal {
+			@media screen and (max-height: 782px) {
+				@apply yst-py-4;
+			}
+		}
+		.yst-modal__panel {
+			@media screen and (max-height: 782px) {
+				/* 2rem space (2 times 1rem from py-4). */
+				@apply yst-max-h-[calc(100vh-2rem)];
+			}
+		}
+
 		.yst-modal__close {
 			@apply yst-top-2 yst-right-2;
 

--- a/packages/js/src/settings/components/introduction.js
+++ b/packages/js/src/settings/components/introduction.js
@@ -147,7 +147,7 @@ const Introduction = () => {
 			tabIndex="-1"
 			ref={ modalDialogRef }
 		>
-			<div className="yst-modal__panel yst-max-w-[37rem] yst-p-0 yst-rounded-2xl sm:yst-rounded-3xl">
+			<Modal.Panel className="yst-max-w-[37rem] yst-p-0 yst-rounded-2xl sm:yst-rounded-3xl">
 
 				{ /* //checks ther is permission from wista to add video and add js script, Helmet component adds the script tp the head */ }
 				{ wistiaEmbedPermission.value && <Helmet>
@@ -311,7 +311,7 @@ const Introduction = () => {
 						</Button> }
 					</div>
 				</div>
-			</div>
+			</Modal.Panel>
 		</Modal>
 	);
 };

--- a/packages/js/src/settings/components/introduction.js
+++ b/packages/js/src/settings/components/introduction.js
@@ -141,13 +141,14 @@ const Introduction = () => {
 	return (
 		// handleClose function is closing the modal and setting the user meta to not show introduction again
 		<Modal
+			id="modal-introduction"
 			onClose={ handleClose }
 			isOpen={ isOpen }
 			aria-label={ __( "Introduction to settings", "wordpress-seo" ) }
 			tabIndex="-1"
 			ref={ modalDialogRef }
 		>
-			<Modal.Panel className="yst-max-w-[37rem] yst-p-0 yst-rounded-2xl sm:yst-rounded-3xl">
+			<Modal.Panel className="yst-max-w-[37rem] yst-overflow-y-auto yst-p-0 yst-rounded-2xl sm:yst-rounded-3xl">
 
 				{ /* //checks ther is permission from wista to add video and add js script, Helmet component adds the script tp the head */ }
 				{ wistiaEmbedPermission.value && <Helmet>


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Fix the introduction modal on wide screens with < ~700px height.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the settings' introduction modal would not be visible on wider screens with less than ~700 pixels height.

## Relevant technical choices:

* Use the `Modal.Panel` to get the close button (and outside click functionality).
* Add overflow-y-auto to the introduction modal' panel and the max-height only when on < 782px.
* Add an ID for easier CSS targeting.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Create a new user to get the introduction modal again or by changing the database value that you find in:
  * the `usermeta` table (probably prefixed with something like `wp_`)
  * the row with the name `_yoast_settings_introduction`
  * the value `show` (boolean) will be `0`, change it to `1` to show the modal again
* Go to Settings
* Make your browser window less tall, but keep it wide
* Verify you get a vertical scrollbar so you can still reach all the content of the modal
* Verify the introduction modal has a close button in the form of an X in the top right corner
* Verify the introduction modal closes when you click outside of the modal

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The setting' introduction modal.

## UI changes

* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [x] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #19706 
