### PR TITLE
HTML parser - Don't tokenize elements that should always be filtered out

### DIFF
--- a/packages/yoastseo/spec/parse/build/buildSpec.js
+++ b/packages/yoastseo/spec/parse/build/buildSpec.js
@@ -427,4 +427,57 @@ describe( "The parse function", () => {
 			],
 		} );
 	} );
+	it( "parses a basic HTML text and filters out an elements that should be filtered out", () => {
+		const html = "<div class='wp-block-yoast-seo-table-of-contents yoast-table-of-contents'>Hey, this is a table of contents.</div><div><p class='yoast'>Hello, world!<script>console.log(\"Hello, world!\")</script></p></div>";
+
+		const researcher = Factory.buildMockResearcher( {}, true, false, false,
+			{ memoizedTokenizer: memoizedSentenceTokenizer } );
+		const languageProcessor = new LanguageProcessor( researcher );
+
+		expect( build( html, languageProcessor ) ).toEqual( {
+			name: "#document-fragment",
+			attributes: {},
+			childNodes: [ {
+				name: "div",
+				sourceCodeLocation: {
+					startOffset: 113,
+					endOffset: 203,
+					startTag: {
+						startOffset: 113,
+						endOffset: 118,
+					},
+					endTag: {
+						startOffset: 197,
+						endOffset: 203,
+					},
+				},
+				attributes: {},
+				childNodes: [ {
+					name: "p",
+					isImplicit: false,
+					attributes: {
+						"class": new Set( [ "yoast" ] ),
+					},
+					sentences: [ { text: "Hello, world!", tokens: [] } ],
+					childNodes: [ {
+						name: "#text",
+						value: "Hello, world!",
+					} ],
+					sourceCodeLocation: {
+						startOffset: 118,
+						endOffset: 197,
+						startTag: {
+							startOffset: 118,
+							endOffset: 135,
+						},
+						endTag: {
+							startOffset: 193,
+							endOffset: 197,
+						},
+					},
+				} ],
+			} ],
+		} );
+	} );
+
 } );

--- a/packages/yoastseo/spec/parse/build/buildSpec.js
+++ b/packages/yoastseo/spec/parse/build/buildSpec.js
@@ -427,7 +427,7 @@ describe( "The parse function", () => {
 			],
 		} );
 	} );
-	it( "parses a basic HTML text and filters out an elements that should be filtered out", () => {
+	it( "parses a basic HTML text and filters out elements that should be filtered out", () => {
 		const html = "<div class='wp-block-yoast-seo-table-of-contents yoast-table-of-contents'>Hey, this is a table of contents.</div><div><p class='yoast'>Hello, world!<script>console.log(\"Hello, world!\")</script></p></div>";
 
 		const researcher = Factory.buildMockResearcher( {}, true, false, false,
@@ -479,5 +479,4 @@ describe( "The parse function", () => {
 			} ],
 		} );
 	} );
-
 } );

--- a/packages/yoastseo/spec/parse/build/private/filterTreeSpec.js
+++ b/packages/yoastseo/spec/parse/build/private/filterTreeSpec.js
@@ -1,24 +1,15 @@
+// External dependencies.
+import { parseFragment } from "parse5";
+// Internal dependencies.
 import filterTree from "../../../../src/parse/build/private/filterTree";
-import build from "../../../../src/parse/build/build";
-import LanguageProcessor from "../../../../src/parse/language/LanguageProcessor";
-import Factory from "../../../specHelpers/factory";
+import adapt from "../../../../src/parse/build/private/adapt";
 import permanentFilters from "../../../../src/parse/build/private/alwaysFilterElements";
