### PR TITLE
Change every `WPSEO` in deprecation messages to `Yoast SEO`

### DIFF
--- a/admin/class-config.php
+++ b/admin/class-config.php
@@ -120,7 +120,7 @@ class WPSEO_Admin_Pages {
 	 * @return array The replacement and recommended replacement variables.
 	 */
 	public function get_replace_vars_script_data() {
-		_deprecated_function( __METHOD__, 'WPSEO 20.3' );
+		_deprecated_function( __METHOD__, 'Yoast SEO 20.3' );
 		$replace_vars                 = new WPSEO_Replace_Vars();
 		$recommended_replace_vars     = new WPSEO_Admin_Recommended_Replace_Vars();
 		$editor_specific_replace_vars = new WPSEO_Admin_Editor_Specific_Replace_Vars();

--- a/admin/class-helpscout.php
+++ b/admin/class-helpscout.php
@@ -32,7 +32,7 @@ class WPSEO_HelpScout implements WPSEO_WordPress_Integration {
 	 * @param bool   $ask_consent Optional. Whether to ask for consent before loading in HelpScout.
 	 */
 	public function __construct( $beacon_id, array $pages, array $products, $ask_consent = false ) {
-		_deprecated_function( __METHOD__, 'WPSEO 20.3' );
+		_deprecated_function( __METHOD__, 'Yoast SEO 20.3' );
 	}
 
 	/**
@@ -46,7 +46,7 @@ class WPSEO_HelpScout implements WPSEO_WordPress_Integration {
 			return;
 		}
 
-		_deprecated_function( __METHOD__, 'WPSEO 20.3', 'HelpScout_Beacon::register_hooks' );
+		_deprecated_function( __METHOD__, 'Yoast SEO 20.3', 'HelpScout_Beacon::register_hooks' );
 	}
 
 	/**
@@ -56,7 +56,7 @@ class WPSEO_HelpScout implements WPSEO_WordPress_Integration {
 	 * @deprecated 20.3
 	 */
 	public function enqueue_help_scout_script() {
-		_deprecated_function( __METHOD__, 'WPSEO 20.3', 'HelpScout_Beacon::enqueue_help_scout_script' );
+		_deprecated_function( __METHOD__, 'Yoast SEO 20.3', 'HelpScout_Beacon::enqueue_help_scout_script' );
 	}
 
 	/**
@@ -66,6 +66,6 @@ class WPSEO_HelpScout implements WPSEO_WordPress_Integration {
 	 * @deprecated 20.3
 	 */
 	public function output_beacon_js() {
-		_deprecated_function( __METHOD__, 'WPSEO 20.3', 'HelpScout_Beacon::output_beacon_js' );
+		_deprecated_function( __METHOD__, 'Yoast SEO 20.3', 'HelpScout_Beacon::output_beacon_js' );
 	}
 }

--- a/admin/google_search_console/views/gsc-redirect-nopremium.php
+++ b/admin/google_search_console/views/gsc-redirect-nopremium.php
@@ -7,7 +7,7 @@
  * @package WPSEO\Admin\Google_Search_Console
  */
 
-_deprecated_file( __FILE__, 'WPSEO 9.5' );
+_deprecated_file( __FILE__, 'Yoast SEO 9.5' );
 
 echo '<h1 class="wpseo-redirect-url-title">';
 printf(

--- a/admin/roles/class-role-manager-vip.php
+++ b/admin/roles/class-role-manager-vip.php
@@ -26,7 +26,7 @@ final class WPSEO_Role_Manager_VIP extends WPSEO_Abstract_Role_Manager {
 	 * @return void
 	 */
 	protected function add_role( $role, $display_name, array $capabilities = [] ) {
-		_deprecated_function( __METHOD__, 'WPSEO 19.9' );
+		_deprecated_function( __METHOD__, 'Yoast SEO 19.9' );
 
 		$enabled_capabilities  = [];
 		$disabled_capabilities = [];
@@ -59,7 +59,7 @@ final class WPSEO_Role_Manager_VIP extends WPSEO_Abstract_Role_Manager {
 	 * @return void
 	 */
 	protected function remove_role( $role ) {
-		_deprecated_function( __METHOD__, 'WPSEO 19.9' );
+		_deprecated_function( __METHOD__, 'Yoast SEO 19.9' );
 
 		remove_role( $role );
 	}

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -1111,7 +1111,7 @@ class WPSEO_Utils {
 	 * @return string
 	 */
 	public static function translate_score( $val, $css_value = true ) {
-		_deprecated_function( __METHOD__, 'WPSEO 19.5', 'YoastSEO()->helpers->score_icon' );
+		_deprecated_function( __METHOD__, 'Yoast SEO 19.5', 'YoastSEO()->helpers->score_icon' );
 
 		$seo_rank = WPSEO_Rank::from_numeric_score( $val );
 

--- a/inc/language-utils.php
+++ b/inc/language-utils.php
@@ -59,7 +59,7 @@ class WPSEO_Language_Utils {
 	 * @return array The l10n array.
 	 */
 	public static function get_knowledge_graph_company_info_missing_l10n() {
-		_deprecated_function( __METHOD__, 'WPSEO 20.3' );
+		_deprecated_function( __METHOD__, 'Yoast SEO 20.3' );
 
 		return [
 			'URL'     => esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/3r3' ) ),

--- a/inc/sitemaps/class-sitemaps.php
+++ b/inc/sitemaps/class-sitemaps.php
@@ -552,7 +552,7 @@ class WPSEO_Sitemaps {
 	 * @param string|null $url Optional URL to make the ping for.
 	 */
 	public static function ping_search_engines( $url = null ) {
-		_deprecated_function( __METHOD__, 'WPSEO 19.2', 'WPSEO_Sitemaps_Admin::ping_search_engines' );
+		_deprecated_function( __METHOD__, 'Yoast SEO 19.2', 'WPSEO_Sitemaps_Admin::ping_search_engines' );
 
 		$admin = new WPSEO_Sitemaps_Admin();
 		$admin->ping_search_engines();

--- a/inc/wpseo-functions-deprecated.php
+++ b/inc/wpseo-functions-deprecated.php
@@ -15,6 +15,6 @@ if ( ! function_exists( 'wpseo_cli_init' ) ) {
 	 * @codeCoverageIgnore
 	 */
 	function wpseo_cli_init() {
-		_deprecated_function( __FUNCTION__, 'WPSEO 19.6.1' );
+		_deprecated_function( __FUNCTION__, 'Yoast SEO 19.6.1' );
 	}
 }

--- a/src/config/schema-types.php
+++ b/src/config/schema-types.php
@@ -176,7 +176,7 @@ class Schema_Types {
 	 * @return array[] The values of the Schema article type options.
 	 */
 	public function get_article_type_options_values() {
-		\_deprecated_function( __METHOD__, 'WPSEO 19.12' );
+		\_deprecated_function( __METHOD__, 'Yoast SEO 19.12' );
 		$article_types       = $this->get_article_type_options();
 		$article_type_values = [];
 

--- a/src/deprecated/admin/ryte/class-ryte.php
+++ b/src/deprecated/admin/ryte/class-ryte.php
@@ -33,7 +33,7 @@ class WPSEO_Ryte implements WPSEO_WordPress_Integration {
 	 * @codeCoverageIgnore
 	 */
 	public function __construct() {
-		_deprecated_function( __METHOD__, 'WPSEO 18.5' );
+		_deprecated_function( __METHOD__, 'Yoast SEO 18.5' );
 		$this->maybe_add_weekly_schedule();
 	}
 
@@ -46,7 +46,7 @@ class WPSEO_Ryte implements WPSEO_WordPress_Integration {
 	 * @return void
 	 */
 	public function register_hooks() {
-		_deprecated_function( __METHOD__, 'WPSEO 18.5' );
+		_deprecated_function( __METHOD__, 'Yoast SEO 18.5' );
 		if ( ! self::is_active() ) {
 			return;
 		}
@@ -64,7 +64,7 @@ class WPSEO_Ryte implements WPSEO_WordPress_Integration {
 	 * @return bool True if this functionality can be used.
 	 */
 	public static function is_active() {
-		_deprecated_function( __METHOD__, 'WPSEO 18.5' );
+		_deprecated_function( __METHOD__, 'Yoast SEO 18.5' );
 		if ( wp_doing_ajax() ) {
 			return false;
 		}
@@ -83,7 +83,7 @@ class WPSEO_Ryte implements WPSEO_WordPress_Integration {
 	 * @codeCoverageIgnore
 	 */
 	public function activate_hooks() {
-		_deprecated_function( __METHOD__, 'WPSEO 18.5' );
+		_deprecated_function( __METHOD__, 'Yoast SEO 18.5' );
 		if ( $this->get_option()->is_enabled() ) {
 			$this->schedule_cron();
 
@@ -102,7 +102,7 @@ class WPSEO_Ryte implements WPSEO_WordPress_Integration {
 	 * @return void
 	 */
 	public function maybe_add_weekly_schedule() {
-		_deprecated_function( __METHOD__, 'WPSEO 18.5' );
+		_deprecated_function( __METHOD__, 'Yoast SEO 18.5' );
 		// If there's no default cron weekly schedule, add a custom one.
 		add_filter( 'cron_schedules', [ $this, 'add_weekly_schedule' ] );
 	}
@@ -118,7 +118,7 @@ class WPSEO_Ryte implements WPSEO_WordPress_Integration {
 	 * @return array Enriched list of custom cron schedules.
 	 */
 	public function add_weekly_schedule( $schedules ) {
-		_deprecated_function( __METHOD__, 'WPSEO 18.5' );
+		_deprecated_function( __METHOD__, 'Yoast SEO 18.5' );
 		if ( ! is_array( $schedules ) ) {
 			$schedules = [];
 		}
@@ -149,7 +149,7 @@ class WPSEO_Ryte implements WPSEO_WordPress_Integration {
 	 * @return bool|null Whether the request ran.
 	 */
 	public function fetch_from_ryte() {
-		_deprecated_function( __METHOD__, 'WPSEO 18.5' );
+		_deprecated_function( __METHOD__, 'Yoast SEO 18.5' );
 		// Don't do anything when the WordPress environment type isn't "production".
 		if ( wp_get_environment_type() !== 'production' ) {
 			return;
@@ -180,7 +180,7 @@ class WPSEO_Ryte implements WPSEO_WordPress_Integration {
 	 * @return WPSEO_Ryte_Option The option.
 	 */
 	protected function get_option() {
-		_deprecated_function( __METHOD__, 'WPSEO 18.5' );
+		_deprecated_function( __METHOD__, 'Yoast SEO 18.5' );
 		return new WPSEO_Ryte_Option();
 	}
 
@@ -193,7 +193,7 @@ class WPSEO_Ryte implements WPSEO_WordPress_Integration {
 	 * @return int The indexability status value.
 	 */
 	protected function request_indexability() {
-		_deprecated_function( __METHOD__, 'WPSEO 18.5' );
+		_deprecated_function( __METHOD__, 'Yoast SEO 18.5' );
 		$parameters = [];
 		if ( $this->wordfence_protection_enabled() ) {
 			$parameters['wf_strict'] = 1;
@@ -223,7 +223,7 @@ class WPSEO_Ryte implements WPSEO_WordPress_Integration {
 	 * @return void
 	 */
 	private function schedule_cron() {
-		_deprecated_function( __METHOD__, 'WPSEO 18.5' );
+		_deprecated_function( __METHOD__, 'Yoast SEO 18.5' );
 		if ( wp_next_scheduled( 'wpseo_ryte_fetch' ) ) {
 			return;
 		}
@@ -240,7 +240,7 @@ class WPSEO_Ryte implements WPSEO_WordPress_Integration {
 	 * @return void
 	 */
 	private function unschedule_cron() {
-		_deprecated_function( __METHOD__, 'WPSEO 18.5' );
+		_deprecated_function( __METHOD__, 'Yoast SEO 18.5' );
 		if ( ! wp_next_scheduled( 'wpseo_ryte_fetch' ) ) {
 			return;
 		}
@@ -257,7 +257,7 @@ class WPSEO_Ryte implements WPSEO_WordPress_Integration {
 	 * @return bool True if WordFence protects the site.
 	 */
 	private function wordfence_protection_enabled() {
-		_deprecated_function( __METHOD__, 'WPSEO 18.5' );
+		_deprecated_function( __METHOD__, 'Yoast SEO 18.5' );
 		if ( ! class_exists( 'wfConfig' ) ) {
 			return false;
 		}
@@ -278,7 +278,7 @@ class WPSEO_Ryte implements WPSEO_WordPress_Integration {
 	 * @return array|WP_Error The response or WP_Error on failure.
 	 */
 	public function get_response() {
-		_deprecated_function( __METHOD__, 'WPSEO 18.5' );
+		_deprecated_function( __METHOD__, 'Yoast SEO 18.5' );
 		return $this->ryte_response;
 	}
 }

--- a/src/deprecated/admin/views/class-view-utils.php
+++ b/src/deprecated/admin/views/class-view-utils.php
@@ -29,7 +29,7 @@ class Yoast_View_Utils {
 	 * @codeCoverageIgnore
 	 */
 	public function __construct() {
-		_deprecated_function( __METHOD__, 'WPSEO 20.3' );
+		_deprecated_function( __METHOD__, 'Yoast SEO 20.3' );
 		$this->form = Yoast_Form::get_instance();
 	}
 
@@ -47,7 +47,7 @@ class Yoast_View_Utils {
 	 * @return object The help panel instance.
 	 */
 	public function search_results_setting_help( $post_type, $help_text_switch = '' ) {
-		_deprecated_function( __METHOD__, 'WPSEO 20.3' );
+		_deprecated_function( __METHOD__, 'Yoast SEO 20.3' );
 		if ( ! is_object( $post_type ) ) {
 			$post_type = get_post_type_object( $post_type );
 		}
@@ -87,7 +87,7 @@ class Yoast_View_Utils {
 	 * @return string The alert. Returns an empty string if the setting is enabled.
 	 */
 	public function generate_opengraph_disabled_alert( $type = '' ) {
-		_deprecated_function( __METHOD__, 'WPSEO 20.3' );
+		_deprecated_function( __METHOD__, 'Yoast SEO 20.3' );
 		$is_enabled = WPSEO_Options::get( 'opengraph', true );
 
 		if ( $is_enabled ) {

--- a/src/deprecated/frontend/frontend.php
+++ b/src/deprecated/frontend/frontend.php
@@ -66,7 +66,7 @@ class WPSEO_Frontend {
 	 * @return mixed
 	 */
 	public function __call( $method, $arguments ) {
-		_deprecated_function( $method, 'WPSEO 14.0' );
+		_deprecated_function( $method, 'Yoast SEO 14.0' );
 
 		$title_methods = [
 			'title',
@@ -109,7 +109,7 @@ class WPSEO_Frontend {
 	 * @return string|void
 	 */
 	public function canonical( $echo = true, $un_paged = false, $no_override = false ) {
-		_deprecated_function( __METHOD__, 'WPSEO 14.0' );
+		_deprecated_function( __METHOD__, 'Yoast SEO 14.0' );
 
 		$presentation = $this->get_current_page_presentation();
 		$presenter    = new Canonical_Presenter();
@@ -131,7 +131,7 @@ class WPSEO_Frontend {
 	 * @return string
 	 */
 	public function get_robots() {
-		_deprecated_function( __METHOD__, 'WPSEO 14.0' );
+		_deprecated_function( __METHOD__, 'Yoast SEO 14.0' );
 
 		$presentation = $this->get_current_page_presentation();
 		return $presentation->robots;
@@ -141,7 +141,7 @@ class WPSEO_Frontend {
 	 * Outputs the meta robots value.
 	 */
 	public function robots() {
-		_deprecated_function( __METHOD__, 'WPSEO 14.0' );
+		_deprecated_function( __METHOD__, 'Yoast SEO 14.0' );
 
 		$presentation            = $this->get_current_page_presentation();
 		$presenter               = new Robots_Presenter();
@@ -160,7 +160,7 @@ class WPSEO_Frontend {
 	 * @return array
 	 */
 	public function robots_for_single_post( $robots, $post_id = 0 ) {
-		_deprecated_function( __METHOD__, 'WPSEO 14.0' );
+		_deprecated_function( __METHOD__, 'Yoast SEO 14.0' );
 
 		$presentation = $this->get_current_page_presentation();
 
@@ -175,7 +175,7 @@ class WPSEO_Frontend {
 	 * @return string The content title.
 	 */
 	private function get_title( $object = null ) {
-		_deprecated_function( __METHOD__, 'WPSEO 14.0' );
+		_deprecated_function( __METHOD__, 'Yoast SEO 14.0' );
 
 		$presentation = $this->get_current_page_presentation();
 		$title        = $presentation->title;
@@ -193,7 +193,7 @@ class WPSEO_Frontend {
 	 * @return string
 	 */
 	public function add_paging_to_title( $sep, $seplocation, $title ) {
-		_deprecated_function( __METHOD__, 'WPSEO 14.0' );
+		_deprecated_function( __METHOD__, 'Yoast SEO 14.0' );
 
 		return $title;
 	}
@@ -209,7 +209,7 @@ class WPSEO_Frontend {
 	 * @return string
 	 */
 	public function add_to_title( $sep, $seplocation, $title, $title_part ) {
-		_deprecated_function( __METHOD__, 'WPSEO 14.0' );
+		_deprecated_function( __METHOD__, 'Yoast SEO 14.0' );
 
 		if ( $seplocation === 'right' ) {
 			return $title . $sep . $title_part;
@@ -224,7 +224,7 @@ class WPSEO_Frontend {
 	 * @link http://googlewebmastercentral.blogspot.com/2011/09/pagination-with-relnext-and-relprev.html
 	 */
 	public function adjacent_rel_links() {
-		_deprecated_function( __METHOD__, 'WPSEO 14.0' );
+		_deprecated_function( __METHOD__, 'Yoast SEO 14.0' );
 
 		$presentation = $this->get_current_page_presentation();
 
@@ -249,7 +249,7 @@ class WPSEO_Frontend {
 	 * @return string
 	 */
 	public function metadesc( $echo = true ) {
-		_deprecated_function( __METHOD__, 'WPSEO 14.0' );
+		_deprecated_function( __METHOD__, 'Yoast SEO 14.0' );
 
 		$presentation            = $this->get_current_page_presentation();
 		$presenter               = new Meta_Description_Presenter();

--- a/src/deprecated/i18n/i18n-v3.php
+++ b/src/deprecated/i18n/i18n-v3.php
@@ -25,7 +25,7 @@ class Yoast_I18n_v3 {
 	 * @param bool  $show_translation_box Whether the translation box should be shown.
 	 */
 	public function __construct( $args, $show_translation_box = true ) {
-		\_deprecated_function( __METHOD__, 'WPSEO 19.12' );
+		\_deprecated_function( __METHOD__, 'Yoast SEO 19.12' );
 	}
 
 	/**
@@ -39,7 +39,7 @@ class Yoast_I18n_v3 {
 	 * @return bool Returns true if the language is en_US.
 	 */
 	protected function is_default_language( $language ) {
-		\_deprecated_function( __METHOD__, 'WPSEO 19.12' );
+		\_deprecated_function( __METHOD__, 'Yoast SEO 19.12' );
 		return true;
 	}
 
@@ -54,7 +54,7 @@ class Yoast_I18n_v3 {
 	 * @return string The i18n promo message.
 	 */
 	public function get_promo_message() {
-		\_deprecated_function( __METHOD__, 'WPSEO 19.12' );
+		\_deprecated_function( __METHOD__, 'Yoast SEO 19.12' );
 		return '';
 	}
 
@@ -69,7 +69,7 @@ class Yoast_I18n_v3 {
 	 * @return string
 	 */
 	public function get_dismiss_i18n_message_button() {
-		\_deprecated_function( __METHOD__, 'WPSEO 19.12' );
+		\_deprecated_function( __METHOD__, 'Yoast SEO 19.12' );
 		return '';
 	}
 
@@ -82,7 +82,7 @@ class Yoast_I18n_v3 {
 	 * @access public
 	 */
 	public function promo() {
-		\_deprecated_function( __METHOD__, 'WPSEO 19.12' );
+		\_deprecated_function( __METHOD__, 'Yoast SEO 19.12' );
 	}
 
 	/**
@@ -94,6 +94,6 @@ class Yoast_I18n_v3 {
 	 * @param string $api_url The new API URL.
 	 */
 	public function set_api_url( $api_url ) {
-		\_deprecated_function( __METHOD__, 'WPSEO 19.12' );
+		\_deprecated_function( __METHOD__, 'Yoast SEO 19.12' );
 	}
 }

--- a/src/deprecated/src/conditionals/front-end-inspector-conditional.php
+++ b/src/deprecated/src/conditionals/front-end-inspector-conditional.php
@@ -17,7 +17,7 @@ class Front_End_Inspector_Conditional extends Feature_Flag_Conditional {
 	 * @return string The name of the feature flag.
 	 */
 	protected function get_feature_flag() {
-		\_deprecated_function( __METHOD__, 'WPSEO 19.5' );
+		\_deprecated_function( __METHOD__, 'Yoast SEO 19.5' );
 		return 'FRONT_END_INSPECTOR';
 	}
 }

--- a/src/deprecated/src/conditionals/japanese-support-conditional.php
+++ b/src/deprecated/src/conditionals/japanese-support-conditional.php
@@ -20,7 +20,7 @@ class Japanese_Support_Conditional extends Feature_Flag_Conditional {
 	 * @return string the name of the feature flag.
 	 */
 	public function get_feature_flag() {
-		\_deprecated_function( __METHOD__, 'WPSEO 17.9' );
+		\_deprecated_function( __METHOD__, 'Yoast SEO 17.9' );
 		return 'JAPANESE_SUPPORT';
 	}
 }

--- a/src/deprecated/src/conditionals/the-events-calendar-conditional.php
+++ b/src/deprecated/src/conditionals/the-events-calendar-conditional.php
@@ -19,7 +19,7 @@ class The_Events_Calendar_Conditional implements Conditional {
 	 * @return bool Whether the conditional is met.
 	 */
 	public function is_met() {
-		\_deprecated_function( __METHOD__, 'WPSEO 19.12' );
+		\_deprecated_function( __METHOD__, 'Yoast SEO 19.12' );
 		return false;
 	}
 }

--- a/src/deprecated/src/conditionals/third-party/coauthors-plus-activated-conditional.php
+++ b/src/deprecated/src/conditionals/third-party/coauthors-plus-activated-conditional.php
@@ -21,7 +21,7 @@ class CoAuthors_Plus_Activated_Conditional implements Conditional {
 	 * @return bool `true` when the CoAuthors Plus plugin is installed and activated.
 	 */
 	public function is_met() {
-		\_deprecated_function( __METHOD__, 'WPSEO 19.12' );
+		\_deprecated_function( __METHOD__, 'Yoast SEO 19.12' );
 		return \defined( 'COAUTHORS_PLUS_VERSION' );
 	}
 }

--- a/src/deprecated/src/generators/schema/third-party/coauthor.php
+++ b/src/deprecated/src/generators/schema/third-party/coauthor.php
@@ -28,7 +28,7 @@ class CoAuthor extends Author {
 	 * @return bool
 	 */
 	public function is_needed() {
-		\_deprecated_function( __METHOD__, 'WPSEO 19.12' );
+		\_deprecated_function( __METHOD__, 'Yoast SEO 19.12' );
 		return true;
 	}
 
@@ -41,7 +41,7 @@ class CoAuthor extends Author {
 	 * @return bool|array Person data on success, false on failure.
 	 */
 	public function generate() {
-		\_deprecated_function( __METHOD__, 'WPSEO 19.12' );
+		\_deprecated_function( __METHOD__, 'Yoast SEO 19.12' );
 		$user_id = $this->determine_user_id();
 		if ( ! $user_id ) {
 			return false;
@@ -71,7 +71,7 @@ class CoAuthor extends Author {
 	 * @return array|bool
 	 */
 	public function generate_from_user_id( $user_id ) {
-		\_deprecated_function( __METHOD__, 'WPSEO 19.12' );
+		\_deprecated_function( __METHOD__, 'Yoast SEO 19.12' );
 		$this->user_id = $user_id;
 
 		return $this->generate();

--- a/src/deprecated/src/generators/schema/third-party/events-calendar-schema.php
+++ b/src/deprecated/src/generators/schema/third-party/events-calendar-schema.php
@@ -37,7 +37,7 @@ class Events_Calendar_Schema extends Abstract_Schema_Piece {
 	 * @return bool
 	 */
 	public function is_needed() {
-		\_deprecated_function( __METHOD__, 'WPSEO 19.12' );
+		\_deprecated_function( __METHOD__, 'Yoast SEO 19.12' );
 		return false;
 	}
 
@@ -53,7 +53,7 @@ class Events_Calendar_Schema extends Abstract_Schema_Piece {
 	 * @return array Event Schema markup
 	 */
 	public function generate() {
-		\_deprecated_function( __METHOD__, 'WPSEO 19.12' );
+		\_deprecated_function( __METHOD__, 'Yoast SEO 19.12' );
 		return [];
 	}
 }

--- a/src/deprecated/src/helpers/input-helper.php
+++ b/src/deprecated/src/helpers/input-helper.php
@@ -23,7 +23,7 @@ class Input_Helper {
 	 * @return string The result of the get input.
 	 */
 	public function filter( $input_type, $search_string, $filter = \FILTER_DEFAULT ) {
-		\_deprecated_function( __METHOD__, 'WPSEO 20.3' );
+		\_deprecated_function( __METHOD__, 'Yoast SEO 20.3' );
 
 		return \filter_input( $input_type, $search_string, $filter );
 	}

--- a/src/deprecated/src/integrations/admin/social-templates-integration.php
+++ b/src/deprecated/src/integrations/admin/social-templates-integration.php
@@ -56,7 +56,7 @@ class Social_Templates_Integration implements Integration_Interface {
 	 * @return array
 	 */
 	public static function get_conditionals() {
-		_deprecated_function( __METHOD__, 'WPSEO 20.3' );
+		_deprecated_function( __METHOD__, 'Yoast SEO 20.3' );
 		return [ Admin_Conditional::class, Open_Graph_Conditional::class ];
 	}
 
@@ -67,7 +67,7 @@ class Social_Templates_Integration implements Integration_Interface {
 	 * @codeCoverageIgnore
 	 */
 	public function register_hooks() {
-		_deprecated_function( __METHOD__, 'WPSEO 20.3' );
+		_deprecated_function( __METHOD__, 'Yoast SEO 20.3' );
 		\add_action( 'Yoast\WP\SEO\admin_author_archives_meta_internal', [ $this, 'social_author_archives' ] );
 		\add_action( 'Yoast\WP\SEO\admin_date_archives_meta_internal', [ $this, 'social_date_archives' ] );
 		\add_action( 'Yoast\WP\SEO\admin_post_types_beforearchive_internal', [ $this, 'social_post_type' ], \PHP_INT_MAX, 2 );
@@ -110,7 +110,7 @@ class Social_Templates_Integration implements Integration_Interface {
 	 * @param Yoast_Form $yform The form builder.
 	 */
 	public function social_author_archives( $yform ) {
-		_deprecated_function( __METHOD__, 'WPSEO 20.3' );
+		_deprecated_function( __METHOD__, 'Yoast SEO 20.3' );
 		$identifier            = 'author-wpseo';
 		$page_type_recommended = $this->get_admin_recommended_replace_vars()->determine_for_archive( 'author' );
 		$page_type_specific    = $this->get_admin_editor_specific_replace_vars()->determine_for_archive( 'author' );
@@ -127,7 +127,7 @@ class Social_Templates_Integration implements Integration_Interface {
 	 * @param Yoast_Form $yform The form builder.
 	 */
 	public function social_date_archives( $yform ) {
-		_deprecated_function( __METHOD__, 'WPSEO 20.3' );
+		_deprecated_function( __METHOD__, 'Yoast SEO 20.3' );
 		$identifier            = 'archive-wpseo';
 		$page_type_recommended = $this->get_admin_recommended_replace_vars()->determine_for_archive( 'date' );
 		$page_type_specific    = $this->get_admin_editor_specific_replace_vars()->determine_for_archive( 'date' );
@@ -145,7 +145,7 @@ class Social_Templates_Integration implements Integration_Interface {
 	 * @param string     $post_type_name The name of the current post_type that gets the social fields added.
 	 */
 	public function social_post_type( $yform, $post_type_name ) {
-		_deprecated_function( __METHOD__, 'WPSEO 20.3' );
+		_deprecated_function( __METHOD__, 'Yoast SEO 20.3' );
 		if ( $post_type_name === 'attachment' ) {
 			return;
 		}
@@ -166,7 +166,7 @@ class Social_Templates_Integration implements Integration_Interface {
 	 * @param string     $post_type_name The name of the current post_type that gets the social fields added.
 	 */
 	public function social_post_types_archive( $yform, $post_type_name ) {
-		_deprecated_function( __METHOD__, 'WPSEO 20.3' );
+		_deprecated_function( __METHOD__, 'Yoast SEO 20.3' );
 		$identifier            = 'ptarchive-' . $post_type_name;
 		$page_type_recommended = $this->get_admin_recommended_replace_vars()->determine_for_archive( $post_type_name );
 		$page_type_specific    = $this->get_admin_editor_specific_replace_vars()->determine_for_archive( $post_type_name );
@@ -184,7 +184,7 @@ class Social_Templates_Integration implements Integration_Interface {
 	 * @param WP_Taxonomy $taxonomy The taxonomy that gets the social fields added.
 	 */
 	public function social_taxonomies( $yform, $taxonomy ) {
-		_deprecated_function( __METHOD__, 'WPSEO 20.3' );
+		_deprecated_function( __METHOD__, 'Yoast SEO 20.3' );
 		$identifier            = 'tax-' . $taxonomy->name;
 		$page_type_recommended = $this->get_admin_recommended_replace_vars()->determine_for_term( $taxonomy->name );
 		$page_type_specific    = $this->get_admin_editor_specific_replace_vars()->determine_for_term( $taxonomy->name );

--- a/src/deprecated/src/integrations/third-party/coauthors-plus.php
+++ b/src/deprecated/src/integrations/third-party/coauthors-plus.php
@@ -36,7 +36,7 @@ class CoAuthors_Plus implements Integration_Interface {
 	 * @return void
 	 */
 	public function register_hooks() {
-		\_deprecated_function( __METHOD__, 'WPSEO 19.12' );
+		\_deprecated_function( __METHOD__, 'Yoast SEO 19.12' );
 		\add_filter( 'wpseo_schema_graph', [ $this, 'filter_graph' ], 11, 2 );
 		\add_filter( 'wpseo_schema_author', [ $this, 'filter_author_graph' ], 11, 4 );
 	}
@@ -50,7 +50,7 @@ class CoAuthors_Plus implements Integration_Interface {
 	 * @return array
 	 */
 	public static function get_conditionals() {
-		\_deprecated_function( __METHOD__, 'WPSEO 19.12' );
+		\_deprecated_function( __METHOD__, 'Yoast SEO 19.12' );
 		return [
 			CoAuthors_Plus_Activated_Conditional::class,
 			CoAuthors_Plus_Flag_Conditional::class,
@@ -66,7 +66,7 @@ class CoAuthors_Plus implements Integration_Interface {
 	 * @param Helpers_Surface $helpers The helper surface.
 	 */
 	public function __construct( Helpers_Surface $helpers ) {
-		\_deprecated_function( __METHOD__, 'WPSEO 19.12' );
+		\_deprecated_function( __METHOD__, 'Yoast SEO 19.12' );
 		$this->helpers = $helpers;
 	}
 
@@ -84,7 +84,7 @@ class CoAuthors_Plus implements Integration_Interface {
 	 * @return array The (potentially altered) schema graph.
 	 */
 	public function filter_author_graph( $data, $context, $graph_piece_generator, $graph_piece_generators ) {
-		\_deprecated_function( __METHOD__, 'WPSEO 19.12' );
+		\_deprecated_function( __METHOD__, 'Yoast SEO 19.12' );
 		if ( ! isset( $data['image']['url'] ) ) {
 			return $data;
 		}
@@ -112,7 +112,7 @@ class CoAuthors_Plus implements Integration_Interface {
 	 * @return array The (potentially altered) schema graph.
 	 */
 	public function filter_graph( $data, $context ) {
-		\_deprecated_function( __METHOD__, 'WPSEO 19.12' );
+		\_deprecated_function( __METHOD__, 'Yoast SEO 19.12' );
 		if ( ! \is_singular() ) {
 			return $data;
 		}

--- a/src/deprecated/src/integrations/third-party/the-events-calendar.php
+++ b/src/deprecated/src/integrations/third-party/the-events-calendar.php
@@ -24,7 +24,7 @@ class The_Events_Calendar implements Integration_Interface {
 	 * @return array
 	 */
 	public static function get_conditionals() {
-		\_deprecated_function( __METHOD__, 'WPSEO 19.12' );
+		\_deprecated_function( __METHOD__, 'Yoast SEO 19.12' );
 		return [ Front_End_Conditional::class, Open_Graph_Conditional::class ];
 	}
 
@@ -39,7 +39,7 @@ class The_Events_Calendar implements Integration_Interface {
 	 * @return void
 	 */
 	public function register_hooks() {
-		\_deprecated_function( __METHOD__, 'WPSEO 19.12' );
+		\_deprecated_function( __METHOD__, 'Yoast SEO 19.12' );
 	}
 
 	/**
@@ -54,7 +54,7 @@ class The_Events_Calendar implements Integration_Interface {
 	 * @return array Extended graph pieces.
 	 */
 	public function add_graph_pieces( $pieces, $context ) {
-		\_deprecated_function( __METHOD__, 'WPSEO 19.12' );
+		\_deprecated_function( __METHOD__, 'Yoast SEO 19.12' );
 
 		return $pieces;
 	}

--- a/src/deprecated/src/presenters/admin/auto-update-notification-presenter.php
+++ b/src/deprecated/src/presenters/admin/auto-update-notification-presenter.php
@@ -21,7 +21,7 @@ class Auto_Update_Notification_Presenter extends Abstract_Presenter {
 	 * @return string The notification in an HTML string representation.
 	 */
 	public function present() {
-		\_deprecated_function( __METHOD__, 'WPSEO 19.8' );
+		\_deprecated_function( __METHOD__, 'Yoast SEO 19.8' );
 
 		return '';
 	}
@@ -35,7 +35,7 @@ class Auto_Update_Notification_Presenter extends Abstract_Presenter {
 	 * @return string The message.
 	 */
 	protected function get_message() {
-		\_deprecated_function( __METHOD__, 'WPSEO 19.8' );
+		\_deprecated_function( __METHOD__, 'Yoast SEO 19.8' );
 
 		return '';
 	}

--- a/src/deprecated/src/routes/configuration-workout-route.php
+++ b/src/deprecated/src/routes/configuration-workout-route.php
@@ -62,7 +62,7 @@ class Configuration_Workout_Route implements Route_Interface {
 	public function __construct(
 		Configuration_Workout_Action $configuration_workout_action
 	) {
-		\_deprecated_function( __METHOD__, 'WPSEO 19.0' );
+		\_deprecated_function( __METHOD__, 'Yoast SEO 19.0' );
 	}
 
 	/**
@@ -74,7 +74,7 @@ class Configuration_Workout_Route implements Route_Interface {
 	 * @return void
 	 */
 	public function register_routes() {
-		\_deprecated_function( __METHOD__, 'WPSEO 19.0', '\Yoast\WP\SEO\Routes\First_Time_Configuration_Route::register_routes' );
+		\_deprecated_function( __METHOD__, 'Yoast SEO 19.0', '\Yoast\WP\SEO\Routes\First_Time_Configuration_Route::register_routes' );
 	}
 
 	/**
@@ -88,7 +88,7 @@ class Configuration_Workout_Route implements Route_Interface {
 	 * @return void
 	 */
 	public function set_site_representation( WP_REST_Request $request ) {
-		\_deprecated_function( __METHOD__, 'WPSEO 19.0', '\Yoast\WP\SEO\Routes\First_Time_Configuration_Route::set_site_representation' );
+		\_deprecated_function( __METHOD__, 'Yoast SEO 19.0', '\Yoast\WP\SEO\Routes\First_Time_Configuration_Route::set_site_representation' );
 	}
 
 	/**
@@ -102,7 +102,7 @@ class Configuration_Workout_Route implements Route_Interface {
 	 * @return void
 	 */
 	public function set_social_profiles( WP_REST_Request $request ) {
-		\_deprecated_function( __METHOD__, 'WPSEO 19.0', '\Yoast\WP\SEO\Routes\First_Time_Configuration_Route::set_social_profiles' );
+		\_deprecated_function( __METHOD__, 'Yoast SEO 19.0', '\Yoast\WP\SEO\Routes\First_Time_Configuration_Route::set_social_profiles' );
 	}
 
 	/**
@@ -116,7 +116,7 @@ class Configuration_Workout_Route implements Route_Interface {
 	 * @return void
 	 */
 	public function get_person_social_profiles( WP_REST_Request $request ) {
-		\_deprecated_function( __METHOD__, 'WPSEO 19.0', '\Yoast\WP\SEO\Routes\First_Time_Configuration_Route::get_person_social_profiles' );
+		\_deprecated_function( __METHOD__, 'Yoast SEO 19.0', '\Yoast\WP\SEO\Routes\First_Time_Configuration_Route::get_person_social_profiles' );
 	}
 
 	/**
@@ -130,7 +130,7 @@ class Configuration_Workout_Route implements Route_Interface {
 	 * @return void
 	 */
 	public function set_person_social_profiles( WP_REST_Request $request ) {
-		\_deprecated_function( __METHOD__, 'WPSEO 19.0', '\Yoast\WP\SEO\Routes\First_Time_Configuration_Route::set_person_social_profiles' );
+		\_deprecated_function( __METHOD__, 'Yoast SEO 19.0', '\Yoast\WP\SEO\Routes\First_Time_Configuration_Route::set_person_social_profiles' );
 	}
 
 	/**
@@ -144,7 +144,7 @@ class Configuration_Workout_Route implements Route_Interface {
 	 * @return void
 	 */
 	public function check_capability( WP_REST_Request $request ) {
-		\_deprecated_function( __METHOD__, 'WPSEO 19.0', '\Yoast\WP\SEO\Routes\First_Time_Configuration_Route::check_capability' );
+		\_deprecated_function( __METHOD__, 'Yoast SEO 19.0', '\Yoast\WP\SEO\Routes\First_Time_Configuration_Route::check_capability' );
 	}
 
 	/**
@@ -158,7 +158,7 @@ class Configuration_Workout_Route implements Route_Interface {
 	 * @return void
 	 */
 	public function set_enable_tracking( WP_REST_Request $request ) {
-		\_deprecated_function( __METHOD__, 'WPSEO 19.0', '\Yoast\WP\SEO\Routes\First_Time_Configuration_Route::set_enable_tracking' );
+		\_deprecated_function( __METHOD__, 'Yoast SEO 19.0', '\Yoast\WP\SEO\Routes\First_Time_Configuration_Route::set_enable_tracking' );
 	}
 
 	/**
@@ -170,7 +170,7 @@ class Configuration_Workout_Route implements Route_Interface {
 	 * @return bool
 	 */
 	public function can_manage_options() {
-		\_deprecated_function( __METHOD__, 'WPSEO 19.0', '\Yoast\WP\SEO\Routes\First_Time_Configuration_Route::can_manage_options' );
+		\_deprecated_function( __METHOD__, 'Yoast SEO 19.0', '\Yoast\WP\SEO\Routes\First_Time_Configuration_Route::can_manage_options' );
 
 		return \current_user_can( 'wpseo_manage_options' );
 	}
@@ -183,6 +183,6 @@ class Configuration_Workout_Route implements Route_Interface {
 	 * @return void
 	 */
 	public function can_edit_user( WP_REST_Request $request ) {
-		\_deprecated_function( __METHOD__, 'WPSEO 19.0', '\Yoast\WP\SEO\Routes\First_Time_Configuration_Route::can_edit_user' );
+		\_deprecated_function( __METHOD__, 'Yoast SEO 19.0', '\Yoast\WP\SEO\Routes\First_Time_Configuration_Route::can_edit_user' );
 	}
 }

--- a/src/integrations/third-party/wincher.php
+++ b/src/integrations/third-party/wincher.php
@@ -89,7 +89,7 @@ class Wincher implements Integration_Interface {
 	 * @param Yoast_Feature_Toggle $integration The integration toggle class.
 	 */
 	public function after_integration_toggle( $integration ) {
-		_deprecated_function( __METHOD__, 'WPSEO 20.3' );
+		_deprecated_function( __METHOD__, 'Yoast SEO 20.3' );
 		if ( $integration->setting === 'wincher_integration_active' ) {
 			if ( \is_multisite() ) {
 				$this->get_disabled_note();

--- a/src/integrations/third-party/wordproof-integration-toggle.php
+++ b/src/integrations/third-party/wordproof-integration-toggle.php
@@ -117,7 +117,7 @@ class Wordproof_Integration_Toggle implements Integration_Interface {
 	 * @param Yoast_Feature_Toggle $integration The integration toggle class.
 	 */
 	public function after_integration_toggle( $integration ) {
-		_deprecated_function( __METHOD__, 'WPSEO 20.3' );
+		_deprecated_function( __METHOD__, 'Yoast SEO 20.3' );
 		if ( $integration->setting === 'wordproof_integration_active' ) {
 			if ( $integration->disabled ) {
 

--- a/src/repositories/indexable-repository.php
+++ b/src/repositories/indexable-repository.php
@@ -489,7 +489,7 @@ class Indexable_Repository {
 	public function ensure_permalink( $indexable ) {
 		// @phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- self::class is safe.
 		// @phpcs:ignore Squiz.PHP.CommentedOutCode.Found
-		// _deprecated_function( __METHOD__, 'WPSEO 17.3', self::class . '::upgrade_indexable' );
+		// _deprecated_function( __METHOD__, 'Yoast SEO 17.3', self::class . '::upgrade_indexable' );
 
 		return $this->upgrade_indexable( $indexable );
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to be consistent and always use "Yoast SEO" in deprecation messages.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Changes every `WPSEO` in deprecation messages to `Yoast SEO`.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* NA

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
