### PR TITLE
Schedule cleanup when the Enable Media pages setting is turned off

### DIFF
--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -968,11 +968,6 @@ class WPSEO_Upgrade {
 	 * Performs the 20.1 upgrade routine.
 	 */
 	private function upgrade_201() {
-		if ( ! \wp_next_scheduled( Cleanup_Integration::START_HOOK ) ) {
-			// This just schedules the cleanup routine cron again, since in combination of premium cleans up the prominent words table.
-			\wp_schedule_single_event( ( time() + ( MINUTE_IN_SECONDS * 5 ) ), Cleanup_Integration::START_HOOK );
-		}
-
 		if ( WPSEO_Options::get( 'disable-attachment', true ) ) {
 			$attachment_cleanup_helper = YoastSEO()->helpers->attachment_cleanup;
 
@@ -981,6 +976,11 @@ class WPSEO_Upgrade {
 		}
 
 		$this->clean_unindexed_indexable_rows_with_no_object_id();
+
+		if ( ! \wp_next_scheduled( Cleanup_Integration::START_HOOK ) ) {
+			// This schedules the cleanup routine cron again, since in combination of premium cleans up the prominent words table. We also want to cleanup possible orphaned hierarchies from the above cleanups.
+			\wp_schedule_single_event( ( time() + ( MINUTE_IN_SECONDS * 5 ) ), Cleanup_Integration::START_HOOK );
+		}
 	}
 
 	/**

--- a/src/integrations/watchers/indexable-attachment-watcher.php
+++ b/src/integrations/watchers/indexable-attachment-watcher.php
@@ -8,6 +8,7 @@ use Yoast\WP\SEO\Conditionals\Migrations_Conditional;
 use Yoast\WP\SEO\Config\Indexing_Reasons;
 use Yoast\WP\SEO\Helpers\Attachment_Cleanup_Helper;
 use Yoast\WP\SEO\Helpers\Indexing_Helper;
+use Yoast\WP\SEO\Integrations\Cleanup_Integration;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
 
 /**
@@ -112,6 +113,11 @@ class Indexable_Attachment_Watcher implements Integration_Interface {
 				case true:
 					$this->attachment_cleanup->remove_attachment_indexables( false );
 					$this->attachment_cleanup->clean_attachment_links_from_target_indexable_ids( false );
+
+					if ( ! \wp_next_scheduled( Cleanup_Integration::START_HOOK ) ) {
+						// This just schedules the cleanup routine cron again.
+						\wp_schedule_single_event( ( time() + ( MINUTE_IN_SECONDS * 5 ) ), Cleanup_Integration::START_HOOK );
+					}
 					return;
 				default:
 					return;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to clean up orphaned hierarchies when we automatically clean up attachment indexables upon toggling the **Enable Media pages** setting
* Also, a minor improvement was made in the upgrade routine, where we schedule chunked cleanups *after* we clean up the attachment indexables, instead of *before*, to make sure we clean up orphaned hierarchies as well.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Schedules cleanup when the `Enable Media pages` setting is turned off
* Moves scheduling of chunked cleanups at the end of the upgrade routine

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

**For the cleanup scheduling after the toggle of the setting**:
* On a brand new site with no images uploaded and the `Enable Media pages` turned on, install this PR/RC and upload 3 images. Also install WP Crontrol because we will use it.
  * The first one, upload it in a post
  * The second one, upload it in a subpage (so, a page that has another page as a parent)
  * The third one, upload it via the Media uploader (so, not in a page/post/CPT)
* Confirm in your wp_yoast_indexable_hierarchy table that you have exactly 4 hierarchies that are associated with attachment indexables. This query does that and returns only the rows of hierarchies that are associated with attachment indexables:
```
SELECT
        h.indexable_id, h.ancestor_id, i.permalink, i.object_id, i.object_sub_type
    FROM
        wp_yoast_indexable_hierarchy AS h
            LEFT JOIN wp_yoast_indexable AS i ON h.indexable_id = i.id
    WHERE
        i.id IS NOT NULL AND i.object_sub_type = 'attachment'
```
* Take note of those rows and also take a note of the amount of rows in the wp_yoast_indexable_hierarchy table
* Now, turn off the `Enable Media pages` setting
* You should get a `wpseo_start_cleanup_indexables` scheduled job in your Tools->Cron events page. Wait 5 minutes and then refresh that page. You will get no `wpseo_start_cleanup_indexables` or `wpseo_cleanup_cron` entries in that page anymore
* Now check if the rows you took note of above and confirm that they have been cleaned up. But those are the only rows that were deleted, so confirm that the new size of the wp_yoast_indexable_hierarchy table is the old size minus 4.
* For the next sections, continue from here

**For the cleanup scheduling after the toggle of the setting (but now in chunks)**:
* Now, add this filter:
```
add_filter( 'wpseo_cron_query_limit_size', 'custom_cron_query_limit_size', 10 );
function custom_cron_query_limit_size() {
    return 2;
}
```
* This makes it that the cleanup will happen in chunks of 2
* Now, turn on the `Enable Media pages` setting again, run the seo optimization and once it completes, turn it off again
* Again, confirm that you get a `wpseo_start_cleanup_indexables` scheduled job in your Tools->Cron events page. Wait 5 minutes and then refresh that page. Now, you won't have a `wpseo_start_cleanup_indexables` cron there but you will have a `wpseo_cleanup_cron` one, that's supposed to run in an hour. If you dont have that much time to spend, you can run it manually. But before you do, check that the hierarchy table has only 2 of those rows you have took not of
* Once the `wpseo_cleanup_cron` will run the next 2 rows will also be cleaned up and the `wpseo_cleanup_cron` cron will delete itself once they do.

**For the upgrade routine cleanup**:
* Repeat the above test, but in a new site instead of installing the current PR/RC, install main/the production version. Make sure the `Enable Media pages` is turned off.
* For this test, we won't toggle the setting, but after you've uploaded the images, checkout/install the current PR/RC and run the upgrade routine 

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