-import memoizedSentenceTokenizer from "../../../../src/languageProcessing/helpers/sentence/memoizedSentenceTokenizer";
-
 
 describe( "A test for filterTree", () => {
-	let languageProcessor;
-
-	beforeEach( () => {
-		const researcher = Factory.buildMockResearcher( {}, true, false, false,
-			{ memoizedTokenizer: memoizedSentenceTokenizer } );
-		languageProcessor = new LanguageProcessor( researcher );
-	} );
-
 	it( "should filter script elements", () => {
 		const html = "<script>console.log(\"Hello, world!\")</script><div>A div</div>";
 
-		const tree = build( html, languageProcessor );
+		const tree = adapt( parseFragment( html, { sourceCodeLocationInfo: true } ) );
 		expect( tree.findAll( child => child.name === "script" ) ).toHaveLength( 1 );
 		const filteredTree = filterTree( tree, permanentFilters );
 		expect( filteredTree.findAll( child => child.name === "script" ) ).toHaveLength( 0 );
@@ -27,7 +18,7 @@ describe( "A test for filterTree", () => {
 	it( "should filter style elements", () => {
 		const html = "<style>div { color: #FF00FF}</style><div>A div</div>";
 
-		const tree = build( html, languageProcessor );
+		const tree = adapt( parseFragment( html, { sourceCodeLocationInfo: true } ) );
 		expect( tree.findAll( child => child.name === "style" ) ).toHaveLength( 1 );
 		const filteredTree = filterTree( tree, permanentFilters );
 		expect( filteredTree.findAll( child => child.name === "style" ) ).toHaveLength( 0 );
@@ -39,7 +30,7 @@ describe( "A test for filterTree", () => {
 			"WWF works in 100 countries and is supported by 1.2 million members in the United States and close to 5 million globally.\n" +
 			"</blockquote><div>A div</div>";
 
-		const tree = build( html, languageProcessor );
+		const tree = adapt( parseFragment( html, { sourceCodeLocationInfo: true } ) );
 		expect( tree.findAll( child => child.name === "blockquote" ) ).toHaveLength( 1 );
 		const filteredTree = filterTree( tree, permanentFilters );
 		expect( filteredTree.findAll( child => child.name === "blockquote" ) ).toHaveLength( 0 );
@@ -49,7 +40,7 @@ describe( "A test for filterTree", () => {
 		const html = "<div class='wp-block-yoast-seo-table-of-contents yoast-table-of-contents'>Hey, this is a table of contents.</div>" +
 			"<div>A div</div>";
 
-		const tree = build( html, languageProcessor );
+		const tree = adapt( parseFragment( html, { sourceCodeLocationInfo: true } ) );
 		const filteredTree = filterTree( tree, permanentFilters );
 
 		expect( filteredTree ).toEqual( {
@@ -68,7 +59,6 @@ describe( "A test for filterTree", () => {
 							value: "A div",
 						},
 					],
-					sentences: [ { text: "A div", tokens: [] } ],
 					sourceCodeLocation: {
 						startOffset: 118,
 						endOffset: 123,
@@ -94,7 +84,7 @@ describe( "A test for filterTree", () => {
 		const html = "<p class='yoast-reading-time__wrapper'></p>" +
 			"<div>A div</div>";
 
-		const tree = build( html, languageProcessor );
+		const tree = adapt( parseFragment( html, { sourceCodeLocationInfo: true } ) );
 		const filteredTree = filterTree( tree, permanentFilters );
 
 		expect( filteredTree ).toEqual( {
@@ -113,7 +103,6 @@ describe( "A test for filterTree", () => {
 							value: "A div",
 						},
 					],
-					sentences: [ { text: "A div", tokens: [] } ],
 					sourceCodeLocation: {
 						startOffset: 48,
 						endOffset: 53,
@@ -139,7 +128,7 @@ describe( "A test for filterTree", () => {
 		const html = "<div class=\"yoast-breadcrumbs\"><span><span><a href=\"http://wordpress.test/\">Home</a></span></span></div>" +
 			"<div>Hello world!</div>";
 
-		const tree = build( html, languageProcessor );
+		const tree = adapt( parseFragment( html, { sourceCodeLocationInfo: true } ) );
 		const filteredTree = filterTree( tree, permanentFilters );
 
 		expect( filteredTree ).toEqual( {
@@ -159,7 +148,6 @@ describe( "A test for filterTree", () => {
 								value: "Hello world!",
 							},
 						],
-						sentences: [ { text: "Hello world!", tokens: [] } ],
 						sourceCodeLocation: {
 							startOffset: 109,
 							endOffset: 121,
@@ -185,7 +173,7 @@ describe( "A test for filterTree", () => {
 	it( "should correctly filter when a custom filter is provided.", function() {
 		const html = "<div data-test='blah'></div><div>Hello world!</div>";
 
-		const tree = build( html, languageProcessor );
+		const tree = adapt( parseFragment( html, { sourceCodeLocationInfo: true } ) );
 		const filteredTree = filterTree( tree, [ ( elem ) => {
 			return elem.name === "div" && elem.attributes[ "data-test" ] && elem.attributes[ "data-test" ] === "blah";
 		} ] );
@@ -207,7 +195,6 @@ describe( "A test for filterTree", () => {
 								value: "Hello world!",
 							},
 						],
-						sentences: [ { text: "Hello world!", tokens: [] } ],
 						sourceCodeLocation: {
 							startOffset: 33,
 							endOffset: 45,

--- a/packages/yoastseo/src/parse/build/build.js
+++ b/packages/yoastseo/src/parse/build/build.js
@@ -3,6 +3,8 @@ import { parseFragment } from "parse5";
 // Internal dependencies.
 import adapt from "./private/adapt";
 import tokenize from "./private/tokenize";
+import filterTree from "./private/filterTree";
+import permanentFilters from "./private/alwaysFilterElements";
 
 /**
  * Parses the HTML string to a tree representation of
@@ -14,6 +16,7 @@ import tokenize from "./private/tokenize";
  * @returns {Node} The tree representation of the HTML string.
  */
 export default function build( htmlString, languageProcessor ) {
-	const tree = adapt( parseFragment( htmlString, { sourceCodeLocationInfo: true } ) );
+	let tree = adapt( parseFragment( htmlString, { sourceCodeLocationInfo: true } ) );
+	tree = filterTree( tree, permanentFilters );
 	return tokenize( tree, languageProcessor );
 }

--- a/packages/yoastseo/src/worker/AnalysisWebWorker.js
+++ b/packages/yoastseo/src/worker/AnalysisWebWorker.js
@@ -19,8 +19,6 @@ import InclusiveLanguageAssessor from "../scoring/inclusiveLanguageAssessor";
 
 import { build } from "../parse/build";
 import LanguageProcessor from "../parse/language/LanguageProcessor";
-import permanentFilters from "../parse/build/private/alwaysFilterElements";
-import filterTree from "../parse/build/private/filterTree";
 
 // Internal dependencies.
 import CornerstoneContentAssessor from "../scoring/cornerstone/contentAssessor";
@@ -1091,7 +1089,7 @@ export default class AnalysisWebWorker {
 			this._researcher.setPaper( this._paper );
 
 			const languageProcessor = new LanguageProcessor( this._researcher );
-			this._paper.setTree( filterTree( build( this._paper.getText(), languageProcessor ), permanentFilters ) );
+			this._paper.setTree( build( this._paper.getText(), languageProcessor ) );
 
 			// Update the configuration locale to the paper locale.
 			this.setLocale( this._paper.getLocale() );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* It is not necessary to tokenize elements that will always be filtered out. This PR moves the step to filter out the tree so that it's before the tokenization step.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [yoastseo] Filters out elements that we don't want to analyze before tokenizing them.

## Relevant technical choices:

* The unit tests in `filterTreeSpec` were adapted to be run on an untokenized tree. Most of the existing unit tests are for elements that should always be filtered out, which is now done before tokenization. In addition, tokenizing shouldn't affect the behavior of `filterTree` as it only adds an extra property (`sentences`) to the node. And it's simpler and more efficient to not tokenize the tree in a unit test.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Confirm that all unit tests pass

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [x] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes [HTML parser - don't tokenize elements that should always be filtered out](https://github.com/Yoast/lingo-other-tasks/issues/137)
