### PR TITLE
Move the creation of anchor opening tag to after merging the configs

### DIFF
--- a/packages/yoastseo/spec/scoring/collectionPages/cornerstone/seoAssessorSpec.js
+++ b/packages/yoastseo/spec/scoring/collectionPages/cornerstone/seoAssessorSpec.js
@@ -3,7 +3,7 @@ import Assessor from "../../../../src/scoring/collectionPages/cornerstone/seoAss
 import Paper from "../../../../src/values/Paper.js";
 import getResults from "../../../specHelpers/getAssessorResults";
 import keyPhraseDistribution from "../../../../src/languageProcessing/researches/keyphraseDistribution";
-
+import KeyphraseDistributionAssessment from "../../../../src/scoring/assessments/seo/KeyphraseDistributionAssessment";
 
 describe( "running assessments in the collection page cornerstone SEO assessor", function() {
 	let assessor;
@@ -44,8 +44,6 @@ describe( "running assessments in the collection page cornerstone SEO assessor",
 			imageKeyphraseCTAUrl: "https://yoast.com/30",
 			imageAltTagsUrlTitle: "https://yoast.com/31",
 			imageAltTagsCTAUrl: "https://yoast.com/32",
-			keyphraseDistributionUrlTitle: "https://yoast.com/33",
-			keyphraseDistributionCTAUrl: "https://yoast.com/34",
 			productIdentifierUrlTitle: "https://yoast.com/35",
 			productIdentifierCTAUrl: "https://yoast.com/36",
 			productSKUUrlTitle: "https://yoast.com/37",
@@ -54,6 +52,11 @@ describe( "running assessments in the collection page cornerstone SEO assessor",
 
 		researcher.addResearch( "keyphraseDistribution", keyPhraseDistribution );
 		assessor = new Assessor( researcher, options );
+		// Add Keyphrase distribution assessment to the assessor, which is available in this assessor in Shopify.
+		assessor.addAssessment( "keyphraseDistribution", new KeyphraseDistributionAssessment( {
+			urlTitle: "https://yoa.st/shopify30",
+			urlCallToAction: "https://yoa.st/shopify31",
+		} ) );
 	} );
 
 	it( "runs assessments without any specific requirements", function() {

--- a/packages/yoastseo/spec/scoring/collectionPages/fullTextTests/runFullTextTests.js
+++ b/packages/yoastseo/spec/scoring/collectionPages/fullTextTests/runFullTextTests.js
@@ -106,8 +106,8 @@ testPapers.forEach( function( testPaper ) {
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify55" ),
 		} );
 		const keyphraseDistributionAssessment = new KeyphraseDistribution( {
-			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify30" ),
-			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify31" ),
+			urlTitle: "https://yoa.st/shopify30",
+			urlCallToAction: "https://yoa.st/shopify31",
 		} );
 		const subheadingDistributionTooLongAssessment = new SubheadingDistributionTooLongAssessment( {
 			shouldNotAppearInShortText: true,
@@ -139,8 +139,8 @@ testPapers.forEach( function( testPaper ) {
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify65" ),
 		} );
 		const wordComplexityAssessment = new WordComplexityAssessment( {
-			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify77" ),
-			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify78" ),
+			urlTitle: "https://yoa.st/shopify77",
+			urlCallToAction: "https://yoa.st/shopify78",
 		} );
 
 		// SEO assessments.

--- a/packages/yoastseo/spec/scoring/collectionPages/seoAssessorSpec.js
+++ b/packages/yoastseo/spec/scoring/collectionPages/seoAssessorSpec.js
@@ -2,6 +2,7 @@ import DefaultResearcher from "../../../src/languageProcessing/languages/_defaul
 import Assessor from "../../../src/scoring/collectionPages/seoAssessor.js";
 import Paper from "../../../src/values/Paper.js";
 import getResults from "../../specHelpers/getAssessorResults";
+import KeyphraseDistributionAssessment from "../../../src/scoring/assessments/seo/KeyphraseDistributionAssessment";
 import keyPhraseDistribution from "../../../src/languageProcessing/researches/keyphraseDistribution";
 
 describe( "running assessments in the collection page SEO assessor", function() {
@@ -11,6 +12,11 @@ describe( "running assessments in the collection page SEO assessor", function() 
 		const researcher = new DefaultResearcher();
 		researcher.addResearch( "keyphraseDistribution", keyPhraseDistribution );
 		assessor = new Assessor( researcher );
+		// Add Keyphrase distribution assessment to the assessor, which is available in this assessor in Shopify.
+		assessor.addAssessment( "keyphraseDistribution", new KeyphraseDistributionAssessment( {
+			urlTitle: "https://yoa.st/shopify30",
+			urlCallToAction: "https://yoa.st/shopify31",
+		} ) );
 	} );
 
 	it( "runs assessments without any specific requirements", function() {

--- a/packages/yoastseo/spec/scoring/productPages/fullTextTests/runFullTextTests.js
+++ b/packages/yoastseo/spec/scoring/productPages/fullTextTests/runFullTextTests.js
@@ -160,8 +160,8 @@ testPapers.forEach( function( testPaper ) {
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify41" ),
 		} );
 		const keyphraseDistributionAssessment = new KeyphraseDistribution( {
-			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify30" ),
-			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify31" ),
+			urlTitle: "https://yoa.st/shopify30",
+			urlCallToAction: "https://yoa.st/shopify31",
 		} );
 		const subheadingDistributionTooLongAssessment = new SubheadingDistributionTooLongAssessment( {
 			shouldNotAppearInShortText: true,
@@ -199,8 +199,8 @@ testPapers.forEach( function( testPaper ) {
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify39" ),
 		} );
 		const wordComplexityAssessment = new WordComplexityAssessment( {
-			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify77" ),
-			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify78" ),
+			urlTitle: "https://yoa.st/shopify77",
+			urlCallToAction: "https://yoa.st/shopify78",
 		} );
 
 		// SEO assessments.

--- a/packages/yoastseo/spec/scoring/storePostsAndPages/contentAssessorSpec.js
+++ b/packages/yoastseo/spec/scoring/storePostsAndPages/contentAssessorSpec.js
@@ -1,27 +1,43 @@
-import EnglishResearcher from "../../../src/languageProcessing/languages/en/Researcher";
-import DutchResearcher from "../../../src/languageProcessing/languages/nl/Researcher";
-import DefaultResearcher from "../../../src/languageProcessing/languages/_default/Researcher";
+import { forEach } from "lodash-es";
 import ContentAssessor from "../../../src/scoring/storePostsAndPages/contentAssessor.js";
 import AssessmentResult from "../../../src/values/AssessmentResult.js";
 import Paper from "../../../src/values/Paper.js";
 
-import { forEach } from "lodash-es";
+import EnglishResearcher from "../../../src/languageProcessing/languages/en/Researcher";
+import DutchResearcher from "../../../src/languageProcessing/languages/nl/Researcher";
+import DefaultResearcher from "../../../src/languageProcessing/languages/_default/Researcher";
+import WordComplexityAssessment from "../../../src/scoring/assessments/readability/WordComplexityAssessment";
+import wordComplexity from "../../../src/languageProcessing/researches/wordComplexity";
 
-describe( "A content assessor", function() {
+import getWordComplexityConfig from "../../specHelpers/getWordComplexityConfig";
+import getWordComplexityHelper from "../../specHelpers/getWordComplexityHelper";
+
+describe( "A content assessor for English", function() {
+	let results, contentAssessor, researcher, paper;
+
+	beforeAll( function() {
+		paper = new Paper();
+		researcher = new EnglishResearcher( paper );
+		// Also register the assessment, research, helper, and config for Word Complexity for testing purposes.
+		researcher.addResearch( "wordComplexity", wordComplexity );
+		researcher.addHelper( "checkIfWordIsComplex", getWordComplexityHelper( "en" ) );
+		researcher.addConfig( "wordComplexity", getWordComplexityConfig( "en" ) );
+		contentAssessor = new ContentAssessor( researcher );
+		contentAssessor.addAssessment( "wordComplexity", new WordComplexityAssessment( {
+			urlTitle: "https://yoa.st/shopify77",
+			urlCallToAction: "https://yoa.st/shopify78",
+		} ) );
+
+		contentAssessor.getValidResults = function() {
+			return results;
+		};
+
+		contentAssessor.getPaper = function() {
+			return paper;
+		};
+	} );
+
 	describe( "calculatePenaltyPoints", function() {
-		let contentAssessor;
-		let results;
-		const paper = new Paper();
-		beforeEach( function() {
-			contentAssessor = new ContentAssessor( new EnglishResearcher( paper ) );
-			contentAssessor.getValidResults = function() {
-				return results;
-			};
-			contentAssessor.getPaper = function() {
-				return paper;
-			};
-		} );
-
 		it( "should have no points for an empty result set", function() {
 			results = [];
 			const expected = 0;
@@ -96,18 +112,10 @@ describe( "A content assessor", function() {
 	} );
 
 	describe( "calculateOverallScore for English", function() {
-		let points, results, contentAssessor;
-
+		let points;
 		beforeEach( function() {
-			contentAssessor = new ContentAssessor( new EnglishResearcher() );
-			contentAssessor.getValidResults = function() {
-				return results;
-			};
 			contentAssessor.calculatePenaltyPoints = function() {
 				return points;
-			};
-			contentAssessor.getPaper = function() {
-				return new Paper();
 			};
 		} );
 
@@ -149,102 +157,10 @@ describe( "A content assessor", function() {
 		} );
 	} );
 
-	describe( "calculateOverallScore for non English with a text containing more than 200 words", function() {
-		let points, results, contentAssessor;
-
-		const paper = new Paper( "Lorem ipsum dolor sit amet, voluptua probatus ullamcorper id vis, ceteros consetetur qui ea, " +
-			"nam movet populo aliquam te. His eu debitis fastidii. Pri ea amet dicant. Ut his suas corpora, eu reformidans " +
-			"signiferumque duo. At erant expetenda patrioque quo, rebum atqui nam ad, tempor elaboraret interpretaris pri ad. " +
-			"Novum postea sea in. Placerat recteque cu usu. Cu nam sadipscing disputationi, sed labitur elaboraret et. Eu sed " +
-			"accumsan prodesset. Posse integre et nec, usu assum audiam erroribus eu. Ei viris eirmod interesset usu, " +
-			"usu homero liberavisse in, solet disputando ea vim. Mei eu inani nonumes consulatu, ea alterum menandri ius, " +
-			"ne euismod neglegentur sed. Vis te deleniti suscipit, fabellas laboramus pri ei. Te quo aliquip offendit. " +
-			"Vero paulo regione ei eum, sed at atqui meliore copiosae. Has et vocent vivendum. Mundi graeco latine cum ne, " +
-			"no cum laoreet alienum. Quo cu vero utinam constituto. Vis omnium vivendum ea. Eum lorem ludus possim ut. Eu has eius " +
-			"munere explicari, atqui ullamcorper eos no, harum epicuri per ut. Utamur volumus minimum ea vel, duo eu praesent " +
-			"accommodare. Mutat gloriatur ex cum, rebum salutandi ei his, vis delenit quaestio ne. Iisque qualisque duo ei. " +
-			"Splendide tincidunt te sit, commune oporteat quo id. Sumo recusabo suscipiantur duo an, no eum malis vulputate " +
-			"consectetuer. Mel te noster invenire, nec ad vidisse constituto. Eos ut quod.", { locale: "nl_NL" } );
-
-		beforeEach( function() {
-			contentAssessor = new ContentAssessor( new DutchResearcher( paper ) );
-			contentAssessor.getValidResults = function() {
-				return results;
-			};
-			contentAssessor.calculatePenaltyPoints = function() {
-				return points;
-			};
-			contentAssessor.getPaper = function() {
-				return paper;
-			};
-		} );
-
-		it( "should give worse results based on the negative points", function() {
-			results = [
-				new AssessmentResult(),
-				new AssessmentResult(),
-			];
-			const testCases = [
-				{ points: 6, expected: 30 },
-				{ points: 4, expected: 60 },
-				{ points: 3, expected: 60 },
-				{ points: 2, expected: 90 },
-			];
-
-			forEach( testCases, function( testCase ) {
-				points = testCase.points;
-
-				const actual = contentAssessor.calculateOverallScore();
-
-				expect( actual ).toBe( testCase.expected );
-			} );
-		} );
-	} );
-
-	describe( "calculateOverallScore for non English with an empty paper", function() {
-		let points, results, contentAssessor;
-
-		const paper = new Paper( "", { locale: "jv_ID" } );
-
-		beforeEach( function() {
-			contentAssessor = new ContentAssessor( new DefaultResearcher( paper ) );
-			contentAssessor.getValidResults = function() {
-				return results;
-			};
-			contentAssessor.calculatePenaltyPoints = function() {
-				return points;
-			};
-			contentAssessor.getPaper = function() {
-				return paper;
-			};
-		} );
-
-		it( "should give worse results based on the negative points", function() {
-			results = [
-				new AssessmentResult(),
-				new AssessmentResult(),
-			];
-			const testCases = [
-				{ points: 6, expected: 30 },
-				{ points: 4, expected: 60 },
-				{ points: 3, expected: 60 },
-				{ points: 2, expected: 90 },
-			];
-
-			forEach( testCases, function( testCase ) {
-				points = testCase.points;
-
-				const actual = contentAssessor.calculateOverallScore();
-
-				expect( actual ).toBe( testCase.expected );
-			} );
-		} );
-	} );
-
 	describe( "Checks the applicable assessments", function() {
-		it( "Should have 7 available assessments for a fully supported language. " +
+		it( "Should have 8 available assessments for a fully supported language. " +
 			"This doesn't include Word complexity assessment since the registration is done from Shopify side.", function() {
-			const paper = new Paper( "Lorem ipsum dolor sit amet, voluptua probatus ullamcorper id vis, ceteros consetetur qui ea, " +
+			paper = new Paper( "Lorem ipsum dolor sit amet, voluptua probatus ullamcorper id vis, ceteros consetetur qui ea, " +
 				"nam movet populo aliquam te. His eu debitis fastidii. Pri ea amet dicant. Ut his suas corpora, eu reformidans " +
 				"signiferumque duo. At erant expetenda patrioque quo, rebum atqui nam ad, tempor elaboraret interpretaris pri ad. " +
 				"Novum postea sea in. Placerat recteque cu usu. Cu nam sadipscing disputationi, sed labitur elaboraret et. Eu sed " +
@@ -257,46 +173,30 @@ describe( "A content assessor", function() {
 				"accommodare. Mutat gloriatur ex cum, rebum salutandi ei his, vis delenit quaestio ne. Iisque qualisque duo ei. " +
 				"Splendide tincidunt te sit, commune oporteat quo id. Sumo recusabo suscipiantur duo an, no eum malis vulputate " +
 				"consectetuer. Mel te noster invenire, nec ad vidisse constituto. Eos ut quod.", { locale: "en_US" } );
-			const contentAssessor = new ContentAssessor( new EnglishResearcher( paper ) );
-
+			researcher.setPaper( paper );
 			contentAssessor.getPaper = function() {
 				return paper;
 			};
-			const actual = contentAssessor.getApplicableAssessments().length;
-			const expected = 7;
-			expect( actual ).toBe( expected );
-		} );
+			const assessments = contentAssessor.getApplicableAssessments();
+			const expected = 8;
 
-		it( "Should have 4 available assessments for a basic supported language", function() {
-			// A text of at least 50 characters.
-			const longEnoughText = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis sagittis. There is more";
-			const paper = new Paper( longEnoughText, { locale: "xx_XX" } );
-			const contentAssessor = new ContentAssessor( new DefaultResearcher( paper ) );
-
-			contentAssessor.getPaper = function() {
-				return paper;
-			};
-
-			const actual = contentAssessor.getApplicableAssessments().length;
-			const expected = 4;
-			expect( actual ).toBe( expected );
+			expect( assessments.length ).toBe( expected );
+			expect( assessments.map( ( { identifier } ) => identifier ) ).toEqual(
+				[
+					"subheadingsTooLong",
+					"textParagraphTooLong",
+					"textSentenceLength",
+					"textTransitionWords",
+					"passiveVoice",
+					"textPresence",
+					"sentenceBeginnings",
+					"wordComplexity",
+				]
+			);
 		} );
 	} );
 
 	describe( "has configuration overrides", () => {
-		let contentAssessor;
-		let results;
-		const paper = new Paper();
-		beforeEach( function() {
-			contentAssessor = new ContentAssessor( new EnglishResearcher( paper ) );
-			contentAssessor.getValidResults = function() {
-				return results;
-			};
-			contentAssessor.getPaper = function() {
-				return paper;
-			};
-		} );
-
 		test( "SubheadingsDistributionTooLong", () => {
 			const assessment = contentAssessor.getAssessment( "subheadingsTooLong" );
 
@@ -359,6 +259,126 @@ describe( "A content assessor", function() {
 			expect( assessment._config ).toBeDefined();
 			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoa.st/shopify5' target='_blank'>" );
 			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoa.st/shopify65' target='_blank'>" );
+		} );
+	} );
+} );
+
+describe( "A test for content assessor for non-English", () => {
+	describe( "calculateOverallScore for non English with a text containing more than 200 words", function() {
+		let points, results, contentAssessor;
+
+		const paper = new Paper( "Lorem ipsum dolor sit amet, voluptua probatus ullamcorper id vis, ceteros consetetur qui ea, " +
+			"nam movet populo aliquam te. His eu debitis fastidii. Pri ea amet dicant. Ut his suas corpora, eu reformidans " +
+			"signiferumque duo. At erant expetenda patrioque quo, rebum atqui nam ad, tempor elaboraret interpretaris pri ad. " +
+			"Novum postea sea in. Placerat recteque cu usu. Cu nam sadipscing disputationi, sed labitur elaboraret et. Eu sed " +
+			"accumsan prodesset. Posse integre et nec, usu assum audiam erroribus eu. Ei viris eirmod interesset usu, " +
+			"usu homero liberavisse in, solet disputando ea vim. Mei eu inani nonumes consulatu, ea alterum menandri ius, " +
+			"ne euismod neglegentur sed. Vis te deleniti suscipit, fabellas laboramus pri ei. Te quo aliquip offendit. " +
+			"Vero paulo regione ei eum, sed at atqui meliore copiosae. Has et vocent vivendum. Mundi graeco latine cum ne, " +
+			"no cum laoreet alienum. Quo cu vero utinam constituto. Vis omnium vivendum ea. Eum lorem ludus possim ut. Eu has eius " +
+			"munere explicari, atqui ullamcorper eos no, harum epicuri per ut. Utamur volumus minimum ea vel, duo eu praesent " +
+			"accommodare. Mutat gloriatur ex cum, rebum salutandi ei his, vis delenit quaestio ne. Iisque qualisque duo ei. " +
+			"Splendide tincidunt te sit, commune oporteat quo id. Sumo recusabo suscipiantur duo an, no eum malis vulputate " +
+			"consectetuer. Mel te noster invenire, nec ad vidisse constituto. Eos ut quod.", { locale: "nl_NL" } );
+
+		beforeEach( function() {
+			contentAssessor = new ContentAssessor( new DutchResearcher( paper ) );
+			contentAssessor.addAssessment( "wordComplexity", new WordComplexityAssessment( {
+				urlTitle: "https://yoa.st/shopify77",
+				urlCallToAction: "https://yoa.st/shopify78",
+			} ) );
+			contentAssessor.getValidResults = function() {
+				return results;
+			};
+			contentAssessor.calculatePenaltyPoints = function() {
+				return points;
+			};
+			contentAssessor.getPaper = function() {
+				return paper;
+			};
+		} );
+
+		it( "should give worse results based on the negative points", function() {
+			results = [
+				new AssessmentResult(),
+				new AssessmentResult(),
+			];
+			const testCases = [
+				{ points: 6, expected: 30 },
+				{ points: 4, expected: 60 },
+				{ points: 3, expected: 60 },
+				{ points: 2, expected: 90 },
+			];
+
+			forEach( testCases, function( testCase ) {
+				points = testCase.points;
+
+				const actual = contentAssessor.calculateOverallScore();
+
+				expect( actual ).toBe( testCase.expected );
+			} );
+		} );
+	} );
+
+	describe( "calculateOverallScore for non English with an empty paper", function() {
+		let points, results, contentAssessor;
+
+		let paper = new Paper( "", { locale: "jv_ID" } );
+
+		beforeEach( function() {
+			contentAssessor = new ContentAssessor( new DefaultResearcher( paper ) );
+			contentAssessor.addAssessment( "wordComplexity", new WordComplexityAssessment( {
+				urlTitle: "https://yoa.st/shopify77",
+				urlCallToAction: "https://yoa.st/shopify78",
+			} ) );
+			contentAssessor.getValidResults = function() {
+				return results;
+			};
+			contentAssessor.calculatePenaltyPoints = function() {
+				return points;
+			};
+			contentAssessor.getPaper = function() {
+				return paper;
+			};
+		} );
+
+		it( "should give worse results based on the negative points", function() {
+			results = [
+				new AssessmentResult(),
+				new AssessmentResult(),
+			];
+			const testCases = [
+				{ points: 6, expected: 30 },
+				{ points: 4, expected: 60 },
+				{ points: 3, expected: 60 },
+				{ points: 2, expected: 90 },
+			];
+
+			forEach( testCases, function( testCase ) {
+				points = testCase.points;
+
+				const actual = contentAssessor.calculateOverallScore();
+
+				expect( actual ).toBe( testCase.expected );
+			} );
+		} );
+
+		// A text of at least 50 characters.
+		const longEnoughText = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis sagittis. There is more";
+		paper = new Paper( longEnoughText, { locale: "xx_XX" } );
+
+		it( "Should have 4 available assessments for a basic supported language", function() {
+			const assessments = contentAssessor.getApplicableAssessments();
+			const expected = 4;
+			expect( assessments.length ).toBe( expected );
+			expect( assessments.map( ( { identifier } ) => identifier ) ).toEqual(
+				[
+					"subheadingsTooLong",
+					"textParagraphTooLong",
+					"textSentenceLength",
+					"textPresence",
+				]
+			);
 		} );
 	} );
 } );

--- a/packages/yoastseo/spec/scoring/storePostsAndPages/cornerstone/contentAssessorSpec.js
+++ b/packages/yoastseo/spec/scoring/storePostsAndPages/cornerstone/contentAssessorSpec.js
@@ -2,26 +2,42 @@ import { forEach } from "lodash-es";
 import DefaultResearcher from "../../../../src/languageProcessing/languages/_default/Researcher";
 import EnglishResearcher from "../../../../src/languageProcessing/languages/en/Researcher";
 import DutchResearcher from "../../../../src/languageProcessing/languages/nl/Researcher";
+import wordComplexity from "../../../../src/languageProcessing/researches/wordComplexity";
+import WordComplexityAssessment from "../../../../src/scoring/assessments/readability/WordComplexityAssessment";
 
 import ContentAssessor from "../../../../src/scoring/storePostsAndPages/cornerstone/contentAssessor";
 import AssessmentResult from "../../../../src/values/AssessmentResult";
 import Paper from "../../../../src/values/Paper";
+import getWordComplexityConfig from "../../../specHelpers/getWordComplexityConfig";
+import getWordComplexityHelper from "../../../specHelpers/getWordComplexityHelper";
 
-describe( "A content assessor", function() {
-	describe( "calculatePenaltyPoints", function() {
-		let contentAssessor;
-		let results;
-		const paper = new Paper();
-		beforeEach( function() {
-			contentAssessor = new ContentAssessor( new EnglishResearcher( paper ) );
-			contentAssessor.getValidResults = function() {
-				return results;
-			};
-			contentAssessor.getPaper = function() {
-				return paper;
-			};
-		} );
+describe( "A test for content assessor for English", function() {
+	let contentAssessor, results, researcher, paper;
+	beforeAll( function() {
+		paper = new Paper();
+		researcher = new EnglishResearcher( paper );
+		contentAssessor = new ContentAssessor( researcher );
+		// Also register the assessment, research, helper, and config for Word Complexity for testing purposes.
+		researcher.addResearch( "wordComplexity", wordComplexity );
+		researcher.addHelper( "checkIfWordIsComplex", getWordComplexityHelper( "en" ) );
+		researcher.addConfig( "wordComplexity", getWordComplexityConfig( "en" ) );
+		contentAssessor = new ContentAssessor( researcher );
+		contentAssessor.addAssessment( "wordComplexity", new WordComplexityAssessment( {
+			scores: {
+				acceptableAmount: 3,
+			},
+			urlTitle: "https://yoa.st/shopify77",
+			urlCallToAction: "https://yoa.st/shopify78",
+		} ) );
+		contentAssessor.getValidResults = function() {
+			return results;
+		};
+		contentAssessor.getPaper = function() {
+			return paper;
+		};
+	} );
 
+	describe( "calculatePenaltyPoints for English", function() {
 		it( "should have no points for an empty result set", function() {
 			results = [];
 			const expected = 0;
@@ -98,18 +114,10 @@ describe( "A content assessor", function() {
 	} );
 
 	describe( "calculateOverallScore for English", function() {
-		let points, results, contentAssessor;
-
+		let points;
 		beforeEach( function() {
-			contentAssessor = new ContentAssessor( new EnglishResearcher() );
-			contentAssessor.getValidResults = function() {
-				return results;
-			};
 			contentAssessor.calculatePenaltyPoints = function() {
 				return points;
-			};
-			contentAssessor.getPaper = function() {
-				return new Paper();
 			};
 		} );
 
@@ -151,36 +159,131 @@ describe( "A content assessor", function() {
 		} );
 	} );
 
-	describe( "calculateOverallScore for non English with a text containing more than 200 words", function() {
-		let points, results, contentAssessor;
-
-		const paper = new Paper( "Lorem ipsum dolor sit amet, voluptua probatus ullamcorper id vis, ceteros consetetur qui ea, " +
-			"nam movet populo aliquam te. His eu debitis fastidii. Pri ea amet dicant. Ut his suas corpora, eu reformidans " +
-			"signiferumque duo. At erant expetenda patrioque quo, rebum atqui nam ad, tempor elaboraret interpretaris pri ad. " +
-			"Novum postea sea in. Placerat recteque cu usu. Cu nam sadipscing disputationi, sed labitur elaboraret et. Eu sed " +
-			"accumsan prodesset. Posse integre et nec, usu assum audiam erroribus eu. Ei viris eirmod interesset usu, " +
-			"usu homero liberavisse in, solet disputando ea vim. Mei eu inani nonumes consulatu, ea alterum menandri ius, " +
-			"ne euismod neglegentur sed. Vis te deleniti suscipit, fabellas laboramus pri ei. Te quo aliquip offendit. " +
-			"Vero paulo regione ei eum, sed at atqui meliore copiosae. Has et vocent vivendum. Mundi graeco latine cum ne, " +
-			"no cum laoreet alienum. Quo cu vero utinam constituto. Vis omnium vivendum ea. Eum lorem ludus possim ut. Eu has eius " +
-			"munere explicari, atqui ullamcorper eos no, harum epicuri per ut. Utamur volumus minimum ea vel, duo eu praesent " +
-			"accommodare. Mutat gloriatur ex cum, rebum salutandi ei his, vis delenit quaestio ne. Iisque qualisque duo ei. " +
-			"Splendide tincidunt te sit, commune oporteat quo id. Sumo recusabo suscipiantur duo an, no eum malis vulputate " +
-			"consectetuer. Mel te noster invenire, nec ad vidisse constituto. Eos ut quod.", { locale: "nl_NL" } );
-
-		beforeEach( function() {
-			contentAssessor = new ContentAssessor( new DutchResearcher( paper ) );
-			contentAssessor.getValidResults = function() {
-				return results;
-			};
-			contentAssessor.calculatePenaltyPoints = function() {
-				return points;
-			};
+	describe( "Checks the applicable assessments for English", function() {
+		it( "Should have 8 available assessments for a fully supported language.", function() {
+			paper = new Paper( "Lorem ipsum dolor sit amet, voluptua probatus ullamcorper id vis, ceteros consetetur qui ea, " +
+				"nam movet populo aliquam te. His eu debitis fastidii. Pri ea amet dicant. Ut his suas corpora, eu reformidans " +
+				"signiferumque duo. At erant expetenda patrioque quo, rebum atqui nam ad, tempor elaboraret interpretaris pri ad. " +
+				"Novum postea sea in. Placerat recteque cu usu. Cu nam sadipscing disputationi, sed labitur elaboraret et. Eu sed " +
+				"accumsan prodesset. Posse integre et nec, usu assum audiam erroribus eu. Ei viris eirmod interesset usu, " +
+				"usu homero liberavisse in, solet disputando ea vim. Mei eu inani nonumes consulatu, ea alterum menandri ius, " +
+				"ne euismod neglegentur sed. Vis te deleniti suscipit, fabellas laboramus pri ei. Te quo aliquip offendit. " +
+				"Vero paulo regione ei eum, sed at atqui meliore copiosae. Has et vocent vivendum. Mundi graeco latine cum ne, " +
+				"no cum laoreet alienum. Quo cu vero utinam constituto. Vis omnium vivendum ea. Eum lorem ludus possim ut. Eu has eius " +
+				"munere explicari, atqui ullamcorper eos no, harum epicuri per ut. Utamur volumus minimum ea vel, duo eu praesent " +
+				"accommodare. Mutat gloriatur ex cum, rebum salutandi ei his, vis delenit quaestio ne. Iisque qualisque duo ei. " +
+				"Splendide tincidunt te sit, commune oporteat quo id. Sumo recusabo suscipiantur duo an, no eum malis vulputate " +
+				"consectetuer. Mel te noster invenire, nec ad vidisse constituto. Eos ut quod." );
+			researcher.setPaper( paper );
 			contentAssessor.getPaper = function() {
 				return paper;
 			};
-		} );
 
+			const assessments = contentAssessor.getApplicableAssessments();
+			const expected = 8;
+
+			expect( assessments.length ).toBe( expected );
+			expect( assessments.map( ( { identifier } ) => identifier ) ).toEqual(
+				[
+					"subheadingsTooLong",
+					"textParagraphTooLong",
+					"textSentenceLength",
+					"textTransitionWords",
+					"passiveVoice",
+					"textPresence",
+					"sentenceBeginnings",
+					"wordComplexity",
+				]
+			);
+		} );
+	} );
+} );
+
+describe( "A test for content assessor for non-English that has language-specific researcher", function() {
+	let points, results, contentAssessor;
+
+	const paper = new Paper( "Lorem ipsum dolor sit amet, voluptua probatus ullamcorper id vis, ceteros consetetur qui ea, " +
+		"nam movet populo aliquam te. His eu debitis fastidii. Pri ea amet dicant. Ut his suas corpora, eu reformidans " +
+		"signiferumque duo. At erant expetenda patrioque quo, rebum atqui nam ad, tempor elaboraret interpretaris pri ad. " +
+		"Novum postea sea in. Placerat recteque cu usu. Cu nam sadipscing disputationi, sed labitur elaboraret et. Eu sed " +
+		"accumsan prodesset. Posse integre et nec, usu assum audiam erroribus eu. Ei viris eirmod interesset usu, " +
+		"usu homero liberavisse in, solet disputando ea vim. Mei eu inani nonumes consulatu, ea alterum menandri ius, " +
+		"ne euismod neglegentur sed. Vis te deleniti suscipit, fabellas laboramus pri ei. Te quo aliquip offendit. " +
+		"Vero paulo regione ei eum, sed at atqui meliore copiosae. Has et vocent vivendum. Mundi graeco latine cum ne, " +
+		"no cum laoreet alienum. Quo cu vero utinam constituto. Vis omnium vivendum ea. Eum lorem ludus possim ut. Eu has eius " +
+		"munere explicari, atqui ullamcorper eos no, harum epicuri per ut. Utamur volumus minimum ea vel, duo eu praesent " +
+		"accommodare. Mutat gloriatur ex cum, rebum salutandi ei his, vis delenit quaestio ne. Iisque qualisque duo ei. " +
+		"Splendide tincidunt te sit, commune oporteat quo id. Sumo recusabo suscipiantur duo an, no eum malis vulputate " +
+		"consectetuer. Mel te noster invenire, nec ad vidisse constituto. Eos ut quod.", { locale: "nl_NL" } );
+
+	beforeEach( function() {
+		contentAssessor = new ContentAssessor( new DutchResearcher( paper ) );
+		contentAssessor.addAssessment( "wordComplexity", new WordComplexityAssessment( {
+			scores: {
+				acceptableAmount: 3,
+			},
+			urlTitle: "https://yoa.st/shopify77",
+			urlCallToAction: "https://yoa.st/shopify78",
+		} ) );
+		contentAssessor.getValidResults = function() {
+			return results;
+		};
+		contentAssessor.calculatePenaltyPoints = function() {
+			return points;
+		};
+		contentAssessor.getPaper = function() {
+			return paper;
+		};
+	} );
+
+	it( "should give worse results based on the negative points", function() {
+		results = [
+			new AssessmentResult(),
+			new AssessmentResult(),
+		];
+		const testCases = [
+			{ points: 6, expected: 30 },
+			{ points: 4, expected: 60 },
+			{ points: 3, expected: 60 },
+			{ points: 2, expected: 90 },
+		];
+
+		forEach( testCases, function( testCase ) {
+			points = testCase.points;
+
+			const actual = contentAssessor.calculateOverallScore();
+
+			expect( actual ).toBe( testCase.expected );
+		} );
+	} );
+} );
+
+describe( "calculateOverallScore for non-English that uses Default researcher", function() {
+	let points, results, contentAssessor;
+	let paper = new Paper( "", { locale: "jv_ID" } );
+
+	beforeAll( () => {
+		const researcher = new DefaultResearcher( paper );
+		contentAssessor = new ContentAssessor( researcher );
+		contentAssessor.addAssessment( "wordComplexity", new WordComplexityAssessment( {
+			scores: {
+				acceptableAmount: 3,
+			},
+			urlTitle: "https://yoa.st/shopify77",
+			urlCallToAction: "https://yoa.st/shopify78",
+		} ) );
+		contentAssessor.getValidResults = function() {
+			return results;
+		};
+		contentAssessor.calculatePenaltyPoints = function() {
+			return points;
+		};
+		contentAssessor.getPaper = function() {
+			return paper;
+		};
+	} );
+
+	describe( "calculateOverallScore for non-English that uses Default researcher", function() {
 		it( "should give worse results based on the negative points", function() {
 			results = [
 				new AssessmentResult(),
@@ -201,50 +304,7 @@ describe( "A content assessor", function() {
 				expect( actual ).toBe( testCase.expected );
 			} );
 		} );
-	} );
-
-	describe( "calculateOverallScore for non English with an empty paper", function() {
-		let points, results, contentAssessor;
-
-		const paper = new Paper( "", { locale: "jv_ID" } );
-
-		beforeEach( function() {
-			contentAssessor = new ContentAssessor( new DefaultResearcher( paper ) );
-			contentAssessor.getValidResults = function() {
-				return results;
-			};
-			contentAssessor.calculatePenaltyPoints = function() {
-				return points;
-			};
-			contentAssessor.getPaper = function() {
-				return paper;
-			};
-		} );
-
-		it( "should give worse results based on the negative points", function() {
-			results = [
-				new AssessmentResult(),
-				new AssessmentResult(),
-			];
-			const testCases = [
-				{ points: 6, expected: 30 },
-				{ points: 4, expected: 60 },
-				{ points: 3, expected: 60 },
-				{ points: 2, expected: 90 },
-			];
-
-			forEach( testCases, function( testCase ) {
-				points = testCase.points;
-
-				const actual = contentAssessor.calculateOverallScore();
-
-				expect( actual ).toBe( testCase.expected );
-			} );
-		} );
-	} );
-
-	describe( "Checks the applicable assessments", function() {
-		const paper = new Paper( "Lorem ipsum dolor sit amet, voluptua probatus ullamcorper id vis, ceteros consetetur qui ea, " +
+		paper = new Paper( "Lorem ipsum dolor sit amet, voluptua probatus ullamcorper id vis, ceteros consetetur qui ea, " +
 			"nam movet populo aliquam te. His eu debitis fastidii. Pri ea amet dicant. Ut his suas corpora, eu reformidans " +
 			"signiferumque duo. At erant expetenda patrioque quo, rebum atqui nam ad, tempor elaboraret interpretaris pri ad. " +
 			"Novum postea sea in. Placerat recteque cu usu. Cu nam sadipscing disputationi, sed labitur elaboraret et. Eu sed " +
@@ -256,36 +316,25 @@ describe( "A content assessor", function() {
 			"munere explicari, atqui ullamcorper eos no, harum epicuri per ut. Utamur volumus minimum ea vel, duo eu praesent " +
 			"accommodare. Mutat gloriatur ex cum, rebum salutandi ei his, vis delenit quaestio ne. Iisque qualisque duo ei. " +
 			"Splendide tincidunt te sit, commune oporteat quo id. Sumo recusabo suscipiantur duo an, no eum malis vulputate " +
-			"consectetuer. Mel te noster invenire, nec ad vidisse constituto. Eos ut quod." );
-		it( "Should have 7 available assessments for a fully supported language. " +
-			"This doesn't include Word complexity assessment since the registration is done from Shopify side.", function() {
-			const contentAssessor = new ContentAssessor( new EnglishResearcher( paper ) );
-			contentAssessor.getPaper = function() {
-				return paper;
-			};
-
-			const actual = contentAssessor.getApplicableAssessments().length;
-			const expected = 7;
-			expect( actual ).toBe( expected );
-		} );
-
+			"consectetuer. Mel te noster invenire, nec ad vidisse constituto. Eos ut quod.", { locale: "xx_XX" } );
 		it( "Should have 4 available assessments for a basic supported language", function() {
-			const contentAssessor = new ContentAssessor( new DefaultResearcher( paper ) );
-			contentAssessor.getPaper = function() {
-				return paper;
-			};
-
-			const actual = contentAssessor.getApplicableAssessments().length;
+			const assessments = contentAssessor.getApplicableAssessments();
 			const expected = 4;
-			expect( actual ).toBe( expected );
+			expect( assessments.length ).toBe( expected );
+			expect( assessments.map( ( { identifier } ) => identifier ) ).toEqual(
+				[
+					"subheadingsTooLong",
+					"textParagraphTooLong",
+					"textSentenceLength",
+					"textPresence",
+				]
+			);
 		} );
 	} );
 
-	describe( "has configuration overrides", () => {
-		const assessor = new ContentAssessor( new DefaultResearcher() );
-
+	describe( "has configuration overrides for non-English", () => {
 		test( "SubheadingsDistributionTooLong", () => {
-			const assessment = assessor.getAssessment( "subheadingsTooLong" );
+			const assessment = contentAssessor.getAssessment( "subheadingsTooLong" );
 
 			expect( assessment ).toBeDefined();
 			expect( assessment._config ).toBeDefined();
@@ -297,7 +346,7 @@ describe( "A content assessor", function() {
 		} );
 
 		test( "SentenceLengthAssessment", () => {
-			const assessment = assessor.getAssessment( "textSentenceLength" );
+			const assessment = contentAssessor.getAssessment( "textSentenceLength" );
 
 			expect( assessment ).toBeDefined();
 			expect( assessment._config ).toBeDefined();
@@ -309,7 +358,7 @@ describe( "A content assessor", function() {
 		} );
 
 		test( "ParagraphTooLong", () => {
-			const assessment = assessor.getAssessment( "textParagraphTooLong" );
+			const assessment = contentAssessor.getAssessment( "textParagraphTooLong" );
 
 			expect( assessment ).toBeDefined();
 			expect( assessment._config ).toBeDefined();
@@ -320,7 +369,7 @@ describe( "A content assessor", function() {
 		} );
 
 		test( "TransitionWords", () => {
-			const assessment = assessor.getAssessment( "textTransitionWords" );
+			const assessment = contentAssessor.getAssessment( "textTransitionWords" );
 
 			expect( assessment ).toBeDefined();
 			expect( assessment._config ).toBeDefined();
@@ -329,7 +378,7 @@ describe( "A content assessor", function() {
 		} );
 
 		test( "PassiveVoice", () => {
-			const assessment = assessor.getAssessment( "passiveVoice" );
+			const assessment = contentAssessor.getAssessment( "passiveVoice" );
 
 			expect( assessment ).toBeDefined();
 			expect( assessment._config ).toBeDefined();
@@ -338,7 +387,7 @@ describe( "A content assessor", function() {
 		} );
 
 		test( "TextPresence", () => {
-			const assessment = assessor.getAssessment( "textPresence" );
+			const assessment = contentAssessor.getAssessment( "textPresence" );
 
 			expect( assessment ).toBeDefined();
 			expect( assessment._config ).toBeDefined();
@@ -347,7 +396,7 @@ describe( "A content assessor", function() {
 		} );
 
 		test( "SentenceBeginnings", () => {
-			const assessment = assessor.getAssessment( "sentenceBeginnings" );
+			const assessment = contentAssessor.getAssessment( "sentenceBeginnings" );
 
 			expect( assessment ).toBeDefined();
 			expect( assessment._config ).toBeDefined();

--- a/packages/yoastseo/spec/scoring/storePostsAndPages/cornerstone/seoAssessorSpec.js
+++ b/packages/yoastseo/spec/scoring/storePostsAndPages/cornerstone/seoAssessorSpec.js
@@ -2,6 +2,7 @@ import EnglishResearcher from "../../../../src/languageProcessing/languages/en/R
 import Assessor from "../../../../src/scoring/storePostsAndPages/cornerstone/seoAssessor.js";
 import Paper from "../../../../src/values/Paper.js";
 import getResults from "../../../specHelpers/getAssessorResults";
+import KeyphraseDistributionAssessment from "../../../../src/scoring/assessments/seo/KeyphraseDistributionAssessment";
 import keyPhraseDistribution from "../../../../src/languageProcessing/researches/keyphraseDistribution";
 
 describe( "running assessments in the assessor", function() {
@@ -11,6 +12,11 @@ describe( "running assessments in the assessor", function() {
 		const researcher = new EnglishResearcher();
 		researcher.addResearch( "keyphraseDistribution", keyPhraseDistribution );
 		assessor = new Assessor( researcher );
+		// Add Keyphrase distribution assessment to the assessor, which is available in this assessor in Shopify.
+		assessor.addAssessment( "keyphraseDistribution", new KeyphraseDistributionAssessment( {
+			urlTitle: "https://yoa.st/shopify30",
+			urlCallToAction: "https://yoa.st/shopify31",
+		} ) );
 	} );
 
 	it( "runs assessments without any specific requirements", function() {

--- a/packages/yoastseo/spec/scoring/storePostsAndPages/seoAssessorSpec.js
+++ b/packages/yoastseo/spec/scoring/storePostsAndPages/seoAssessorSpec.js
@@ -2,6 +2,7 @@ import DefaultResearcher from "../../../src/languageProcessing/languages/_defaul
 import Assessor from "../../../src/scoring/storePostsAndPages/seoAssessor.js";
 import Paper from "../../../src/values/Paper.js";
 import getResults from "../../specHelpers/getAssessorResults";
+import KeyphraseDistributionAssessment from "../../../src/scoring/assessments/seo/KeyphraseDistributionAssessment";
 import keyPhraseDistribution from "../../../src/languageProcessing/researches/keyphraseDistribution";
 
 describe( "running assessments in the assessor", function() {
@@ -11,6 +12,11 @@ describe( "running assessments in the assessor", function() {
 		const researcher = new DefaultResearcher();
 		researcher.addResearch( "keyphraseDistribution", keyPhraseDistribution );
 		assessor = new Assessor( researcher );
+		// Add Keyphrase distribution assessment to the assessor, which is available in this assessor in Shopify.
+		assessor.addAssessment( "keyphraseDistribution", new KeyphraseDistributionAssessment( {
+			urlTitle: "https://yoa.st/shopify30",
+			urlCallToAction: "https://yoa.st/shopify31",
+		} ) );
 	} );
 
 	it( "runs assessments without any specific requirements", function() {

--- a/packages/yoastseo/src/scoring/assessments/readability/WordComplexityAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/readability/WordComplexityAssessment.js
@@ -27,8 +27,8 @@ export default class WordComplexityAssessment extends Assessment {
 				acceptableAmount: 6,
 				goodAmount: 9,
 			},
-			urlTitle: createAnchorOpeningTag( "https://yoa.st/4ls" ),
-			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/4lt" ),
+			urlTitle: "https://yoa.st/4ls",
+			urlCallToAction: "https://yoa.st/4lt",
 		};
 
 		/*
@@ -39,6 +39,10 @@ export default class WordComplexityAssessment extends Assessment {
 		this.name = __( "Word complexity", "wordpress-seo" );
 		this.identifier = "wordComplexity";
 		this._config = merge( defaultConfig, config );
+
+		// Creates an anchor opening tag for the shortlinks.
+		this._config.urlTitle = createAnchorOpeningTag( this._config.urlTitle );
+		this._config.urlCallToAction = createAnchorOpeningTag( this._config.urlCallToAction );
 	}
 
 	/**

--- a/packages/yoastseo/src/scoring/assessments/seo/KeyphraseDistributionAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/KeyphraseDistributionAssessment.js
@@ -23,7 +23,8 @@ class KeyphraseDistributionAssessment extends Assessment {
 	 * @param {number} [config.scores.okay]             The score to return if keyword occurrences are somewhat unevenly distributed.
 	 * @param {number} [config.scores.bad]              The score to return if there is way too much text between keyword occurrences.
 	 * @param {number} [config.scores.consideration]    The score to return if there are no keyword occurrences.
-	 * @param {string} [config.url]                     The URL to the relevant KB article.
+	 * @param {string} [config.urlTitle]                The URL to the article about this assessment.
+	 * @param {string} [config.urlCallToAction]         The URL to the help article for this assessment.
 	 *
 	 * @returns {void}
 	 */

--- a/packages/yoastseo/src/scoring/assessments/seo/KeyphraseDistributionAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/KeyphraseDistributionAssessment.js
@@ -41,12 +41,16 @@ class KeyphraseDistributionAssessment extends Assessment {
 				bad: 1,
 				consideration: 0,
 			},
-			urlTitle: createAnchorOpeningTag( "https://yoa.st/33q" ),
-			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/33u" ),
+			urlTitle: "https://yoa.st/33q",
+			urlCallToAction: "https://yoa.st/33u",
 		};
 
 		this.identifier = "keyphraseDistribution";
 		this._config = merge( defaultConfig, config );
+
+		// Creates an anchor opening tag for the shortlinks.
+		this._config.urlTitle = createAnchorOpeningTag( this._config.urlTitle );
+		this._config.urlCallToAction = createAnchorOpeningTag( this._config.urlCallToAction );
 	}
 
 	/**

--- a/packages/yoastseo/src/scoring/collectionPages/cornerstone/seoAssessor.js
+++ b/packages/yoastseo/src/scoring/collectionPages/cornerstone/seoAssessor.js
@@ -94,8 +94,8 @@ const CollectionCornerstoneSEOAssessor = function( researcher, options ) {
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify55" ),
 		} ),
 		new KeyphraseDistribution( {
-			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify30" ),
-			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify31" ),
+			urlTitle: "https://yoa.st/shopify30",
+			urlCallToAction: "https://yoa.st/shopify31",
 		} ),
 	];
 };

--- a/packages/yoastseo/src/scoring/collectionPages/cornerstone/seoAssessor.js
+++ b/packages/yoastseo/src/scoring/collectionPages/cornerstone/seoAssessor.js
@@ -13,7 +13,6 @@ import TextLengthAssessment from "./../../assessments/seo/TextLengthAssessment";
 import PageTitleWidthAssessment from "./../../assessments/seo/PageTitleWidthAssessment";
 import FunctionWordsInKeyphrase from "./../../assessments/seo/FunctionWordsInKeyphraseAssessment";
 import SingleH1Assessment from "./../../assessments/seo/SingleH1Assessment";
-import KeyphraseDistribution from "./../../assessments/seo/KeyphraseDistributionAssessment";
 
 /**
  * Creates the Assessor used for collection pages.
@@ -92,10 +91,6 @@ const CollectionCornerstoneSEOAssessor = function( researcher, options ) {
 		new SingleH1Assessment( {
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify54" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify55" ),
-		} ),
-		new KeyphraseDistribution( {
-			urlTitle: "https://yoa.st/shopify30",
-			urlCallToAction: "https://yoa.st/shopify31",
 		} ),
 	];
 };

--- a/packages/yoastseo/src/scoring/collectionPages/seoAssessor.js
+++ b/packages/yoastseo/src/scoring/collectionPages/seoAssessor.js
@@ -80,8 +80,8 @@ const CollectionSEOAssessor = function( researcher, options ) {
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify55" ),
 		} ),
 		new KeyphraseDistribution( {
-			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify30" ),
-			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify31" ),
+			urlTitle: "https://yoa.st/shopify30",
+			urlCallToAction: "https://yoa.st/shopify31",
 		} ),
 	];
 };

--- a/packages/yoastseo/src/scoring/collectionPages/seoAssessor.js
+++ b/packages/yoastseo/src/scoring/collectionPages/seoAssessor.js
@@ -13,7 +13,6 @@ import TextLengthAssessment from "./../assessments/seo/TextLengthAssessment";
 import PageTitleWidthAssessment from "./../assessments/seo/PageTitleWidthAssessment";
 import FunctionWordsInKeyphrase from "./../assessments/seo/FunctionWordsInKeyphraseAssessment";
 import SingleH1Assessment from "./../assessments/seo/SingleH1Assessment";
-import KeyphraseDistribution from "./../assessments/seo/KeyphraseDistributionAssessment";
 
 /**
  * Creates the Assessor used for collection pages.
@@ -78,10 +77,6 @@ const CollectionSEOAssessor = function( researcher, options ) {
 		new SingleH1Assessment( {
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify54" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify55" ),
-		} ),
-		new KeyphraseDistribution( {
-			urlTitle: "https://yoa.st/shopify30",
-			urlCallToAction: "https://yoa.st/shopify31",
 		} ),
 	];
 };

--- a/packages/yoastseo/src/scoring/storeBlog/seoAssessor.js
+++ b/packages/yoastseo/src/scoring/storeBlog/seoAssessor.js
@@ -9,6 +9,7 @@ import Assessor from "../assessor";
 import MetaDescriptionLength from "../assessments/seo/MetaDescriptionLengthAssessment";
 import TitleWidth from "../assessments/seo/PageTitleWidthAssessment";
 import FunctionWordsInKeyphrase from "../assessments/seo/FunctionWordsInKeyphraseAssessment";
+
 /**
  * Creates the Assessor
  *

--- a/packages/yoastseo/src/scoring/storePostsAndPages/contentAssessor.js
+++ b/packages/yoastseo/src/scoring/storePostsAndPages/contentAssessor.js
@@ -62,8 +62,8 @@ const StorePostsAndPagesContentAssessor = function( researcher, options = {} ) {
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify65" ),
 		} ),
 		new WordComplexityAssessment( {
-			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify77" ),
-			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify78" ),
+			urlTitle: "https://yoa.st/shopify77",
+			urlCallToAction: "https://yoa.st/shopify78",
 		} ),
 	];
 };

--- a/packages/yoastseo/src/scoring/storePostsAndPages/contentAssessor.js
+++ b/packages/yoastseo/src/scoring/storePostsAndPages/contentAssessor.js
@@ -1,5 +1,4 @@
 import { createAnchorOpeningTag } from "../../helpers/shortlinker";
-import WordComplexityAssessment from "../assessments/readability/WordComplexityAssessment";
 import Assessor from "../assessor.js";
 import ParagraphTooLong from "../assessments/readability/ParagraphTooLongAssessment.js";
 import SentenceLengthInText from "../assessments/readability/SentenceLengthInTextAssessment.js";
@@ -60,10 +59,6 @@ const StorePostsAndPagesContentAssessor = function( researcher, options = {} ) {
 		new SentenceBeginnings( {
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify5" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify65" ),
-		} ),
-		new WordComplexityAssessment( {
-			urlTitle: "https://yoa.st/shopify77",
-			urlCallToAction: "https://yoa.st/shopify78",
 		} ),
 	];
 };

--- a/packages/yoastseo/src/scoring/storePostsAndPages/cornerstone/contentAssessor.js
+++ b/packages/yoastseo/src/scoring/storePostsAndPages/cornerstone/contentAssessor.js
@@ -70,8 +70,8 @@ const StorePostsAndPagesCornerstoneContentAssessor = function( researcher, optio
 			scores: {
 				acceptableAmount: 3,
 			},
-			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify77" ),
-			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify78" ),
+			urlTitle: "https://yoa.st/shopify77",
+			urlCallToAction: "https://yoa.st/shopify78",
 		} ),
 	];
 };

--- a/packages/yoastseo/src/scoring/storePostsAndPages/cornerstone/contentAssessor.js
+++ b/packages/yoastseo/src/scoring/storePostsAndPages/cornerstone/contentAssessor.js
@@ -8,7 +8,6 @@ import TransitionWords from "../../assessments/readability/TransitionWordsAssess
 import PassiveVoice from "../../assessments/readability/PassiveVoiceAssessment.js";
 import SentenceBeginnings from "../../assessments/readability/SentenceBeginningsAssessment.js";
 import TextPresence from "../../assessments/readability/TextPresenceAssessment.js";
-import WordComplexityAssessment from "../../assessments/readability/WordComplexityAssessment";
 
 /*
  Temporarily disabled:
@@ -65,13 +64,6 @@ const StorePostsAndPagesCornerstoneContentAssessor = function( researcher, optio
 		new SentenceBeginnings( {
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify5" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify65" ),
-		} ),
-		new WordComplexityAssessment( {
-			scores: {
-				acceptableAmount: 3,
-			},
-			urlTitle: "https://yoa.st/shopify77",
-			urlCallToAction: "https://yoa.st/shopify78",
 		} ),
 	];
 };

--- a/packages/yoastseo/src/scoring/storePostsAndPages/cornerstone/seoAssessor.js
+++ b/packages/yoastseo/src/scoring/storePostsAndPages/cornerstone/seoAssessor.js
@@ -135,8 +135,8 @@ const StorePostsAndPagesCornerstoneSEOAssessor = function( researcher, options )
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify55" ),
 		} ),
 		new KeyphraseDistribution( {
-			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify30" ),
-			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify31" ),
+			urlTitle: "https://yoa.st/shopify30",
+			urlCallToAction: "https://yoa.st/shopify31",
 		} ),
 	];
 };

--- a/packages/yoastseo/src/scoring/storePostsAndPages/cornerstone/seoAssessor.js
+++ b/packages/yoastseo/src/scoring/storePostsAndPages/cornerstone/seoAssessor.js
@@ -20,8 +20,6 @@ import OutboundLinks from "../../assessments/seo/OutboundLinksAssessment";
 import TitleWidth from "../../assessments/seo/PageTitleWidthAssessment";
 import FunctionWordsInKeyphrase from "../../assessments/seo/FunctionWordsInKeyphraseAssessment";
 import SingleH1Assessment from "../../assessments/seo/SingleH1Assessment";
-import KeyphraseDistribution from "../../assessments/seo/KeyphraseDistributionAssessment";
-
 
 /**
  * Creates the Assessor
@@ -133,10 +131,6 @@ const StorePostsAndPagesCornerstoneSEOAssessor = function( researcher, options )
 		new SingleH1Assessment( {
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify54" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify55" ),
-		} ),
-		new KeyphraseDistribution( {
-			urlTitle: "https://yoa.st/shopify30",
-			urlCallToAction: "https://yoa.st/shopify31",
 		} ),
 	];
 };

--- a/packages/yoastseo/src/scoring/storePostsAndPages/seoAssessor.js
+++ b/packages/yoastseo/src/scoring/storePostsAndPages/seoAssessor.js
@@ -19,7 +19,7 @@ import OutboundLinks from "../assessments/seo/OutboundLinksAssessment";
 import TitleWidth from "../assessments/seo/PageTitleWidthAssessment";
 import FunctionWordsInKeyphrase from "../assessments/seo/FunctionWordsInKeyphraseAssessment";
 import SingleH1Assessment from "../assessments/seo/SingleH1Assessment";
-import KeyphraseDistribution from "../assessments/seo/KeyphraseDistributionAssessment";
+
 /**
  * Creates the Assessor
  *
@@ -104,10 +104,6 @@ const StorePostsAndPagesSEOAssessor = function( researcher,  options ) {
 		new SingleH1Assessment( {
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify54" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify55" ),
-		} ),
-		new KeyphraseDistribution( {
-			urlTitle: "https://yoa.st/shopify30",
-			urlCallToAction: "https://yoa.st/shopify31",
 		} ),
 	];
 };

--- a/packages/yoastseo/src/scoring/storePostsAndPages/seoAssessor.js
+++ b/packages/yoastseo/src/scoring/storePostsAndPages/seoAssessor.js
@@ -106,8 +106,8 @@ const StorePostsAndPagesSEOAssessor = function( researcher,  options ) {
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify55" ),
 		} ),
 		new KeyphraseDistribution( {
-			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify30" ),
-			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify31" ),
+			urlTitle: "https://yoa.st/shopify30",
+			urlCallToAction: "https://yoa.st/shopify31",
 		} ),
 	];
 };


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [yoastseo] Creates the anchor opening tag after merging the configs in _keyphrase distribution_ and _word complexity_ assessments.
* [yoastseo] Removes _keyphrase distribution_ and _word complexity_ assessments from non-product eCommerce assessors.

## Relevant technical choices:

* In this PR, we change the way we create the opening anchor tag ONLY in keyphrase distribution and word complexity assessments. This is to limit the impact scope.
* This change is necessary so that the assessment shortlinks passed from shopify side are also processed properly.
* In this PR, the word complexity and keyphrase distribution assessments are also removed from other (non-product) eCommerce assessors. This is because, in Shopify, we register both assessments to ALL relevant assessors. Hence, registering both assessments within the assessors in `yoastseo` is no longer necessary.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:
#### WordPress
* Install and activate Yoast SEO
* Install and activate Yoast SEO Premium
   * If building the plugin, test in `wordpress-seo-premium` from `feature/yoastseo-refactor` branch
   * Run  `composer require yoast/wordpress-seo:dev-1027-re-add-word-complexity-and-keyphrase-distribution-assessments-on-shopify-product-pages@dev` before building
* Install and activate Yoast SEO for WooCommerce
    * If building the plugin, test in `wpseo-woocommerce` from `feature/yoastseo-refactor` branch
    * Run  `composer require yoast/wordpress-seo:dev-1027-re-add-word-complexity-and-keyphrase-distribution-assessments-on-shopify-product-pages@dev --dev` before building
* Set the site language to English
* Create a post/product
* Add this text
[study.txt](https://github.com/Yoast/wordpress-seo/files/10815329/study.txt)

##### Keyphrase distribution
* Set a focus keyphrase, but don't add the keyphrase in the text
* Go to the keyphrase distribution assessment
* Make sure that the shortlink that appears when hovering over the assessment title is "https://yoa.st/33q" along with tracking parameters (php version, platform, etc)
* Make sure that the shortlink that appears when hovering over the assessment's Call To Action is "https://yoa.st/33u" along with tracking parameters (php version, platform, etc)

##### Word complexity
* Go to Word complexity assessment
* Make sure that the shortlink that appears when hovering over the assessment title is "https://yoa.st/4ls" along with tracking parameters (php version, platform, etc)
* Make sure that the shortlink that appears when hovering over the assessment's Call To Action is "https://yoa.st/4lt" along with tracking parameters (php version, platform, etc)

##### WooCommerce product
* Repeat the test instruction in **Keyphrase distribution** and **Word complexity** above and confirm that you get the same result

#### Shopify
* Test together with this accompanying PR: https://github.com/Yoast/shopify-seo/pull/1051

* Check out [this ATP for word complexity](https://docs.google.com/document/d/1fWX_8YkvSqcsqmwan_gwJjYqGOKIcTBTv0FbLKz47ig/edit#heading=h.adgajq24246l) and follow the test instruction in scenario 1.2.1 - 1.2.5
* Check out [this ATP for keyphrase distribution](https://docs.google.com/document/d/1fWX_8YkvSqcsqmwan_gwJjYqGOKIcTBTv0FbLKz47ig/edit#heading=h.75yuwvrnjbdk) and follow the test instruction in scenario 1.1.2 and 1.1.3
* Smoke testing the analysis result in all content types is sufficient
* However, always do the following in all content types:
   * Do check that the assessments receive the correct shortlinks in all content types
   * Pay extra attention that the assessments don't appear twice in the analysis result

#### Test the cornerstone toggle of word complexity assessment
* Follow the test instruction in [this scenario](https://docs.google.com/document/d/1fWX_8YkvSqcsqmwan_gwJjYqGOKIcTBTv0FbLKz47ig/edit#heading=h.oqdkk3nha7qr)



#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* This PR has impact on the shortlinks for word complexity and keyphrase distribution assessments. This impact was taken into consideration when working out the test instructions.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
