### PR TITLE
Disable primary term functionality by adding register_taxonomy() argument

### DIFF
--- a/src/helpers/primary-term-helper.php
+++ b/src/helpers/primary-term-helper.php
@@ -19,7 +19,7 @@ class Primary_Term_Helper {
 	public function get_primary_term_taxonomies( $post_id ) {
 		$post_type      = \get_post_type( $post_id );
 		$all_taxonomies = \get_object_taxonomies( $post_type, 'objects' );
-		$all_taxonomies = \array_filter( $all_taxonomies, [ $this, 'filter_hierarchical_taxonomies' ] );
+		$all_taxonomies = \array_filter( $all_taxonomies, [ $this, 'filter_hierarchical_or_disabled_taxonomies' ] );
 
 		/**
 		 * Filters which taxonomies for which the user can choose the primary term.
@@ -36,13 +36,16 @@ class Primary_Term_Helper {
 	}
 
 	/**
-	 * Returns whether or not a taxonomy is hierarchical.
+	 * Returns whether or not a taxonomy is hierarchical and not has the arg 'wpseo_disable_primary_term' => true.
 	 *
 	 * @param stdClass $taxonomy Taxonomy object.
 	 *
-	 * @return bool True for hierarchical taxonomy.
+	 * @return bool True for hierarchical taxonomy and False when wpseo_disable_primary_term arg is set.
 	 */
-	protected function filter_hierarchical_taxonomies( $taxonomy ) {
+	protected function filter_hierarchical_or_disabled_taxonomies( $taxonomy ) {
+		if (true === $taxonomy->wpseo_disable_primary_term){
+			return false;
+		}
 		return (bool) $taxonomy->hierarchical;
 	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

This adds the possibility to disable the primary term functionality by adding `'wpseo_disable_primary_term' => true` as argument when registering a taxonomy. Why? Because I think it's more convenient than using the `'wpseo_primary_term_taxonomies'` filter

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

*changelog: enhancement

## Relevant technical choices:

--

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

```
function instruction_register_taxonomy() {
 	$args = array(
		'label'        => __( 'Genre', 'textdomain' ),
		'hierarchical' => true,
		'wpseo_disable_primary_term' => true,
	);
	
	register_taxonomy( 'genre', 'post', $args );
}
add_action( 'init', 'instruction_register_taxonomy', 0 );
```

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
