### PR TITLE
Fixes a bug where the previously used keyphrase analysis did not work in Elementor.

### DIFF
--- a/src/integrations/third-party/elementor.php
+++ b/src/integrations/third-party/elementor.php
@@ -449,7 +449,7 @@ class Elementor implements Integration_Interface {
 			],
 			'dismissedAlerts'          => $dismissed_alerts,
 			'webinarIntroElementorUrl' => WPSEO_Shortlinker::get( 'https://yoa.st/webinar-intro-elementor' ),
-			'usedKeywordsNonce'        => \wp_create_nonce( 'wpseo-keyword-usage' ),
+			'usedKeywordsNonce'        => \wp_create_nonce( 'wpseo-keyword-usage-and-post-types' ),
 		];
 
 		if ( \post_type_supports( $this->get_metabox_post()->post_type, 'thumbnail' ) ) {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Fixes a bug that was introduced in https://github.com/Yoast/wordpress-seo/pull/19800 . The previously used keyphrase would not work in Elementor. The source of the bug was that the previously used keyphrase analysis was initialized with the old ajax-action (`wpseo-keyword-usage`) instead of the new one (`wpseo-keyword-usage-and-post-types`).
* The old ajax-action is still used in some places of the code. Namely the code for the previously used keyphrase in taxonomies/terms. This analysis is broken and it was decided to solve this in a separate issue: https://github.com/Yoast/wordpress-seo/issues/19808

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the _previously used keyphrase analysis_ did not work in Elementor.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

Test instructions are copied and adapted from https://github.com/Yoast/wordpress-seo/pull/19800 

* Install and acticate YoastSEO Free
* Install and activate Elementor.
* NOTE: test with console open

##### Scenario 1: make sure that the previously used keyphrase works as expected in elementor.
* Create a **Page** in Elementor and give it a keyphrase that you do not have on your website yet. For example `guinea pig`.
* Make sure that the previously used keyphrase assessment gives a green bullet and the following feedback `Previously used keyphrase: You've not used this keyphrase before, very good.`
* Add a title and publish the post.

###### Scenario 1.1: kephrase used once before.
* Create a **Page** in Elementor and give it a different keyphrase than for the page above: for example `hamster`.
* Make sure that there is no console error like: `POST http://wordpress.test/wp-admin/admin-ajax.php 403 (Forbidden)`
* Make sure the previously used keyphrase analysis gives the following feedback: `Previously used keyphrase: You've not used this keyphrase before, very good.`
* Change the keyphrase to the same keyphrase as for the page created above. For example (`guinea pig`).
* Make sure that there is no console error like: `POST http://wordpress.test/wp-admin/admin-ajax.php 403 (Forbidden)`
* Make sure that the previously used keyphrase assessment gives an orange bullet and the following feedback `Previously used keyphrase: You've used this keyphrase once before. Do not use your keyphrase more than once.`
* Click the link at `once before`.
* Make sure that it opens a new tab with the page created above.
* Close this tab and go back to the Post
* Publish the post

###### Scenario 1.2: kepyhrase used twice before.
* Create a **Post**  and give it a keyphrase that was not used before. For example `
gerbil`.
* Make sure that there is no console error like: `POST http://wordpress.test/wp-admin/admin-ajax.php 403 (Forbidden)`
* Make sure the previously used keyphrase analysis gives the following feedback: `Previously used keyphrase: You've not used this keyphrase before, very good.`
* Change the keyphrase to the same keyphrase as for the page created above. For example (`guinea pig`).
* Make sure that there is no console error like: `POST http://wordpress.test/wp-admin/admin-ajax.php 403 (Forbidden)`
* Make sure that the previously used keyphrase assessment gives a red bullet and the following feedback `Previously used keyphrase: You've used this keyphrase multiple times before. Do not use your keyphrase more than once.`
* Click the link at `multiple times before`.
* Make sure this opens a new tab with a list of the Pages created above.

##### Scenario 2: Smoke test other editors.
This PR should not affect other editors. But repeat scenario 1 for classic editor and block editor to be sure.


#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [x] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* This PR should only affect previously used keyphrase assessment in Elementor. I added tests for other editors to be 100% sure.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #https://github.com/Yoast/wordpress-seo/issues/20038
