### PR TITLE
Improve webinar registration button in ftc

### DIFF
--- a/admin/class-config.php
+++ b/admin/class-config.php
@@ -158,7 +158,7 @@ class WPSEO_Admin_Pages {
 		if ( YoastSEO()->helpers->product->is_premium() ) {
 			return WPSEO_Shortlinker::get( 'https://yoa.st/webinar-intro-first-time-config-premium' );
 		}
-		
+
 		return WPSEO_Shortlinker::get( 'https://yoa.st/webinar-intro-first-time-config' );
 	}
 }

--- a/admin/class-config.php
+++ b/admin/class-config.php
@@ -87,7 +87,7 @@ class WPSEO_Admin_Pages {
 			'isRtl'                          => is_rtl(),
 			'isPremium'                      => YoastSEO()->helpers->product->is_premium(),
 			'webinarIntroSettingsUrl'        => WPSEO_Shortlinker::get( 'https://yoa.st/webinar-intro-settings' ),
-			'webinarIntroFirstTimeConfigUrl' => WPSEO_Shortlinker::get( 'https://yoa.st/webinar-intro-first-time-config' ),
+			'webinarIntroFirstTimeConfigUrl' => $this->get_webinar_shortlink(),
 		];
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Reason: We are not processing form information.
@@ -149,5 +149,16 @@ class WPSEO_Admin_Pages {
 		if ( $tool === 'bulk-editor' ) {
 			$this->asset_manager->enqueue_script( 'bulk-editor' );
 		}
+	}
+
+	/**
+	 * Returns the appropriate shortlink for the Webinar.
+	 */
+	private function get_webinar_shortlink() {
+		if ( YoastSEO()->helpers->product->is_premium() ) {
+			return WPSEO_Shortlinker::get( 'https://yoa.st/webinar-intro-first-time-config-premium' );
+		}
+		
+		return WPSEO_Shortlinker::get( 'https://yoa.st/webinar-intro-first-time-config' );
 	}
 }

