### PR TITLE
Google preview: fix breadcrumb duplicate slug when it includes encoded parts

### DIFF
--- a/packages/js/src/analysis/blockEditorData.js
+++ b/packages/js/src/analysis/blockEditorData.js
@@ -171,7 +171,11 @@ export default class BlockEditorData {
 
 		// When no custom slug is provided we should use the generated_slug attribute.
 		const slug = this.getPostAttribute( "slug" ) || generatedSlug;
-		return decodeURIComponent( slug );
+		try {
+			return decodeURI( slug );
+		} catch ( e ) {
+			return slug;
+		}
 	}
 
 	/**

--- a/packages/js/tests/blockEditorData.test.js
+++ b/packages/js/tests/blockEditorData.test.js
@@ -22,7 +22,8 @@ jest.mock( "@wordpress/data", () => {
 				getEditedPostAttribute: mockGetEditedPostAttribute,
 				getEditedPostContent: jest.fn().mockReturnValue( "" ),
 				getActiveMarker: () => null,
-				getPermalink: jest.fn().mockReturnValue( "https://www.yoast.com/" ),
+				getPermalinkParts: jest.fn().mockReturnValue( { prefix: "https://www.yoast.com/", postName: "", suffix: "/" } ),
+				isEditedPostNew: jest.fn().mockReturnValue( false ),
 			};
 		},
 		subscribe: () => {},


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Note that some things mentioned in the issue are already fixed in the meantime [20.4 RC] (hence the outdated issue)
  * https://github.com/Yoast/wordpress-seo/pull/20012
  * https://github.com/Yoast/wordpress-seo/pull/20031

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the Google preview would show a duplicate slug in the breadcrumbs when the slug included encoded characters.
* [@yoast/search-metadata-previews 0.1.0] Improves the parsing of the SnippetPreview's breadcrumbs.

## Relevant technical choices:

* Rewrote the breadcrumb handling in the SnippetPreview
  * Use the URL constructor instead of a deprecated `parse`
  * Decoding individual URL parts to try and decode as much as possible
  * Remove unneeded `replaceSpecialCharactersAndDiacritics` surrounding the url for the breadcrumbs, because nothing is highlighted in the breadcrumbs
* Replace the complex logic in the block editor data' `getPostBaseUrl`
  * Rely on WP selector `getPermalinkParts` to get rid of the `slug` within the URL
  * On initial load, this return `null`, use our (already existing) fallback at that time
  * For auto-draft posts the `?={ID}` part is included for some reason, get rid of that
* There is still plenty of room for improvement. For example, if we store the raw value, we might only decode when needed. However, that would require an overhaul I'm not prepared for

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Pages or CPTs
* Create a new page
* In the Google preview, enter `%21` as a slug (decoded as `!`)
* Verify that the slug
  * is not previewed twice in the Google preview breadcrumbs
  * is show as `!`
* Save the page (need to add some content or title, which might already trigger an autosave)
* Verify that
  * the breadcrumbs still look the same (before it would be `%21 › !`)
  * already the case, but notice that the slug input value changes to `!`
* Add `%21` to the slug
* Verify that
  * `%21` changes to `!` in the slug input
  * the breadcrumbs changes to `!-!` (before it would be `!%20%21 › !-!`)
* Note: not working is when the decoding breaks again, e.g. `%21%`. That will _not_ be shown `!%`.

#### Posts
* Create a new category with the slug `🙂`
* Change your site' permalink structure to be `/%category%/%postname%/`
* Create a new post
* Change the category to your new one with the slug `🙂`
* Save the post (only then will you get the actual breadcrumbs)
* Verify that the `🙂` in the breadcrumb is show as such (before it would be the encoded value)

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Google preview *and* the block editor

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [x] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes https://github.com/Yoast/wordpress-seo/issues/19907
