### PR TITLE
Add meta from post indexable only when indexable exists

### DIFF
--- a/tests/unit/integrations/front-end/open-graph-oembed-test.php
+++ b/tests/unit/integrations/front-end/open-graph-oembed-test.php
@@ -97,7 +97,7 @@ class Open_Graph_OEmbed_Test extends TestCase {
 
 		$this->meta
 			->expects( 'for_post' )
-			->times( 3 )
+			->once()
 			->with( 1337 )
 			->andReturn( (object) $meta_data );
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to fix the errors from this report: https://wordpress.org/support/topic/fatal-error-with-opengraph-on-20-2/#post-16523301

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where a fatal error would appear in oEmbed pages for media pages, when those are disabled from Yoast settings.

## Relevant technical choices:

* A small performance improvement is also included here, by quering for the post's indexable just once in the beginning instead of three times.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* On PHP 8+, make sure you have `Enable Media pages` as disabled
* On the oEmbed link for a media page, eg. for the `http://wordpress.test/small-image-5/` media page:

**Without this PR:**
* We throw a Fatal Error there, so the `http://wordpress.test/wp-json/oembed/1.0/embed?url=http%3A%2F%2Fwordpress.test%2Fsmall-image-5%2F` page throws a broken page
* Same for the XML page of that: `http://wordpress.test/wp-json/oembed/1.0/embed?url=http%3A%2F%2Fwordpress.test%2Fsmall-image-5%2F&format=xml`
* It also throws a couple of warnings before that:
```
PHP Warning:  Attempt to read property "open_graph_title" on bool in /wordpress-seo/src/integrations/front-end/open-graph-oembed.php on line 95
PHP Warning:  Attempt to read property "open_graph_description" on bool in /wordpress-seo/src/integrations/front-end/open-graph-oembed.php on line 106
PHP Warning:  Attempt to read property "open_graph_images" on bool in /wordpress-seo/src/integrations/front-end/open-graph-oembed.php on line 117
```
**With this PR:**
* We throw no Fatal errors and warnings in the `http://wordpress.test/wp-json/oembed/1.0/embed?url=http%3A%2F%2Fwordpress.test%2Fsmall-image-5%2F` page
* In fact, that page shows the same content with Yoast SEO enabled or disabled (except maybe the title)
* Same for the XML page of that: `http://wordpress.test/wp-json/oembed/1.0/embed?url=http%3A%2F%2Fwordpress.test%2Fsmall-image-5%2F&format=xml`

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* oEmbed pages in general
  * A good PR to repeat its Test Instructions to ensure no regressions is https://github.com/Yoast/wordpress-seo/pull/14784

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
