### PR TITLE
Restructuring yoastseo: improve the js bundle in woocommerce and shopify

### DIFF
--- a/packages/yoastseo/src/scoring/assessments/readability/ListAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/readability/ListAssessment.js
@@ -1,8 +1,9 @@
 import { __, sprintf } from "@wordpress/i18n";
-import Assessment from "../assessment";
-import { createAnchorOpeningTag } from "../../../helpers";
-import AssessmentResult from "../../../values/AssessmentResult";
 import { merge } from "lodash-es";
+
+import { Assessment, AssessmentResult, helpers } from "yoastseo";
+
+const { createAnchorOpeningTag } = helpers;
 
 /**
  * Represents the assessment that will look if the text has a list (only applicable for product pages).

--- a/packages/yoastseo/src/scoring/collectionPages/cornerstone/relatedKeywordAssessor.js
+++ b/packages/yoastseo/src/scoring/collectionPages/cornerstone/relatedKeywordAssessor.js
@@ -1,12 +1,15 @@
 import { inherits } from "util";
-import { createAnchorOpeningTag } from "../../../helpers/shortlinker";
 
-import IntroductionKeywordAssessment from "./../../assessments/seo/IntroductionKeywordAssessment";
-import KeyphraseLengthAssessment from "./../../assessments/seo/KeyphraseLengthAssessment";
-import KeywordDensityAssessment from "./../../assessments/seo/KeywordDensityAssessment";
-import MetaDescriptionKeywordAssessment from "./../../assessments/seo/MetaDescriptionKeywordAssessment";
-import Assessor from "./../../assessor";
-import FunctionWordsInKeyphrase from "./../../assessments/seo/FunctionWordsInKeyphraseAssessment";
+import { Assessor, assessments, helpers } from "yoastseo";
+const { createAnchorOpeningTag } = helpers;
+
+const {
+	IntroductionKeywordAssessment,
+	KeyphraseLengthAssessment,
+	KeywordDensityAssessment,
+	MetaDescriptionKeywordAssessment,
+	FunctionWordsInKeyphraseAssessment,
+} = assessments.seo;
 
 /**
  * Creates the Assessor used for collection pages.
@@ -41,7 +44,7 @@ const CollectionCornerstoneRelatedKeywordAssessor = function( researcher, option
 				urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify15" ),
 			}
 		),
-		new FunctionWordsInKeyphrase( {
+		new FunctionWordsInKeyphraseAssessment( {
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify50" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify51" ),
 		} ),

--- a/packages/yoastseo/src/scoring/collectionPages/cornerstone/seoAssessor.js
+++ b/packages/yoastseo/src/scoring/collectionPages/cornerstone/seoAssessor.js
@@ -1,18 +1,22 @@
 import { inherits } from "util";
-import { createAnchorOpeningTag } from "../../../helpers/shortlinker";
 
-import IntroductionKeywordAssessment from "./../../assessments/seo/IntroductionKeywordAssessment";
-import KeyphraseLengthAssessment from "./../../assessments/seo/KeyphraseLengthAssessment";
-import KeywordDensityAssessment from "./../../assessments/seo/KeywordDensityAssessment";
-import MetaDescriptionKeywordAssessment from "./../../assessments/seo/MetaDescriptionKeywordAssessment";
-import KeyphraseInSEOTitleAssessment from "../../assessments/seo/KeyphraseInSEOTitleAssessment";
-import SlugKeywordAssessment from "../../assessments/seo/UrlKeywordAssessment";
-import Assessor from "./../../assessor";
-import MetaDescriptionLengthAssessment from "./../../assessments/seo/MetaDescriptionLengthAssessment";
-import TextLengthAssessment from "./../../assessments/seo/TextLengthAssessment";
-import PageTitleWidthAssessment from "./../../assessments/seo/PageTitleWidthAssessment";
-import FunctionWordsInKeyphrase from "./../../assessments/seo/FunctionWordsInKeyphraseAssessment";
-import SingleH1Assessment from "./../../assessments/seo/SingleH1Assessment";
+import { Assessor, assessments, helpers } from "yoastseo";
+const { createAnchorOpeningTag } = helpers;
+
+const {
+	IntroductionKeywordAssessment,
+	KeyphraseLengthAssessment,
+	KeywordDensityAssessment,
+	MetaDescriptionKeywordAssessment,
+	KeyphraseInSEOTitleAssessment,
+	SlugKeywordAssessment,
+	MetaDescriptionLengthAssessment,
+	TextLengthAssessment,
+	PageTitleWidthAssessment,
+	FunctionWordsInKeyphraseAssessment,
+	SingleH1Assessment,
+} = assessments.seo;
+
 
 /**
  * Creates the Assessor used for collection pages.
@@ -84,7 +88,7 @@ const CollectionCornerstoneSEOAssessor = function( researcher, options ) {
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify26" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify27" ),
 		} ),
-		new FunctionWordsInKeyphrase( {
+		new FunctionWordsInKeyphraseAssessment( {
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify50" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify51" ),
 		} ),

--- a/packages/yoastseo/src/scoring/collectionPages/relatedKeywordAssessor.js
+++ b/packages/yoastseo/src/scoring/collectionPages/relatedKeywordAssessor.js
@@ -1,12 +1,15 @@
 import { inherits } from "util";
-import { createAnchorOpeningTag } from "../../helpers/shortlinker";
 
-import IntroductionKeywordAssessment from "./../assessments/seo/IntroductionKeywordAssessment";
-import KeyphraseLengthAssessment from "./../assessments/seo/KeyphraseLengthAssessment";
-import KeywordDensityAssessment from "./../assessments/seo/KeywordDensityAssessment";
-import MetaDescriptionKeywordAssessment from "./../assessments/seo/MetaDescriptionKeywordAssessment";
-import Assessor from "./../assessor";
-import FunctionWordsInKeyphrase from "./../assessments/seo/FunctionWordsInKeyphraseAssessment";
+import { Assessor, assessments, helpers } from "yoastseo";
+const { createAnchorOpeningTag } = helpers;
+
+const {
+	IntroductionKeywordAssessment,
+	KeyphraseLengthAssessment,
+	KeywordDensityAssessment,
+	MetaDescriptionKeywordAssessment,
+	FunctionWordsInKeyphraseAssessment,
+} = assessments.seo;
 
 /**
  * Creates the Assessor used for collection pages.
@@ -38,8 +41,7 @@ const CollectionRelatedKeywordAssessor = function( researcher, options ) {
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify14" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify15" ),
 		} ),
-		// Text Images assessment here.
-		new FunctionWordsInKeyphrase( {
+		new FunctionWordsInKeyphraseAssessment( {
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify50" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify51" ),
 		} ),

--- a/packages/yoastseo/src/scoring/collectionPages/seoAssessor.js
+++ b/packages/yoastseo/src/scoring/collectionPages/seoAssessor.js
@@ -1,18 +1,21 @@
 import { inherits } from "util";
-import { createAnchorOpeningTag } from "../../helpers/shortlinker";
 
-import IntroductionKeywordAssessment from "./../assessments/seo/IntroductionKeywordAssessment";
-import KeyphraseLengthAssessment from "./../assessments/seo/KeyphraseLengthAssessment";
-import KeywordDensityAssessment from "./../assessments/seo/KeywordDensityAssessment";
-import MetaDescriptionKeywordAssessment from "./../assessments/seo/MetaDescriptionKeywordAssessment";
-import KeyphraseInSEOTitleAssessment from "../assessments/seo/KeyphraseInSEOTitleAssessment";
-import SlugKeywordAssessment from "../assessments/seo/UrlKeywordAssessment";
-import Assessor from "./../assessor";
-import MetaDescriptionLengthAssessment from "./../assessments/seo/MetaDescriptionLengthAssessment";
-import TextLengthAssessment from "./../assessments/seo/TextLengthAssessment";
-import PageTitleWidthAssessment from "./../assessments/seo/PageTitleWidthAssessment";
-import FunctionWordsInKeyphrase from "./../assessments/seo/FunctionWordsInKeyphraseAssessment";
-import SingleH1Assessment from "./../assessments/seo/SingleH1Assessment";
+import { Assessor, assessments, helpers } from "yoastseo";
+const { createAnchorOpeningTag } = helpers;
+
+const {
+	IntroductionKeywordAssessment,
+	KeyphraseLengthAssessment,
+	KeywordDensityAssessment,
+	MetaDescriptionKeywordAssessment,
+	KeyphraseInSEOTitleAssessment,
+	SlugKeywordAssessment,
+	MetaDescriptionLengthAssessment,
+	TextLengthAssessment,
+	PageTitleWidthAssessment,
+	FunctionWordsInKeyphraseAssessment,
+	SingleH1Assessment,
+} = assessments.seo;
 
 /**
  * Creates the Assessor used for collection pages.
@@ -70,7 +73,7 @@ const CollectionSEOAssessor = function( researcher, options ) {
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify26" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify27" ),
 		} ),
-		new FunctionWordsInKeyphrase(  {
+		new FunctionWordsInKeyphraseAssessment(  {
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify50" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify51" ),
 		} ),

--- a/packages/yoastseo/src/scoring/productPages/contentAssessor.js
+++ b/packages/yoastseo/src/scoring/productPages/contentAssessor.js
@@ -1,14 +1,16 @@
+import { inherits } from "util";
+
 import { Assessor, ContentAssessor, assessments, helpers } from "yoastseo";
+import ListsPresenceAssessment  from "../assessments/readability/ListAssessment";
 const { createAnchorOpeningTag } = helpers;
 
 const {
-	ParagraphTooLong,
-	SentenceLengthInText,
-	SubheadingDistributionTooLong,
-	TransitionWords,
-	PassiveVoice,
-	TextPresence,
-	ListsPresence,
+	ParagraphTooLongAssessment,
+	SentenceLengthInTextAssessment,
+	SubheadingDistributionTooLongAssessment,
+	TransitionWordsAssessment,
+	PassiveVoiceAssessment,
+	TextPresenceAssessment,
 } = assessments.readability;
 
 /**
@@ -24,12 +26,12 @@ const ProductContentAssessor = function( researcher, options ) {
 	this.type = "productContentAssessor";
 
 	this._assessments = [
-		new SubheadingDistributionTooLong( {
+		new SubheadingDistributionTooLongAssessment( {
 			shouldNotAppearInShortText: true,
 			urlTitle: createAnchorOpeningTag( options.subheadingUrlTitle ),
 			urlCallToAction: createAnchorOpeningTag( options.subheadingCTAUrl ),
 		} ),
-		new ParagraphTooLong( {
+		new ParagraphTooLongAssessment( {
 			parameters: {
 				recommendedLength: 70,
 				maximumRecommendedLength: 100,
@@ -37,32 +39,32 @@ const ProductContentAssessor = function( researcher, options ) {
 			urlTitle: createAnchorOpeningTag( options.paragraphUrlTitle ),
 			urlCallToAction: createAnchorOpeningTag( options.paragraphCTAUrl ),
 		}, true ),
-		new SentenceLengthInText( {
+		new SentenceLengthInTextAssessment( {
 			slightlyTooMany: 20,
 			farTooMany: 25,
 			urlTitle: createAnchorOpeningTag( options.sentenceLengthUrlTitle ),
 			urlCallToAction: createAnchorOpeningTag( options.sentenceLengthCTAUrl ),
 		}, false, true ),
-		new TransitionWords( {
+		new TransitionWordsAssessment( {
 			urlTitle: createAnchorOpeningTag( options.transitionWordsUrlTitle ),
 			urlCallToAction: createAnchorOpeningTag( options.transitionWordsCTAUrl ),
 		} ),
-		new PassiveVoice( {
+		new PassiveVoiceAssessment( {
 			urlTitle: createAnchorOpeningTag( options.passiveVoiceUrlTitle ),
 			urlCallToAction: createAnchorOpeningTag( options.passiveVoiceCTAUrl ),
 		} ),
-		new TextPresence( {
+		new TextPresenceAssessment( {
 			urlTitle: createAnchorOpeningTag( options.textPresenceUrlTitle ),
 			urlCallToAction: createAnchorOpeningTag( options.textPresenceCTAUrl ),
 		} ),
-		new ListsPresence( {
+		new ListsPresenceAssessment( {
 			urlTitle: createAnchorOpeningTag( options.listsUrlTitle ),
 			urlCallToAction: createAnchorOpeningTag( options.listsCTAUrl ),
 		} ),
 	];
 };
 
-require( "util" ).inherits( ProductContentAssessor, ContentAssessor );
+inherits( ProductContentAssessor, ContentAssessor );
 
 
 export default ProductContentAssessor;

--- a/packages/yoastseo/src/scoring/productPages/contentAssessor.js
+++ b/packages/yoastseo/src/scoring/productPages/contentAssessor.js
@@ -1,14 +1,15 @@
-import { createAnchorOpeningTag } from "../../helpers/shortlinker";
+import { Assessor, ContentAssessor, assessments, helpers } from "yoastseo";
+const { createAnchorOpeningTag } = helpers;
 
-import Assessor from "../assessor.js";
-import ContentAssessor from "../contentAssessor";
-import ParagraphTooLong from "../assessments/readability/ParagraphTooLongAssessment.js";
-import SentenceLengthInText from "../assessments/readability/SentenceLengthInTextAssessment.js";
-import SubheadingDistributionTooLong from "../assessments/readability/SubheadingDistributionTooLongAssessment.js";
-import TransitionWords from "../assessments/readability/TransitionWordsAssessment.js";
-import PassiveVoice from "../assessments/readability/PassiveVoiceAssessment.js";
-import TextPresence from "../assessments/readability/TextPresenceAssessment.js";
-import ListsPresence from "../assessments/readability/ListAssessment.js";
+const {
+	ParagraphTooLong,
+	SentenceLengthInText,
+	SubheadingDistributionTooLong,
+	TransitionWords,
+	PassiveVoice,
+	TextPresence,
+	ListsPresence,
+} = assessments.readability;
 
 /**
  * Creates the Assessor

--- a/packages/yoastseo/src/scoring/productPages/cornerstone/contentAssessor.js
+++ b/packages/yoastseo/src/scoring/productPages/cornerstone/contentAssessor.js
@@ -13,7 +13,6 @@ const {
 	TextPresenceAssessment,
 } = assessments.readability;
 
-
 /**
  * Creates the Assessor
  *

--- a/packages/yoastseo/src/scoring/productPages/cornerstone/contentAssessor.js
+++ b/packages/yoastseo/src/scoring/productPages/cornerstone/contentAssessor.js
@@ -1,13 +1,16 @@
-import { createAnchorOpeningTag } from "../../../helpers/shortlinker";
-import Assessor from "../../assessor.js";
-import ContentAssessor from "../../contentAssessor";
-import ParagraphTooLong from "../../assessments/readability/ParagraphTooLongAssessment.js";
-import SentenceLengthInText from "../../assessments/readability/SentenceLengthInTextAssessment.js";
-import SubheadingDistributionTooLong from "../../assessments/readability/SubheadingDistributionTooLongAssessment.js";
-import TransitionWords from "../../assessments/readability/TransitionWordsAssessment.js";
-import PassiveVoice from "../../assessments/readability/PassiveVoiceAssessment.js";
-import TextPresence from "../../assessments/readability/TextPresenceAssessment.js";
-import ListsPresence from "../../assessments/readability/ListAssessment.js";
+import { Assessor, ContentAssessor, assessments, helpers } from "yoastseo";
+const { createAnchorOpeningTag } = helpers;
+
+const {
+	ParagraphTooLong,
+	SentenceLengthInText,
+	SubheadingDistributionTooLong,
+	TransitionWords,
+	PassiveVoice,
+	TextPresence,
+	ListsPresence,
+} = assessments.readability;
+
 
 /**
  * Creates the Assessor

--- a/packages/yoastseo/src/scoring/productPages/cornerstone/contentAssessor.js
+++ b/packages/yoastseo/src/scoring/productPages/cornerstone/contentAssessor.js
@@ -1,14 +1,16 @@
+import { inherits } from "util";
+
 import { Assessor, ContentAssessor, assessments, helpers } from "yoastseo";
+import ListsPresenceAssessment  from "../../assessments/readability/ListAssessment";
 const { createAnchorOpeningTag } = helpers;
 
 const {
-	ParagraphTooLong,
-	SentenceLengthInText,
-	SubheadingDistributionTooLong,
-	TransitionWords,
-	PassiveVoice,
-	TextPresence,
-	ListsPresence,
+	ParagraphTooLongAssessment,
+	SentenceLengthInTextAssessment,
+	SubheadingDistributionTooLongAssessment,
+	TransitionWordsAssessment,
+	PassiveVoiceAssessment,
+	TextPresenceAssessment,
 } = assessments.readability;
 
 
@@ -25,7 +27,7 @@ const ProductCornerstoneContentAssessor = function( researcher, options ) {
 	this.type = "productCornerstoneContentAssessor";
 
 	this._assessments = [
-		new SubheadingDistributionTooLong( {
+		new SubheadingDistributionTooLongAssessment( {
 			parameters:	{
 				slightlyTooMany: 250,
 				farTooMany: 300,
@@ -37,7 +39,7 @@ const ProductCornerstoneContentAssessor = function( researcher, options ) {
 			urlCallToAction: createAnchorOpeningTag( options.subheadingCTAUrl ),
 			cornerstoneContent: true,
 		} ),
-		new ParagraphTooLong( {
+		new ParagraphTooLongAssessment( {
 			parameters: {
 				recommendedLength: 70,
 				maximumRecommendedLength: 100,
@@ -45,32 +47,32 @@ const ProductCornerstoneContentAssessor = function( researcher, options ) {
 			urlTitle: createAnchorOpeningTag( options.paragraphUrlTitle ),
 			urlCallToAction: createAnchorOpeningTag( options.paragraphCTAUrl ),
 		}, true ),
-		new SentenceLengthInText( {
+		new SentenceLengthInTextAssessment( {
 			slightlyTooMany: 15,
 			farTooMany: 20,
 			urlTitle: createAnchorOpeningTag( options.sentenceLengthUrlTitle ),
 			urlCallToAction: createAnchorOpeningTag( options.sentenceLengthCTAUrl ),
 		}, true, true ),
-		new TransitionWords( {
+		new TransitionWordsAssessment( {
 			urlTitle: createAnchorOpeningTag( options.transitionWordsUrlTitle ),
 			urlCallToAction: createAnchorOpeningTag( options.transitionWordsCTAUrl ),
 		} ),
-		new PassiveVoice( {
+		new PassiveVoiceAssessment( {
 			urlTitle: createAnchorOpeningTag( options.passiveVoiceUrlTitle ),
 			urlCallToAction: createAnchorOpeningTag( options.passiveVoiceCTAUrl ),
 		} ),
-		new TextPresence( {
+		new TextPresenceAssessment( {
 			urlTitle: createAnchorOpeningTag( options.textPresenceUrlTitle ),
 			urlCallToAction: createAnchorOpeningTag( options.textPresenceCTAUrl ),
 		} ),
-		new ListsPresence( {
+		new ListsPresenceAssessment( {
 			urlTitle: createAnchorOpeningTag( options.listsUrlTitle ),
 			urlCallToAction: createAnchorOpeningTag( options.listsCTAUrl ),
 		} ),
 	];
 };
 
-require( "util" ).inherits( ProductCornerstoneContentAssessor, ContentAssessor );
+inherits( ProductCornerstoneContentAssessor, ContentAssessor );
 
 
 export default ProductCornerstoneContentAssessor;

--- a/packages/yoastseo/src/scoring/productPages/cornerstone/relatedKeywordAssessor.js
+++ b/packages/yoastseo/src/scoring/productPages/cornerstone/relatedKeywordAssessor.js
@@ -1,14 +1,17 @@
 import { inherits } from "util";
-import { createAnchorOpeningTag } from "../../../helpers/shortlinker";
-import Assessor from "../../assessor.js";
 
-import IntroductionKeyword from "../../assessments/seo/IntroductionKeywordAssessment.js";
-import KeyphraseLength from "../../assessments/seo/KeyphraseLengthAssessment.js";
-import KeywordDensity from "../../assessments/seo/KeywordDensityAssessment.js";
-import MetaDescriptionKeyword from "../../assessments/seo/MetaDescriptionKeywordAssessment.js";
-import ImageKeyphrase from "../../assessments/seo/KeyphraseInImageTextAssessment";
-import TextCompetingLinks from "../../assessments/seo/TextCompetingLinksAssessment.js";
-import FunctionWordsInKeyphrase from "../../assessments/seo/FunctionWordsInKeyphraseAssessment";
+import { Assessor, assessments, helpers } from "yoastseo";
+const { createAnchorOpeningTag } = helpers;
+
+const {
+	IntroductionKeywordAssessment,
+	KeyphraseLengthAssessment,
+	KeywordDensityAssessment,
+	MetaDescriptionKeywordAssessment,
+	TextCompetingLinksAssessment,
+	ImageKeyphraseAssessment,
+	FunctionWordsInKeyphraseAssessment,
+} = assessments.seo;
 
 /**
  * Creates the Assessor
@@ -23,11 +26,11 @@ const ProductCornerStoneRelatedKeywordAssessor = function( researcher, options )
 	this.type = "productPageCornerstoneRelatedKeywordAssessor";
 
 	this._assessments = [
-		new IntroductionKeyword( {
+		new IntroductionKeywordAssessment( {
 			urlTitle: createAnchorOpeningTag( options.introductionKeyphraseUrlTitle ),
 			urlCallToAction: createAnchorOpeningTag( options.introductionKeyphraseCTAUrl ),
 		} ),
-		new KeyphraseLength( {
+		new KeyphraseLengthAssessment( {
 			parameters: {
 				recommendedMinimum: 4,
 				recommendedMaximum: 6,
@@ -38,23 +41,23 @@ const ProductCornerStoneRelatedKeywordAssessor = function( researcher, options )
 			urlTitle: createAnchorOpeningTag( options.keyphraseLengthUrlTitle ),
 			urlCallToAction: createAnchorOpeningTag( options.keyphraseLengthCTAUrl ),
 		}, true ),
-		new KeywordDensity( {
+		new KeywordDensityAssessment( {
 			urlTitle: createAnchorOpeningTag( options.keyphraseDensityUrlTitle ),
 			urlCallToAction: createAnchorOpeningTag( options.keyphraseDensityCTAUrl ),
 		} ),
-		new MetaDescriptionKeyword( {
+		new MetaDescriptionKeywordAssessment( {
 			urlTitle: createAnchorOpeningTag( options.metaDescriptionKeyphraseUrlTitle ),
 			urlCallToAction: createAnchorOpeningTag( options.metaDescriptionKeyphraseCTAUrl ),
 		} ),
-		new TextCompetingLinks( {
+		new TextCompetingLinksAssessment( {
 			urlTitle: createAnchorOpeningTag( options.textCompetingLinksUrlTitle ),
 			urlCallToAction: createAnchorOpeningTag( options.textCompetingLinksCTAUrl ),
 		} ),
-		new FunctionWordsInKeyphrase( {
+		new FunctionWordsInKeyphraseAssessment( {
 			urlTitle: createAnchorOpeningTag( options.functionWordsInKeyphraseUrlTitle ),
 			urlCallToAction: createAnchorOpeningTag( options.functionWordsInKeyphraseCTAUrl ),
 		} ),
-		new ImageKeyphrase( {
+		new ImageKeyphraseAssessment( {
 			scores: {
 				withAltNonKeyword: 3,
 				withAlt: 3,

--- a/packages/yoastseo/src/scoring/productPages/cornerstone/seoAssessor.js
+++ b/packages/yoastseo/src/scoring/productPages/cornerstone/seoAssessor.js
@@ -1,26 +1,28 @@
 import { inherits } from "util";
-import { createAnchorOpeningTag } from "../../../helpers/shortlinker";
-import ImageAltTags from "../../assessments/seo/ImageAltTagsAssessment";
 
-import IntroductionKeywordAssessment from "../../assessments/seo/IntroductionKeywordAssessment";
-import KeyphraseLengthAssessment from "../../assessments/seo/KeyphraseLengthAssessment";
-import KeywordDensityAssessment from "../../assessments/seo/KeywordDensityAssessment";
-import MetaDescriptionKeywordAssessment from "../../assessments/seo/MetaDescriptionKeywordAssessment";
-import TextCompetingLinksAssessment from "../../assessments/seo/TextCompetingLinksAssessment";
-import KeyphraseInSEOTitleAssessment from "../../assessments/seo/KeyphraseInSEOTitleAssessment";
-import SlugKeywordAssessment from "../../assessments/seo/UrlKeywordAssessment";
-import Assessor from "../../assessor";
-import SEOAssessor from "../seoAssessor";
-import MetaDescriptionLength from "../../assessments/seo/MetaDescriptionLengthAssessment";
-import SubheadingsKeyword from "../../assessments/seo/SubHeadingsKeywordAssessment";
-import ImageKeyphrase from "../../assessments/seo/KeyphraseInImageTextAssessment";
-import ImageCount from "../../assessments/seo/ImageCountAssessment";
-import TextLength from "../../assessments/seo/TextLengthAssessment";
-import TitleWidth from "../../assessments/seo/PageTitleWidthAssessment";
-import FunctionWordsInKeyphrase from "../../assessments/seo/FunctionWordsInKeyphraseAssessment";
-import SingleH1Assessment from "../../assessments/seo/SingleH1Assessment";
-import ProductIdentifiersAssessment from "../../assessments/seo/ProductIdentifiersAssessment";
-import ProductSKUAssessment from "../../assessments/seo/ProductSKUAssessment";
+import { Assessor, SEOAssessor, assessments, helpers } from "yoastseo";
+const { createAnchorOpeningTag } = helpers;
+
+const {
+	IntroductionKeywordAssessment,
+	KeyphraseLengthAssessment,
+	KeywordDensityAssessment,
+	MetaDescriptionKeywordAssessment,
+	TextCompetingLinksAssessment,
+	KeyphraseInSEOTitleAssessment,
+	SlugKeywordAssessment,
+	MetaDescriptionLengthAssessment,
+	SubheadingsKeywordAssessment,
+	ImageKeyphraseAssessment,
+	ImageCountAssessment,
+	TextLengthAssessment,
+	PageTitleWidthAssessment,
+	FunctionWordsInKeyphraseAssessment,
+	SingleH1Assessment,
+	ProductIdentifiersAssessment,
+	ProductSKUAssessment,
+	ImageAltTagsAssessment,
+} = assessments.seo;
 
 /**
  * Creates the Assessor
@@ -57,7 +59,7 @@ const ProductCornerstoneSEOAssessor = function( researcher, options ) {
 			urlTitle: createAnchorOpeningTag( options.metaDescriptionKeyphraseUrlTitle ),
 			urlCallToAction: createAnchorOpeningTag( options.metaDescriptionKeyphraseCTAUrl ),
 		} ),
-		new MetaDescriptionLength( {
+		new MetaDescriptionLengthAssessment( {
 			scores:	{
 				tooLong: 3,
 				tooShort: 3,
@@ -65,7 +67,7 @@ const ProductCornerstoneSEOAssessor = function( researcher, options ) {
 			urlTitle: createAnchorOpeningTag( options.metaDescriptionLengthUrlTitle ),
 			urlCallToAction: createAnchorOpeningTag( options.metaDescriptionLengthCTAUrl ),
 		} ),
-		new SubheadingsKeyword( {
+		new SubheadingsKeywordAssessment( {
 			urlTitle: createAnchorOpeningTag( options.subheadingsKeyphraseUrlTitle ),
 			urlCallToAction: createAnchorOpeningTag( options.subheadingsKeyphraseCTAUrl ),
 		} ),
@@ -73,7 +75,7 @@ const ProductCornerstoneSEOAssessor = function( researcher, options ) {
 			urlTitle: createAnchorOpeningTag( options.textCompetingLinksUrlTitle ),
 			urlCallToAction: createAnchorOpeningTag( options.textCompetingLinksCTAUrl ),
 		} ),
-		new TextLength( {
+		new TextLengthAssessment( {
 			recommendedMinimum: 400,
 			slightlyBelowMinimum: 300,
 			belowMinimum: 200,
@@ -91,7 +93,7 @@ const ProductCornerstoneSEOAssessor = function( researcher, options ) {
 			urlTitle: createAnchorOpeningTag( options.titleKeyphraseUrlTitle ),
 			urlCallToAction: createAnchorOpeningTag( options.titleKeyphraseCTAUrl ),
 		} ),
-		new TitleWidth( {
+		new PageTitleWidthAssessment( {
 			scores: {
 				widthTooShort: 9,
 			},
@@ -107,7 +109,7 @@ const ProductCornerstoneSEOAssessor = function( researcher, options ) {
 				urlCallToAction: createAnchorOpeningTag( options.urlKeyphraseCTAUrl ),
 			}
 		),
-		new FunctionWordsInKeyphrase( {
+		new FunctionWordsInKeyphraseAssessment( {
 			urlTitle: createAnchorOpeningTag( options.functionWordsInKeyphraseUrlTitle ),
 			urlCallToAction: createAnchorOpeningTag( options.functionWordsInKeyphraseCTAUrl ),
 		} ),
@@ -115,7 +117,7 @@ const ProductCornerstoneSEOAssessor = function( researcher, options ) {
 			urlTitle: createAnchorOpeningTag( options.singleH1UrlTitle ),
 			urlCallToAction: createAnchorOpeningTag( options.singleH1CTAUrl ),
 		} ),
-		new ImageCount( {
+		new ImageCountAssessment( {
 			scores: {
 				okay: 6,
 			},
@@ -123,7 +125,7 @@ const ProductCornerstoneSEOAssessor = function( researcher, options ) {
 			urlTitle: createAnchorOpeningTag( options.imageCountUrlTitle ),
 			urlCallToAction: createAnchorOpeningTag( options.imageCountCTAUrl ),
 		}, options.countVideos ),
-		new ImageKeyphrase( {
+		new ImageKeyphraseAssessment( {
 			scores: {
 				withAltNonKeyword: 3,
 				withAlt: 3,
@@ -132,7 +134,7 @@ const ProductCornerstoneSEOAssessor = function( researcher, options ) {
 			urlTitle: createAnchorOpeningTag( options.imageKeyphraseUrlTitle ),
 			urlCallToAction: createAnchorOpeningTag( options.imageKeyphraseCTAUrl ),
 		} ),
-		new ImageAltTags( {
+		new ImageAltTagsAssessment( {
 			urlTitle: createAnchorOpeningTag( options.imageAltTagsUrlTitle ),
 			urlCallToAction: createAnchorOpeningTag( options.imageAltTagsCTAUrl ),
 		} ),

--- a/packages/yoastseo/src/scoring/productPages/cornerstone/seoAssessor.js
+++ b/packages/yoastseo/src/scoring/productPages/cornerstone/seoAssessor.js
@@ -1,6 +1,6 @@
 import { inherits } from "util";
 
-import { Assessor, SEOAssessor, assessments, helpers } from "yoastseo";
+import { Assessor, SeoAssessor, assessments, helpers } from "yoastseo";
 const { createAnchorOpeningTag } = helpers;
 
 const {
@@ -153,6 +153,6 @@ const ProductCornerstoneSEOAssessor = function( researcher, options ) {
 	];
 };
 
-inherits( ProductCornerstoneSEOAssessor, SEOAssessor );
+inherits( ProductCornerstoneSEOAssessor, SeoAssessor );
 
 export default ProductCornerstoneSEOAssessor;

--- a/packages/yoastseo/src/scoring/productPages/relatedKeywordAssessor.js
+++ b/packages/yoastseo/src/scoring/productPages/relatedKeywordAssessor.js
@@ -1,14 +1,18 @@
 import { inherits } from "util";
-import { createAnchorOpeningTag } from "../../helpers/shortlinker";
 
-import Assessor from "../assessor.js";
-import IntroductionKeyword from "../assessments/seo/IntroductionKeywordAssessment.js";
-import KeyphraseLength from "../assessments/seo/KeyphraseLengthAssessment.js";
-import KeywordDensity from "../assessments/seo/KeywordDensityAssessment.js";
-import MetaDescriptionKeyword from "../assessments/seo/MetaDescriptionKeywordAssessment.js";
-import ImageKeyphrase from "../assessments/seo/KeyphraseInImageTextAssessment";
-import TextCompetingLinks from "../assessments/seo/TextCompetingLinksAssessment.js";
-import FunctionWordsInKeyphrase from "../assessments/seo/FunctionWordsInKeyphraseAssessment";
+import { Assessor, assessments, helpers } from "yoastseo";
+const { createAnchorOpeningTag } = helpers;
+
+const {
+	IntroductionKeywordAssessment,
+	KeyphraseLengthAssessment,
+	KeywordDensityAssessment,
+	MetaDescriptionKeywordAssessment,
+	TextCompetingLinksAssessment,
+	ImageKeyphraseAssessment,
+	FunctionWordsInKeyphraseAssessment,
+} = assessments.seo;
+
 
 /**
  * Creates the Assessor
@@ -23,11 +27,11 @@ const ProductRelatedKeywordAssessor = function( researcher, options ) {
 	this.type = "productPageRelatedKeywordAssessor";
 
 	this._assessments = [
-		new IntroductionKeyword( {
+		new IntroductionKeywordAssessment( {
 			urlTitle: createAnchorOpeningTag( options.introductionKeyphraseUrlTitle ),
 			urlCallToAction: createAnchorOpeningTag( options.introductionKeyphraseCTAUrl ),
 		} ),
-		new KeyphraseLength( {
+		new KeyphraseLengthAssessment( {
 			parameters: {
 				recommendedMinimum: 4,
 				recommendedMaximum: 6,
@@ -38,23 +42,23 @@ const ProductRelatedKeywordAssessor = function( researcher, options ) {
 			urlTitle: createAnchorOpeningTag( options.keyphraseLengthUrlTitle ),
 			urlCallToAction: createAnchorOpeningTag( options.keyphraseLengthCTAUrl ),
 		}, true ),
-		new KeywordDensity( {
+		new KeywordDensityAssessment( {
 			urlTitle: createAnchorOpeningTag( options.keyphraseDensityUrlTitle ),
 			urlCallToAction: createAnchorOpeningTag( options.keyphraseDensityCTAUrl ),
 		} ),
-		new MetaDescriptionKeyword( {
+		new MetaDescriptionKeywordAssessment( {
 			urlTitle: createAnchorOpeningTag( options.metaDescriptionKeyphraseUrlTitle ),
 			urlCallToAction: createAnchorOpeningTag( options.metaDescriptionKeyphraseCTAUrl ),
 		} ),
-		new TextCompetingLinks( {
+		new TextCompetingLinksAssessment( {
 			urlTitle: createAnchorOpeningTag( options.textCompetingLinksUrlTitle ),
 			urlCallToAction: createAnchorOpeningTag( options.textCompetingLinksCTAUrl ),
 		} ),
-		new FunctionWordsInKeyphrase( {
+		new FunctionWordsInKeyphraseAssessment( {
 			urlTitle: createAnchorOpeningTag( options.functionWordsInKeyphraseUrlTitle ),
 			urlCallToAction: createAnchorOpeningTag( options.functionWordsInKeyphraseCTAUrl ),
 		} ),
-		new ImageKeyphrase( {
+		new ImageKeyphraseAssessment( {
 			urlTitle: createAnchorOpeningTag( options.imageKeyphraseUrlTitle ),
 			urlCallToAction: createAnchorOpeningTag( options.imageKeyphraseCTAUrl ),
 		} ),

--- a/packages/yoastseo/src/scoring/productPages/relatedKeywordAssessor.js
+++ b/packages/yoastseo/src/scoring/productPages/relatedKeywordAssessor.js
@@ -13,7 +13,6 @@ const {
 	FunctionWordsInKeyphraseAssessment,
 } = assessments.seo;
 
-
 /**
  * Creates the Assessor
  *

--- a/packages/yoastseo/src/scoring/productPages/seoAssessor.js
+++ b/packages/yoastseo/src/scoring/productPages/seoAssessor.js
@@ -24,7 +24,6 @@ const {
 	ImageAltTagsAssessment,
 } = assessments.seo;
 
-
 /**
  * Creates the Assessor
  *
@@ -119,8 +118,7 @@ const ProductSEOAssessor = function( researcher, options ) {
 		new ImageAltTagsAssessment( {
 			urlTitle: createAnchorOpeningTag( options.imageAltTagsUrlTitle ),
 			urlCallToAction: createAnchorOpeningTag( options.imageAltTagsCTAUrl ),
-		}
-		),
+		} ),
 		new ProductIdentifiersAssessment( {
 			urlTitle: createAnchorOpeningTag( options.productIdentifierUrlTitle ),
 			urlCallToAction: createAnchorOpeningTag( options.productIdentifierCTAUrl ),

--- a/packages/yoastseo/src/scoring/productPages/seoAssessor.js
+++ b/packages/yoastseo/src/scoring/productPages/seoAssessor.js
@@ -1,24 +1,29 @@
 import { inherits } from "util";
-import { createAnchorOpeningTag } from "../../helpers/shortlinker";
-import ImageAltTags from "../assessments/seo/ImageAltTagsAssessment";
-import IntroductionKeywordAssessment from "../assessments/seo/IntroductionKeywordAssessment";
-import KeyphraseLengthAssessment from "../assessments/seo/KeyphraseLengthAssessment";
-import KeywordDensityAssessment from "../assessments/seo/KeywordDensityAssessment";
-import MetaDescriptionKeywordAssessment from "../assessments/seo/MetaDescriptionKeywordAssessment";
-import TextCompetingLinksAssessment from "../assessments/seo/TextCompetingLinksAssessment";
-import KeyphraseInSEOTitleAssessment from "../assessments/seo/KeyphraseInSEOTitleAssessment";
-import SlugKeywordAssessment from "../assessments/seo/UrlKeywordAssessment";
-import Assessor from "../assessor";
-import MetaDescriptionLength from "../assessments/seo/MetaDescriptionLengthAssessment";
-import SubheadingsKeyword from "../assessments/seo/SubHeadingsKeywordAssessment";
-import ImageKeyphrase from "../assessments/seo/KeyphraseInImageTextAssessment";
-import ImageCount from "../assessments/seo/ImageCountAssessment";
-import TextLength from "../assessments/seo/TextLengthAssessment";
-import TitleWidth from "../assessments/seo/PageTitleWidthAssessment";
-import SingleH1Assessment from "../assessments/seo/SingleH1Assessment";
-import FunctionWordsInKeyphrase from "../assessments/seo/FunctionWordsInKeyphraseAssessment";
-import ProductIdentifiersAssessment from "../assessments/seo/ProductIdentifiersAssessment";
-import ProductSKUAssessment from "../assessments/seo/ProductSKUAssessment";
+
+import { Assessor, assessments, helpers } from "yoastseo";
+const { createAnchorOpeningTag } = helpers;
+
+const {
+	IntroductionKeywordAssessment,
+	KeyphraseLengthAssessment,
+	KeywordDensityAssessment,
+	MetaDescriptionKeywordAssessment,
+	TextCompetingLinksAssessment,
+	KeyphraseInSEOTitleAssessment,
+	SlugKeywordAssessment,
+	MetaDescriptionLengthAssessment,
+	SubheadingsKeywordAssessment,
+	ImageKeyphraseAssessment,
+	ImageCountAssessment,
+	TextLengthAssessment,
+	PageTitleWidthAssessment,
+	FunctionWordsInKeyphraseAssessment,
+	SingleH1Assessment,
+	ProductIdentifiersAssessment,
+	ProductSKUAssessment,
+	ImageAltTagsAssessment,
+} = assessments.seo;
+
 
 /**
  * Creates the Assessor
@@ -55,11 +60,11 @@ const ProductSEOAssessor = function( researcher, options ) {
 			urlTitle: createAnchorOpeningTag( options.metaDescriptionKeyphraseUrlTitle ),
 			urlCallToAction: createAnchorOpeningTag( options.metaDescriptionKeyphraseCTAUrl ),
 		} ),
-		new MetaDescriptionLength( {
+		new MetaDescriptionLengthAssessment( {
 			urlTitle: createAnchorOpeningTag( options.metaDescriptionLengthUrlTitle ),
 			urlCallToAction: createAnchorOpeningTag( options.metaDescriptionLengthCTAUrl ),
 		} ),
-		new SubheadingsKeyword( {
+		new SubheadingsKeywordAssessment( {
 			urlTitle: createAnchorOpeningTag( options.subheadingsKeyphraseUrlTitle ),
 			urlCallToAction: createAnchorOpeningTag( options.subheadingsKeyphraseCTAUrl ),
 		} ),
@@ -67,7 +72,7 @@ const ProductSEOAssessor = function( researcher, options ) {
 			urlTitle: createAnchorOpeningTag( options.textCompetingLinksUrlTitle ),
 			urlCallToAction: createAnchorOpeningTag( options.textCompetingLinksCTAUrl ),
 		} ),
-		new TextLength( {
+		new TextLengthAssessment( {
 			recommendedMinimum: 200,
 			slightlyBelowMinimum: 150,
 			belowMinimum: 100,
@@ -80,7 +85,7 @@ const ProductSEOAssessor = function( researcher, options ) {
 			urlTitle: createAnchorOpeningTag( options.titleKeyphraseUrlTitle ),
 			urlCallToAction: createAnchorOpeningTag( options.titleKeyphraseCTAUrl ),
 		} ),
-		new TitleWidth( {
+		new PageTitleWidthAssessment( {
 			scores: {
 				widthTooShort: 9,
 			},
@@ -91,7 +96,7 @@ const ProductSEOAssessor = function( researcher, options ) {
 			urlTitle: createAnchorOpeningTag( options.urlKeyphraseUrlTitle ),
 			urlCallToAction: createAnchorOpeningTag( options.urlKeyphraseCTAUrl ),
 		} ),
-		new FunctionWordsInKeyphrase( {
+		new FunctionWordsInKeyphraseAssessment( {
 			urlTitle: createAnchorOpeningTag( options.functionWordsInKeyphraseUrlTitle ),
 			urlCallToAction: createAnchorOpeningTag( options.functionWordsInKeyphraseCTAUrl ),
 		} ),
@@ -99,7 +104,7 @@ const ProductSEOAssessor = function( researcher, options ) {
 			urlTitle: createAnchorOpeningTag( options.singleH1UrlTitle ),
 			urlCallToAction: createAnchorOpeningTag( options.singleH1CTAUrl ),
 		} ),
-		new ImageCount( {
+		new ImageCountAssessment( {
 			scores: {
 				okay: 6,
 			},
@@ -107,11 +112,11 @@ const ProductSEOAssessor = function( researcher, options ) {
 			urlTitle: createAnchorOpeningTag( options.imageCountUrlTitle ),
 			urlCallToAction: createAnchorOpeningTag( options.imageCountCTAUrl ),
 		}, options.countVideos ),
-		new ImageKeyphrase( {
+		new ImageKeyphraseAssessment( {
 			urlTitle: createAnchorOpeningTag( options.imageKeyphraseUrlTitle ),
 			urlCallToAction: createAnchorOpeningTag( options.imageKeyphraseCTAUrl ),
 		} ),
-		new ImageAltTags( {
+		new ImageAltTagsAssessment( {
 			urlTitle: createAnchorOpeningTag( options.imageAltTagsUrlTitle ),
 			urlCallToAction: createAnchorOpeningTag( options.imageAltTagsCTAUrl ),
 		}

--- a/packages/yoastseo/src/scoring/storeBlog/cornerstone/seoAssessor.js
+++ b/packages/yoastseo/src/scoring/storeBlog/cornerstone/seoAssessor.js
@@ -1,15 +1,17 @@
 import { inherits } from "util";
-import { createAnchorOpeningTag } from "../../../helpers/shortlinker";
 
-import KeyphraseLengthAssessment from "../../assessments/seo/KeyphraseLengthAssessment";
-import MetaDescriptionKeywordAssessment from "../../assessments/seo/MetaDescriptionKeywordAssessment";
-import KeyphraseInSEOTitleAssessment from "../../assessments/seo/KeyphraseInSEOTitleAssessment";
-import SlugKeywordAssessment from "../../assessments/seo/UrlKeywordAssessment";
-import Assessor from "../../assessor";
-import SEOAssessor from "../seoAssessor";
-import MetaDescriptionLength from "../../assessments/seo/MetaDescriptionLengthAssessment";
-import TitleWidth from "../../assessments/seo/PageTitleWidthAssessment";
-import FunctionWordsInKeyphrase from "../../assessments/seo/FunctionWordsInKeyphraseAssessment";
+import { Assessor, SeoAssessor, assessments, helpers } from "yoastseo";
+const { createAnchorOpeningTag } = helpers;
+
+const {
+	KeyphraseLengthAssessment,
+	MetaDescriptionKeywordAssessment,
+	KeyphraseInSEOTitleAssessment,
+	SlugKeywordAssessment,
+	MetaDescriptionLengthAssessment,
+	PageTitleWidthAssessment,
+	FunctionWordsInKeyphraseAssessment,
+} = assessments.seo;
 
 /**
  * Creates the Assessor
@@ -33,7 +35,7 @@ const StoreBlogCornerstoneSEOAssessor = function( researcher, options ) {
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify14" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify15" ),
 		} ),
-		new MetaDescriptionLength( {
+		new MetaDescriptionLengthAssessment( {
 			scores:	{
 				tooLong: 3,
 				tooShort: 3,
@@ -45,7 +47,7 @@ const StoreBlogCornerstoneSEOAssessor = function( researcher, options ) {
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify24" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify25" ),
 		} ),
-		new TitleWidth( {
+		new PageTitleWidthAssessment( {
 			scores: {
 				widthTooShort: 9,
 			},
@@ -61,13 +63,13 @@ const StoreBlogCornerstoneSEOAssessor = function( researcher, options ) {
 				urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify27" ),
 			}
 		),
-		new FunctionWordsInKeyphrase( {
+		new FunctionWordsInKeyphraseAssessment( {
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify50" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify51" ),
 		} ),
 	];
 };
 
-inherits( StoreBlogCornerstoneSEOAssessor, SEOAssessor );
+inherits( StoreBlogCornerstoneSEOAssessor, SeoAssessor );
 
 export default StoreBlogCornerstoneSEOAssessor;

--- a/packages/yoastseo/src/scoring/storeBlog/seoAssessor.js
+++ b/packages/yoastseo/src/scoring/storeBlog/seoAssessor.js
@@ -1,14 +1,17 @@
 import { inherits } from "util";
-import { createAnchorOpeningTag } from "../../helpers/shortlinker";
 
-import KeyphraseLengthAssessment from "../assessments/seo/KeyphraseLengthAssessment";
-import MetaDescriptionKeywordAssessment from "../assessments/seo/MetaDescriptionKeywordAssessment";
-import KeyphraseInSEOTitleAssessment from "../assessments/seo/KeyphraseInSEOTitleAssessment";
-import SlugKeywordAssessment from "../assessments/seo/UrlKeywordAssessment";
-import Assessor from "../assessor";
-import MetaDescriptionLength from "../assessments/seo/MetaDescriptionLengthAssessment";
-import TitleWidth from "../assessments/seo/PageTitleWidthAssessment";
-import FunctionWordsInKeyphrase from "../assessments/seo/FunctionWordsInKeyphraseAssessment";
+import { Assessor, assessments, helpers } from "yoastseo";
+const { createAnchorOpeningTag } = helpers;
+
+const {
+	KeyphraseLengthAssessment,
+	MetaDescriptionKeywordAssessment,
+	KeyphraseInSEOTitleAssessment,
+	SlugKeywordAssessment,
+	MetaDescriptionLengthAssessment,
+	PageTitleWidthAssessment,
+	FunctionWordsInKeyphraseAssessment,
+} = assessments.seo;
 
 /**
  * Creates the Assessor
@@ -32,7 +35,7 @@ const StoreBlogSEOAssessor = function( researcher, options ) {
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify14" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify15" ),
 		} ),
-		new MetaDescriptionLength( {
+		new MetaDescriptionLengthAssessment( {
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify46" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify47" ),
 		} ),
@@ -40,7 +43,7 @@ const StoreBlogSEOAssessor = function( researcher, options ) {
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify24" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify25" ),
 		} ),
-		new TitleWidth( {
+		new PageTitleWidthAssessment( {
 			scores: {
 				widthTooShort: 9,
 			},
@@ -51,7 +54,7 @@ const StoreBlogSEOAssessor = function( researcher, options ) {
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify26" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify27" ),
 		} ),
-		new FunctionWordsInKeyphrase( {
+		new FunctionWordsInKeyphraseAssessment( {
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify50" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify51" ),
 		} ),

--- a/packages/yoastseo/src/scoring/storePostsAndPages/contentAssessor.js
+++ b/packages/yoastseo/src/scoring/storePostsAndPages/contentAssessor.js
@@ -1,22 +1,24 @@
-import { createAnchorOpeningTag } from "../../helpers/shortlinker";
-import Assessor from "../assessor.js";
-import ParagraphTooLong from "../assessments/readability/ParagraphTooLongAssessment.js";
-import SentenceLengthInText from "../assessments/readability/SentenceLengthInTextAssessment.js";
-import SubheadingDistributionTooLong from "../assessments/readability/SubheadingDistributionTooLongAssessment.js";
-import TransitionWords from "../assessments/readability/TransitionWordsAssessment.js";
-import PassiveVoice from "../assessments/readability/PassiveVoiceAssessment.js";
-import SentenceBeginnings from "../assessments/readability/SentenceBeginningsAssessment.js";
-import TextPresence from "../assessments/readability/TextPresenceAssessment.js";
+import { map, sum } from "lodash-es";
+import { inherits } from "util";
+
+import { Assessor, assessments, helpers, interpreters } from "yoastseo";
+const { createAnchorOpeningTag } = helpers;
+const { scoreToRating } = interpreters;
+
+const {
+	ParagraphTooLongAssessment,
+	SentenceLengthInTextAssessment,
+	SubheadingDistributionTooLongAssessment,
+	TransitionWordsAssessment,
+	PassiveVoiceAssessment,
+	TextPresenceAssessment,
+	SentenceBeginningsAssessment,
+} = assessments.readability;
 
 /*
 	Temporarily disabled:
 	var sentenceLengthInDescription = require( "./assessments/sentenceLengthInDescriptionAssessment.js" );
  */
