### PR TITLE
Send extra information to the newsletter subscription

### DIFF
--- a/packages/js/src/first-time-configuration/tailwind-components/steps/personal-preferences/newsletter-signup.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/steps/personal-preferences/newsletter-signup.js
@@ -31,6 +31,7 @@ async function postSignUp( email ) {
 					email,
 				},
 				list: "Yoast newsletter",
+				source: "free",
 			}
 		),
 	} );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* To accompany platform's https://github.com/Yoast/my-yoast/pull/4254 where the extra information of the `source` is now expected

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Sends a `source` parameter to MyYoast upon newsletter subscription

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Have the `Network` tab open and go to the FTC (while you have Premium not active)
* At the last step, `Sign up` for the newsletter
* In the `Network` tab, confirm that the `subscribe` request returned with a 201 response code:

![image](https://user-images.githubusercontent.com/12400734/224992341-3d39beb7-bd22-42b8-a94e-92690a912ef6.png)

* Also check the payload of that request and confirm that it includes a `source : "free"` parameter

![image](https://user-images.githubusercontent.com/12400734/224992506-9fb2d01f-f0d3-46f4-b85e-6a6b048924aa.png)


#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

* Go to the last step of the FTC, while having Premium disabled.
* input a valid email address to subscribe to the newsletter ( [bob+anotherValidEmail@yoast.com](mailto:bob+anotherValidEmail@yoast.com) for instance ), and click the button to subscribe that email address to the newsletter.
* Visit [this link](https://elk.yoast.com/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-3h,to:now))&_a=(columns:!(),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'05aaa9d0-8dae-11ed-aa74-b5999ab440d6',key:fields.context,negate:!f,params:(query:MailingListController),type:phrase),query:(match_phrase:(fields.context:MailingListController)))),index:'05aaa9d0-8dae-11ed-aa74-b5999ab440d6',interval:auto,query:(language:kuery,query:''),sort:!(!('@timestamp',desc)))). this is a link to our logging system. DevOps should've given you access before testing this. It features logs from the last three hours.
* For the attempted newsletter subscription just now, there should see a new record added to the logging system linked above. pressing the two blue arrows pointing to eachother ( 1 ) expands information on that specific log.
* The message field (2) should describe the kind of premium installation the newsletter subscription came from. 'free' for a yoast seo free installation, and 'premium' for a yoast seo premium installation. Because we believe only free has one of the newsletter forms, we believe this should only ever be 'free' during your tests

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
