### PR TITLE
Changes to jetpack boost integration card

### DIFF
--- a/packages/js/src/integrations-page/jetpack-boost-integration.js
+++ b/packages/js/src/integrations-page/jetpack-boost-integration.js
@@ -10,10 +10,6 @@ import { Card } from "./tailwind-components/card";
 /**
  * An integration for Jetpack Boost.
  *
- * @param {object} integration           The integration data object.
- * @param {bool}   isJetpackBoostActive  True if the Jetpack Boost is active.
- * @param {bool}   isJetpackBoostPremium True if the Jetpack Boost is premium.
- *
  * @returns {WPElement} A card representing an integration for Jetpack Boost.
  */
 export const JetpackBoostIntegration = () => {
@@ -152,11 +148,11 @@ export const JetpackBoostIntegration = () => {
 					</span>
 					<XIcon className="yst-h-5 yst-w-5 yst-text-red-500 yst-flex-shrink-0" />
 				</p> }
-				{ isJetpackBoostActive && ! isJetpackBoostPremium && <p className="yst-flex yst-items-start yst-justify-between">
+				{ isJetpackBoostActive && ! isJetpackBoostPremium && <p className="yst-flex yst-items-center yst-justify-between">
 					<span className="yst-text-slate-700 yst-font-medium">
 						{ __( "Integration active, upgrade available", "wordpress-seo" ) }
 					</span>
-					<ExclamationIcon className="yst-h-5 yst-w-5 yst-text-orange-400 yst-flex-shrink-0" />
+					<ExclamationIcon className="yst-h-5 yst-w-5 yst-text-amber-500 yst-flex-shrink-0" />
 				</p> }
 				{ isJetpackBoostActive && isJetpackBoostPremium && <p className="yst-flex yst-items-start yst-justify-between">
 					<span className="yst-text-slate-700 yst-font-medium">

--- a/src/integrations/admin/integrations-page.php
+++ b/src/integrations/admin/integrations-page.php
@@ -193,7 +193,7 @@ class Integrations_Page implements Integration_Interface {
 				'jetpack-boost_logo_link'            => WPSEO_Shortlinker::get( 'https://yoa.st/integrations-logo-jetpack-boost' ),
 				'jetpack-boost_get_link'             => WPSEO_Shortlinker::get( 'https://yoa.st/integrations-get-jetpack-boost?domain=' . $host ),
 				'jetpack-boost_upgrade_link'         => WPSEO_Shortlinker::get( 'https://yoa.st/integrations-upgrade-jetpack-boost?domain=' . $host ),
-				'jetpack-boost_learn_more_link'      => WPSEO_Shortlinker::get( 'https://yoa.st/integrations-about-jetpack-boost' ),
+				'jetpack-boost_learn_more_link'      => \admin_url( "admin.php?page=jetpack-boost" )
 			]
 		);
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Changes icon color and alignment, and  "Learn more" destination URL for the Jetpack Boost integration card.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install and activate Jetpack Boost, but don't set a premium subscription
* visit the integrations page and look at the Jetpack Boost card
* check that the :warning: icon is vertically centered to the two text lines 
* check that the color is `amber-500` (#f59e0b - rgb(245, 158, 11) ) instead of `orange-400` (#fb923c - rgb(251, 146, 60) )
* set up a premium subscription for Jetpack Boost and re-check the card
* check that the `Learn More` link opens (in a new tab) to `wp-admin/admin.php?page=jetpack-boost`

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #20034
