### PR TITLE
Removes including the `slug` key in our own plugin data

### DIFF
--- a/inc/class-addon-manager.php
+++ b/inc/class-addon-manager.php
@@ -509,7 +509,7 @@ class WPSEO_Addon_Manager {
 		return (object) [
 			'new_version'      => $subscription->product->version,
 			'name'             => $subscription->product->name,
-			'slug'             => $subscription->product->slug,
+			// Do not include slug to make sure we show, visit plugin site.
 			'plugin'           => $plugin_file,
 			'url'              => $subscription->product->store_url,
 			'last_update'      => $subscription->product->last_updated,

--- a/tests/unit/inc/addon-manager-test.php
+++ b/tests/unit/inc/addon-manager-test.php
@@ -611,7 +611,6 @@ class Addon_Manager_Test extends TestCase {
 			(object) [
 				'new_version'      => '10.0',
 				'name'             => 'Extension',
-				'slug'             => 'yoast-seo-wordpress-premium',
 				'plugin'           => '',
 				'url'              => 'https://example.org/store',
 				'last_update'      => 'yesterday',
@@ -859,7 +858,6 @@ class Addon_Manager_Test extends TestCase {
 						'wp-seo-premium.php' => (object) [
 							'new_version'      => '10.0',
 							'name'             => 'Extension',
-							'slug'             => 'yoast-seo-wordpress-premium',
 							'plugin'           => '',
 							'url'              => 'https://example.org/store',
 							'last_update'      => 'yesterday',
@@ -920,7 +918,6 @@ class Addon_Manager_Test extends TestCase {
 				'expected' => (object) [
 					'new_version'      => '10.0',
 					'name'             => 'Extension',
-					'slug'             => 'yoast-seo-wordpress-premium',
 					'plugin'           => '',
 					'url'              => 'https://example.org/store',
 					'last_update'      => 'yesterday',


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We do not want to show the `view details` option in the plugin overview for our premium plugins. We want to show `visit plugin site` instead.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Changes `view details` to `visit plugin site` for all our premium plugins in the plugin overview.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Open the plugin overview page with at least premium installed and maybe with some add-ons. They don't have to be activated, but you will need an active license. 
* `without` this PR. make sure the plugins show `view details` as seen on the screenshot. Besides `Team Yoast` and the version.

<img width="1127" alt="image" src="https://user-images.githubusercontent.com/6975345/216271994-59095f13-f411-4898-847c-7edc0797be3a.png">

* Checkout this PR or the RC.
* Remove all transient cache by running to following query:
`DELETE FROM wp_options WHERE option_name LIKE ('%\_transient\_%');`
* Refresh the page and make sure `view details` is now `Visit plugin site` as shown on the screenshot.
<img width="1177" alt="image" src="https://user-images.githubusercontent.com/6975345/216273026-f02fa4bf-620b-4fea-9ef0-d1162ddedc10.png">


#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

This removes the slug variable for our premium plugins for which you have a license. Things to smoke test could be wp-admin/admin.php?page=wpseo_licenses. To make sure there are no changes between this PR and trunk. Remember to clear your transients every time you switch branches/RC's.
If there are any other places where we display information about our plugins whenever you have an active license check those too. For example wp-admin/site-health.php?tab=debug

## UI changes

* [X] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes [“Install Now” button is shown for active Yoast add-ons#19454](https://github.com/Yoast/wordpress-seo/issues/19454)
