### PR TITLE
Wrong canonical/prev/next URLs on paginated pages with query params

### DIFF
--- a/src/helpers/pagination-helper.php
+++ b/src/helpers/pagination-helper.php
@@ -68,7 +68,23 @@ class Pagination_Helper {
 		$wp_rewrite = $this->wp_rewrite_wrapper->get();
 
 		if ( $wp_rewrite->using_permalinks() ) {
-			$url = \trailingslashit( $url );
+			$url_parts      = \wp_parse_url( $url );
+			$has_url_params = \array_key_exists( 'query', $url_parts );
+
+			if ( $has_url_params ) {
+				// We need to first remove the query params, before potentially adding the pagination parts.
+				\wp_parse_str( $url_parts['query'], $query_parts );
+
+				$url = \trailingslashit( \remove_query_arg( \array_keys( $query_parts ), $url ) );
+
+				if ( $add_pagination_base ) {
+					$url .= \trailingslashit( $wp_rewrite->pagination_base );
+				}
+
+				// We can now re-add the query params, after appending the last pagination parts. 
+				return \add_query_arg( $query_parts, \user_trailingslashit( $url . $page ) );
+			}
+
 			if ( $add_pagination_base ) {
 				$url .= \trailingslashit( $wp_rewrite->pagination_base );
 			}

--- a/src/helpers/pagination-helper.php
+++ b/src/helpers/pagination-helper.php
@@ -81,7 +81,7 @@ class Pagination_Helper {
 					$url .= \trailingslashit( $wp_rewrite->pagination_base );
 				}
 
-				// We can now re-add the query params, after appending the last pagination parts. 
+				// We can now re-add the query params, after appending the last pagination parts.
 				return \add_query_arg( $query_parts, \user_trailingslashit( $url . $page ) );
 			}
 

--- a/src/helpers/pagination-helper.php
+++ b/src/helpers/pagination-helper.php
@@ -86,7 +86,6 @@ class Pagination_Helper {
 			}
 
 			$url = \trailingslashit( $url );
-
 			if ( $add_pagination_base ) {
 				$url .= \trailingslashit( $wp_rewrite->pagination_base );
 			}

--- a/src/helpers/pagination-helper.php
+++ b/src/helpers/pagination-helper.php
@@ -85,6 +85,8 @@ class Pagination_Helper {
 				return \add_query_arg( $query_parts, \user_trailingslashit( $url . $page ) );
 			}
 
+			$url = \trailingslashit( $url );
+
 			if ( $add_pagination_base ) {
 				$url .= \trailingslashit( $wp_rewrite->pagination_base );
 			}

--- a/tests/unit/helpers/pagination-helper-test.php
+++ b/tests/unit/helpers/pagination-helper-test.php
@@ -106,6 +106,16 @@ class Pagination_Helper_Test extends TestCase {
 	public function test_get_paginated_url_using_permalinks_without_pagination_base() {
 		$this->using_permalinks( true );
 
+		$parsed_url = [
+			'scheme' => 'https',
+			'host'   => 'example.com',
+			'path'   => 'my-post',
+		];
+
+		Monkey\Functions\expect( 'wp_parse_url' )
+			->once()
+			->andReturn( $parsed_url );
+
 		$actual   = $this->instance->get_paginated_url( 'https://example.com/my-post/', 2, false );
 		$expected = 'https://example.com/my-post/2/';
 
@@ -119,6 +129,16 @@ class Pagination_Helper_Test extends TestCase {
 	 */
 	public function test_get_paginated_url_using_permalinks_with_pagination_base() {
 		$this->using_permalinks( true );
+
+		$parsed_url = [
+			'scheme' => 'https',
+			'host'   => 'example.com',
+			'path'   => 'my-post/page',
+		];
+
+		Monkey\Functions\expect( 'wp_parse_url' )
+			->once()
+			->andReturn( $parsed_url );
 
 		$actual   = $this->instance->get_paginated_url( 'https://example.com/my-post/', 2, true );
 		$expected = 'https://example.com/my-post/page/2/';

--- a/tests/unit/helpers/pagination-helper-test.php
+++ b/tests/unit/helpers/pagination-helper-test.php
@@ -105,6 +105,7 @@ class Pagination_Helper_Test extends TestCase {
 	 */
 	public function test_get_paginated_url_using_permalinks_without_pagination_base() {
 		$this->using_permalinks( true );
+		$url = 'https://example.com/my-post/';
 
 		$parsed_url = [
 			'scheme' => 'https',
@@ -114,9 +115,10 @@ class Pagination_Helper_Test extends TestCase {
 
 		Monkey\Functions\expect( 'wp_parse_url' )
 			->once()
+			->with( $url )
 			->andReturn( $parsed_url );
 
-		$actual   = $this->instance->get_paginated_url( 'https://example.com/my-post/', 2, false );
+		$actual   = $this->instance->get_paginated_url( $url, 2, false );
 		$expected = 'https://example.com/my-post/2/';
 
 		$this->assertEquals( $expected, $actual );
@@ -129,6 +131,7 @@ class Pagination_Helper_Test extends TestCase {
 	 */
 	public function test_get_paginated_url_using_permalinks_with_pagination_base() {
 		$this->using_permalinks( true );
+		$url = 'https://example.com/my-post/';
 
 		$parsed_url = [
 			'scheme' => 'https',
@@ -138,6 +141,7 @@ class Pagination_Helper_Test extends TestCase {
 
 		Monkey\Functions\expect( 'wp_parse_url' )
 			->once()
+			->with( $url )
 			->andReturn( $parsed_url );
 
 		$actual   = $this->instance->get_paginated_url( 'https://example.com/my-post/', 2, true );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to fix a bug with the canonical/prev/next URLs of paginated pages that have query parameters.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where query parameters would be added in the middle of canonical and prev and next links, in paginated pages. Props to @andreas-pa

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

### Before you start make sure that you have the option `Show author archives in search results` and `Show date archives in search results`

#### For paginated terms:
* Add the following filter on your theme's functions.php
```
add_filter( 'term_link', function( $url ) {
	$args = [
		'foo' => 'bar',
		'x' => 'y',
	];
	return add_query_arg( $args, $url );
} );
```
* To make testing easier, go to Settings->Reading and set `Blog pages show at most` to 2. Then create 8 posts for a category
* Visit the frontend of the 3rd page of that category, eg. `http://wordpress.test/category/uncategorized/page/3/?foo=bar&x=y` and check the page source

_Without this PR/RC_:
* You would have the following tags for canonical/next/prev URLs: (notice the params being in the middle of the URLs)
```
	<link rel="canonical" href="http://wordpress.test/category/uncategorized/?foo=bar&x=y/page/3/" class="yoast-seo-meta-tag" />
	<link rel="prev" href="http://wordpress.test/category/uncategorized/?foo=bar&x=y/page/2/" class="yoast-seo-meta-tag" />
	<link rel="next" href="http://wordpress.test/category/uncategorized/?foo=bar&x=y/page/4/" class="yoast-seo-meta-tag" />
```
_With this PR/RC_:
* You would have the following tags for canonical/next/prev URLs: (notice the params being in the end of the URLs)
```
	<link rel="canonical" href="http://wordpress.test/category/uncategorized/page/3/?foo=bar&x=y" class="yoast-seo-meta-tag" />
	<link rel="prev" href="http://wordpress.test/category/uncategorized/page/2/?foo=bar&x=y" class="yoast-seo-meta-tag" />
	<link rel="next" href="http://wordpress.test/category/uncategorized/page/4/?foo=bar&x=y" class="yoast-seo-meta-tag" />
```

#### For paginated homepage:
* Continuing from above, install WPML (and cleanup indexable when you do) and create translated posts for at least 6 of the created posts
* In Settings->Reading, make sure you have `Your latest posts` as Your homepage displays.
* Go to the 2nd page of the homepage for the translated language, eg. `http://wordpress.test/page/2/?lang=el`
_Without this PR/RC_:
* You would have the following tags for canonical/next/prev URLs: (notice the params being in the middle of the URLs)
```
	<link rel="canonical" href="http://wordpress.test/?lang=el/page/2/" class="yoast-seo-meta-tag" />
	<link rel="prev" href="http://wordpress.test/?lang=el" class="yoast-seo-meta-tag" />
	<link rel="next" href="http://wordpress.test/?lang=el/page/3/" class="yoast-seo-meta-tag" />
```
_With this PR/RC_:
* You would have the following tags for canonical/next/prev URLs: (notice the params being in the end of the URLs)
```
	<link rel="canonical" href="http://wordpress.test/page/2/?lang=el" class="yoast-seo-meta-tag" />
	<link rel="prev" href="http://wordpress.test/?lang=el" class="yoast-seo-meta-tag" />
	<link rel="next" href="http://wordpress.test/page/3/?lang=el" class="yoast-seo-meta-tag" />
```
#### For paginated post types (eg. pages):
* Create a page and add 3 page break blocks in the content.
* Install WPML and set up a new language.
* Go to the page you created and duplicate it to the new language 
* Go to the site's homepage, navigate to the 3rd page of it, eg. `http://wordpress.test/test/3/` and from there visit the other language's respective page, eg `wordpress.test/test/3/?lang=el`:
_Without this PR/RC_:
* You would have the following tags for canonical/next/prev URLs: (notice the params being in the middle of the URLs)
```
	<link rel="canonical" href="http://wordpress.test/test/?lang=el/3/" class="yoast-seo-meta-tag" />
	<link rel="prev" href="http://wordpress.test/test/?lang=el/2/" class="yoast-seo-meta-tag" />
	<link rel="next" href="http://wordpress.test/test/?lang=el/4/" class="yoast-seo-meta-tag" />
```
_With this PR/RC_:
* You would have the following tags for canonical/next/prev URLs: (notice the params being in the end of the URLs)
```
	<link rel="canonical" href="http://wordpress.test/test/3/?lang=el" class="yoast-seo-meta-tag" />
	<link rel="prev" href="http://wordpress.test/test/2/?lang=el" class="yoast-seo-meta-tag" />
	<link rel="next" href="http://wordpress.test/test/4/?lang=el" class="yoast-seo-meta-tag" />
```

#### For paginated author pages:
* Add the following filter on your theme's functions.php
```
add_filter( 'author_link', function( $url ) {
	$args = [
		'foo' => 'bar',
	];
	return add_query_arg( $args, $url );
} );
```
* To make testing easier, go to Settings->Reading and set `Blog pages show at most` to 2. Then create 4 posts from a user
* Visit the frontend of the 2nd page of that user, eg. `http://wordpress.test/author/admin/page/2/?foo=bar` and check the page source

_Without this PR/RC_:
* You would have the following tags for canonical/next/prev URLs: (notice the params being in the middle of the URLs)
```
	<link rel="canonical" href="http://wordpress.test/author/admin/?foo=bar/page/2/" class="yoast-seo-meta-tag" />
	<link rel="prev" href="http://wordpress.test/author/admin/?foo=bar" class="yoast-seo-meta-tag" />
	<link rel="next" href="http://wordpress.test/author/admin/?foo=bar/page/3/" class="yoast-seo-meta-tag" />
```
_With this PR/RC_:
* You would have the following tags for canonical/next/prev URLs: (notice the params being in the end of the URLs)
```
	<link rel="canonical" href="http://wordpress.test/author/admin/page/2/?foo=bar" class="yoast-seo-meta-tag" />
	<link rel="prev" href="http://wordpress.test/author/admin/?foo=bar" class="yoast-seo-meta-tag" />
	<link rel="next" href="http://wordpress.test/author/admin/page/3/?foo=bar" class="yoast-seo-meta-tag" />
```

#### For paginated Woo pages:
* Set up WooCommerce and Yoast SEO
* Have this filter active:
```
add_filter( 'page_link', function( $url ) {
    return add_query_arg( 'foo', 'bar', $url );
} );
```
* Go to Appearance > Customize > WooCommerce > Product catalog > Set "Products per row:2" and "Rows per page:1"
* Go to the Shop page and navigate to its 2nd page, eg. http://wordpress.test/shop/page/2/?foo=bar and check the page source

_Without this PR/RC_:
* You would have the following tags for canonical/next/prev URLs: (notice the params being in the middle of the URLs)
```
	<link rel="canonical" href="http://wordpress.test/shop/?foo=bar/page/2/" class="yoast-seo-meta-tag" />
	<link rel="prev" href="http://wordpress.test/shop/?foo=bar" class="yoast-seo-meta-tag" />
```
_With this PR/RC_:
* You would have the following tags for canonical/next/prev URLs: (notice the params being in the end of the URLs)
```
	<link rel="canonical" href="http://wordpress.test/shop/page/2/?foo=bar"" class="yoast-seo-meta-tag" />
	<link rel="prev" href="http://wordpress.test/shop/?foo=bar" class="yoast-seo-meta-tag" />
```

#### For paginated static home pages:
* Create a page and add 3 page break blocks in the content.
* Make that page the site's homepage
* Install WPML and set up a new language.
* Go to the page you created and duplicate it to the new language 
* Go to the site's homepage, navigate to the 3rd page of it, eg. `http://wordpress.test/page/3` and from there visit the other language's respective page, eg `http://wordpress.test/page/3/?lang=el`:
_Without this PR/RC_:
* You would have the following tags for canonical/next/prev URLs: (notice the params being in the middle of the URLs)
```
	<link rel="canonical" href="http://wordpress.test/?lang=el/page/3/" class="yoast-seo-meta-tag" />
	<link rel="prev" href="http://wordpress.test/?lang=el/page/2/" class="yoast-seo-meta-tag" />
	<link rel="next" href="http://wordpress.test/?lang=el/page/4/" class="yoast-seo-meta-tag" />
```
_With this PR/RC_:
* You would have the following tags for canonical/next/prev URLs: (notice the params being in the end of the URLs)
```
	<link rel="canonical" href="http://wordpress.test/page/3/?lang=el" class="yoast-seo-meta-tag" />
	<link rel="prev" href="http://wordpress.test/page/2/?lang=el" class="yoast-seo-meta-tag" />
	<link rel="next" href="http://wordpress.test/page/4/?lang=el" class="yoast-seo-meta-tag" />
```

#### For paginated date archives:
* Have this filter active:
```
add_filter( 'year_link', function( $url ) {
    return add_query_arg( 'foo', 'bar', $url );
} );
```
* Create a post and add an `Archives` block there, that sorts posts based on the year. Publish the post and go to its frontend
* Click on one year's link and go to eg. `http://wordpress.test/2023/?foo=bar`
```
	<link rel="canonical" href="http://wordpress.test/2023/?foo=bar" class="yoast-seo-meta-tag" />
	<link rel="next" href="http://wordpress.test/2023/?foo=bar/page/2/" class="yoast-seo-meta-tag" />
```
_With this PR/RC_:
* You would have the following tags for canonical/next/prev URLs: (notice the params being in the end of the URLs)
```
	<link rel="canonical" href="http://wordpress.test/2023/?foo=bar" class="yoast-seo-meta-tag" />
	<link rel="next" href="http://wordpress.test/2023/page/2/?foo=bar" class="yoast-seo-meta-tag" />
```

#### For paginated static post page:
* Add the following filter on your theme's functions.php
```
add_filter( 'page_link', function( $url ) {
	$args = [
		'foo' => 'bar',
	];
	return add_query_arg( $args, $url );
} );
```
* Go to Reading->Settings, and set the Posts Page as a page you have created (you can use a subpage for that, eg. `http://wordpress.test/test-page/subpage`)
* Visit the frontend of the 2nd page of that page, eg. `http://wordpress.test/test-page/subpage/?foo=bar` and check the page source

_Without this PR/RC_:
* You would have the following tags for canonical/next/prev URLs: (notice the params being in the middle of the URLs)
```
	<link rel="canonical" href="http://wordpress.test/test-page/subpage/?foo=bar/page/2/" class="yoast-seo-meta-tag" />
	<link rel="prev" href="http://wordpress.test/test-page/subpage/?foo=bar" class="yoast-seo-meta-tag" />
	<link rel="next" href="http://wordpress.test/test-page/subpage/?foo=bar/page/3/" class="yoast-seo-meta-tag" />
```
_With this PR/RC_:
* You would have the following tags for canonical/next/prev URLs: (notice the params being in the end of the URLs)
```
	<link rel="canonical" href="http://wordpress.test/test-page/subpage/page/2/?foo=bar" class="yoast-seo-meta-tag" />
	<link rel="prev" href="http://wordpress.test/test-page/subpage/?foo=bar" class="yoast-seo-meta-tag" />
	<link rel="next" href="http://wordpress.test/test-page/subpage/page/3/?foo=bar" class="yoast-seo-meta-tag" />
```

#### For paginated post type archives:
* Install WPML and Yoast Test Helper (clean up indexables also)
* Activate Books from the Test Helper and go to WPML's settings and activate books for translations (Post Types Translation)
* Create 3 Books and translate them all 
* Go to the second page of the book archive in the translated languages, eg. `http://wordpress.test/my-books/page/2/?lang=el`
_Without this PR/RC_:
* You would have the following tags for canonical/next/prev URLs: (notice the params being in the middle of the URLs)
```
	<link rel="canonical" href="http://wordpress.test/my-books/?lang=el/page/2/" class="yoast-seo-meta-tag" />
	<link rel="prev" href="http://wordpress.test/my-books/?lang=el" class="yoast-seo-meta-tag" />
```
_With this PR/RC_:
* You would have the following tags for canonical/next/prev URLs: (notice the params being in the end of the URLs)
```
	<link rel="canonical" href="http://wordpress.test/my-books/page/2/?lang=el" class="yoast-seo-meta-tag" />
	<link rel="prev" href="http://wordpress.test/my-books/?lang=el" class="yoast-seo-meta-tag" />
```
#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Pagination.
  * A good test for that would be to repeat the test instructions, but without the filters (or in the case of the Home page section, without WPML enabled) and confirm that the canonical/prev/next URLs are the same with the production versions.
  * Make sure that when you remove the filters, you clean up indexables as well.
  * Check that functionality `Crawl Cleanup -> Advanced: URL cleanup` works as expected.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
