### PR TITLE
Improves copy of notifications.

### DIFF
--- a/css/src/admin-global.css
+++ b/css/src/admin-global.css
@@ -848,5 +848,7 @@ body.folded .wpseo-admin-submit-fixed {
 .yoast .indexables-indexing-error summary {
   font-weight: 700;
 }
-
+.yoast-dashicons-notice {
+	color: #dba617;
+}
 /*# sourceMappingURL=admin-global.css.map */

--- a/inc/class-addon-manager.php
+++ b/inc/class-addon-manager.php
@@ -79,6 +79,34 @@ class WPSEO_Addon_Manager {
 		'local-seo.php'         => self::LOCAL_SLUG,
 	];
 
+	private $addon_details = [
+		self::PREMIUM_SLUG     => [
+			'name'                  => 'Yoast SEO Premium',
+			'short_link_activation' => 'https://yoa.st/13j',
+			'short_link_renewal'    => 'https://yoa.st/4ey',
+		],
+		self::NEWS_SLUG        => [
+			'name'                  => 'News SEO',
+			'short_link_activation' => 'https://yoa.st/4xq',
+			'short_link_renewal'    => 'https://yoa.st/4xv',
+		],
+		self::WOOCOMMERCE_SLUG => [
+			'name'                  => 'Yoast WooCommerce SEO',
+			'short_link_activation' => 'https://yoa.st/4xs',
+			'short_link_renewal'    => 'https://yoa.st/4xx',
+		],
+		self::VIDEO_SLUG       => [
+			'name'                  => 'Video SEO',
+			'short_link_activation' => 'https://yoa.st/4xr',
+			'short_link_renewal'    => 'https://yoa.st/4xw',
+		],
+		self::LOCAL_SLUG       => [
+			'name'                  => 'Local SEO',
+			'short_link_activation' => 'https://yoa.st/4xp',
+			'short_link_renewal'    => 'https://yoa.st/4xu',
+		],
+	];
+
 	/**
 	 * Holds the site information data.
 	 *
@@ -365,13 +393,14 @@ class WPSEO_Addon_Manager {
 	public function expired_subscription_warning( $plugin_data ) {
 		$subscription = $this->get_subscription( $plugin_data['slug'] );
 		if ( $subscription && $this->has_subscription_expired( $subscription ) ) {
+			$addon_link = ( isset( $this->addon_details[ $plugin_data['slug'] ] ) ) ? $this->addon_details[ $plugin_data['slug'] ]['short_link_renewal'] : $this->addon_details[ self::PREMIUM_SLUG ]['short_link_renewal'];
 			echo '<br><br>';
 			/* translators: %1$s is the plugin name, %2$s and %3$s are a link. */
 			echo '<strong><span class="wp-ui-text-notification warning dashicons dashicons-warning"></span> ' .
 				sprintf(
 					esc_html__( '%1$s can\'t be updated because your product subscription is expired. %2$sRenew your product subscription%3$s to get updates again and use all the features of %1$s.', 'wordpress-seo' ),
 					esc_html( $plugin_data['name'] ),
-					'<a href="' . esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/4ey' ) ) . '">',
+					'<a href="' . esc_url( WPSEO_Shortlinker::get( $addon_link ) ) . '">',
 					'</a>'
 				) . '</strong>';
 		}
@@ -421,34 +450,12 @@ class WPSEO_Addon_Manager {
 			return;
 		}
 
-		$addons = [
-			'Yoast SEO Premium'     => [
-				'slug'       => static::PREMIUM_SLUG,
-				'short_link' => 'yoa.st/13j',
-			],
-			'News SEO'              => [
-				'slug'       => static::NEWS_SLUG,
-				'short_link' => 'yoa.st/13j',
-			],
-			'Yoast WooCommerce SEO' => [
-				'slug'       => static::WOOCOMMERCE_SLUG,
-				'short_link' => 'yoa.st/13j',
-			],
-			'Video SEO'             => [
-				'slug'       => static::VIDEO_SLUG,
-				'short_link' => 'yoa.st/13j',
-			],
-			'Local SEO'             => [
-				'slug'       => static::LOCAL_SLUG,
-				'short_link' => 'yoa.st/13j',
-			],
-		];
 
