### PR TITLE
Settings UI: hides Enable "SEO controls and assessments" when show_ui is false

### DIFF
--- a/packages/js/src/settings/routes/templates/taxonomy.js
+++ b/packages/js/src/settings/routes/templates/taxonomy.js
@@ -28,7 +28,7 @@ const FormikReplacementVariableEditorFieldWithDummy = withFormikDummyField( Form
  * @returns {JSX.Element} The taxonomy element.
  */
 // eslint-disable-next-line complexity
-const Taxonomy = ( { name, label, postTypes: postTypeNames, showUI } ) => {
+const Taxonomy = ( { name, label, postTypes: postTypeNames, showUi } ) => {
 	const postTypes = useSelectSettings( "selectPostTypes", [ postTypeNames ], postTypeNames );
 	const premiumUpsellConfig = useSelectSettings( "selectUpsellSettingsAsProps" );
 	const replacementVariables = useSelectSettings( "selectReplacementVariablesFor", [ name ], name, "term-in-custom-taxonomy" );
@@ -234,7 +234,7 @@ const Taxonomy = ( { name, label, postTypes: postTypeNames, showUI } ) => {
 						</FeatureUpsell>
 					</FieldsetLayout>
 
-					{ showUI &&
+					{ showUi &&
 					<>
 						<hr className="yst-my-8" />
 						<FieldsetLayout
@@ -268,7 +268,7 @@ Taxonomy.propTypes = {
 	name: PropTypes.string.isRequired,
 	label: PropTypes.string.isRequired,
 	postTypes: PropTypes.arrayOf( PropTypes.string ).isRequired,
-	showUI: PropTypes.bool.isRequired,
+	showUi: PropTypes.bool.isRequired,
 };
 
 export default Taxonomy;

--- a/packages/js/src/settings/routes/templates/taxonomy.js
+++ b/packages/js/src/settings/routes/templates/taxonomy.js
@@ -27,7 +27,6 @@ const FormikReplacementVariableEditorFieldWithDummy = withFormikDummyField( Form
  * @param {string[]} postTypes The connected post types.
  * @returns {JSX.Element} The taxonomy element.
  */
-// eslint-disable-next-line complexity
 const Taxonomy = ( { name, label, postTypes: postTypeNames, showUi } ) => {
 	const postTypes = useSelectSettings( "selectPostTypes", [ postTypeNames ], postTypeNames );
 	const premiumUpsellConfig = useSelectSettings( "selectUpsellSettingsAsProps" );
@@ -105,6 +104,9 @@ const Taxonomy = ( { name, label, postTypes: postTypeNames, showUi } ) => {
 	const { values: formValues } = useFormikContext();
 	const { opengraph } = formValues.wpseo_social;
 
+	const taxonomyMessage = useMemo( () => {
+		return initialPostTypeValues.length > 1 ? taxonomyMultiplePostTypesMessage : taxonomySinglePostTypeMessage;
+	}, [ initialPostTypeValues, taxonomyMultiplePostTypesMessage, taxonomySinglePostTypeMessage ] );
 	return (
 		<RouteLayout
 			title={ label }
@@ -117,7 +119,7 @@ const Taxonomy = ( { name, label, postTypes: postTypeNames, showUi } ) => {
 				{ ! isEmpty( postTypeValues ) && (
 					<>
 						<br />
-						{ initialPostTypeValues.length > 1 ? taxonomyMultiplePostTypesMessage : taxonomySinglePostTypeMessage }
+						{ taxonomyMessage }
 					</>
 				) }
 			</> }

--- a/packages/js/src/settings/routes/templates/taxonomy.js
+++ b/packages/js/src/settings/routes/templates/taxonomy.js
@@ -1,3 +1,4 @@
+/* eslint-disable require-jsdoc */
 import { createInterpolateElement, useMemo } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
 import { Badge, Code, FeatureUpsell, Link, ToggleField } from "@yoast/ui-library";
@@ -26,7 +27,8 @@ const FormikReplacementVariableEditorFieldWithDummy = withFormikDummyField( Form
  * @param {string[]} postTypes The connected post types.
  * @returns {JSX.Element} The taxonomy element.
  */
-const Taxonomy = ( { name, label, postTypes: postTypeNames } ) => {
+// eslint-disable-next-line complexity
+const Taxonomy = ( { name, label, postTypes: postTypeNames, showUI } ) => {
 	const postTypes = useSelectSettings( "selectPostTypes", [ postTypeNames ], postTypeNames );
 	const premiumUpsellConfig = useSelectSettings( "selectUpsellSettingsAsProps" );
 	const replacementVariables = useSelectSettings( "selectReplacementVariablesFor", [ name ], name, "term-in-custom-taxonomy" );
@@ -231,27 +233,31 @@ const Taxonomy = ( { name, label, postTypes: postTypeNames } ) => {
 							/>
 						</FeatureUpsell>
 					</FieldsetLayout>
-					<hr className="yst-my-8" />
-					<FieldsetLayout
-						title={ __( "Additional settings", "wordpress-seo" ) }
-					>
-						<FormikValueChangeField
-							as={ ToggleField }
-							type="checkbox"
-							name={ `wpseo_titles.display-metabox-tax-${ name }` }
-							id={ `input-wpseo_titles-display-metabox-tax-${ name }` }
-							label={ __( "Enable SEO controls and assessments", "wordpress-seo" ) }
-							description={ __( "Show or hide our tools and controls in the content editor.", "wordpress-seo" ) }
-							className="yst-max-w-sm"
-						/>
-						{ name === "category" && <FormikFlippedToggleField
-							name="wpseo_titles.stripcategorybase"
-							id="input-wpseo_titles-stripcategorybase"
-							label={ __( "Show the categories prefix in the slug", "wordpress-seo" ) }
-							description={ stripCategoryBaseDescription }
-							className="yst-max-w-sm"
-						/> }
-					</FieldsetLayout>
+
+					{ showUI &&
+					<>
+						<hr className="yst-my-8" />
+						<FieldsetLayout
+							title={ __( "Additional settings", "wordpress-seo" ) }
+						>
+							<FormikValueChangeField
+								as={ ToggleField }
+								type="checkbox"
+								name={ `wpseo_titles.display-metabox-tax-${ name }` }
+								id={ `input-wpseo_titles-display-metabox-tax-${ name }` }
+								label={ __( "Enable SEO controls and assessments", "wordpress-seo" ) }
+								description={ __( "Show or hide our tools and controls in the content editor.", "wordpress-seo" ) }
+								className="yst-max-w-sm"
+							/>
+							{ name === "category" && <FormikFlippedToggleField
+								name="wpseo_titles.stripcategorybase"
+								id="input-wpseo_titles-stripcategorybase"
+								label={ __( "Show the categories prefix in the slug", "wordpress-seo" ) }
+								description={ stripCategoryBaseDescription }
+								className="yst-max-w-sm"
+							/> }
+						</FieldsetLayout>
+					</> }
 				</div>
 			</FormLayout>
 		</RouteLayout>
@@ -262,6 +268,7 @@ Taxonomy.propTypes = {
 	name: PropTypes.string.isRequired,
 	label: PropTypes.string.isRequired,
 	postTypes: PropTypes.arrayOf( PropTypes.string ).isRequired,
+	showUI: PropTypes.bool.isRequired,
 };
 
 export default Taxonomy;

--- a/packages/js/src/settings/routes/templates/taxonomy.js
+++ b/packages/js/src/settings/routes/templates/taxonomy.js
@@ -1,5 +1,5 @@
 /* eslint-disable require-jsdoc */
-import { createInterpolateElement, useMemo } from "@wordpress/element";
+import { createInterpolateElement, useMemo, useCallback } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
 import { Badge, Code, FeatureUpsell, Link, ToggleField } from "@yoast/ui-library";
 import { useFormikContext } from "formik";
@@ -107,6 +107,28 @@ const Taxonomy = ( { name, label, postTypes: postTypeNames, showUi } ) => {
 	const taxonomyMessage = useMemo( () => {
 		return initialPostTypeValues.length > 1 ? taxonomyMultiplePostTypesMessage : taxonomySinglePostTypeMessage;
 	}, [ initialPostTypeValues, taxonomyMultiplePostTypesMessage, taxonomySinglePostTypeMessage ] );
+
+	const enableSeoControl = useCallback( () => {
+		return showUi && <FormikValueChangeField
+			as={ ToggleField }
+			type="checkbox"
+			name={ `wpseo_titles.display-metabox-tax-${ name }` }
+			id={ `input-wpseo_titles-display-metabox-tax-${ name }` }
+			label={ __( "Enable SEO controls and assessments", "wordpress-seo" ) }
+			description={ __( "Show or hide our tools and controls in the content editor.", "wordpress-seo" ) }
+			className="yst-max-w-sm"
+		/>;
+	}, [ showUi, name ] );
+
+	const stripCategoryBase = useCallback( () => {
+		return name === "category" && <FormikFlippedToggleField
+			name="wpseo_titles.stripcategorybase"
+			id="input-wpseo_titles-stripcategorybase"
+			label={ __( "Show the categories prefix in the slug", "wordpress-seo" ) }
+			description={ stripCategoryBaseDescription }
+			className="yst-max-w-sm"
+		/>;
+	}, [ name, stripCategoryBaseDescription ] );
 	return (
 		<RouteLayout
 			title={ label }
@@ -236,29 +258,14 @@ const Taxonomy = ( { name, label, postTypes: postTypeNames, showUi } ) => {
 						</FeatureUpsell>
 					</FieldsetLayout>
 
-					{ showUi &&
+					{ ( showUi || name === "category" ) &&
 					<>
 						<hr className="yst-my-8" />
 						<FieldsetLayout
 							title={ __( "Additional settings", "wordpress-seo" ) }
-						>
-							<FormikValueChangeField
-								as={ ToggleField }
-								type="checkbox"
-								name={ `wpseo_titles.display-metabox-tax-${ name }` }
-								id={ `input-wpseo_titles-display-metabox-tax-${ name }` }
-								label={ __( "Enable SEO controls and assessments", "wordpress-seo" ) }
-								description={ __( "Show or hide our tools and controls in the content editor.", "wordpress-seo" ) }
-								className="yst-max-w-sm"
-							/>
-							{ name === "category" && <FormikFlippedToggleField
-								name="wpseo_titles.stripcategorybase"
-								id="input-wpseo_titles-stripcategorybase"
-								label={ __( "Show the categories prefix in the slug", "wordpress-seo" ) }
-								description={ stripCategoryBaseDescription }
-								className="yst-max-w-sm"
-							/> }
-						</FieldsetLayout>
+						/>
+						{ enableSeoControl() }
+						{ stripCategoryBase() }
 					</> }
 				</div>
 			</FormLayout>

--- a/packages/js/src/settings/routes/templates/taxonomy.js
+++ b/packages/js/src/settings/routes/templates/taxonomy.js
@@ -1,4 +1,3 @@
-/* eslint-disable require-jsdoc */
 import { createInterpolateElement, useMemo, useCallback } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
 import { Badge, Code, FeatureUpsell, Link, ToggleField } from "@yoast/ui-library";
@@ -58,6 +57,7 @@ const Taxonomy = ( { name, label, postTypes: postTypeNames, showUi } ) => {
 			strong: <strong className="yst-font-semibold" />,
 		}
 	), [] );
+
 	const stripCategoryBaseDescription = useMemo( () => createInterpolateElement(
 		sprintf(
 			/* translators: %s expands to <code>/category/</code> */
@@ -68,6 +68,7 @@ const Taxonomy = ( { name, label, postTypes: postTypeNames, showUi } ) => {
 			code: <Code>/category/</Code>,
 		}
 	), [] );
+
 	const taxonomyMultiplePostTypesMessage = useMemo( () => createInterpolateElement(
 		sprintf(
 			/**
@@ -88,6 +89,7 @@ const Taxonomy = ( { name, label, postTypes: postTypeNames, showUi } ) => {
 			code2: <Code>{ lastPostTypeValue?.label }</Code>,
 		}
 	), [ label, initialPostTypeValues, lastPostTypeValue ] );
+
 	const taxonomySinglePostTypeMessage = useMemo( () => createInterpolateElement(
 		sprintf(
 			/**
@@ -129,6 +131,7 @@ const Taxonomy = ( { name, label, postTypes: postTypeNames, showUi } ) => {
 			className="yst-max-w-sm"
 		/>;
 	}, [ name, stripCategoryBaseDescription ] );
+
 	return (
 		<RouteLayout
 			title={ label }

--- a/src/integrations/settings-integration.php
+++ b/src/integrations/settings-integration.php
@@ -780,7 +780,7 @@ class Settings_Integration implements Integration_Interface {
 				'name'          => $taxonomy->name,
 				'route'         => $this->get_route( $taxonomy->name, $taxonomy->rewrite, $taxonomy->rest_base ),
 				'label'         => $taxonomy->label,
-				'showUI'        => $taxonomy->show_ui,
+				'showUi'        => $taxonomy->show_ui,
 				'singularLabel' => $taxonomy->labels->singular_name,
 				'postTypes'     => \array_filter(
 					$taxonomy->object_type,

--- a/src/integrations/settings-integration.php
+++ b/src/integrations/settings-integration.php
@@ -780,6 +780,7 @@ class Settings_Integration implements Integration_Interface {
 				'name'          => $taxonomy->name,
 				'route'         => $this->get_route( $taxonomy->name, $taxonomy->rewrite, $taxonomy->rest_base ),
 				'label'         => $taxonomy->label,
+				'showUI'		=> $taxonomy->show_ui,
 				'singularLabel' => $taxonomy->labels->singular_name,
 				'postTypes'     => \array_filter(
 					$taxonomy->object_type,

--- a/src/integrations/settings-integration.php
+++ b/src/integrations/settings-integration.php
@@ -780,7 +780,7 @@ class Settings_Integration implements Integration_Interface {
 				'name'          => $taxonomy->name,
 				'route'         => $this->get_route( $taxonomy->name, $taxonomy->rewrite, $taxonomy->rest_base ),
 				'label'         => $taxonomy->label,
-				'showUI'		=> $taxonomy->show_ui,
+				'showUI'        => $taxonomy->show_ui,
 				'singularLabel' => $taxonomy->labels->singular_name,
 				'postTypes'     => \array_filter(
 					$taxonomy->object_type,


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Hides "Enable SEO controls and assessments"  option from `Product shipping classes` in Settings

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Hides "Enable SEO controls and assessments" option from taxonomies that has no standard WP UI.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install WooCommerce
* Go to `WooCommerce`->`Settings`
* Select `Shipping` tab
* Select in the navigation of that tab `Shipping classes`
* Add Shipping class (e.g. testShipping).
* Go back to WP menu and select `Products`->`Add new`
* Add title, price and select `Shipping` tab to add `Shipping class`, select the shipping class you created and save.
* Go to `YoastSEO`->`Settings`->`Categories & tags`->`Product shipping classes`
* Scroll all the way to the end of the page and check if there is `Enable SEO controls and assessments` option.

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [X] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes [Hide some parts of "Product shipping classes" from Settings > Categories & Tags#19614](https://github.com/Yoast/wordpress-seo/issues/19614)[Hide some parts of "Product shipping classes" from Settings > Categories & Tags#19614](https://github.com/Yoast/wordpress-seo/issues/19614)[Hide some parts of "Product shipping classes" from Settings > Categories & Tags#19614](https://github.com/Yoast/wordpress-seo/issues/19614)
