### PR TITLE
Revert "Removes including the `slug` key in our own plugin data"

### DIFF
--- a/inc/class-addon-manager.php
+++ b/inc/class-addon-manager.php
@@ -509,7 +509,7 @@ class WPSEO_Addon_Manager {
 		return (object) [
 			'new_version'      => $subscription->product->version,
 			'name'             => $subscription->product->name,
-			// Do not include slug to make sure we show, visit plugin site.
+			'slug'             => $subscription->product->slug,
 			'plugin'           => $plugin_file,
 			'url'              => $subscription->product->store_url,
 			'last_update'      => $subscription->product->last_updated,

--- a/tests/unit/inc/addon-manager-test.php
+++ b/tests/unit/inc/addon-manager-test.php
@@ -611,6 +611,7 @@ class Addon_Manager_Test extends TestCase {
 			(object) [
 				'new_version'      => '10.0',
 				'name'             => 'Extension',
+				'slug'             => 'yoast-seo-wordpress-premium',
 				'plugin'           => '',
 				'url'              => 'https://example.org/store',
 				'last_update'      => 'yesterday',
@@ -858,6 +859,7 @@ class Addon_Manager_Test extends TestCase {
 						'wp-seo-premium.php' => (object) [
 							'new_version'      => '10.0',
 							'name'             => 'Extension',
+							'slug'             => 'yoast-seo-wordpress-premium',
 							'plugin'           => '',
 							'url'              => 'https://example.org/store',
 							'last_update'      => 'yesterday',
@@ -918,6 +920,7 @@ class Addon_Manager_Test extends TestCase {
 				'expected' => (object) [
 					'new_version'      => '10.0',
 					'name'             => 'Extension',
+					'slug'             => 'yoast-seo-wordpress-premium',
 					'plugin'           => '',
 					'url'              => 'https://example.org/store',
 					'last_update'      => 'yesterday',


### PR DESCRIPTION
Reverts #19789

## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to revert #19789

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Reverts #19789 (Changes `view details` to `visit plugin site` for all our premium plugins in the plugin overview.)

Fixes [“Install Now” button is shown for active Yoast add-ons#19454](https://github.com/Yoast/wordpress-seo/issues/19454)
