### PR TITLE
Non-inclusive phrase "ex-offenders" returns with two feedback strings

### DIFF
--- a/packages/yoastseo/spec/scoring/InclusiveLanguageAssessorSpec.js
+++ b/packages/yoastseo/spec/scoring/InclusiveLanguageAssessorSpec.js
@@ -236,3 +236,16 @@ describe( "a test for the inclusive language assessor when run in Shopify", () =
 		} );
 	} );
 } );
+
+describe( "The inclusive language assessor", () => {
+	it( "should target 'ex-offenders' only once", () => {
+		const paper = new Paper( "This sentence contains the word ex-offenders." );
+		const researcher = new EnglishResearcher( paper );
+
+		const assessor = new InclusiveLanguageAssessor( researcher, {} );
+
+		assessor.assess( paper );
+
+		expect( assessor.getValidResults() ).toHaveLength( 1 );
+	} );
+} );

--- a/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/sesAssessmentsSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/sesAssessmentsSpec.js
@@ -183,7 +183,7 @@ describe( "a test for targeting non-inclusive phrases in other assessments", () 
 				identifier: "felon",
 				text: "That person is a felon",
 				expectedFeedback: "Be careful when using <i>felon</i> as it is potentially harmful. Consider using an alternative, such as " +
-					"<i>person with felony convictions, person who have been incarcerated</i>. " +
+					"<i>person with felony convictions, person who has been incarcerated</i>. " +
 					"<a href='https://yoa.st/inclusive-language-ses' target='_blank'>Learn more.</a>",
 				expectedScore: 6,
 			},

--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/sesAssessments.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/sesAssessments.js
@@ -76,7 +76,7 @@ const sesAssessments = [
 	},
 	{
 		identifier: "ex-offender",
-		nonInclusivePhrases: [ "ex-offender", "ex-offenders" ],
+		nonInclusivePhrases: [ "ex-offender" ],
 		inclusiveAlternatives: "<i>formerly incarcerated person</i>",
 		score: SCORES.NON_INCLUSIVE,
 		feedbackFormat: potentiallyHarmful,

--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/sesAssessments.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/sesAssessments.js
@@ -63,7 +63,7 @@ const sesAssessments = [
 	{
 		identifier: "felon",
 		nonInclusivePhrases: [ "felon" ],
-		inclusiveAlternatives: "<i>person with felony convictions, person who have been incarcerated</i>",
+		inclusiveAlternatives: "<i>person with felony convictions, person who has been incarcerated</i>",
 		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
 		feedbackFormat: potentiallyHarmfulCareful,
 	},


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where the potentially non-inclusive phrase 'ex-offenders' was targeted twice by two separate Inclusive Language assessments.
* Fixes an unreleased typo in the feedback text of the 'felon' Inclusive Language assessment. 

## Relevant technical choices:

* 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Fixes an unreleased bug where the potentially non-inclusive phrase 'ex-offenders' was targeted twice by two separate Inclusive Language assessments.
1. Install and activate Yoast SEO 20.1-RC1
2. Enable Inclusive language analysis feature in the setting
3. Create a post
4. Add this phrase: ex-offenders
5. You should only see one assessment result for this phrase under the Inclusive language analysis tab
   > Avoid using _ex-offenders_ as it is potentially harmful. Consider using an alternative, such as _formerly incarcerated people_.

#### Fixes an unreleased typo in the feedback text of the 'felon' Inclusive Language assessment.
1. Install and activate Yoast SEO 20.1-RC1
2. Enable Inclusive language analysis feature in the setting
3. Create a post
4. Add this phrase: felon
5. You should only see one assessment result for this phrase under the Inclusive language analysis tab
   > Be careful when using _felon_ as it is potentially harmful. Consider using an alternative, such as person with felony convictions, person who has been incarcerated.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The impact is limited to the Inclusive Language assessments targeting 'ex-offenders' and 'felon'. No other assessments are impacted.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes https://github.com/Yoast/plugins-automated-testing/issues/429
