### PR TITLE
Updates notification copy.

### DIFF
--- a/packages/js/src/components/WebinarPromoNotification.js
+++ b/packages/js/src/components/WebinarPromoNotification.js
@@ -30,7 +30,7 @@ const WebinarPromoNotification = ( {
 			url={ url }
 			{ ...props }
 		>
-			{ __( "Want to optimize even further with the help of our SEO experts? Sign up for our free weekly webinar!", "wordpress-seo" ) }
+			{ __( "Learn how to improve your rankings with Yoast SEO. Ask your questions to our SEO experts during the free live Q&A.", "wordpress-seo" ) }
 			&nbsp;<a href={ url } target="_blank" rel="noreferrer">
 				{ __( "Register now!", "wordpress-seo" ) }
 			</a>

--- a/packages/js/src/components/WebinarPromoNotification.js
+++ b/packages/js/src/components/WebinarPromoNotification.js
@@ -1,4 +1,4 @@
-import { __ } from "@wordpress/i18n";
+import { __, sprintf } from "@wordpress/i18n";
 import { useSelect } from "@wordpress/data";
 import PropTypes from "prop-types";
 
@@ -25,12 +25,20 @@ const WebinarPromoNotification = ( {
 			alertKey="webinar-promo-notification"
 			store={ store }
 			id="webinar-promo-notification"
-			title={ __( "Get the most out of Yoast SEO", "wordpress-seo" ) }
+			title={ sprintf(
+				/* translators: 1: Yoast SEO. */
+				__( "Get the most out of %1$s", "wordpress-seo" ),
+				"Yoast SEO"
+			) }
 			image={ Image }
 			url={ url }
 			{ ...props }
 		>
-			{ __( "Learn how to improve your rankings with Yoast SEO. Ask your questions to our SEO experts during the free live Q&A.", "wordpress-seo" ) }
+			{ sprintf(
+				/* translators: 1: Yoast SEO. */
+				__( "Learn how to improve your rankings with %1$s. Ask your questions to our SEO experts during the free live Q&A.", "wordpress-seo" ),
+				"Yoast SEO"
+			) }
 			&nbsp;<a href={ url } target="_blank" rel="noreferrer">
 				{ __( "Register now!", "wordpress-seo" ) }
 			</a>


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to update the copy of the `Get the most out of Yoast SEO` notification

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Updates the copy of the `Get the most out of Yoast SEO` notification.

## Relevant technical choices:

* Also moved "Yoast SEO" out of the translatable strings

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Open https://basic.wordpress.test/wp-admin/admin.php?page=wpseo_dashboard 
* You should see the following notification

<img width="812" alt="image" src="https://user-images.githubusercontent.com/6975345/226355654-eeaf1cab-359f-4a70-b06a-d2612d0ec997.png">

* Make sure the copy is as described in https://github.com/Yoast/growth/issues/13
* If you don't see the notification log in as a new user with at least the seo_manager role.
* create a new post in the block editor
* open the Yoast SEO sidebar
  * check that the notification displays the same copy as above.


#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
