### PR TITLE
Remove the encoded slug

### DIFF
--- a/packages/js/src/analysis/blockEditorData.js
+++ b/packages/js/src/analysis/blockEditorData.js
@@ -193,7 +193,7 @@ export default class BlockEditorData {
 			baseUrl = window.wpseoScriptData.metabox.base_url;
 		}
 		// Strip slug from the url.
-		baseUrl = baseUrl.replace( new RegExp( slug + "/$" ), "" );
+		baseUrl = baseUrl.replace( new RegExp( encodeURI( slug ) + "/$", "i" ), "" );
 		// Enforce ending with a slash because of the internal handling in the SnippetEditor component.
 		if ( ! baseUrl.endsWith( "/" ) ) {
 			baseUrl += "/";

--- a/packages/js/src/analysis/blockEditorData.js
+++ b/packages/js/src/analysis/blockEditorData.js
@@ -187,7 +187,7 @@ export default class BlockEditorData {
 		let baseUrl = "";
 		try {
 			url = new URL( permalink );
-			baseUrl = url.href;
+			baseUrl = url.origin + url.pathname;
 		} catch ( e ) {
 			// Fallback on the base url retrieved from the wpseoScriptData.
 			baseUrl = window.wpseoScriptData.metabox.base_url;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Finetune https://github.com/Yoast/wordpress-seo/pull/18227 a bit

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the Google preview would show the post ID in the breadcrumbs when creating a new post with a slug but without a title yet.

## Relevant technical choices:

### non-user-facing changelog entry
* Fixes an unreleased bug where the Google preview would show the `slug` twice in the breadcrumbs if it contains encoded characters.

### tech choices:
* Do a case insensitive check on the encoded slug
* Change the `href` to only `origin` and `pathname` so we effectively ignore the `search` and `hash` parts

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Verify "double" slug is fixed
* Edit a post in the block editor
* Add something non-latin as a slug
  * Like `مرحبًا` (which is hello according to Google translate)
  * Or `🙂1234567890`
* Verify the breadcrumb in the preview only contains the `url` and `slug` parts.
  * E.g. 
![image](https://user-images.githubusercontent.com/35524806/225282266-9dac932b-5556-4bd6-9635-5ab0cb4f4302.png)
  * Before it would result in (the actual decoded slug is chopped off)
![image](https://user-images.githubusercontent.com/35524806/225282400-a7c4d522-9cb5-4532-99d9-2deedfcf6477.png)

#### Verify post ID of auto-draft is fixed
* Create a new post
* Add a slug (can be non-latin to check the above too)
* Verify the breadcrumb in the preview does not contain a `p={post ID}` part
  * E.g.
![image](https://user-images.githubusercontent.com/35524806/225283455-ea2cc3a3-4bbb-48e4-8f75-54f5d55f0290.png)
  * Before it would result in
![image](https://user-images.githubusercontent.com/35524806/225283231-3d46b1a4-8c4b-46fd-b21a-f017785fa14a.png)

#### For extra safety
* You can test the original PR instructions: https://github.com/Yoast/wordpress-seo/pull/18227
* I checked the `Test custom permalink with categories` part from there myself

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* In the block editor, when using a slug with encoded characters.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes https://github.com/Yoast/wordpress-seo/issues/20010
