### PR TITLE
Inclusive language: improve feedback string for some non-inclusive phrases

### DIFF
--- a/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessmentsSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessmentsSpec.js
@@ -377,6 +377,7 @@ describe( "A test for Disability assessments", function() {
 	} );
 } );
 
+// eslint-disable-next-line max-statements
 describe( "a test for targeting non-inclusive phrases in disability assessments", () => {
 	it( "should return the appropriate score and feedback string for: 'binge' and its other forms", () => {
 		const testData = [
@@ -384,7 +385,7 @@ describe( "a test for targeting non-inclusive phrases in disability assessments"
 				identifier: "binge",
 				text: "I binge on ice cream.",
 				expectedFeedback: "Be careful when using <i>binge</i>, unless talking about a symptom of a medical condition. " +
-					"If you are not referencing a medical condition, consider other alternatives to describe the trait or behavior, " +
+					"If you are not referencing a symptom, consider other alternatives to describe the trait or behavior, " +
 					"such as <i>indulge, satiate, wallow, spree, marathon, consume excessively</i>. " +
 					"<a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
 				expectedScore: 6,
@@ -393,7 +394,7 @@ describe( "a test for targeting non-inclusive phrases in disability assessments"
 				identifier: "binges",
 				text: "She binges on Netflix series.",
 				expectedFeedback: "Be careful when using <i>binges</i>, unless talking about a symptom of a medical condition. " +
-					"If you are not referencing a medical condition, consider other alternatives to describe the trait or behavior, " +
+					"If you are not referencing a symptom, consider other alternatives to describe the trait or behavior, " +
 					"such as <i>indulges, satiates, wallows, sprees, marathons, consumes excessively</i>. " +
 					"<a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
 				expectedScore: 6,
@@ -402,7 +403,7 @@ describe( "a test for targeting non-inclusive phrases in disability assessments"
 				identifier: "bingeing",
 				text: "She is bingeing the new Korean drama on Netflix.",
 				expectedFeedback: "Be careful when using <i>bingeing</i>, unless talking about a symptom of a medical condition. " +
-					"If you are not referencing a medical condition, consider other alternatives to describe the trait or behavior, " +
+					"If you are not referencing a symptom, consider other alternatives to describe the trait or behavior, " +
 					"such as <i>indulging, satiating, wallowing, spreeing, marathoning, consuming excessively</i>." +
 					" <a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
 				expectedScore: 6,
@@ -411,7 +412,7 @@ describe( "a test for targeting non-inclusive phrases in disability assessments"
 				identifier: "bingeing",
 				text: "She is binging the new Korean drama on Netflix.",
 				expectedFeedback: "Be careful when using <i>binging</i>, unless talking about a symptom of a medical condition. " +
-					"If you are not referencing a medical condition, consider other alternatives to describe the trait or behavior, " +
+					"If you are not referencing a symptom, consider other alternatives to describe the trait or behavior, " +
 					"such as <i>indulging, satiating, wallowing, spreeing, marathoning, consuming excessively</i>." +
 					" <a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
 				expectedScore: 6,
@@ -420,7 +421,7 @@ describe( "a test for targeting non-inclusive phrases in disability assessments"
 				identifier: "binged",
 				text: "She binged the new Korean drama on Netflix.",
 				expectedFeedback: "Be careful when using <i>binged</i>, unless talking about a symptom of a medical condition. " +
-					"If you are not referencing a medical condition, consider other alternatives to describe the trait or behavior, " +
+					"If you are not referencing a symptom, consider other alternatives to describe the trait or behavior, " +
 					"such as <i>indulged, satiated, wallowed, spreed, marathoned, consumed excessively</i>. " +
 					"<a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
 				expectedScore: 6,
@@ -429,8 +430,7 @@ describe( "a test for targeting non-inclusive phrases in disability assessments"
 
 		testInclusiveLanguageAssessments( testData );
 	} );
-
-	it( "should return the appropriate score and feedback string for: 'crippled'", () => {
+	it( "should return the appropriate score and feedback string for: 'crippled' and 'cripple'", () => {
 		const testData = [
 			{
 				identifier: "crippled",
@@ -440,12 +440,6 @@ describe( "a test for targeting non-inclusive phrases in disability assessments"
 					"<a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
 				expectedScore: 3,
 			},
-		];
-		testInclusiveLanguageAssessments( testData );
-	} );
-
-	it( "should return the appropriate score and feedback string for: 'cripple'", () => {
-		const testData = [
 			{
 				identifier: "cripple",
 				text: "He's afraid to look like a cripple.",
@@ -457,36 +451,7 @@ describe( "a test for targeting non-inclusive phrases in disability assessments"
 		];
 		testInclusiveLanguageAssessments( testData );
 	} );
-
-	it( "should return the appropriate score and feedback string for: 'cripple'", () => {
-		const testData = [
-			{
-				identifier: "cripple",
-				text: "He's afraid to look like a cripple.",
-				expectedFeedback: "Avoid using <i>a cripple</i> as it is derogatory. Consider using an alternative, such as " +
-					"<i>person with a physical disability, a physically disabled person</i> instead. " +
-					"<a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
-				expectedScore: 3,
-			},
-		];
-		testInclusiveLanguageAssessments( testData );
-	} );
-
-	it( "should return the appropriate score and feedback string for: 'cripple'", () => {
-		const testData = [
-			{
-				identifier: "cripple",
-				text: "He's afraid to look like a cripple.",
-				expectedFeedback: "Avoid using <i>a cripple</i> as it is derogatory. Consider using an alternative, such as " +
-					"<i>person with a physical disability, a physically disabled person</i> instead. " +
-					"<a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
-				expectedScore: 3,
-			},
-		];
-		testInclusiveLanguageAssessments( testData );
-	} );
-
-	it( "should return the appropriate score and feedback string for: 'handicapped'", () => {
+	it( "should return the appropriate score and feedback string for: 'handicapped' and 'handicap'", () => {
 		const testData = [
 			{
 				identifier: "handicapped",
@@ -496,12 +461,6 @@ describe( "a test for targeting non-inclusive phrases in disability assessments"
 					"<a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
 				expectedScore: 3,
 			},
-		];
-		testInclusiveLanguageAssessments( testData );
-	} );
-
-	it( "should return the appropriate score and feedback string for: 'handicap'", () => {
-		const testData = [
 			{
 				identifier: "handicap",
 				text: "They are in the handicap situation.",
@@ -512,7 +471,6 @@ describe( "a test for targeting non-inclusive phrases in disability assessments"
 		];
 		testInclusiveLanguageAssessments( testData );
 	} );
-
 	it( "should return the appropriate score and feedback string for: 'insane'", () => {
 		const testData = [
 			{
@@ -539,19 +497,6 @@ describe( "a test for targeting non-inclusive phrases in disability assessments"
 		];
 		testInclusiveLanguageAssessments( testData );
 	} );
-
-	it( "should return the appropriate score and feedback string for: 'handicap'", () => {
-		const testData = [
-			{
-				identifier: "handicap",
-				text: "They are in the handicap situation.",
-				expectedFeedback: "Avoid using <i>handicap</i> as it is potentially harmful. Consider using an alternative, such as " +
-					"<i>disability</i>. <a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
-				expectedScore: 3,
-			},
-		];
-		testInclusiveLanguageAssessments( testData );
-	} );
 	it( "should return the appropriate score and feedback string for: 'hearing impaired'", () => {
 		const testData = [
 			{
@@ -565,7 +510,7 @@ describe( "a test for targeting non-inclusive phrases in disability assessments"
 		];
 		testInclusiveLanguageAssessments( testData );
 	} );
-	it( "should return the appropriate score and feedback string for: 'functioning'", () => {
+	it( "should return the appropriate score and feedback string for: 'high functioning' and 'low functioning'", () => {
 		const testData = [
 			{
 				identifier: "functioning",
@@ -575,50 +520,6 @@ describe( "a test for targeting non-inclusive phrases in disability assessments"
 					"<a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
 				expectedScore: 6,
 			},
-		];
-		testInclusiveLanguageAssessments( testData );
-	} );
-	it( "should return the appropriate score and feedback string for: 'hearing impaired'", () => {
-		const testData = [
-			{
-				identifier: "hearingImpaired",
-				text: "Speak louder for the hearing impaired people.",
-				expectedFeedback: "Avoid using <i>hearing impaired</i> as it is potentially harmful. Consider using an alternative, such as " +
-					"<i>deaf or hard of hearing, partially deaf, has partial hearing loss</i>. " +
-					"<a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
-				expectedScore: 3,
-			},
-		];
-		testInclusiveLanguageAssessments( testData );
-	} );
-	it( "should return the appropriate score and feedback string for: ' high functioning'", () => {
-		const testData = [
-			{
-				identifier: "functioning",
-				text: "They have high functioning depression.",
-				expectedFeedback: "Be careful when using <i>high functioning</i> as it is potentially harmful. Consider using an alternative, " +
-					"such as describing the specific characteristic or experience, unless referring to how you characterize your own condition. " +
-					"<a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
-				expectedScore: 6,
-			},
-		];
-		testInclusiveLanguageAssessments( testData );
-	} );
-	it( "should return the appropriate score and feedback string for: 'low functioning'", () => {
-		const testData = [
-			{
-				identifier: "functioning",
-				text: "They have low functioning depression.",
-				expectedFeedback: "Be careful when using <i>low functioning</i> as it is potentially harmful. Consider using an alternative, " +
-					"such as describing the specific characteristic or experience, unless referring to how you characterize your own condition. " +
-					"<a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
-				expectedScore: 6,
-			},
-		];
-		testInclusiveLanguageAssessments( testData );
-	} );
-	it( "should return the appropriate score and feedback string for: 'low functioning'", () => {
-		const testData = [
 			{
 				identifier: "functioning",
 				text: "They have low functioning depression.",
@@ -823,8 +724,9 @@ describe( "a test for targeting non-inclusive phrases in disability assessments"
 
 		testInclusiveLanguageAssessments( testData );
 	} );
-	it( "should return the appropriate score and feedback string for: 'deaf-mute'", () => {
+	it( "should return the appropriate score and feedback string for non-inclusive phrases related to 'deaf'", () => {
 		const testData = [
+			// Non-inclusive: deaf-mute.
 			{
 				identifier: "deaf",
 				text: "They were born deaf-mute.",
@@ -833,24 +735,7 @@ describe( "a test for targeting non-inclusive phrases in disability assessments"
 					"<a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
 				expectedScore: 3,
 			},
-		];
-		testInclusiveLanguageAssessments( testData );
-	} );
-	it( "should return the appropriate score and feedback string for: 'deaf and dumb'", () => {
-		const testData = [
-			{
-				identifier: "deaf",
-				text: "They were born deaf and dumb.",
-				expectedFeedback: "Avoid using <i>deaf and dumb</i> as it is potentially harmful. Consider using an alternative, " +
-					"such as <i>deaf</i>. " +
-					"<a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
-				expectedScore: 3,
-			},
-		];
-		testInclusiveLanguageAssessments( testData );
-	} );
-	it( "should return the appropriate score and feedback string for: 'deaf and dumb'", () => {
-		const testData = [
+			// Non-inclusive: deaf and dumb.
 			{
 				identifier: "deaf",
 				text: "They were born deaf and dumb.",
@@ -893,19 +778,6 @@ describe( "a test for targeting non-inclusive phrases in disability assessments"
 				expectedFeedback: "Avoid using <i>sanity check</i> as it is potentially harmful. Consider using an alternative, " +
 						"such as <i>final check, confidence check, rationality check, soundness check</i>. " +
 						"<a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
-				expectedScore: 3,
-			},
-		];
-		testInclusiveLanguageAssessments( testData );
-	} );
-	it( "should return the appropriate score and feedback string for: 'sanity check'", () => {
-		const testData = [
-			{
-				identifier: "sanityCheck",
-				text: "Those who decided this need a sanity check.",
-				expectedFeedback: "Avoid using <i>sanity check</i> as it is potentially harmful. Consider using an alternative, " +
-					"such as <i>final check, confidence check, rationality check, soundness check</i>. " +
-					"<a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
 				expectedScore: 3,
 			},
 		];
@@ -1050,7 +922,7 @@ describe( "a test for targeting non-inclusive phrases in disability assessments"
 				identifier: "to be not crazy about",
 				text: "They are not crazy about this album.",
 				expectedFeedback: "Avoid using <i>crazy</i> as it is potentially harmful. " +
-					"Consider using an alternative, such as <i>to be not impressed by, to not be enthusiastic about, to not be into, " +
+					"Consider using an alternative, such as <i>to be not impressed by, to be not enthusiastic about, to be not into, " +
 					"to not like</i>. <a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
 				expectedScore: 3,
 			},
@@ -1059,7 +931,7 @@ describe( "a test for targeting non-inclusive phrases in disability assessments"
 				identifier: "to be not crazy about",
 				text: "They are not too crazy about this album.",
 				expectedFeedback: "Avoid using <i>crazy</i> as it is potentially harmful. " +
-					"Consider using an alternative, such as <i>to be not impressed by, to not be enthusiastic about, to not be into, " +
+					"Consider using an alternative, such as <i>to be not impressed by, to be not enthusiastic about, to be not into, " +
 					"to not like</i>. <a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
 				expectedScore: 3,
 			},
@@ -1068,7 +940,7 @@ describe( "a test for targeting non-inclusive phrases in disability assessments"
 				identifier: "to be not crazy about",
 				text: "They aren't too crazy about this album.",
 				expectedFeedback: "Avoid using <i>crazy</i> as it is potentially harmful. " +
-					"Consider using an alternative, such as <i>to be not impressed by, to not be enthusiastic about, to not be into, " +
+					"Consider using an alternative, such as <i>to be not impressed by, to be not enthusiastic about, to be not into, " +
 					"to not like</i>. <a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
 				expectedScore: 3,
 			},
@@ -1099,7 +971,7 @@ describe( "a test for targeting non-inclusive phrases in disability assessments"
 				identifier: "to go crazy",
 				text: "It's going crazy out here.",
 				expectedFeedback: "Avoid using <i>crazy</i> as it is potentially harmful. " +
-					"Consider using an alternative, such as <i>to go wild, to go out of control, to go up the wall, to get in one's head, " +
+					"Consider using an alternative, such as <i>to go wild, to go out of control, to go up the wall, " +
 					"to be aggravated, to get confused</i>. <a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
 				expectedScore: 3,
 			},
@@ -1108,7 +980,7 @@ describe( "a test for targeting non-inclusive phrases in disability assessments"
 				identifier: "to go crazy",
 				text: "They go crazy out here.",
 				expectedFeedback: "Avoid using <i>crazy</i> as it is potentially harmful. " +
-					"Consider using an alternative, such as <i>to go wild, to go out of control, to go up the wall, to get in one's head, " +
+					"Consider using an alternative, such as <i>to go wild, to go out of control, to go up the wall, " +
 					"to be aggravated, to get confused</i>. <a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
 				expectedScore: 3,
 			},
@@ -1117,7 +989,7 @@ describe( "a test for targeting non-inclusive phrases in disability assessments"
 				identifier: "to go crazy",
 				text: "He goes crazy out here.",
 				expectedFeedback: "Avoid using <i>crazy</i> as it is potentially harmful. " +
-					"Consider using an alternative, such as <i>to go wild, to go out of control, to go up the wall, to get in one's head, " +
+					"Consider using an alternative, such as <i>to go wild, to go out of control, to go up the wall, " +
 					"to be aggravated, to get confused</i>. <a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
 				expectedScore: 3,
 			},
@@ -1126,7 +998,7 @@ describe( "a test for targeting non-inclusive phrases in disability assessments"
 				identifier: "to go crazy",
 				text: "They went crazy out there.",
 				expectedFeedback: "Avoid using <i>crazy</i> as it is potentially harmful. " +
-					"Consider using an alternative, such as <i>to go wild, to go out of control, to go up the wall, to get in one's head, " +
+					"Consider using an alternative, such as <i>to go wild, to go out of control, to go up the wall, " +
 					"to be aggravated, to get confused</i>. <a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
 				expectedScore: 3,
 			},
@@ -1135,7 +1007,7 @@ describe( "a test for targeting non-inclusive phrases in disability assessments"
 				identifier: "to go crazy",
 				text: "They have gone crazy out there.",
 				expectedFeedback: "Avoid using <i>crazy</i> as it is potentially harmful. " +
-					"Consider using an alternative, such as <i>to go wild, to go out of control, to go up the wall, to get in one's head, " +
+					"Consider using an alternative, such as <i>to go wild, to go out of control, to go up the wall, " +
 					"to be aggravated, to get confused</i>. <a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
 				expectedScore: 3,
 			},

--- a/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessmentsSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessmentsSpec.js
@@ -307,28 +307,6 @@ describe( "A test for Disability assessments", function() {
 			original: "This sentence contains low-functioning autism." } } ]
 		);
 	} );
-	it( "correctly identifies 'deaf-mute'", () => {
-		const mockPaper = new Paper( "This sentence contains deaf-mute." );
-		const mockResearcher = Factory.buildMockResearcher( [ "This sentence contains deaf-mute." ] );
-		const assessor = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "deaf" ) );
-
-		const isApplicable = assessor.isApplicable( mockPaper, mockResearcher );
-
-		expect( isApplicable ).toBeTruthy();
-		const assessmentResult = assessor.getResult();
-		expect( assessmentResult.getScore() ).toEqual( 3 );
-		expect( assessmentResult.getText() ).toEqual(
-			"Avoid using <i>deaf-mute</i> as it is potentially harmful. " +
-			"Consider using an alternative, such as <i>deaf</i>. " +
-			"<a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>"
-		);
-		expect( assessmentResult.hasMarks() ).toBeTruthy();
-		expect( assessor.getMarks() ).toEqual(   [ { _properties: {
-			fieldsToMark: [],
-			marked: "<yoastmark class='yoast-text-mark'>This sentence contains deaf-mute.</yoastmark>",
-			original: "This sentence contains deaf-mute." } } ]
-		);
-	} );
 	it( "correctly identifies 'brain-damaged'", () => {
 		const mockPaper = new Paper( "This sentence contains brain-damaged." );
 		const mockResearcher = Factory.buildMockResearcher( [ "This sentence contains brain-damaged." ] );
@@ -350,29 +328,6 @@ describe( "A test for Disability assessments", function() {
 			fieldsToMark: [],
 			marked: "<yoastmark class='yoast-text-mark'>This sentence contains brain-damaged.</yoastmark>",
 			original: "This sentence contains brain-damaged." } } ]
-		);
-	} );
-	it( "correctly identifies 'differently-abled'", () => {
-		const mockPaper = new Paper( "This sentence contains differently-abled." );
-		const mockResearcher = Factory.buildMockResearcher( [ "This sentence contains differently-abled." ] );
-		const assessor = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "differentlyAbled" ) );
-
-		const isApplicable = assessor.isApplicable( mockPaper, mockResearcher );
-
-		expect( isApplicable ).toBeTruthy();
-		const assessmentResult = assessor.getResult();
-		expect( assessmentResult.getScore() ).toEqual( 6 );
-		expect( assessmentResult.getText() ).toEqual(
-			"Be careful when using <i>differently-abled</i> as it is potentially harmful. " +
-			"Consider using an alternative, such as <i>disabled, person with a disability</i>, " +
-			"unless referring to someone who explicitly wants to be referred to with this term. " +
-			"<a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>"
-		);
-		expect( assessmentResult.hasMarks() ).toBeTruthy();
-		expect( assessor.getMarks() ).toEqual(   [ { _properties: {
-			fieldsToMark: [],
-			marked: "<yoastmark class='yoast-text-mark'>This sentence contains differently-abled.</yoastmark>",
-			original: "This sentence contains differently-abled." } } ]
 		);
 	} );
 } );
@@ -803,7 +758,6 @@ describe( "a test for targeting non-inclusive phrases in disability assessments"
 
 		testInclusiveLanguageAssessments( testData );
 	} );
-
 	it( "correctly identifies 'differently-abled'", () => {
 		const mockPaper = new Paper( "This sentence contains differently-abled." );
 		const mockResearcher = Factory.buildMockResearcher( [ "This sentence contains differently-abled." ] );
@@ -882,7 +836,6 @@ describe( "a test for targeting non-inclusive phrases in disability assessments"
 		];
 		testInclusiveLanguageAssessments( testData );
 	} );
-
 	it( "should return the appropriate score and feedback string for: the non-negated phrase of 'crazy about'", () => {
 		const testData = [
 			// The non-negated phrase for 'crazy about' without an intensifier.
@@ -906,7 +859,6 @@ describe( "a test for targeting non-inclusive phrases in disability assessments"
 		];
 		testInclusiveLanguageAssessments( testData );
 	} );
-
 	it( "should not show the feedback for the non-negated form of 'crazy about' when the negated form is used.", () => {
 		const mockPaper = new Paper( "I am not so crazy about this album." );
 		const mockResearcher = Factory.buildMockResearcher( [ "I am not so crazy about this album." ] );
@@ -914,7 +866,6 @@ describe( "a test for targeting non-inclusive phrases in disability assessments"
 		const isApplicable = assessor.isApplicable( mockPaper, mockResearcher );
 		expect( isApplicable ).toBeFalsy();
 	} );
-
 	it( "should return the appropriate score and feedback string for: the negated phrase of 'crazy about'", () => {
 		const testData = [
 			// The negated phrase for 'crazy about' without an intensifier.
@@ -947,7 +898,6 @@ describe( "a test for targeting non-inclusive phrases in disability assessments"
 		];
 		testInclusiveLanguageAssessments( testData );
 	} );
-
 	it( "should not show the feedback for the non-negated form of 'crazy about' when the negated form is used.", () => {
 		const mockPaper = new Paper( "I am so crazy about this album." );
 		const mockResearcher = Factory.buildMockResearcher( [ "I am so crazy about this album." ] );
@@ -955,7 +905,6 @@ describe( "a test for targeting non-inclusive phrases in disability assessments"
 		const isApplicable = assessor.isApplicable( mockPaper, mockResearcher );
 		expect( isApplicable ).toBeFalsy();
 	} );
-
 	it( "should not show the feedback for standalone crazy when it's used as part of a more specific phrase.", () => {
 		const mockPaper = new Paper( "I am so crazy about this album." );
 		const mockResearcher = Factory.buildMockResearcher( [ "I am so crazy about this album." ] );
@@ -963,7 +912,6 @@ describe( "a test for targeting non-inclusive phrases in disability assessments"
 		const isApplicable = assessor.isApplicable( mockPaper, mockResearcher );
 		expect( isApplicable ).toBeFalsy();
 	} );
-
 	it( "should return the appropriate score and feedback string for: 'to go crazy' and its other forms", () => {
 		const testData = [
 			// Form: going crazy.
@@ -1015,7 +963,6 @@ describe( "a test for targeting non-inclusive phrases in disability assessments"
 
 		testInclusiveLanguageAssessments( testData );
 	} );
-
 	it( "should target the phrase 'crazy in love' and retrieve correct feedback.", () => {
 		const mockPaper = new Paper( "They seem crazy in love." );
 		const mockResearcher = Factory.buildMockResearcher( [ "They seem crazy in love." ] );
@@ -1036,64 +983,62 @@ describe( "a test for targeting non-inclusive phrases in disability assessments"
 			marked: "<yoastmark class='yoast-text-mark'>They seem crazy in love.</yoastmark>",
 		} ) ] );
 	} );
-
 	it( "should return the appropriate score and feedback string for: 'to drive crazy' and its other forms", () => {
 		const testData = [
 			// Form: driving (someone) crazy.
 			{
 				identifier: "to drive crazy",
 				text: "This math problem is driving me crazy.",
-				expectedFeedback: "Avoid using <i>crazy</i> as it is potentially harmful. " +
-					"Consider using an alternative, such as <i>to drive to one's limit, to get on one's last nerve, to make one livid, " +
-					"to aggravate, to make blood boil, to exasperate, to irritate to the limit</i>. " +
-					"<a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
+				expectedFeedback: "Avoid using <i>crazy</i> as it is potentially harmful. Consider using an alternative, " +
+					"such as <i>to drive one to their limit, to get on one's last nerve, to make one livid, to aggravate, " +
+					"to make one’s blood boil, to exasperate, to get into one's head</i>." +
+					" <a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
 				expectedScore: 3,
 			},
 			// Form: drive (someone) crazy.
 			{
 				identifier: "to drive crazy",
 				text: "They drive everyone crazy.",
-				expectedFeedback: "Avoid using <i>crazy</i> as it is potentially harmful. " +
-					"Consider using an alternative, such as <i>to drive to one's limit, to get on one's last nerve, to make one livid, " +
-					"to aggravate, to make blood boil, to exasperate, to irritate to the limit</i>. " +
-					"<a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
+				expectedFeedback: "Avoid using <i>crazy</i> as it is potentially harmful. Consider using an alternative, " +
+					"such as <i>to drive one to their limit, to get on one's last nerve, to make one livid, to aggravate, " +
+					"to make one’s blood boil, to exasperate, to get into one's head</i>." +
+					" <a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
 				expectedScore: 3,
 			},
 			// Form: drove (someone) crazy.
 			{
 				identifier: "to drive crazy",
 				text: "They drove him crazy.",
-				expectedFeedback: "Avoid using <i>crazy</i> as it is potentially harmful. " +
-					"Consider using an alternative, such as <i>to drive to one's limit, to get on one's last nerve, to make one livid, " +
-					"to aggravate, to make blood boil, to exasperate, to irritate to the limit</i>. " +
-					"<a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
+				expectedFeedback: "Avoid using <i>crazy</i> as it is potentially harmful. Consider using an alternative, " +
+					"such as <i>to drive one to their limit, to get on one's last nerve, to make one livid, to aggravate, " +
+					"to make one’s blood boil, to exasperate, to get into one's head</i>." +
+					" <a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
 				expectedScore: 3,
 			},
 			// Form: drives (someone) crazy.
 			{
 				identifier: "to drive crazy",
 				text: "She drives somebody crazy.",
-				expectedFeedback: "Avoid using <i>crazy</i> as it is potentially harmful. " +
-					"Consider using an alternative, such as <i>to drive to one's limit, to get on one's last nerve, to make one livid, " +
-					"to aggravate, to make blood boil, to exasperate, to irritate to the limit</i>. " +
-					"<a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
+				expectedFeedback: "Avoid using <i>crazy</i> as it is potentially harmful. Consider using an alternative, " +
+					"such as <i>to drive one to their limit, to get on one's last nerve, to make one livid, to aggravate, " +
+					"to make one’s blood boil, to exasperate, to get into one's head</i>." +
+					" <a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
 				expectedScore: 3,
 			},
 			// Form: driven (someone) crazy.
 			{
 				identifier: "to drive crazy",
 				text: "He has driven them crazy.",
-				expectedFeedback: "Avoid using <i>crazy</i> as it is potentially harmful. " +
-					"Consider using an alternative, such as <i>to drive to one's limit, to get on one's last nerve, to make one livid, " +
-					"to aggravate, to make blood boil, to exasperate, to irritate to the limit</i>. " +
-					"<a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
+				expectedFeedback: "Avoid using <i>crazy</i> as it is potentially harmful. Consider using an alternative, " +
+					"such as <i>to drive one to their limit, to get on one's last nerve, to make one livid, to aggravate, " +
+					"to make one’s blood boil, to exasperate, to get into one's head</i>." +
+					" <a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
 				expectedScore: 3,
 			},
 		];
 
 		testInclusiveLanguageAssessments( testData );
 	} );
-
 	it( "should return the appropriate score and feedback string for: 'psychopath' and its other forms", () => {
 		// The different forms of "psychopath" is one entry under the same identifier.
 		const testData = [
@@ -1192,21 +1137,7 @@ describe( "a test for targeting non-inclusive phrases in disability assessments"
 		];
 		testInclusiveLanguageAssessments( testData );
 	} );
-	it( "should return the appropriate score and feedback string for: 'schizophrenic'", () => {
-		const testData = [
-			{
-				identifier: "schizophrenic",
-				text: "It's like he's schizophrenic.",
-				expectedFeedback: "Be careful when using <i>schizophrenic</i> as it is potentially harmful. Unless you are referencing the " +
-					"specific medical condition, consider using another alternative to describe the trait or behavior, such as " +
-					"<i>of two minds, chaotic, confusing</i>. " +
-					"<a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
-				expectedScore: 6,
-			},
-		];
-		testInclusiveLanguageAssessments( testData );
-	} );
-	it( "should return the appropriate score and feedback string for: 'schizophrenic'", () => {
+	it( "should return the appropriate score and feedback string for: 'paranoid'", () => {
 		const testData = [
 			{
 				identifier: "paranoid",
@@ -1220,7 +1151,7 @@ describe( "a test for targeting non-inclusive phrases in disability assessments"
 		];
 		testInclusiveLanguageAssessments( testData );
 	} );
-	it( "should return the appropriate score and feedback string for: 'schizophrenic'", () => {
+	it( "should return the appropriate score and feedback string for: 'manic'", () => {
 		const testData = [
 			{
 				identifier: "manic",

--- a/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessmentsSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessmentsSpec.js
@@ -991,7 +991,7 @@ describe( "a test for targeting non-inclusive phrases in disability assessments"
 				text: "This math problem is driving me crazy.",
 				expectedFeedback: "Avoid using <i>crazy</i> as it is potentially harmful. Consider using an alternative, " +
 					"such as <i>to drive one to their limit, to get on one's last nerve, to make one livid, to aggravate, " +
-					"to make one’s blood boil, to exasperate, to get into one's head</i>." +
+					"to make one's blood boil, to exasperate, to get into one's head</i>." +
 					" <a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
 				expectedScore: 3,
 			},
@@ -1001,7 +1001,7 @@ describe( "a test for targeting non-inclusive phrases in disability assessments"
 				text: "They drive everyone crazy.",
 				expectedFeedback: "Avoid using <i>crazy</i> as it is potentially harmful. Consider using an alternative, " +
 					"such as <i>to drive one to their limit, to get on one's last nerve, to make one livid, to aggravate, " +
-					"to make one’s blood boil, to exasperate, to get into one's head</i>." +
+					"to make one's blood boil, to exasperate, to get into one's head</i>." +
 					" <a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
 				expectedScore: 3,
 			},
@@ -1011,7 +1011,7 @@ describe( "a test for targeting non-inclusive phrases in disability assessments"
 				text: "They drove him crazy.",
 				expectedFeedback: "Avoid using <i>crazy</i> as it is potentially harmful. Consider using an alternative, " +
 					"such as <i>to drive one to their limit, to get on one's last nerve, to make one livid, to aggravate, " +
-					"to make one’s blood boil, to exasperate, to get into one's head</i>." +
+					"to make one's blood boil, to exasperate, to get into one's head</i>." +
 					" <a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
 				expectedScore: 3,
 			},
@@ -1021,7 +1021,7 @@ describe( "a test for targeting non-inclusive phrases in disability assessments"
 				text: "She drives somebody crazy.",
 				expectedFeedback: "Avoid using <i>crazy</i> as it is potentially harmful. Consider using an alternative, " +
 					"such as <i>to drive one to their limit, to get on one's last nerve, to make one livid, to aggravate, " +
-					"to make one’s blood boil, to exasperate, to get into one's head</i>." +
+					"to make one's blood boil, to exasperate, to get into one's head</i>." +
 					" <a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
 				expectedScore: 3,
 			},
@@ -1031,7 +1031,7 @@ describe( "a test for targeting non-inclusive phrases in disability assessments"
 				text: "He has driven them crazy.",
 				expectedFeedback: "Avoid using <i>crazy</i> as it is potentially harmful. Consider using an alternative, " +
 					"such as <i>to drive one to their limit, to get on one's last nerve, to make one livid, to aggravate, " +
-					"to make one’s blood boil, to exasperate, to get into one's head</i>." +
+					"to make one's blood boil, to exasperate, to get into one's head</i>." +
 					" <a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
 				expectedScore: 3,
 			},

--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessments.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessments.js
@@ -56,7 +56,7 @@ const disabilityAssessments =  [
 		inclusiveAlternatives: "<i>indulge, satiate, wallow, spree, marathon, consume excessively</i>",
 		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
 		feedbackFormat: "Be careful when using <i>%1$s</i>, unless talking about a symptom of a medical condition. " +
-			"If you are not referencing a medical condition, consider other alternatives to describe the trait or behavior, such as %2$s.",
+			"If you are not referencing a symptom, consider other alternatives to describe the trait or behavior, such as %2$s.",
 		rule: ( words, nonInclusivePhrase ) => includesConsecutiveWords( words, nonInclusivePhrase )
 			.filter( isNotFollowedByException( words, nonInclusivePhrase, [ "drink", "drinks", "drinking" ] ) ),
 	},
@@ -66,7 +66,7 @@ const disabilityAssessments =  [
 		inclusiveAlternatives: "<i>indulging, satiating, wallowing, spreeing, marathoning, consuming excessively</i>",
 		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
 		feedbackFormat: "Be careful when using <i>%1$s</i>, unless talking about a symptom of a medical condition. " +
-			"If you are not referencing a medical condition, consider other alternatives to describe the trait or behavior, such as %2$s.",
+			"If you are not referencing a symptom, consider other alternatives to describe the trait or behavior, such as %2$s.",
 	},
 	{
 		identifier: "binged",
@@ -74,7 +74,7 @@ const disabilityAssessments =  [
 		inclusiveAlternatives: "<i>indulged, satiated, wallowed, spreed, marathoned, consumed excessively</i>",
 		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
 		feedbackFormat: "Be careful when using <i>%1$s</i>, unless talking about a symptom of a medical condition. " +
-			"If you are not referencing a medical condition, consider other alternatives to describe the trait or behavior, such as %2$s.",
+			"If you are not referencing a symptom, consider other alternatives to describe the trait or behavior, such as %2$s.",
 	},
 	{
 		identifier: "binges",
@@ -82,7 +82,7 @@ const disabilityAssessments =  [
 		inclusiveAlternatives: "<i>indulges, satiates, wallows, sprees, marathons, consumes excessively</i>",
 		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
 		feedbackFormat: "Be careful when using <i>%1$s</i>, unless talking about a symptom of a medical condition. " +
-			"If you are not referencing a medical condition, consider other alternatives to describe the trait or behavior, such as %2$s.",
+			"If you are not referencing a symptom, consider other alternatives to describe the trait or behavior, such as %2$s.",
 	},
 	{
 		identifier: "wheelchairBound",
@@ -402,7 +402,7 @@ const disabilityAssessments =  [
 	{
 		identifier: "to be not crazy about",
 		nonInclusivePhrases: [ "crazy about" ],
-		inclusiveAlternatives: "<i>to be not impressed by, to not be enthusiastic about, to not be into, to not like</i>",
+		inclusiveAlternatives: "<i>to be not impressed by, to be not enthusiastic about, to be not into, to not like</i>",
 		score: SCORES.NON_INCLUSIVE,
 		feedbackFormat: phrasesWithCrazyFeedback,
 		// Target only when preceded by a form of "to be", the negation "not", and an an optional intensifier (e.g. "is not so crazy about" ).
@@ -433,7 +433,7 @@ const disabilityAssessments =  [
 	{
 		identifier: "to go crazy",
 		nonInclusivePhrases: [ "crazy" ],
-		inclusiveAlternatives: "<i>to go wild, to go out of control, to go up the wall, to get in one's head, to be aggravated," +
+		inclusiveAlternatives: "<i>to go wild, to go out of control, to go up the wall, to be aggravated," +
 			" to get confused</i>",
 		score: SCORES.NON_INCLUSIVE,
 		feedbackFormat: potentiallyHarmful,
@@ -446,8 +446,8 @@ const disabilityAssessments =  [
 	{
 		identifier: "to drive crazy",
 		nonInclusivePhrases: [ "crazy" ],
-		inclusiveAlternatives: "<i>to drive to one's limit, to get on one's last nerve, to make one livid, to aggravate, to make blood boil, " +
-			"to exasperate, to irritate to the limit</i>",
+		inclusiveAlternatives: "<i>to drive one to their limit, to get on one's last nerve, to make one livid, to aggravate, " +
+			"to make one’s blood boil, to exasperate, to get into one's head</i>",
 		score: SCORES.NON_INCLUSIVE,
 		feedbackFormat: potentiallyHarmful,
 		// Target only when preceded by a form of 'to drive' and an object pronoun (e.g. 'driving me crazy', 'drove everyone crazy').

--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessments.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessments.js
@@ -447,7 +447,7 @@ const disabilityAssessments =  [
 		identifier: "to drive crazy",
 		nonInclusivePhrases: [ "crazy" ],
 		inclusiveAlternatives: "<i>to drive one to their limit, to get on one's last nerve, to make one livid, to aggravate, " +
-			"to make one’s blood boil, to exasperate, to get into one's head</i>",
+			"to make one's blood boil, to exasperate, to get into one's head</i>",
 		score: SCORES.NON_INCLUSIVE,
 		feedbackFormat: potentiallyHarmful,
 		// Target only when preceded by a form of 'to drive' and an object pronoun (e.g. 'driving me crazy', 'drove everyone crazy').


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves the feedback strings of some non-inclusive phrases.
* [shopify-seo] Improves the feedback strings of some non-inclusive phrases.

## Relevant technical choices:

* In this PR, I also removed duplicated unit tests in `disabilityAssessmentsSpec.js`.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Test the improved feedback strings
* Install and activate Yoast SEO
* Set the site language to English
* Enable the Inclusive language analysis feature in the setting
* Create a post

##### Non-inclusive phrase "to drive someone crazy"
* Add this sentence to the post:  This math problem is driving me crazy.
* Confirm that you get the following result in the inclusive language analysis:
   * Bullet: red
   * Feedback:  "Avoid using _crazy_ as it is potentially harmful. Consider using an alternative, such as _to drive one to their limit, to get on one's last nerve, to make one livid, to aggravate, to make one’s blood boil, to exasperate, to get into one's head._"
* Remove the previous sentence, and add this sentence: They drive everyone crazy.
* Confirm that you still get the same feedback
* Remove the previous sentence, and add this sentence: They drove him crazy.
* Confirm that you still get the same feedback
* Remove the previous sentence, and add this sentence: She drives somebody crazy.
* Confirm that you still get the same feedback
* Remove the previous sentence, and add this sentence: He has driven them crazy.
* Confirm that you still get the same feedback

##### Non-inclusive phrase "to go crazy"
* Add this sentence to the post:  It's going crazy out there.
* Confirm that you get the following result in the inclusive language analysis:
   * Bullet: red
   * Feedback:  "Avoid using _crazy_ as it is potentially harmful. Consider using an alternative, such as _to go wild, to go out of control, to go up the wall, to be aggravated, to get confused_. "
* Remove the previous sentence, and add this sentence: They go crazy out there.
* Confirm that you still get the same feedback
* Remove the previous sentence, and add this sentence: He goes crazy out there.
* Confirm that you still get the same feedback
* Remove the previous sentence, and add this sentence: They went crazy out there.
* Confirm that you still get the same feedback
* Remove the previous sentence, and add this sentence: They have gone crazy out there.
* Confirm that you still get the same feedback

##### Non-inclusive phrase "to be not crazy about"
* Add this sentence to the post: They are not crazy about this album.
* Confirm that you get the following result in the inclusive language analysis:
   * Bullet: red
   * Feedback:  "Avoid using _crazy_ as it is potentially harmful. Consider using an alternative, such as _to be not impressed by, to be not enthusiastic about, to be not into, to not like_. "
* Remove the previous sentence, and add this sentence: They are not too crazy about this album.
* Confirm that you still get the same feedback
* Remove the previous sentence, and add this sentence: They aren't too crazy about this album.
* Confirm that you still get the same feedback

##### Non-inclusive phrase "binge"
* Add this sentence to the post:  I binge on ice cream.
* Confirm that you get the following result in the inclusive language analysis:
   * Bullet: orange
   * Feedback:  "Be careful when using _binge_, unless talking about a symptom of a medical condition. If you are not referencing a symptom, consider other alternatives to describe the trait or behavior, such as _indulge, satiate, wallow, spree, marathon, consume excessively_."
* Add this sentence to the post: She binges on Netflix series.
* Confirm that you get the following result in the inclusive language analysis:
   * Bullet: orange
   * Feedback:  "Be careful when using _binges_, unless talking about a symptom of a medical condition. If you are not referencing a symptom, consider other alternatives to describe the trait or behavior, such as _indulges, satiates, wallows, sprees, marathons, consumes excessively_."
* Add this sentence to the post:  She is bingeing the new Korean drama on Netflix.
* Confirm that you get the following result in the inclusive language analysis:
   * Bullet: orange
   * Feedback:  "Be careful when using _bingeing_, unless talking about a symptom of a medical condition. If you are not referencing a symptom, consider other alternatives to describe the trait or behavior, such as _indulging, satiating, wallowing, spreeing, marathoning, consuming excessively_."
* Add this sentence to the post:  She binged the new Korean drama on Netflix.
* Confirm that you get the following result in the inclusive language analysis:
   * Bullet: orange
   * Feedback:  "Be careful when using _bingeing_, unless talking about a symptom of a medical condition. If you are not referencing a symptom, consider other alternatives to describe the trait or behavior, such as _indulged, satiated, wallowed, spreed, marathoned, consumed excessively."


#### Upgrade flow
* Install and activate the previous (RC) version of Yoast SEO
* Set the site language to English
* Enable the Inclusive language analysis feature in the setting
* Create a post
* Add this sentence to the post:  This math problem is driving me crazy.
* Confirm that you get the following result in the inclusive language analysis:
   * Bullet: red
   * Feedback:  "Avoid using _crazy_ as it is potentially harmful. Consider using an alternative, such as _to drive to one's limit, to get on one's last nerve, to make one livid, to aggravate, to make blood boil, to exasperate, to irritate to the limit_."
* Save the post
* Upgrade Yoast SEO to the version that includes this fix
* Go to the previous post
* Confirm the feedback for the sentence above changes to:
   * Bullet: red
   * Feedback:  "Avoid using _crazy_ as it is potentially harmful. Consider using an alternative, such as _to drive one to their limit, to get on one's last nerve, to make one livid, to aggravate, to make one’s blood boil, to exasperate, to get into one's head._"
   

#### Shopify
* Repeat the test instructions above
* Test fully in one content type and smoke test in others

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies/products
* [x] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The changes introduced in this PR only touch the feedback strings of the non-inclusive phrases mentioned in the testing steps. Hence, testing other functionality parts is not necessary. 

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [x] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes https://github.com/Yoast/plugins-automated-testing/issues/432