### PR TITLE
Update the wpseo_primary_term_taxonomies filter items

### DIFF
--- a/src/helpers/primary-term-helper.php
+++ b/src/helpers/primary-term-helper.php
@@ -19,7 +19,7 @@ class Primary_Term_Helper {
 	public function get_primary_term_taxonomies( $post_id ) {
 		$post_type      = \get_post_type( $post_id );
 		$all_taxonomies = \get_object_taxonomies( $post_type, 'objects' );
-		$all_taxonomies = \array_filter( $all_taxonomies, [ $this, 'filter_hierarchical_taxonomies' ] );
+		$filtered_taxonomies = \array_filter( $all_taxonomies, [ $this, 'filter_hierarchical_taxonomies' ] );
 
 		/**
 		 * Filters which taxonomies for which the user can choose the primary term.
@@ -30,7 +30,7 @@ class Primary_Term_Helper {
 		 * @param array  $all_taxonomies All taxonomies for this post types, even ones that don't have primary term
 		 *                               enabled.
 		 */
-		$taxonomies = (array) \apply_filters( 'wpseo_primary_term_taxonomies', $all_taxonomies, $post_type, $all_taxonomies );
+		$taxonomies = (array) \apply_filters( 'wpseo_primary_term_taxonomies', $filtered_taxonomies, $post_type, $all_taxonomies );
 
 		return $taxonomies;
 	}


### PR DESCRIPTION
## Context

This PR corrects the values passed to the `wpseo_primary_term_taxonomies` filter. It is intended to have the third argument pass _all_ of the taxonomies, and the way it's written, it's simply passing the same set of taxonomies twice.


## Summary

This PR can be summarized in the following changelog entry:

* `wpseo_primary_term_taxonomies` filter now passes all taxonomies in the arguments.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
