### PR TITLE
settings-UI: fix add profile accessibility

### DIFF
--- a/packages/js/src/settings/routes/site-representation.js
+++ b/packages/js/src/settings/routes/site-representation.js
@@ -12,6 +12,7 @@ import { addLinkToString } from "../../helpers/stringHelpers";
 import { FieldsetLayout, FormikMediaSelectField, FormikUserSelectField, FormikWithErrorField, FormLayout, RouteLayout } from "../components";
 import { withFormikDummyField } from "../hocs";
 import { useSelectSettings } from "../hooks";
+import { useCallback } from "@wordpress/element";
 
 const FormikWithErrorFieldWithDummy = withFormikDummyField( FormikWithErrorField );
 
@@ -43,6 +44,11 @@ const SiteRepresentation = () => {
 	const premiumUpsellConfig = useSelectSettings( "selectUpsellSettingsAsProps" );
 	const mastodonPremiumLink = useSelectSettings( "selectLink", [], "https://yoa.st/get-mastodon-integration" );
 	const mastodonUrlLink = useSelectSettings( "selectLink", [], "https://yoa.st/site-representation-mastodon" );
+
+	const handleAddProfile = useCallback( async( arrayHelpers ) => {
+		await arrayHelpers.push( null, "" );
+		document.getElementById( `input-wpseo_social-other_social_urls-${ otherSocialUrls.length }` )?.focus();
+	}, [ otherSocialUrls ] );
 
 	return (
 		<RouteLayout
@@ -241,6 +247,8 @@ const SiteRepresentation = () => {
 															// eslint-disable-next-line react/jsx-no-bind
 															onClick={ arrayHelpers.remove.bind( null, index ) }
 															className="yst-mt-7 yst-p-2.5"
+															// translators: %1$s expands to array index + 1.
+															aria-label={ sprintf( __( "Remove Other profile %1$s", "wordpress-seo" ), index + 1 ) }
 														>
 															<TrashIcon className="yst-h-5 yst-w-5" />
 														</Button>
@@ -248,7 +256,7 @@ const SiteRepresentation = () => {
 												</Transition>
 											) ) }
 											{ /* eslint-disable-next-line react/jsx-no-bind */ }
-											<Button id="button-add-social-profile" variant="secondary" onClick={ arrayHelpers.push.bind( null, "" ) }>
+											<Button id="button-add-social-profile" variant="secondary" onClick={ ()=>handleAddProfile( arrayHelpers ) }>
 												<PlusIcon className="yst--ml-1 yst-mr-1 yst-h-5 yst-w-5 yst-text-slate-400" />
 												{ __( "Add another profile", "wordpress-seo" ) }
 											</Button>


### PR DESCRIPTION
* Added aria label to the remove button
* added focus of input of profile that is added

## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Change focus after adding new profile to the new input.
* Add `aria-label` to the delete/Trash icon.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Changes focus after adding new profile to the new input for accessibility.
* Adds `aria-label` to the Trash icon for accessibility.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Open `YoastSEO`->`Settings`->`Site representation`
* Select `Organization` in `Organization/person`
* Scroll down to `Other profiles`
* Click on `Add another profile`
* Check focus is on the new input field for the profile.
* Turn on screen reader and use tab to move to the `Add another profile`, click on it
* Use tab to reach the Trash icon to delete the profile. Check the description is clear: 'Remove Other profile...`

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [X] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes [nother profile' feature#19541](https://github.com/Yoast/wordpress-seo/issues/19541)
