### PR TITLE
Restructuring yoastseo: unbundle the ecommerce assessments from the free assessments module

### DIFF
--- a/packages/yoastseo/src/scoring/assessments/index.js
+++ b/packages/yoastseo/src/scoring/assessments/index.js
@@ -25,9 +25,6 @@ import KeyphraseInSEOTitleAssessment from "./seo/KeyphraseInSEOTitleAssessment";
 import { SlugKeywordAssessment, UrlKeywordAssessment } from "./seo/UrlKeywordAssessment";
 import ImageKeyphraseAssessment from "./seo/KeyphraseInImageTextAssessment";
 import ImageCountAssessment from "./seo/ImageCountAssessment";
-import ImageAltTagsAssessment from "./seo/ImageAltTagsAssessment";
-import ProductIdentifiersAssessment from "./seo/ProductIdentifiersAssessment";
-import ProductSKUAssessment from "./seo/ProductSKUAssessment";
 
 import InclusiveLanguageAssessment from "./inclusiveLanguage/InclusiveLanguageAssessment";
 
@@ -61,9 +58,6 @@ const seo = {
 	UrlKeywordAssessment,
 	ImageKeyphraseAssessment,
 	ImageCountAssessment,
-	ImageAltTagsAssessment,
-	ProductIdentifiersAssessment,
-	ProductSKUAssessment,
 };
 
 const inclusiveLanguage = {

--- a/packages/yoastseo/src/scoring/assessments/seo/ImageAltTagsAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/ImageAltTagsAssessment.js
@@ -1,9 +1,9 @@
 import { __, _n, sprintf } from "@wordpress/i18n";
 import { merge } from "lodash-es";
 
-import Assessment from "../assessment";
-import { createAnchorOpeningTag } from "../../../helpers/shortlinker";
-import AssessmentResult from "../../../values/AssessmentResult";
+import { Assessment, AssessmentResult, helpers } from "yoastseo";
+
+const { createAnchorOpeningTag } = helpers;
 
 /**
  * Represents the assessment that checks if all images have alt tags (only applicable for product pages).

--- a/packages/yoastseo/src/scoring/assessments/seo/ImageAltTagsAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/ImageAltTagsAssessment.js
@@ -33,7 +33,7 @@ export default class ImageAltTagsAssessment extends Assessment {
 	}
 
 	/**
-	 * Execute the Assessment and return a result.
+	 * Executes the Assessment and return a result.
 	 *
 	 * @param {Paper}       paper       The Paper object to assess.
 	 * @param {Researcher}  researcher  The Researcher object containing all available researches.
@@ -67,7 +67,7 @@ export default class ImageAltTagsAssessment extends Assessment {
 	}
 
 	/**
-	 * Calculate the result based on the availability of images in the text, including videos in product pages.
+	 * Calculates the result based on the availability of images in the text, including videos in product pages.
 	 *
 	 * @returns {Object} The calculated result.
 	 */

--- a/packages/yoastseo/src/scoring/assessments/seo/ProductIdentifiersAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/ProductIdentifiersAssessment.js
@@ -5,7 +5,7 @@ import { Assessment, AssessmentResult, helpers } from "yoastseo";
 const { createAnchorOpeningTag } = helpers;
 
 /**
- * Represents the assessment for the product identifiers.
+ * Represents the assessment that checks whether a product has identifier(s).
  */
 export default class ProductIdentifiersAssessment extends Assessment {
 	/**
@@ -35,7 +35,7 @@ export default class ProductIdentifiersAssessment extends Assessment {
 	}
 
 	/**
-	 * Tests whether a product has product identifiers and returns an assessment result based on the research.
+	 * Executes the assessment and returns a result based on the research.
 	 *
 	 * @param {Paper}       paper       The paper to use for the assessment.
 	 *

--- a/packages/yoastseo/src/scoring/assessments/seo/ProductIdentifiersAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/ProductIdentifiersAssessment.js
@@ -1,8 +1,8 @@
-import Assessment from "../assessment";
-import AssessmentResult from "../../../values/AssessmentResult";
 import { merge } from "lodash-es";
-import { createAnchorOpeningTag } from "../../../helpers/shortlinker";
 import { __, sprintf } from "@wordpress/i18n";
+import { Assessment, AssessmentResult, helpers } from "yoastseo";
+
+const { createAnchorOpeningTag } = helpers;
 
 /**
  * Represents the assessment for the product identifiers.

--- a/packages/yoastseo/src/scoring/assessments/seo/ProductSKUAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/ProductSKUAssessment.js
@@ -5,7 +5,7 @@ import { Assessment, AssessmentResult, helpers } from "yoastseo";
 const { createAnchorOpeningTag } = helpers;
 
 /**
- * Represents the assessment for the product SKU.
+ * Represents the assessment checks whether the product has a SKU.
  */
 export default class ProductSKUAssessment extends Assessment {
 	/**
@@ -34,7 +34,7 @@ export default class ProductSKUAssessment extends Assessment {
 	}
 
 	/**
-	 * Tests whether a product has a SKU and returns an assessment result based on the research.
+	 * Executes the assessment and returns an result based on the research.
 	 *
 	 * @param {Paper}       paper       The paper to use for the assessment.
 	 *

--- a/packages/yoastseo/src/scoring/assessments/seo/ProductSKUAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/ProductSKUAssessment.js
@@ -1,8 +1,8 @@
-import Assessment from "../assessment";
-import AssessmentResult from "../../../values/AssessmentResult";
 import { merge } from "lodash-es";
-import { createAnchorOpeningTag } from "../../../helpers/shortlinker";
 import { __, sprintf } from "@wordpress/i18n";
+import { Assessment, AssessmentResult, helpers } from "yoastseo";
+
+const { createAnchorOpeningTag } = helpers;
 
 /**
  * Represents the assessment for the product SKU.

--- a/packages/yoastseo/src/scoring/productPages/cornerstone/seoAssessor.js
+++ b/packages/yoastseo/src/scoring/productPages/cornerstone/seoAssessor.js
@@ -1,6 +1,12 @@
 import { inherits } from "util";
 
 import { Assessor, SeoAssessor, assessments, helpers } from "yoastseo";
+
+// Product-specific assessments.
+import ImageAltTagsAssessment from "../../assessments/seo/ImageAltTagsAssessment";
+import ProductIdentifiersAssessment from "../../assessments/seo/ProductIdentifiersAssessment";
+import ProductSKUAssessment from "../../assessments/seo/ProductSKUAssessment";
+
 const { createAnchorOpeningTag } = helpers;
 
 const {
@@ -19,9 +25,6 @@ const {
 	PageTitleWidthAssessment,
 	FunctionWordsInKeyphraseAssessment,
 	SingleH1Assessment,
-	ProductIdentifiersAssessment,
-	ProductSKUAssessment,
-	ImageAltTagsAssessment,
 } = assessments.seo;
 
 /**

--- a/packages/yoastseo/src/scoring/productPages/seoAssessor.js
+++ b/packages/yoastseo/src/scoring/productPages/seoAssessor.js
@@ -1,6 +1,12 @@
 import { inherits } from "util";
 
 import { Assessor, assessments, helpers } from "yoastseo";
+
+// Product-specific assessments.
+import ImageAltTagsAssessment from "../assessments/seo/ImageAltTagsAssessment";
+import ProductIdentifiersAssessment from "../assessments/seo/ProductIdentifiersAssessment";
+import ProductSKUAssessment from "../assessments/seo/ProductSKUAssessment";
+
 const { createAnchorOpeningTag } = helpers;
 
 const {
@@ -19,9 +25,6 @@ const {
 	PageTitleWidthAssessment,
 	FunctionWordsInKeyphraseAssessment,
 	SingleH1Assessment,
-	ProductIdentifiersAssessment,
-	ProductSKUAssessment,
-	ImageAltTagsAssessment,
 } = assessments.seo;
 
 /**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Previously, the product-specific assessments `ProductSKUAssessment`, `ProductIdentifiersAssessment`, and `ImageAltTagsAssessment` are included in `assessments/index.js` module. They are the assessments that will be used only on product pages. Loading them together with the other assessments that are available in Yoast SEO (Free) doesn't make sense.
* This PR is to make the aforementioned eCommerce (hence non-Free) assessments not be loaded in Free when Yoast SEO for WooCommerce is not activated.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [yoastseo] Removes `ProductSKUAssessment`, `ProductIdentifiersAssessment`, and `ImageAltTagsAssessment` from the assessments module.


## Relevant technical choices:

* The way the assessments' dependencies are loaded is also changed. This is to make sure that those dependencies are also not bundled wherever we register those assessments, e.g. in `wpseo-woocommerce` and in `shopify-seo`

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### WordPress
* Repeat the test instructions in the following scenarios:
   * [Scenario 2.3. Image alt tags assessment ](https://docs.google.com/document/d/1fWX_8YkvSqcsqmwan_gwJjYqGOKIcTBTv0FbLKz47ig/edit#heading=h.52m3v2800v9v)
   * [Scenario 2.4. Product identifiers assessment](https://docs.google.com/document/d/1fWX_8YkvSqcsqmwan_gwJjYqGOKIcTBTv0FbLKz47ig/edit#heading=h.j5esafeib3gd)
   * [Scenario 2.5. Product SKU assessment](https://docs.google.com/document/d/1fWX_8YkvSqcsqmwan_gwJjYqGOKIcTBTv0FbLKz47ig/edit#heading=h.poywl7bw11lw)
   * [Scenario 2.7. Bundle size](https://docs.google.com/document/d/1fWX_8YkvSqcsqmwan_gwJjYqGOKIcTBTv0FbLKz47ig/edit#heading=h.af3c5ctvr0ya)
   * Scenario 3.1.3 for [Image Alt Tags assessment](https://docs.google.com/document/d/1fWX_8YkvSqcsqmwan_gwJjYqGOKIcTBTv0FbLKz47ig/edit#heading=h.z2ptmmr9t2gz), [Product identifiers assessment](https://docs.google.com/document/d/1fWX_8YkvSqcsqmwan_gwJjYqGOKIcTBTv0FbLKz47ig/edit#heading=h.jrpvwc38p41b) and [Product SKU assessment](https://docs.google.com/document/d/1fWX_8YkvSqcsqmwan_gwJjYqGOKIcTBTv0FbLKz47ig/edit#heading=h.dll034p0hpx7)
   * Scenario 3.2.3 for [Image Alt Tags assessment](https://docs.google.com/document/d/1fWX_8YkvSqcsqmwan_gwJjYqGOKIcTBTv0FbLKz47ig/edit#heading=h.71nusrbd7sek), [Product identifiers assessment](https://docs.google.com/document/d/1fWX_8YkvSqcsqmwan_gwJjYqGOKIcTBTv0FbLKz47ig/edit#heading=h.bf5n2pk5yf3m) and [Product SKU assessment](https://docs.google.com/document/d/1fWX_8YkvSqcsqmwan_gwJjYqGOKIcTBTv0FbLKz47ig/edit#heading=h.j0hox6mkpp7e) 
   * Scenario 3.4 for [Image Alt Tags assessment](https://docs.google.com/document/d/1fWX_8YkvSqcsqmwan_gwJjYqGOKIcTBTv0FbLKz47ig/edit#heading=h.4dke8lly4vgp), [Product identifiers assessment](https://docs.google.com/document/d/1fWX_8YkvSqcsqmwan_gwJjYqGOKIcTBTv0FbLKz47ig/edit#heading=h.xh7yogrwdvs1) and [Product SKU assessment](https://docs.google.com/document/d/1fWX_8YkvSqcsqmwan_gwJjYqGOKIcTBTv0FbLKz47ig/edit#heading=h.amvhw4ogrohg) 
   * Scenario 3.5 for [Image Alt Tags assessment](https://docs.google.com/document/d/1fWX_8YkvSqcsqmwan_gwJjYqGOKIcTBTv0FbLKz47ig/edit#heading=h.n0djkoash6lj), [Product identifiers assessment](https://docs.google.com/document/d/1fWX_8YkvSqcsqmwan_gwJjYqGOKIcTBTv0FbLKz47ig/edit#heading=h.g8etvhh3hdef) and [Product SKU assessment](https://docs.google.com/document/d/1fWX_8YkvSqcsqmwan_gwJjYqGOKIcTBTv0FbLKz47ig/edit#heading=h.u21b06fib6hm) 
   *  Scenario 3.6 for [Image Alt Tags assessment](https://docs.google.com/document/d/1fWX_8YkvSqcsqmwan_gwJjYqGOKIcTBTv0FbLKz47ig/edit#heading=h.2hy4mrowgfbb), [Product identifiers assessment](https://docs.google.com/document/d/1fWX_8YkvSqcsqmwan_gwJjYqGOKIcTBTv0FbLKz47ig/edit#heading=h.t9wi8iab0aoz) and [Product SKU assessment](https://docs.google.com/document/d/1fWX_8YkvSqcsqmwan_gwJjYqGOKIcTBTv0FbLKz47ig/edit#heading=h.9il2bhs2dz9p) 
#### Shopify
* Repeat the test instruction below in a Shopify product
   * [Scenario 2.3. Image alt tags assessment ](https://docs.google.com/document/d/1fWX_8YkvSqcsqmwan_gwJjYqGOKIcTBTv0FbLKz47ig/edit#heading=h.52m3v2800v9v)
   * [Scenario 2.4. Product identifiers assessment](https://docs.google.com/document/d/1fWX_8YkvSqcsqmwan_gwJjYqGOKIcTBTv0FbLKz47ig/edit#heading=h.j5esafeib3gd)
   * [Scenario 2.5. Product SKU assessment](https://docs.google.com/document/d/1fWX_8YkvSqcsqmwan_gwJjYqGOKIcTBTv0FbLKz47ig/edit#heading=h.poywl7bw11lw)

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
