### PR TITLE
Google preview: custom post type double slug

### DIFF
--- a/packages/js/src/analysis/blockEditorData.js
+++ b/packages/js/src/analysis/blockEditorData.js
@@ -185,6 +185,13 @@ export default class BlockEditorData {
 		const permalink = select( "core/editor" ).getPermalink();
 		let url;
 		let baseUrl = "";
+
+		if ( slug === "" ) {
+			// Fall back to the snippet editor's slug.
+			// This case should only happen with auto-drafts, where we save "our" slug before we pass it to the editor.
+			slug = select( "yoast-seo/editor" ).getSnippetEditorSlug();
+		}
+
 		try {
 			url = new URL( permalink );
 			baseUrl = url.origin + url.pathname;

--- a/packages/js/src/analysis/blockEditorData.js
+++ b/packages/js/src/analysis/blockEditorData.js
@@ -199,8 +199,15 @@ export default class BlockEditorData {
 			// Fallback on the base url retrieved from the wpseoScriptData.
 			baseUrl = window.wpseoScriptData.metabox.base_url;
 		}
-		// Strip slug from the url.
-		baseUrl = baseUrl.replace( new RegExp( encodeURI( slug ) + "/$", "i" ), "" );
+		try {
+			// Encode the slug, because the permalink is expected to be encoded.
+			slug = encodeURI( slug );
+		} catch ( e ) {
+			// Ignore this error.
+		}
+
+		// Strip slug from the url. Can also be `auto-draft` (which we filter out in `getSlug()`).
+		baseUrl = baseUrl.replace( new RegExp( `(?:${ slug }|auto-draft)/$`, "i" ), "" );
 		// Enforce ending with a slash because of the internal handling in the SnippetEditor component.
 		if ( ! baseUrl.endsWith( "/" ) ) {
 			baseUrl += "/";


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Addendum for https://github.com/Yoast/wordpress-seo/pull/20012 to fix similar problems for custom post types and pages (in the block editor).

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the Google preview breadcrumbs in the Block editor would show the slug twice when creating a new page or custom post. This would only happen before (auto-)saving the page or custom post.
* Fixes a bug where the Google preview breadcrumbs in the Block editor would show `auto-draft` when creating a new page or custom post. This would only happen before (auto-)saving the page or custom post.

## Relevant technical choices:

* When we update the slug in the editor, it triggers this baseUrl refetching, but it does not have the slug yet. In order to prevent a double slug ending up in our chain, we get the slug from the editor
* Because we filter `auto-draft` in our slug retrieval, it could still end up in the `baseUrl`

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Create a new page
* Enter a slug (that does not include any encoding -- still a problem)
* Verify the preview' url/breadcrumbs look correct
* Repeat for a custom post type (you can use the Yoast Test Helper to add one and enable the block editor for it)

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Block editor only

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes https://github.com/Yoast/plugins-automated-testing/issues/567
