### PR TITLE
Add check to ensure author is correctly initialised

### DIFF
--- a/src/generators/schema/article.php
+++ b/src/generators/schema/article.php
@@ -49,7 +49,7 @@ class Article extends Abstract_Schema_Piece {
 			'@id'              => $this->context->canonical . Schema_IDs::ARTICLE_HASH,
 			'isPartOf'         => [ '@id' => $this->context->main_schema_id ],
 			'author'           => [
-				'name' => $this->helpers->schema->html->smart_strip_tags( $author->display_name ),
+				'name' => ( $author instanceof \WP_User ) ? $this->helpers->schema->html->smart_strip_tags( $author->display_name ) : '',
 				'@id'  => $this->helpers->schema->id->get_user_schema_id( $this->context->post->post_author, $this->context ),
 			],
 			'headline'         => $this->helpers->schema->html->smart_strip_tags( $this->helpers->post->get_post_title_with_fallback( $this->context->id ) ),

--- a/tests/unit/generators/schema/article-test.php
+++ b/tests/unit/generators/schema/article-test.php
@@ -257,7 +257,7 @@ class Article_Test extends TestCase {
 			->once()
 			->andReturn( $values_to_test['categories'] );
 
-		$user               = new \WP_User( 3 ); 
+		$user               = new \WP_User( 3 );
 		$user->display_name = 'John Doe';
 		Monkey\Functions\expect( 'get_userdata' )
 			->with( 3 )

--- a/tests/unit/generators/schema/article-test.php
+++ b/tests/unit/generators/schema/article-test.php
@@ -257,10 +257,12 @@ class Article_Test extends TestCase {
 			->once()
 			->andReturn( $values_to_test['categories'] );
 
+		$user               = new \WP_User( 3 ); 
+		$user->display_name = 'John Doe';
 		Monkey\Functions\expect( 'get_userdata' )
 			->with( 3 )
 			->once()
-			->andReturn( (object) [ 'display_name' => 'John Doe' ] );
+			->andReturn( $user );
 
 		$this->html
 			->expects( 'smart_strip_tags' )


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to avoid showing a php warning by ensuring we're using an instance of `WP_User` when expected.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Avoids issuing a php warning because of wrong variable type.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Create a new user with an `author` role
* Login with the new user account
* Create and publish a post
* Delete the user you've just created through the database `wp_users` table.
* Visit the post in the frontend and verify no php warnings stating `Attempt to read property "display_name" on bool` are issued
* Inspect the page code and verify:
  * the schema is valid 
  * the `author` property of the `Article` piece is as follows:
  ```
   "author": {
	   "name": "",
	    "@id": ""
   }
   ``` 
  * the `Person` piece is as follows:
  ```
   {
	"@type": "Person",
	"@id": "",
	"url": "https://wordpress.test/author/"
   }
  ```
#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* No other parts of the plugin other than the generation of the `Article` schema piece need to be tested.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes https://github.com/Yoast/wordpress-seo/issues/19623
