### PR TITLE
19892 check for dead code related to old wp versions

### DIFF
--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -5,7 +5,6 @@
  * @package WPSEO\Admin
  */
 
-use Yoast\WP\SEO\Helpers\Wordpress_Helper;
 use Yoast\WP\SEO\Integrations\Settings_Integration;
 
 /**
@@ -316,16 +315,8 @@ class WPSEO_Admin {
 	 * Log the updated timestamp for user profiles when theme is changed.
 	 */
 	public function switch_theme() {
-		$wordpress_helper  = new Wordpress_Helper();
-		$wordpress_version = $wordpress_helper->get_wordpress_version();
 
-		// Capability queries were only introduced in WP 5.9.
-		if ( version_compare( $wordpress_version, '5.8.99', '<' ) ) {
-			$users = get_users( [ 'who' => 'authors' ] );
-		}
-		else {
-			$users = get_users( [ 'capability' => [ 'edit_posts' ] ] );
-		}
+		$users = get_users( [ 'capability' => [ 'edit_posts' ] ] );
 
 		if ( is_array( $users ) && $users !== [] ) {
 			foreach ( $users as $user ) {

--- a/admin/formatter/class-term-metabox-formatter.php
+++ b/admin/formatter/class-term-metabox-formatter.php
@@ -116,8 +116,7 @@ class WPSEO_Term_Metabox_Formatter implements WPSEO_Metabox_Formatter_Interface 
 	 * @return string
 	 */
 	private function edit_url() {
-		$script_filename = 'term';
-		return admin_url( $script_filename . '.php?action=edit&taxonomy=' . $this->term->taxonomy . '&tag_ID={id}' );
+		return admin_url( 'term.php?action=edit&taxonomy=' . $this->term->taxonomy . '&tag_ID={id}' );
 	}
 
 	/**

--- a/admin/formatter/class-term-metabox-formatter.php
+++ b/admin/formatter/class-term-metabox-formatter.php
@@ -116,8 +116,7 @@ class WPSEO_Term_Metabox_Formatter implements WPSEO_Metabox_Formatter_Interface 
 	 * @return string
 	 */
 	private function edit_url() {
-		global $wp_version;
-		$script_filename = version_compare( $wp_version, '4.5', '<' ) ? 'edit-tags' : 'term';
+		$script_filename = 'term';
 		return admin_url( $script_filename . '.php?action=edit&taxonomy=' . $this->term->taxonomy . '&tag_ID={id}' );
 	}
 

--- a/admin/taxonomy/class-taxonomy.php
+++ b/admin/taxonomy/class-taxonomy.php
@@ -69,6 +69,7 @@ class WPSEO_Taxonomy {
 			return;
 		}
 
+		// Adds custom category description editor. Needs a hook that runs before the description field.
 		add_action( "{$this->taxonomy}_term_edit_form_top", [ $this, 'custom_category_description_editor' ] );
 
 		add_action( sanitize_text_field( $this->taxonomy ) . '_edit_form', [ $this, 'term_metabox' ], 90, 1 );

--- a/admin/taxonomy/class-taxonomy.php
+++ b/admin/taxonomy/class-taxonomy.php
@@ -69,7 +69,7 @@ class WPSEO_Taxonomy {
 			return;
 		}
 
-		$this->insert_description_field_editor();
+		add_action( "{$this->taxonomy}_term_edit_form_top", [ $this, 'custom_category_description_editor' ] );
 
 		add_action( sanitize_text_field( $this->taxonomy ) . '_edit_form', [ $this, 'term_metabox' ], 90, 1 );
 		add_action( 'admin_enqueue_scripts', [ $this, 'admin_enqueue_scripts' ] );
@@ -443,15 +443,5 @@ class WPSEO_Taxonomy {
 		$page_type = $recommended_replace_vars->determine_for_term( $taxonomy );
 
 		return $recommended_replace_vars->get_recommended_replacevars_for( $page_type );
-	}
-
-	/**
-	 * Adds custom category description editor.
-	 * Needs a hook that runs before the description field.
-	 *
-	 * @return void
-	 */
-	private function insert_description_field_editor() {
-		add_action( "{$this->taxonomy}_term_edit_form_top", [ $this, 'custom_category_description_editor' ] );
 	}
 }

--- a/admin/taxonomy/class-taxonomy.php
+++ b/admin/taxonomy/class-taxonomy.php
@@ -447,17 +447,11 @@ class WPSEO_Taxonomy {
 
 	/**
 	 * Adds custom category description editor.
-	 * Needs a hook that runs before the description field. Prior to WP version 4.5 we need to use edit_form as
-	 * term_edit_form_top was introduced in WP 4.5. This can be removed after <4.5 is no longer supported.
+	 * Needs a hook that runs before the description field.
 	 *
 	 * @return void
 	 */
 	private function insert_description_field_editor() {
-		if ( version_compare( $GLOBALS['wp_version'], '4.5', '<' ) ) {
-			add_action( "{$this->taxonomy}_edit_form", [ $this, 'custom_category_description_editor' ] );
-			return;
-		}
-
 		add_action( "{$this->taxonomy}_term_edit_form_top", [ $this, 'custom_category_description_editor' ] );
 	}
 }

--- a/inc/sitemaps/class-author-sitemap-provider.php
+++ b/inc/sitemaps/class-author-sitemap-provider.php
@@ -5,8 +5,6 @@
  * @package WPSEO\XML_Sitemaps
  */
 
-use Yoast\WP\SEO\Helpers\Wordpress_Helper;
-
 /**
  * Sitemap provider for author archives.
  */
@@ -119,17 +117,8 @@ class WPSEO_Author_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 			],
 		];
 
