### PR TITLE
Settings: improve the quick search modal dialog a11y

### DIFF
--- a/css/src/new-settings.css
+++ b/css/src/new-settings.css
@@ -67,6 +67,10 @@
 			}
 		}
 	}
+
+	#modal-search .yst-modal__close {
+		margin-top: -0.25rem;
+	}
 }
 
 @layer base {

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@draft-js-plugins/mention": "^5.0.0",
-    "@headlessui/react": "^1.7.7",
+    "@headlessui/react": "^1.7.8",
     "@heroicons/react": "^1.0.6",
     "@wordpress/api-fetch": "^6.13.0",
     "@wordpress/blocks": "^11.1.2",

--- a/packages/js/src/settings/components/search.js
+++ b/packages/js/src/settings/components/search.js
@@ -261,11 +261,15 @@ const Search = ( { buttonId = "button-search", modalId = "modal-search" } ) => {
 							className="yst-max-h-[calc(90vh-10rem)] yst-scroll-pt-11 yst-scroll-pb-2 yst-space-y-2 yst-overflow-y-auto yst-pb-2"
 						>
 							{ map( results, ( groupedItems, index ) => (
-								<li key={ groupedItems?.[ 0 ]?.route || `group-${ index }` }>
-									<Title as="h4" size="5" className="yst-bg-slate-100 yst-font-semibold yst-py-3 yst-px-4">
+								<div key={ groupedItems?.[ 0 ]?.route || `group-${ index }` } role="presentation">
+									<Title
+										id={ `group-${ index }-title` } as="h4" size="5"
+										className="yst-bg-slate-100 yst-font-semibold yst-py-3 yst-px-4" role="presentation" aria-hidden="true"
+									>
 										{ first( groupedItems ).routeLabel }
 									</Title>
-									<ul role="listbox">
+									{ /* Don't use the `role="group"` here, or Voice Over no longer reads the items. */ }
+									<div role="presentation">
 										{ map( groupedItems, ( item ) => (
 											<Combobox.Option
 												key={ item.fieldId }
@@ -275,8 +279,8 @@ const Search = ( { buttonId = "button-search", modalId = "modal-search" } ) => {
 												<SearchResultLabel { ...item } />
 											</Combobox.Option>
 										) ) }
-									</ul>
-								</li>
+									</div>
+								</div>
 							) ) }
 						</Combobox.Options>
 					) }

--- a/packages/js/src/settings/components/search.js
+++ b/packages/js/src/settings/components/search.js
@@ -222,7 +222,7 @@ const Search = ( { buttonId = "button-search", modalId = "modal-search" } ) => {
 							aria-label={ __( "Search", "wordpress-seo" ) }
 							value={ query }
 							onChange={ handleQueryChange }
-							className="yst-h-12 yst-w-full yst-border-0 yst-rounded-lg sm:yst-text-sm yst-bg-transparent yst-px-11 yst-text-slate-800 yst-placeholder-slate-400 focus:yst-outline-none focus:yst-ring-inset focus:yst-ring-2 focus:yst-ring-primary-500 focus:yst-border-primary-500"
+							className="yst-h-12 yst-w-full yst-border-0 yst-rounded-lg sm:yst-text-sm yst-bg-transparent yst-px-11 yst-text-slate-800 yst-placeholder-slate-500 focus:yst-outline-none focus:yst-ring-inset focus:yst-ring-2 focus:yst-ring-primary-500 focus:yst-border-primary-500"
 						/>
 					</div>
 					{ query.length >= queryMinChars && ! isEmpty( results ) && (

--- a/packages/js/src/settings/components/search.js
+++ b/packages/js/src/settings/components/search.js
@@ -68,9 +68,10 @@ SearchNoResultsContent.propTypes = {
 
 /**
  * @param {string} [buttonId] The ID for the search button.
+ * @param {string} [modalId] The ID for the modal.
  * @returns {JSX.Element} The element.
  */
-const Search = ( { buttonId = "button-search" } ) => {
+const Search = ( { buttonId = "button-search", modalId = "modal-search" } ) => {
 	const [ isOpen, , , setOpen, setClose ] = useToggleState( false );
 	const [ query, setQuery ] = useState( "" );
 	const userLocale = useSelectSettings( "selectPreference", [], "userLocale" );
@@ -200,6 +201,7 @@ const Search = ( { buttonId = "button-search" } ) => {
 			) }
 		</button>
 		<Modal
+			id={ modalId }
 			onClose={ setClose }
 			isOpen={ isOpen }
 			initialFocus={ inputRef }
@@ -207,7 +209,7 @@ const Search = ( { buttonId = "button-search" } ) => {
 			aria-label={ __( "Search", "wordpress-seo" ) }
 		>
 			<Modal.Panel closeButtonScreenReaderText={ __( "Close", "wordpress-seo" ) }>
-				<Combobox as="div" className="yst--m-6 yst--mt-5" onChange={ handleNavigate }>
+				<Combobox as="div" className="yst--m-6" onChange={ handleNavigate }>
 					<div className="yst-relative">
 						<SearchIcon
 							className="yst-pointer-events-none yst-absolute yst-top-3.5 yst-left-4 yst-h-5 yst-w-5 yst-text-slate-400"
@@ -220,7 +222,7 @@ const Search = ( { buttonId = "button-search" } ) => {
 							aria-label={ __( "Search", "wordpress-seo" ) }
 							value={ query }
 							onChange={ handleQueryChange }
-							className="yst-h-12 yst-w-full yst-border-0 yst-bg-transparent yst-px-11 yst-text-slate-800 yst-placeholder-slate-400 focus:yst-ring-0 sm:yst-text-sm"
+							className="yst-h-12 yst-w-full yst-border-0 yst-rounded-lg sm:yst-text-sm yst-bg-transparent yst-px-11 yst-text-slate-800 yst-placeholder-slate-400 focus:yst-outline-none focus:yst-ring-inset focus:yst-ring-2 focus:yst-ring-primary-500 focus:yst-border-primary-500"
 						/>
 					</div>
 					{ query.length >= queryMinChars && ! isEmpty( results ) && (
@@ -266,6 +268,7 @@ const Search = ( { buttonId = "button-search" } ) => {
 
 Search.propTypes = {
 	buttonId: PropTypes.string,
+	modalId: PropTypes.string,
 };
 
 export default Search;

--- a/packages/js/src/settings/components/search.js
+++ b/packages/js/src/settings/components/search.js
@@ -1,6 +1,6 @@
 /* eslint-disable complexity */
 import { Combobox } from "@headlessui/react";
-import { SearchIcon } from "@heroicons/react/outline";
+import { SearchIcon, XIcon } from "@heroicons/react/outline";
 import { useCallback, useMemo, useRef, useState } from "@wordpress/element";
 import { __, _n, sprintf } from "@wordpress/i18n";
 import { Code, Modal, Title, useNavigationContext, useSvgAria, useToggleState } from "@yoast/ui-library";
@@ -235,7 +235,7 @@ const Search = ( { buttonId = "button-search", modalId = "modal-search" } ) => {
 			position="top-center"
 			aria-label={ __( "Search", "wordpress-seo" ) }
 		>
-			<Modal.Panel closeButtonScreenReaderText={ __( "Close", "wordpress-seo" ) }>
+			<Modal.Panel hasCloseButton={ false }>
 				<LiveAnnouncer>
 					{ a11yMessage && <LiveMessage message={ a11yMessage } aria-live="polite" /> }
 				</LiveAnnouncer>
@@ -254,6 +254,17 @@ const Search = ( { buttonId = "button-search", modalId = "modal-search" } ) => {
 							onChange={ handleQueryChange }
 							className="yst-h-12 yst-w-full yst-border-0 yst-rounded-lg sm:yst-text-sm yst-bg-transparent yst-px-11 yst-text-slate-800 yst-placeholder-slate-500 focus:yst-outline-none focus:yst-ring-inset focus:yst-ring-2 focus:yst-ring-primary-500 focus:yst-border-primary-500"
 						/>
+						{ /* Implement own close button to match the visual order to the DOM order, for a11y. */ }
+						<div className="yst-modal__close">
+							<button
+								type="button"
+								onClick={ setClose }
+								className="yst-modal__close-button"
+							>
+								<span className="yst-sr-only">{ __( "Close", "wordpress-seo" ) }</span>
+								<XIcon className="yst-h-6 yst-w-6" { ...ariaSvgProps } />
+							</button>
+						</div>
 					</div>
 					{ query.length >= queryMinChars && ! isEmpty( results ) && (
 						<Combobox.Options
@@ -312,4 +323,3 @@ Search.propTypes = {
 };
 
 export default Search;
-

--- a/packages/js/src/settings/components/search.js
+++ b/packages/js/src/settings/components/search.js
@@ -15,6 +15,8 @@ import { useParsedUserAgent, useSelectSettings } from "../hooks";
 
 const POST_TYPE_OR_TAXONOMY_BREADCRUMB_SETTING_REGEXP = new RegExp( /^input-wpseo_titles-(post_types|taxonomy)-(?<name>\S+)-(maintax|ptparent)$/is );
 
+const DUMMY_ITEM = { fieldId: "DUMMY_ITEM" };
+
 /**
  * @param {string} fieldId The item field ID.
  * @param {string} fieldLabel The item label.
@@ -119,6 +121,10 @@ const Search = ( { buttonId = "button-search", modalId = "modal-search" } ) => {
 	);
 
 	const handleNavigate = useCallback( ( { route, fieldId } ) => {
+		if ( fieldId === DUMMY_ITEM.fieldId ) {
+			// The item is our dummy, do not navigate.
+			return;
+		}
 		setMobileMenuOpen( false );
 		setClose();
 		setQuery( "" );
@@ -280,9 +286,15 @@ const Search = ( { buttonId = "button-search", modalId = "modal-search" } ) => {
 						</SearchNoResultsContent>
 					) }
 					{ query.length >= queryMinChars && isEmpty( results ) && (
-						<SearchNoResultsContent title={ __( "No results found", "wordpress-seo" ) }>
-							<p className="yst-text-slate-500">{ __( "We couldn’t find anything with that term.", "wordpress-seo" ) }</p>
-						</SearchNoResultsContent>
+						<>
+							<SearchNoResultsContent title={ __( "No results found", "wordpress-seo" ) }>
+								<p className="yst-text-slate-500">{ __( "We couldn’t find anything with that term.", "wordpress-seo" ) }</p>
+							</SearchNoResultsContent>
+							{ /* This dummy prevents a reset of the Combobox.Input when pressing enter (via a dummy check in the onChange). */ }
+							<Combobox.Options className="yst-visible-">
+								<Combobox.Option value={ DUMMY_ITEM } />
+							</Combobox.Options>
+						</>
 					) }
 				</Combobox>
 			</Modal.Panel>

--- a/packages/js/src/settings/components/search.js
+++ b/packages/js/src/settings/components/search.js
@@ -217,6 +217,7 @@ const Search = ( { buttonId = "button-search" } ) => {
 							ref={ inputRef }
 							id="input-search"
 							placeholder={ __( "Search...", "wordpress-seo" ) }
+							aria-label={ __( "Search", "wordpress-seo" ) }
 							value={ query }
 							onChange={ handleQueryChange }
 							className="yst-h-12 yst-w-full yst-border-0 yst-bg-transparent yst-px-11 yst-text-slate-800 yst-placeholder-slate-400 focus:yst-ring-0 sm:yst-text-sm"

--- a/packages/js/tests/settings/__snapshots__/search.test.js.snap
+++ b/packages/js/tests/settings/__snapshots__/search.test.js.snap
@@ -8,12 +8,21 @@ exports[`Search test should match search snapshot 1`] = `
       Quick search...
     </span>
   </button>
-  <Modal onClose={[Function (anonymous)]} isOpen={false} initialFocus={{...}} position=\\"top-center\\" aria-label=\\"Search\\">
-    <Modal.Panel closeButtonScreenReaderText=\\"Close\\">
-      <ComboboxFn as=\\"div\\" className=\\"yst--m-6 yst--mt-5\\" onChange={[Function (anonymous)]}>
+  <Modal id=\\"modal-search\\" onClose={[Function (anonymous)]} isOpen={false} initialFocus={{...}} position=\\"top-center\\" aria-label=\\"Search\\">
+    <Modal.Panel hasCloseButton={false}>
+      <LiveAnnouncer />
+      <ComboboxFn as=\\"div\\" className=\\"yst--m-6\\" onChange={[Function (anonymous)]}>
         <div className=\\"yst-relative\\">
           <ForwardRef(SearchIcon) className=\\"yst-pointer-events-none yst-absolute yst-top-3.5 yst-left-4 yst-h-5 yst-w-5 yst-text-slate-400\\" role=\\"img\\" aria-hidden=\\"true\\" />
-          <Input2 id=\\"input-search\\" placeholder=\\"Search...\\" value=\\"\\" onChange={[Function (anonymous)]} className=\\"yst-h-12 yst-w-full yst-border-0 yst-bg-transparent yst-px-11 yst-text-slate-800 yst-placeholder-slate-400 focus:yst-ring-0 sm:yst-text-sm\\" />
+          <Input2 id=\\"input-search\\" placeholder=\\"Search...\\" aria-label=\\"Search\\" value=\\"\\" onChange={[Function (anonymous)]} className=\\"yst-h-12 yst-w-full yst-border-0 yst-rounded-lg sm:yst-text-sm yst-bg-transparent yst-px-11 yst-text-slate-800 yst-placeholder-slate-500 focus:yst-outline-none focus:yst-ring-inset focus:yst-ring-2 focus:yst-ring-primary-500 focus:yst-border-primary-500\\" />
+          <div className=\\"yst-modal__close\\">
+            <button type=\\"button\\" onClick={[Function (anonymous)]} className=\\"yst-modal__close-button\\">
+              <span className=\\"yst-sr-only\\">
+                Close
+              </span>
+              <ForwardRef(XIcon) className=\\"yst-h-6 yst-w-6\\" role=\\"img\\" aria-hidden=\\"true\\" />
+            </button>
+          </div>
         </div>
         <SearchNoResultsContent title=\\"Search\\">
           <p className=\\"yst-text-slate-500\\">

--- a/packages/js/tests/settings/search.test.js
+++ b/packages/js/tests/settings/search.test.js
@@ -10,7 +10,7 @@ describe( "Search test", () => {
 	} );
 
 	it( "Should have 'Quick Search' text on search button", () => {
-		expect( wrapper.find( "button" ).text() ).toContain( "Quick search..." );
+		expect( wrapper.find( "button" ).first().text() ).toContain( "Quick search..." );
 	} );
 
 	it( "should open Modal", () => {
@@ -32,7 +32,7 @@ describe( "Search test", () => {
 	it( "should match button text to input value", () => {
 		wrapper.find( "button" ).at( 0 ).simulate( "click" );
 		wrapper.find( "#input-search" ).at( 0 ).simulate( "change", { target: { value: "seo title" } } );
-		expect( wrapper.find( "button" ).text() ).toContain( "seo title" );
+		expect( wrapper.find( "button" ).first().text() ).toContain( "seo title" );
 	} );
 
 	it( "Results not found", () => {

--- a/packages/ui-library/package.json
+++ b/packages/ui-library/package.json
@@ -61,7 +61,7 @@
     "tailwindcss": "^3.2.4"
   },
   "dependencies": {
-    "@headlessui/react": "^1.7.7",
+    "@headlessui/react": "^1.7.8",
     "@heroicons/react": "^1.0.6",
     "classnames": "^2.3.2",
     "lodash": "^4.17.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2495,10 +2495,10 @@
   dependencies:
     "@hapi/hoek" "^9.0.0"
 
-"@headlessui/react@^1.7.7":
-  version "1.7.7"
-  resolved "https://registry.yarnpkg.com/@headlessui/react/-/react-1.7.7.tgz#d6f8708d8943ae8ebb1a6929108234e4515ac7e8"
-  integrity sha512-BqDOd/tB9u2tA0T3Z0fn18ktw+KbVwMnkxxsGPIH2hzssrQhKB5n/6StZOyvLYP/FsYtvuXfi9I0YowKPv2c1w==
+"@headlessui/react@^1.7.8":
+  version "1.7.8"
+  resolved "https://registry.yarnpkg.com/@headlessui/react/-/react-1.7.8.tgz#d7b4a95d50f9a386f7d1259d5ff8a6d7eb552ef0"
+  integrity sha512-zcwb0kd7L05hxmoAMIioEaOn235Dg0fUO+iGbLPgLVSjzl/l39V6DTpC2Df49PE5aG5/f5q0PZ9ZHZ78ENNV+A==
   dependencies:
     client-only "^0.0.1"
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Address some a11y issues of the Settings' search modal:
  * ✅ Visual order and DOM order of the search field and Close button don’t match
  * ✅ The search field is unlabelled
  * ✅ The search field has no focus style
  * ✅ The list of suggestions isn’t read out by VoiceOver
  * ✅ The ‘No results found’ message is not announced in any way.
  * ✅ Same goes for the amount of results found: there’s no announcement.
  * ✅ When there are no results, pressing Enter clears the search field
  * ❌ Pressing the Tab key while a suggestions is highlighted selects the suggestion and triggers navigation
    * Andrea commented on an existing issue (though closed) upstream: https://github.com/tailwindlabs/headlessui/issues/2017

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves the Settings' search modal accessibility.
* [@yoast/ui-library] Updates minimum `@headlessui/react` dependency from `1.7.7` to `1.7.8`.

## Relevant technical choices:

* Bumps `@headlessui/react` dependency from `1.7.7` to [1.7.8](https://github.com/tailwindlabs/headlessui/releases/tag/%40headlessui%2Freact%40v1.7.8), to get the Combobox a11y fix.
* Do not use `role="group"` for the search result groups. This does not play nice with Voice Over and no results will be announced anymore. Instead, use one big list and "hide" the group titles.
* Use `react-aria-live` to announce and change the `a11yMessage` on every query results change. Even an empty string to keep announcing the change. If there is no change in the result, but you did add a character, it should announce again.
* Implement own close button to fix the DOM order.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Go to Settings
* Open the search
* _Visual order and DOM order of the search field and Close button don’t match_
  * Verify the close button is now after the search
  * In Chrome you can enable the _Enable full-page accessibility tree_ in the accessibility tab, then click the a11y person icon in the inspector. This will allow you to see the order for a11y (inspect the search), in which the close button is now after the search input ![chrome-a11y](https://user-images.githubusercontent.com/35524806/215513189-be70fb83-3b1e-4225-a455-4c46963d0544.png)
* _The search field is unlabelled_
  * Verify the search input has the attribute: `aria-label="Search"`
* _The search field has no focus style_
  * Verify the search input has a focus style 
![image](https://user-images.githubusercontent.com/35524806/215515098-225dfe99-7e4c-497f-a3b4-56f18e263977.png)
* VoiceOver announcements: _Search results_, _No results found_ and the _Amount of results found_
  * Open the Settings in Safari
  * Activate VoiceOver (cmd+F5)
  * Search for something that has results, `pre` for example
    * Verify VoiceOver announces:
      * `x results found, use up and down arrow keys to navigate` 
      * and when browsing the results with the arrow keys: the item. Note that it still does happen that they are not announced. Andrea mentioned this is a VoiceOver bug. If this happens, delete and re-add a letter in your search to trigger it again.
  * Search for something that does not yield results
    * Verify VoiceOver announces `No results found`
    * Type another letter, it should repeat `No results found`
  * Remove the search string
    * Verify VoiceOver announces `Search`
  * You can disable VoiceOver again
* _When there are no results, pressing Enter clears the search field_
  * Open the search and search for something that does not exist
  * Press `enter`
  * Verify the search input did not empty

#### Impact
Due to the bump of `@headlessui/react` you might want to verify the usage of those components. A quick "nothing broken?" check should suffice:
* UI library
  * Transition in _File import_
  * Dialog and transitions in _Modal_
  * Transition in _Notifications_
  * Dialog in _SidebarNavigation.Mobile_
  * Switch in _ToggleField_
  * Combobox and Transition in _Autocomplete_
  * Listbox and Transition in _Select_
  * Switch and Transition in _Toggle_
* Settings
  * Transition in the Site representation (when you switch from organization to user)
  * Search modal (tested plenty in the above instructions)
  * The above from UI library
* First time configuration
  * Dialog and Transition in _TailwindModal_
  * Combobox in _YoastComboBox_
  * Listbox and Transition in _Select_
  * Transition in _Configuration indexation_ and _Indexation_
* Indexables page
  * Menu and Transition in _card options_

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Settings' search. But also a lot of components due to the patch version upgrade, nothing is expected to break here. See the test instructions.

## UI changes

* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [x] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [x] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes https://github.com/Yoast/wordpress-seo/issues/19540
