### PR TITLE
Add correct slug for the modal and add a version to make the buttons behave

### DIFF
--- a/inc/class-addon-manager.php
+++ b/inc/class-addon-manager.php
@@ -80,6 +80,19 @@ class WPSEO_Addon_Manager {
 	];
 
 	/**
+	 * Mapping of internal slugs to public slugs.
+	 *
+	 * @var array
+	 */
+	protected static $public_slugs = [
+		self::PREMIUM_SLUG      => 'wordpress-seo-premium',
+		self::NEWS_SLUG         => 'wpseo-news',
+		self::VIDEO_SLUG        => 'wpseo-video',
+		self::WOOCOMMERCE_SLUG  => 'wpseo-woocommerce',
+		self::LOCAL_SLUG        => 'wordpress-seo-local',
+	];
+
+	/**
 	 * Holds the site information data.
 	 *
 	 * @var stdClass
@@ -506,10 +519,13 @@ class WPSEO_Addon_Manager {
 			'requires'     => ( $plugin_info ) ? YOAST_SEO_WP_REQUIRED : null,
 		];
 
+		$slug = ( $plugin_info ) ? self::$public_slugs[ $subscription->product->slug ] : $subscription->product->slug;
+
 		return (object) [
+			'version'          => $subscription->product->version,
 			'new_version'      => $subscription->product->version,
 			'name'             => $subscription->product->name,
-			'slug'             => $subscription->product->slug,
+			'slug'             => $slug,
 			'plugin'           => $plugin_file,
 			'url'              => $subscription->product->store_url,
 			'last_update'      => $subscription->product->last_updated,

--- a/tests/unit/inc/addon-manager-test.php
+++ b/tests/unit/inc/addon-manager-test.php
@@ -610,6 +610,7 @@ class Addon_Manager_Test extends TestCase {
 		$this->assertEquals(
 			(object) [
 				'new_version'      => '10.0',
+				'version'          => '10.0',
 				'name'             => 'Extension',
 				'slug'             => 'yoast-seo-wordpress-premium',
 				'plugin'           => '',
@@ -858,6 +859,7 @@ class Addon_Manager_Test extends TestCase {
 					'response' => [
 						'wp-seo-premium.php' => (object) [
 							'new_version'      => '10.0',
+							'version'          => '10.0',
 							'name'             => 'Extension',
 							'slug'             => 'yoast-seo-wordpress-premium',
 							'plugin'           => '',
@@ -919,8 +921,9 @@ class Addon_Manager_Test extends TestCase {
 				'args'     => [ 'slug' => 'yoast-seo-wordpress-premium' ],
 				'expected' => (object) [
 					'new_version'      => '10.0',
+					'version'          => '10.0',
 					'name'             => 'Extension',
-					'slug'             => 'yoast-seo-wordpress-premium',
+					'slug'             => 'wordpress-seo-premium',
 					'plugin'           => '',
 					'url'              => 'https://example.org/store',
 					'last_update'      => 'yesterday',


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to show the correct values in the `view details` modal in the plugin overview.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Shows correct buttons in the plugin overview `view details` modal.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install the latest released versions of premium + all addons together with this PR.
* Make sure all the add-ons show the following information on the `view details` screen.
For example for `news`:
It shows the newest version: in this case 13.1 and it show a button that shows Latest Version Installed. This should be the case for all add-ons and premium.
<img width="774" alt="Untitled" src="https://user-images.githubusercontent.com/6975345/218698990-8b177fd2-4b88-4ddc-95df-db54e4cefe74.png">

* Download an older release of a plugin. And make sure it shows the following information.
It shows an upgrade banner that shows the actual newest version. And on the view details it shows `no` button.
<img width="1551" alt="image" src="https://user-images.githubusercontent.com/6975345/218699343-4441e789-c9b9-4c53-ab8d-dbbfb32203ae.png">

<img width="262" alt="image" src="https://user-images.githubusercontent.com/6975345/218699410-54a95a4e-6349-4424-86a2-270a3427c8b5.png">

* Download the newest premium RC. And make sure it shows the following information:
The version should still be the newest release version, but the button should show `Newer Version (20.*-RC1) Installed`
<img width="287" alt="image" src="https://user-images.githubusercontent.com/6975345/218701112-4ab73401-c3e9-4e97-abc5-40d3f5db8431.png">


#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:


This PR should only change the slug for add-ons/premium when the modal is open. But to make sure there are no unexpected changes.
Things to smoke test could be wp-admin/admin.php?page=wpseo_licenses. To make sure there are no changes between this PR and trunk. Remember to clear your transients every time you switch branches/RC's.
If there are any other places where we display information about our plugins whenever you have an active license check those too. For example wp-admin/site-health.php?tab=debug

## UI changes

* [X] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