-		foreach ( $addons as $product_name => $addon_info ) {
-			$notification = $this->create_notification( $product_name, $addon_info['short_link'] );
+		foreach ( $this->addon_details as $slug => $addon_info ) {
+			$notification = $this->create_notification( $addon_info['name'], $addon_info['short_link_activation'] );
 
 			// Add a notification when the installed plugin isn't activated in My Yoast.
-			if ( $this->is_installed( $addon_info['slug'] ) && ! $this->has_valid_subscription( $addon_info['slug'] ) ) {
+			if ( $this->is_installed( $slug ) && ! $this->has_valid_subscription( $slug ) ) {
 				$notification_center->add_notification( $notification );
 
 				continue;
@@ -528,7 +535,7 @@ class WPSEO_Addon_Manager {
 		// If we're running this because we want to just show the plugin info in the version details modal, we can fallback to the Yoast Free constants, since that modal will not be accessible anyway in the event that the new Free version increases those constants.
 		$defaults = [
 			// It can be expanded if we have the 'tested' and 'requires_php' data be returned from wp.org in the future.
-			'requires'     => ( $plugin_info ) ? YOAST_SEO_WP_REQUIRED : null,
+			'requires' => ( $plugin_info ) ? YOAST_SEO_WP_REQUIRED : null,
 		];
 
 		return (object) [
@@ -833,12 +840,12 @@ class WPSEO_Addon_Manager {
 	 */
 	protected function get_support_section() {
 		return '<h4>' . __( 'Need support?', 'wordpress-seo' ) . '</h4>'
-			. '<p>'
-			/* translators: 1: expands to <a> that refers to the help page, 2: </a> closing tag. */
-			. sprintf( __( 'You can probably find an answer to your question in our %1$shelp center%2$s.', 'wordpress-seo' ), '<a href="https://yoast.com/help/">', '</a>' )
-			. ' '
-			/* translators: %s expands to a mailto support link. */
-			. sprintf( __( 'If you still need support and have an active subscription for this product, please email %s.', 'wordpress-seo' ), '<a href="mailto:support@yoast.com">support@yoast.com</a>' )
-			. '</p>';
+			   . '<p>'
+			   /* translators: 1: expands to <a> that refers to the help page, 2: </a> closing tag. */
+			   . sprintf( __( 'You can probably find an answer to your question in our %1$shelp center%2$s.', 'wordpress-seo' ), '<a href="https://yoast.com/help/">', '</a>' )
+			   . ' '
+			   /* translators: %s expands to a mailto support link. */
+			   . sprintf( __( 'If you still need support and have an active subscription for this product, please email %s.', 'wordpress-seo' ), '<a href="mailto:support@yoast.com">support@yoast.com</a>' )
+			   . '</p>';
 	}
 }

--- a/inc/class-addon-manager.php
+++ b/inc/class-addon-manager.php
@@ -79,6 +79,11 @@ class WPSEO_Addon_Manager {
 		'local-seo.php'         => self::LOCAL_SLUG,
 	];
 
+	/**
+	 * The addon data for the shortlinks.
+	 *
+	 * @var array
+	 */
 	private $addon_details = [
 		self::PREMIUM_SLUG     => [
 			'name'                  => 'Yoast SEO Premium',
@@ -535,7 +540,7 @@ class WPSEO_Addon_Manager {
 		// If we're running this because we want to just show the plugin info in the version details modal, we can fallback to the Yoast Free constants, since that modal will not be accessible anyway in the event that the new Free version increases those constants.
 		$defaults = [
 			// It can be expanded if we have the 'tested' and 'requires_php' data be returned from wp.org in the future.
-			'requires' => ( $plugin_info ) ? YOAST_SEO_WP_REQUIRED : null,
+			'requires'     => ( $plugin_info ) ? YOAST_SEO_WP_REQUIRED : null,
 		];
 
 		return (object) [
@@ -840,12 +845,12 @@ class WPSEO_Addon_Manager {
 	 */
 	protected function get_support_section() {
 		return '<h4>' . __( 'Need support?', 'wordpress-seo' ) . '</h4>'
-			   . '<p>'
-			   /* translators: 1: expands to <a> that refers to the help page, 2: </a> closing tag. */
-			   . sprintf( __( 'You can probably find an answer to your question in our %1$shelp center%2$s.', 'wordpress-seo' ), '<a href="https://yoast.com/help/">', '</a>' )
-			   . ' '
-			   /* translators: %s expands to a mailto support link. */
-			   . sprintf( __( 'If you still need support and have an active subscription for this product, please email %s.', 'wordpress-seo' ), '<a href="mailto:support@yoast.com">support@yoast.com</a>' )
-			   . '</p>';
+			. '<p>'
+			/* translators: 1: expands to <a> that refers to the help page, 2: </a> closing tag. */
+			. sprintf( __( 'You can probably find an answer to your question in our %1$shelp center%2$s.', 'wordpress-seo' ), '<a href="https://yoast.com/help/">', '</a>' )
+			. ' '
+			/* translators: %s expands to a mailto support link. */
+			. sprintf( __( 'If you still need support and have an active subscription for this product, please email %s.', 'wordpress-seo' ), '<a href="mailto:support@yoast.com">support@yoast.com</a>' )
+			. '</p>';
 	}
 }

--- a/inc/class-addon-manager.php
+++ b/inc/class-addon-manager.php
@@ -400,9 +400,9 @@ class WPSEO_Addon_Manager {
 		if ( $subscription && $this->has_subscription_expired( $subscription ) ) {
 			$addon_link = ( isset( $this->addon_details[ $plugin_data['slug'] ] ) ) ? $this->addon_details[ $plugin_data['slug'] ]['short_link_renewal'] : $this->addon_details[ self::PREMIUM_SLUG ]['short_link_renewal'];
 			echo '<br><br>';
-			/* translators: %1$s is the plugin name, %2$s and %3$s are a link. */
 			echo '<strong><span class="yoast-dashicons-notice warning dashicons dashicons-warning"></span> ' .
 				sprintf(
+					/* translators: %1$s is the plugin name, %2$s and %3$s are a link. */
 					esc_html__( '%1$s can\'t be updated because your product subscription is expired. %2$sRenew your product subscription%3$s to get updates again and use all the features of %1$s.', 'wordpress-seo' ),
 					esc_html( $plugin_data['name'] ),
 					'<a href="' . esc_url( WPSEO_Shortlinker::get( $addon_link ) ) . '">',

--- a/inc/class-addon-manager.php
+++ b/inc/class-addon-manager.php
@@ -422,18 +422,33 @@ class WPSEO_Addon_Manager {
 		}
 
 		$addons = [
-			'Yoast SEO Premium'     => static::PREMIUM_SLUG,
-			'News SEO'              => static::NEWS_SLUG,
-			'Yoast WooCommerce SEO' => static::WOOCOMMERCE_SLUG,
-			'Video SEO'             => static::VIDEO_SLUG,
-			'Local SEO'             => static::LOCAL_SLUG,
+			'Yoast SEO Premium'     => [
+				'slug'       => static::PREMIUM_SLUG,
+				'short_link' => 'yoa.st/13j',
+			],
+			'News SEO'              => [
+				'slug'       => static::NEWS_SLUG,
+				'short_link' => 'yoa.st/13j',
+			],
+			'Yoast WooCommerce SEO' => [
+				'slug'       => static::WOOCOMMERCE_SLUG,
+				'short_link' => 'yoa.st/13j',
+			],
+			'Video SEO'             => [
+				'slug'       => static::VIDEO_SLUG,
+				'short_link' => 'yoa.st/13j',
+			],
+			'Local SEO'             => [
+				'slug'       => static::LOCAL_SLUG,
+				'short_link' => 'yoa.st/13j',
+			],
 		];
 
-		foreach ( $addons as $product_name => $slug ) {
-			$notification = $this->create_notification( $product_name );
+		foreach ( $addons as $product_name => $addon_info ) {
+			$notification = $this->create_notification( $product_name, $addon_info['short_link'] );
 
 			// Add a notification when the installed plugin isn't activated in My Yoast.
-			if ( $this->is_installed( $slug ) && ! $this->has_valid_subscription( $slug ) ) {
+			if ( $this->is_installed( $addon_info['slug'] ) && ! $this->has_valid_subscription( $addon_info['slug'] ) ) {
 				$notification_center->add_notification( $notification );
 
 				continue;
@@ -459,10 +474,11 @@ class WPSEO_Addon_Manager {
 	 * Creates an instance of Yoast_Notification.
 	 *
 	 * @param string $product_name The product to create the notification for.
+	 * @param string $short_link   The short link for the addon notification.
 	 *
 	 * @return Yoast_Notification The created notification.
 	 */
-	protected function create_notification( $product_name ) {
+	protected function create_notification( $product_name, $short_link ) {
 		$notification_options = [
 			'type'         => Yoast_Notification::ERROR,
 			'id'           => 'wpseo-dismiss-' . sanitize_title_with_dashes( $product_name, null, 'save' ),
@@ -476,8 +492,8 @@ class WPSEO_Addon_Manager {
 				'<strong>',
 				$product_name,
 				'</strong>',
-				'<a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/13j' ) . '" target="_blank">activate your product subscription in MyYoast</a>',
-				$product_name,
+				'<a href="' . WPSEO_Shortlinker::get( $short_link ) . '" target="_blank">activate your product subscription in MyYoast</a>',
+				$product_name
 			),
 			$notification_options
 		);

--- a/inc/class-addon-manager.php
+++ b/inc/class-addon-manager.php
@@ -91,7 +91,7 @@ class WPSEO_Addon_Manager {
 			'short_link_renewal'    => 'https://yoa.st/4ey',
 		],
 		self::NEWS_SLUG        => [
-			'name'                  => 'News SEO',
+			'name'                  => 'Yoast News SEO',
 			'short_link_activation' => 'https://yoa.st/4xq',
 			'short_link_renewal'    => 'https://yoa.st/4xv',
 		],
@@ -101,12 +101,12 @@ class WPSEO_Addon_Manager {
 			'short_link_renewal'    => 'https://yoa.st/4xx',
 		],
 		self::VIDEO_SLUG       => [
-			'name'                  => 'Video SEO',
+			'name'                  => 'Yoast Video SEO',
 			'short_link_activation' => 'https://yoa.st/4xr',
 			'short_link_renewal'    => 'https://yoa.st/4xw',
 		],
 		self::LOCAL_SLUG       => [
-			'name'                  => 'Local SEO',
+			'name'                  => 'Yoast Local SEO',
 			'short_link_activation' => 'https://yoa.st/4xp',
 			'short_link_renewal'    => 'https://yoa.st/4xu',
 		],
@@ -401,7 +401,7 @@ class WPSEO_Addon_Manager {
 			$addon_link = ( isset( $this->addon_details[ $plugin_data['slug'] ] ) ) ? $this->addon_details[ $plugin_data['slug'] ]['short_link_renewal'] : $this->addon_details[ self::PREMIUM_SLUG ]['short_link_renewal'];
 			echo '<br><br>';
 			/* translators: %1$s is the plugin name, %2$s and %3$s are a link. */
-			echo '<strong><span class="wp-ui-text-notification warning dashicons dashicons-warning"></span> ' .
+			echo '<strong><span class="yoast-dashicons-notice warning dashicons dashicons-warning"></span> ' .
 				sprintf(
 					esc_html__( '%1$s can\'t be updated because your product subscription is expired. %2$sRenew your product subscription%3$s to get updates again and use all the features of %1$s.', 'wordpress-seo' ),
 					esc_html( $plugin_data['name'] ),
@@ -499,12 +499,13 @@ class WPSEO_Addon_Manager {
 
 		return new Yoast_Notification(
 			sprintf(
-			/* translators: %1$s expands to a strong tag, %2$s expands to the product name, %3$s expands to a closing strong tag, %4$s expands to the product name. %5$s expands to activate your product subscription in MyYoast  */
-				__( '%1$s %2$s isn\'t working as expected %3$s and you are not receiving updates or support! Make sure to %4$s to unlock all the features of %5$s.', 'wordpress-seo' ),
+			/* translators: %1$s expands to a strong tag, %2$s expands to the product name, %3$s expands to a closing strong tag, %4$s expands to an a tag. %5$s expands to MyYoast with a closing a tag,  %6$s expands to the product name  */
+				__( '%1$s %2$s isn\'t working as expected %3$s and you are not receiving updates or support! Make sure to %4$s activate your product subscription in %5$s to unlock all the features of %6$s.', 'wordpress-seo' ),
 				'<strong>',
 				$product_name,
 				'</strong>',
-				'<a href="' . WPSEO_Shortlinker::get( $short_link ) . '" target="_blank">activate your product subscription in MyYoast</a>',
+				'<a href="' . WPSEO_Shortlinker::get( $short_link ) . '" target="_blank">',
+				' MyYoast</a>',
 				$product_name
 			),
 			$notification_options

--- a/inc/class-addon-manager.php
+++ b/inc/class-addon-manager.php
@@ -367,7 +367,13 @@ class WPSEO_Addon_Manager {
 		if ( $subscription && $this->has_subscription_expired( $subscription ) ) {
 			echo '<br><br>';
 			/* translators: %1$s is the plugin name, %2$s and %3$s are a link. */
-			echo '<strong><span class="wp-ui-text-notification alert dashicons dashicons-warning"></span> ' . sprintf( esc_html__( 'A new version of %1$s is available. %2$sRenew your subscription%3$s if you want to update to the latest version.', 'wordpress-seo' ), esc_html( $plugin_data['name'] ), '<a href="' . esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/4ey' ) ) . '">', '</a>' ) . '</strong>';
+			echo '<strong><span class="wp-ui-text-notification warning dashicons dashicons-warning"></span> ' .
+				sprintf(
+					esc_html__( '%1$s can\'t be updated because your product subscription is expired. %2$sRenew your product subscription%3$s to get updates again and use all the features of %1$s.', 'wordpress-seo' ),
+					esc_html( $plugin_data['name'] ),
+					'<a href="' . esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/4ey' ) ) . '">',
+					'</a>'
+				) . '</strong>';
 		}
 	}
 
@@ -465,10 +471,13 @@ class WPSEO_Addon_Manager {
 
 		return new Yoast_Notification(
 			sprintf(
-			/* translators: %1$s expands to the product name. %2$s expands to a link to My Yoast  */
-				__( 'You are not receiving updates or support! Fix this problem by adding this site and enabling %1$s for it in %2$s.', 'wordpress-seo' ),
+			/* translators: %1$s expands to a strong tag, %2$s expands to the product name, %3$s expands to a closing strong tag, %4$s expands to the product name. %5$s expands to activate your product subscription in MyYoast  */
+				__( '%1$s %2$s isn\'t working as expected %3$s and you are not receiving updates or support! Make sure to %4$s to unlock all the features of %5$s.', 'wordpress-seo' ),
+				'<strong>',
 				$product_name,
-				'<a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/13j' ) . '" target="_blank">My Yoast</a>'
+				'</strong>',
+				'<a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/13j' ) . '" target="_blank">activate your product subscription in MyYoast</a>',
+				$product_name,
 			),
 			$notification_options
 		);


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to update some copy about our error messages.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Updates copy of the update notification when there is a new update and you don't have a valid subscription.
* Updates copy of the notification centre message when you don't have a valid subscription. 

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Open a site with an active premium subscription and all add-ons installed and activated . 
* Make sure all add-on show `view details` in the plugin overview (this means there was a connection with My-yoast made).
* Add `return true` to `/wordpress-seo/inc/class-addon-manager.php`  on line 517 just above the current return of the function `has_subscription_expired`.
* Open the Yoast seo dashboard and make sure the notification looks like:
 
<img width="1270" alt="image" src="https://user-images.githubusercontent.com/6975345/225306421-7abe7633-30a5-4e7a-843c-f35b0e117902.png">

* Make sure all the short links for the addons are corresponding to the these shortlinks:

yoa.st/13j -> premium activation warning
yoa.st/4xp -> local activation warning
yoa.st/4xq -> news activaiton warning
yoa.st/4xr --> video activation warning
yoast/4xs --> woocommerce activation warning

* Install a previous version of Yoast SEO Premium
* Open the plugin overview and make sure the message for premium looks like:

<img width="1521" alt="image" src="https://user-images.githubusercontent.com/6975345/225306590-42743050-f5b4-4f3d-ac1b-0044310da620.png">

* Do the same for all the addons and make sure all the `Renew your product subscription` shortlinks are corresponding to the these shortlinks:

yoa.st/4ey -> premium renewal warning
yoa.st/4xu -> Local renewal warning
yoa.st/4xv -> News renewal warning
yoa.st/4xw -> Video renewal warning
yoa.st/4xx -> Woocommerce renewal warning


#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [X] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
