### PR TITLE
Introduce and use a new option to keep track when a notice to update Premium has been dismissed

### DIFF
--- a/inc/options/class-wpseo-option-wpseo.php
+++ b/inc/options/class-wpseo-option-wpseo.php
@@ -87,7 +87,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 		'configuration_finished_steps'             => [],
 		'dismiss_configuration_workout_notice'     => false,
 		'dismiss_premium_deactivated_notice'       => false,
-		'dismiss_old_premium_notice'               => false,
+		'dismiss_old_premium_version_notice'       => '',
 		'importing_completed'                      => [],
 		'wincher_integration_active'               => true,
 		'wincher_tokens'                           => [],
@@ -323,6 +323,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 				case 'wincher_website_id':
 				case 'clean_permalinks_extra_variables':
 				case 'indexables_overview_state':
+				case 'dismiss_old_premium_version_notice':
 					if ( isset( $dirty[ $key ] ) ) {
 						$clean[ $key ] = $dirty[ $key ];
 					}

--- a/src/integrations/admin/old-premium-integration.php
+++ b/src/integrations/admin/old-premium-integration.php
@@ -105,7 +105,7 @@ class Old_Premium_Integration implements Integration_Interface {
 			return;
 		}
 
-		if ( $this->options_helper->get( 'dismiss_old_premium_notice', false ) === true ) {
+		if ( $this->notice_was_dismissed_after_current_min_premium_version() ) {
 			return;
 		}
 
@@ -163,7 +163,7 @@ class Old_Premium_Integration implements Integration_Interface {
 	 * @return bool
 	 */
 	public function dismiss_old_premium_notice() {
-		return $this->options_helper->set( 'dismiss_old_premium_notice', true );
+		return $this->options_helper->set( 'dismiss_old_premium_version_notice', self::MINIMUM_PREMIUM_VERSION );
 	}
 
 	/**
@@ -175,6 +175,20 @@ class Old_Premium_Integration implements Integration_Interface {
 		$premium_version = $this->product_helper->get_premium_version();
 		if ( ! \is_null( $premium_version ) ) {
 			return \version_compare( $premium_version, self::MINIMUM_PREMIUM_VERSION, '<' );
+		}
+
+		return false;
+	}
+
+	/**
+	 * Returns whether the notification was dismissed in a version later than the minimum premium version.
+	 *
+	 * @return bool Whether the notification was dismissed in a version later than the minimum premium version.
+	 */
+	protected function notice_was_dismissed_after_current_min_premium_version() {
+		$dismissed_notification_version = $this->options_helper->get( 'dismiss_old_premium_version_notice', '' );
+		if ( ! empty( $dismissed_notification_version ) ) {
+			return \version_compare( $dismissed_notification_version, self::MINIMUM_PREMIUM_VERSION, '>=' );
 		}
 
 		return false;

--- a/tests/unit/integrations/admin/old-premium-integration-test.php
+++ b/tests/unit/integrations/admin/old-premium-integration-test.php
@@ -153,12 +153,13 @@ class Old_Premium_Integration_Test extends TestCase {
 	 * Tests showing the notice when all the conditions are true.
 	 *
 	 * @covers ::old_premium_notice
+	 * @covers ::notice_was_dismissed_after_current_min_premium_version
 	 * @covers ::premium_is_old
 	 */
 	public function test_old_premium_notice() {
 		$this->options_helper
 			->expects( 'get' )
-			->with( 'dismiss_old_premium_notice', false )
+			->with( 'dismiss_old_premium_version_notice', '' )
 			->andReturnFalse();
 
 		$this->capability_helper
@@ -235,6 +236,7 @@ class Old_Premium_Integration_Test extends TestCase {
 	 * Tests showing the notice when the notice has been dismissed.
 	 *
 	 * @covers ::old_premium_notice
+	 * @covers ::notice_was_dismissed_after_current_min_premium_version
 	 */
 	public function test_old_premium_notice_if_dismissed() {
 		global $pagenow;
@@ -242,8 +244,8 @@ class Old_Premium_Integration_Test extends TestCase {
 
 		$this->options_helper
 			->expects( 'get' )
-			->with( 'dismiss_old_premium_notice', false )
-			->andReturnTrue();
+			->with( 'dismiss_old_premium_version_notice', '' )
+			->andReturn( '20.1-RC0' );
 
 		// Nothing should be output.
 		$this->expectOutputString( '' );
@@ -254,6 +256,7 @@ class Old_Premium_Integration_Test extends TestCase {
 	 * Tests showing the notice when the user doesn't have the right capability.
 	 *
 	 * @covers ::old_premium_notice
+	 * @covers ::notice_was_dismissed_after_current_min_premium_version
 	 */
 	public function test_old_premium_notice_if_no_capabilities() {
 		global $pagenow;
@@ -261,7 +264,7 @@ class Old_Premium_Integration_Test extends TestCase {
 
 		$this->options_helper
 			->expects( 'get' )
-			->with( 'dismiss_old_premium_notice', false )
+			->with( 'dismiss_old_premium_version_notice', '' )
 			->andReturnFalse();
 
 		$this->capability_helper
@@ -278,6 +281,7 @@ class Old_Premium_Integration_Test extends TestCase {
 	 * Tests showing the notice when Premium is not active.
 	 *
 	 * @covers ::old_premium_notice
+	 * @covers ::notice_was_dismissed_after_current_min_premium_version
 	 * @covers ::premium_is_old
 	 */
 	public function test_old_premium_notice_if_no_premium_active() {
@@ -286,7 +290,7 @@ class Old_Premium_Integration_Test extends TestCase {
 
 		$this->options_helper
 			->expects( 'get' )
-			->with( 'dismiss_old_premium_notice', false )
+			->with( 'dismiss_old_premium_version_notice', '' )
 			->andReturnFalse();
 
 		$this->capability_helper
@@ -311,7 +315,7 @@ class Old_Premium_Integration_Test extends TestCase {
 	public function test_dismiss_premium_deactivated_notice() {
 		$this->options_helper
 			->expects( 'set' )
-			->with( 'dismiss_old_premium_notice', true );
+			->with( 'dismiss_old_premium_version_notice', '20.1-RC0' );
 
 		$this->instance->dismiss_old_premium_notice();
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Introduces a new option to keep track when a notice to update Premium has been dismissed.

## Relevant technical choices:

* Removes `dismiss_old_premium_notice` (a boolean) in favor of `dismiss_old_premium_version_notice` (a string storing the minimum Premium version number required)

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

Test these cases:
* Install with the current Premium RC
  * check that you see the notification, dismiss it, and check that it stays dismissed
* Test the upgrade:
  * reset the options/use a new environment
  * install Free 20.0 + Premium 19.*
  * dismiss the notification
  * upgrade Free to this RC
  * check that the notification is back

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes https://github.com/Yoast/plugins-automated-testing/issues/441