-
-import scoreToRating from "../interpreters/scoreToRating";
-
-import { map } from "lodash-es";
-import { sum } from "lodash-es";
 
 /**
  * Creates the Assessor
@@ -32,38 +34,38 @@ const StorePostsAndPagesContentAssessor = function( researcher, options = {} ) {
 	this.type = "storePostsAndPagesContentAssessor";
 	this._assessments = [
 
-		new SubheadingDistributionTooLong( {
+		new SubheadingDistributionTooLongAssessment( {
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify68" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify69" ),
 		} ),
-		new ParagraphTooLong( {
+		new ParagraphTooLongAssessment( {
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify66" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify67" ),
 		} ),
-		new SentenceLengthInText( {
+		new SentenceLengthInTextAssessment( {
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify48" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify49" ),
 		} ),
-		new TransitionWords( {
+		new TransitionWordsAssessment( {
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify44" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify45" ),
 		} ),
-		new PassiveVoice( {
+		new PassiveVoiceAssessment( {
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify42" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify43" ),
 		} ),
-		new TextPresence( {
+		new TextPresenceAssessment( {
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify56" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify57" ),
 		} ),
-		new SentenceBeginnings( {
+		new SentenceBeginningsAssessment( {
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify5" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify65" ),
 		} ),
 	];
 };
 
-require( "util" ).inherits( StorePostsAndPagesContentAssessor, Assessor );
+inherits( StorePostsAndPagesContentAssessor, Assessor );
 
 /**
  * Calculates the weighted rating for languages that have all assessments based on a given rating.

--- a/packages/yoastseo/src/scoring/storePostsAndPages/contentAssessor.js
+++ b/packages/yoastseo/src/scoring/storePostsAndPages/contentAssessor.js
@@ -1,9 +1,7 @@
-import { map, sum } from "lodash-es";
 import { inherits } from "util";
 
-import { Assessor, ContentAssessor, assessments, helpers, interpreters } from "yoastseo";
+import { Assessor, ContentAssessor, assessments, helpers } from "yoastseo";
 const { createAnchorOpeningTag } = helpers;
-const { scoreToRating } = interpreters;
 
 const {
 	ParagraphTooLongAssessment,

--- a/packages/yoastseo/src/scoring/storePostsAndPages/contentAssessor.js
+++ b/packages/yoastseo/src/scoring/storePostsAndPages/contentAssessor.js
@@ -1,7 +1,7 @@
 import { map, sum } from "lodash-es";
 import { inherits } from "util";
 
-import { Assessor, assessments, helpers, interpreters } from "yoastseo";
+import { Assessor, ContentAssessor, assessments, helpers, interpreters } from "yoastseo";
 const { createAnchorOpeningTag } = helpers;
 const { scoreToRating } = interpreters;
 
@@ -21,11 +21,10 @@ const {
  */
 
 /**
- * Creates the Assessor
+ * Creates the Assessor for e-commerce posts and pages content types.
  *
  * @param {object}  researcher      The researcher to use for the analysis.
  * @param {Object}  options         The options for this assessor.
- * @param {Object}  options.marker  The marker to pass the list of marks to.
  *
  * @constructor
  */
