### PR TITLE
19957 Review usage of dangerouslySetInnerHTML

### DIFF
--- a/packages/analysis-report/src/AnalysisResult.js
+++ b/packages/analysis-report/src/AnalysisResult.js
@@ -4,6 +4,11 @@ import styled from "styled-components";
 import { noop } from "lodash";
 
 import { SvgIcon, IconButtonToggle, IconCTAEditButton, BetaBadge } from "@yoast/components";
+import { strings } from "@yoast/helpers";
+
+const { stripTagsFromHtmlString } = strings;
+
+const ALLOWED_TAGS = [ "a", "b", "strong", "em", "i" ];
 
 const AnalysisResultBase = styled.li`
 	// This is the height of the IconButtonToggle.
@@ -110,7 +115,7 @@ const AnalysisResult = ( { markButtonFactory, ...props } ) => {
 			/>
 			<AnalysisResultText suppressedText={ props.suppressedText }>
 				{ props.hasBetaBadgeLabel && <BetaBadge /> }
-				<span dangerouslySetInnerHTML={ { __html: props.text } } />
+				<span dangerouslySetInnerHTML={ { __html: stripTagsFromHtmlString( props.text, ALLOWED_TAGS ) } } />
 			</AnalysisResultText>
 			{ marksButton }
 			{

--- a/packages/components/src/ScoreAssessments.js
+++ b/packages/components/src/ScoreAssessments.js
@@ -1,6 +1,11 @@
+import { strings } from "@yoast/helpers";
 import React from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
+
+const { stripTagsFromHtmlString } = strings;
+
+const ALLOWED_TAGS = [ "a", "b", "strong", "em", "i", "span", "p", "ul", "ol", "li", "div" ];
 
 const ScoreAssessmentItem = styled.li`
 	display: table-row;
