### PR TITLE
19858 WP 6.2 compatibility use React createRoot instead of render

### DIFF
--- a/admin/class-admin-asset-manager.php
+++ b/admin/class-admin-asset-manager.php
@@ -399,6 +399,9 @@ class WPSEO_Admin_Asset_Manager {
 			if ( in_array( self::PREFIX . 'analysis-package', $script['deps'], true ) ) {
 				$scripts[ $name ]['deps'][] = self::PREFIX . YoastSEO()->helpers->language->get_researcher_language() . '-language';
 			}
+			if ( in_array( 'wp-element', $script['deps'], true ) ) {
+				$scripts[ $name ]['deps'][] = self::PREFIX . 'wp-element-patch';
+			}
 		}
 
 		return $scripts;

--- a/config/webpack/paths.js
+++ b/config/webpack/paths.js
@@ -49,6 +49,7 @@ const getEntries = ( sourceDirectory = "./packages/js/src" ) => ( {
 	workouts: `${ sourceDirectory }/workouts.js`,
 	"wordproof-uikit": `${ sourceDirectory }/wordproof-uikit.js`,
 	"frontend-inspector-resources": `${ sourceDirectory }/frontend-inspector-resources.js`,
+	"wp-element-patch": `${ sourceDirectory }/wp-element-patch.js`,
 } );
 
 /**

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -15,7 +15,7 @@
     "@wordpress/blocks": "^11.1.2",
     "@wordpress/data": "^4.10.0",
     "@wordpress/dom-ready": "^2.10.0",
-    "@wordpress/element": "^2.19.1",
+    "@wordpress/element": "^5.3.1",
     "@wordpress/i18n": "^4.14.0",
     "@wordpress/url": "^3.17.0",
     "@yoast/analysis-report": "^1.21.0",
@@ -55,7 +55,7 @@
     "yup": "^0.32.11",
     "bowser": "^2.11.0",
     "react-hotkeys-hook": "^4.0.5",
-	"react-aria-live": "^2.0.5"
+    "react-aria-live": "^2.0.5"
   },
   "devDependencies": {
     "@babel/core": "^7.17.9",
@@ -75,7 +75,7 @@
     "jest": "^27.5.1"
   },
   "peerDependencies": {
-    "react": "16.14.0",
-    "react-dom": "16.14.0"
+    "react": "16.14.0 || ^17.0.2 || ^18.2.0",
+    "react-dom": "16.14.0 || ^17.0.2 || ^18.2.0"
   }
 }

--- a/packages/js/src/addon-installation.js
+++ b/packages/js/src/addon-installation.js
@@ -1,13 +1,12 @@
 /* global wpseoAddonInstallationL10n */
 
-import { render } from "@wordpress/element";
+import { createRoot } from "@wordpress/element";
 import AddonInstallation from "./components/AddonInstallation";
 
 const element = document.createElement( "div" );
 element.setAttribute( "id", "wpseo-app-element" );
 document.getElementById( "extensions" ).append( element );
 
