### PR TITLE
HTML Parser - Add sentences to paragraph and heading nodes

### DIFF
--- a/packages/yoastseo/spec/languageProcessing/AbstractResearcherSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/AbstractResearcherSpec.js
@@ -13,21 +13,34 @@ describe( "Creating a Researcher", function() {
 	} );
 } );
 
-describe( "Calling a Researcher", function() {
+describe( "Calling a Research", function() {
 	var researcher = new Researcher( new Paper( "This is another paper!" ) );
 
-	it( "throws an error if no name is given", function() {
+	it( "throws an error if no research name is given", function() {
 		expect( function() {
 			researcher.getResearch( "" );
 		} ).toThrowError( MissingArgument );
 	} );
 
-	it( "returns false if an unknown name is given", function() {
+	it( "returns false if an unknown research name is given", function() {
 		expect( researcher.getResearch( "foobar" ) ).toBeFalsy();
 	} );
 
-	it( "returns a word count result when calling the wordCountInText researcher", function() {
+	it( "returns a word count result when calling the wordCountInText research", function() {
 		expect( researcher.getResearch( "wordCountInText" ).count ).toEqual( 4 );
+	} );
+} );
+
+describe( "Calling a helper", function() {
+	const researcher = new Researcher( new Paper( "This is another paper!" ) );
+
+	it( "returns false if an unknown helper name is given", function() {
+		expect( researcher.getHelper( "foobar" ) ).toBeFalsy();
+	} );
+
+	it( "returns an array of sentences when calling the memoizedTokenizer helper", function() {
+		expect( researcher.getHelper( "memoizedTokenizer" )( "One sentence. Another sentence." ) )
+			.toEqual( [ "One sentence.", "Another sentence." ] );
 	} );
 } );
 

--- a/packages/yoastseo/spec/languageProcessing/helpers/sentence/countSentencesSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/helpers/sentence/countSentencesSpec.js
@@ -1,9 +1,10 @@
 import sentenceCount from "../../../../src/languageProcessing/helpers/sentence/countSentences.js";
+import memoizedSentenceTokenizer from "../../../../src/languageProcessing/helpers/sentence/memoizedSentenceTokenizer";
 
 describe( "Counting of sentences", function() {
 	it( "returns the number of sentences in a string", function() {
-		expect( sentenceCount( "First sentence. Second sentence. 3rd sentence." ) ).toBe( 3 );
-		expect( sentenceCount( "<p></p>" ) ).toBe( 0 );
+		expect( sentenceCount( "First sentence. Second sentence. 3rd sentence.", memoizedSentenceTokenizer ) ).toBe( 3 );
+		expect( sentenceCount( "<p></p>", memoizedSentenceTokenizer ) ).toBe( 0 );
 
 		// These don't work yet because of the repeated sentence terminators, but they aren't important right now.
 		// Expect( sentenceCount( "First sentence.. Second sentence. 3rd sentence." ) ).toBe( 3 );

--- a/packages/yoastseo/spec/languageProcessing/helpers/sentence/getSentencesSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/helpers/sentence/getSentencesSpec.js
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 import getSentences from "../../../../src/languageProcessing/helpers/sentence/getSentences.js";
+import defaultSentenceTokenizer from "../../../../src/languageProcessing/helpers/sentence/memoizedSentenceTokenizer"
 import japaneseSentenceTokenizer from "../../../../src/languageProcessing/languages/ja/helpers/memoizedSentenceTokenizer";
 
 import {
@@ -18,7 +19,6 @@ import {
 } from "../sanitize/mergeListItemsSpec";
 
 import { forEach } from "lodash-es";
-import memoizedSentenceTokenizer from "../../../../src/languageProcessing/helpers/sentence/memoizedSentenceTokenizer";
 
 /**
  * Helper to test sentence detection.
@@ -29,51 +29,50 @@ import memoizedSentenceTokenizer from "../../../../src/languageProcessing/helper
  */
 function testGetSentences( testCases ) {
 	forEach( testCases, function( testCase ) {
-		expect( getSentences( testCase.input ) ).toEqual( testCase.expected );
+		expect( getSentences( testCase.input, defaultSentenceTokenizer ) ).toEqual( testCase.expected );
 	} );
 }
 
 describe( "Get sentences from text", function() {
-	memoizedSentenceTokenizer.cache.clear();
 	it( "does not split sentences ending on a quotation mark without a preceding period", function() {
 		const sentence = "Hello. \"How are you\" Bye";
-		expect( getSentences( sentence ) ).toEqual( [ "Hello.", "\"How are you\" Bye" ] );
+		expect( getSentences( sentence, defaultSentenceTokenizer ) ).toEqual( [ "Hello.", "\"How are you\" Bye" ] );
 	} );
 	it( "splits sentences ending on a quotation mark preceded by a period", function() {
 		const sentence = "Hello. \"How are you.\" Bye";
-		expect( getSentences( sentence ) ).toEqual( [ "Hello.", "\"How are you.\"", "Bye" ] );
+		expect( getSentences( sentence, defaultSentenceTokenizer ) ).toEqual( [ "Hello.", "\"How are you.\"", "Bye" ] );
 	} );
 	it( "splits sentences ending on a quotation mark followed by a period", function() {
 		const sentence = "Hello. \"How are you\". Bye";
-		expect( getSentences( sentence ) ).toEqual( [ "Hello.", "\"How are you\".", "Bye" ] );
+		expect( getSentences( sentence, defaultSentenceTokenizer ) ).toEqual( [ "Hello.", "\"How are you\".", "Bye" ] );
 	} );
 	it( "returns sentences", function() {
 		const sentence = "Hello. How are you? Bye";
-		expect( getSentences( sentence ) ).toEqual( [ "Hello.", "How are you?", "Bye" ] );
+		expect( getSentences( sentence, defaultSentenceTokenizer ) ).toEqual( [ "Hello.", "How are you?", "Bye" ] );
 	} );
 	it( "returns sentences with digits", function() {
 		const sentence = "Hello. 123 Bye";
-		expect( getSentences( sentence ) ).toEqual( [ "Hello.", "123 Bye" ] );
+		expect( getSentences( sentence, defaultSentenceTokenizer ) ).toEqual( [ "Hello.", "123 Bye" ] );
 	} );
 
 	it( "returns sentences with abbreviations", function() {
 		const sentence = "It was a lot. Approx. two hundred";
-		expect( getSentences( sentence ) ).toEqual( [ "It was a lot.", "Approx. two hundred" ] );
+		expect( getSentences( sentence, defaultSentenceTokenizer ) ).toEqual( [ "It was a lot.", "Approx. two hundred" ] );
 	} );
 
 	it( "returns sentences with multiple sentence delimiters at the end", function() {
 		const sentence = "Was it a lot!?!??! Yes, it was!";
-		expect( getSentences( sentence ) ).toEqual( [ "Was it a lot!?!??!", "Yes, it was!" ] );
+		expect( getSentences( sentence, defaultSentenceTokenizer ) ).toEqual( [ "Was it a lot!?!??!", "Yes, it was!" ] );
 	} );
 
 	it( "returns sentences with multiple periods at the end", function() {
 		const sentence = "It was a lot... Approx. two hundred.";
-		expect( getSentences( sentence ) ).toEqual( [ "It was a lot...", "Approx. two hundred." ] );
+		expect( getSentences( sentence, defaultSentenceTokenizer ) ).toEqual( [ "It was a lot...", "Approx. two hundred." ] );
 	} );
 
 	it( "returns sentences, with :", function() {
 		const sentence = "One. Two. Three: Four! Five.";
-		expect( getSentences( sentence ).length ).toBe( 4 );
+		expect( getSentences( sentence, defaultSentenceTokenizer ).length ).toBe( 4 );
 	} );
 
 	it( "returns sentences with a text with H2 tags", function() {
@@ -84,29 +83,29 @@ describe( "Get sentences from text", function() {
 		const expected = [ "Four types of comments", "The comments people leave on blogs can be divided into four types:",
 			"Positive feedback", "First, the positive feedback." ];
 
-		const actual = getSentences( text );
+		const actual = getSentences( text, defaultSentenceTokenizer );
 
 		expect( actual ).toEqual( expected );
 	} );
 
 	it( "returns a sentence with incomplete tags", function() {
 		const text = "<p>Some text. More Text.</p>";
-		expect( getSentences( text ) ).toEqual( [ "Some text.", "More Text." ] );
+		expect( getSentences( text, defaultSentenceTokenizer ) ).toEqual( [ "Some text.", "More Text." ] );
 	} );
 
 	it( "returns a sentence with incomplete tags per sentence", function() {
 		const text = "<p><span>Some text. More Text.</span></p>";
-		expect( getSentences( text ) ).toEqual( [ "Some text.", "More Text." ] );
+		expect( getSentences( text, defaultSentenceTokenizer ) ).toEqual( [ "Some text.", "More Text." ] );
 	} );
 
 	it( "returns a sentence with incomplete tags with a link", function() {
 		const text = "Some text. More Text with <a href='http://yoast.com'>a link</a>.";
-		expect( getSentences( text ) ).toEqual( [ "Some text.", "More Text with <a href='http://yoast.com'>a link</a>." ] );
+		expect( getSentences( text, defaultSentenceTokenizer ) ).toEqual( [ "Some text.", "More Text with <a href='http://yoast.com'>a link</a>." ] );
 	} );
 
 	it( "can deal with self-closing tags", function() {
 		const text = "A sentence with an image <samp src='http://google.com' />";
-		expect( getSentences( text ) ).toEqual( [ "A sentence with an image <samp src='http://google.com' />" ] );
+		expect( getSentences( text, defaultSentenceTokenizer ) ).toEqual( [ "A sentence with an image <samp src='http://google.com' />" ] );
 	} );
 
 	it( "can deal with newlines", function() {
@@ -159,7 +158,7 @@ describe( "Get sentences from text", function() {
 			"[Third sentence.]",
 		];
 
-		const actual = getSentences( text );
+		const actual = getSentences( text, defaultSentenceTokenizer );
 
 		expect( actual ).toEqual( expected );
 	} );
@@ -168,7 +167,7 @@ describe( "Get sentences from text", function() {
 		const text = "A sentence with (parentheses).";
 		const expected = [ "A sentence with (parentheses)." ];
 
-		const actual = getSentences( text );
+		const actual = getSentences( text, defaultSentenceTokenizer );
 
 		expect( actual ).toEqual( expected );
 	} );
@@ -181,7 +180,7 @@ describe( "Get sentences from text", function() {
 			"Third sentence",
 		];
 
-		const actual = getSentences( text );
+		const actual = getSentences( text, defaultSentenceTokenizer );
 
 		expect( actual ).toEqual( expected );
 	} );
@@ -201,7 +200,7 @@ describe( "Get sentences from text", function() {
 		];
 
 		for ( let i = 0; i < texts.length; i++ ) {
-			expect( getSentences( texts[ i ] ) ).toEqual( [ expected[ i ] ] );
+			expect( getSentences( texts[ i ], defaultSentenceTokenizer ) ).toEqual( [ expected[ i ] ] );
 		}
 	} );
 
@@ -211,7 +210,7 @@ describe( "Get sentences from text", function() {
 			"If you want to know something specific.\n" +
 			"    If you want to end the discussion you&#8217;re having in the car and need to know exactly how many people live in France.</p>";
 
-		expect( getSentences( texts ) ).toEqual( [
+		expect( getSentences( texts, defaultSentenceTokenizer ) ).toEqual( [
 			"<p>The results that voice gives us are always singular.",
 			"Siri will set a timer, Google Home will play the song.",
 			"Joost:  &#8216;Voice results only make sense if you&#8217;re looking for a singular result.",
@@ -251,7 +250,7 @@ describe( "Get sentences from text", function() {
 			"Read more about the SEO copywriting training -- linken naar sales pagina",
 		];
 
-		const actual = getSentences( text );
+		const actual = getSentences( text, defaultSentenceTokenizer );
 
 		expect( actual ).toEqual( expected );
 	} );
@@ -297,7 +296,7 @@ describe( "Get sentences from text", function() {
 			"<p>\n" +
 			"</p>\n";
 
-		expect( getSentences( text ) ).toEqual( [
+		expect( getSentences( text, defaultSentenceTokenizer ) ).toEqual( [
 			"Tempeh or tempe (/ˈtɛmpeɪ/; Javanese: ꦠꦺꦩ꧀ꦥꦺ, romanized: témpé, pronounced [tempe]) is a " +
 			"traditional Indonesian food made from fermented soybeans.",
 			"It is made by a natural culturing and controlled fermentation process that binds soybeans into a cake form.",
@@ -430,7 +429,7 @@ describe( "Get sentences from text", function() {
 
 	it( "should not split on semicolons", () => {
 		const text = "This house is built in 1990; a nice house. This house is built in 1990; A nice house.";
-		expect( getSentences( text ) ).toEqual( [
+		expect( getSentences( text, defaultSentenceTokenizer ) ).toEqual( [
 			"This house is built in 1990; a nice house.",
 			"This house is built in 1990; A nice house." ] );
 	} );
@@ -483,13 +482,13 @@ describe( "a test for when texts containing sentence delimiter", () => {
 	it( "should always break on ? and ! even when it's not followed by a valid sentence beginning", function() {
 		let text = "First sentence. second sentence! third sentence? fourth sentence";
 
-		expect( getSentences( text ) ).toEqual( [
+		expect( getSentences( text, defaultSentenceTokenizer ) ).toEqual( [
 			"First sentence. second sentence!",
 			"third sentence?",
 			"fourth sentence" ] );
 
 		text = "First sentence. Second sentence! Third sentence? Fourth sentence";
-		expect( getSentences( text ) ).toEqual( [
+		expect( getSentences( text, defaultSentenceTokenizer ) ).toEqual( [
 			"First sentence.",
 			"Second sentence!",
 			"Third sentence?",
@@ -499,27 +498,27 @@ describe( "a test for when texts containing sentence delimiter", () => {
 		"when the next character is valid sentence beginning", function() {
 		let text = "This is the first sentence… Followed by a second one.";
 
-		expect( getSentences( text ) ).toEqual( [ "This is the first sentence…", "Followed by a second one." ] );
+		expect( getSentences( text, defaultSentenceTokenizer ) ).toEqual( [ "This is the first sentence…", "Followed by a second one." ] );
 
 		text = "This is the first sentence\u2026 Followed by a second one.";
-		expect( getSentences( text ) ).toEqual( [ "This is the first sentence\u2026", "Followed by a second one." ] );
+		expect( getSentences( text, defaultSentenceTokenizer ) ).toEqual( [ "This is the first sentence\u2026", "Followed by a second one." ] );
 
 		text = "This is the first sentence... Followed by a second one.";
-		expect( getSentences( text ) ).toEqual( [ "This is the first sentence...", "Followed by a second one." ] );
+		expect( getSentences( text, defaultSentenceTokenizer ) ).toEqual( [ "This is the first sentence...", "Followed by a second one." ] );
 	} );
 	it( "should not split text into sentences if the next character after an ellipsis is not a valid sentence beginning", () => {
 		let text = "This house is built in 1990\u2026 a nice house.";
-		expect( getSentences( text ) ).toEqual( [
+		expect( getSentences( text, defaultSentenceTokenizer ) ).toEqual( [
 			"This house is built in 1990\u2026 a nice house.",
 		] );
 
 		text = "This house is built in 1990… a nice house.";
-		expect( getSentences( text ) ).toEqual( [
+		expect( getSentences( text, defaultSentenceTokenizer ) ).toEqual( [
 			"This house is built in 1990… a nice house.",
 		] );
 
 		text = "This house is built in 1990... a nice house.";
-		expect( getSentences( text ) ).toEqual( [
+		expect( getSentences( text, defaultSentenceTokenizer ) ).toEqual( [
 			"This house is built in 1990... a nice house.",
 		] );
 	} );
@@ -540,28 +539,28 @@ describe( "a test for when texts containing sentence delimiter", () => {
 
 	it( "can deal with the edge case of quotes around initials.", ()=>{
 		const text = "The reprint was favourably reviewed by \"A. B.\" in The Musical Times in 1935, who commented \"Praise is due to Mr Mercer.";
-		expect( getSentences( text ) ).toEqual(
+		expect( getSentences( text, defaultSentenceTokenizer ) ).toEqual(
 			[ "The reprint was favourably reviewed by \"A. B.\" in The Musical Times in 1935, who commented \"Praise is due to Mr Mercer." ] );
 	} );
 
 	it( "should not break when the text starts with double quotation mark followed by space", ()=>{
 		let text = "\" This is a text with double quotation mark.";
-		expect( getSentences( text ) ).toEqual( [ "\"", "This is a text with double quotation mark." ] );
+		expect( getSentences( text, defaultSentenceTokenizer ) ).toEqual( [ "\"", "This is a text with double quotation mark." ] );
 
 		text = "\" \"This is a text with two double quotation marks.";
-		expect( getSentences( text ) ).toEqual(  [ "\"", "\"This is a text with two double quotation marks." ] );
+		expect( getSentences( text, defaultSentenceTokenizer ) ).toEqual(  [ "\"", "\"This is a text with two double quotation marks." ] );
 
 		text = "” This is a text with double quotation mark.";
-		expect( getSentences( text ) ).toEqual( [ "”", "This is a text with double quotation mark." ] );
+		expect( getSentences( text, defaultSentenceTokenizer ) ).toEqual( [ "”", "This is a text with double quotation mark." ] );
 
 		text = "„ This is a text with double quotation mark.";
-		expect( getSentences( text ) ).toEqual( [ "„", "This is a text with double quotation mark." ] );
+		expect( getSentences( text, defaultSentenceTokenizer ) ).toEqual( [ "„", "This is a text with double quotation mark." ] );
 
 		text = "» This is a text with double quotation mark.";
-		expect( getSentences( text ) ).toEqual( [ "»", "This is a text with double quotation mark." ] );
+		expect( getSentences( text, defaultSentenceTokenizer ) ).toEqual( [ "»", "This is a text with double quotation mark." ] );
 
 		text = "« »This is a text with two double quotation marks.";
-		expect( getSentences( text ) ).toEqual( [ "« »This is a text with two double quotation marks." ] );
+		expect( getSentences( text, defaultSentenceTokenizer ) ).toEqual( [ "« »This is a text with two double quotation marks." ] );
 	} );
 } );
 
@@ -671,7 +670,7 @@ describe( "parses Japanese text", () => {
 			"なにしようか？",
 			"」と言った。" ];
 
-		const actual = getSentences( text );
+		const actual = getSentences( text, defaultSentenceTokenizer );
 
 		expect( actual ).toEqual( expected );
 	} );
@@ -751,7 +750,7 @@ describe( "Parse languages written right-to-left", function() {
 			" וזאת על בסיס עבודתו של ברט ובדומה לתאוריית ההתפתחות הקוגניטיבית של פיאז'ה; עבודתו זו מהווה עד היום בסיס לבחינת התפתחות ציורי ילדים.",
 		];
 
-		const actual = getSentences( text );
+		const actual = getSentences( text, defaultSentenceTokenizer );
 
 		expect( actual ).toEqual( expected );
 	} );
@@ -817,7 +816,7 @@ describe( "Parse languages written right-to-left", function() {
 			"برزت عبر السنوات عدة شخصيات شريرة مناوئة لباتمان حقق بعضها شهرة واسعة بين محبي وهواة القصص المصورة، يبقى الجوكر أبرزها بلا منازع.",
 		];
 
-		const actual = getSentences( text );
+		const actual = getSentences( text, defaultSentenceTokenizer );
 
 		expect( actual ).toEqual( expected );
 	} );
@@ -840,7 +839,7 @@ describe( "Parse languages written right-to-left", function() {
 			"أنَّ ليختنشتاين ألغت جيشها في عام 1868 لأنه كان مُكلفًا للغاية لها؟",
 		];
 
-		const actual = getSentences( text );
+		const actual = getSentences( text, defaultSentenceTokenizer );
 
 		expect( actual ).toEqual( expected );
 	} );
@@ -883,7 +882,7 @@ describe( "Parse languages written right-to-left", function() {
 			"تابوت کوروش بین میز و نیمکت قرار داشت.",
 		];
 
-		const actual = getSentences( text );
+		const actual = getSentences( text, defaultSentenceTokenizer );
 
 		expect( actual ).toEqual( expected );
 	} );
@@ -907,7 +906,7 @@ describe( "Parse languages written right-to-left", function() {
 			"1980ء میں یونیسکو نے اسے یونیسکو عالمی ثقافتی ورثہ قرار دیا۔",
 		];
 
-		const actual = getSentences( text );
+		const actual = getSentences( text, defaultSentenceTokenizer );
 
 		expect( actual ).toEqual( expected );
 	} );

--- a/packages/yoastseo/spec/languageProcessing/helpers/sentence/getSentencesSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/helpers/sentence/getSentencesSpec.js
@@ -18,6 +18,7 @@ import {
 } from "../sanitize/mergeListItemsSpec";
 
 import { forEach } from "lodash-es";
+import memoizedSentenceTokenizer from "../../../../src/languageProcessing/helpers/sentence/memoizedSentenceTokenizer";
 
 /**
  * Helper to test sentence detection.
@@ -33,6 +34,7 @@ function testGetSentences( testCases ) {
 }
 
 describe( "Get sentences from text", function() {
+	memoizedSentenceTokenizer.cache.clear();
 	it( "does not split sentences ending on a quotation mark without a preceding period", function() {
 		const sentence = "Hello. \"How are you\" Bye";
 		expect( getSentences( sentence ) ).toEqual( [ "Hello.", "\"How are you\" Bye" ] );

--- a/packages/yoastseo/spec/languageProcessing/helpers/sentence/getSentencesSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/helpers/sentence/getSentencesSpec.js
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 import getSentences from "../../../../src/languageProcessing/helpers/sentence/getSentences.js";
-import defaultSentenceTokenizer from "../../../../src/languageProcessing/helpers/sentence/memoizedSentenceTokenizer"
+import defaultSentenceTokenizer from "../../../../src/languageProcessing/helpers/sentence/memoizedSentenceTokenizer";
 import japaneseSentenceTokenizer from "../../../../src/languageProcessing/languages/ja/helpers/memoizedSentenceTokenizer";
 
 import {

--- a/packages/yoastseo/spec/languageProcessing/helpers/sentence/memoizedSentenceTokenizerSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/helpers/sentence/memoizedSentenceTokenizerSpec.js
@@ -1,0 +1,20 @@
+import memoizedSentenceTokenizer from "../../../../src/languageProcessing/helpers/sentence/memoizedSentenceTokenizer";
+
+const blockWithSpaces = "<p> Hello, world. Goodbye, world. </p>";
+
+describe( "A test for the memoized sentence tokenizer", function() {
+	it( "Returns an array of sentences from an HTML block", function() {
+		const block = "<p>Hello, world. Goodbye, world.</p>";
+		expect( memoizedSentenceTokenizer( block ) ).toEqual( [ "Hello, world.", "Goodbye, world." ] );
+	} );
+	it( "Trims spaces from the beginning and end of the sentences", function() {
+		expect( memoizedSentenceTokenizer( blockWithSpaces ) ).toEqual( [ "Hello, world.", "Goodbye, world." ] );
+	} );
+	it( "Does not trim spaces if the tokenizer is called on the same block as previously," +
+		" but with the trimSentences flag set to 'false'", function() {
+		expect( memoizedSentenceTokenizer( blockWithSpaces, false ) ).toEqual( [ " Hello, world.", " Goodbye, world. " ] );
+	} );
+	it( "Trims spaces again", function() {
+		expect( memoizedSentenceTokenizer( blockWithSpaces, true ) ).toEqual( [ "Hello, world.", "Goodbye, world." ] );
+	} );
+} );

--- a/packages/yoastseo/spec/languageProcessing/researches/keywordCountSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/keywordCountSpec.js
@@ -4,6 +4,8 @@ import factory from "../../specHelpers/factory";
 import Mark from "../../../src/values/Mark";
 import wordsCountHelper from "../../../src/languageProcessing/languages/ja/helpers/wordsCharacterCount";
 import matchWordsHelper from "../../../src/languageProcessing/languages/ja/helpers/matchTextWithWord";
+import memoizedSentenceTokenizer from "../../../src/languageProcessing/helpers/sentence/memoizedSentenceTokenizer";
+import japaneseMemoizedSentenceTokenizer from "../../../src/languageProcessing/languages/ja/helpers/memoizedSentenceTokenizer";
 
 /**
  * Adds morphological forms to the mock researcher.
@@ -17,7 +19,7 @@ const buildMorphologyMockResearcher = function( keyphraseForms ) {
 		morphology: {
 			keyphraseForms: keyphraseForms,
 		},
-	}, true );
+	}, true, false,false, { memoizedTokenizer: memoizedSentenceTokenizer } );
 };
 
 const mockResearcher = buildMorphologyMockResearcher( [ [ "keyword", "keywords" ] ] );
@@ -198,6 +200,7 @@ const buildJapaneseMockResearcher = function( keyphraseForms, helper1, helper2 )
 	{
 		wordsCharacterCount: helper1,
 		matchWordCustomHelper: helper2,
+		memoizedTokenizer: japaneseMemoizedSentenceTokenizer,
 	} );
 };
 

--- a/packages/yoastseo/spec/languageProcessing/researches/keywordCountSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/keywordCountSpec.js
@@ -19,7 +19,7 @@ const buildMorphologyMockResearcher = function( keyphraseForms ) {
 		morphology: {
 			keyphraseForms: keyphraseForms,
 		},
-	}, true, false,false, { memoizedTokenizer: memoizedSentenceTokenizer } );
+	}, true, false, false, { memoizedTokenizer: memoizedSentenceTokenizer } );
 };
 
 const mockResearcher = buildMorphologyMockResearcher( [ [ "keyword", "keywords" ] ] );

--- a/packages/yoastseo/spec/parse/build/buildSpec.js
+++ b/packages/yoastseo/spec/parse/build/buildSpec.js
@@ -1,12 +1,14 @@
 import build from "../../../src/parse/build/build";
 import LanguageProcessor from "../../../src/parse/language/LanguageProcessor";
 import Factory from "../../specHelpers/factory";
+import memoizedSentenceTokenizer from "../../../src/languageProcessing/helpers/sentence/memoizedSentenceTokenizer";
 
 describe( "The parse function", () => {
 	it( "parses a basic HTML text", () => {
 		const html = "<div><p class='yoast'>Hello, world!</p></div>";
 
-		const researcher = Factory.buildMockResearcher( {} );
+		const researcher = Factory.buildMockResearcher( {}, true, false, false,
+			{ memoizedTokenizer: memoizedSentenceTokenizer } );
 		const languageProcessor = new LanguageProcessor( researcher );
 
 		expect( build( html, languageProcessor ) ).toEqual( {
@@ -21,7 +23,7 @@ describe( "The parse function", () => {
 					attributes: {
 						"class": "yoast",
 					},
-					sentences: [],
+					sentences: [ { text: "Hello, world!", tokens: [] } ],
 					childNodes: [ {
 						name: "#text",
 						value: "Hello, world!",
@@ -34,7 +36,8 @@ describe( "The parse function", () => {
 	it( "adds implicit paragraphs around phrasing content outside of paragraphs and headings", () => {
 		const html = "<div>Hello <span>World!</span></div>";
 
-		const researcher = Factory.buildMockResearcher( {} );
+		const researcher = Factory.buildMockResearcher( {}, true, false, false,
+			{ memoizedTokenizer: memoizedSentenceTokenizer } );
 		const languageProcessor = new LanguageProcessor( researcher );
 
 		/*
@@ -59,7 +62,7 @@ describe( "The parse function", () => {
 					name: "p",
 					isImplicit: true,
 					attributes: {},
-					sentences: [],
+					sentences: [ { text: "Hello World!", tokens: [] } ],
 					childNodes: [
 						{
 							name: "#text",
@@ -82,7 +85,8 @@ describe( "The parse function", () => {
 	it( "parses another HTML text and adds implicit paragraphs where needed", () => {
 		const html = "<div>Hello <p>World!</p></div>";
 
-		const researcher = Factory.buildMockResearcher( {} );
+		const researcher = Factory.buildMockResearcher( {}, true, false, false,
+			{ memoizedTokenizer: memoizedSentenceTokenizer } );
 		const languageProcessor = new LanguageProcessor( researcher );
 
 		/*
@@ -112,7 +116,7 @@ describe( "The parse function", () => {
 							name: "p",
 							isImplicit: true,
 							attributes: {},
-							sentences: [],
+							sentences: [ { text: "Hello " , tokens: [] } ],
 							childNodes: [
 								{
 									name: "#text",
@@ -125,7 +129,7 @@ describe( "The parse function", () => {
 							name: "p",
 							isImplicit: false,
 							attributes: {},
-							sentences: [],
+							sentences: [ { text: "World!" , tokens: [] } ],
 							childNodes: [
 								{
 									name: "#text",

--- a/packages/yoastseo/spec/parse/build/buildSpec.js
+++ b/packages/yoastseo/spec/parse/build/buildSpec.js
@@ -116,7 +116,7 @@ describe( "The parse function", () => {
 							name: "p",
 							isImplicit: true,
 							attributes: {},
-							sentences: [ { text: "Hello " , tokens: [] } ],
+							sentences: [ { text: "Hello ", tokens: [] } ],
 							childNodes: [
 								{
 									name: "#text",
@@ -129,7 +129,7 @@ describe( "The parse function", () => {
 							name: "p",
 							isImplicit: false,
 							attributes: {},
-							sentences: [ { text: "World!" , tokens: [] } ],
+							sentences: [ { text: "World!", tokens: [] } ],
 							childNodes: [
 								{
 									name: "#text",

--- a/packages/yoastseo/spec/parse/build/private/filterTreeSpec.js
+++ b/packages/yoastseo/spec/parse/build/private/filterTreeSpec.js
@@ -3,12 +3,14 @@ import build from "../../../../src/parse/build/build";
 import LanguageProcessor from "../../../../src/parse/language/LanguageProcessor";
 import Factory from "../../../specHelpers/factory";
 import permanentFilters from "../../../../src/parse/build/private/alwaysFilterElements";
+import memoizedSentenceTokenizer from "../../../../src/languageProcessing/helpers/sentence/memoizedSentenceTokenizer";
 
 
 describe( "A test for filterTree", () => {
 	let languageProcessor;
 	beforeEach( () => {
-		const researcher = Factory.buildMockResearcher( {} );
+		const researcher = Factory.buildMockResearcher( {}, true, false, false,
+			{ memoizedTokenizer: memoizedSentenceTokenizer } );
 		languageProcessor = new LanguageProcessor( researcher );
 	} );
 	it( "should filter script elements", () => {
@@ -58,7 +60,7 @@ describe( "A test for filterTree", () => {
 					} ],
 					isImplicit: true,
 					name: "p",
-					sentences: [],
+					sentences: [ { text: "A div", tokens: [] } ],
 				} ],
 				name: "div",
 			} ],
@@ -85,7 +87,7 @@ describe( "A test for filterTree", () => {
 					} ],
 					isImplicit: true,
 					name: "p",
-					sentences: [],
+					sentences: [ { text: "A div", tokens: [] } ],
 				} ],
 				name: "div",
 			} ],
@@ -114,7 +116,7 @@ describe( "A test for filterTree", () => {
 					} ],
 					isImplicit: true,
 					name: "p",
-					sentences: [],
+					sentences: [ { text: "Hello world!", tokens: [] } ],
 				} ],
 				name: "div",
 			} ],
@@ -143,7 +145,7 @@ describe( "A test for filterTree", () => {
 					} ],
 					isImplicit: true,
 					name: "p",
-					sentences: [],
+					sentences: [ { text: "Hello world!", tokens: [] } ],
 				} ],
 				name: "div",
 			} ],

--- a/packages/yoastseo/spec/parse/language/LanguageProcessorSpec.js
+++ b/packages/yoastseo/spec/parse/language/LanguageProcessorSpec.js
@@ -1,0 +1,21 @@
+import LanguageProcessor from "../../../src/parse/language/LanguageProcessor";
+import Factory from "../../specHelpers/factory";
+import memoizedSentenceTokenizer from "../../../src/languageProcessing/helpers/sentence/memoizedSentenceTokenizer";
+
+const researcher = Factory.buildMockResearcher( {}, true, false, false,
+	{ memoizedTokenizer: memoizedSentenceTokenizer } );
+
+describe( "A test for the LanguageProcessor object", () => {
+	it( "should correctly create a simple LanguageProcessor object", function() {
+		expect( new LanguageProcessor( researcher ) ).toEqual( { researcher: researcher } );
+	} );
+} );
+
+describe( "A test for the splitIntoSentences method", () => {
+	it( "should return an array of sentence objects", function() {
+		const languageProcessor = new LanguageProcessor( researcher );
+
+		const sentences = languageProcessor.splitIntoSentences( "Hello, world! Hello, Yoast!" );
+		expect( sentences ).toEqual( [ { text: "Hello, world!", tokens: [] }, { text: " Hello, Yoast!", tokens: [] } ] );
+	} );
+} );

--- a/packages/yoastseo/spec/parse/language/LanguageProcessorSpec.js
+++ b/packages/yoastseo/spec/parse/language/LanguageProcessorSpec.js
@@ -18,4 +18,10 @@ describe( "A test for the splitIntoSentences method", () => {
 		const sentences = languageProcessor.splitIntoSentences( "Hello, world! Hello, Yoast!" );
 		expect( sentences ).toEqual( [ { text: "Hello, world!", tokens: [] }, { text: " Hello, Yoast!", tokens: [] } ] );
 	} );
+	it( "the last sentence should not consist of a whitespace if the text ends in a whitespace", function() {
+		const languageProcessor = new LanguageProcessor( researcher );
+
+		const sentences = languageProcessor.splitIntoSentences( "Hello, world! Hello, Yoast! " );
+		expect( sentences ).toEqual( [ { text: "Hello, world!", tokens: [] }, { text: " Hello, Yoast!", tokens: [] }  ] );
+	} );
 } );

--- a/packages/yoastseo/spec/parse/structure/NodeSpec.js
+++ b/packages/yoastseo/spec/parse/structure/NodeSpec.js
@@ -27,7 +27,7 @@ describe( "A test for the findAll method", () => {
 			attributes: { "class": "yoast" },
 			childNodes: [ { name: "#text", value: "Hello, world! " } ],
 			isImplicit: false,
-			sentences: [ { text: "Hello, world!", tokens: [] }, { text: " ", tokens: [] } ],
+			sentences: [ { text: "Hello, world!", tokens: [] } ],
 		},
 		{
 			name: "p",

--- a/packages/yoastseo/spec/parse/structure/NodeSpec.js
+++ b/packages/yoastseo/spec/parse/structure/NodeSpec.js
@@ -2,6 +2,7 @@ import Node from "../../../src/parse/structure/Node";
 import LanguageProcessor from "../../../src/parse/language/LanguageProcessor";
 import Factory from "../../specHelpers/factory";
 import build from "../../../src/parse/build/build";
+import memoizedSentenceTokenizer from "../../../src/languageProcessing/helpers/sentence/memoizedSentenceTokenizer";
 
 describe( "A test for the Node object", () => {
 	it( "should correctly create a simple Node object", function() {
@@ -13,7 +14,8 @@ describe( "A test for the findAll method", () => {
 	it( "should find all occurrences of a p tag", function() {
 		const html = "<div><p class='yoast'>Hello, world! </p><p class='yoast'>Hello, yoast!</p></div>";
 
-		const researcher = Factory.buildMockResearcher( {} );
+		const researcher = Factory.buildMockResearcher( {}, true, false, false,
+			{ memoizedTokenizer: memoizedSentenceTokenizer } );
 		const languageProcessor = new LanguageProcessor( researcher );
 
 		const tree = build( html, languageProcessor );
@@ -25,14 +27,14 @@ describe( "A test for the findAll method", () => {
 			attributes: { "class": "yoast" },
 			childNodes: [ { name: "#text", value: "Hello, world! " } ],
 			isImplicit: false,
-			sentences: [],
+			sentences: [ { text: "Hello, world!", tokens: [] }, { text: " ", tokens: [] } ],
 		},
 		{
 			name: "p",
 			attributes: { "class": "yoast" },
 			childNodes: [ { name: "#text", value: "Hello, yoast!" } ],
 			isImplicit: false,
-			sentences: [],
+			sentences: [ { text: "Hello, yoast!", tokens: [] } ],
 		} ];
 
 		expect( searchResult ).toEqual( expected );
@@ -42,7 +44,8 @@ describe( "A test for the findAll method", () => {
 describe( "A test for the innerText method", () => {
 	const html = "<div><p class='yoast'>Hello, world! </p><p class='yoast'>Hello, yoast!</p></div>";
 
-	const researcher = Factory.buildMockResearcher( {} );
+	const researcher = Factory.buildMockResearcher( {}, true, false, false,
+		{ memoizedTokenizer: memoizedSentenceTokenizer } );
 	const languageProcessor = new LanguageProcessor( researcher );
 
 	const tree = build( html, languageProcessor );

--- a/packages/yoastseo/spec/parse/traverse/findAllInTreeSpec.js
+++ b/packages/yoastseo/spec/parse/traverse/findAllInTreeSpec.js
@@ -24,11 +24,11 @@ describe( "A test for findAllInTree", () => {
 				attributes: { "class": "yoast" },
 				childNodes: [
 					{ name: "#text", value: "Hello, world! " },
-				], isImplicit: false, name: "p", sentences: [ { text: "Hello, world!", tokens: [] }, { text: " ", tokens: [] } ],
+				], isImplicit: false, name: "p", sentences: [ { text: "Hello, world!", tokens: [] } ],
 			}, { attributes: { "class": "yoast" },
 				childNodes: [
 					{ name: "#text", value: "Hello, yoast! " },
-				], isImplicit: false, name: "p", sentences: [ { text: "Hello, yoast!", tokens: [] }, { text: " ", tokens: [] } ],
+				], isImplicit: false, name: "p", sentences: [ { text: "Hello, yoast!", tokens: [] } ],
 			} ];
 
 		expect( searchResult ).toEqual( expected );

--- a/packages/yoastseo/spec/parse/traverse/findAllInTreeSpec.js
+++ b/packages/yoastseo/spec/parse/traverse/findAllInTreeSpec.js
@@ -2,11 +2,13 @@ import findAllInTree from "../../../src/parse/traverse/findAllInTree";
 import build from "../../../src/parse/build/build";
 import LanguageProcessor from "../../../src/parse/language/LanguageProcessor";
 import Factory from "../../specHelpers/factory";
+import memoizedSentenceTokenizer from "../../../src/languageProcessing/helpers/sentence/memoizedSentenceTokenizer";
 
 let languageProcessor;
 
 beforeEach( () => {
-	const researcher = Factory.buildMockResearcher( {} );
+	const researcher = Factory.buildMockResearcher( {}, true, false, false,
+		{ memoizedTokenizer: memoizedSentenceTokenizer } );
 	languageProcessor = new LanguageProcessor( researcher );
 } );
 
@@ -22,11 +24,11 @@ describe( "A test for findAllInTree", () => {
 				attributes: { "class": "yoast" },
 				childNodes: [
 					{ name: "#text", value: "Hello, world! " },
-				], isImplicit: false, name: "p", sentences: [],
+				], isImplicit: false, name: "p", sentences: [ { text: "Hello, world!", tokens: [] }, { text: " ", tokens: [] } ],
 			}, { attributes: { "class": "yoast" },
 				childNodes: [
 					{ name: "#text", value: "Hello, yoast! " },
-				], isImplicit: false, name: "p", sentences: [],
+				], isImplicit: false, name: "p", sentences: [ { text: "Hello, yoast!", tokens: [] }, { text: " ", tokens: [] } ],
 			} ];
 
 		expect( searchResult ).toEqual( expected );

--- a/packages/yoastseo/spec/parse/traverse/innerTextSpec.js
+++ b/packages/yoastseo/spec/parse/traverse/innerTextSpec.js
@@ -3,11 +3,13 @@ import build from "../../../src/parse/build/build";
 import LanguageProcessor from "../../../src/parse/language/LanguageProcessor";
 import Factory from "../../specHelpers/factory";
 import Node from "../../../src/parse/structure/Node";
+import memoizedSentenceTokenizer from "../../../src/languageProcessing/helpers/sentence/memoizedSentenceTokenizer";
 
 let languageProcessor;
 
 beforeEach( () => {
-	const researcher = Factory.buildMockResearcher( {} );
+	const researcher = Factory.buildMockResearcher( {}, true, false, false,
+		{ memoizedTokenizer: memoizedSentenceTokenizer } );
 	languageProcessor = new LanguageProcessor( researcher );
 } );
 

--- a/packages/yoastseo/src/languageProcessing/AbstractResearcher.js
+++ b/packages/yoastseo/src/languageProcessing/AbstractResearcher.js
@@ -38,6 +38,9 @@ import videoCount from "./researches/videoCount";
 import wordCountInText from "./researches/wordCountInText.js";
 import wordComplexity from "./researches/wordComplexity";
 
+// All helpers.
+import memoizedTokenizer from "./helpers/sentence/memoizedSentenceTokenizer";
+
 /**
  * The researches contains all the researches
  */
@@ -93,7 +96,9 @@ export default class AbstractResearcher {
 
 		this.customResearches = {};
 
-		this.helpers = {};
+		this.helpers = {
+			memoizedTokenizer,
+		};
 
 		this.config = {};
 	}

--- a/packages/yoastseo/src/languageProcessing/helpers/sentence/getSentences.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/sentence/getSentences.js
@@ -57,7 +57,7 @@ export default function( text, memoizedTokenizer ) {
 	 * We use the `map` method followed by `flat` instead of `flatMap` because `flatMap` would override the second
 	 * argument of the memoizedTokenizer with the index of the iteratee.
 	 */
-	let sentences = blocks.map( block => memoizedTokenizer( block ) );
+	const sentences = blocks.map( block => memoizedTokenizer( block ) );
 
 	return filter( sentences.flat(), negate( isEmpty ) );
 }

--- a/packages/yoastseo/src/languageProcessing/helpers/sentence/getSentences.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/sentence/getSentences.js
@@ -1,5 +1,5 @@
 // Lodash imports.
-import { filter, flatMap, isEmpty, negate, memoize } from "lodash-es";
+import { filter, flatMap, isEmpty, negate } from "lodash-es";
 
 // Internal dependencies.
 import { getBlocks } from "../html/html.js";
@@ -7,7 +7,7 @@ import { imageRegex } from "../image/imageInText";
 import excludeTableOfContentsTag from "../sanitize/excludeTableOfContentsTag";
 import excludeEstimatedReadingTime from "../sanitize/excludeEstimatedReadingTime";
 import { unifyNonBreakingSpace } from "../sanitize/unifyWhitespace";
-import SentenceTokenizer from "./SentenceTokenizer";
+import defaultMemoizedSentenceTokenizer from "./memoizedSentenceTokenizer";
 
 // Character classes.
 const newLines = "\n\r|\n|\r";
@@ -15,27 +15,6 @@ const newLines = "\n\r|\n|\r";
 // Regular expressions.
 const newLineRegex = new RegExp( newLines );
 
-
-/**
- * Returns the sentences from a certain block.
- *
- * @param {string} block The HTML inside a HTML block.
- * @returns {Array<string>} The list of sentences in the block.
- */
-function getSentenceTokenizer( block ) {
-	const sentenceTokenizer = new SentenceTokenizer();
-	const { tokenizer, tokens } = sentenceTokenizer.createTokenizer();
-	sentenceTokenizer.tokenize( tokenizer, block );
-	const paragraphTagsRegex = new RegExp( "^(<p>|</p>)$" );
-	/*
-	 * Filter block that contain only paragraph tags. This step is necessary
-	 * since switching between editors might add extra paragraph tags with a new line tag in the end
-	 * that are incorrectly converted into separate blocks.
-	 */
-	return ( tokens.length === 0 || paragraphTagsRegex.test( block ) ) ? [] : sentenceTokenizer.getSentencesFromTokens( tokens );
-}
-
-const getSentencesFromBlockCached = memoize( getSentenceTokenizer );
 /**
  * Returns sentences in a string.
  *
@@ -46,8 +25,12 @@ const getSentencesFromBlockCached = memoize( getSentenceTokenizer );
  */
 export default function( text, memoizedTokenizer ) {
 	if ( ! memoizedTokenizer ) {
-		memoizedTokenizer = getSentencesFromBlockCached;
+		memoizedTokenizer = defaultMemoizedSentenceTokenizer;
 	}
+	const cache = memoizedTokenizer.cache.__data__.hash.__data__;
+	const formatted = JSON.stringify(cache);
+	console.log( formatted, "Tokenizer Cache" );
+
 	// We don't remove the other HTML tags here since removing them might lead to incorrect results when running the sentence tokenizer.
 	// Remove Table of Contents.
 	text = excludeTableOfContentsTag( text );
@@ -67,6 +50,7 @@ export default function( text, memoizedTokenizer ) {
 	} );
 
 	const sentences = flatMap( blocks, memoizedTokenizer );
+	console.log( sentences, "sentences" );
 
 	return filter( sentences, negate( isEmpty ) );
 }

--- a/packages/yoastseo/src/languageProcessing/helpers/sentence/getSentences.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/sentence/getSentences.js
@@ -27,9 +27,6 @@ export default function( text, memoizedTokenizer ) {
 	if ( ! memoizedTokenizer ) {
 		memoizedTokenizer = defaultMemoizedSentenceTokenizer;
 	}
-	const cache = memoizedTokenizer.cache.__data__.hash.__data__;
-	const formatted = JSON.stringify(cache);
-	console.log( formatted, "Tokenizer Cache" );
 
 	// We don't remove the other HTML tags here since removing them might lead to incorrect results when running the sentence tokenizer.
 	// Remove Table of Contents.
@@ -49,8 +46,11 @@ export default function( text, memoizedTokenizer ) {
 		return block.split( newLineRegex );
 	} );
 
-	const sentences = flatMap( blocks, memoizedTokenizer );
-	console.log( sentences, "sentences" );
+	/*
+	 * We use the `map` method followed by `flat` instead of `flatMap` because `flatMap` would override the second
+	 * argument of the memoizedTokenizer with the index of the iteratee.
+	 */
+	let sentences = blocks.map( block => memoizedTokenizer( block ) );
 
-	return filter( sentences, negate( isEmpty ) );
+	return filter( sentences.flat(), negate( isEmpty ) );
 }

--- a/packages/yoastseo/src/languageProcessing/helpers/sentence/getSentences.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/sentence/getSentences.js
@@ -7,7 +7,6 @@ import { imageRegex } from "../image/imageInText";
 import excludeTableOfContentsTag from "../sanitize/excludeTableOfContentsTag";
 import excludeEstimatedReadingTime from "../sanitize/excludeEstimatedReadingTime";
 import { unifyNonBreakingSpace } from "../sanitize/unifyWhitespace";
-import defaultMemoizedSentenceTokenizer from "./memoizedSentenceTokenizer";
 
 // Character classes.
 const newLines = "\n\r|\n|\r";
@@ -24,10 +23,6 @@ const newLineRegex = new RegExp( newLines );
  * @returns {Array} Sentences found in the text.
  */
 export default function( text, memoizedTokenizer ) {
-	if ( ! memoizedTokenizer ) {
-		memoizedTokenizer = defaultMemoizedSentenceTokenizer;
-	}
-
 	// We don't remove the other HTML tags here since removing them might lead to incorrect results when running the sentence tokenizer.
 	// Remove Table of Contents.
 	text = excludeTableOfContentsTag( text );

--- a/packages/yoastseo/src/languageProcessing/helpers/sentence/getSentences.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/sentence/getSentences.js
@@ -7,6 +7,7 @@ import { imageRegex } from "../image/imageInText";
 import excludeTableOfContentsTag from "../sanitize/excludeTableOfContentsTag";
 import excludeEstimatedReadingTime from "../sanitize/excludeEstimatedReadingTime";
 import { unifyNonBreakingSpace } from "../sanitize/unifyWhitespace";
+import defaultSentenceTokenizer from "./memoizedSentenceTokenizer";
 
 // Character classes.
 const newLines = "\n\r|\n|\r";
@@ -23,6 +24,9 @@ const newLineRegex = new RegExp( newLines );
  * @returns {Array} Sentences found in the text.
  */
 export default function( text, memoizedTokenizer ) {
+	if ( ! memoizedTokenizer ) {
+		memoizedTokenizer = defaultSentenceTokenizer;
+	}
 	// We don't remove the other HTML tags here since removing them might lead to incorrect results when running the sentence tokenizer.
 	// Remove Table of Contents.
 	text = excludeTableOfContentsTag( text );

--- a/packages/yoastseo/src/languageProcessing/helpers/sentence/getSentences.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/sentence/getSentences.js
@@ -14,6 +14,7 @@ const newLines = "\n\r|\n|\r";
 
 // Regular expressions.
 const newLineRegex = new RegExp( newLines );
+const paragraphTagsRegex = new RegExp( "^(<p>|</p>)$" );
 
 /**
  * Returns sentences in a string.
@@ -44,6 +45,13 @@ export default function( text, memoizedTokenizer ) {
 	blocks = flatMap( blocks, function( block ) {
 		return block.split( newLineRegex );
 	} );
+
+	/*
+	 * Filter blocks that contain only paragraph tags. This step is necessary
+	 * since switching between editors might add extra paragraph tags with a new line tag in the end
+	 * that are incorrectly converted into separate blocks.
+	 */
+	blocks = blocks.filter( block => ! paragraphTagsRegex.test( block ) );
 
 	/*
 	 * We use the `map` method followed by `flat` instead of `flatMap` because `flatMap` would override the second

--- a/packages/yoastseo/src/languageProcessing/helpers/sentence/getSentences.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/sentence/getSentences.js
@@ -24,10 +24,7 @@ const paragraphTagsRegex = new RegExp( "^(<p>|</p>)$" );
  *
  * @returns {Array} Sentences found in the text.
  */
-export default function( text, memoizedTokenizer ) {
-	if ( ! memoizedTokenizer ) {
-		memoizedTokenizer = defaultSentenceTokenizer;
-	}
+export default function( text, memoizedTokenizer = defaultSentenceTokenizer ) {
 	// We don't remove the other HTML tags here since removing them might lead to incorrect results when running the sentence tokenizer.
 	// Remove Table of Contents.
 	text = excludeTableOfContentsTag( text );

--- a/packages/yoastseo/src/languageProcessing/helpers/sentence/memoizedSentenceTokenizer.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/sentence/memoizedSentenceTokenizer.js
@@ -19,7 +19,6 @@ function getSentenceTokenizer( block, trimSentences = true ) {
 	 * since switching between editors might add extra paragraph tags with a new line tag in the end
 	 * that are incorrectly converted into separate blocks.
 	 */
-	console.log( trimSentences, "trimSentences" );
 	return ( tokens.length === 0 || paragraphTagsRegex.test( block ) ) ? [] : sentenceTokenizer.getSentencesFromTokens( tokens, trimSentences );
 }
 

--- a/packages/yoastseo/src/languageProcessing/helpers/sentence/memoizedSentenceTokenizer.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/sentence/memoizedSentenceTokenizer.js
@@ -23,6 +23,6 @@ function getSentenceTokenizer( block, trimSentences = true ) {
  * This is needed because by default, only the first argument to a function is used as the map cache key by the memoize function.
  * This means that a function is only re-run if the value of the first argument changes.
  * We want to re-run the getSentenceTokenizer function also when only the second argument changes to prevent cache collisions.
- * See: https://lodash.com/docs/4.17.15#memoize
+ * @see https://lodash.com/docs/4.17.15#memoize
  */
 export default memoize( getSentenceTokenizer, ( ...args ) => JSON.stringify( args ) );

--- a/packages/yoastseo/src/languageProcessing/helpers/sentence/memoizedSentenceTokenizer.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/sentence/memoizedSentenceTokenizer.js
@@ -1,5 +1,5 @@
-import { memoize } from "lodash-es";
-import SentenceTokenizer from "./internal/SentenceTokenizer";
+import SentenceTokenizer from "./SentenceTokenizer";
+import {memoize} from "lodash-es";
 
 /**
  * Returns the sentences from a certain block.
@@ -19,6 +19,7 @@ function getSentenceTokenizer( block, trimSentences = true ) {
 	 * since switching between editors might add extra paragraph tags with a new line tag in the end
 	 * that are incorrectly converted into separate blocks.
 	 */
+	console.log( trimSentences, "trimSentences" );
 	return ( tokens.length === 0 || paragraphTagsRegex.test( block ) ) ? [] : sentenceTokenizer.getSentencesFromTokens( tokens, trimSentences );
 }
 

--- a/packages/yoastseo/src/languageProcessing/helpers/sentence/memoizedSentenceTokenizer.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/sentence/memoizedSentenceTokenizer.js
@@ -2,17 +2,17 @@ import SentenceTokenizer from "./SentenceTokenizer";
 import { memoize } from "lodash-es";
 
 /**
- * Returns the sentences from a certain block.
+ * Returns the sentences from a certain text.
  *
- * @param {string} block 					The HTML inside a HTML block.
+ * @param {string} text 					The text to retrieve sentences from.
  * @param {boolean} [trimSentences=true] 	Whether to trim whitespace from the beginning and end of the sentences or not.
  *
- * @returns {Array<string>} The list of sentences in the block.
+ * @returns {Array<string>} The list of sentences in the text.
  */
-function getSentenceTokenizer( block, trimSentences = true ) {
+function getSentenceTokenizer( text, trimSentences = true ) {
 	const sentenceTokenizer = new SentenceTokenizer();
 	const { tokenizer, tokens } = sentenceTokenizer.createTokenizer();
-	sentenceTokenizer.tokenize( tokenizer, block );
+	sentenceTokenizer.tokenize( tokenizer, text );
 
 	return ( tokens.length === 0 ? [] : sentenceTokenizer.getSentencesFromTokens( tokens, trimSentences ) );
 }

--- a/packages/yoastseo/src/languageProcessing/helpers/sentence/memoizedSentenceTokenizer.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/sentence/memoizedSentenceTokenizer.js
@@ -1,5 +1,5 @@
 import SentenceTokenizer from "./SentenceTokenizer";
-import {memoize} from "lodash-es";
+import { memoize } from "lodash-es";
 
 /**
  * Returns the sentences from a certain block.

--- a/packages/yoastseo/src/languageProcessing/helpers/sentence/memoizedSentenceTokenizer.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/sentence/memoizedSentenceTokenizer.js
@@ -13,13 +13,8 @@ function getSentenceTokenizer( block, trimSentences = true ) {
 	const sentenceTokenizer = new SentenceTokenizer();
 	const { tokenizer, tokens } = sentenceTokenizer.createTokenizer();
 	sentenceTokenizer.tokenize( tokenizer, block );
-	const paragraphTagsRegex = new RegExp( "^(<p>|</p>)$" );
-	/*
-	 * Filter block that contain only paragraph tags. This step is necessary
-	 * since switching between editors might add extra paragraph tags with a new line tag in the end
-	 * that are incorrectly converted into separate blocks.
-	 */
-	return ( tokens.length === 0 || paragraphTagsRegex.test( block ) ) ? [] : sentenceTokenizer.getSentencesFromTokens( tokens, trimSentences );
+
+	return ( tokens.length === 0 ? [] : sentenceTokenizer.getSentencesFromTokens( tokens, trimSentences ) );
 }
 
 /*

--- a/packages/yoastseo/src/languageProcessing/languages/de/helpers/memoizedSentenceTokenizer.js
+++ b/packages/yoastseo/src/languageProcessing/languages/de/helpers/memoizedSentenceTokenizer.js
@@ -23,6 +23,6 @@ function getSentenceTokenizer( block, trimSentences = true ) {
  * This is needed because by default, only the first argument to a function is used as the map cache key by the memoize function.
  * This means that a function is only re-run if the value of the first argument changes.
  * We want to re-run the getSentenceTokenizer function also when only the second argument changes to prevent cache collisions.
- * See: https://lodash.com/docs/4.17.15#memoize
+ * @see https://lodash.com/docs/4.17.15#memoize
  */
 export default memoize( getSentenceTokenizer, ( ...args ) => JSON.stringify( args ) );

--- a/packages/yoastseo/src/languageProcessing/languages/de/helpers/memoizedSentenceTokenizer.js
+++ b/packages/yoastseo/src/languageProcessing/languages/de/helpers/memoizedSentenceTokenizer.js
@@ -2,17 +2,17 @@ import { memoize } from "lodash-es";
 import SentenceTokenizer from "./internal/SentenceTokenizer";
 
 /**
- * Returns the sentences from a certain block.
+ * Returns the sentences from a certain text.
  *
- * @param {string} block 					The HTML inside a HTML block.
+ * @param {string} text 					The text to retrieve sentences from.
  * @param {boolean} [trimSentences=true] 	Whether to trim whitespace from the beginning and end of the sentences or not.
  *
- * @returns {Array<string>} The list of sentences in the block.
+ * @returns {Array<string>} The list of sentences in the text.
  */
-function getSentenceTokenizer( block, trimSentences = true ) {
+function getSentenceTokenizer( text, trimSentences = true ) {
 	const sentenceTokenizer = new SentenceTokenizer();
 	const { tokenizer, tokens } = sentenceTokenizer.createTokenizer();
-	sentenceTokenizer.tokenize( tokenizer, block );
+	sentenceTokenizer.tokenize( tokenizer, text );
 
 	return ( tokens.length === 0 ? [] : sentenceTokenizer.getSentencesFromTokens( tokens, trimSentences ) );
 }

--- a/packages/yoastseo/src/languageProcessing/languages/de/helpers/memoizedSentenceTokenizer.js
+++ b/packages/yoastseo/src/languageProcessing/languages/de/helpers/memoizedSentenceTokenizer.js
@@ -13,13 +13,8 @@ function getSentenceTokenizer( block, trimSentences = true ) {
 	const sentenceTokenizer = new SentenceTokenizer();
 	const { tokenizer, tokens } = sentenceTokenizer.createTokenizer();
 	sentenceTokenizer.tokenize( tokenizer, block );
-	const paragraphTagsRegex = new RegExp( "^(<p>|</p>)$" );
-	/*
-	 * Filter block that contain only paragraph tags. This step is necessary
-	 * since switching between editors might add extra paragraph tags with a new line tag in the end
-	 * that are incorrectly converted into separate blocks.
-	 */
-	return ( tokens.length === 0 || paragraphTagsRegex.test( block ) ) ? [] : sentenceTokenizer.getSentencesFromTokens( tokens, trimSentences );
+
+	return ( tokens.length === 0 ? [] : sentenceTokenizer.getSentencesFromTokens( tokens, trimSentences ) );
 }
 
 /*

--- a/packages/yoastseo/src/languageProcessing/languages/ja/helpers/memoizedSentenceTokenizer.js
+++ b/packages/yoastseo/src/languageProcessing/languages/ja/helpers/memoizedSentenceTokenizer.js
@@ -4,10 +4,12 @@ import SentenceTokenizer from "./internal/SentenceTokenizer";
 /**
  * Returns the sentences from a certain block.
  *
- * @param {string} block The HTML inside a HTML block.
+ * @param {string} block 					The HTML inside a HTML block.
+ * @param {boolean} [trimSentences=true] 	Whether to trim whitespace from the beginning and end of the sentences or not.
+ *
  * @returns {Array<string>} The list of sentences in the block.
  */
-function getSentenceTokenizer( block ) {
+function getSentenceTokenizer( block, trimSentences = true ) {
 	const sentenceTokenizer = new SentenceTokenizer();
 	const { tokenizer, tokens } = sentenceTokenizer.createTokenizer();
 	sentenceTokenizer.tokenize( tokenizer, block );
@@ -17,7 +19,15 @@ function getSentenceTokenizer( block ) {
 	 * since switching between editors might add extra paragraph tags with a new line tag in the end
 	 * that are incorrectly converted into separate blocks.
 	 */
-	return ( tokens.length === 0 || paragraphTagsRegex.test( block ) ) ? [] : sentenceTokenizer.getSentencesFromTokens( tokens );
+	return ( tokens.length === 0 || paragraphTagsRegex.test( block ) ) ? [] : sentenceTokenizer.getSentencesFromTokens( tokens, trimSentences );
 }
 
-export default memoize( getSentenceTokenizer );
+/*
+ * The second argument to the memoize function is a so-called resolver function.
+ * It creates a cache key consisting of a combination of all arguments to a function.
+ * This is needed because by default, only the first argument to a function is used as the map cache key by the memoize function.
+ * This means that a function is only re-run if the value of the first argument changes.
+ * We want to re-run the getSentenceTokenizer function also when only the second argument changes to prevent cache collisions.
+ * See: https://lodash.com/docs/4.17.15#memoize
+ */
+export default memoize( getSentenceTokenizer, ( ...args ) => JSON.stringify( args ) );

--- a/packages/yoastseo/src/languageProcessing/languages/ja/helpers/memoizedSentenceTokenizer.js
+++ b/packages/yoastseo/src/languageProcessing/languages/ja/helpers/memoizedSentenceTokenizer.js
@@ -23,6 +23,6 @@ function getSentenceTokenizer( block, trimSentences = true ) {
  * This is needed because by default, only the first argument to a function is used as the map cache key by the memoize function.
  * This means that a function is only re-run if the value of the first argument changes.
  * We want to re-run the getSentenceTokenizer function also when only the second argument changes to prevent cache collisions.
- * See: https://lodash.com/docs/4.17.15#memoize
+ * @see https://lodash.com/docs/4.17.15#memoize
  */
 export default memoize( getSentenceTokenizer, ( ...args ) => JSON.stringify( args ) );

--- a/packages/yoastseo/src/languageProcessing/languages/ja/helpers/memoizedSentenceTokenizer.js
+++ b/packages/yoastseo/src/languageProcessing/languages/ja/helpers/memoizedSentenceTokenizer.js
@@ -2,17 +2,17 @@ import { memoize } from "lodash-es";
 import SentenceTokenizer from "./internal/SentenceTokenizer";
 
 /**
- * Returns the sentences from a certain block.
+ * Returns the sentences from a certain text.
  *
- * @param {string} block 					The HTML inside a HTML block.
+ * @param {string} text 					The text to retrieve sentences from..
  * @param {boolean} [trimSentences=true] 	Whether to trim whitespace from the beginning and end of the sentences or not.
  *
- * @returns {Array<string>} The list of sentences in the block.
+ * @returns {Array<string>} The list of sentences in the text.
  */
-function getSentenceTokenizer( block, trimSentences = true ) {
+function getSentenceTokenizer( text, trimSentences = true ) {
 	const sentenceTokenizer = new SentenceTokenizer();
 	const { tokenizer, tokens } = sentenceTokenizer.createTokenizer();
-	sentenceTokenizer.tokenize( tokenizer, block );
+	sentenceTokenizer.tokenize( tokenizer, text );
 
 	return ( tokens.length === 0 ? [] : sentenceTokenizer.getSentencesFromTokens( tokens, trimSentences ) );
 }

--- a/packages/yoastseo/src/languageProcessing/languages/ja/helpers/memoizedSentenceTokenizer.js
+++ b/packages/yoastseo/src/languageProcessing/languages/ja/helpers/memoizedSentenceTokenizer.js
@@ -13,13 +13,8 @@ function getSentenceTokenizer( block, trimSentences = true ) {
 	const sentenceTokenizer = new SentenceTokenizer();
 	const { tokenizer, tokens } = sentenceTokenizer.createTokenizer();
 	sentenceTokenizer.tokenize( tokenizer, block );
-	const paragraphTagsRegex = new RegExp( "^(<p>|</p>)$" );
-	/*
-	 * Filter block that contain only paragraph tags. This step is necessary
-	 * since switching between editors might add extra paragraph tags with a new line tag in the end
-	 * that are incorrectly converted into separate blocks.
-	 */
-	return ( tokens.length === 0 || paragraphTagsRegex.test( block ) ) ? [] : sentenceTokenizer.getSentencesFromTokens( tokens, trimSentences );
+
+	return ( tokens.length === 0 ? [] : sentenceTokenizer.getSentencesFromTokens( tokens, trimSentences ) );
 }
 
 /*

--- a/packages/yoastseo/src/languageProcessing/researches/getPassiveVoiceResult.js
+++ b/packages/yoastseo/src/languageProcessing/researches/getPassiveVoiceResult.js
@@ -17,9 +17,6 @@ export const getMorphologicalPassives = function( paper, researcher ) {
 	const isPassiveSentence = researcher.getHelper( "isPassiveSentence" );
 	const text = paper.getText();
 	const memoizedTokenizer = researcher.getHelper( "memoizedTokenizer" );
-	// eslint-disable-next-line max-len
-	// It's not necessary to pass the memoized tokenizer from the researcher here, since only Japanese and German have the language specific tokenizer.
-	// Passive voice analysis is not supported in Japanese. In German, passive voice is periphrastic.
 	const sentences = getSentences( text, memoizedTokenizer )
 		.map( function( sentence ) {
 			return new Sentence( sentence );

--- a/packages/yoastseo/src/languageProcessing/researches/getPassiveVoiceResult.js
+++ b/packages/yoastseo/src/languageProcessing/researches/getPassiveVoiceResult.js
@@ -16,10 +16,11 @@ import { forEach } from "lodash-es";
 export const getMorphologicalPassives = function( paper, researcher ) {
 	const isPassiveSentence = researcher.getHelper( "isPassiveSentence" );
 	const text = paper.getText();
+	const memoizedTokenizer = researcher.getHelper( "memoizedTokenizer" );
 	// eslint-disable-next-line max-len
 	// It's not necessary to pass the memoized tokenizer from the researcher here, since only Japanese and German have the language specific tokenizer.
 	// Passive voice analysis is not supported in Japanese. In German, passive voice is periphrastic.
-	const sentences = getSentences( text )
+	const sentences = getSentences( text, memoizedTokenizer )
 		.map( function( sentence ) {
 			return new Sentence( sentence );
 		} );

--- a/packages/yoastseo/src/parse/build/private/filterTree.js
+++ b/packages/yoastseo/src/parse/build/private/filterTree.js
@@ -16,18 +16,18 @@ function shouldRemoveNode( node, filters ) {
 }
 
 /**
- * A recursive fuunction that removes all nodes based on an array of filters.
+ * A recursive function that removes all nodes based on an array of filters.
  * @param {Node} node A node. (Could be the entire tree.)
  * @param {array} filters An array of callbacks. If a callback returns true, the node is discarded.
  * @returns {Node} A Node with all undesired subtrees removed.
  */
 export default function filterTree( node, filters ) {
-	// If the node should be disregarded. Return an empy node.
+	// If the node should be disregarded. Return an empty node.
 	if ( shouldRemoveNode( node, filters ) ) {
 		return;
 	}
 
-	// If the node has childs.
+	// If the node has children.
 	if ( node.childNodes ) {
 		node.childNodes = node.childNodes.filter( childNode => filterTree( childNode, filters ) );
 	}

--- a/packages/yoastseo/src/parse/language/LanguageProcessor.js
+++ b/packages/yoastseo/src/parse/language/LanguageProcessor.js
@@ -1,3 +1,5 @@
+import Sentence from "../structure/Sentence";
+
 /**
  * Contains language-specific logic for splitting a text into sentences and tokens.
  */
@@ -19,8 +21,11 @@ class LanguageProcessor {
 	 * @returns {Sentence[]} The sentences.
 	 */
 	splitIntoSentences( text ) {
-		// TODO: split text into sentences.
-		return [];
+		const memoizedTokenizer = this.researcher.getHelper( "memoizedTokenizer" );
+		return memoizedTokenizer( text, false )
+			.map( function( sentence ) {
+				return new Sentence( sentence );
+			} );
 	}
 
 	/**

--- a/packages/yoastseo/src/parse/language/LanguageProcessor.js
+++ b/packages/yoastseo/src/parse/language/LanguageProcessor.js
@@ -22,14 +22,17 @@ class LanguageProcessor {
 	 */
 	splitIntoSentences( text ) {
 		const memoizedTokenizer = this.researcher.getHelper( "memoizedTokenizer" );
+		/*
+		 * Set the `trimSentences` flag to false. We want to keep whitespaces to be able to correctly assess the
+		 * position of sentences within the source code.
+		 */
 		const sentences = memoizedTokenizer( text, false );
 
 		/*
 		 * If the last element in the array of sentences contains only whitespaces, remove it.
 		 * This will be the case if the text ends in a whitespace - that whitespace ends up being tokenized as a
-		 * separate sentence.
-		 * We don't want to remove any potential whitespace "sentences" that are not at the end,
-		 * because they are needed to ensure correct calculation of the sentence positions later on.
+		 * separate sentence. A space at the end of the text is not needed for calculating the position of
+		 * sentences so it can be safely removed.
 		 */
 		if ( whitespaceRegex.test( sentences[ sentences.length - 1 ] ) ) {
 			sentences.pop();

--- a/packages/yoastseo/src/parse/language/LanguageProcessor.js
+++ b/packages/yoastseo/src/parse/language/LanguageProcessor.js
@@ -1,5 +1,5 @@
 import Sentence from "../structure/Sentence";
-
+const whitespaceRegex = /^\s+$/
 /**
  * Contains language-specific logic for splitting a text into sentences and tokens.
  */
@@ -22,8 +22,20 @@ class LanguageProcessor {
 	 */
 	splitIntoSentences( text ) {
 		const memoizedTokenizer = this.researcher.getHelper( "memoizedTokenizer" );
-		return memoizedTokenizer( text, false )
-			.map( function( sentence ) {
+		let sentences = memoizedTokenizer( text, false );
+
+		/*
+		 * If the last element in the array of sentences contains only whitespaces, remove it.
+		 * This will be the case if the text ends in a whitespace - that whitespace ends up being tokenized as a
+		 * separate sentence.
+		 * We don't want to remove any potential whitespace "sentences" that are not at the end,
+		 * because they are needed to ensure correct calculation of the sentence positions later on.
+		 */
+		if ( whitespaceRegex.test( sentences[ sentences.length - 1 ] ) ) {
+			sentences.pop();
+		}
+
+		return sentences.map( function( sentence ) {
 				return new Sentence( sentence );
 			} );
 	}

--- a/packages/yoastseo/src/parse/language/LanguageProcessor.js
+++ b/packages/yoastseo/src/parse/language/LanguageProcessor.js
@@ -1,5 +1,5 @@
 import Sentence from "../structure/Sentence";
-const whitespaceRegex = /^\s+$/
+const whitespaceRegex = /^\s+$/;
 /**
  * Contains language-specific logic for splitting a text into sentences and tokens.
  */
@@ -22,7 +22,7 @@ class LanguageProcessor {
 	 */
 	splitIntoSentences( text ) {
 		const memoizedTokenizer = this.researcher.getHelper( "memoizedTokenizer" );
-		let sentences = memoizedTokenizer( text, false );
+		const sentences = memoizedTokenizer( text, false );
 
 		/*
 		 * If the last element in the array of sentences contains only whitespaces, remove it.
@@ -36,8 +36,8 @@ class LanguageProcessor {
 		}
 
 		return sentences.map( function( sentence ) {
-				return new Sentence( sentence );
-			} );
+			return new Sentence( sentence );
+		} );
 	}
 
 	/**

--- a/packages/yoastseo/src/parse/traverse/innerText.js
+++ b/packages/yoastseo/src/parse/traverse/innerText.js
@@ -10,8 +10,7 @@ import { isEmpty } from "lodash-es";
 export default function innerText( node ) {
 	let text = "";
 
-	if ( ! isEmpty(node.childNodes) ) {
-
+	if ( ! isEmpty( node.childNodes ) ) {
 		node.childNodes.forEach( child => {
 			if ( child.name === "#text" ) {
 				text += child.value;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [yoastseo] Adds sentences to paragraph and heading nodes.

## Relevant technical choices:

* The default memoized sentence tokenizer is moved to a separate file and added to the Abstract Researcher. This way, the way we retrieve the tokenizer (through the researcher) is consistent for all languages.
* Filtering out blocks consisting of `<p>` tags is moved out of the tokenizer and into the `getSentences` function. This step is only needed when retrieving sentences through the `getSentences` function (not through the `splitIntoSentences` method of the `LanguageProcessor`) so it makes more sense to have it inside that function. It also helps with not having to repeat the same code in every language-specific tokenizer.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Smoke test the getSentences functionality
* Activate Yoast SEO
* Set your site language to English
* Create a post and add the following text: 
`The cat (felis catus) is a domestic species of small carnivorous mammal and it is the only domesticated species in the family Felidae and is commonly referred to as the domestic cat or house cat to distinguish it from the wild members of the family. Cats are commonly kept as house pets but can also be farm cats or feral cats. Cats that are feral range freely and avoid human contact. Cats that are domesticated are valued by humans for companionship and their ability to kill rodents.`
* Confirm that the passive voice assessment returns the following result: `Passive voice: 75% of the sentences contain passive voice, which is more than the recommended maximum of 10%. Try to use their active counterparts.` 
* Click the highlight button for the passive voice assessment and confirm all sentences apart from the second-to-last sentence are highlighted.
* Confirm that the consecutive sentences assessment returns the following result: `Consecutive sentences: The text contains 3 consecutive sentences starting with the same word. Try to mix things up!`
* Click the highlight button for the consecutive sentences assessment and confirm the last 3 sentences of the text are highlighted.
* Confirm that the sentence length assessment returns the following result: `Sentence length: Great!`
* Click the highlight button for the sentence length assessment and confirm the first sentence of the text is highlighted.

* Change the site language to German
* Create a post and add the following text: 
`Schwarze Katzen haben eine Mutation des Agouti-Locus, durch die das Phäomelanin vollständig durch Eumelanin verdrängt wird, so dass die Fellzeichnung nicht mehr sichtbar ist. Dagegen fehlt roten Katzen jegliches Eumelanin, da das Non-Agouti-Gen bewirkt, dass das Phäomelanin am ganzen Körper das Eumelanin unterdrückt. Das hat keine Auswirkung auf die Fellzeichnung roter Katzen: sie zeigen immer das Tabby-Muster. Eindeutige Darstellungen von Hauskatzen finden sich auf griechischen Vasen aus der Zeit um 480 und 440 v. Chr. Im 1. bis 3. Jahrhundert verbreitete sich die Hauskatze im Römischen Reich und erreichte Hildesheim-Bavenstedt nach Funden im 3. bis 5. Jahrhundert n. Chr. und Wiesbaden-Biebrich im 6. Jahrhundert. `
* Confirm that the passive voice assessment returns the following result: `Passive Sätze: 16.7% der Sätze sind passiv, was mehr ist als das empfohlene Maximum von 10%. Versuche mehr aktive Sätze zu benutzen.` 
* Click the highlight button for the passive voice assessment and confirm that the first sentence of the text is highlighted.
* Confirm that the sentence length assessment returns the following result: `Satzlänge: 33.3% der Sätze haben mehr als 20 Wörter, was mehr ist als das empfohlene Maximum von 25%. Versuche die Sätze zu kürzen.`
* Click the highlight button for the sentence length assessment and confirm that the first sentence and the second-to-last sentences of the text are highlighted.

* Change site language to Japanese
* Create a post and add the following text: 
`ネコの語源が「寝子」であるという説もあるほどにイエネコの睡眠時間は人間に比べて長い。一般的に、ネコは一日の大半を寝て過ごすといわれている。ネコの飼い方の本（獣医師による解説）などでは、一般に14時間程度とか16時間程度と解説されていることが多い。また「長いネコでは20時間程度眠る」といった解説も多い。なお、睡眠時間が長い傾向にあるのは、ネコ科の動物、肉食動物に共通して見られる傾向である。草食動物に比べて食物を得る機会に乏しい反面、その食物は草食動物の場合と比べて高カロリーであり、一度食物を得るとしばらくは食べる必要が無いため、何もしない時間帯は寝ることでカロリーの消費を抑えていると考えられる。`
* Confirm that the sentence length assessment returns the following result: `文の長さ: 66.7% の文が 40 文字以上の長さです。これは推奨する最大値 25% を上回ります。文をもっと短くしてみましょう。` 
* Click the highlight button for the sentence length assessment and confirm that first, third, and the two last sentences are highlighted.
<img width="679" alt="Screenshot 2023-03-20 at 17 08 31" src="https://user-images.githubusercontent.com/32479012/226400416-420722c0-03e1-4ddc-b16c-68798e375d29.png">

#### Test that blocks containing only `<p>` tags are removed before getting sentences from the text
* Follow the steps for WordPress from [this PR](https://github.com/Yoast/wordpress-seo/pull/18416).

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The PR refactors some code for the existing functionality of getting sentences from the text. Smoke testing steps for English as well as languages with their own sentence tokenizers (German and Japanese) were included in the test instructions. Additionally, steps for testing the analysis with texts that contain excessive paragraph tags were added, since the part of the code responsible for correctly retrieving sentences from such texts was also refactored.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [x] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes [HTML Parser - Add sentences to paragraph and heading nodes](https://github.com/Yoast/lingo-other-tasks/issues/110)
