### PR TITLE
Update cleanup routine query to take object_type into account.

### DIFF
--- a/src/integrations/cleanup-integration.php
+++ b/src/integrations/cleanup-integration.php
@@ -600,7 +600,7 @@ class Cleanup_Integration implements Integration_Interface {
 		}
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Reason: Already prepared.
-		return $wpdb->query( "DELETE FROM $indexable_table WHERE object_id IN( " . \implode( ',', $orphans ) . ' )' );
+		return $wpdb->query( "DELETE FROM $indexable_table WHERE object_type = '{$object_type}' AND object_id IN( " . \implode( ',', $orphans ) . ' )' );
 	}
 
 	/**

--- a/tests/unit/integrations/cleanup-integration-test.php
+++ b/tests/unit/integrations/cleanup-integration-test.php
@@ -733,7 +733,7 @@ class Cleanup_Integration_Test extends TestCase {
 
 		$this->wpdb->shouldReceive( 'query' )
 			->once()
-			->with( 'DELETE FROM wp_yoast_indexable WHERE object_id IN( ' . \implode( ',', $ids ) . ' )' )
+			->with( "DELETE FROM wp_yoast_indexable WHERE object_type = '{$object_type}' AND object_id IN( " . \implode( ',', $ids ) . ' )' )
 			->andReturn( 50 );
 	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to be more specific in our cleanup routine delete queyr.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a non release bug where to many indexables where deleted when they shared an object_id with another indexable.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Disable Free and make sure `WP Crontrol` is installed
* Run the following query to find a post and term with the same id:
``` select * from wp_posts p where id in (select term_id from wp_terms); ```
* Note down one of the ID's and run the following query to confirm: 
* Run ```select * from wp_yoast_indexable where wp_yoast_indexable.object_id= {your id};``` and make sure there are at least 2 records (one for the post and one for the term) 
* if the above is true, remove to corresponding post. (not just trash really remove)
* Run the following query to make sure the post indexable is now `orpahend` 

```
SELECT * FROM wp_yoast_indexable as i LEFT JOIN wp_posts as p on i.object_id = p.ID WHERE i.object_type = 'post' AND p.ID IS NULL;
```
Your ID should be in there.
* Run the following query to make sure your term with the same ID is `not` orphaned
```
SELECT * FROM wp_yoast_indexable as i LEFT JOIN wp_terms as t on i.object_id = t.term_id WHERE i.object_type = 'term' AND t.term_id IS NULL;
```
The ID should `not` be in the list.

* Activate free and run the cleanup routine (it should be scheduled by activating the plugin) go to /wp-admin/tools.php?page=crontrol_admin_manage_page and find `wpseo_start_cleanup_indexables` hover over it and hit `run now`.

* Run  ```select * from wp_yoast_indexable where wp_yoast_indexable.object_id= {your id};``` again. The post indexable should be gone and the term indexable should still be there.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