--- a/admin/class-config.php
+++ b/admin/class-config.php
@@ -153,6 +153,8 @@ class WPSEO_Admin_Pages {
 
 	/**
 	 * Returns the appropriate shortlink for the Webinar.
+	 *
+	 * @return string The shortlink for the Webinar.
 	 */
 	private function get_webinar_shortlink() {
 		if ( YoastSEO()->helpers->product->is_premium() ) {

--- a/packages/js/src/first-time-configuration/first-time-configuration-steps.js
+++ b/packages/js/src/first-time-configuration/first-time-configuration-steps.js
@@ -460,7 +460,7 @@ export default function FirstTimeConfigurationSteps() {
 	}, [ beforeUnloadEventHandler ] );
 
 	return (
-		<div id="yoast-configuration" className="yst-max-w-[715px] yst-mt-6 yst-p-8 yst-rounded-lg yst-bg-white yst-shadow yst-text-slate-500">
+		<div id="yoast-configuration" className="yst-max-w-[715px] yst-mt-6 yst-p-8 yst-rounded-lg yst-bg-white yst-shadow yst-text-slate-600">
 			<h2 id="yoast-configuration-title" className="yst-text-lg yst-text-primary-500 yst-font-medium">{ __( "Tell us about your site, so we can get your site ranked!", "wordpress-seo" ) }</h2>
 			<p className="yst-py-2">
 				{

--- a/packages/js/src/first-time-configuration/tailwind-components/base/image-select.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/base/image-select.js
@@ -59,7 +59,7 @@ export default function ImageSelect( {
 			return <img src={ fallbackUrl } alt={ imageAltText } className="yst-w-full yst-h-full yst-object-contain" />;
 		}
 
-		return <PhotographIcon id={ `${ id }-no-image-svg` } className="yst-w-14 yst-h-14 yst-text-slate-500" />;
+		return <PhotographIcon id={ `${ id }-no-image-svg` } className="yst-w-14 yst-h-14 yst-text-slate-600" />;
 	}, [ status, id, url, imageAltText ] );
 
 	return (

--- a/packages/js/src/first-time-configuration/tailwind-components/base/image-select.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/base/image-select.js
@@ -59,7 +59,7 @@ export default function ImageSelect( {
 			return <img src={ fallbackUrl } alt={ imageAltText } className="yst-w-full yst-h-full yst-object-contain" />;
 		}
 
-		return <PhotographIcon id={ `${ id }-no-image-svg` } className="yst-w-14 yst-h-14 yst-text-slate-600" />;
+		return <PhotographIcon id={ `${ id }-no-image-svg` } className="yst-w-14 yst-h-14 yst-text-slate-500" />;
 	}, [ status, id, url, imageAltText ] );
 
 	return (

--- a/packages/js/src/first-time-configuration/tailwind-components/step-header.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/step-header.js
@@ -19,7 +19,7 @@ function getNameClassNames( isFinished, isActiveStep, isLastStep ) {
 	if ( isActiveStep && ! isLastStep ) {
 		return "yst-text-primary-500";
 	}
-	return isFinished ? "yst-text-slate-900" : "yst-text-slate-500";
+	return isFinished ? "yst-text-slate-900" : "yst-text-slate-600";
 }
 
 /* eslint-disable complexity */
@@ -69,7 +69,7 @@ export default function StepHeader( { name, description, isFinished, children } 
 			<span className={ `yst-transition-colors yst-duration-500 yst-text-xs yst-font-[650] yst-tracking-wide yst-uppercase ${ nameClassNames }` }>
 				{ name }
 			</span>
-			{ description && <span className="yst-text-sm yst-text-slate-500">{ description }</span> }
+			{ description && <span className="yst-text-sm yst-text-slate-600">{ description }</span> }
 		</span>
 		{ children }
 	</div>;

--- a/packages/js/src/first-time-configuration/tailwind-components/steps/finish/finish-step.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/steps/finish/finish-step.js
@@ -1,7 +1,8 @@
-import { useSelect } from "@wordpress/data";
+import { ArrowNarrowRightIcon } from "@heroicons/react/outline";
 import { __ } from "@wordpress/i18n";
 import { get } from "lodash";
 import { ReactComponent as ConfigurationFinishImage } from "../../../../../images/indexables_2_left_bubble_optm.svg";
+import { Button, Link } from "@yoast/ui-library";
 
 /**
  * Goes to the Dashboard tab by clicking the tab button.
@@ -13,61 +14,40 @@ function goToSEODashboard() {
 }
 
 /**
- * @returns {WPElement} The regular content.
- */
-function regularContent() {
-	return (
-		<>
-			<p className="yst-text-sm yst-mb-6">{ __( "That’s it! By providing this information our indexables squad has been able to do a lot of optimization for your site already. Now, let's have a look at the SEO fitness of your site!", "wordpress-seo" ) }</p>
-			<button
-				type="button"
-				id="button-seo-dashboard"
-				onClick={ goToSEODashboard }
-				className={ "yst-button yst-button--primary" }
-			>{ __( "Go to your SEO dashboard", "wordpress-seo" ) }</button>
-		</>
-	);
-}
-
-/**
- * @returns {WPElement} The webinar promo content.
- */
-function webinarPromoContent() {
-	const webinarIntroFirstTimeConfigUrl = get( window, "wpseoScriptData.webinarIntroFirstTimeConfigUrl", "https://yoa.st/webinar-intro-first-time-config" );
-
-	return (
-		<>
-			<p className="yst-text-sm yst-mb-4">
-				{ __( "That's it! By providing this information our Indexables squad has been able to do a lot of optimization for your site already.", "wordpress-seo" ) }
-			</p>
-			<p className="yst-text-sm yst-mb-6">
-				{ __( "Want to optimize even further and get the most out of Yoast SEO? Make sure you don't miss our free weekly webinar!", "wordpress-seo" ) }
-			</p>
-			<a href={ webinarIntroFirstTimeConfigUrl } id="link-webinar-register" target="_blank" className="yst-button yst-button--primary yst-text-white" rel="noreferrer">
-				{ __( "Register now!", "wordpress-seo" ) }
-			</a>
-			<button
-				type="button"
-				id="button-webinar-seo-dashboard"
-				onClick={ goToSEODashboard }
-				className={ "yst-ml-4 yst-text-indigo-600 hover:yst-text-indigo-500" }
-			>{ __( "Or visit your SEO dashboard", "wordpress-seo" ) }</button>
-		</>
-	);
-}
-
-/**
  * The last step of the Stepper: the Finish step.
  *
  * @returns {WPElement} The Finish step.
  */
 export default function FinishStep() {
-	const isPremium = useSelect( select => select( "yoast-seo/settings" ).getIsPremium() );
+	const webinarIntroFirstTimeConfigUrl = get( window, "wpseoScriptData.webinarIntroFirstTimeConfigUrl", "https://yoa.st/webinar-intro-first-time-config" );
 
 	return (
 		<div className="yst-flex yst-flex-row yst-justify-between yst-items-center yst--mt-4">
 			<div className="yst-mr-6">
-				{ isPremium ? regularContent() : webinarPromoContent() }
+				<p className="yst-text-sm yst-mb-4">
+					{ __( "That's it! By providing this information, our Indexables squad has been able to do a lot of optimization for your site already. But there's more to do!", "wordpress-seo" ) }
+				</p>
+				<p className="yst-text-sm yst-mb-6">
+					{ __( "Learn how to get the most out of Yoast SEO in an easy-to-follow video, ask questions in the live Q&A with our experts, or sign up for Yoast Academy for free to take control of your SEO!", "wordpress-seo" ) }
+				</p>
+				<Button
+					as="a"
+					id="link-webinar-register"
+					href={ webinarIntroFirstTimeConfigUrl }
+					target="_blank"
+				>
+					{ __( "Learn how to get the most out of Yoast SEO!", "wordpress-seo" ) }
+					<ArrowNarrowRightIcon className="yst-w-4 yst-h-4 yst-icon-rtl yst-ml-2" />
+				</Button>
+				<p className="yst-mt-4">
+					<Link
+						as="button"
+						id="button-webinar-seo-dashboard"
+						onClick={ goToSEODashboard }
+					>
+						{ __( "Or go to your SEO dashboard", "wordpress-seo" ) }
+					</Link>
+				</p>
 			</div>
 			<ConfigurationFinishImage className="yst-shrink-0 yst-h-28" />
 		</div>

--- a/packages/js/src/first-time-configuration/tailwind-components/steps/finish/finish-step.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/steps/finish/finish-step.js
@@ -48,7 +48,7 @@ export default function FinishStep() {
 					</Link>
 				</p>
 			</div>
-			<ConfigurationFinishImage className="yst-shrink-0 yst-h-28 yst-ml-9" />
+			<ConfigurationFinishImage className="yst-shrink-0 yst-h-28 yst-mb-24" />
 		</div>
 	);
 }

--- a/packages/js/src/first-time-configuration/tailwind-components/steps/finish/finish-step.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/steps/finish/finish-step.js
@@ -32,7 +32,7 @@ export default function FinishStep() {
 				</p>
 				<Button
 					as="a"
-					id="link-webinar-register"
+					id="button-webinar-seo-dashboard"
 					href={ webinarIntroFirstTimeConfigUrl }
 					target="_blank"
 				>
@@ -41,15 +41,14 @@ export default function FinishStep() {
 				</Button>
 				<p className="yst-mt-4">
 					<Link
-						as="button"
-						id="button-webinar-seo-dashboard"
+						id="link-webinar-register"
 						onClick={ goToSEODashboard }
 					>
 						{ __( "Or go to your SEO dashboard", "wordpress-seo" ) }
 					</Link>
 				</p>
 			</div>
-			<ConfigurationFinishImage className="yst-shrink-0 yst-h-28" />
+			<ConfigurationFinishImage className="yst-shrink-0 yst-h-28 yst-ml-9" />
 		</div>
 	);
 }

--- a/packages/js/src/first-time-configuration/tailwind-components/steps/personal-preferences/newsletter-signup.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/steps/personal-preferences/newsletter-signup.js
@@ -127,7 +127,7 @@ export function NewsletterSignup( { gdprLink } ) {
 					{ __( "Sign up!", "wordpress-seo" ) }
 				</button>
 			</div>
-			<p className="yst-text-slate-500 yst-text-xxs yst-leading-4">
+			<p className="yst-text-slate-600 yst-text-xxs yst-leading-4">
 				{
 					addLinkToString(
 						sprintf(

--- a/packages/js/src/first-time-configuration/tailwind-components/tailwind-modal.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/tailwind-modal.js
@@ -53,7 +53,7 @@ export default function TailwindModal( { isOpen, handleClose, hasCloseButton, ch
 								<button
 									type="button"
 									onClick={ handleClose }
-									className="yst-bg-white yst-rounded-md yst-text-slate-400 hover:yst-text-slate-500 focus:yst-outline-none focus:yst-ring-2 focus:yst-ring-offset-2 focus:yst-ring-primary-500"
+									className="yst-bg-white yst-rounded-md yst-text-slate-400 hover:yst-text-slate-600 focus:yst-outline-none focus:yst-ring-2 focus:yst-ring-offset-2 focus:yst-ring-primary-500"
 								>
 									<span className="yst-sr-only">{ __( "Close", "admin-ui" ) }</span>
 									<XIcon className="yst-h-6 yst-w-6" />


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to change the last step of the `First-time configuration` to make more clear the flow from it to the free webinar page.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Changes the last step of the `First-time configuration` to highlight the free webinar availability.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Deactivate Yoast SEO Premium if you have it activated
* Go to `Yoast SEO` -> `General` -> `First-time configuration` tab
* Finish the `First-time configuration` and verify:
  * the step looks as follows 
<img width="1550" alt="Screenshot 2023-03-24 at 10 03 13" src="https://user-images.githubusercontent.com/68744851/227473783-3b27b61c-23d4-46ed-807a-5163d4422b25.png">

  * the `Learn how to get the most out of Yoast SEO!` button has the following shortlink: `https://yoa.st/webinar-intro-first-time-config`
  * the link above has the query vars added
* Click on `Or go to your SEO dashboard` and verify you switch to the `Dashboard` tab
* Activate Yoast SEO Premium
* Go back to  Go to `Yoast SEO` -> `General` -> `First-time configuration` tab
* Go to the next step and verify that:
  * the step content is the same as before 
  * the `Learn how to get the most out of Yoast SEO!` button now has the following shortlink: `https://yoa.st/webinar-intro-first-time-config-premium`
* Finally, check that the content of each step gets the `yst-text-slate-600` class and not `yst-text-slate-500` (only placeholder values must use `yst-text-slate-500`). Look [here](https://tailwindcss.com/docs/background-color) for the exact color/values

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* N/A

## UI changes

* [X] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes https://github.com/Yoast/growth/issues/12