@@ -65,134 +64,7 @@ const StorePostsAndPagesContentAssessor = function( researcher, options = {} ) {
 	];
 };
 
-inherits( StorePostsAndPagesContentAssessor, Assessor );
-
-/**
- * Calculates the weighted rating for languages that have all assessments based on a given rating.
- *
- * @param {number} rating The rating to be weighted.
- * @returns {number} The weighted rating.
- */
-StorePostsAndPagesContentAssessor.prototype.calculatePenaltyPointsFullSupport = function( rating ) {
-	switch ( rating ) {
-		case "bad":
-			return 3;
-		case "ok":
-			return 2;
-		default:
-		case "good":
-			return 0;
-	}
-};
-
-/**
- * Calculates the weighted rating for languages that don't have all assessments based on a given rating.
- *
- * @param {number} rating The rating to be weighted.
- * @returns {number} The weighted rating.
- */
-StorePostsAndPagesContentAssessor.prototype.calculatePenaltyPointsPartialSupport = function( rating ) {
-	switch ( rating ) {
-		case "bad":
-			return 4;
-		case "ok":
-			return 2;
-		default:
-		case "good":
-			return 0;
-	}
-};
-
-/**
- * Determines whether a language is fully supported. If a language supports 8 content assessments
- * it is fully supported
- *
- * @returns {boolean} True if fully supported.
- */
-StorePostsAndPagesContentAssessor.prototype._allAssessmentsSupported = function() {
-	const numberOfAssessments = this._assessments.length;
-	const applicableAssessments = this.getApplicableAssessments();
-	return applicableAssessments.length === numberOfAssessments;
-};
-
-/**
- * Calculates the penalty points based on the assessment results.
- *
- * @returns {number} The total penalty points for the results.
- */
-StorePostsAndPagesContentAssessor.prototype.calculatePenaltyPoints = function() {
-	const results = this.getValidResults();
-
-	const penaltyPoints = map( results, function( result ) {
-		const rating = scoreToRating( result.getScore() );
-
-		if ( this._allAssessmentsSupported() ) {
-			return this.calculatePenaltyPointsFullSupport( rating );
-		}
-
-		return this.calculatePenaltyPointsPartialSupport( rating );
-	}.bind( this ) );
-
-	return sum( penaltyPoints );
-};
-
-/**
- * Rates the penalty points
- *
- * @param {number} totalPenaltyPoints The amount of penalty points.
- * @returns {number} The score based on the amount of penalty points.
- *
- * @private
- */
-StorePostsAndPagesContentAssessor.prototype._ratePenaltyPoints = function( totalPenaltyPoints ) {
-	if ( this.getValidResults().length === 1 ) {
-		// If we have only 1 result, we only have a "no content" result
-		return 30;
-	}
-
-	if ( this._allAssessmentsSupported() ) {
-		// Determine the total score based on the total penalty points.
-		if ( totalPenaltyPoints > 6 ) {
-			// A red indicator.
-			return 30;
-		}
-
-		if ( totalPenaltyPoints > 4 ) {
-			// An orange indicator.
-			return 60;
-		}
-	} else {
-		if ( totalPenaltyPoints > 4 ) {
-			// A red indicator.
-			return 30;
-		}
-
-		if ( totalPenaltyPoints > 2 ) {
-			// An orange indicator.
-			return 60;
-		}
-	}
-	// A green indicator.
-	return 90;
-};
-
-/**
- * Calculates the overall score based on the assessment results.
- *
- * @returns {number} The overall score.
- */
-StorePostsAndPagesContentAssessor.prototype.calculateOverallScore = function() {
-	const results = this.getValidResults();
-
-	// If you have no content, you have a red indicator.
-	if ( results.length === 0 ) {
-		return 30;
-	}
-
-	const totalPenaltyPoints = this.calculatePenaltyPoints();
-
-	return this._ratePenaltyPoints( totalPenaltyPoints );
-};
+inherits( StorePostsAndPagesContentAssessor, ContentAssessor );
 
 export default StorePostsAndPagesContentAssessor;
 

