### PR TITLE
19792 Change CTB ID

### DIFF
--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -263,7 +263,7 @@ class WPSEO_Admin {
 		}
 
 		// Add link to premium landing page.
-		$premium_link = '<a style="font-weight: bold;" href="' . esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/1yb' ) ) . '" target="_blank" data-action="load-nfd-ctb" data-ctb-id="57d6a568-783c-45e2-a388-847cff155897">' . __( 'Get Premium', 'wordpress-seo' ) . '</a>';
+		$premium_link = '<a style="font-weight: bold;" href="' . esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/1yb' ) ) . '" target="_blank" data-action="load-nfd-ctb" data-ctb-id="f6a84663-465f-4cb5-8ba5-f7a6d72224b2">' . __( 'Get Premium', 'wordpress-seo' ) . '</a>';
 		array_unshift( $links, $premium_link );
 
 		return $links;

--- a/admin/class-premium-upsell-admin-block.php
+++ b/admin/class-premium-upsell-admin-block.php
@@ -69,7 +69,7 @@ class WPSEO_Premium_Upsell_Admin_Block {
 			'<span aria-hidden="true" class="yoast-button-upsell__caret"></span>';
 
 		$upgrade_button = sprintf(
-			'<a id="%1$s" class="yoast-button-upsell" data-action="load-nfd-ctb" data-ctb-id="57d6a568-783c-45e2-a388-847cff155897" href="%2$s" target="_blank">%3$s</a>',
+			'<a id="%1$s" class="yoast-button-upsell" data-action="load-nfd-ctb" data-ctb-id="f6a84663-465f-4cb5-8ba5-f7a6d72224b2" href="%2$s" target="_blank">%3$s</a>',
 			esc_attr( 'wpseo-' . $this->identifier . '-popup-button' ),
 			esc_url( $url ),
 			$button_text

--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -909,7 +909,7 @@ class Yoast_Form {
 
 		$upsell_button = '';
 		if ( $has_premium_upsell ) {
-			$upsell_button = '<a class="yoast-button yoast-button--buy yoast-button--small" data-action="load-nfd-ctb" data-ctb-id="57d6a568-783c-45e2-a388-847cff155897" href=' . esc_url( $attr['premium_upsell_url'] ) . ' target="_blank">' . esc_html__( 'Unlock with Premium!', 'wordpress-seo' ) . '<span class="screen-reader-text">' . esc_html__( '(Opens in a new browser tab)', 'wordpress-seo' ) . '</span>' .
+			$upsell_button = '<a class="yoast-button yoast-button--buy yoast-button--small" data-action="load-nfd-ctb" data-ctb-id="f6a84663-465f-4cb5-8ba5-f7a6d72224b2" href=' . esc_url( $attr['premium_upsell_url'] ) . ' target="_blank">' . esc_html__( 'Unlock with Premium!', 'wordpress-seo' ) . '<span class="screen-reader-text">' . esc_html__( '(Opens in a new browser tab)', 'wordpress-seo' ) . '</span>' .
 			'<span aria-hidden="true" class="yoast-button--buy__caret"></span></a>';
 		}
 

--- a/admin/views/licenses.php
+++ b/admin/views/licenses.php
@@ -217,7 +217,7 @@ $new_tab_message         = sprintf(
 
 			<?php else : ?>
 
-				<a target="_blank" data-action="load-nfd-ctb" data-ctb-id="57d6a568-783c-45e2-a388-847cff155897" href="<?php echo esc_url( $premium_extension['buyUrl'] ); ?>" class="yoast-button-upsell">
+				<a target="_blank" data-action="load-nfd-ctb" data-ctb-id="f6a84663-465f-4cb5-8ba5-f7a6d72224b2" href="<?php echo esc_url( $premium_extension['buyUrl'] ); ?>" class="yoast-button-upsell">
 					<?php
 					printf(
 						/* translators: $s expands to Yoast SEO Premium */

--- a/admin/views/redirects.php
+++ b/admin/views/redirects.php
@@ -17,7 +17,7 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 	<h1 id="wpseo-title"><?php echo \esc_html( \get_admin_page_title() ); ?></h1>
 	<div class="wpseo_content_wrapper" style="position: relative;">
 		<div style="position: absolute;top: 0;bottom: 0;left: 0;right: 0;z-index: 100; display: flex;justify-content: center;align-items: center;background: radial-gradient(#ffffffcf 20%, #ffffff00 50%);">
-			<a class="yoast-button-upsell" data-action="load-nfd-ctb" data-ctb-id="57d6a568-783c-45e2-a388-847cff155897" href="<?php echo \esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/4e0/' ) ); ?>" target="_blank">
+			<a class="yoast-button-upsell" data-action="load-nfd-ctb" data-ctb-id="f6a84663-465f-4cb5-8ba5-f7a6d72224b2" href="<?php echo \esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/4e0/' ) ); ?>" target="_blank">
 				<?php
 				echo \esc_html__( 'Unlock with Premium', 'wordpress-seo' )
 					// phpcs:ignore WordPress.Security.EscapeOutput -- Already escapes correctly.

--- a/inc/class-wpseo-admin-bar-menu.php
+++ b/inc/class-wpseo-admin-bar-menu.php
@@ -583,7 +583,7 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 				'id'     => 'wpseo-get-premium',
 				// Circumvent an issue in the WP admin bar API in order to pass `data` attributes. See https://core.trac.wordpress.org/ticket/38636.
 				'title'  => sprintf(
-					'<a href="%1$s" target="_blank" data-action="load-nfd-ctb" data-ctb-id="57d6a568-783c-45e2-a388-847cff155897" style="padding:0;">%2$s &raquo;</a>',
+					'<a href="%1$s" target="_blank" data-action="load-nfd-ctb" data-ctb-id="f6a84663-465f-4cb5-8ba5-f7a6d72224b2" style="padding:0;">%2$s &raquo;</a>',
 					$this->shortlinker->build_shortlink( 'https://yoa.st/admin-bar-get-premium' ),
 					__( 'Get Yoast SEO Premium', 'wordpress-seo' )
 				),

--- a/packages/js/src/components/AnalysisUpsell.js
+++ b/packages/js/src/components/AnalysisUpsell.js
@@ -59,7 +59,7 @@ const AnalysisUpsell = ( props ) => {
 				<OutboundLinkButton
 					href={ url } className={ "UpsellLinkButton" }
 					data-action="load-nfd-ctb"
-					data-ctb-id="57d6a568-783c-45e2-a388-847cff155897"
+					data-ctb-id="f6a84663-465f-4cb5-8ba5-f7a6d72224b2"
 				>
 					{ sprintf(
 						/* translators: %s expands to Premium */

--- a/packages/js/src/components/contentAnalysis/ReadabilityAnalysis.js
+++ b/packages/js/src/components/contentAnalysis/ReadabilityAnalysis.js
@@ -104,7 +104,7 @@ class ReadabilityAnalysis extends Component {
 			),
 			"<span style='text-decoration: underline'>",
 			"</span>",
-			`<a href="${ link }" data-action="load-nfd-ctb" data-ctb-id="57d6a568-783c-45e2-a388-847cff155897">`,
+			`<a href="${ link }" data-action="load-nfd-ctb" data-ctb-id="f6a84663-465f-4cb5-8ba5-f7a6d72224b2">`,
 			"</a>"
 		);
 

--- a/packages/js/src/components/contentAnalysis/SeoAnalysis.js
+++ b/packages/js/src/components/contentAnalysis/SeoAnalysis.js
@@ -210,7 +210,7 @@ class SeoAnalysis extends Component {
 			),
 			"<span style='text-decoration: underline'>",
 			"</span>",
-			`<a href="${ link }" data-action="load-nfd-ctb" data-ctb-id="57d6a568-783c-45e2-a388-847cff155897">`,
+			`<a href="${ link }" data-action="load-nfd-ctb" data-ctb-id="f6a84663-465f-4cb5-8ba5-f7a6d72224b2">`,
 			"</a>"
 		);
 

--- a/packages/js/src/components/modals/KeywordSynonyms.js
+++ b/packages/js/src/components/modals/KeywordSynonyms.js
@@ -66,7 +66,7 @@ const KeywordSynonyms = ( props ) => {
 				href: props.buyLink,
 				className: "yoast-button-upsell",
 				rel: null,
-				"data-ctb-id": "57d6a568-783c-45e2-a388-847cff155897",
+				"data-ctb-id": "f6a84663-465f-4cb5-8ba5-f7a6d72224b2",
 				"data-action": "load-nfd-ctb",
 			} }
 			upsellButtonLabel={ __( "1 year free support and updates included!", "wordpress-seo" ) }

--- a/packages/js/src/components/modals/MultipleKeywords.js
+++ b/packages/js/src/components/modals/MultipleKeywords.js
@@ -69,7 +69,7 @@ const MultipleKeywords = ( props ) => {
 				href: addQueryArgs( props.buyLink, { context: locationContext } ),
 				className: "yoast-button-upsell",
 				rel: null,
-				"data-ctb-id": "57d6a568-783c-45e2-a388-847cff155897",
+				"data-ctb-id": "f6a84663-465f-4cb5-8ba5-f7a6d72224b2",
 				"data-action": "load-nfd-ctb",
 			} }
 			upsellButtonLabel={ __( "1 year free support and updates included!", "wordpress-seo" ) }

--- a/packages/js/src/components/modals/PremiumSEOAnalysisUpsell.js
+++ b/packages/js/src/components/modals/PremiumSEOAnalysisUpsell.js
@@ -40,7 +40,7 @@ const PremiumSEOAnalysisUpsell = ( props ) => {
 				href: buyLink,
 				className: "yoast-button-upsell",
 				rel: null,
-				"data-ctb-id": "57d6a568-783c-45e2-a388-847cff155897",
+				"data-ctb-id": "f6a84663-465f-4cb5-8ba5-f7a6d72224b2",
 				"data-action": "load-nfd-ctb",
 			} }
 			upsellButtonLabel={ __( "1 year of premium support and updates included!", "wordpress-seo" ) }

--- a/packages/js/src/components/social/SocialUpsell.js
+++ b/packages/js/src/components/social/SocialUpsell.js
@@ -52,7 +52,7 @@ const SocialUpsell = ( props ) => {
 				<br />
 				<YoastShortLink
 					data-action="load-nfd-ctb"
-					data-ctb-id="57d6a568-783c-45e2-a388-847cff155897"
+					data-ctb-id="f6a84663-465f-4cb5-8ba5-f7a6d72224b2"
 					href={ addQueryArgs( wpseoAdminL10n[ "shortlinks.upsell.social_preview." + props.socialMediumName.toLowerCase() ], { context: locationContext } ) }
 				>
 					<p>{ upgradeText }</p>

--- a/packages/js/src/insights/components/prominent-words.js
+++ b/packages/js/src/insights/components/prominent-words.js
@@ -86,7 +86,7 @@ const ProminentWords = ( { location } ) => { // eslint-disable-line complexity
 				}
 			</p> }
 			{ shouldUpsell && <p>{ upsellDescription }</p> }
-			{ shouldUpsell && <OutboundLink href={ addQueryArgs( upsellLink, { context: locationContext } ) } data-action="load-nfd-ctb" data-ctb-id="57d6a568-783c-45e2-a388-847cff155897" className="yoast-button yoast-button-upsell">
+			{ shouldUpsell && <OutboundLink href={ addQueryArgs( upsellLink, { context: locationContext } ) } data-action="load-nfd-ctb" data-ctb-id="f6a84663-465f-4cb5-8ba5-f7a6d72224b2" className="yoast-button yoast-button-upsell">
 				{ sprintf(
 					// translators: %s expands to `Premium` (part of add-on name).
 					__( "Unlock with %s", "wordpress-seo" ),

--- a/packages/js/src/integrations-page/simple-integration.js
+++ b/packages/js/src/integrations-page/simple-integration.js
@@ -76,7 +76,7 @@ export const SimpleIntegration = ( { integration, isActive, children } ) => {
 					href={ integration.upsellLink }
 					variant="upsell"
 					data-action="load-nfd-ctb"
-					data-ctb-id="57d6a568-783c-45e2-a388-847cff155897"
+					data-ctb-id="f6a84663-465f-4cb5-8ba5-f7a6d72224b2"
 					className="yst-w-full yst-text-slate-800"
 					target="_blank"
 				>

--- a/packages/js/src/integrations-page/toggleable-integration.js
+++ b/packages/js/src/integrations-page/toggleable-integration.js
@@ -115,7 +115,7 @@ export const ToggleableIntegration = ( {
 					href={ integration.upsellLink }
 					variant="upsell"
 					data-action="load-nfd-ctb"
-					data-ctb-id="57d6a568-783c-45e2-a388-847cff155897"
+					data-ctb-id="f6a84663-465f-4cb5-8ba5-f7a6d72224b2"
 					className="yst-w-full yst-text-slate-800"
 					target="_blank"
 				>

--- a/packages/js/src/workouts/components/WorkoutCard.js
+++ b/packages/js/src/workouts/components/WorkoutCard.js
@@ -92,7 +92,7 @@ export default function WorkoutCard( {
 				{ /* eslint-disable-next-line max-len */ }
 				{ workout && <Button id={ `${ id }-action-button` } className={ `yoast-button yoast-button--${ isToggle ? "secondary" : "primary" }` } onClick={ onClick }>{ buttonText }</Button> }
 				{ ! workout &&
-					<UpsellButton id={ `${ id }-upsell-button` } href={ upsellLink } className="yoast-button yoast-button-upsell" data-action="load-nfd-ctb" data-ctb-id="57d6a568-783c-45e2-a388-847cff155897">
+					<UpsellButton id={ `${ id }-upsell-button` } href={ upsellLink } className="yoast-button yoast-button-upsell" data-action="load-nfd-ctb" data-ctb-id="f6a84663-465f-4cb5-8ba5-f7a6d72224b2">
 						{ actualUpsellText }
 						<span aria-hidden="true" className="yoast-button-upsell__caret" />
 					</UpsellButton>

--- a/src/integrations/admin/crawl-settings-integration.php
+++ b/src/integrations/admin/crawl-settings-integration.php
@@ -324,7 +324,7 @@ class Crawl_Settings_Integration implements Integration_Interface {
 	 * Displays the Premium upsell button.
 	 */
 	public function display_premium_upsell_btn() {
-		echo '<a class="yoast-button-upsell" data-action="load-nfd-ctb" data-ctb-id="57d6a568-783c-45e2-a388-847cff155897" href="';
+		echo '<a class="yoast-button-upsell" data-action="load-nfd-ctb" data-ctb-id="f6a84663-465f-4cb5-8ba5-f7a6d72224b2" href="';
 		echo \esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/crawl-settings-upsell' ) );
 		echo '" target="_blank" style=" margin-top: 16px; margin-bottom: 16px; ">';
 

--- a/src/integrations/admin/social-templates-integration.php
+++ b/src/integrations/admin/social-templates-integration.php
@@ -247,7 +247,7 @@ class Social_Templates_Integration implements Integration_Interface {
 
 			echo '<div class="yoast-settings-section-upsell">';
 
-			echo '<a class="yoast-button-upsell" data-action="load-nfd-ctb" data-ctb-id="57d6a568-783c-45e2-a388-847cff155897" href="' . \esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/4e0' ) ) . '" target="_blank">'
+			echo '<a class="yoast-button-upsell" data-action="load-nfd-ctb" data-ctb-id="f6a84663-465f-4cb5-8ba5-f7a6d72224b2" href="' . \esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/4e0' ) ) . '" target="_blank">'
 			. \esc_html__( 'Unlock with Premium', 'wordpress-seo' )
 			// phpcs:ignore WordPress.Security.EscapeOutput -- Already escapes correctly.
 			. WPSEO_Admin_Utils::get_new_tab_message()

--- a/src/integrations/settings-integration.php
+++ b/src/integrations/settings-integration.php
@@ -517,7 +517,7 @@ class Settings_Integration implements Integration_Interface {
 	public function get_upsell_settings() {
 		return [
 			'actionId'     => 'load-nfd-ctb',
-			'premiumCtbId' => '57d6a568-783c-45e2-a388-847cff155897',
+			'premiumCtbId' => 'f6a84663-465f-4cb5-8ba5-f7a6d72224b2',
 		];
 	}
 

--- a/src/presenters/admin/sidebar-presenter.php
+++ b/src/presenters/admin/sidebar-presenter.php
@@ -55,7 +55,7 @@ class Sidebar_Presenter extends Abstract_Presenter {
 							?>
 						</p>
 						<p class="plugin-buy-button">
-							<a class="yoast-button-upsell" data-action="load-nfd-ctb" data-ctb-id="57d6a568-783c-45e2-a388-847cff155897" target="_blank" href="<?php echo \esc_url( $buy_yoast_seo_shortlink ); ?>">
+							<a class="yoast-button-upsell" data-action="load-nfd-ctb" data-ctb-id="f6a84663-465f-4cb5-8ba5-f7a6d72224b2" target="_blank" href="<?php echo \esc_url( $buy_yoast_seo_shortlink ); ?>">
 								<?php
 								/* translators: %s expands to Yoast SEO Premium */
 								\printf( \esc_html__( 'Get %s', 'wordpress-seo' ), 'Yoast SEO Premium' );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The CTB ID needs to be updated from 57d6a568-783c-45e2-a388-847cff155897 to f6a84663-465f-4cb5-8ba5-f7a6d72224b2

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Changes the CTB ID on our Unlock with Premium buttons

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Confirm that the upsell buttons now have the CTB ID f6a84663-465f-4cb5-8ba5-f7a6d72224b2 where they had 57d6a568-783c-45e2-a388-847cff155897
* If you happen to have a live BlueHost testing site, also create an zip with this changes and confirm that you get the new CTB popup when clicking one of the buttons with the CTB ID

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #19792 
