### PR TITLE
Re-instate background indexing via WP Cron

### DIFF
--- a/admin/tracking/class-tracking-settings-data.php
+++ b/admin/tracking/class-tracking-settings-data.php
@@ -176,6 +176,7 @@ class WPSEO_Tracking_Settings_Data implements WPSEO_Collection {
 		'wikipedia_url',
 		'mastodon_url',
 		'indexables_indexing_completed',
+		'last_completely_indexed_versions',
 		'semrush_integration_active',
 		'semrush_tokens',
 		'semrush_country_code',

--- a/inc/options/class-wpseo-option-wpseo.php
+++ b/inc/options/class-wpseo-option-wpseo.php
@@ -36,6 +36,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 		'indexing_reason'                          => '',
 		'indexables_indexing_completed'            => false,
 		'index_now_key'                            => '',
+		'last_completely_indexed_versions'         => '',
 		// Non-form field, should only be set via validation routine.
 		'version'                                  => '', // Leave default as empty to ensure activation/upgrade works.
 		'previous_version'                         => '',
@@ -325,6 +326,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 				case 'clean_permalinks_extra_variables':
 				case 'indexables_overview_state':
 				case 'dismiss_old_premium_version_notice':
+				case 'last_completely_indexed_versions':
 					if ( isset( $dirty[ $key ] ) ) {
 						$clean[ $key ] = $dirty[ $key ];
 					}

--- a/src/conditionals/wp-cron-enabled-conditional.php
+++ b/src/conditionals/wp-cron-enabled-conditional.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Yoast\WP\SEO\Conditionals;
+
+/**
+ * Class that checks if WP_CRON is enabled.
+ */
+class WP_CRON_Enabled_Conditional implements Conditional {
+
+	/**
+	 * Checks if WP_CRON is enabled.
+	 *
+	 * @return bool True when WP_CRON is enabled.
+	 */
+	public function is_met() {
+		return ! ( defined( 'DISABLE_WP_CRON' ) && DISABLE_WP_CRON );
+	}
+}

--- a/src/helpers/indexing-helper.php
+++ b/src/helpers/indexing-helper.php
@@ -13,6 +13,7 @@ use Yoast\WP\SEO\Actions\Indexing\Term_Link_Indexing_Action;
 use Yoast\WP\SEO\Config\Indexing_Reasons;
 use Yoast\WP\SEO\Integrations\Admin\Indexing_Notification_Integration;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
+use Yoast\WP\SEO\Values\Indexables\Indexable_Builder_Versions;
 use Yoast_Notification_Center;
 
 /**
@@ -56,20 +57,30 @@ class Indexing_Helper {
 	protected $indexable_repository;
 
 	/**
+	 * Stores the version of each Indexable type.
+	 *
+	 * @var Indexable_Builder_Versions The current versions of all indexable builders.
+	 */
+	protected $indexable_builder_versions;
+
+	/**
 	 * Indexing_Helper constructor.
 	 *
-	 * @param Options_Helper            $options_helper      The options helper.
-	 * @param Date_Helper               $date_helper         The date helper.
-	 * @param Yoast_Notification_Center $notification_center The notification center.
+	 * @param Options_Helper             $options_helper             The options helper.
+	 * @param Date_Helper                $date_helper                The date helper.
+	 * @param Yoast_Notification_Center  $notification_center        The notification center.
+	 * @param Indexable_Builder_Versions $indexable_builder_versions Stores the version of each Indexable type.
 	 */
 	public function __construct(
 		Options_Helper $options_helper,
 		Date_Helper $date_helper,
-		Yoast_Notification_Center $notification_center
+		Yoast_Notification_Center $notification_center,
+		Indexable_Builder_Versions $indexable_builder_versions
 	) {
-		$this->options_helper      = $options_helper;
-		$this->date_helper         = $date_helper;
-		$this->notification_center = $notification_center;
+		$this->options_helper             = $options_helper;
+		$this->date_helper                = $date_helper;
+		$this->notification_center        = $notification_center;
+		$this->indexable_builder_versions = $indexable_builder_versions;
 	}
 
 	/**
@@ -235,6 +246,28 @@ class Indexing_Helper {
 	 */
 	public function is_finished_indexables_indexing() {
 		return $this->options_helper->get( 'indexables_indexing_completed', false );
+	}
+
+	/**
+	 * Checks if all indexables are complete and up to date.
+	 * If the indexables are complete, they will always be considered complete until one or more
+	 * indexable builders get a version bump.
+	 *
+	 * @return bool Whether the index is up to date.
+	 */
+	public function is_index_up_to_date() {
+		$last_completed_index_version = $this->options_helper->get( 'last_completely_indexed_versions' );
+		$combined_version_key         = $this->indexable_builder_versions->get_combined_version_key();
+		if ( $last_completed_index_version === $combined_version_key ) {
+			return true;
+		}
+
+		$has_unindexed = $this->get_limited_filtered_unindexed_count( 1 ) > 0;
+		if ( $has_unindexed === false ) {
+			$this->options_helper->set( 'last_completely_indexed_versions', $combined_version_key );
+		}
+
+		return ! $has_unindexed;
 	}
 
 	/**

--- a/src/integrations/admin/background-indexing-integration.php
+++ b/src/integrations/admin/background-indexing-integration.php
@@ -11,6 +11,7 @@ use Yoast\WP\SEO\Actions\Indexing\Post_Link_Indexing_Action;
 use Yoast\WP\SEO\Actions\Indexing\Term_Link_Indexing_Action;
 use Yoast\WP\SEO\Conditionals\Get_Request_Conditional;
 use Yoast\WP\SEO\Conditionals\Migrations_Conditional;
+use Yoast\WP\SEO\Conditionals\WP_CRON_Enabled_Conditional;
 use Yoast\WP\SEO\Conditionals\Yoast_Admin_And_Dashboard_Conditional;
 use Yoast\WP\SEO\Helpers\Indexing_Helper;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
@@ -79,29 +80,51 @@ class Background_Indexing_Integration implements Integration_Interface {
 	protected $indexing_helper;
 
 	/**
+	 * An object that checks if we are on the Yoast admin or on the dashboard page.
+	 *
+	 * @var Yoast_Admin_And_Dashboard_Conditional
+	 */
+	protected $yoast_admin_and_dashboard_conditional;
+
+	/**
+	 * An object that checks if we are handling a GET request.
+	 *
+	 * @var Get_Request_Conditional
+	 */
+	private $get_request_conditional;
+
+	/**
+	 * An object that checks if WP_CRON is enabled.
+	 *
+	 * @var WP_CRON_Enabled_Conditional
+	 */
+	private $wp_cron_enabled_conditional;
+
+	/**
 	 * Returns the conditionals based on which this integration should be active.
 	 *
 	 * @return array The array of conditionals.
 	 */
 	public static function get_conditionals() {
 		return [
-			Yoast_Admin_And_Dashboard_Conditional::class,
 			Migrations_Conditional::class,
-			Get_Request_Conditional::class,
 		];
 	}
 
 	/**
 	 * Shutdown_Indexing_Integration constructor.
 	 *
-	 * @param Indexable_Post_Indexation_Action              $post_indexation              The post indexing action.
-	 * @param Indexable_Term_Indexation_Action              $term_indexation              The term indexing action.
-	 * @param Indexable_Post_Type_Archive_Indexation_Action $post_type_archive_indexation The post type archive indexing action.
-	 * @param Indexable_General_Indexation_Action           $general_indexation           The general indexing action.
-	 * @param Indexable_Indexing_Complete_Action            $complete_indexation_action   The complete indexing action.
-	 * @param Post_Link_Indexing_Action                     $post_link_indexing_action    The post indexing action.
-	 * @param Term_Link_Indexing_Action                     $term_link_indexing_action    The term indexing action.
-	 * @param Indexing_Helper                               $indexing_helper              The indexing helper.
+	 * @param Indexable_Post_Indexation_Action              $post_indexation                       The post indexing action.
+	 * @param Indexable_Term_Indexation_Action              $term_indexation                       The term indexing action.
+	 * @param Indexable_Post_Type_Archive_Indexation_Action $post_type_archive_indexation          The post type archive indexing action.
+	 * @param Indexable_General_Indexation_Action           $general_indexation                    The general indexing action.
+	 * @param Indexable_Indexing_Complete_Action            $complete_indexation_action            The complete indexing action.
+	 * @param Post_Link_Indexing_Action                     $post_link_indexing_action             The post indexing action.
+	 * @param Term_Link_Indexing_Action                     $term_link_indexing_action             The term indexing action.
+	 * @param Indexing_Helper                               $indexing_helper                       The indexing helper.
+	 * @param Yoast_Admin_And_Dashboard_Conditional         $yoast_admin_and_dashboard_conditional An object that checks if we are on the Yoast admin or on the dashboard page.
+	 * @param Get_Request_Conditional                       $get_request_conditional               An object that checks if we are handling a GET request.
+	 * @param WP_CRON_Enabled_Conditional                   $wp_cron_enabled_conditional           An object that checks if WP_CRON is enabled.
 	 */
 	public function __construct(
 		Indexable_Post_Indexation_Action $post_indexation,
@@ -111,23 +134,34 @@ class Background_Indexing_Integration implements Integration_Interface {
 		Indexable_Indexing_Complete_Action $complete_indexation_action,
 		Post_Link_Indexing_Action $post_link_indexing_action,
 		Term_Link_Indexing_Action $term_link_indexing_action,
-		Indexing_Helper $indexing_helper
+		Indexing_Helper $indexing_helper,
+		Yoast_Admin_And_Dashboard_Conditional $yoast_admin_and_dashboard_conditional,
+		Get_Request_Conditional $get_request_conditional,
+		WP_CRON_Enabled_Conditional $wp_cron_enabled_conditional
 	) {
-		$this->post_indexation              = $post_indexation;
-		$this->term_indexation              = $term_indexation;
-		$this->post_type_archive_indexation = $post_type_archive_indexation;
-		$this->general_indexation           = $general_indexation;
-		$this->complete_indexation_action   = $complete_indexation_action;
-		$this->post_link_indexing_action    = $post_link_indexing_action;
-		$this->term_link_indexing_action    = $term_link_indexing_action;
-		$this->indexing_helper              = $indexing_helper;
+		$this->post_indexation                       = $post_indexation;
+		$this->term_indexation                       = $term_indexation;
+		$this->post_type_archive_indexation          = $post_type_archive_indexation;
+		$this->general_indexation                    = $general_indexation;
+		$this->complete_indexation_action            = $complete_indexation_action;
+		$this->post_link_indexing_action             = $post_link_indexing_action;
+		$this->term_link_indexing_action             = $term_link_indexing_action;
+		$this->indexing_helper                       = $indexing_helper;
+		$this->yoast_admin_and_dashboard_conditional = $yoast_admin_and_dashboard_conditional;
+		$this->get_request_conditional               = $get_request_conditional;
+		$this->wp_cron_enabled_conditional           = $wp_cron_enabled_conditional;
 	}
 
 	/**
 	 * Register hooks.
 	 */
 	public function register_hooks() {
-		\add_action( 'admin_init', [ $this, 'register_shutdown_indexing' ], 10 );
+		\add_action( 'admin_init', [ $this, 'register_shutdown_indexing' ] );
+		\add_action( 'Yoast\WP\SEO\index', [ $this, 'index' ] );
+		// phpcs:ignore WordPress.WP.CronInterval -- The sniff doesn't understand values with parentheses. https://github.com/WordPress/WordPress-Coding-Standards/issues/2025
+		\add_filter( 'cron_schedules', [ $this, 'add_cron_schedule' ] );
+		\add_action( 'init', [ $this, 'schedule_cron_indexing' ], 11 );
+		\add_filter( 'wpseo_post_indexation_limit', [ $this, 'throttle_cron_indexing' ] );
 	}
 
 	/**
@@ -137,7 +171,7 @@ class Background_Indexing_Integration implements Integration_Interface {
 	 */
 	public function register_shutdown_indexing() {
 		if ( $this->should_index_on_shutdown( $this->get_shutdown_limit() ) ) {
-			\register_shutdown_function( [ $this, 'index' ] );
+			$this->register_shutdown_function( 'index' );
 		}
 	}
 
@@ -147,13 +181,99 @@ class Background_Indexing_Integration implements Integration_Interface {
 	 * @return void
 	 */
 	public function index() {
+		if ( wp_doing_cron() && ! $this->should_index_on_cron() ) {
+			$this->unschedule_cron_indexing();
+
+			return;
+		}
+
 		$this->post_indexation->index();
 		$this->term_indexation->index();
 		$this->general_indexation->index();
 		$this->post_type_archive_indexation->index();
 		$this->post_link_indexing_action->index();
 		$this->term_link_indexing_action->index();
-		$this->complete_indexation_action->complete();
+
+		if ( $this->indexing_helper->is_index_up_to_date() ) {
+			$this->complete_indexation_action->complete();
+		}
+	}
+
+	/**
+	 * Adds the 'Every fifteen minutes' cron schedule to WP-Cron.
+	 *
+	 * @param array $schedules The existing schedules.
+	 *
+	 * @return array The schedules containing the fifteen_minutes schedule.
+	 */
+	public function add_cron_schedule( $schedules ) {
+		if ( ! is_array( $schedules ) ) {
+			return $schedules;
+		}
+
+		$schedules['fifteen_minutes'] = [
+			'interval' => ( 15 * MINUTE_IN_SECONDS ),
+			'display'  => esc_html__( 'Every fifteen minutes', 'wordpress-seo' ),
+		];
+
+		return $schedules;
+	}
+
+	/**
+	 * Schedule background indexing every 5 minutes if the index isn't already up to date.
+	 *
+	 * @return void
+	 */
+	public function schedule_cron_indexing() {
+		if ( ! wp_next_scheduled( 'Yoast\WP\SEO\index' ) && $this->should_index_on_cron() ) {
+			wp_schedule_event( time(), 'fifteen_minutes', 'Yoast\WP\SEO\index' );
+		}
+	}
+
+	/**
+	 * Limit cron indexing to 15 indexables per batch instead of 25.
+	 *
+	 * @param int $indexation_limit The current limit (filter input).
+	 *
+	 * @return int The new batch limit.
+	 */
+	public function throttle_cron_indexing( $indexation_limit ) {
+		if ( wp_doing_cron() ) {
+			return 15;
+		}
+
+		return $indexation_limit;
+	}
+
+	/**
+	 * Determine whether cron indexation should be performed.
+	 *
+	 * @return bool Should cron indexation be performed.
+	 */
+	protected function should_index_on_cron() {
+		$enabled = apply_filters( 'Yoast\WP\SEO\enable_cron_indexing', true ) === true;
+
+		return $enabled && ! $this->indexing_helper->is_index_up_to_date();
+	}
+
+	/**
+	 * Determine whether background indexation should be performed.
+	 *
+	 * @param int $shutdown_limit The shutdown limit used to determine whether indexation should be run.
+	 *
+	 * @return bool Should background indexation be performed.
+	 */
+	protected function should_index_on_shutdown( $shutdown_limit ) {
+		if ( ! $this->yoast_admin_and_dashboard_conditional->is_met() || ! $this->get_request_conditional->is_met() ) {
+			return false;
+		}
+
+		$total_unindexed = $this->indexing_helper->get_limited_filtered_unindexed_count( $shutdown_limit );
+		if ( $total_unindexed === 0 || $total_unindexed > $shutdown_limit ) {
+			return false;
+		}
+
+		return ! $this->wp_cron_enabled_conditional->is_met();
 	}
 
 	/**
@@ -171,15 +291,26 @@ class Background_Indexing_Integration implements Integration_Interface {
 	}
 
 	/**
-	 * Determine whether background indexation should be performed.
+	 * Removes the cron indexing job from the scheduled event queue.
 	 *
-	 * @param int $shutdown_limit The shutdown limit used to determine whether indexation should be run.
-	 *
-	 * @return bool Should background indexation be performed.
+	 * @return void
 	 */
-	public function should_index_on_shutdown( $shutdown_limit ) {
-		$total = $this->indexing_helper->get_limited_filtered_unindexed_count( $shutdown_limit );
+	protected function unschedule_cron_indexing() {
+		$scheduled = wp_next_scheduled( 'Yoast\WP\SEO\index' );
+		if ( $scheduled ) {
+			wp_unschedule_event( $scheduled, 'Yoast\WP\SEO\index' );
+		}
+	}
 
-		return ( $total > 0 && $total < $shutdown_limit );
+	/**
+	 * Registers a method to be executed on shutdown.
+	 * This wrapper mostly exists for making this class more unittestable.
+	 *
+	 * @param string $method_name The name of the method on the current instance to register.
+	 *
+	 * @return void
+	 */
+	protected function register_shutdown_function( $method_name ) {
+		\register_shutdown_function( [ $this, $method_name ] );
 	}
 }

--- a/src/values/indexables/indexable-builder-versions.php
+++ b/src/values/indexables/indexable-builder-versions.php
@@ -41,4 +41,13 @@ class Indexable_Builder_Versions {
 
 		return $this->indexable_builder_versions_by_type[ $object_type ];
 	}
+
+	/**
+	 * Get a unique key for the current state of all combined indexable versions.
+	 *
+	 * @return string a unique key for the current state of all combined indexable versions.
+	 */
+	public function get_combined_version_key() {
+		return implode( '-', array_values( $this->indexable_builder_versions_by_type ) );
+	}
 }

--- a/tests/unit/generators/schema/webpage-test.php
+++ b/tests/unit/generators/schema/webpage-test.php
@@ -85,8 +85,8 @@ class WebPage_Test extends TestCase {
 		$this->meta_tags_context = Mockery::mock( Meta_Tags_Context_Mock::class );
 		$this->id                = Mockery::mock( ID_Helper::class );
 
-		$this->instance          = Mockery::mock( WebPage::class )
-			->makePartial();
+		$this->instance = new WebPage();
+
 		$this->instance->context = $this->meta_tags_context;
 		$this->instance->helpers = (object) [
 			'current_page' => $this->current_page,

--- a/tests/unit/helpers/indexing-helper-test.php
+++ b/tests/unit/helpers/indexing-helper-test.php
@@ -16,6 +16,7 @@ use Yoast\WP\SEO\Helpers\Indexing_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Integrations\Admin\Indexing_Notification_Integration;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
+use Yoast\WP\SEO\Values\Indexables\Indexable_Builder_Versions;
 use Yoast_Notification_Center;
 
 /**
@@ -24,8 +25,8 @@ use Yoast_Notification_Center;
  * @coversDefaultClass \Yoast\WP\SEO\Helpers\Indexing_Helper
  * @covers \Yoast\WP\SEO\Helpers\Indexing_Helper
  *
- * @group helpers
- * @group indexing
+ * @group  helpers
+ * @group  indexing
  */
 class Indexing_Helper_Test extends TestCase {
 
@@ -56,6 +57,13 @@ class Indexing_Helper_Test extends TestCase {
 	 * @var Mockery\MockInterface|Yoast_Notification_Center
 	 */
 	protected $notification_center;
+
+	/**
+	 * The indexable builder version mock.
+	 *
+	 * @var Mockery\MockInterface|Indexable_Builder_Versions
+	 */
+	protected $indexable_builder_versions;
 
 	/**
 	 * The post indexable indexation action.
@@ -105,13 +113,15 @@ class Indexing_Helper_Test extends TestCase {
 	protected function set_up() {
 		parent::set_up();
 
-		$this->options_helper      = Mockery::mock( Options_Helper::class );
-		$this->date_helper         = Mockery::mock( Date_Helper::class );
-		$this->notification_center = Mockery::mock( Yoast_Notification_Center::class );
-		$this->instance            = new Indexing_Helper(
+		$this->options_helper             = Mockery::mock( Options_Helper::class );
+		$this->date_helper                = Mockery::mock( Date_Helper::class );
+		$this->notification_center        = Mockery::mock( Yoast_Notification_Center::class );
+		$this->indexable_builder_versions = Mockery::mock( Indexable_Builder_Versions::class );
+		$this->instance                   = new Indexing_Helper(
 			$this->options_helper,
 			$this->date_helper,
-			$this->notification_center
+			$this->notification_center,
+			$this->indexable_builder_versions
 		);
 
 		$this->post_indexation              = Mockery::mock( Indexable_Post_Indexation_Action::class );

--- a/tests/unit/integrations/admin/background-indexing-integration-test.php
+++ b/tests/unit/integrations/admin/background-indexing-integration-test.php
@@ -13,10 +13,10 @@ use Yoast\WP\SEO\Actions\Indexing\Post_Link_Indexing_Action;
 use Yoast\WP\SEO\Actions\Indexing\Term_Link_Indexing_Action;
 use Yoast\WP\SEO\Conditionals\Get_Request_Conditional;
 use Yoast\WP\SEO\Conditionals\Migrations_Conditional;
+use Yoast\WP\SEO\Conditionals\WP_CRON_Enabled_Conditional;
 use Yoast\WP\SEO\Conditionals\Yoast_Admin_And_Dashboard_Conditional;
 use Yoast\WP\SEO\Helpers\Indexing_Helper;
 use Yoast\WP\SEO\Integrations\Admin\Background_Indexing_Integration;
-use Yoast\WP\SEO\Integrations\Admin\Indexing_Tool_Integration;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
@@ -32,7 +32,7 @@ class Background_Indexing_Integration_Test extends TestCase {
 	/**
 	 * The indexation integration under test.
 	 *
-	 * @var Indexing_Tool_Integration
+	 * @var Mockery\MockInterface|Background_Indexing_Integration
 	 */
 	protected $instance;
 
@@ -93,30 +93,61 @@ class Background_Indexing_Integration_Test extends TestCase {
 	protected $indexing_helper;
 
 	/**
+	 * The Yoast_Admin_And_Dashboard_Conditional mock.
+	 *
+	 * @var Mockery\MockInterface|Yoast_Admin_And_Dashboard_Conditional
+	 */
+	protected $yoast_admin_and_dashboard_conditional;
+
+	/**
+	 * The Get_Request_Conditional mock.
+	 *
+	 * @var Mockery\MockInterface|Get_Request_Conditional
+	 */
+	private $get_request_conditional;
+
+	/**
+	 * The WP_CRON_Conditional mock.
+	 *
+	 * @var Mockery\MockInterface|WP_CRON_Enabled_Conditional
+	 */
+	private $wp_cron_enabled_conditional;
+
+	/**
 	 * Sets up the tests.
 	 */
 	protected function set_up() {
 		parent::set_up();
 
-		$this->post_indexation              = Mockery::mock( Indexable_Post_Indexation_Action::class );
-		$this->term_indexation              = Mockery::mock( Indexable_Term_Indexation_Action::class );
-		$this->post_type_archive_indexation = Mockery::mock( Indexable_Post_Type_Archive_Indexation_Action::class );
-		$this->general_indexation           = Mockery::mock( Indexable_General_Indexation_Action::class );
-		$this->complete_indexation_action   = Mockery::mock( Indexable_Indexing_Complete_Action::class );
-		$this->post_link_indexing_action    = Mockery::mock( Post_Link_Indexing_Action::class );
-		$this->term_link_indexing_action    = Mockery::mock( Term_Link_Indexing_Action::class );
-		$this->indexing_helper              = Mockery::mock( Indexing_Helper::class );
+		$this->post_indexation                       = Mockery::mock( Indexable_Post_Indexation_Action::class );
+		$this->term_indexation                       = Mockery::mock( Indexable_Term_Indexation_Action::class );
+		$this->post_type_archive_indexation          = Mockery::mock( Indexable_Post_Type_Archive_Indexation_Action::class );
+		$this->general_indexation                    = Mockery::mock( Indexable_General_Indexation_Action::class );
+		$this->complete_indexation_action            = Mockery::mock( Indexable_Indexing_Complete_Action::class );
+		$this->post_link_indexing_action             = Mockery::mock( Post_Link_Indexing_Action::class );
+		$this->term_link_indexing_action             = Mockery::mock( Term_Link_Indexing_Action::class );
+		$this->indexing_helper                       = Mockery::mock( Indexing_Helper::class );
+		$this->yoast_admin_and_dashboard_conditional = Mockery::mock( Yoast_Admin_And_Dashboard_Conditional::class );
+		$this->get_request_conditional               = Mockery::mock( Get_Request_Conditional::class );
+		$this->wp_cron_enabled_conditional           = Mockery::mock( WP_CRON_Enabled_Conditional::class );
 
-		$this->instance = new Background_Indexing_Integration(
-			$this->post_indexation,
-			$this->term_indexation,
-			$this->post_type_archive_indexation,
-			$this->general_indexation,
-			$this->complete_indexation_action,
-			$this->post_link_indexing_action,
-			$this->term_link_indexing_action,
-			$this->indexing_helper
-		);
+		// This is a partial mock, so we can get test the registering of the shutdown hook.
+		$this->instance = Mockery::mock(
+			Background_Indexing_Integration::class,
+			[
+				$this->post_indexation,
+				$this->term_indexation,
+				$this->post_type_archive_indexation,
+				$this->general_indexation,
+				$this->complete_indexation_action,
+				$this->post_link_indexing_action,
+				$this->term_link_indexing_action,
+				$this->indexing_helper,
+				$this->yoast_admin_and_dashboard_conditional,
+				$this->get_request_conditional,
+				$this->wp_cron_enabled_conditional,
+			]
+		)->makePartial()->shouldAllowMockingProtectedMethods();
 	}
 
 	/**
@@ -127,9 +158,7 @@ class Background_Indexing_Integration_Test extends TestCase {
 	public function test_get_conditionals() {
 		static::assertEquals(
 			[
-				Yoast_Admin_And_Dashboard_Conditional::class,
 				Migrations_Conditional::class,
-				Get_Request_Conditional::class,
 			],
 			Background_Indexing_Integration::get_conditionals()
 		);
@@ -165,6 +194,10 @@ class Background_Indexing_Integration_Test extends TestCase {
 			Indexing_Helper::class,
 			$this->getPropertyValue( $this->instance, 'indexing_helper' )
 		);
+		static::assertInstanceOf(
+			Yoast_Admin_And_Dashboard_Conditional::class,
+			$this->getPropertyValue( $this->instance, 'yoast_admin_and_dashboard_conditional' )
+		);
 	}
 
 	/**
@@ -174,14 +207,19 @@ class Background_Indexing_Integration_Test extends TestCase {
 	 */
 	public function test_register_hooks() {
 		Monkey\Actions\expectAdded( 'admin_init' );
+		Monkey\Actions\expectAdded( 'Yoast\WP\SEO\index' );
+		Monkey\Filters\expectAdded( 'cron_schedules' );
+		Monkey\Actions\expectAdded( 'init' );
+		Monkey\Filters\expectAdded( 'wpseo_post_indexation_limit' );
 
 		$this->instance->register_hooks();
 	}
 
 	/**
-	 * Tests the enqueue_scripts method.
+	 * Tests the test_register_shutdown_indexing method.
 	 *
 	 * @covers ::register_shutdown_indexing
+	 * @covers ::should_index_on_shutdown
 	 * @covers ::get_shutdown_limit
 	 */
 	public function test_register_shutdown_indexing() {
@@ -190,15 +228,111 @@ class Background_Indexing_Integration_Test extends TestCase {
 			->once()
 			->andReturn( 10 );
 
-		/**
-		 * We have to register the shutdown function here to prevent a fatal PHP error,
-		 * which would occur because the registered shutdown function is executed
-		 * after the unit test has already completed.
-		 */
-		\register_shutdown_function( [ $this, 'shutdown_indexation_expectations' ] );
+		$this->yoast_admin_and_dashboard_conditional
+			->expects( 'is_met' )
+			->once()
+			->andReturn( true );
+
+		$this->get_request_conditional
+			->expects( 'is_met' )
+			->once()
+			->andReturn( true );
+
+		$this->wp_cron_enabled_conditional
+			->expects( 'is_met' )
+			->once()
+			->andReturn( false );
 
 		Monkey\Filters\expectApplied( 'wpseo_shutdown_indexation_limit' )
 			->andReturn( 25 );
+
+		$this->instance
+			->expects( 'register_shutdown_function' )
+			->once()
+			->with( 'index' );
+
+		$this->instance->register_shutdown_indexing();
+	}
+
+	/**
+	 * Tests the test_register_shutdown_indexing method with wp-cron enabled.
+	 *
+	 * @covers ::register_shutdown_indexing
+	 * @covers ::should_index_on_shutdown
+	 * @covers ::get_shutdown_limit
+	 */
+	public function test_register_shutdown_indexing_with_wp_cron_enabled() {
+		$this->indexing_helper
+			->expects( 'get_limited_filtered_unindexed_count' )
+			->once()
+			->andReturn( 10 );
+
+		$this->yoast_admin_and_dashboard_conditional
+			->expects( 'is_met' )
+			->once()
+			->andReturn( true );
+
+		$this->get_request_conditional
+			->expects( 'is_met' )
+			->once()
+			->andReturn( true );
+
+		$this->wp_cron_enabled_conditional
+			->expects( 'is_met' )
+			->once()
+			->andReturn( true );
+
+		Monkey\Filters\expectApplied( 'wpseo_shutdown_indexation_limit' )
+			->andReturn( 25 );
+
+		$this->instance
+			->expects( 'register_shutdown_function' )
+			->never();
+
+		$this->instance->register_shutdown_indexing();
+	}
+
+	/**
+	 * Tests the register_shutdown_indexing method when on a page that shouldn't receive shutdown background indexing.
+	 *
+	 * @covers ::register_shutdown_indexing
+	 * @covers ::should_index_on_shutdown
+	 * @covers ::get_shutdown_limit
+	 */
+	public function test_register_shutdown_indexing_on_invalid_pages() {
+		$this->yoast_admin_and_dashboard_conditional
+			->expects( 'is_met' )
+			->once()
+			->andReturn( false );
+
+		$this->instance
+			->expects( 'register_shutdown_function' )
+			->never();
+
+		$this->instance->register_shutdown_indexing();
+	}
+
+	/**
+	 * Tests the register_shutdown_indexing method on post requests. This should not trigger shutdown background indexing.
+	 *
+	 * @covers ::register_shutdown_indexing
+	 * @covers ::should_index_on_shutdown
+	 * @covers ::get_shutdown_limit
+	 */
+	public function test_register_shutdown_indexing_on_post_request() {
+		$this->yoast_admin_and_dashboard_conditional
+			->expects( 'is_met' )
+			->once()
+			->andReturn( true );
+
+		$this->get_request_conditional
+			->expects( 'is_met' )
+			->once()
+			->andReturn( false );
+
+		$this->instance
+			->expects( 'register_shutdown_function' )
+			->never();
 
 		$this->instance->register_shutdown_indexing();
 	}
@@ -207,31 +341,22 @@ class Background_Indexing_Integration_Test extends TestCase {
 	 * Tests the shutdown indexing method.
 	 *
 	 * @covers ::index
+	 * @covers ::should_index_on_cron
 	 */
 	public function test_index() {
-		$this->term_indexation
-			->expects( 'index' )
-			->once();
+		Monkey\Functions\when( 'wp_doing_cron' )->justReturn( false );
 
-		$this->post_indexation
-			->expects( 'index' )
-			->once();
+		$this->term_indexation->expects( 'index' )->once();
+		$this->post_indexation->expects( 'index' )->once();
+		$this->general_indexation->expects( 'index' )->once();
+		$this->post_type_archive_indexation->expects( 'index' )->once();
+		$this->post_link_indexing_action->expects( 'index' )->once();
+		$this->term_link_indexing_action->expects( 'index' )->once();
 
-		$this->general_indexation
-			->expects( 'index' )
-			->once();
-
-		$this->post_type_archive_indexation
-			->expects( 'index' )
-			->once();
-
-		$this->post_link_indexing_action
-			->expects( 'index' )
-			->once();
-
-		$this->term_link_indexing_action
-			->expects( 'index' )
-			->once();
+		$this->indexing_helper
+			->expects( 'is_index_up_to_date' )
+			->once()
+			->andReturn( true );
 
 		$this->complete_indexation_action
 			->expects( 'complete' )
@@ -241,15 +366,176 @@ class Background_Indexing_Integration_Test extends TestCase {
 	}
 
 	/**
-	 * Sets the expectations for the shutdown indexation.
+	 * Tests the indexing method while doing wp cron.
+	 *
+	 * @covers ::index
+	 * @covers ::should_index_on_cron
 	 */
-	public function shutdown_indexation_expectations() {
-		$this->post_indexation->expects( 'index' )->once();
+	public function test_index_with_wp_cron() {
+		Monkey\Functions\when( 'wp_doing_cron' )->justReturn( true );
+
+		Monkey\Filters\expectApplied( 'Yoast\WP\SEO\enable_cron_indexing' )
+			->with( true )
+			->andReturn( true );
+
+
+		$this->indexing_helper
+			->expects( 'is_index_up_to_date' )
+			->times( 2 )
+			->andReturn( false );
+
+
 		$this->term_indexation->expects( 'index' )->once();
+		$this->post_indexation->expects( 'index' )->once();
 		$this->general_indexation->expects( 'index' )->once();
 		$this->post_type_archive_indexation->expects( 'index' )->once();
-		$this->complete_indexation_action->expects( 'complete' )->once();
 		$this->post_link_indexing_action->expects( 'index' )->once();
 		$this->term_link_indexing_action->expects( 'index' )->once();
+
+		$this->instance->index();
+	}
+
+	/**
+	 * Tests the indexing method while doing wp cron with wp-cron-indexing disabled.
+	 *
+	 * @covers ::index
+	 * @covers ::should_index_on_cron
+	 */
+	public function test_index_with_wp_cron_with_cron_indexing_disabled() {
+		Monkey\Functions\when( 'wp_doing_cron' )->justReturn( true );
+
+		Monkey\Filters\expectApplied( 'Yoast\WP\SEO\enable_cron_indexing' )
+			->with( true )
+			->andReturn( false );
+
+		Monkey\Functions\expect( 'wp_next_scheduled' )->once()->with( 'Yoast\WP\SEO\index' )->andReturn( 12345 );
+		Monkey\Functions\expect( 'wp_unschedule_event' )->once()->with( 12345, 'Yoast\WP\SEO\index' );
+
+		$this->instance->index();
+	}
+
+	/**
+	 * Tests the indexing method while doing wp cron with an already complete index.
+	 *
+	 * @covers ::index
+	 * @covers ::should_index_on_cron
+	 */
+	public function test_index_with_wp_cron_with_complete_index() {
+		Monkey\Functions\when( 'wp_doing_cron' )->justReturn( true );
+
+		Monkey\Filters\expectApplied( 'Yoast\WP\SEO\enable_cron_indexing' )
+			->with( true )
+			->andReturn( true );
+
+
+		$this->indexing_helper
+			->expects( 'is_index_up_to_date' )
+			->once()
+			->andReturn( true );
+
+
+		Monkey\Functions\expect( 'wp_next_scheduled' )->once()->with( 'Yoast\WP\SEO\index' )->andReturn( 12345 );
+		Monkey\Functions\expect( 'wp_unschedule_event' )->once()->with( 12345, 'Yoast\WP\SEO\index' );
+
+		$this->instance->index();
+	}
+
+	/**
+	 * Tests the indexing method while doing wp cron with an already complete index but without a scheduled cron task.
+	 *
+	 * @covers ::index
+	 * @covers ::should_index_on_cron
+	 */
+	public function test_index_with_wp_cron_with_complete_index_without_scheduled_task() {
+		Monkey\Functions\when( 'wp_doing_cron' )->justReturn( true );
+
+		Monkey\Filters\expectApplied( 'Yoast\WP\SEO\enable_cron_indexing' )
+			->with( true )
+			->andReturn( true );
+
+
+		$this->indexing_helper
+			->expects( 'is_index_up_to_date' )
+			->once()
+			->andReturn( true );
+
+
+		Monkey\Functions\expect( 'wp_next_scheduled' )->once()->with( 'Yoast\WP\SEO\index' )->andReturn( false );
+		Monkey\Functions\expect( 'wp_unschedule_event' )->never();
+
+		$this->instance->index();
+	}
+
+	/**
+	 * Tests that the schedule_cron_indexing function schedules a cron job that performs the Yoast\WP\SEO\index action.
+	 *
+	 * @covers ::schedule_cron_indexing
+	 */
+	public function test_schedule_cron_indexing() {
+		Monkey\Functions\expect( 'wp_next_scheduled' )->once()->with( 'Yoast\WP\SEO\index' )->andReturn( false );
+		$this->indexing_helper->expects( 'is_index_up_to_date' )->once()->andReturn( false );
+		Monkey\Functions\expect( 'wp_schedule_event' )->once()->with( time(), 'fifteen_minutes', 'Yoast\WP\SEO\index' );
+
+		$this->instance->schedule_cron_indexing();
+	}
+
+	/**
+	 * Tests that no cron job is scheduled when the cron job is already scheduled.
+	 *
+	 * @covers ::schedule_cron_indexing
+	 */
+	public function test_schedule_cron_indexing_already_scheduled() {
+		Monkey\Functions\expect( 'wp_next_scheduled' )->once()->with( 'Yoast\WP\SEO\index' )->andReturn( 987654321 );
+		Monkey\Functions\expect( 'wp_schedule_event' )->never();
+
+		$this->instance->schedule_cron_indexing();
+	}
+
+	/**
+	 * Tests that no cron job is scheduled when the cron indexing is disabled through the Yoast\WP\SEO\enable_cron_indexing filter.
+	 *
+	 * @covers ::schedule_cron_indexing
+	 */
+	public function test_schedule_cron_indexing_cron_indexing_disabled() {
+		Monkey\Functions\expect( 'wp_next_scheduled' )->once()->with( 'Yoast\WP\SEO\index' )->andReturn( false );
+		Monkey\Filters\expectApplied( 'Yoast\WP\SEO\enable_cron_indexing' )->with( true )->andReturn( false );
+		Monkey\Functions\expect( 'wp_schedule_event' )->never();
+
+		$this->instance->schedule_cron_indexing();
+	}
+
+	/**
+	 * Tests that no cron job is scheduled when the indexing process is already complete.
+	 *
+	 * @covers ::schedule_cron_indexing
+	 */
+	public function test_schedule_cron_indexing_index_complete() {
+		Monkey\Functions\expect( 'wp_next_scheduled' )->once()->with( 'Yoast\WP\SEO\index' )->andReturn( false );
+		$this->indexing_helper->expects( 'is_index_up_to_date' )->once()->andReturn( true );
+		Monkey\Functions\expect( 'wp_schedule_event' )->never();
+
+		$this->instance->schedule_cron_indexing();
+	}
+
+	/**
+	 * Tests that the background indexing pace stays untouched when not doing cron.
+	 *
+	 * @covers ::throttle_cron_indexing
+	 */
+	public function test_throttle_cron_indexing() {
+		Monkey\Functions\when( 'wp_doing_cron' )->justReturn( false );
+
+		$this->assertSame( 25, $this->instance->throttle_cron_indexing( 25 ) );
+	}
+
+	/**
+	 * Tests that the background indexing pace is throttled to 15 when doing cron.
+	 *
+	 * @covers ::throttle_cron_indexing
+	 */
+	public function test_throttle_cron_indexing_while_doing_cron() {
+		Monkey\Functions\when( 'wp_doing_cron' )->justReturn( true );
+
+		$this->assertSame( 15, $this->instance->throttle_cron_indexing( 25 ) );
 	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Sets up background indexation via WP Cron

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

*

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