-render(
-	<AddonInstallation nonce={ wpseoAddonInstallationL10n.nonce } addons={ wpseoAddonInstallationL10n.addons } />,
-	element
+createRoot( element ).render(
+	<AddonInstallation nonce={ wpseoAddonInstallationL10n.nonce } addons={ wpseoAddonInstallationL10n.addons } />
 );

--- a/packages/js/src/dashboard-widget.js
+++ b/packages/js/src/dashboard-widget.js
@@ -1,6 +1,6 @@
 /* global wpseoDashboardWidgetL10n, wpseoApi */
 // External dependencies.
-import { Component, render } from "@wordpress/element";
+import { Component, createRoot } from "@wordpress/element";
 
 /* Yoast dependencies */
 import { ArticleList as WordpressFeed } from "@yoast/components";
@@ -316,5 +316,5 @@ class DashboardWidget extends Component {
 const element = document.getElementById( "yoast-seo-dashboard-widget" );
 
 if ( element ) {
-	render( <DashboardWidget />, element );
+	createRoot( element ).render( <DashboardWidget /> );
 }

--- a/packages/js/src/first-time-configuration.js
+++ b/packages/js/src/first-time-configuration.js
@@ -1,5 +1,5 @@
 import domReady from "@wordpress/dom-ready";
-import { render } from "@wordpress/element";
+import { createRoot } from "@wordpress/element";
 import { Root } from "@yoast/ui-library";
 import { get } from "lodash";
 import FirstTimeConfigurationSteps from "./first-time-configuration/first-time-configuration-steps";
@@ -13,10 +13,9 @@ domReady( () => {
 		return;
 	}
 
-	render(
+	createRoot( root ).render(
 		<Root context={ context }>
 			<FirstTimeConfigurationSteps />
-		</Root>,
-		root
+		</Root>
 	);
 } );

--- a/packages/js/src/help-scout-beacon.js
+++ b/packages/js/src/help-scout-beacon.js
@@ -1,4 +1,4 @@
-import { render, useState, Fragment } from "@wordpress/element";
+import { createRoot, useState, Fragment } from "@wordpress/element";
 import styled, { createGlobalStyle } from "styled-components";
 import { __ } from "@wordpress/i18n";
 
@@ -21,7 +21,7 @@ function renderComponent( component ) {
 	const element = document.createElement( "div" );
 	element.setAttribute( "id", "yoast-helpscout-beacon" );
 
-	render( component, element );
+	createRoot( element ).render( component );
 
 	document.body.appendChild( element );
 }

--- a/packages/js/src/helpers/classicEditor.js
+++ b/packages/js/src/helpers/classicEditor.js
@@ -1,4 +1,4 @@
-import { render, Component as wpComponent, createRef } from "@wordpress/element";
+import { Component as wpComponent, createRef, createRoot } from "@wordpress/element";
 import { SlotFillProvider } from "@wordpress/components";
 import MetaboxPortal from "../components/portals/MetaboxPortal";
 import getL10nObject from "../analysis/getL10nObject";
@@ -73,20 +73,22 @@ export function renderClassicEditorMetabox( store ) {
 		isRtl: localizedData.isRtl,
 	};
 
-	render(
-		(
-			<SlotFillProvider>
-				<Root context={ classicMetaboxContext }>
-					<MetaboxPortal
-						target="wpseo-metabox-root"
-						store={ store }
-						theme={ theme }
-					/>
-				</Root>
-				<RegisteredComponentsContainer ref={ containerRef } />
-			</SlotFillProvider>
-		),
-		document.getElementById( "wpseo-metabox-root" )
+	const root = document.getElementById( "wpseo-metabox-root" );
+	if ( ! root ) {
+		return;
+	}
+
+	createRoot( root ).render(
+		<SlotFillProvider>
+			<Root context={ classicMetaboxContext }>
+				<MetaboxPortal
+					target="wpseo-metabox-root"
+					store={ store }
+					theme={ theme }
+				/>
+			</Root>
+			<RegisteredComponentsContainer ref={ containerRef } />
+		</SlotFillProvider>
 	);
 
 	registeredComponents.forEach( ( registered ) => {

--- a/packages/js/src/helpers/reactRoot.js
+++ b/packages/js/src/helpers/reactRoot.js
@@ -1,5 +1,5 @@
 import { SlotFillProvider } from "@wordpress/components";
-import { Component as wpComponent, createRef, Fragment, render } from "@wordpress/element";
+import { Component as wpComponent, createRef, createRoot, Fragment } from "@wordpress/element";
 import getL10nObject from "../analysis/getL10nObject";
 import TopLevelProviders from "../components/TopLevelProviders";
 
@@ -73,21 +73,23 @@ export function renderReactRoot( target, children ) {
 		isRtl: localizedData.isRtl,
 	};
 
-	render(
-		(
-			<TopLevelProviders
-				theme={ theme }
-				location={ "sidebar" }
-			>
-				<SlotFillProvider>
-					<Fragment>
-						{ children }
-						<RegisteredComponentsContainer ref={ containerRef } />
-					</Fragment>
-				</SlotFillProvider>
-			</TopLevelProviders>
-		),
-		document.getElementById( target )
+	const root = document.getElementById( target );
+	if ( ! root ) {
+		return;
+	}
+
+	createRoot( root ).render(
+		<TopLevelProviders
+			theme={ theme }
+			location={ "sidebar" }
+		>
+			<SlotFillProvider>
+				<Fragment>
+					{ children }
+					<RegisteredComponentsContainer ref={ containerRef } />
+				</Fragment>
+			</SlotFillProvider>
+		</TopLevelProviders>
 	);
 
 	registeredComponents.forEach( ( registered ) => {

--- a/packages/js/src/indexables-page.js
+++ b/packages/js/src/indexables-page.js
@@ -1,5 +1,5 @@
 import domReady from "@wordpress/dom-ready";
-import { render } from "@wordpress/element";
+import { createRoot } from "@wordpress/element";
 import { Root } from "@yoast/ui-library";
 import { get } from "lodash";
 import LandingPage from "./indexables-page/landing-page";
@@ -13,12 +13,11 @@ domReady( () => {
 		return;
 	}
 
-	render(
+	createRoot( root ).render(
 		<Root context={ context }>
 			<div className="yst-max-w-7xl yst-h-full yst-border-y yst-border-gray-300 yst-py-2">
 				<LandingPage />
 			</div>
-		</Root>,
-		root
+		</Root>
 	);
 } );

--- a/packages/js/src/indexation.js
+++ b/packages/js/src/indexation.js
@@ -1,4 +1,4 @@
-import { render } from "@wordpress/element";
+import { createRoot } from "@wordpress/element";
 import jQuery from "jquery";
 
 import Indexation from "./components/Indexation";
@@ -22,10 +22,12 @@ function renderRoot() {
 	}
 
 	if ( root ) {
-		render( <Indexation
-			preIndexingActions={ window.yoast.indexing.preIndexingActions }
-			indexingActions={ window.yoast.indexing.indexingActions }
-		/>, root );
+		createRoot( root ).render(
+			<Indexation
+				preIndexingActions={ window.yoast.indexing.preIndexingActions }
+				indexingActions={ window.yoast.indexing.indexingActions }
+			/>
+		);
 	}
 }
 

--- a/packages/js/src/initializers/settings-header.js
+++ b/packages/js/src/initializers/settings-header.js
@@ -1,5 +1,5 @@
 import { get } from "lodash";
-import { render } from "@wordpress/element";
+import { createRoot } from "@wordpress/element";
 import { ThemeProvider } from "styled-components";
 import WebinarPromoNotification from "../components/WebinarPromoNotification";
 
@@ -14,11 +14,10 @@ const initSettingsHeader = () => {
 	const webinarIntroSettingsUrl = get( window, "wpseoScriptData.webinarIntroSettingsUrl", "https://yoa.st/webinar-intro-settings" );
 
 	if ( reactRoot ) {
-		render(
+		createRoot( reactRoot ).render(
 			<ThemeProvider theme={ { isRtl } }>
 				<WebinarPromoNotification store="yoast-seo/settings" url={ webinarIntroSettingsUrl } />
-			</ThemeProvider>,
-			reactRoot
+			</ThemeProvider>
 		);
 	}
 };

--- a/packages/js/src/initializers/social-settings.js
+++ b/packages/js/src/initializers/social-settings.js
@@ -1,6 +1,6 @@
 import PropTypes from "prop-types";
 import apiFetch from "@wordpress/api-fetch";
-import { render, Fragment, useState, useCallback, useEffect } from "@wordpress/element";
+import { createRoot, Fragment, useState, useCallback, useEffect } from "@wordpress/element";
 import { CheckIcon } from "@heroicons/react/solid";
 import ImageSelectPortal from "../components/portals/ImageSelectPortal";
 import Portal from "../components/portals/Portal";
@@ -246,7 +246,7 @@ export default function initSocialSettings() {
 	const element = document.createElement( "div" );
 	document.body.appendChild( element );
 
-	render(
+	createRoot( element ).render(
 		<Fragment>
 			<ImageSelectPortal
 				label={ __( "Image", "wordpress-seo" ) }
@@ -264,7 +264,6 @@ export default function initSocialSettings() {
 			>
 				<SocialProfilesWrapper />
 			</Portal>
-		</Fragment>,
-		element
+		</Fragment>
 	);
 }

--- a/packages/js/src/settings/initialize.js
+++ b/packages/js/src/settings/initialize.js
@@ -1,7 +1,7 @@
 import { SlotFillProvider } from "@wordpress/components";
 import { dispatch, select } from "@wordpress/data";
 import domReady from "@wordpress/dom-ready";
-import { render } from "@wordpress/element";
+import { createRoot } from "@wordpress/element";
 import { Root } from "@yoast/ui-library";
 import { Formik } from "formik";
 import { chunk, filter, forEach, get, includes, reduce } from "lodash";
@@ -108,7 +108,7 @@ domReady( () => {
 
 	const isRtl = select( STORE_NAME ).selectPreference( "isRtl", false );
 
-	render(
+	createRoot( root ).render(
 		<Root context={ { isRtl } }>
 			<StyleSheetManager target={ shadowRoot }>
 				<SlotFillProvider>
@@ -123,7 +123,6 @@ domReady( () => {
 					</HashRouter>
 				</SlotFillProvider>
 			</StyleSheetManager>
-		</Root>,
-		root
+		</Root>
 	);
 } );

--- a/packages/js/src/wp-element-patch.js
+++ b/packages/js/src/wp-element-patch.js
@@ -1,0 +1,27 @@
+/**
+ * Ensures `reactRoot` is available on `window.wp.element`.
+ *
+ * In React 18 `render` is deprecated and `createRoot` should be used instead.
+ * WP 6.2 upgrades React to 18, via `@wordpress/element` (5.0.0).
+ * Therefor, we have to support both `render` and `createRoot`.
+ *
+ * This patch makes it so that we can always use `createRoot` in our code:
+ * * If you are on < WP 6.2 you will use `render` via this patch.
+ * * If you are on >= WP 6.2 you will use the normal `createRoot`.
+ *
+ * This patch can be removed once the lowest supported WP version is 6.2.
+ */
+if ( ! window.wp?.element?.createRoot && typeof window.wp?.element?.render === "function" ) {
+	/**
+	 * Adds a monkey patched `createRoot` that returns the old `render` with the new API.
+	 * @param {HTMLElement} domNode The node to render in.
+	 * @returns {{unmount: (function(): void), render: (function(*): *)}} Polyfill of `createRoot` via `render`.
+	 */
+	window.wp.element.createRoot = ( domNode ) => ( {
+		render: ( reactNode ) => {
+			console.warn( "Yoast SEO: Using patched `reactRoot.render()`!", domNode );
+			window.wp.element.render( reactNode, domNode );
+		},
+		unmount: () => console.error( "Unsupported in this patch!" ),
+	} );
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5678,6 +5678,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-dom@^18.0.6":
+  version "18.0.10"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.0.10.tgz#3b66dec56aa0f16a6cc26da9e9ca96c35c0b4352"
+  integrity sha512-E42GW/JA4Qv15wQdqJq8DL4JhNpB3prJgjgapN3qJT9K2zO5IIAQh4VXvCEDupoqAwnz0cY4RlXeC/ajX5SFHg==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-test-renderer@^16.9.5":
   version "16.9.5"
   resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-16.9.5.tgz#edab67da470f7c3e997f58d55dcfe2643cc30a68"
@@ -5707,6 +5714,15 @@
   version "17.0.39"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.39.tgz#d0f4cde092502a6db00a1cded6e6bf2abb7633ce"
   integrity sha512-UVavlfAxDd/AgAacMa60Azl7ygyQNRwC/DsHZmKgNvPmRR5p70AJ5Q9EAmL2NWOJmeV+vVUI4IAP7GZrN8h8Ug==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
+"@types/react@^18.0.21":
+  version "18.0.28"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.28.tgz#accaeb8b86f4908057ad629a26635fe641480065"
+  integrity sha512-RD0ivG1kEztNBdoAK7lekI9M+azSnitIn85h4iOiaLjaTrMjzslhaqCGaI4IyCJ1RljWiLCEu4jyrLLgqxBTew==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -6986,7 +7002,7 @@
     react-autosize-textarea "^7.1.0"
     rememo "^3.0.0"
 
-"@wordpress/element@^2.14.0", "@wordpress/element@^2.19.1", "@wordpress/element@^2.20.1":
+"@wordpress/element@^2.14.0", "@wordpress/element@^2.20.1":
   version "2.20.1"
   resolved "https://registry.yarnpkg.com/@wordpress/element/-/element-2.20.1.tgz#19333bafe932c3be89df385c832c28dc76df3395"
   integrity sha512-aHfv3rnY8yea3VvfabPpyQXuYTQLKMcOSRxG+ydxptQNlQjEBe+KtCXyqr5g7bpqEBT5waFSr3IbJKk+G+hZxA==
@@ -7049,6 +7065,20 @@
     react "^17.0.2"
     react-dom "^17.0.2"
 
+"@wordpress/element@^5.3.1":
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/@wordpress/element/-/element-5.3.1.tgz#d363258a393bcf2abc7c28b410dd6d5d96035c59"
+  integrity sha512-nclaoD9jFXZVCWDkjplLySkqDQcmvgJYKZRMKaOOyHZmjHboOSVJF1zhNtpES2Mr2McHDWqEbJ5hoWkkA8eZVg==
+  dependencies:
+    "@babel/runtime" "^7.16.0"
+    "@types/react" "^18.0.21"
+    "@types/react-dom" "^18.0.6"
+    "@wordpress/escape-html" "^2.26.1"
+    change-case "^4.1.2"
+    is-plain-object "^5.0.0"
+    react "^18.2.0"
+    react-dom "^18.2.0"
+
 "@wordpress/escape-html@^1.12.1":
   version "1.12.1"
   resolved "https://registry.yarnpkg.com/@wordpress/escape-html/-/escape-html-1.12.1.tgz#1ecb9a269786706bbc7a4c06ddf2b949dca272d3"
@@ -7074,6 +7104,13 @@
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/@wordpress/escape-html/-/escape-html-2.11.0.tgz#26bb0cf4788c33eb9a8873aa2ff3c5ee57e0147d"
   integrity sha512-cEnYvKlgnJeapP3CXW5OqcLKWUkpwehm0RsVHZN05xkwf6A431hsAf2kgij455+rNxuR42nbd7JA50wIbK8Xig==
+  dependencies:
+    "@babel/runtime" "^7.16.0"
+
+"@wordpress/escape-html@^2.26.1":
+  version "2.26.1"
+  resolved "https://registry.yarnpkg.com/@wordpress/escape-html/-/escape-html-2.26.1.tgz#8c2432d5f86b3757d0da7c693ccf089f200804ed"
+  integrity sha512-gej9h7t6j2X7vM9eFREdNAZ4ExHAkvnSHTe8NMr4iCDG+Vr891MHRLqTcqaVg5kOeQEnSnBgesXRXShUpUvqJw==
   dependencies:
     "@babel/runtime" "^7.16.0"
 
@@ -10738,7 +10775,7 @@ callsites@^3.0.0:
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
   integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
 
-camel-case@^4.1.1:
+camel-case@^4.1.1, camel-case@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/camel-case/-/camel-case-4.1.2.tgz#9728072a954f805228225a6deea6b38461e1bd5a"
   integrity sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==
@@ -10817,6 +10854,15 @@ capability@^0.2.5:
   version "0.2.5"
   resolved "https://registry.yarnpkg.com/capability/-/capability-0.2.5.tgz#51ad87353f1936ffd77f2f21c74633a4dea88801"
   integrity sha1-Ua2HNT8ZNv/Xfy8hx0YzpN6oiAE=
+
+capital-case@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/capital-case/-/capital-case-1.0.4.tgz#9d130292353c9249f6b00fa5852bee38a717e669"
+  integrity sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==
+  dependencies:
+    no-case "^3.0.4"
+    tslib "^2.0.3"
+    upper-case-first "^2.0.2"
 
 capture-exit@^1.2.0:
   version "1.2.0"
@@ -10940,6 +10986,24 @@ chalk@~0.4.0:
     ansi-styles "~1.0.0"
     has-color "~0.1.0"
     strip-ansi "~0.1.0"
+
+change-case@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/change-case/-/change-case-4.1.2.tgz#fedfc5f136045e2398c0410ee441f95704641e12"
+  integrity sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==
+  dependencies:
+    camel-case "^4.1.2"
+    capital-case "^1.0.4"
+    constant-case "^3.0.4"
+    dot-case "^3.0.4"
+    header-case "^2.0.4"
+    no-case "^3.0.4"
+    param-case "^3.0.4"
+    pascal-case "^3.1.2"
+    path-case "^3.0.4"
+    sentence-case "^3.0.4"
+    snake-case "^3.0.4"
+    tslib "^2.0.3"
 
 change-emitter@^0.1.2:
   version "0.1.6"
@@ -11770,6 +11834,15 @@ console.table@^0.10.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/consolidated-events/-/consolidated-events-2.0.2.tgz#da8d8f8c2b232831413d9e190dc11669c79f4a91"
   integrity sha512-2/uRVMdRypf5z/TW/ncD/66l75P5hH2vM/GR8Jf8HLc2xnfJtmina6F6du8+v4Z2vTrMo7jC+W1tmEEuuELgkQ==
+
+constant-case@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/constant-case/-/constant-case-3.0.4.tgz#3b84a9aeaf4cf31ec45e6bf5de91bdfb0589faf1"
+  integrity sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==
+  dependencies:
+    no-case "^3.0.4"
+    tslib "^2.0.3"
+    upper-case "^2.0.2"
 
 constants-browserify@^1.0.0:
   version "1.0.0"
@@ -17311,6 +17384,14 @@ he@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
+
+header-case@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/header-case/-/header-case-2.0.4.tgz#5a42e63b55177349cf405beb8d775acabb92c063"
+  integrity sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==
+  dependencies:
+    capital-case "^1.0.4"
+    tslib "^2.0.3"
 
 hex-color-regex@^1.1.0:
   version "1.1.0"
@@ -24380,7 +24461,7 @@ parallel-transform@^1.1.0:
     inherits "^2.0.3"
     readable-stream "^2.1.5"
 
-param-case@^3.0.3:
+param-case@^3.0.3, param-case@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/param-case/-/param-case-3.0.4.tgz#7d17fe4aa12bde34d4a77d91acfb6219caad01c5"
   integrity sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==
@@ -24558,6 +24639,14 @@ path-browserify@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-0.0.1.tgz#e6c4ddd7ed3aa27c68a20cc4e50e1a4ee83bbc4a"
   integrity sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==
+
+path-case@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/path-case/-/path-case-3.0.4.tgz#9168645334eb942658375c56f80b4c0cb5f82c6f"
+  integrity sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==
+  dependencies:
+    dot-case "^3.0.4"
+    tslib "^2.0.3"
 
 path-dirname@^1.0.0:
   version "1.0.2"
@@ -26595,6 +26684,14 @@ react-dom@^17.0.2:
     object-assign "^4.1.1"
     scheduler "^0.20.2"
 
+react-dom@^18.2.0:
+  version "18.2.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.2.0.tgz#22aaf38708db2674ed9ada224ca4aa708d821e3d"
+  integrity sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==
+  dependencies:
+    loose-envify "^1.1.0"
+    scheduler "^0.23.0"
+
 react-element-to-jsx-string@^14.3.4:
   version "14.3.4"
   resolved "https://registry.yarnpkg.com/react-element-to-jsx-string/-/react-element-to-jsx-string-14.3.4.tgz#709125bc72f06800b68f9f4db485f2c7d31218a8"
@@ -26971,6 +27068,13 @@ react@^17.0.2:
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
+
+react@^18.2.0:
+  version "18.2.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"
+  integrity sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==
+  dependencies:
+    loose-envify "^1.1.0"
 
 read-cache@^1.0.0:
   version "1.0.0"
@@ -28241,6 +28345,13 @@ scheduler@^0.20.2:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
 
+scheduler@^0.23.0:
+  version "0.23.0"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.23.0.tgz#ba8041afc3d30eb206a487b6b384002e4e61fdfe"
+  integrity sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==
+  dependencies:
+    loose-envify "^1.1.0"
+
 schema-utils@2.7.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-2.7.0.tgz#17151f76d8eae67fbbf77960c33c676ad9f4efc7"
@@ -28399,6 +28510,15 @@ send@0.17.1:
     on-finished "~2.3.0"
     range-parser "~1.2.1"
     statuses "~1.5.0"
+
+sentence-case@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/sentence-case/-/sentence-case-3.0.4.tgz#3645a7b8c117c787fde8702056225bb62a45131f"
+  integrity sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==
+  dependencies:
+    no-case "^3.0.4"
+    tslib "^2.0.3"
+    upper-case-first "^2.0.2"
 
 serialize-javascript@^1.4.0:
   version "1.9.1"
@@ -28706,6 +28826,14 @@ smart-buffer@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/smart-buffer/-/smart-buffer-4.2.0.tgz#6e1d71fa4f18c05f7d0ff216dd16a481d0e8d9ae"
   integrity sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==
+
+snake-case@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/snake-case/-/snake-case-3.0.4.tgz#4f2bbd568e9935abdfd593f34c691dadb49c452c"
+  integrity sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==
+  dependencies:
+    dot-case "^3.0.4"
+    tslib "^2.0.3"
 
 snapdragon-node@^2.0.1:
   version "2.1.1"
@@ -31167,6 +31295,20 @@ update-browserslist-db@^1.0.9:
   dependencies:
     escalade "^3.1.1"
     picocolors "^1.0.0"
+
+upper-case-first@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/upper-case-first/-/upper-case-first-2.0.2.tgz#992c3273f882abd19d1e02894cc147117f844324"
+  integrity sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==
+  dependencies:
+    tslib "^2.0.3"
+
+upper-case@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/upper-case/-/upper-case-2.0.2.tgz#d89810823faab1df1549b7d97a76f8662bae6f7a"
+  integrity sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==
+  dependencies:
+    tslib "^2.0.3"
 
 uri-js@^4.2.2:
   version "4.4.1"


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* React 18 is included in WP 6.2. This PR aims to increase compatibility between our plugin and WP 6.2 and WP 6.1.1 (and WP 6.0). By patching `window.wp.element` to include `createRoot` if not there while `render` is available, we make it so we can use the `createRoot` API. When the time comes to drop < WP 6.2 support, we can remove this WP element patch.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds a WP element `createRoot` "polyfill" to keep using the same API without React 18 support.

## Relevant technical choices:

* Patch `wp.element` to always have `createRoot` (if `render` is present). See context.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

*

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [x] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Anywhere we use `wp.element.createRoot` or import it from `@wordpress/element`.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes https://github.com/Yoast/wordpress-seo/issues/19858
