### PR TITLE
[classic editor] Readability improvement highlights unfocus (blur) the editor and make editing difficult

### DIFF
--- a/packages/js/src/analysis/getApplyMarks.js
+++ b/packages/js/src/analysis/getApplyMarks.js
@@ -60,7 +60,7 @@ export default function getApplyMarks() {
 	const showMarkers = select( "yoast-seo/editor" ).isMarkingAvailable();
 	const markersPaused = select( "yoast-seo/editor" ).getMarkerPauseStatus();
 
-	if ( ! showMarkers || markersPaused) {
+	if ( ! showMarkers || markersPaused ) {
 		return noop;
 	}
 

--- a/packages/js/src/analysis/getApplyMarks.js
+++ b/packages/js/src/analysis/getApplyMarks.js
@@ -58,8 +58,9 @@ function applyMarks( paper, marks ) {
  */
 export default function getApplyMarks() {
 	const showMarkers = select( "yoast-seo/editor" ).isMarkingAvailable();
+	const markersPaused = select( "yoast-seo/editor" ).getMarkerPauseStatus();
 
-	if ( ! showMarkers ) {
+	if ( ! showMarkers || markersPaused) {
 		return noop;
 	}
 

--- a/packages/js/src/lib/tinymce.js
+++ b/packages/js/src/lib/tinymce.js
@@ -257,7 +257,7 @@ export function tinyMceEventBinder( refreshAnalysis, tinyMceId ) {
 		pauseMarkers();
 	} );
 
-	addEventHandler("content", [ "blur" ], function( evt) {
+	addEventHandler( "content", [ "blur" ], function() {
 		resumeMarkers();
 	} );
 }

--- a/packages/js/src/lib/tinymce.js
+++ b/packages/js/src/lib/tinymce.js
@@ -169,6 +169,28 @@ export function enableMarkerButtons() {
 }
 
 /**
+ * Calls the function in the YoastSEO.js app that pauses to display the markers in the TinyMCE editor.
+ *
+ * @returns {void}
+ */
+export function pauseMarkers() {
+	if ( ! isUndefined( store ) ) {
+		store.dispatch( actions.setMarkerPauseStatus( true ) );
+	}
+}
+
+/**
+ * Calls the function in the YoastSEO.js app that restores showing markers in the TinyMCE editor.
+ *
+ * @returns {void}
+ */
+export function resumeMarkers() {
+	if ( ! isUndefined( store ) ) {
+		store.dispatch( actions.setMarkerPauseStatus( false ) );
+	}
+}
+
+/**
  * If #wp-content-wrap has the 'html-active' class, text view is enabled in WordPress.
  * TMCE is not available, the text cannot be marked and so the marker buttons are disabled.
  *
@@ -224,12 +246,18 @@ export function tinyMceEventBinder( refreshAnalysis, tinyMceId ) {
 	addEventHandler( tinyMceId, enableEvents, enableMarkerButtons );
 
 	addEventHandler( "content", [ "focus" ], function( evt ) {
-		var editor = evt.target;
+		const editor = evt.target;
 
 		if ( editorHasMarks( editor ) ) {
 			editorRemoveMarks( editor );
 
 			YoastSEO.app.disableMarkers();
 		}
+
+		pauseMarkers();
+	} );
+
+	addEventHandler("content", [ "blur" ], function( evt) {
+		resumeMarkers();
 	} );
 }

--- a/packages/yoastseo/src/app.js
+++ b/packages/yoastseo/src/app.js
@@ -565,7 +565,7 @@ App.prototype.initSnippetPreview = function() {
 };
 
 /**
- * Initializes the assessorpresenters for content and SEO.
+ * Initializes the assessor presenters for content and SEO.
  *
  * @returns {void}
  */


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* After turning on the readability improvement suggestions, when editing text in the classic editor, after a second the editor is blurred and the window is focused instead of the editor field. This makes it impossible to correct the highlighted suggestions.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where an attempt on editing the text in Classic editor would result in unfocused text and make the cursor jumps to the beginning of the text when the highlight feature toggle is enabled.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install and activate Classic editor
* Create a post in Classic editor
* Start editing a post
* Remove everything and put the following text "Even as it is I have not been defeated by this bastard." into the editor
* Switch to the Readability tab 
* Go to Passive voice assessment and enable the eye icon
* Confirm that the sentence above is highlighted
* Try editing any text in the post, for example, add another sentence that is not passive: "The bastard doesn't defeat me."
* Confirm that the editor remains focused when you are typing/editing, and that the cursor doesn't jump to the beginning of the text
* Confirm that the result of Passive voice assessment is updated accordingly

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
   * Testing in taxonomies might not be necessary since the highlighting feature is not available there
* [x] Changes should be tested on different editors (Block/Classic/Elementor/other) 
   *  Testing in Elementor might not be necessary since the highlighting feature is not available there
* [x] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* No extra testing needed

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes [#19490](https://github.com/Yoast/wordpress-seo/issues/19490)
