### PR TITLE
Separate `@yoast/ui-library` readme from Storybook introduction

### DIFF
--- a/packages/ui-library/.storybook/main.js
+++ b/packages/ui-library/.storybook/main.js
@@ -1,5 +1,9 @@
 module.exports = {
 	stories: [
+		"../src/introduction.stories.mdx",
+		"../src/installation.stories.mdx",
+		"../src/contributing.stories.mdx",
+		"../src/changelog.stories.mdx",
 		"../src/**/*.stories.@(js|mdx)",
 		"../src/**/stories.@(js|mdx)",
 	],

--- a/packages/ui-library/changelog.md
+++ b/packages/ui-library/changelog.md
@@ -1,4 +1,4 @@
-# CHANGELOG.md
+# Changelog
 
 ## 3.1.0
 

--- a/packages/ui-library/changelog.md
+++ b/packages/ui-library/changelog.md
@@ -3,7 +3,7 @@
 ## 3.1.0
 
 * Improves the focus style of anchors by making it more pronounced. This affects: all anchors within the `yst-root` and `yst-validation-message` classes as well as the `Link` and `SidebarNavigation.SubmenuItem` components. And lastly, the `Button` element, if rendered `as` an anchor. [#19535](https://github.com/Yoast/wordpress-seo/pull/19535)
-* Removes the `TagInput`' _tabindex_ override. [#19535](https://github.com/Yoast/wordpress-seo/pull/19535)
+* Removes the `TagInput` _tabindex_ override. [#19535](https://github.com/Yoast/wordpress-seo/pull/19535)
 * Adds `openButtonId` and `closeButtonId` props to the _SidebarNavigation.Mobile_ component. [#19646](https://github.com/Yoast/wordpress-seo/pull/19646)
 * Adds focus to radio buttons with `inline-block` variant. [#19633](https://github.com/Yoast/wordpress-seo/pull/19633)
 * Notifications will now provide vertical scrolling if the content does not fit. [#19658](https://github.com/Yoast/wordpress-seo/pull/19658)

--- a/packages/ui-library/contributing.md
+++ b/packages/ui-library/contributing.md
@@ -1,0 +1,17 @@
+# Contributing to the Yoast UI Library
+The Yoast UI library is a React component library for building Yoast user interfaces. You can contribute to the UI library by adding more stories or creating new components.
+
+## Local development
+The components in this library are developed in isolation inside a [Storybook](https://storybook.js.org/), a visual tool for building component libraries. Developing components in isolation helps keep the interfaces flexible while ignoring implementation details.
+
+```shell
+# Install dependencies
+yarn install
+# Run Storybook for local development
+yarn storybook
+# Build a static Storybook
+yarn build:storybook
+```
+
+## Contributions
+If you've developed a React component that you think belongs in this library, feel free to reach out to the Components team or open a pull request and request a review from one of the Components teams developers.

--- a/packages/ui-library/readme.md
+++ b/packages/ui-library/readme.md
@@ -1,7 +1,7 @@
 # Welcome to the Yoast UI Library
 A React component library for building Yoast user interfaces. Please visit [the Storybook](https://ui-library.yoast.com/) for an interactive overview of all available components and examples on how to use them.
 
-[View the 3.0 changelog here](https://github.com/Yoast/wordpress-seo/blob/trunk/packages/ui-library/changelog.md).
+[View the changelog here](https://github.com/Yoast/wordpress-seo/blob/trunk/packages/ui-library/changelog.md).
 
 ## Important!
 **These components are UI components only and should remain free from business logic, translations, implementation details and other non-general concepts.**

--- a/packages/ui-library/readme.md
+++ b/packages/ui-library/readme.md
@@ -1,7 +1,7 @@
 # Welcome to the Yoast UI Library
 A React component library for building Yoast user interfaces. Please visit [the Storybook](https://ui-library.yoast.com/) for an interactive overview of all available components and examples on how to use them.
 
-[View the 3.0 changelog here](https://github.com/Yoast/wordpress-seo/blob/feature/ui-library-3/packages/ui-library/changelog.md).
+[View the 3.0 changelog here](https://github.com/Yoast/wordpress-seo/blob/trunk/packages/ui-library/changelog.md).
 
 ## Important!
 **These components are UI components only and should remain free from business logic, translations, implementation details and other non-general concepts.**

--- a/packages/ui-library/src/changelog.stories.mdx
+++ b/packages/ui-library/src/changelog.stories.mdx
@@ -1,0 +1,6 @@
+import { Description, Meta } from "@storybook/addon-docs";
+import changelog from "../changelog.md";
+
+<Meta title="Changelog" parameters={ { storyshots: { disable: true } } } />
+
+<Description markdown={ changelog } />

--- a/packages/ui-library/src/contributing.stories.mdx
+++ b/packages/ui-library/src/contributing.stories.mdx
@@ -1,0 +1,6 @@
+import { Description, Meta } from "@storybook/addon-docs";
+import contributing from "../contributing.md";
+
+<Meta title="Contributing" parameters={ { storyshots: { disable: true } } } />
+
+<Description markdown={ contributing } />

--- a/packages/ui-library/src/installation.md
+++ b/packages/ui-library/src/installation.md
@@ -1,0 +1,54 @@
+# Installation of the Yoast UI Library
+To install the Yoast UI library, start with installing the package and its peer dependencies from NPM.
+
+```shell
+# Add dependencies with Yarn
+yarn add @yoast/ui-library @wordpress/element
+```
+
+## Setup
+This package assumes the use of [`tailwindcss`](https://tailwindcss.com/) for building CSS and therefore ships with Tailwind layered CSS. You can easily set up Tailwind using the [`@yoast/tailwindcss-preset`](https://github.com/Yoast/wordpress-seo/tree/trunk/packages/tailwindcss-preset) package.
+
+In your `tailwind.config.js`, make sure to include this package in your `content` configuration to prevent Tailwind from purging its styles like so:
+
+```js
+module.exports = {
+    presets: [ require( "@yoast/tailwindcss-preset" ) ],
+    content: [
+        // Include all JS files inside the UI library in your content.
+        "./node_modules/@yoast/ui-library/**/*.js",
+        "./path/to/your/content/**/*.js",
+    ],
+};
+```
+
+To include this packages CSS in your build, import it in your stylesheet **before** the Tailwind layers like so:
+
+```css
+/* Import main CSS including all components. */
+@import "@yoast/ui-library";
+
+/* Tailwind layers */
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+```
+
+Now that your CSS is set up, you can start using the React components. Always start your React tree with the `Root` component, which provides a context for general options and a CSS classname for scoping this libraries CSS. Without it, components in this library will not render properly. Check out the `Root` component in [the Storybook](https://ui-library.yoast.com/?path=/docs/2-components-root--factory).
+
+```jsx
+import { Root, Alert } from "@yoast/ui-library";
+
+export default () => (
+    <Root context={ { isRtl: false } }>
+        <Alert variant="success">
+            Congrats! You've successfully setup the UI library.
+        </Alert>
+    </Root>
+);
+```
+
+Please note that the CSS scoping adds one level of CSS specificity. Therefore `@yoast/tailwindcss-preset` does the following:
+1. Enables the `important` rule for all utilities.
+2. Disables the Tailwind `preflight` styles (they are included in the `Root` component's CSS).
+3. Configures `@tailwindcss/forms` to use the `class` strategy (they are included in the `Root` component's CSS).

--- a/packages/ui-library/src/installation.stories.mdx
+++ b/packages/ui-library/src/installation.stories.mdx
@@ -1,0 +1,7 @@
+import { Description, Meta } from "@storybook/addon-docs";
+import installation from "./installation.md";
+
+<Meta title="Installation" parameters={ { storyshots: { disable: true } } } />
+
+<Description markdown={ installation } />
+

--- a/packages/ui-library/src/introduction.md
+++ b/packages/ui-library/src/introduction.md
@@ -1,0 +1,33 @@
+# Welcome to the Yoast UI Library
+The Yoast UI library is a React component library for building Yoast user interfaces. This Storybook provides an interactive overview of all available components and examples on how to use them.
+
+[View the changelog here](https://github.com/Yoast/wordpress-seo/blob/trunk/packages/ui-library/changelog.md).
+
+## Important!
+**These components are UI components only and should remain free from business logic, translations, implementation details and other non-general concepts.**
+
+## Elements, components & patterns
+To improve the flexibility and re-usability of this library its split into three layers: elements, components & patterns. Each layer adds upon the preceding layer in terms of complexity and specificity. The goal of this split is to provide the most useful interfaces for regular use cases, but to remain flexibile enough to handle edge case implementations that require a different structure. If, for instance, a component or pattern turns out to be too opinionated, you can always fall back to building with elements only without having to reinvent the wheel entirely.
+
+### Elements
+The elements layer contains the simplest and stupidest components. They are the smallest building blocks. They are opinionated, will hardly ever contain internal state and basically represent regular HTML elements with some added branding. Examples of elements are the `Button`, `Input` and `Title` components.
+
+### Components
+The components layer contains more complex and smarter components. They are probably the most used building blocks. They are a little opinionated, will sometimes contain internal state and represent regular use case components that group multiple elements together into a friendly interface. Examples of components are the `InputField` and other form field components, that provide an interface for adding labelling and error messaging to an input element.
+
+### Patterns
+The patterns layer contains example implementations of standardized element/component combinations. They are not actually components you can import and use in your code, but function more as a reference on how to work with the UI library to create rich interfaces. Examples of patterns could be `PageLayout` and `Header`, that combine multiple elements/components/plain HTML elements.
+
+## The `as` property
+To make components in this library as flexible as possible, most of them implement the `as` property pattern. The idea is simple: it allows you to render a component as every valid JSX element, so HTML elements or custom React components. It can be read in a sentence like this: "Render `ComponentA` **as** `ComponentB`". Popular examples are rendering an anchor that looks like a button, or a label that looks like a title:
+
+```jsx
+import { Button, Title } from "@yoast/ui-library";
+
+export default () => (
+    <>
+        <Button as="a" href="https://yoast.com">I look like a button but am actually an achor.</Button>
+        <Title as="label">I look like a title but am actually a label.</Title>
+    </>
+);
+```

--- a/packages/ui-library/src/introduction.stories.mdx
+++ b/packages/ui-library/src/introduction.stories.mdx
@@ -1,7 +1,7 @@
 import { Description, Meta } from "@storybook/addon-docs";
-import readme from "../readme.md";
+import introduction from "./introduction.md";
 
 <Meta title="Introduction" parameters={ { storyshots: { disable: true } } } />
 
-<Description markdown={ readme } />
+<Description markdown={ introduction } />
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The README of the `@yoast/ui-library` should be aimed at a different target audience, then the Storybook is aimed at.
  * The README should focus on developers interested on adding to the UI Library or its storybook,
  * The Storybook should focus on developers interested on using the UI library or checking the storybook.
* To give more room to certain parts of the introduction, this also splits up the introduction of the Storybook into several smaller pages.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves the documentation of the Storybook for the UI Library.

## Relevant technical choices:

* I've based this branch on top of a5539ebfb4ff5267cb09c33902d220af3bd342bf. This was the last commit in https://github.com/Yoast/wordpress-seo/pull/19775, which ensures the code of the UI library hasn't changed compared to the published (3.1.0) version. So the Storybook can be published from this branch, without showing a potentially changed UI library.
* The new documentation mainly spreads the original `README` over separate files, and rephrases some of its parts for the target audience.
  * Introduces a `contributing.md` to explain contributions. I've considered referencing the `/.github/CONTRIBUTING.md` file, but it's not that helpful on how to actively contribute.
  * Reuses the content of the `changelog.md` in the Storybook.
  * Hardcoded the order of these pages in the `.storybook/main.js` config. I came up with the order myself, it's definitely still open for discussion.
* Storybook uses PrismJS to render code snippets. Somehow that requires (shell) code snippets to contain at least 2 lines, before it applies a pretty formatting. So the first snippet in the installation guide now has an additional comment.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* From the root of the project run: `$ yarn && yarn workspace @yoast/ui-library storybook`
* The Storybook opens in your browser, check the new pages for any errors.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Only documentation for the Storybook, does not affect the UI library itself nor the plugin.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes https://github.com/Yoast/ui-library-storybook/issues/5.