-		$wordpress_helper  = new Wordpress_Helper();
-		$wordpress_version = $wordpress_helper->get_wordpress_version();
-
-		// Capability queries were only introduced in WP 5.9.
-		if ( version_compare( $wordpress_version, '5.8.99', '<' ) ) {
-			$defaults['who'] = 'authors';
-			unset( $defaults['capability'] );
-		}
-
 		if ( WPSEO_Options::get( 'noindex-author-noposts-wpseo', true ) ) {
-			unset( $defaults['who'], $defaults['capability'] ); // Otherwise it cancels out next argument.
+			unset( $defaults['capability'] ); // Otherwise it cancels out next argument.
 			$defaults['has_published_posts'] = YoastSEO()->helpers->author_archive->get_author_archive_post_types();
 		}
 
@@ -224,15 +213,6 @@ class WPSEO_Author_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 				],
 			],
 		];
-
-		$wordpress_helper  = new Wordpress_Helper();
-		$wordpress_version = $wordpress_helper->get_wordpress_version();
-
-		// Capability queries were only introduced in WP 5.9.
-		if ( version_compare( $wordpress_version, '5.8.99', '<' ) ) {
-			$user_criteria['who'] = 'authors';
-			unset( $user_criteria['capability'] );
-		}
 
 		$users = get_users( $user_criteria );
 

--- a/src/integrations/blocks/block-categories.php
+++ b/src/integrations/blocks/block-categories.php
@@ -2,29 +2,12 @@
 
 namespace Yoast\WP\SEO\Integrations\Blocks;
 