--- a/packages/yoastseo/src/scoring/storePostsAndPages/cornerstone/contentAssessor.js
+++ b/packages/yoastseo/src/scoring/storePostsAndPages/cornerstone/contentAssessor.js
@@ -1,13 +1,17 @@
-import { createAnchorOpeningTag } from "../../../helpers/shortlinker";
-import Assessor from "../../assessor.js";
-import ContentAssessor from "../../contentAssessor";
-import ParagraphTooLong from "../../assessments/readability/ParagraphTooLongAssessment.js";
-import SentenceLengthInText from "../../assessments/readability/SentenceLengthInTextAssessment.js";
-import SubheadingDistributionTooLong from "../../assessments/readability/SubheadingDistributionTooLongAssessment.js";
-import TransitionWords from "../../assessments/readability/TransitionWordsAssessment.js";
-import PassiveVoice from "../../assessments/readability/PassiveVoiceAssessment.js";
-import SentenceBeginnings from "../../assessments/readability/SentenceBeginningsAssessment.js";
-import TextPresence from "../../assessments/readability/TextPresenceAssessment.js";
+import { inherits } from "util";
+
+import { Assessor, ContentAssessor, assessments, helpers } from "yoastseo";
+const { createAnchorOpeningTag } = helpers;
+
+const {
+	ParagraphTooLongAssessment,
+	SentenceLengthInTextAssessment,
+	SubheadingDistributionTooLongAssessment,
+	TransitionWordsAssessment,
+	PassiveVoiceAssessment,
+	TextPresenceAssessment,
+	SentenceBeginningsAssessment,
+} = assessments.readability;
 
 /*
  Temporarily disabled:
@@ -29,7 +33,7 @@ const StorePostsAndPagesCornerstoneContentAssessor = function( researcher, optio
 
 	this._assessments = [
 
-		new SubheadingDistributionTooLong( {
+		new SubheadingDistributionTooLongAssessment( {
 			parameters:	{
 				slightlyTooMany: 250,
 				farTooMany: 300,
@@ -39,36 +43,36 @@ const StorePostsAndPagesCornerstoneContentAssessor = function( researcher, optio
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify69" ),
 			cornerstoneContent: true,
 		} ),
-		new ParagraphTooLong( {
+		new ParagraphTooLongAssessment( {
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify66" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify67" ),
 		} ),
-		new SentenceLengthInText( {
+		new SentenceLengthInTextAssessment( {
 			slightlyTooMany: 20,
 			farTooMany: 25,
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify48" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify49" ),
 		}, true ),
-		new TransitionWords( {
+		new TransitionWordsAssessment( {
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify44" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify45" ),
 		} ),
-		new PassiveVoice( {
+		new PassiveVoiceAssessment( {
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify42" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify43" ),
 		} ),
-		new TextPresence( {
+		new TextPresenceAssessment( {
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify56" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify57" ),
 		} ),
-		new SentenceBeginnings( {
+		new SentenceBeginningsAssessment( {
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify5" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify65" ),
 		} ),
 	];
 };
 
-require( "util" ).inherits( StorePostsAndPagesCornerstoneContentAssessor, ContentAssessor );
+inherits( StorePostsAndPagesCornerstoneContentAssessor, ContentAssessor );
 
 
 export default StorePostsAndPagesCornerstoneContentAssessor;

--- a/packages/yoastseo/src/scoring/storePostsAndPages/cornerstone/relatedKeywordAssessor.js
+++ b/packages/yoastseo/src/scoring/storePostsAndPages/cornerstone/relatedKeywordAssessor.js
@@ -1,14 +1,17 @@
 import { inherits } from "util";
-import { createAnchorOpeningTag } from "../../../helpers/shortlinker";
-import Assessor from "../../assessor.js";
 
-import IntroductionKeyword from "../../assessments/seo/IntroductionKeywordAssessment.js";
-import KeyphraseLength from "../../assessments/seo/KeyphraseLengthAssessment.js";
-import KeywordDensity from "../../assessments/seo/KeywordDensityAssessment.js";
-import MetaDescriptionKeyword from "../../assessments/seo/MetaDescriptionKeywordAssessment.js";
-import TextCompetingLinks from "../../assessments/seo/TextCompetingLinksAssessment.js";
-import FunctionWordsInKeyphrase from "../../assessments/seo/FunctionWordsInKeyphraseAssessment";
-import ImageKeyphrase from "../../assessments/seo/KeyphraseInImageTextAssessment";
+import { Assessor, assessments, helpers } from "yoastseo";
+const { createAnchorOpeningTag } = helpers;
+
+const {
+	IntroductionKeywordAssessment,
+	KeyphraseLengthAssessment,
+	KeywordDensityAssessment,
+	MetaDescriptionKeywordAssessment,
+	TextCompetingLinksAssessment,
+	ImageKeyphraseAssessment,
+	FunctionWordsInKeyphraseAssessment,
+} = assessments.seo;
 
 /**
  * Creates the Assessor
@@ -24,32 +27,32 @@ const StorePostsAndPagesCornerstoneRelatedKeywordAssessor = function( researcher
 	this.type = "storePostsAndPagesCornerstoneRelatedKeywordAssessor";
 
 	this._assessments = [
-		new IntroductionKeyword( {
+		new IntroductionKeywordAssessment( {
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify8" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify9" ),
 		} ),
-		new KeyphraseLength( {
+		new KeyphraseLengthAssessment( {
 			isRelatedKeyphrase: true,
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify10" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify11" ),
 		} ),
-		new KeywordDensity( {
+		new KeywordDensityAssessment( {
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify12" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify13" ),
 		} ),
-		new MetaDescriptionKeyword( {
+		new MetaDescriptionKeywordAssessment( {
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify14" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify15" ),
 		} ),
-		new TextCompetingLinks( {
+		new TextCompetingLinksAssessment( {
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify18" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify19" ),
 		} ),
-		new FunctionWordsInKeyphrase( {
+		new FunctionWordsInKeyphraseAssessment( {
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify50" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify51" ),
 		} ),
-		new ImageKeyphrase( {
+		new ImageKeyphraseAssessment( {
 			scores: {
 				withAltNonKeyword: 3,
 				withAlt: 3,

--- a/packages/yoastseo/src/scoring/storePostsAndPages/cornerstone/seoAssessor.js
+++ b/packages/yoastseo/src/scoring/storePostsAndPages/cornerstone/seoAssessor.js
@@ -1,25 +1,27 @@
 import { inherits } from "util";
-import { createAnchorOpeningTag } from "../../../helpers/shortlinker";
 
-import IntroductionKeywordAssessment from "../../assessments/seo/IntroductionKeywordAssessment";
-import KeyphraseLengthAssessment from "../../assessments/seo/KeyphraseLengthAssessment";
-import KeywordDensityAssessment from "../../assessments/seo/KeywordDensityAssessment";
-import MetaDescriptionKeywordAssessment from "../../assessments/seo/MetaDescriptionKeywordAssessment";
-import TextCompetingLinksAssessment from "../../assessments/seo/TextCompetingLinksAssessment";
-import InternalLinksAssessment from "../../assessments/seo/InternalLinksAssessment";
-import KeyphraseInSEOTitleAssessment from "../../assessments/seo/KeyphraseInSEOTitleAssessment";
-import SlugKeywordAssessment from "../../assessments/seo/UrlKeywordAssessment";
-import Assessor from "../../assessor";
-import SEOAssessor from "../seoAssessor";
-import MetaDescriptionLength from "../../assessments/seo/MetaDescriptionLengthAssessment";
-import SubheadingsKeyword from "../../assessments/seo/SubHeadingsKeywordAssessment";
-import ImageKeyphrase from "../../assessments/seo/KeyphraseInImageTextAssessment";
-import ImageCount from "../../assessments/seo/ImageCountAssessment";
-import TextLength from "../../assessments/seo/TextLengthAssessment";
-import OutboundLinks from "../../assessments/seo/OutboundLinksAssessment";
-import TitleWidth from "../../assessments/seo/PageTitleWidthAssessment";
-import FunctionWordsInKeyphrase from "../../assessments/seo/FunctionWordsInKeyphraseAssessment";
-import SingleH1Assessment from "../../assessments/seo/SingleH1Assessment";
+import { Assessor, SeoAssessor, assessments, helpers } from "yoastseo";
+const { createAnchorOpeningTag } = helpers;
+
+const {
+	IntroductionKeywordAssessment,
+	KeyphraseLengthAssessment,
+	KeywordDensityAssessment,
+	MetaDescriptionKeywordAssessment,
+	KeyphraseInSEOTitleAssessment,
+	SlugKeywordAssessment,
+	MetaDescriptionLengthAssessment,
+	TextLengthAssessment,
+	PageTitleWidthAssessment,
+	FunctionWordsInKeyphraseAssessment,
+	SingleH1Assessment,
+	OutboundLinksAssessment,
+	InternalLinksAssessment,
+	ImageCountAssessment,
+	ImageKeyphraseAssessment,
+	TextCompetingLinksAssessment,
+	SubheadingsKeywordAssessment,
+} = assessments.seo;
 
 /**
  * Creates the Assessor
@@ -51,7 +53,7 @@ const StorePostsAndPagesCornerstoneSEOAssessor = function( researcher, options )
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify14" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify15" ),
 		} ),
-		new MetaDescriptionLength( {
+		new MetaDescriptionLengthAssessment( {
 			scores:	{
 				tooLong: 3,
 				tooShort: 3,
@@ -59,7 +61,7 @@ const StorePostsAndPagesCornerstoneSEOAssessor = function( researcher, options )
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify46" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify47" ),
 		} ),
-		new SubheadingsKeyword( {
+		new SubheadingsKeywordAssessment( {
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify16" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify17" ),
 		} ),
@@ -67,7 +69,7 @@ const StorePostsAndPagesCornerstoneSEOAssessor = function( researcher, options )
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify18" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify19" ),
 		} ),
-		new ImageKeyphrase( {
+		new ImageKeyphraseAssessment( {
 			scores: {
 				withAltNonKeyword: 3,
 				withAlt: 3,
@@ -76,11 +78,11 @@ const StorePostsAndPagesCornerstoneSEOAssessor = function( researcher, options )
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify22" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify23" ),
 		} ),
-		new ImageCount( {
+		new ImageCountAssessment( {
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify20" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify21" ),
 		} ),
-		new TextLength( {
+		new TextLengthAssessment( {
 			recommendedMinimum: 900,
 			slightlyBelowMinimum: 400,
 			belowMinimum: 300,
@@ -93,7 +95,7 @@ const StorePostsAndPagesCornerstoneSEOAssessor = function( researcher, options )
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify59" ),
 			cornerstoneContent: true,
 		} ),
-		new OutboundLinks( {
+		new OutboundLinksAssessment( {
 			scores: {
 				noLinks: 3,
 			},
@@ -108,7 +110,7 @@ const StorePostsAndPagesCornerstoneSEOAssessor = function( researcher, options )
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify60" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify61" ),
 		} ),
-		new TitleWidth( {
+		new PageTitleWidthAssessment( {
 			scores: {
 				widthTooShort: 9,
 			},
@@ -124,7 +126,7 @@ const StorePostsAndPagesCornerstoneSEOAssessor = function( researcher, options )
 				urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify27" ),
 			}
 		),
-		new FunctionWordsInKeyphrase( {
+		new FunctionWordsInKeyphraseAssessment( {
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify50" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify51" ),
 		} ),
@@ -135,6 +137,6 @@ const StorePostsAndPagesCornerstoneSEOAssessor = function( researcher, options )
 	];
 };
 
-inherits( StorePostsAndPagesCornerstoneSEOAssessor, SEOAssessor );
+inherits( StorePostsAndPagesCornerstoneSEOAssessor, SeoAssessor );
 
 export default StorePostsAndPagesCornerstoneSEOAssessor;

--- a/packages/yoastseo/src/scoring/storePostsAndPages/relatedKeywordAssessor.js
+++ b/packages/yoastseo/src/scoring/storePostsAndPages/relatedKeywordAssessor.js
@@ -1,14 +1,17 @@
 import { inherits } from "util";
-import { createAnchorOpeningTag } from "../../helpers/shortlinker";
 
-import Assessor from "../assessor.js";
-import IntroductionKeyword from "../assessments/seo/IntroductionKeywordAssessment.js";
-import KeyphraseLength from "../assessments/seo/KeyphraseLengthAssessment.js";
-import KeywordDensity from "../assessments/seo/KeywordDensityAssessment.js";
-import MetaDescriptionKeyword from "../assessments/seo/MetaDescriptionKeywordAssessment.js";
-import ImageKeyphrase from "../assessments/seo/KeyphraseInImageTextAssessment";
-import TextCompetingLinks from "../assessments/seo/TextCompetingLinksAssessment.js";
-import FunctionWordsInKeyphrase from "../assessments/seo/FunctionWordsInKeyphraseAssessment";
+import { Assessor, assessments, helpers } from "yoastseo";
+const { createAnchorOpeningTag } = helpers;
+
+const {
+	IntroductionKeywordAssessment,
+	KeyphraseLengthAssessment,
+	KeywordDensityAssessment,
+	MetaDescriptionKeywordAssessment,
+	TextCompetingLinksAssessment,
+	ImageKeyphraseAssessment,
+	FunctionWordsInKeyphraseAssessment,
+} = assessments.seo;
 
 /**
  * Creates the Assessor
@@ -24,32 +27,32 @@ const StorePostsAndPagesRelatedKeywordAssessor = function( researcher, options )
 	this.type = "storePostsAndPagesRelatedKeywordAssessor";
 
 	this._assessments = [
-		new IntroductionKeyword( {
+		new IntroductionKeywordAssessment( {
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify8" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify9" ),
 		} ),
-		new KeyphraseLength( {
+		new KeyphraseLengthAssessment( {
 			isRelatedKeyphrase: true,
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify10" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify11" ),
 		} ),
-		new KeywordDensity( {
+		new KeywordDensityAssessment( {
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify12" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify13" ),
 		} ),
-		new MetaDescriptionKeyword( {
+		new MetaDescriptionKeywordAssessment( {
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify14" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify15" ),
 		} ),
-		new TextCompetingLinks( {
+		new TextCompetingLinksAssessment( {
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify18" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify19" ),
 		} ),
-		new FunctionWordsInKeyphrase( {
+		new FunctionWordsInKeyphraseAssessment( {
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify50" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify51" ),
 		} ),
-		new ImageKeyphrase( {
+		new ImageKeyphraseAssessment( {
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify22" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify23" ),
 		} ),

--- a/packages/yoastseo/src/scoring/storePostsAndPages/seoAssessor.js
+++ b/packages/yoastseo/src/scoring/storePostsAndPages/seoAssessor.js
@@ -1,24 +1,27 @@
 import { inherits } from "util";
-import { createAnchorOpeningTag } from "../../helpers/shortlinker";
 
-import IntroductionKeywordAssessment from "../assessments/seo/IntroductionKeywordAssessment";
-import KeyphraseLengthAssessment from "../assessments/seo/KeyphraseLengthAssessment";
-import KeywordDensityAssessment from "../assessments/seo/KeywordDensityAssessment";
-import MetaDescriptionKeywordAssessment from "../assessments/seo/MetaDescriptionKeywordAssessment";
-import TextCompetingLinksAssessment from "../assessments/seo/TextCompetingLinksAssessment";
-import InternalLinksAssessment from "../assessments/seo/InternalLinksAssessment";
-import KeyphraseInSEOTitleAssessment from "../assessments/seo/KeyphraseInSEOTitleAssessment";
-import SlugKeywordAssessment from "../assessments/seo/UrlKeywordAssessment";
-import Assessor from "../assessor";
-import MetaDescriptionLength from "../assessments/seo/MetaDescriptionLengthAssessment";
-import SubheadingsKeyword from "../assessments/seo/SubHeadingsKeywordAssessment";
-import ImageKeyphrase from "../assessments/seo/KeyphraseInImageTextAssessment";
-import ImageCount from "../assessments/seo/ImageCountAssessment";
-import TextLength from "../assessments/seo/TextLengthAssessment";
-import OutboundLinks from "../assessments/seo/OutboundLinksAssessment";
-import TitleWidth from "../assessments/seo/PageTitleWidthAssessment";
-import FunctionWordsInKeyphrase from "../assessments/seo/FunctionWordsInKeyphraseAssessment";
-import SingleH1Assessment from "../assessments/seo/SingleH1Assessment";
+import { Assessor, assessments, helpers } from "yoastseo";
+const { createAnchorOpeningTag } = helpers;
+
+const {
+	IntroductionKeywordAssessment,
+	KeyphraseLengthAssessment,
+	KeywordDensityAssessment,
+	MetaDescriptionKeywordAssessment,
+	KeyphraseInSEOTitleAssessment,
+	SlugKeywordAssessment,
+	MetaDescriptionLengthAssessment,
+	TextLengthAssessment,
+	PageTitleWidthAssessment,
+	FunctionWordsInKeyphraseAssessment,
+	SingleH1Assessment,
+	OutboundLinksAssessment,
+	InternalLinksAssessment,
+	ImageCountAssessment,
+	ImageKeyphraseAssessment,
+	TextCompetingLinksAssessment,
+	SubheadingsKeywordAssessment,
+} = assessments.seo;
 
 /**
  * Creates the Assessor
@@ -50,11 +53,11 @@ const StorePostsAndPagesSEOAssessor = function( researcher,  options ) {
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify14" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify15" ),
 		} ),
-		new MetaDescriptionLength( {
+		new MetaDescriptionLengthAssessment( {
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify46" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify47" ),
 		} ),
-		new SubheadingsKeyword( {
+		new SubheadingsKeywordAssessment( {
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify16" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify17" ),
 		} ),
@@ -62,19 +65,19 @@ const StorePostsAndPagesSEOAssessor = function( researcher,  options ) {
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify18" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify19" ),
 		} ),
-		new ImageKeyphrase( {
+		new ImageKeyphraseAssessment( {
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify22" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify23" ),
 		} ),
-		new ImageCount( {
+		new ImageCountAssessment( {
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify20" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify21" ),
 		} ),
-		new TextLength( {
+		new TextLengthAssessment( {
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify58" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify59" ),
 		} ),
-		new OutboundLinks( {
+		new OutboundLinksAssessment( {
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify62" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify63" ),
 		} ),
@@ -86,7 +89,7 @@ const StorePostsAndPagesSEOAssessor = function( researcher,  options ) {
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify60" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify61" ),
 		} ),
-		new TitleWidth( {
+		new PageTitleWidthAssessment( {
 			scores: {
 				widthTooShort: 9,
 			},
@@ -97,7 +100,7 @@ const StorePostsAndPagesSEOAssessor = function( researcher,  options ) {
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify26" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify27" ),
 		} ),
-		new FunctionWordsInKeyphrase( {
+		new FunctionWordsInKeyphraseAssessment( {
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify50" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify51" ),
 		} ),


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [yoastseo] Imports the e-Commerce assessors' dependencies from `index.js` if applicable.
* [wpseo-woocommerce] Imports the e-Commerce assessors' dependencies from `index.js` if applicable.
* [shopify-seo] Imports the e-Commerce assessors' dependencies from `index.js` if applicable.

## Relevant technical choices:

* In `packages/yoastseo/src/scoring/storePostsAndPages/contentAssessor.js`, I changed the class the assessor inherits from. Initially, the class inherits from `Assessor` and duplicates many `ContentAssessor` 's additional methods there. The duplication of those methods is not necessary anymore when `packages/yoastseo/src/scoring/storePostsAndPages/contentAssessor.js` inherits form `ContentAssessor` (instead of `Assessor`)

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### WooCommerce
* Test together with this PR: https://github.com/Yoast/wpseo-woocommerce/pull/889
##### Bundle size (during development/acceptance testing)
* In `wpseo-woocommerce`, run `yarn webpack-analyze-bundle` (run `yarn install` first)
* Confirm:
   * In  `yoastseo-woo-worker` bundle and other bundles, `lodash` and `lodash-es` are not bundled
   * From `yoastseo` in `yoastseo-woo-worker`, we should only bundle the e-commerce (product) assessors and ListAssessment
<img width="1284" alt="Screenshot 2023-02-28 at 17 03 22" src="https://user-images.githubusercontent.com/48715883/221909647-fc87c6e0-a804-4541-b9f7-e74aeeea6bed.png">

##### Smoke test analysis
* Install and activate Yoast SEO
* Install and activate Yoast SEO Premium
* Install and activate WooCommerce
* Install and activate Yoast SEO for WooCommerce
* Create a product
* Smoke test the Readability assessments
* Smoke test the SEO assessments
* Smoke test Related keyphrase assessments

#### Shopify

##### Bundle size (during development/acceptance testing)
* Test together with this PR: https://github.com/Yoast/shopify-seo/pull/1068

* In `shopify-seo/app`:
   * link `wordpress-seo` (to this branch `19916-restructuring-yoastseo-improve-the-js-bundle-in-woocommerce-and-shopify`
   * run `yarn build:analyze` (run `yarn install` first)
   * Confirm that the `analysis-worker.js` bundle stat size is 2.16MB 
   * link `wordpress-seo` to the `feature/yoastseo-refactor` branch
   * run `yarn build:analyze` (run `yarn install` first)
   * Confirm that the `analysis-worker.js` bundle stat size is 2.17MB 

##### Smoke test analysis
* Install and activate Yoast SEO for Shopify 
   * if building the app, build from this branch `19916-restructuring-yoastseo-improve-the-js-bundle-in-woocommerce-and-shopify` and link to `wordpress-seo` branch with the same name
* Create a product
* Smoke test the Readability assessments
* Smoke test the SEO assessments
* Smoke test Related keyphrase assessments
* Repeat the step in all other content types

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The changes in this PR impacts the analysis in Woo products. I've already added the test instruction to smoke test the analysis in products.
* Additionally, in Shopify, it also impacts the analysis in other content types. I've also added the test instruction to smoke test the analysis in all content types.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [x] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
