### PR TITLE
19674 percentages of passive voice vary depending on editor

### DIFF
--- a/packages/yoastseo/src/languageProcessing/helpers/sentence/getSentences.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/sentence/getSentences.js
@@ -61,7 +61,7 @@ export default function( text, memoizedTokenizer ) {
 	text = text.replace( imageRegex, "" );
 
 	// Remove any HTML whitespace padding and replace it with a single whitespace.
-    text = text.replace( /[\n]+/g, " " );
+    //text = text.replace( /[\n]+/g, " " );
 
 	console.log( text, "text" );
 

--- a/packages/yoastseo/src/languageProcessing/helpers/sentence/getSentences.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/sentence/getSentences.js
@@ -26,6 +26,7 @@ function getSentenceTokenizer( block ) {
 	const sentenceTokenizer = new SentenceTokenizer();
 	const { tokenizer, tokens } = sentenceTokenizer.createTokenizer();
 	sentenceTokenizer.tokenize( tokenizer, block );
+	console.log( tokens, "tokens" );
 	const paragraphTagsRegex = new RegExp( "^(<p>|</p>)$" );
 	/*
 	 * Filter block that contain only paragraph tags. This step is necessary
@@ -65,12 +66,13 @@ export default function( text, memoizedTokenizer ) {
 	console.log( text, "text" );
 
 	let blocks = getBlocks( text );
-	console.log( blocks, "blocks" );
 
 	// Split each block on newlines.
 	blocks = flatMap( blocks, function( block ) {
 		return block.split( newLineRegex );
 	} );
+	console.log( blocks, "blocks" );
+
 
 	const sentences = flatMap( blocks, memoizedTokenizer );
 

--- a/packages/yoastseo/src/languageProcessing/helpers/sentence/getSentences.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/sentence/getSentences.js
@@ -59,7 +59,13 @@ export default function( text, memoizedTokenizer ) {
 	// This step is done here so that applying highlight in captions is possible for all assessments that use this helper.
 	text = text.replace( imageRegex, "" );
 
+	// Remove any HTML whitespace padding and replace it with a single whitespace.
+    text = text.replace( /[\n]+/g, " " );
+
+	console.log( text, "text" );
+
 	let blocks = getBlocks( text );
+	console.log( blocks, "blocks" );
 
 	// Split each block on newlines.
 	blocks = flatMap( blocks, function( block ) {

--- a/packages/yoastseo/src/languageProcessing/researches/countSentencesFromText.js
+++ b/packages/yoastseo/src/languageProcessing/researches/countSentencesFromText.js
@@ -10,5 +10,6 @@ import sentencesLength from "../helpers/sentence/sentencesLength.js";
 export default function( paper, researcher ) {
 	const memoizedTokenizer = researcher.getHelper( "memoizedTokenizer" );
 	const sentences = getSentences( paper.getText(), memoizedTokenizer );
+	console.log( sentences, "sentences in countSentencesFromText (sentence length assessment)" );
 	return sentencesLength( sentences, researcher );
 }

--- a/packages/yoastseo/src/languageProcessing/researches/getPassiveVoiceResult.js
+++ b/packages/yoastseo/src/languageProcessing/researches/getPassiveVoiceResult.js
@@ -59,6 +59,7 @@ export const getPeriphrasticPassives = function( paper, researcher ) {
 		.map( function( sentence ) {
 			return new Sentence( sentence );
 		} );
+	console.log( sentences, "sentences in get passive voice result" );
 	const totalNumberSentences = sentences.length;
 	const passiveSentences = [];
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes incorrect result for passive voice assessment when for posts created in Classic editor and opened in Block editor.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

*

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
