### PR TITLE
Revert #19399 highlighting support in captions in classic editor

### DIFF
--- a/packages/yoastseo/spec/fullTextTests/testTexts/pl/polishPaper.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/pl/polishPaper.js
@@ -119,7 +119,7 @@ const expectedResults = {
 	passiveVoice: {
 		isApplicable: true,
 		score: 3,
-		resultText: "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: 16.1% of the sentences contain passive voice, which is more than the recommended maximum of 10%. <a href='https://yoa.st/34u' target='_blank'>Try to use their active counterparts</a>.",
+		resultText: "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: 15.9% of the sentences contain passive voice, which is more than the recommended maximum of 10%. <a href='https://yoa.st/34u' target='_blank'>Try to use their active counterparts</a>.",
 	},
 	textPresence: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/languageProcessing/helpers/sentence/getSentencesSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/helpers/sentence/getSentencesSpec.js
@@ -337,7 +337,7 @@ describe( "Get sentences from text", function() {
 		testGetSentences( testCases );
 	} );
 
-	it( "should strip images from the sentence", function() {
+	xit( "should strip images from the sentence", function() {
 		const testCases = [
 			{
 				input: "<img class=\"size-medium wp-image-32\" src=\"https://basic.wordpress.test/wp-content/uploads/2021/" +

--- a/packages/yoastseo/spec/scoring/collectionPages/fullTextTests/testTexts/en/englishPaper1.js
+++ b/packages/yoastseo/spec/scoring/collectionPages/fullTextTests/testTexts/en/englishPaper1.js
@@ -79,7 +79,7 @@ const expectedResults = {
 		resultText: "",
 	},
 	keyphraseDistribution: {
-		isApplicable: false,
+		isApplicable: true,
 		score: 9,
 		resultText: "<a href='https://yoa.st/shopify30' target='_blank'>Keyphrase distribution</a>: Good job!",
 	},
@@ -101,13 +101,13 @@ const expectedResults = {
 	textTransitionWords: {
 		isApplicable: true,
 		score: 6,
-		resultText: "<a href='https://yoa.st/shopify44' target='_blank'>Transition words</a>: Only 25% of the sentences contain " +
+		resultText: "<a href='https://yoa.st/shopify44' target='_blank'>Transition words</a>: Only 20% of the sentences contain " +
 			"transition words, which is not enough. <a href='https://yoa.st/shopify45' target='_blank'>Use more of them</a>.",
 	},
 	passiveVoice: {
 		isApplicable: true,
 		score: 3,
-		resultText: "<a href='https://yoa.st/shopify42' target='_blank'>Passive voice</a>: 33.3% of the sentences contain passive voice, " +
+		resultText: "<a href='https://yoa.st/shopify42' target='_blank'>Passive voice</a>: 26.7% of the sentences contain passive voice, " +
 			"which is more than the recommended maximum of 10%. <a href='https://yoa.st/shopify43' target='_blank'>" +
 			"Try to use their active counterparts</a>.",
 	},

--- a/packages/yoastseo/spec/scoring/collectionPages/fullTextTests/testTexts/en/englishPaper2.js
+++ b/packages/yoastseo/spec/scoring/collectionPages/fullTextTests/testTexts/en/englishPaper2.js
@@ -102,7 +102,7 @@ const expectedResults = {
 	passiveVoice: {
 		isApplicable: true,
 		score: 3,
-		resultText: "<a href='https://yoa.st/shopify42' target='_blank'>Passive voice</a>: 20% of the sentences contain passive voice, " +
+		resultText: "<a href='https://yoa.st/shopify42' target='_blank'>Passive voice</a>: 15.4% of the sentences contain passive voice, " +
 			"which is more than the recommended maximum of 10%. <a href='https://yoa.st/shopify43' target='_blank'>" +
 			"Try to use their active counterparts</a>.",
 	},

--- a/packages/yoastseo/spec/scoring/collectionPages/fullTextTests/testTexts/en/englishPaper3.js
+++ b/packages/yoastseo/spec/scoring/collectionPages/fullTextTests/testTexts/en/englishPaper3.js
@@ -103,15 +103,14 @@ const expectedResults = {
 	textTransitionWords: {
 		isApplicable: true,
 		score: 6,
-		resultText: "<a href='https://yoa.st/shopify44' target='_blank'>Transition words</a>: Only 28.6% of the sentences " +
-
+		resultText: "<a href='https://yoa.st/shopify44' target='_blank'>Transition words</a>: Only 26.7% of the sentences " +
 			"contain transition words, which is not enough. <a href='https://yoa.st/shopify45' target='_blank'>Use more of them</a>.",
 	},
 	passiveVoice: {
 		isApplicable: true,
 		score: 3,
 
-		resultText: "<a href='https://yoa.st/shopify42' target='_blank'>Passive voice</a>: 25% of the sentences contain passive voice, " +
+		resultText: "<a href='https://yoa.st/shopify42' target='_blank'>Passive voice</a>: 23.3% of the sentences contain passive voice, " +
 			"which is more than the recommended maximum of 10%. <a href='https://yoa.st/shopify43' target='_blank'>" +
 			"Try to use their active counterparts</a>.",
 	},

--- a/packages/yoastseo/spec/scoring/productPages/fullTextTests/testTexts/en/englishPaper2.js
+++ b/packages/yoastseo/spec/scoring/productPages/fullTextTests/testTexts/en/englishPaper2.js
@@ -133,9 +133,8 @@ const expectedResults = {
 	keyphraseDistribution: {
 		isApplicable: true,
 		score: 1,
-		resultText: "<a href='https://yoa.st/shopify30' target='_blank'>Keyphrase distribution</a>: " +
-			"Uneven. Some parts of your text do not contain the keyphrase or its synonyms. " +
-			"<a href='https://yoa.st/shopify31' target='_blank'>Distribute them more evenly</a>.",
+		resultText: "<a href='https://yoa.st/shopify30' target='_blank'>Keyphrase distribution</a>: Very uneven. Large parts of your text do not " +
+			"contain the keyphrase or its synonyms. <a href='https://yoa.st/shopify31' target='_blank'>Distribute them more evenly</a>.",
 	},
 	subheadingsTooLong: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/scoring/productPages/fullTextTests/testTexts/en/englishPaper2.js
+++ b/packages/yoastseo/spec/scoring/productPages/fullTextTests/testTexts/en/englishPaper2.js
@@ -132,7 +132,7 @@ const expectedResults = {
 	},
 	keyphraseDistribution: {
 		isApplicable: true,
-		score: 6,
+		score: 1,
 		resultText: "<a href='https://yoa.st/shopify30' target='_blank'>Keyphrase distribution</a>: " +
 			"Uneven. Some parts of your text do not contain the keyphrase or its synonyms. " +
 			"<a href='https://yoa.st/shopify31' target='_blank'>Distribute them more evenly</a>.",
@@ -163,7 +163,7 @@ const expectedResults = {
 	passiveVoice: {
 		isApplicable: true,
 		score: 3,
-		resultText: "<a href='https://yoa.st/shopify42' target='_blank'>Passive voice</a>: 25% of the sentences contain passive voice, " +
+		resultText: "<a href='https://yoa.st/shopify42' target='_blank'>Passive voice</a>: 21.1% of the sentences contain passive voice, " +
 			"which is more than the recommended maximum of 10%. <a href='https://yoa.st/shopify43' target='_blank'>" +
 			"Try to use their active counterparts</a>.",
 	},

--- a/packages/yoastseo/src/languageProcessing/helpers/sentence/getSentences.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/sentence/getSentences.js
@@ -3,7 +3,6 @@ import { filter, flatMap, isEmpty, negate, memoize } from "lodash-es";
 
 // Internal dependencies.
 import { getBlocks } from "../html/html.js";
-import { imageRegex } from "../image/imageInText";
 import excludeTableOfContentsTag from "../sanitize/excludeTableOfContentsTag";
 import excludeEstimatedReadingTime from "../sanitize/excludeEstimatedReadingTime";
 import { unifyNonBreakingSpace } from "../sanitize/unifyWhitespace";
@@ -55,9 +54,6 @@ export default function( text, memoizedTokenizer ) {
 	text = excludeEstimatedReadingTime( text );
 	// Unify only non-breaking spaces and not the other whitespaces since a whitespace could signify a sentence break or a new line.
 	text = unifyNonBreakingSpace( text );
-	// Remove images from text before tokenizing it into sentences.
-	// This step is done here so that applying highlight in captions is possible for all assessments that use this helper.
-	text = text.replace( imageRegex, "" );
 
 	let blocks = getBlocks( text );
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Reverts #19399.

## Relevant technical choices:

* This PR only reverts the user-facing change. In this case, it's the change inside `getSentences.js` where we removed the images from the text.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Make sure highlighting doesn't work in image captions when matched in the first sentence
* Install and activate Yoast SEO
* Install and activate Classic editor
* Set the site language to English
* Create a post

##### SEO Analysis
##### Keyphrase density
* Add at least 100 words to the post
* Set a focus keyphrase
* Add an image
* Add a caption to your image and include the focus keyphrase there in the first sentence
* Confirm that the Keyword density assessment detects the focus keyphrase occurrence in the caption
* Click on the eye icon
* Confirm that the focus keyphrase in the image caption is NOT highlighted
* Add a second sentence in the caption and add the focus keyphrase
* Click on the eye icon
* Confirm that the focus keyphrase in the second sentence in the caption is highlighted

**Note**: in case the first sentence in the caption is the same as another sentence elsewhere in the text, and that sentence is highlighted, the first sentence of the caption will also be highlighted. This is pre-existing behavior which affects all assessments.

##### Keyphrase distribution (a premium assessment)
* Install and activate Yoast SEO Premium
   * If building the plugin, run `composer require yoast/wordpress-seo:dev-revert-highlighting-support-in-captions-inclassic-editor@dev` before building it
   * Since this PR will be merged to `release/20.3` branch, in `wordpress-seo-premium` also build from this branch
* Repeat the test steps in **Keyword density**, but make sure that  there are **at least 15 sentences** in the text

**Readability analysis**
##### Word complexity assessment (a premium assessment)
* Install and activate Yoast SEO Premium
   * If building the plugin, run `composer require yoast/wordpress-seo:dev-revert-highlighting-support-in-captions-inclassic-editor@dev` before building it
   * Since this PR will be merged to `release/20.3` branch, in `wordpress-seo-premium` also build from this branch
* Go to the previous post
* Go to the Readability analysis tab
* Add a complex word in the FIRST sentence of the image caption, for example, "hereditary"
* Click on the eye icon of the Word complexity assessment
* Confirm that the word "hereditary" in the image caption is NOT highlighted
* Add a second sentence in the caption and add a complex word "flamboyant"
* Click on the eye icon
* Confirm that the word "flamboyant" in the image caption is highlighted

##### Sentence length assessment
* Go to the previous post
* Add a sentence that is longer than 20 words (this number might differ in different languages, see [this page](https://github.com/Yoast/wordpress-seo/blob/trunk/packages/yoastseo/src/scoring/assessments/SCORING%20READABILITY.md#3-sentence-length) for more info) to the image caption. Add this as the FIRST sentence.
* Click on the eye icon of the Sentence length assessment
* Confirm that the long sentence in the caption is NOT highlighted
* Add another long sentence longer than 20 words in the caption. Add it as a second sentence
* Click on the eye icon of the Sentence length assessment
* Confirm that the second long sentence in the caption is highlighted

##### Passive voice assessment
* Go to the previous post
* Add a sentence that contains a passive construction (e.g. "The cats are well loved) to the image caption. Add this as the FIRST sentence
* Click on the eye icon of the Passive voice assessment
* Confirm that the passive sentence in the caption is NOT highlighted
* Add another sentence containing passive construction in the caption (e.g. "A cat with hereditary cuteness is sought after.". Add it as a second sentence
* Click on the eye icon of the Passive voice assessment
* Confirm that the second passive sentence in the caption is highlighted

##### Transition words assessment 
* Go to the previous post
* Add a sentence that contains a transition word (e.g. "however" ) to the image caption. Add this as the FIRST sentence.
* Click on the eye icon of the Transition words assessment
* Confirm that the sentence containing the transition word in the caption is NOT highlighted
* Add another sentence containing transition word in the caption (e.g. "A tortie is unquestionably cute."). Add it as a second sentence
* Click on the eye icon of the Transition words assessment
* Confirm that the second sentence containing the transition word in the caption is highlighted

##### Consecutive sentences assessment
* (Assessment not available for E-commerce content types)
* Go to the previous post
* Add these three sentences that start with the same words to the image caption:

> Cats are lovely. Cats are fun. Cats are adorable.

NOTE: add the sentences above at the beginning of the caption
* Click on the eye icon of the consecutive sentences assessment
* Confirm that the three sentences above are NOT highlighted
* Add another sentence at the beginning of the caption
* Click on the eye icon of the consecutive sentences assessment
* Confirm that the three sentences above are highlighted

##### Paragraph length assessment 
* Go to the previous post
* Add a text longer than 200 words to the image caption, for example the text below:

> Apart from counting words and characters, our online editor can help you to improve word choice and writing style, and, optionally, help you to detect grammar mistakes and plagiarism. To check word count, simply place your cursor into the text box above and start typing. You'll see the number of characters and words increase or decrease as you type, delete, and edit them. You can also copy and paste text from another program over into the online editor above. The Auto-Save feature will make sure you won't lose any changes while editing, even if you leave the site and come back later. Apart from counting words and characters, our online editor can help you to improve word choice and writing style, and, optionally, help you to detect grammar mistakes and plagiarism. To check word count, simply place your cursor into the text box above and start typing. You'll see the number of characters and words increase or decrease as you type, delete, and edit them. You can also copy and paste text from another program over into the online editor above. The Auto-Save feature will make sure you won't lose any changes while editing, even if you leave the site and come back later.

* Confirm that paragraph length assessment recognizes the long paragraph inside the caption
* Click on the eye icon and confirm that the long text in the caption is NOT highlighted.


**Inclusive language analysis**
* Go to the previous post
* In the image caption, add non-inclusive words like "seniors", "policemen" etc. in the FIRST sentence
* Click on the eye icon of the feedback
* Confirm that sentence in the caption that contains the non-inclusive word is NOT highlighted
* Add a second sentence to the caption and add non-inclusive word "exotic"
* Click on the eye icon of the feedback
* Confirm that sentence in the caption that contains the non-inclusive word  "exotic" is highlighted

##### Smoke test highlighting of text outside captions
* Still in Classic editor, smoke test some of the SEO and readability assessments above for text outside captions. Hence, from the test instruction above, add the text to the text area outside image captions.
* Confirm that the highlighting still works

#### Block editor
* Install and activate Yoast SEO
* Set the site language to English
* Create a post
* Smoke test the highlighting functionality of the assessments mentioned in "Classic editor" section above, but for a text that is outside the image caption

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/custom post types/products
   * Testing in taxonomies is not necessary since we don't support highlighting feature there 
   * When testing in WooCommerce:
      * Install and activate WooCommerce
      * Install and activate Yoast SEO for WooCommerce
         * If building the plugin, run `composer require yoast/wordpress-seo:dev-revert-highlighting-support-in-captions-inclassic-editor@dev --dev` before building it
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