@@ -55,7 +60,7 @@ const ScoreAssessment = ( props ) => {
 			/>
 			<ScoreAssessmentText
 				className={ `${ props.className }-text` }
-				dangerouslySetInnerHTML={ { __html: props.html } }
+				dangerouslySetInnerHTML={ { __html: stripTagsFromHtmlString( props.html, ALLOWED_TAGS ) } }
 			/>
 			{ props.value &&
 				<ScoreAssessmentScore

--- a/packages/helpers/src/strings/index.js
+++ b/packages/helpers/src/strings/index.js
@@ -1,7 +1,3 @@
-import { stripFullTags as stripHTMLTags } from "./stripHTMLTags";
-import stripSpaces from "./stripSpaces";
-
-export {
-	stripHTMLTags,
-	stripSpaces,
-};
+export { stripFullTags as stripHTMLTags } from "./stripHTMLTags";
+export { default as stripSpaces } from "./stripSpaces";
+export { stripTagsFromHtmlString } from "./stripTagsFromHtmlString";

--- a/packages/helpers/src/strings/stripTagsFromHtmlString.js
+++ b/packages/helpers/src/strings/stripTagsFromHtmlString.js
@@ -1,0 +1,53 @@
+/**
+ * Strips tags from HTML nodes.
+ *
+ * @param {NodeListOf<ChildNode>} nodes The nodes.
+ * @param {string[]} [allowedTags] Optional. The allowed tags.
+ *
+ * @returns {void}
+ */
+const stripHtmlTagsFromNodes = ( nodes, allowedTags = [] ) => {
+	// Keep a list, otherwise the loop can go wrong when a node gets replaced.
+	const replaceList = [];
+
+	nodes.forEach( node => {
+		if ( node.nodeType !== Node.ELEMENT_NODE ) {
+			return;
+		}
+
+		const tag = node.nodeName.toLowerCase();
+		if ( tag === "script" || tag === "style" ) {
+			node.remove();
+			return;
+		}
+
+		stripHtmlTagsFromNodes( node.childNodes, allowedTags );
+		if ( allowedTags.includes( tag ) ) {
+			return;
+		}
+
+		replaceList.push( node );
+	} );
+
+	replaceList.forEach( node => node.replaceWith( ...node.childNodes ) );
+};
+
+/**
+ * Strips tags from HTML.
+ *
+ * Note: the inner text is kept!
+ * Note: always removes script and style, including inner text.
+ *
+ * @param {string} html The HTML.
+ * @param {string[]} allowedTags Optional. The allowed tags.
+ *
+ * @returns {string} The stripped HTML.
+ */
+export const stripTagsFromHtmlString = ( html, allowedTags = [] ) => {
+	const parser = new DOMParser();
+	const document = parser.parseFromString( html, "text/html" );
+
+	stripHtmlTagsFromNodes( document.body.childNodes, allowedTags );
+
+	return document.body.innerHTML;
+};

--- a/packages/helpers/src/strings/stripTagsFromHtmlString.js
+++ b/packages/helpers/src/strings/stripTagsFromHtmlString.js
@@ -1,12 +1,39 @@
+const NEVER_ALLOWED_TAGS = [ "script", "style" ];
+const ALLOWED_HREF_PROTOCOLS = [ ":", "https:", "http:" ];
+
+/**
+ * Strips attributes from an HTML node.
+ *
+ * @param {ChildNode} node The node.
+ * @param {string[]} allowedAttributes The allowed attributes.
+ *
+ * @returns {void}
+ */
+const stripHtmlAttributesFromNode = ( node, allowedAttributes ) => {
+	const attributes = node.getAttributeNames();
+	attributes.forEach( attribute => {
+		if ( allowedAttributes.includes( attribute ) ) {
+			if ( attribute === "href" && node.nodeName.toLowerCase() === "a" ) {
+				if ( ! ALLOWED_HREF_PROTOCOLS.includes( node.protocol ) ) {
+					node.removeAttribute( attribute );
+				}
+			}
+			return;
+		}
+		node.removeAttribute( attribute );
+	} );
+};
+
 /**
  * Strips tags from HTML nodes.
  *
  * @param {NodeListOf<ChildNode>} nodes The nodes.
- * @param {string[]} [allowedTags] Optional. The allowed tags.
+ * @param {string[]} allowedTags The allowed tags.
+ * @param {Object} allowedAttributes The allowed attributes, keyed per tag.
  *
  * @returns {void}
  */
-const stripHtmlTagsFromNodes = ( nodes, allowedTags = [] ) => {
+const stripHtmlTagsFromNodes = ( nodes, allowedTags, allowedAttributes ) => {
 	// Keep a list, otherwise the loop can go wrong when a node gets replaced.
 	const replaceList = [];
 
@@ -16,13 +43,14 @@ const stripHtmlTagsFromNodes = ( nodes, allowedTags = [] ) => {
 		}
 
 		const tag = node.nodeName.toLowerCase();
-		if ( tag === "script" || tag === "style" ) {
+		if ( NEVER_ALLOWED_TAGS.includes( tag ) ) {
 			node.remove();
 			return;
 		}
 
-		stripHtmlTagsFromNodes( node.childNodes, allowedTags );
+		stripHtmlTagsFromNodes( node.childNodes, allowedTags, allowedAttributes );
 		if ( allowedTags.includes( tag ) ) {
+			stripHtmlAttributesFromNode( node, allowedAttributes[ tag ] || [] );
 			return;
 		}
 
@@ -39,15 +67,16 @@ const stripHtmlTagsFromNodes = ( nodes, allowedTags = [] ) => {
  * Note: always removes script and style, including inner text.
  *
  * @param {string} html The HTML.
- * @param {string[]} allowedTags Optional. The allowed tags.
+ * @param {string[]} [allowedTags] The allowed tags.
+ * @param {Object} [allowedAttributes] The allowed attributes, keyed per tag.
  *
  * @returns {string} The stripped HTML.
  */
-export const stripTagsFromHtmlString = ( html, allowedTags = [] ) => {
+export const stripTagsFromHtmlString = ( html, allowedTags = [], allowedAttributes = {} ) => {
 	const parser = new DOMParser();
 	const document = parser.parseFromString( html, "text/html" );
 
-	stripHtmlTagsFromNodes( document.body.childNodes, allowedTags );
+	stripHtmlTagsFromNodes( document.body.childNodes, allowedTags, allowedAttributes );
 
 	return document.body.innerHTML;
 };

--- a/packages/helpers/src/strings/stripTagsFromHtmlString.js
+++ b/packages/helpers/src/strings/stripTagsFromHtmlString.js
@@ -1,5 +1,8 @@
 const NEVER_ALLOWED_TAGS = [ "script", "style" ];
 const ALLOWED_HREF_PROTOCOLS = [ ":", "https:", "http:" ];
+const DEFAULT_ALLOWED_ATTRIBUTES = {
+	a: [ "href", "target", "rel" ],
+};
 
 /**
  * Strips attributes from an HTML node.
@@ -50,7 +53,7 @@ const stripHtmlTagsFromNodes = ( nodes, allowedTags, allowedAttributes ) => {
 
 		stripHtmlTagsFromNodes( node.childNodes, allowedTags, allowedAttributes );
 		if ( allowedTags.includes( tag ) ) {
-			stripHtmlAttributesFromNode( node, allowedAttributes[ tag ] || [] );
+			stripHtmlAttributesFromNode( node, allowedAttributes[ tag ] || DEFAULT_ALLOWED_ATTRIBUTES[ tag ] || [] );
 			return;
 		}
 

--- a/packages/helpers/tests/strings/stripTagsFromHtmlStringTest.js
+++ b/packages/helpers/tests/strings/stripTagsFromHtmlStringTest.js
@@ -43,7 +43,7 @@ describe( "stripTagsFromHtmlString", () => {
 			"removes all but the allowed tags",
 			// eslint-disable-next-line max-len
 			"<ul class=\"text-white pt-3\"><li><a href=\"example.com\" target=\"_blank\" rel=\"noreferrer\">one</a></li><li><span class=\"two\">two</span></li><li><h2 data-three=\"3\">three</h2></li></ul>",
-			"<a>one</a>twothree",
+			"<a href=\"example.com\" target=\"_blank\" rel=\"noreferrer\">one</a>twothree",
 			[ "a" ],
 		],
 		[
@@ -60,39 +60,40 @@ describe( "stripTagsFromHtmlString", () => {
 			{ a: [ "href", "rel" ] },
 		],
 		[
+			"anchor tags can keep the href, target and rel attributes by default",
+			"<a href=\"example.com\" target=\"_blank\" rel=\"noreferrer\">attrs</a>",
+			"<a href=\"example.com\" target=\"_blank\" rel=\"noreferrer\">attrs</a>",
+			[ "a" ],
+		],
+		[
 			"anchor tags can keep the href attributes that have the http protocol",
 			"<a href=\"http://example.com\">http</a>",
 			"<a href=\"http://example.com\">http</a>",
 			[ "a" ],
-			{ a: [ "href" ] },
 		],
 		[
 			"anchor tags can keep the href attributes that have the https protocol",
 			"<a href=\"https://example.com\">https</a>",
 			"<a href=\"https://example.com\">https</a>",
 			[ "a" ],
-			{ a: [ "href" ] },
 		],
 		[
 			"anchor tags can keep the href attributes that have no protocol",
 			"<a href=\"example.com\">no protocol</a>",
 			"<a href=\"example.com\">no protocol</a>",
 			[ "a" ],
-			{ a: [ "href" ] },
 		],
 		[
 			"anchor tags href attributes with invalid protocols are removed",
 			"<a href=\"javascript:alert('foo')\">javascript</a><a href=\"mailto:foo@bar.baz\">mailto</a><a href=\"ftp://example.com\">ftp</a>",
 			"<a>javascript</a><a>mailto</a><a>ftp</a>",
 			[ "a" ],
-			{ a: [ "href" ] },
 		],
 		[
 			"converts uppercase tags and attributes",
-			"<A HREF=\"example.com\" target=\"_blank\" rel=\"noreferrer\">link</A>",
+			"<A HREF=\"example.com\">link</A>",
 			"<a href=\"example.com\">link</a>",
 			[ "a" ],
-			{ a: [ "href" ] },
 		],
 	] )( "%s", ( name, html, expected, allowedTags = [], allowedAttributes = {} ) => {
 		expect( stripTagsFromHtmlString( html, allowedTags, allowedAttributes ) ).toBe( expected );

--- a/packages/helpers/tests/strings/stripTagsFromHtmlStringTest.js
+++ b/packages/helpers/tests/strings/stripTagsFromHtmlStringTest.js
@@ -1,0 +1,57 @@
+import { stripTagsFromHtmlString } from "../../src/strings";
+
+describe( "stripTagsFromHtmlString", () => {
+	test.each( [
+		[
+			"removes a script",
+			"<script type='application/javascript' defer>console.log('log');</script>",
+			"",
+		],
+		[
+			"removes a nested script",
+			"<div><script type='application/javascript' defer>console.log('log');</script></div>",
+			"",
+		],
+		[
+			"removes a script next to other nodes",
+			"<h1>Header</h1><script type='application/javascript' defer>console.log('log');</script>",
+			"Header",
+		],
+		[
+			"removes a script next to other nodes that do not have any content",
+			"<div></div><script type='application/javascript' defer>console.log('log');</script>",
+			"",
+		],
+		[
+			"removes all the tags in a full HTML document",
+			// eslint-disable-next-line max-len
+			"<html><head><title>title</title><meta charset=\"utf-8\"><meta name=\"viewport\" content=\"width=device-width,initial-scale=1\"><link rel=\"icon\" type=\"image/x-icon\" href=\"/favicon.ico\"><style>.relative {position: relative}</style></head><body><div id=\"__app\"><div class=\"relative\"><h1 class=\"font-medium\">header</h1><ul class=\"text-white pt-3\"><li><a href=\"example.com\" target=\"_blank\" rel=\"noreferrer\">one</a></li><li><span class=\"two\">two</span></li><li><h2 data-three=\"3\">three</h2></li></ul></div><script type=\"application/javascript\" defer>console.log( \"boo\" );</script></div></body></html>",
+			"headeronetwothree",
+		],
+		[
+			"removes a style",
+			"<style>.relative{ position: relative; }</style>",
+			"",
+		],
+		[
+			"removes script and style, even when specified as allowed",
+			"<style>.relative{ position: relative; }</style><script type='application/javascript'>console.log('log');</script>",
+			"",
+			[ "script", "style" ],
+		],
+		[
+			"removes all but the allowed tags",
+			// eslint-disable-next-line max-len
+			"<ul class=\"text-white pt-3\"><li><a href=\"example.com\" target=\"_blank\" rel=\"noreferrer\">one</a></li><li><span class=\"two\">two</span></li><li><h2 data-three=\"3\">three</h2></li></ul>",
+			"<a href=\"example.com\" target=\"_blank\" rel=\"noreferrer\">one</a>twothree",
+			[ "a" ],
+		],
+		[
+			"keeps inner text",
+			"<div>inner</div>",
+			"inner",
+		],
+	] )( "%s", ( name, html, expected, allowedTags = [] ) => {
+		expect( stripTagsFromHtmlString( html, allowedTags ) ).toBe( expected );
+	} );
+} );

--- a/packages/helpers/tests/strings/stripTagsFromHtmlStringTest.js
+++ b/packages/helpers/tests/strings/stripTagsFromHtmlStringTest.js
@@ -43,7 +43,7 @@ describe( "stripTagsFromHtmlString", () => {
 			"removes all but the allowed tags",
 			// eslint-disable-next-line max-len
 			"<ul class=\"text-white pt-3\"><li><a href=\"example.com\" target=\"_blank\" rel=\"noreferrer\">one</a></li><li><span class=\"two\">two</span></li><li><h2 data-three=\"3\">three</h2></li></ul>",
-			"<a href=\"example.com\" target=\"_blank\" rel=\"noreferrer\">one</a>twothree",
+			"<a>one</a>twothree",
 			[ "a" ],
 		],
 		[
@@ -51,7 +51,50 @@ describe( "stripTagsFromHtmlString", () => {
 			"<div>inner</div>",
 			"inner",
 		],
-	] )( "%s", ( name, html, expected, allowedTags = [] ) => {
-		expect( stripTagsFromHtmlString( html, allowedTags ) ).toBe( expected );
+		[
+			"removes all but the allowed tags, keeping allowed attributes",
+			// eslint-disable-next-line max-len
+			"<ul class=\"text-white pt-3\"><li><a href=\"example.com\" target=\"_blank\" rel=\"noreferrer\">one</a></li><li><span class=\"two\">two</span></li><li><h2 data-three=\"3\">three</h2></li></ul>",
+			"<a href=\"example.com\" rel=\"noreferrer\">one</a>twothree",
+			[ "a" ],
+			{ a: [ "href", "rel" ] },
+		],
+		[
+			"anchor tags can keep the href attributes that have the http protocol",
+			"<a href=\"http://example.com\">http</a>",
+			"<a href=\"http://example.com\">http</a>",
+			[ "a" ],
+			{ a: [ "href" ] },
+		],
+		[
+			"anchor tags can keep the href attributes that have the https protocol",
+			"<a href=\"https://example.com\">https</a>",
+			"<a href=\"https://example.com\">https</a>",
+			[ "a" ],
+			{ a: [ "href" ] },
+		],
+		[
+			"anchor tags can keep the href attributes that have no protocol",
+			"<a href=\"example.com\">no protocol</a>",
+			"<a href=\"example.com\">no protocol</a>",
+			[ "a" ],
+			{ a: [ "href" ] },
+		],
+		[
+			"anchor tags href attributes with invalid protocols are removed",
+			"<a href=\"javascript:alert('foo')\">javascript</a><a href=\"mailto:foo@bar.baz\">mailto</a><a href=\"ftp://example.com\">ftp</a>",
+			"<a>javascript</a><a>mailto</a><a>ftp</a>",
+			[ "a" ],
+			{ a: [ "href" ] },
+		],
+		[
+			"converts uppercase tags and attributes",
+			"<A HREF=\"example.com\" target=\"_blank\" rel=\"noreferrer\">link</A>",
+			"<a href=\"example.com\">link</a>",
+			[ "a" ],
+			{ a: [ "href" ] },
+		],
+	] )( "%s", ( name, html, expected, allowedTags = [], allowedAttributes = {} ) => {
+		expect( stripTagsFromHtmlString( html, allowedTags, allowedAttributes ) ).toBe( expected );
 	} );
 } );

--- a/packages/js/src/components/IndexingError.js
+++ b/packages/js/src/components/IndexingError.js
@@ -1,8 +1,13 @@
-import PropTypes from "prop-types";
-import { Alert } from "@yoast/components";
 import { __ } from "@wordpress/i18n";
-import RequestError from "../errors/RequestError";
+import { Alert } from "@yoast/components";
+import { strings } from "@yoast/helpers";
+import PropTypes from "prop-types";
 import styled from "styled-components";
+import RequestError from "../errors/RequestError";
+
+const { stripTagsFromHtmlString } = strings;
+
+const ALLOWED_TAGS = [ "a", "p" ];
 
 const ErrorDetails = styled.div`
 	margin-top: 8px;
@@ -84,7 +89,7 @@ ErrorBox.defaultProps = {
  */
 export default function IndexingError( { message, error } ) {
 	return <Alert type={ "error" }>
-		<div dangerouslySetInnerHTML={ { __html: message } } />
+		<div dangerouslySetInnerHTML={ { __html: stripTagsFromHtmlString( message, ALLOWED_TAGS ) } } />
 		<details>
 			<summary>{ __( "Error details", "wordpress-seo" ) }</summary>
 			<ErrorDetails>

--- a/packages/js/src/components/contentAnalysis/InclusiveLanguageAnalysis.js
+++ b/packages/js/src/components/contentAnalysis/InclusiveLanguageAnalysis.js
@@ -1,7 +1,7 @@
 /* global wpseoAdminL10n */
 /* External components */
 import { withSelect } from "@wordpress/data";
-import { Fragment } from "@wordpress/element";
+import { Fragment, createInterpolateElement } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
 import { isNil } from "lodash";
 import PropTypes from "prop-types";
@@ -91,14 +91,19 @@ const InclusiveLanguageAnalysis = ( props ) => {
 		);
 	}
 
-	const goodJobFeedback = sprintf(
-		/* Translators: %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag. */
-		__( "%1$sInclusive language%2$s: We haven't detected any potentially non-inclusive phrases. Great work!",
-			"wordpress-seo"
+	const goodJobFeedback = createInterpolateElement(
+		sprintf(
+			/* Translators: %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag. */
+			__( "%1$sInclusive language%2$s: We haven't detected any potentially non-inclusive phrases. Great work!", "wordpress-seo" ),
+			"<a>",
+			"</a>"
 		),
-		`<a href="${ analysisInfoLink }" target="_blank">`,
-		"</a>"
+		{
+			// eslint-disable-next-line jsx-a11y/anchor-has-content
+			a: <a href={ analysisInfoLink } target="_blank" rel="noreferrer" />,
+		}
 	);
+
 
 	/**
 	 * Renders a notice that a multilingual plugin has been
@@ -142,7 +147,7 @@ const InclusiveLanguageAnalysis = ( props ) => {
 						color={ "#7ad03a" }
 						size="13px"
 					/>
-					<span dangerouslySetInnerHTML={ { __html: goodJobFeedback } } />
+					<span>{ goodJobFeedback }</span>
 				</GoodJobAnalysisResult>
 			</Fragment>
 		);

--- a/packages/js/src/first-time-configuration/tailwind-components/steps/indexation/indexing-error.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/steps/indexation/indexing-error.js
@@ -1,8 +1,13 @@
+import { strings } from "@yoast/helpers";
 import PropTypes from "prop-types";
 import { __ } from "@wordpress/i18n";
 
 import RequestError from "../../../../errors/RequestError";
 import Alert from "../../base/alert";
+
+const { stripTagsFromHtmlString } = strings;
+
+const ALLOWED_TAGS = [ "a", "p" ];
 
 /**
  * Shows a value for in the error details.
@@ -76,7 +81,7 @@ export default function IndexingError( { message, error, className } ) {
 		type={ "error" }
 		className={ className }
 	>
-		<div dangerouslySetInnerHTML={ { __html: message } } />
+		<div dangerouslySetInnerHTML={ { __html: stripTagsFromHtmlString( message, ALLOWED_TAGS ) } } />
 		<details>
 			<summary>{ __( "Error details", "wordpress-seo" ) }</summary>
 			<div className="yst-mt-2">

--- a/packages/search-metadata-previews/src/snippet-preview/SnippetPreview.js
+++ b/packages/search-metadata-previews/src/snippet-preview/SnippetPreview.js
@@ -9,7 +9,7 @@ import { __ } from "@wordpress/i18n";
 // Yoast dependencies.
 import { colors, angleLeft, angleRight } from "@yoast/style-guide";
 import { languageProcessing } from "yoastseo";
-import { getDirectionalStyle } from "@yoast/helpers";
+import { decodeHTML, getDirectionalStyle } from "@yoast/helpers";
 import { ScreenReaderText } from "@yoast/components";
 
 const {
@@ -800,15 +800,20 @@ export default class SnippetPreview extends PureComponent {
 			return null;
 		}
 
+		const safeShoppingData = {
+			availability: shoppingData.availability || "",
+			price: shoppingData.price ? decodeHTML( shoppingData.price ) : "",
+			rating: shoppingData.rating || 0,
+			reviewCount: shoppingData.reviewCount || 0,
+		};
+
 		if ( mode === MODE_DESKTOP ) {
 			return (
 				<PartContainer className="yoast-shopping-data-preview--desktop">
 					<ScreenReaderText>
 						{ __( "Shopping data preview:", "wordpress-seo" ) }
 					</ScreenReaderText>
-					<ProductDataDesktop
-						shoppingData={ shoppingData }
-					/>
+					<ProductDataDesktop shoppingData={ safeShoppingData } />
 				</PartContainer>
 			);
 		}
@@ -819,9 +824,7 @@ export default class SnippetPreview extends PureComponent {
 					<ScreenReaderText>
 						{ __( "Shopping data preview:", "wordpress-seo" ) }
 					</ScreenReaderText>
-					<ProductDataMobile
-						shoppingData={ shoppingData }
-					/>
+					<ProductDataMobile shoppingData={ safeShoppingData } />
 				</PartContainer>
 			);
 		}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Prevent usage of dangerouslySetInnerHTML in favor of more precise ways

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [@yoast/helpers 0.1.0] Adds `stripTagsFromHtmlString` to the `strings` export. This helper parses the HTML string and strips any HTML tags that are not specified as allowed.
* [@yoast/analysis-report 0.1.0] Strips HTML tags from the AnalysisResult _text_. Allowed tags are: _a_, _b_, _strong_, _em_ and _i_.
* [@yoast/analysis-report 0.1.0] Strips HTML tags from the ScoreAssessment _html_. Allowed tags are: _a_, _b_, _strong_, _em_, _i_, _span_, _p_, _ul_, _ol_, _li_ and _div_.
* [@yoast/search-metadata-previews 0.1.0] Decodes the `shoppingData.price` instead of allowing HTML.
* Strips HTML tags from the IndexingError _message_ (2 actual components). Allowed tags are: _a_ and _p_.
* Refactors the inclusive language good job feedback string.

## Relevant technical choices:

* Adding a helper to strip HTML tags, except specified ones. We have regex helpers that remove all. But not ones that allow certain ones. In this helper we keep any text inside invalid tags, which is a choice.
  * The attributes also have an allowlist now, with a default for the anchor tag. The `href` always only allows for `http`, `https` or no protocol. This seems like a good catch all to me, so I did not make that part configurable. Is that ok?
* Leaving the unused ones in `@yoast/components` (CourseDetails and Notification) until we define how to deprecate. Created an issue: https://github.com/Yoast/wordpress-seo/issues/20085
* Leaving the Radio in the UI library, because that is very specifically letting the user know this is what is happening, leaving the responsibility to the implementor of that component
* The allowed tags are a bit arbitrary in most cases.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Analysis results
* Edit a post
* Check the SEO, readability and inclusive language results, specifically if the links are still in there properly

#### Inclusive language results
* Edit a post
* Ensure the post is inclusive, e.g. has a green bullet
* Verify the feedback looks good, specifically the link

#### Google preview shopping data
* Enable WooCommerce and Yoast WooCommerce SEO
* Edit a product with a price
* Verify the price in the Google preview looks correct, specifically using `$` instead of the encoded `&#36;`

#### Dashboard widget
* Go to the Dashboard
* Check it looks the same as before, specifically the list of "Posts with ..." part

#### Indexation errors
* Add the following PHP code to make the indexation error (I used Code Snippets plugin)
```php
add_filter( 'wpseo_indexing_endpoints', static function() {
	return [ 'error' => '' ];
} );
```
* Reset your indexables via the Yoast Test Helper, or otherwise make it so you have to index again (changing permalink structure?)
* Go to our Tools page and start the optimization
* Verify the error looks like it did before, e.g. contains the link, details and the strong headers in the details
* Go to our General > FTC > SEO DATA OPTIMIZATION and start the optimization
* Verify the error looks like it did before, e.g. contains the details and the strong headers in the details

### Test instructions for Shopify

#### Analysis results

* Create some content (page/product/collection/blog post)
* Check the SEO, readability and inclusive language results, specifically if the links are still in there properly

#### Inclusive language results

* Create some content (page/product/collection/blog post)
* Ensure it is inclusive, e.g. has a green bullet
* Verify the feedback looks good, specifically the link

#### Google preview shopping data
* Create a new product with several new product variants
* Set a different price for each variant
* Check the price range in the Google Preview is rendered correct
* Create another product with no variants
* Set 1 price for the product
* Check the price in the Google Preview is rendered correct

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The analysis results in the UI
* The inclusive language good job feedback in the UI
* The Google preview' shopping data in the UI
* The score assessment in the UI (dashboard widget)
* The indexation error display in the UI, in both tools and in the first time configuration

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [x] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes https://github.com/Yoast/wordpress-seo/issues/19957
