### PR TITLE
Yoastseo refactor: Create an interface to register helpers in the worker

### DIFF
--- a/packages/yoastseo/spec/languageProcessing/AbstractResearcherSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/AbstractResearcherSpec.js
@@ -31,7 +31,7 @@ describe( "Calling a Researcher", function() {
 	} );
 } );
 
-describe( "Adding to a Researcher", function() {
+describe( "Adding a research to a Researcher", function() {
 	var researcher = new Researcher( new Paper( "This is another paper!" ) );
 
 	it( "throws an error if no name is given", function() {
@@ -58,7 +58,7 @@ describe( "Adding to a Researcher", function() {
 		expect( Object.keys( researcher.customResearches ).length ).toEqual( 1 );
 	} );
 
-	it( "overloads a research in the custom researches object", function() {
+	it( "overwrites a research in the custom researches object", function() {
 		expect( Object.keys( researcher.customResearches ).length ).toEqual( 1 );
 		researcher.addResearch( "foo", function() {
 			return false;
@@ -66,7 +66,7 @@ describe( "Adding to a Researcher", function() {
 		expect( Object.keys( researcher.customResearches ).length ).toEqual( 1 );
 	} );
 
-	it( "overloads a research in the default researches object with a custom one with the same name", function() {
+	it( "overwrites a research in the default researches object with a custom one with the same name", function() {
 		const currentDefaultsLength = Object.keys( researcher.defaultResearches ).length;
 		const currentCustomLength = Object.keys( researcher.customResearches ).length;
 		const totalLength = currentDefaultsLength + currentCustomLength;
@@ -80,6 +80,42 @@ describe( "Adding to a Researcher", function() {
 		} );
 		expect( Object.keys( researcher.getAvailableResearches() ).length ).toEqual( totalLength );
 		expect( researcher.getResearch( "wordCountInText" ).count ).toEqual( 9000 );
+	} );
+} );
+
+describe( "Adding a custom helper to a Researcher", function() {
+	const researcher = new Researcher( new Paper( "This is another paper!" ) );
+
+	it( "throws an error if no name is given", function() {
+		expect( function() {
+			researcher.addHelper( "", function() {} );
+		} ).toThrowError( MissingArgument );
+
+		expect( Object.keys( researcher.helpers ).length ).toEqual( 0 );
+	} );
+
+	it( "throws an error if no function is given", function() {
+		expect( function() {
+			researcher.addHelper( "foobar", null );
+		} ).toThrowError( InvalidTypeError );
+
+		expect( Object.keys( researcher.helpers ).length ).toEqual( 0 );
+	} );
+
+	it( "adds a helper to the helpers object", function() {
+		expect( Object.keys( researcher.helpers ).length ).toEqual( 0 );
+		researcher.addHelper( "foo", function() {
+			return true;
+		} );
+		expect( Object.keys( researcher.helpers ).length ).toEqual( 1 );
+	} );
+
+	it( "overwrites a helper in the helpers object", function() {
+		expect( Object.keys( researcher.helpers ).length ).toEqual( 1 );
+		researcher.addHelper( "foo", function() {
+			return false;
+		} );
+		expect( Object.keys( researcher.helpers ).length ).toEqual( 1 );
 	} );
 } );
 

--- a/packages/yoastseo/spec/worker/AnalysisWebWorkerSpec.js
+++ b/packages/yoastseo/spec/worker/AnalysisWebWorkerSpec.js
@@ -1568,6 +1568,36 @@ describe( "AnalysisWebWorker", () => {
 		} );
 	} );
 
+	describe( "registerHelper", () => {
+		const helperName = "helpful helper";
+		const helper = () => true;
+
+		beforeEach( () => {
+			scope = createScope();
+			worker = new AnalysisWebWorker( scope, researcher );
+			worker.register();
+		} );
+
+		test( "throws an error when passing an invalid name", () => {
+			const errorMessage = "Failed to register the custom helper. Expected parameter `name` to be a string.";
+			expect( () => worker.registerHelper( null, helper ) ).toThrowError( errorMessage );
+		} );
+
+		test( "throws an error when passing an invalid helper", () => {
+			const errorMessage = "Failed to register the custom helper. Expected parameter `helper` to be a function.";
+			expect( () => worker.registerHelper( helperName, null ) ).toThrowError( errorMessage );
+		} );
+
+		test( "adds the helper", () => {
+			scope.onmessage( createMessage( "initialize" ) );
+
+			worker.registerHelper( helperName, helper );
+			const helperFromResearcher = researcher.getHelper( helperName );
+			expect( helperFromResearcher ).toBeDefined();
+			expect( helperFromResearcher ).toBe( helper );
+		} );
+	} );
+
 	describe( "registerMessageHandler", () => {
 		const handlerName = "Knock knock";
 		const pluginName = "Who?";

--- a/packages/yoastseo/spec/worker/AnalysisWebWorkerSpec.js
+++ b/packages/yoastseo/spec/worker/AnalysisWebWorkerSpec.js
@@ -1568,6 +1568,36 @@ describe( "AnalysisWebWorker", () => {
 		} );
 	} );
 
+	describe( "registerResearch", () => {
+		const researchName = "custom research";
+		const research = () => "hello";
+
+		beforeEach( () => {
+			scope = createScope();
+			worker = new AnalysisWebWorker( scope, researcher );
+			worker.register();
+		} );
+
+		test( "throws an error when passing an invalid name", () => {
+			const errorMessage = "Failed to register the custom research. Expected parameter `name` to be a string.";
+			expect( () => worker.registerResearch( null, research ) ).toThrowError( errorMessage );
+		} );
+
+		test( "throws an error when passing an invalid research", () => {
+			const errorMessage = "Failed to register the custom research. Expected parameter `research` to be a function.";
+			expect( () => worker.registerResearch( researchName, null ) ).toThrowError( errorMessage );
+		} );
+
+		test( "adds the research", () => {
+			scope.onmessage( createMessage( "initialize" ) );
+
+			worker.registerResearch( researchName, research );
+			const researchFromResearcher = researcher.getResearch( researchName );
+			expect( researchFromResearcher ).toBeDefined();
+			expect( researchFromResearcher ).toBe( "hello" );
+		} );
+	} );
+
 	describe( "registerHelper", () => {
 		const helperName = "helpful helper";
 		const helper = () => true;

--- a/packages/yoastseo/src/languageProcessing/AbstractResearcher.js
+++ b/packages/yoastseo/src/languageProcessing/AbstractResearcher.js
@@ -135,6 +135,29 @@ export default class AbstractResearcher {
 	}
 
 	/**
+	 * Add a custom helper that will be available within the Researcher.
+	 *
+	 * @param {string}   name     A name to reference the helper by.
+	 * @param {function} helper   The function to be added to the Researcher.
+	 *
+	 * @throws {MissingArgument}  Helper name cannot be empty.
+	 * @throws {InvalidTypeError} The helper requires a valid Function callback.
+	 *
+	 * @returns {void}
+	 */
+	addHelper( name, helper ) {
+		if ( isUndefined( name ) || isEmpty( name ) ) {
+			throw new MissingArgument( "Helper name cannot be empty" );
+		}
+
+		if ( ! ( helper instanceof Function ) ) {
+			throw new InvalidTypeError( "The research requires a Function callback." );
+		}
+
+		this.helpers[ name ] = helper;
+	}
+
+	/**
 	 * Check whether or not the research is known by the Researcher.
 	 *
 	 * @param {string} name The name to reference the research by.
@@ -149,12 +172,35 @@ export default class AbstractResearcher {
 	}
 
 	/**
+	 * Check whether or not the helper is known by the Researcher.
+	 *
+	 * @param {string} name The name to reference the helper by.
+	 *
+	 * @returns {boolean} Whether or not the helper is known by the Researcher.
+	 */
+	hasHelper( name ) {
+		return Object.keys( this.getAvailableHelpers() ).filter(
+			function( helper ) {
+				return helper === name;
+			} ).length > 0;
+	}
+
+	/**
 	 * Return all available researches.
 	 *
 	 * @returns {Object} An object containing all available researches.
 	 */
 	getAvailableResearches() {
 		return merge( this.defaultResearches, this.customResearches );
+	}
+
+	/**
+	 * Return all available helpers.
+	 *
+	 * @returns {Object} An object containing all available helpers.
+	 */
+	getAvailableHelpers() {
+		return this.helpers;
 	}
 
 	/**

--- a/packages/yoastseo/src/worker/AnalysisWebWorker.js
+++ b/packages/yoastseo/src/worker/AnalysisWebWorker.js
@@ -1441,7 +1441,7 @@ export default class AnalysisWebWorker {
 	}
 
 	/**
-	 * Registers custom helpers to the researcher.
+	 * Registers a custom helper to the researcher.
 	 *
 	 * @param {string} name       The name of the helper.
 	 * @param {function} helper   The helper function to add.

--- a/packages/yoastseo/src/worker/AnalysisWebWorker.js
+++ b/packages/yoastseo/src/worker/AnalysisWebWorker.js
@@ -1381,9 +1381,18 @@ export default class AnalysisWebWorker {
 	 *
 	 * @param {string} name         The name of the research.
 	 * @param {function} research   The research function to add.
+	 *
 	 * @returns {void}
 	 */
 	registerResearch( name, research ) {
+		if ( ! isString( name ) ) {
+			throw new InvalidTypeError( "Failed to register the custom research. Expected parameter `name` to be a string." );
+		}
+
+		if ( ! isObject( research ) ) {
+			throw new InvalidTypeError( "Failed to register the custom research. Expected parameter `research` to be a function." );
+		}
+
 		const researcher = this._researcher;
 
 		if ( ! researcher.hasResearch( name ) ) {

--- a/packages/yoastseo/src/worker/AnalysisWebWorker.js
+++ b/packages/yoastseo/src/worker/AnalysisWebWorker.js
@@ -1405,7 +1405,7 @@ export default class AnalysisWebWorker {
 	 *
 	 * @param {number} id     The request id.
 	 * @param {string} name   The name of the research to run.
-	 * @param {Paper} [paper] The paper to run the on if it shouldn't
+	 * @param {Paper} [paper] The paper to run the research on if it shouldn't
 	 *                        be run on the latest paper.
 	 *
 	 * @returns {Object} The result of the research.

--- a/packages/yoastseo/src/worker/AnalysisWebWorker.js
+++ b/packages/yoastseo/src/worker/AnalysisWebWorker.js
@@ -135,6 +135,7 @@ export default class AnalysisWebWorker {
 		this.setCustomCornerstoneRelatedKeywordAssessorClass = this.setCustomCornerstoneRelatedKeywordAssessorClass.bind( this );
 		this.registerAssessor = this.registerAssessor.bind( this );
 		this.registerResearch = this.registerResearch.bind( this );
+		this.registerHelper = this.registerHelper.bind( this );
 		this.setInclusiveLanguageOptions = this.setInclusiveLanguageOptions.bind( this );
 
 		// Bind event handlers to this scope.
@@ -1395,7 +1396,7 @@ export default class AnalysisWebWorker {
 	 *
 	 * @param {number} id     The request id.
 	 * @param {string} name   The name of the research to run.
-	 * @param {Paper} [paper] The paper to run the research on if it shouldn't
+	 * @param {Paper} [paper] The paper to run the on if it shouldn't
 	 *                        be run on the latest paper.
 	 *
 	 * @returns {Object} The result of the research.
@@ -1428,5 +1429,29 @@ export default class AnalysisWebWorker {
 			return;
 		}
 		this.send( "runResearch:done", id, result );
+	}
+
+	/**
+	 * Registers custom helpers to the researcher.
+	 *
+	 * @param {string} name       The name of the helper.
+	 * @param {function} helper   The helper function to add.
+	 *
+	 * @returns {void}
+	 */
+	registerHelper( name, helper ) {
+		if ( ! isString( name ) ) {
+			throw new InvalidTypeError( "Failed to register the custom helper. Expected parameter `name` to be a string." );
+		}
+
+		if ( ! isObject( helper ) ) {
+			throw new InvalidTypeError( "Failed to register the custom helper. Expected parameter `helper` to be a function." );
+		}
+
+		const researcher = this._researcher;
+
+		if ( ! researcher.hasHelper( name ) ) {
+			researcher.addHelper( name, helper );
+		}
 	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Adding an infrastructure to register custom helpers will allow us to load helpers that are needed for add-on-specific assessments only when those add-ons are activated.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [yoastseo] Creates an interface to register helper in the worker, and to add custom helpers to the researcher.
* [yoastseo] Adds type validation to the `registerResearch` method in `AnalysisWebWorker.js` and unit tests to test the method.

## Relevant technical choices:

* I noticed that the `registerResearch` method didn't have any type validation so I added it in this PR. I also added unit tests for this method in `AnalysisWebWorkerSpec.js`.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Confirm all unit tests pass.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* None needed (non-user-facing change).

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [x] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #19752 
