### PR TITLE
Reverts changes to the addon-manager

### DIFF
--- a/inc/class-addon-manager.php
+++ b/inc/class-addon-manager.php
@@ -80,19 +80,6 @@ class WPSEO_Addon_Manager {
 	];
 
 	/**
-	 * Mapping of internal slugs to public slugs.
-	 *
-	 * @var array
-	 */
-	protected static $public_slugs = [
-		self::PREMIUM_SLUG      => 'wordpress-seo-premium',
-		self::NEWS_SLUG         => 'wpseo-news',
-		self::VIDEO_SLUG        => 'wpseo-video',
-		self::WOOCOMMERCE_SLUG  => 'wpseo-woocommerce',
-		self::LOCAL_SLUG        => 'wordpress-seo-local',
-	];
-
-	/**
 	 * Holds the site information data.
 	 *
 	 * @var stdClass
@@ -519,13 +506,10 @@ class WPSEO_Addon_Manager {
 			'requires'     => ( $plugin_info ) ? YOAST_SEO_WP_REQUIRED : null,
 		];
 
-		$slug = ( $plugin_info ) ? self::$public_slugs[ $subscription->product->slug ] : $subscription->product->slug;
-
 		return (object) [
-			'version'          => $subscription->product->version,
 			'new_version'      => $subscription->product->version,
 			'name'             => $subscription->product->name,
-			'slug'             => $slug,
+			'slug'             => $subscription->product->slug,
 			'plugin'           => $plugin_file,
 			'url'              => $subscription->product->store_url,
 			'last_update'      => $subscription->product->last_updated,

--- a/tests/unit/inc/addon-manager-test.php
+++ b/tests/unit/inc/addon-manager-test.php
@@ -610,7 +610,6 @@ class Addon_Manager_Test extends TestCase {
 		$this->assertEquals(
 			(object) [
 				'new_version'      => '10.0',
-				'version'          => '10.0',
 				'name'             => 'Extension',
 				'slug'             => 'yoast-seo-wordpress-premium',
 				'plugin'           => '',
@@ -859,7 +858,6 @@ class Addon_Manager_Test extends TestCase {
 					'response' => [
 						'wp-seo-premium.php' => (object) [
 							'new_version'      => '10.0',
-							'version'          => '10.0',
 							'name'             => 'Extension',
 							'slug'             => 'yoast-seo-wordpress-premium',
 							'plugin'           => '',
@@ -921,9 +919,8 @@ class Addon_Manager_Test extends TestCase {
 				'args'     => [ 'slug' => 'yoast-seo-wordpress-premium' ],
 				'expected' => (object) [
 					'new_version'      => '10.0',
-					'version'          => '10.0',
 					'name'             => 'Extension',
-					'slug'             => 'wordpress-seo-premium',
+					'slug'             => 'yoast-seo-wordpress-premium',
 					'plugin'           => '',
 					'url'              => 'https://example.org/store',
 					'last_update'      => 'yesterday',


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to remove the changes we made to the add-on manager

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Removes non released changes to the add-on manager.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

*

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Smoke test the plugin overview page and view details page to check if there are no errors.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
