### PR TITLE
Jetpack boost ad tweaking

### DIFF
--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -926,6 +926,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 			'webinarIntroBlockEditorUrl' => WPSEO_Shortlinker::get( 'https://yoa.st/webinar-intro-block-editor' ),
 			'isJetpackBoostActive'       => ( $is_block_editor ) ? YoastSEO()->classes->get( Jetpack_Boost_Active_Conditional::class )->is_met() : false,
 			'isJetpackBoostNotPremium'   => ( $is_block_editor ) ? YoastSEO()->classes->get( Jetpack_Boost_Not_Premium_Conditional::class )->is_met() : false,
+			'canShowJetpackBoostAd'      => $this->checkJetpackBoostAdDate(),
 		];
 
 		if ( post_type_supports( get_post_type(), 'thumbnail' ) ) {
@@ -1152,6 +1153,23 @@ class WPSEO_Metabox extends WPSEO_Meta {
 		}
 
 		return $custom_replace_vars;
+	}
+
+	/**
+	 * Checks if we're past the date set for the Jetpack Boost ad.
+	 *
+	 * @return bool Whether the Jetpack Boost ad must be shown.
+	 */
+	private function checkJetpackBoostAdDate() {
+		$now = new DateTime("now");
+		$jetpack_boost_ad_date_string = WPSEO_Options::get( 'jetpack_ad_start_date' );
+		$jetpack_boost_ad_date = new DateTime( $jetpack_boost_ad_date_string );
+
+		if ( $now > $jetpack_boost_ad_date ) {
+			return true;
+		}
+
+		return false;
 	}
 
 	/**

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -1161,9 +1161,9 @@ class WPSEO_Metabox extends WPSEO_Meta {
 	 * @return bool Whether the Jetpack Boost ad must be shown.
 	 */
 	private function checkJetpackBoostAdDate() {
-		$now                          = new DateTime( 'now' );
-		$jetpack_boost_ad_date_string = WPSEO_Options::get( 'jetpack_ad_start_date' );
-		$jetpack_boost_ad_date        = new DateTime( $jetpack_boost_ad_date_string );
+		$now                          = new DateTime( 'now', new DateTimeZone( 'UTC' ) );
+		$jetpack_boost_ad_date_string = WPSEO_Options::get( 'jetpack_ad_start_date', '1970-01-01 00:00:00' );
+		$jetpack_boost_ad_date        = new DateTime( $jetpack_boost_ad_date_string, new DateTimeZone( 'UTC' ) );
 
 		if ( $now > $jetpack_boost_ad_date ) {
 			return true;

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -1161,9 +1161,9 @@ class WPSEO_Metabox extends WPSEO_Meta {
 	 * @return bool Whether the Jetpack Boost ad must be shown.
 	 */
 	private function checkJetpackBoostAdDate() {
-		$now = new DateTime("now");
+		$now                          = new DateTime( 'now' );
 		$jetpack_boost_ad_date_string = WPSEO_Options::get( 'jetpack_ad_start_date' );
-		$jetpack_boost_ad_date = new DateTime( $jetpack_boost_ad_date_string );
+		$jetpack_boost_ad_date        = new DateTime( $jetpack_boost_ad_date_string );
 
 		if ( $now > $jetpack_boost_ad_date ) {
 			return true;

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -1165,11 +1165,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 		$jetpack_boost_ad_date_string = WPSEO_Options::get( 'jetpack_ad_start_date', '1970-01-01 00:00:00' );
 		$jetpack_boost_ad_date        = new DateTime( $jetpack_boost_ad_date_string, new DateTimeZone( 'UTC' ) );
 
-		if ( $now > $jetpack_boost_ad_date ) {
-			return true;
-		}
-
-		return false;
+		return $now > $jetpack_boost_ad_date;
 	}
 
 	/**

--- a/admin/tracking/class-tracking-settings-data.php
+++ b/admin/tracking/class-tracking-settings-data.php
@@ -222,6 +222,7 @@ class WPSEO_Tracking_Settings_Data implements WPSEO_Collection {
 		'indexables_overview_state',
 		'deny_search_crawling',
 		'deny_wp_json_crawling',
+		'jetpack_ad_start_date',
 	];
 
 	/**

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -984,21 +984,26 @@ class WPSEO_Upgrade {
 		}
 	}
 
+	/**
+	 * Performs the 20.4 upgrade routine.
+	 * The routine initializes the jetpack_ad_start_date option to a random date between 1 and MAX_DELAY_IN_DAYS.
+	 * This option will then be used to determine when the Jetpack Ad should be shown.
+	 */
 	private function upgrade_204() {
-		define( "MAX_DELAY_IN_DAYS", 12) ;
-		$now = new DateTime('now', new DateTimeZone('Europe/Amsterdam'));
+		define( 'MAX_DELAY_IN_DAYS', 12 );
+		$now = new DateTime( 'now', new DateTimeZone( 'Europe/Amsterdam' ) );
 
-		if ( \function_exists( 'random_int') ) {
-			$days = \random_int(1, MAX_DELAY_IN_DAYS);
+		if ( \function_exists( 'random_int' ) ) {
+			$days = \random_int( 1, MAX_DELAY_IN_DAYS );
 		}
 		// Needed to support PHP 5.6.
 		else {
-			$days = \rand(1, MAX_DELAY_IN_DAYS);
+			$days = \rand( 1, MAX_DELAY_IN_DAYS );
 		}
-		$interval = DateInterval::createFromDateString("$days days");
-		
-		$start_date = date_add($now,$interval);
-		WPSEO_Options::set( 'jetpack_ad_start_date', $start_date->format('Y-m-d H:i:s'));
+		$interval = DateInterval::createFromDateString( "$days days" );
+
+		$start_date = date_add( $now, $interval );
+		WPSEO_Options::set( 'jetpack_ad_start_date', $start_date->format( 'Y-m-d H:i:s' ) );
 	}
 
 	/**

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -990,19 +990,19 @@ class WPSEO_Upgrade {
 	 * This option will then be used to determine when the Jetpack Ad should be shown.
 	 */
 	private function upgrade_204() {
-		define( 'MAX_DELAY_IN_DAYS', 12 );
-		$now = new DateTime( 'now', new \DateTimeZone( 'Europe/Amsterdam' ) );
+		$max_delay_in_days = 12;
+		$now               = new DateTime( 'now', new DateTimeZone( 'UTC' ) );
 
-		if ( \function_exists( 'random_int' ) ) {
-			$days = \random_int( 1, MAX_DELAY_IN_DAYS );
+		if ( function_exists( 'random_int' ) ) {
+			$days = random_int( 1, $max_delay_in_days );
 		}
 		// Needed to support PHP 5.6.
 		else {
-			$days = \wp_rand( 1, MAX_DELAY_IN_DAYS );
+			$days = wp_rand( 1, $max_delay_in_days );
 		}
-		$interval = \DateInterval::createFromDateString( "$days days" );
+		$interval = DateInterval::createFromDateString( "$days days" );
 
-		$start_date = \date_add( $now, $interval );
+		$start_date = date_add( $now, $interval );
 		WPSEO_Options::set( 'jetpack_ad_start_date', $start_date->format( 'Y-m-d H:i:s' ) );
 	}
 

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -998,7 +998,7 @@ class WPSEO_Upgrade {
 		}
 		// Needed to support PHP 5.6.
 		else {
-			$days = \rand( 1, MAX_DELAY_IN_DAYS );
+			$days = \wp_rand( 1, MAX_DELAY_IN_DAYS );
 		}
 		$interval = \DateInterval::createFromDateString( "$days days" );
 

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -86,6 +86,7 @@ class WPSEO_Upgrade {
 			'19.6-RC0'   => 'upgrade_196',
 			'19.11-RC0'  => 'upgrade_1911',
 			'20.2-RC0'   => 'upgrade_202',
+			'20.4-RC0'   => 'upgrade_204',
 		];
 
 		array_walk( $routines, [ $this, 'run_upgrade_routine' ], $version );
@@ -981,6 +982,23 @@ class WPSEO_Upgrade {
 			// This schedules the cleanup routine cron again, since in combination of premium cleans up the prominent words table. We also want to cleanup possible orphaned hierarchies from the above cleanups.
 			\wp_schedule_single_event( ( time() + ( MINUTE_IN_SECONDS * 5 ) ), Cleanup_Integration::START_HOOK );
 		}
+	}
+
+	private function upgrade_204() {
+		define( "MAX_DELAY_IN_DAYS", 12) ;
+		$now = new DateTime('now', new DateTimeZone('Europe/Amsterdam'));
+
+		if ( \function_exists( 'random_int') ) {
+			$days = \random_int(1, MAX_DELAY_IN_DAYS);
+		}
+		// Needed to support PHP 5.6.
+		else {
+			$days = \rand(1, MAX_DELAY_IN_DAYS);
+		}
+		$interval = DateInterval::createFromDateString("$days days");
+		
+		$start_date = date_add($now,$interval);
+		WPSEO_Options::set( 'jetpack_ad_start_date', $start_date->format('Y-m-d H:i:s'));
 	}
 
 	/**

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -991,7 +991,7 @@ class WPSEO_Upgrade {
 	 */
 	private function upgrade_204() {
 		define( 'MAX_DELAY_IN_DAYS', 12 );
-		$now = new DateTime( 'now', new DateTimeZone( 'Europe/Amsterdam' ) );
+		$now = new DateTime( 'now', new \DateTimeZone( 'Europe/Amsterdam' ) );
 
 		if ( \function_exists( 'random_int' ) ) {
 			$days = \random_int( 1, MAX_DELAY_IN_DAYS );
@@ -1000,9 +1000,9 @@ class WPSEO_Upgrade {
 		else {
 			$days = \rand( 1, MAX_DELAY_IN_DAYS );
 		}
-		$interval = DateInterval::createFromDateString( "$days days" );
+		$interval = \DateInterval::createFromDateString( "$days days" );
 
-		$start_date = date_add( $now, $interval );
+		$start_date = \date_add( $now, $interval );
 		WPSEO_Options::set( 'jetpack_ad_start_date', $start_date->format( 'Y-m-d H:i:s' ) );
 	}
 

--- a/inc/options/class-wpseo-option-wpseo.php
+++ b/inc/options/class-wpseo-option-wpseo.php
@@ -135,6 +135,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 		'indexables_overview_state'                => 'dashboard-not-visited',
 		'last_known_public_post_types'             => [],
 		'last_known_public_taxonomies'             => [],
+		'jetpack_ad_start_date'                         => '', // Date.
 	];
 
 	/**
@@ -325,6 +326,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 				case 'clean_permalinks_extra_variables':
 				case 'indexables_overview_state':
 				case 'dismiss_old_premium_version_notice':
+				case 'jetpack_ad_start_date':
 					if ( isset( $dirty[ $key ] ) ) {
 						$clean[ $key ] = $dirty[ $key ];
 					}

--- a/inc/options/class-wpseo-option-wpseo.php
+++ b/inc/options/class-wpseo-option-wpseo.php
@@ -135,7 +135,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 		'indexables_overview_state'                => 'dashboard-not-visited',
 		'last_known_public_post_types'             => [],
 		'last_known_public_taxonomies'             => [],
-		'jetpack_ad_start_date'                    => '', // Date.
+		'jetpack_ad_start_date'                    => '1970-01-01 00:00:00', // Date.
 	];
 
 	/**
@@ -326,7 +326,6 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 				case 'clean_permalinks_extra_variables':
 				case 'indexables_overview_state':
 				case 'dismiss_old_premium_version_notice':
-				case 'jetpack_ad_start_date':
 					if ( isset( $dirty[ $key ] ) ) {
 						$clean[ $key ] = $dirty[ $key ];
 					}
@@ -451,6 +450,13 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 					// If the setting has changed, record it.
 					if ( $old[ $key ] !== $clean[ $key ] ) {
 						$clean['wordproof_integration_changed'] = true;
+					}
+					break;
+
+				// Date fields.
+				case 'jetpack_ad_start_date':
+					if ( isset( $dirty[ $key ] ) && WPSEO_Utils::is_valid_datetime( $dirty[ $key ] ) ) {
+						$clean[ $key ] = $dirty[ $key ];
 					}
 					break;
 

--- a/inc/options/class-wpseo-option-wpseo.php
+++ b/inc/options/class-wpseo-option-wpseo.php
@@ -135,7 +135,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 		'indexables_overview_state'                => 'dashboard-not-visited',
 		'last_known_public_post_types'             => [],
 		'last_known_public_taxonomies'             => [],
-		'jetpack_ad_start_date'                         => '', // Date.
+		'jetpack_ad_start_date'                    => '', // Date.
 	];
 
 	/**

--- a/packages/js/src/components/JetpackBoost.js
+++ b/packages/js/src/components/JetpackBoost.js
@@ -28,20 +28,22 @@ const getDescription = ( isJetpackBoostActive ) => {
 	);
 };
 
-
+/* eslint-disable complexity */
 /**
  * @param {string} store The redux store key.
  * @param {boolean} isAlertDismissed Whether the "alert" is dismissed.
  * @param {function} onDismissed Function that will dismiss the "alert".
  * @returns {JSX.Element} The JetpackBoost element (which is null when dismissed).
- */
+*/
 const JetpackBoost = ( { store, isAlertDismissed, onDismissed } ) => {
 	const isJetpackBoostActive = get( window, "wpseoScriptData.isJetpackBoostActive", "" ) === "1";
 	const isJetpackBoostNotPremium = get( window, "wpseoScriptData.isJetpackBoostNotPremium", "" ) === "1";
 	const getJetpackBoostPrePublishLink = get( window, "wpseoScriptData.metabox.getJetpackBoostPrePublishLink", "" );
 	const upgradeJetpackBoostPrePublishLink = get( window, "wpseoScriptData.metabox.upgradeJetpackBoostPrePublishLink", "" );
+	const showJetpackBoostAd = get( window, "wpseoScriptData.canShowJetpackBoostAd", false );
+
 	const isPremium = useSelect( select => select( store ).getIsPremium() );
-	if ( isPremium || isAlertDismissed || ! isJetpackBoostNotPremium ) {
+	if ( ! showJetpackBoostAd || isPremium || isAlertDismissed || ! isJetpackBoostNotPremium ) {
 		return null;
 	}
 
@@ -93,6 +95,7 @@ const JetpackBoost = ( { store, isAlertDismissed, onDismissed } ) => {
 		</PluginPrePublishPanel>
 	);
 };
+/* eslint-enable complexity */
 
 JetpackBoost.propTypes = {
 	store: PropTypes.string,

--- a/packages/js/src/initializers/block-editor-integration.js
+++ b/packages/js/src/initializers/block-editor-integration.js
@@ -114,8 +114,6 @@ function registerFills( store ) {
 	const blockSidebarContext = { locationContext: "block-sidebar" };
 	const blockMetaboxContext = { locationContext: "block-metabox" };
 
-	const showJetpackBoostAd = get( window, "wpseoScriptData.canShowJetpackBoostAd", false );
-
 	/**
 	 * Renders the yoast editor fills.
 	 *
@@ -151,7 +149,7 @@ function registerFills( store ) {
 			>
 				<PrePublish />
 			</PluginPrePublishPanel> }
-			{ showJetpackBoostAd && <JetpackBoost alertKey="get-jetpack-boost-pre-publish-notification" /> }
+			<JetpackBoost alertKey="get-jetpack-boost-pre-publish-notification" />
 			<PluginPostPublishPanel
 				className="yoast-seo-sidebar-panel"
 				title={ __( "Yoast SEO", "wordpress-seo" ) }

--- a/packages/js/src/initializers/block-editor-integration.js
+++ b/packages/js/src/initializers/block-editor-integration.js
@@ -114,6 +114,8 @@ function registerFills( store ) {
 	const blockSidebarContext = { locationContext: "block-sidebar" };
 	const blockMetaboxContext = { locationContext: "block-metabox" };
 
+	const showJetpackBoostAd = get( window, "wpseoScriptData.canShowJetpackBoostAd", false );
+
 	/**
 	 * Renders the yoast editor fills.
 	 *
@@ -149,7 +151,7 @@ function registerFills( store ) {
 			>
 				<PrePublish />
 			</PluginPrePublishPanel> }
-			<JetpackBoost alertKey="get-jetpack-boost-pre-publish-notification" />
+			{ showJetpackBoostAd && <JetpackBoost alertKey="get-jetpack-boost-pre-publish-notification" /> }
 			<PluginPostPublishPanel
 				className="yoast-seo-sidebar-panel"
 				title={ __( "Yoast SEO", "wordpress-seo" ) }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Jetpack boost ad tweaking

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Changes the non released Jetpack boost ad.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

*

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes https://github.com/Yoast/wordpress-seo/issues/20035
