### PR TITLE
Advanced crawl cleanup improvements

### DIFF
--- a/packages/js/src/settings/routes/crawl-optimization.js
+++ b/packages/js/src/settings/routes/crawl-optimization.js
@@ -586,11 +586,11 @@ const CrawlOptimization = () => {
 						title={ __( "Advanced: URL cleanup", "wordpress-seo" ) }
 						description={ descriptions.advancedUrlCleanup }
 					>
-						<Alert id="alert-permalink-cleanup-settings" variant="warning">
+						<Alert id="alert-permalink-cleanup-settings" variant="error">
 							{ createInterpolateElement(
 								sprintf(
 									// translators: %1$s and %2$s are replaced by opening and closing <a> tags.
-									__( "These are expert features, so make sure you know what you're doing before removing the parameters. %1$sRead more about how your site can be affected%2$s.", "wordpress-seo" ),
+									__( "Warning! These are expert features, so make sure you know what you're doing before using this setting. You might break your site. %1$sRead more about how your site can be affected%2$s.", "wordpress-seo" ),
 									"<a>",
 									"</a>"
 								), {

--- a/src/initializers/crawl-cleanup-permalinks.php
+++ b/src/initializers/crawl-cleanup-permalinks.php
@@ -269,9 +269,10 @@ class Crawl_Cleanup_Permalinks implements Initializer_Interface {
 			\header_remove( 'X-Pingback' );
 
 			$message = \sprintf(
-				/* translators: %1$s: Yoast SEO */
-				\__( '%1$s: unregistered URL parameter removed', 'wordpress-seo' ),
-				'Yoast SEO'
+				/* translators: %1$s: Yoast SEO, %2$s: URL pointing to documentation.  */
+				\__( '%1$s: unregistered URL parameter removed. See %2$s', 'wordpress-seo' ),
+				'Yoast SEO',
+				'https://yoa.st/advanced-crawl-settings'
 			);
 
 			\wp_safe_redirect( $proper_url, 301, $message );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Changes the copy and severity level of the _Advanced URL cleanup_ alert in the settings.

## Relevant technical choices:

* Also adds a link to the `x-redirect-by` header.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* visit Settings > Advanced > Crawl optimization
* scroll to the bottom and verify the copy and alert variant have changed:
![Screenshot 2023-03-16 at 10-25-40 Crawl optimization ‹ Settings - Yoast SEO ‹ debug — WordPress](https://user-images.githubusercontent.com/15989132/225580606-4eaff0df-f441-40bd-b0fe-de42a0a238bc.png)

* Enable `Remove unregistered URL parameters`
* keep the Network tab of the inspector open 
* visit **while logged out** any front-end page with a bogus param added, e.g. https://basic.wordpress.test/?foo=bar
* see that the `301` redirect header contains `x-redirect-by | Yoast SEO: unregistered URL parameter removed. See https://yoa.st/advanced-crawl-settings`


#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
