### PR TITLE
Improve deprecation of WPSEO_HelpScout and move it to the deprecated folder

### DIFF
--- a/src/deprecated/admin/class-helpscout.php
+++ b/src/deprecated/admin/class-helpscout.php
@@ -14,13 +14,6 @@
 class WPSEO_HelpScout implements WPSEO_WordPress_Integration {
 
 	/**
-	 * Whether to asks the user's consent before loading in HelpScout.
-	 *
-	 * @var bool
-	 */
-	protected $ask_consent;
-
-	/**
 	 * WPSEO_HelpScout constructor.
 	 *
 	 * @codeCoverageIgnore
@@ -42,10 +35,6 @@ class WPSEO_HelpScout implements WPSEO_WordPress_Integration {
 	 * @deprecated 20.3
 	 */
 	public function register_hooks() {
-		if ( ! $this->is_beacon_page() ) {
-			return;
-		}
-
 		_deprecated_function( __METHOD__, 'Yoast SEO 20.3', 'HelpScout_Beacon::register_hooks' );
 	}
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where a fatal error related to HelpScout would be thrown when using a more-than-2-year-old Yoast addon.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Mimic what addons from before spring '21 did by adding the following snippet to your theme's `functions.php`:
```
add_action( 'admin_init', 'test_helpscout_deprecation' );
function test_helpscout_deprecation() {
	$helpscout = new WPSEO_HelpScout(
			'4e7489db-f907-41b3-9e86-93a01b4df9b0',
			[ 'wpseo_dashboard' ],
			[ 'wordpress-seo' ]
		);

	$helpscout->register_hooks();
}
```
* visit the site's backend
  * without this PR: you should get a `Fatal error: Uncaught Error: Call to undefined method WPSEO_HelpScout::is_beacon_page()`
  * with this PR: you should not get any such error
#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
