### PR TITLE
Add Requires at least to readme.txt

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -6,6 +6,7 @@ License URI: http://www.gnu.org/licenses/gpl.html
 Tags: SEO, XML sitemap, Content analysis, Readability, Schema
 Tested up to: 6.1
 Stable tag: 20.3
+Requires at least: 6.0
 Requires PHP: 5.6.20
 
 Improve your WordPress SEO: Write better content and have a fully optimized WordPress site using the Yoast SEO plugin.


### PR DESCRIPTION
It was only in the plugin main file.

## Context

I'm developing a Composer plugin that read WP core and PHP versions from the readme.
`Requires at least` was missing from the readme.
