### PR TITLE
Remove beta label from the inclusive language assessment

### DIFF
--- a/admin/metabox/class-metabox-section-inclusive-language.php
+++ b/admin/metabox/class-metabox-section-inclusive-language.php
@@ -25,10 +25,9 @@ class WPSEO_Metabox_Section_Inclusive_Language implements WPSEO_Metabox_Section 
 	public function display_link() {
 		printf(
 			'<li role="presentation"><a role="tab" href="#wpseo-meta-section-%1$s" id="wpseo-meta-tab-%1$s" aria-controls="wpseo-meta-section-%1$s" class="wpseo-meta-section-link">
-				<div class="wpseo-score-icon-container" id="wpseo-inclusive-language-score-icon"></div><span>%2$s</span>&nbsp;%3$s</a></li>',
+				<div class="wpseo-score-icon-container" id="wpseo-inclusive-language-score-icon"></div><span>%2$s</span></a></li>',
 			esc_attr( $this->name ),
-			esc_html__( 'Inclusive language', 'wordpress-seo' ),
-			new Beta_Badge_Presenter( 'inclusive-language-beta-badge' )
+			esc_html__( 'Inclusive language', 'wordpress-seo' )
 		);
 	}
 

--- a/admin/views/class-yoast-feature-toggles.php
+++ b/admin/views/class-yoast-feature-toggles.php
@@ -89,7 +89,6 @@ class Yoast_Feature_Toggles {
 			],
 			(object) [
 				'name'                => __( 'Inclusive language analysis', 'wordpress-seo' ),
-				'in_beta'             => true,
 				'supported_languages' => Language_Helper::$languages_with_inclusive_language_support,
 				'setting'             => 'inclusive_language_analysis_active',
 				'label'               => __( 'The inclusive language analysis offers suggestions to write more inclusive copy.', 'wordpress-seo' ),

--- a/packages/js/src/components/contentAnalysis/InclusiveLanguageAnalysis.js
+++ b/packages/js/src/components/contentAnalysis/InclusiveLanguageAnalysis.js
@@ -164,7 +164,6 @@ const InclusiveLanguageAnalysis = ( props ) => {
 				prefixIcon={ getIconForScore( inclusiveLanguageScore.className ) }
 				prefixIconCollapsed={ getIconForScore( inclusiveLanguageScore.className ) }
 				id={ "yoast-inclusive-language-analysis-collapsible-sidebar" }
-				hasBetaBadgeLabel={ true }
 			>
 				{ isMultilingualPluginActive() ? renderMultilingualPluginDetectedNotice() : null }
 				{ results.length >= 1 ? renderResults() : renderGoodJob() }

--- a/packages/js/src/settings/routes/site-features.js
+++ b/packages/js/src/settings/routes/site-features.js
@@ -214,7 +214,6 @@ const SiteFeatures = () => {
 								cardId="card-wpseo-inclusive_language_analysis_active"
 								inputId="input-wpseo-inclusive_language_analysis_active"
 								imageSrc="/images/inclusive_language_analysis.png"
-								isBetaFeature={ true }
 								title={ __( "Inclusive language analysis", "wordpress-seo" ) }
 							>
 								<p>{ __( "The inclusive language analysis offers suggestions to write more inclusive copy, so more people will be able to relate to your content.", "wordpress-seo" ) }</p>


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Removes the beta badge for the _inclusive language_ assessment.
* [yoastseo] Removes the beta badge for the  _inclusive language_ assessment.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Without Premium activated
* Install and activate Yoast SEO
* Set the site language to English
* Open Yoast SEO->Settings->Site features
* Check that the Beta label is not present for the _inclusive language_ assessment.
* Enable the Inclusive language feature
* Create or open a post
* Check that _inclusive language_ tab doesn't have beta badge
* Disable the Inclusive language feature
* Check that the Beta label is not present for the _inclusive language_ assessment.

#### With Premium activated
* Install and activate Yoast SEO
* Install and activate Yoast SEO Premium
* Repeat the steps for Free

#### With Woo activated
* Install and activate Yoast SEO
* Install and activate Woocommerce
* Install and activate Yoast SEO for Woocommerce
* Repeat the steps for Free

#### With both Premium and Woo activated
* Install and activate Yoast SEO
* Install and activate Yoast SEO Premium
* Install and activate Woocommerce
* Install and activate Yoast SEO for Woocommerce
* Repeat the steps for Free

#### Multisite
* Repeat the steps for Free in a Post and in a Taxonomy

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [x] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* No extra testing needed

## UI changes

* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes [#19827](https://github.com/Yoast/wordpress-seo/issues/19827)