-use Yoast\WP\SEO\Helpers\Wordpress_Helper;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
 
 /**
  * Internal_Linking_Category block class.
  */
 class Internal_Linking_Category implements Integration_Interface {
-
-	/**
-	 * Represents the WordPress helper.
-	 *
-	 * @var Wordpress_Helper
-	 */
-	protected $wordpress_helper;
-
-	/**
-	 * Internal_Linking_Category constructor.
-	 *
-	 * @param Wordpress_Helper $wordpress_helper The WordPress helper.
-	 */
-	public function __construct( Wordpress_Helper $wordpress_helper ) {
-		$this->wordpress_helper = $wordpress_helper;
-	}
 
 	/**
 	 * {@inheritDoc}
@@ -37,15 +20,7 @@ class Internal_Linking_Category implements Integration_Interface {
 	 * {@inheritDoc}
 	 */
 	public function register_hooks() {
-		$wordpress_version = $this->wordpress_helper->get_wordpress_version();
-
-		// The 'block_categories' filter has been deprecated in WordPress 5.8 and replaced by 'block_categories_all'.
-		if ( \version_compare( $wordpress_version, '5.8-beta0', '<' ) ) {
-			\add_filter( 'block_categories', [ $this, 'add_block_categories' ] );
-		}
-		else {
-			\add_filter( 'block_categories_all', [ $this, 'add_block_categories' ] );
-		}
+		\add_filter( 'block_categories_all', [ $this, 'add_block_categories' ] );
 	}
 
 	/**

--- a/tests/integration/admin/test-class-yoast-network-admin.php
+++ b/tests/integration/admin/test-class-yoast-network-admin.php
@@ -98,12 +98,6 @@ class Yoast_Network_Admin_Test extends WPSEO_UnitTestCase {
 	public function test_get_site_states() {
 		$this->skipWithoutMultisite();
 
-		if ( version_compare( $GLOBALS['wp_version'], '5.1', '>=' ) ) {
-			$this->markTestSkipped( 'Skipped because since WordPress 5.1 the hook wpmu_new_blog is deprecated' );
-
-			return;
-		}
-
 		$admin = new Yoast_Network_Admin();
 
 		$active_states = [

--- a/tests/integration/admin/test-class-yoast-network-admin.php
+++ b/tests/integration/admin/test-class-yoast-network-admin.php
@@ -243,9 +243,6 @@ class Yoast_Network_Admin_Test extends WPSEO_UnitTestCase {
 		$_REQUEST['_wpnonce']         = '';
 
 		$expected_message = 'The link you followed has expired.';
-		if ( version_compare( $GLOBALS['wp_version'], '4.9', '<' ) ) {
-			$expected_message = 'Are you sure you want to do this?';
-		}
 
 		$this->expectException( 'WPDieException' );
 		$this->expectExceptionMessage( $expected_message );

--- a/tests/integration/formatter/test-term-metabox-formatter.php
+++ b/tests/integration/formatter/test-term-metabox-formatter.php
@@ -69,7 +69,7 @@ class WPSEO_Term_Metabox_Formatter_Test extends WPSEO_UnitTestCase {
 
 		$result = $instance->get_values();
 
-		$this->assertEquals( $result['search_url'], admin_url( 'term.php?taxonomy=' . $this->term->taxonomy . '&seo_kw_filter={keyword}' ) );
+		$this->assertEquals( $result['search_url'], admin_url( 'edit-tags.php?taxonomy=' . $this->term->taxonomy . '&seo_kw_filter={keyword}' ) );
 		$this->assertEquals( $result['post_edit_url'], admin_url( 'term.php?action=edit&taxonomy=' . $this->term->taxonomy . '&tag_ID={id}' ) );
 
 		$this->assertEquals( trailingslashit( home_url( 'tag' ) ), $result['base_url'] );
@@ -79,7 +79,7 @@ class WPSEO_Term_Metabox_Formatter_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	 * Get the correct post_edit_url for WP 4.5 and higher.
+	 * Get the correct post_edit_url.
 	 *
 	 * @covers WPSEO_Term_Metabox_Formatter::edit_url
 	 */

--- a/tests/integration/formatter/test-term-metabox-formatter.php
+++ b/tests/integration/formatter/test-term-metabox-formatter.php
@@ -79,20 +79,6 @@ class WPSEO_Term_Metabox_Formatter_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	 * Get the correct post_edit_url.
-	 *
-	 * @covers WPSEO_Term_Metabox_Formatter::edit_url
-	 */
-	public function test_post_edit_url_4_5_and_higher() {
-
-		$instance = new WPSEO_Term_Metabox_Formatter( $this->taxonomy, $this->term, [] );
-
-		$result = $instance->get_values();
-
-		$this->assertEquals( $result['post_edit_url'], admin_url( 'term.php?action=edit&taxonomy=' . $this->term->taxonomy . '&tag_ID={id}' ) );
-	}
-
-	/**
 	 * Test the formatter when there is a taxonomy and term object and without any options.
 	 *
 	 * @covers WPSEO_Term_Metabox_Formatter::get_title_template

--- a/tests/integration/formatter/test-term-metabox-formatter.php
+++ b/tests/integration/formatter/test-term-metabox-formatter.php
@@ -67,16 +67,10 @@ class WPSEO_Term_Metabox_Formatter_Test extends WPSEO_UnitTestCase {
 
 		$instance = new WPSEO_Term_Metabox_Formatter( $this->taxonomy, $this->term );
 
-		global $wp_version;
-		$_wp_version = $wp_version;
-		$wp_version  = '4.4.2';
-
 		$result = $instance->get_values();
 
-		$wp_version = $_wp_version;
-
-		$this->assertEquals( $result['search_url'], admin_url( 'edit-tags.php?taxonomy=' . $this->term->taxonomy . '&seo_kw_filter={keyword}' ) );
-		$this->assertEquals( $result['post_edit_url'], admin_url( 'edit-tags.php?action=edit&taxonomy=' . $this->term->taxonomy . '&tag_ID={id}' ) );
+		$this->assertEquals( $result['search_url'], admin_url( 'term.php?taxonomy=' . $this->term->taxonomy . '&seo_kw_filter={keyword}' ) );
+		$this->assertEquals( $result['post_edit_url'], admin_url( 'term.php?action=edit&taxonomy=' . $this->term->taxonomy . '&tag_ID={id}' ) );
 
 		$this->assertEquals( trailingslashit( home_url( 'tag' ) ), $result['base_url'] );
 		$this->assertEquals( [ '' => [] ], $result['keyword_usage'] );
@@ -90,16 +84,10 @@ class WPSEO_Term_Metabox_Formatter_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Term_Metabox_Formatter::edit_url
 	 */
 	public function test_post_edit_url_4_5_and_higher() {
-		global $wp_version;
 
 		$instance = new WPSEO_Term_Metabox_Formatter( $this->taxonomy, $this->term, [] );
 
-		$_wp_version = $wp_version;
-		$wp_version  = '4.5.0';
-
 		$result = $instance->get_values();
-
-		$wp_version = $_wp_version;
 
 		$this->assertEquals( $result['post_edit_url'], admin_url( 'term.php?action=edit&taxonomy=' . $this->term->taxonomy . '&tag_ID={id}' ) );
 	}

--- a/tests/integration/notifications/test-class-yoast-notification-center.php
+++ b/tests/integration/notifications/test-class-yoast-notification-center.php
@@ -594,6 +594,34 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
+	 * Tests that checking for dismissed notifications applies only to the current site in multisite.
+	 *
+	 * @group ms-required
+	 *
+	 * @covers Yoast_Notification_Center::is_notification_dismissed
+	 */
+	public function test_is_notification_dismissed_is_per_site() {
+		$this->skipWithoutMultisite();
+
+		$site2 = self::factory()->blog->create();
+
+		$notification  = new Yoast_Notification( 'notification', $this->fake_notification_defaults );
+		$dismissal_key = $notification->get_dismissal_key();
+
+		// Dismiss notification for the current site.
+		update_user_option( $this->user_id, $dismissal_key, 'seen' );
+
+		$site1_dismissed = Yoast_Notification_Center::is_notification_dismissed( $notification );
+
+		switch_to_blog( $site2 );
+		$site2_dismissed = Yoast_Notification_Center::is_notification_dismissed( $notification );
+		restore_current_blog();
+
+		$this->assertTrue( $site1_dismissed );
+		$this->assertFalse( $site2_dismissed );
+	}
+
+	/**
 	 * Tests that checking for dismissed notifications falls back to user meta if no user options.
 	 *
 	 * @covers Yoast_Notification_Center::is_notification_dismissed

--- a/tests/integration/notifications/test-class-yoast-notification-center.php
+++ b/tests/integration/notifications/test-class-yoast-notification-center.php
@@ -594,40 +594,6 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	 * Tests that checking for dismissed notifications applies only to the current site in multisite.
-	 *
-	 * @group ms-required
-	 *
-	 * @covers Yoast_Notification_Center::is_notification_dismissed
-	 */
-	public function test_is_notification_dismissed_is_per_site() {
-		$this->skipWithoutMultisite();
-
-		if ( version_compare( $GLOBALS['wp_version'], '5.1', '>=' ) ) {
-			$this->markTestSkipped( 'Skipped because since WordPress 5.1 the hook wpmu_new_blog is deprecated' );
-
-			return;
-		}
-
-		$site2 = self::factory()->blog->create();
-
-		$notification  = new Yoast_Notification( 'notification', $this->fake_notification_defaults );
-		$dismissal_key = $notification->get_dismissal_key();
-
-		// Dismiss notification for the current site.
-		update_user_option( $this->user_id, $dismissal_key, 'seen' );
-
-		$site1_dismissed = Yoast_Notification_Center::is_notification_dismissed( $notification );
-
-		switch_to_blog( $site2 );
-		$site2_dismissed = Yoast_Notification_Center::is_notification_dismissed( $notification );
-		restore_current_blog();
-
-		$this->assertTrue( $site1_dismissed );
-		$this->assertFalse( $site2_dismissed );
-	}
-
-	/**
 	 * Tests that checking for dismissed notifications falls back to user meta if no user options.
 	 *
 	 * @covers Yoast_Notification_Center::is_notification_dismissed

--- a/tests/integration/notifications/test-class-yoast-notification.php
+++ b/tests/integration/notifications/test-class-yoast-notification.php
@@ -290,11 +290,6 @@ class Yoast_Notification_Test extends WPSEO_UnitTestCase {
 	 * @param string $capability Capability to add.
 	 */
 	private function add_cap( $capability ) {
-		// Capabilities have been changed in 4.2: code doesn't fail, just the test.
-		if ( version_compare( $GLOBALS['wp_version'], '4.2', '<' ) ) {
-			$this->markTestSkipped( 'Test requires WP 4.2 or higher' );
-		}
-
 		$me = wp_get_current_user();
 		if ( ! empty( $me ) ) {
 			$me->add_cap( $capability );
@@ -307,11 +302,6 @@ class Yoast_Notification_Test extends WPSEO_UnitTestCase {
 	 * @param string $capability Capability to remove.
 	 */
 	private function remove_cap( $capability ) {
-		// Capabilities have been changed in 4.2: code doesn't fail, just the test.
-		if ( version_compare( $GLOBALS['wp_version'], '4.2', '<' ) ) {
-			$this->markTestSkipped( 'Test requires WP 4.2 or higher' );
-		}
-
 		$me = wp_get_current_user();
 		if ( ! empty( $me ) ) {
 			$me->remove_cap( $capability );

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -442,15 +442,7 @@ if ( ! wp_installing() && ( $spl_autoload_exists && $filter_exists ) ) {
 register_activation_hook( WPSEO_FILE, 'wpseo_activate' );
 register_deactivation_hook( WPSEO_FILE, 'wpseo_deactivate' );
 
-// Wpmu_new_blog has been deprecated in 5.1 and replaced by wp_insert_site.
-global $wp_version;
-if ( version_compare( $wp_version, '5.1', '<' ) ) {
-	add_action( 'wpmu_new_blog', 'wpseo_on_activate_blog' );
-}
-else {
-	add_action( 'wp_initialize_site', 'wpseo_on_activate_blog', 99 );
-}
-
+add_action( 'wp_initialize_site', 'wpseo_on_activate_blog', 99 );
 add_action( 'activate_blog', 'wpseo_on_activate_blog' );
 
 // Registers SEO capabilities.


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Remove dead code related to old WordPress versions that are no longer supported.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Removes dead code related to old WordPress versions that are no longer supported.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Edit a post with block editor.
* Structured data blocks should still work as expected (FAQ block and the How-to block).
* Also confirm that the block categories still work as expected.
    * In a post, click the top left block inserter. See the `Yoast Structured Data Blocks` and `Yoast Internal Linking Blocks` block categories

---
* Check that the author sitemap is correctly being generated.
* Edit a user profile of an admin and save it.
* Repeat the above steps and check all should work again as expected without deprecation notices.
* Also check that the `Last Modified` column of the `http://wordpress.test/author-sitemap.xml` row in the `http://wordpress.test/sitemap_index.xml` page is reflecting the time of the edit of the user profile
---
* Create a user with role `author` and without posts.
* Check that user shows up on the author XML sitemap (but only if  the `Show author archives without posts in search results` setting is enabled)
.
* Check that the author sitemap is correctly being generated.
---
* Go to a term edit page (ie category).
* You should see an editor for the description field.
---
* Go to `Posts`->`Categories`
* Select one of the categories and edit.
* Inspect page and go to console tab
* Write `wpseoScriptData.metabox.post_edit_url`
* Check you get a url `http://basic.wordpress.test/wp-admin/term.php?action=edit&taxonomy=category&tag_ID={id}` If your site name is `basic.wordpress.test` for example.
* Go to a custom taxonomy as well and verify that the `taxonomy` param in that URL is reflecting the slug of the custom taxonomy
---
* Create a multisite.
* Add a new site 
* Check you don't get any warnings such as:
  - Warning: Missing argument 1 for wpseo_activate(), called in ⁓/wp-content/plugins/wordpress-seo/wp-seo-main.php on line 224 and defined in ⁓/wp-content/plugins/wordpress-seo/wp-seo-main.php on line 110
  - Warning: Cannot modify header information - headers already sent by (output started at ⁓/wp-content/plugins/wordpress-seo/wp-seo-main.php:110) in ⁓/wp-includes/pluggable.php on line 1121
---
* Visit the http://wordpress.test/author-sitemap.xml author sitemap
* See the Last Mod. column for the users 
* Switch to a different theme and then refresh the sitemap
* Verify that the Last Mod. columns were modified accordingly, to the time you switched themes.


#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [x] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes[Check for dead code related to old WP versions](https://github.com/Yoast/wordpress-seo/issues/19892)
