### PR TITLE
Mastodon: bump the minimum version in the notification urging to update Premium and update shortlink

### DIFF
--- a/packages/js/src/settings/routes/site-representation.js
+++ b/packages/js/src/settings/routes/site-representation.js
@@ -42,7 +42,7 @@ const SiteRepresentation = () => {
 	const isPremium = useSelectSettings( "selectPreference", [], "isPremium" );
 	const premiumUpsellConfig = useSelectSettings( "selectUpsellSettingsAsProps" );
 	const mastodonPremiumLink = useSelectSettings( "selectLink", [], "https://yoa.st/get-mastodon-integration" );
-	const mastodonUrlLink = useSelectSettings( "selectLink", [], "http://yoa.st/site-representation-mastodon" );
+	const mastodonUrlLink = useSelectSettings( "selectLink", [], "https://yoa.st/site-representation-mastodon" );
 
 	return (
 		<RouteLayout

--- a/packages/js/src/settings/routes/site-representation.js
+++ b/packages/js/src/settings/routes/site-representation.js
@@ -42,7 +42,7 @@ const SiteRepresentation = () => {
 	const isPremium = useSelectSettings( "selectPreference", [], "isPremium" );
 	const premiumUpsellConfig = useSelectSettings( "selectUpsellSettingsAsProps" );
 	const mastodonPremiumLink = useSelectSettings( "selectLink", [], "https://yoa.st/get-mastodon-integration" );
-	const mastodonUrlLink = useSelectSettings( "selectLink", [], "https://yoa.st/mastodon-shortlink" );
+	const mastodonUrlLink = useSelectSettings( "selectLink", [], "http://yoa.st/site-representation-mastodon" );
 
 	return (
 		<RouteLayout

--- a/src/integrations/admin/old-premium-integration.php
+++ b/src/integrations/admin/old-premium-integration.php
@@ -17,6 +17,11 @@ use Yoast\WP\SEO\Presenters\Admin\Notice_Presenter;
 class Old_Premium_Integration implements Integration_Interface {
 
 	/**
+	 * The minimum Premium version.
+	 */
+	const MINIMUM_PREMIUM_VERSION = '20.1-RC0';
+
+	/**
 	 * The options' helper.
 	 *
 	 * @var Options_Helper
@@ -162,14 +167,14 @@ class Old_Premium_Integration implements Integration_Interface {
 	}
 
 	/**
-	 * Returns whether Premium is installed but older than 20.0.
+	 * Returns whether Premium is installed but older than the minimum premium version.
 	 *
-	 * @return bool Whether premium is installed but older than 20.0.
+	 * @return bool Whether premium is installed but older than minimum premium version.
 	 */
 	protected function premium_is_old() {
 		$premium_version = $this->product_helper->get_premium_version();
 		if ( ! \is_null( $premium_version ) ) {
-			return \version_compare( $premium_version, '20.0-RC0', '<' );
+			return \version_compare( $premium_version, self::MINIMUM_PREMIUM_VERSION, '<' );
 		}
 
 		return false;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Bumps the minimum Premium version to 20.1-RC0.
* Changes the shortlink in the Mastodon field description.

## Relevant technical choices:



## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install with Premium < 20.1-RC1 and see you get the "Update to the latest version of Yoast SEO Premium" notification
* Install with Premium >= 20.1-RC1 and see you don't get the notification
* Visit Settings > Site Representation and check that "Read more about how to get your site verified." below the Mastodon field points to http://yoa.st/site-representation-mastodon

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #19723 
