### PR TITLE
Fix highlighting text containing span tags

### DIFF
--- a/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/InclusiveLanguageAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/InclusiveLanguageAssessmentSpec.js
@@ -1,8 +1,9 @@
 import InclusiveLanguageAssessment from "../../../../src/scoring/assessments/inclusiveLanguage/InclusiveLanguageAssessment";
 import assessments from "../../../../src/scoring/assessments/inclusiveLanguage/configuration/cultureAssessments";
 import { values } from "yoastseo";
+import EnglishResearcher from "../../../../src/languageProcessing/languages/en/Researcher";
 
-const { Paper } = values;
+const { Paper, Mark } = values;
 
 describe( "inclusive Language Assessments", () => {
 	it( "should signal it does not have enough content for assessment for short texts", () => {
@@ -21,5 +22,21 @@ describe( "inclusive Language Assessments", () => {
 			"conversations in it, “and what is the use of a book,” thought Alice\n" +
 			"“without pictures or conversations?”" );
 		expect( assessment.hasEnoughContentForAssessment( mockPaper ) ).toBe( true );
+	} );
+
+	it( "creates the marks object for a sentence preceded by span tag", () => {
+		const assessment = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "exotic" ) );
+
+		const mockPaper = new Paper( "[caption id=\"attachment_1276\" align=\"alignnone\" width=\"225\"]<img class=\"size-medium wp-image-1276\" " +
+			"src=\"http://basic.wordpress.test/wp-content/uploads/2023/03/Cat_November_2010-1a-225x300.jpg\" alt=\"\" />" +
+			" <span style=\"font-weight: 400;\">Cats are exotic creatures. Cats are fun. Cats are adorable.</span>[/caption]" );
+		const researcher = new EnglishResearcher( mockPaper );
+		assessment.isApplicable( mockPaper, researcher );
+		expect( assessment.getMarks() ).toEqual( [
+			new Mark( {
+				original: "Cats are exotic creatures.",
+				marked: "<yoastmark class='yoast-text-mark'>Cats are exotic creatures.</yoastmark>",
+			} ),
+		] );
 	} );
 } );

--- a/packages/yoastseo/spec/scoring/assessments/readability/PassiveVoiceAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/readability/PassiveVoiceAssessmentSpec.js
@@ -114,6 +114,20 @@ describe( "A test for marking passive sentences", function() {
 		expect( new PassiveVoiceAssessment().getMarks( paper, passiveVoice ) ).toEqual( expected );
 	} );
 
+	it( "returns markers for a sentence preceded by the span tag", function() {
+		const paper = new Paper( "[caption id=\"attachment_1276\" align=\"alignnone\" width=\"225\"]<img class=\"size-medium wp-image-1276\" " +
+			"src=\"http://basic.wordpress.test/wp-content/uploads/2023/03/Cat_November_2010-1a-225x300.jpg\" alt=\"\" />" +
+			" <span style=\"font-weight: 400;\">Cats are hailed to be the loveliest pets. Cats are fun. Cats are adorable.</span>[/caption]" );
+		const researcher = new EnglishResearcher( paper );
+		const expected = [
+			new Mark( {
+				original: "Cats are hailed to be the loveliest pets.",
+				marked: "<yoastmark class='yoast-text-mark'>Cats are hailed to be the loveliest pets.</yoastmark>" } ),
+		];
+		expect( new PassiveVoiceAssessment().getMarks( paper, researcher ) ).toEqual( expected );
+	} );
+
+
 	it( "returns no markers for active sentences", function() {
 		const paper = new Paper( "This is a very interesting paper." );
 		const passiveVoice = Factory.buildMockResearcher( [ { total: 0, passives: [] } ] );

--- a/packages/yoastseo/spec/scoring/assessments/readability/SentenceBeginningsAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/readability/SentenceBeginningsAssessmentSpec.js
@@ -86,6 +86,25 @@ describe( "A test for marking the sentences", function() {
 		expect( new SentenceBeginningsAssessment().getMarks( paper, sentenceBeginnings ) ).toEqual( expected );
 	} );
 
+	it( "returns markers for a sentence preceded by the span tag", function() {
+		const paper = new Paper( "[caption id=\"attachment_1276\" align=\"alignnone\" width=\"225\"]<img class=\"size-medium wp-image-1276\" " +
+			"src=\"http://basic.wordpress.test/wp-content/uploads/2023/03/Cat_November_2010-1a-225x300.jpg\" alt=\"\" />" +
+			" <span style=\"font-weight: 400;\">Cats are lovely. Cats are fun. Cats are adorable.</span>[/caption]" );
+		const researcher = new EnglishResearcher( paper );
+		const expected = [
+			new Mark( {
+				original: "Cats are lovely.",
+				marked: "<yoastmark class='yoast-text-mark'>Cats are lovely.</yoastmark>" } ),
+			new Mark( {
+				original: "Cats are fun.",
+				marked: "<yoastmark class='yoast-text-mark'>Cats are fun.</yoastmark>" } ),
+			new Mark( {
+				original: "Cats are adorable.",
+				marked: "<yoastmark class='yoast-text-mark'>Cats are adorable.</yoastmark>" } ),
+		];
+		expect( new SentenceBeginningsAssessment().getMarks( paper, researcher ) ).toEqual( expected );
+	} );
+
 	it( "returns no markers", function() {
 		const sentenceBeginnings = Factory.buildMockResearcher( [ { word: "hey", count: 2, sentences: [ "Hey, hello.", "Hey, hey." ] } ] );
 		const expected = [];

--- a/packages/yoastseo/spec/scoring/assessments/readability/SentenceBeginningsAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/readability/SentenceBeginningsAssessmentSpec.js
@@ -87,7 +87,7 @@ describe( "A test for marking the sentences", function() {
 	} );
 
 	it( "returns markers for a sentence preceded by the span tag", function() {
-		const paper = new Paper( "[caption id=\"attachment_1276\" align=\"alignnone\" width=\"225\"]<img class=\"size-medium wp-image-1276\" " +
+		paper = new Paper( "[caption id=\"attachment_1276\" align=\"alignnone\" width=\"225\"]<img class=\"size-medium wp-image-1276\" " +
 			"src=\"http://basic.wordpress.test/wp-content/uploads/2023/03/Cat_November_2010-1a-225x300.jpg\" alt=\"\" />" +
 			" <span style=\"font-weight: 400;\">Cats are lovely. Cats are fun. Cats are adorable.</span>[/caption]" );
 		const researcher = new EnglishResearcher( paper );

--- a/packages/yoastseo/spec/scoring/assessments/readability/SentenceLengthInTextAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/readability/SentenceLengthInTextAssessmentSpec.js
@@ -564,6 +564,22 @@ describe( "A test for marking too long sentences", function() {
 		const expected = [];
 		expect( new SentenceLengthInTextAssessment().getMarks( paper, sentenceLengthInText ) ).toEqual( expected );
 	} );
+
+	it( "returns markers for a sentence preceded by the span tag", function() {
+		const paper = new Paper( "[caption id=\"attachment_1276\" align=\"alignnone\" width=\"225\"]<img class=\"size-medium wp-image-1276\" " +
+			"src=\"http://basic.wordpress.test/wp-content/uploads/2023/03/Cat_November_2010-1a-225x300.jpg\" alt=\"\" />" +
+			" <span style=\"font-weight: 400;\">This is a too long sentence, because it has over twenty words, and that is hard too" +
+			" read, don't you think?. Cats are fun. Cats are adorable.</span>[/caption]" );
+		const researcher = new EnglishResearcher( paper );
+		const expected = [
+			new Mark( {
+				original: "This is a too long sentence, because it has over twenty words, and that is hard too" +
+					" read, don't you think?.",
+				marked: "<yoastmark class='yoast-text-mark'>This is a too long sentence, because it has over twenty words, and that is hard too" +
+					" read, don't you think?.</yoastmark>" } ),
+		];
+		expect( new SentenceLengthInTextAssessment().getMarks( paper, researcher ) ).toEqual( expected );
+	} );
 } );
 
 describe( "A test for marking too long sentences", function() {

--- a/packages/yoastseo/spec/scoring/assessments/readability/TransitionWordsAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/readability/TransitionWordsAssessmentSpec.js
@@ -198,4 +198,17 @@ describe( "A test for marking sentences containing a transition word", function(
 		];
 		expect( new TransitionWordsAssessment().getMarks( paper, researcher ) ).toEqual( expected );
 	} );
+
+	it( "returns markers for a sentence preceded by the span tag", function() {
+		const paper = new Paper( "[caption id=\"attachment_1276\" align=\"alignnone\" width=\"225\"]<img class=\"size-medium wp-image-1276\" " +
+			"src=\"http://basic.wordpress.test/wp-content/uploads/2023/03/Cat_November_2010-1a-225x300.jpg\" alt=\"\" />" +
+			" <span style=\"font-weight: 400;\">Thus, cats are lovely. Cats are fun. Cats are adorable.</span>[/caption]" );
+		const researcher = new EnglishResearcher( paper );
+		const expected = [
+			new Mark( {
+				original: "Thus, cats are lovely.",
+				marked: "<yoastmark class='yoast-text-mark'>Thus, cats are lovely.</yoastmark>" } ),
+		];
+		expect( new TransitionWordsAssessment().getMarks( paper, researcher ) ).toEqual( expected );
+	} );
 } );

--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/InclusiveLanguageAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/InclusiveLanguageAssessment.js
@@ -6,6 +6,7 @@ import Mark from "../../../values/Mark";
 import addMark from "../../../markers/addMark";
 import { createAnchorOpeningTag } from "../../../helpers/shortlinker";
 import { getWords, sanitizeString } from "../../../languageProcessing";
+import { stripFullTags } from "../../../languageProcessing/helpers/sanitize/stripHTMLTags";
 
 import { includesConsecutiveWords } from "./helpers/includesConsecutiveWords";
 
@@ -138,10 +139,12 @@ export default class InclusiveLanguageAssessment {
 		if ( ! this.foundPhrases ) {
 			return [];
 		}
-		return this.foundPhrases.map( foundPhrase =>
-			new Mark( {
-				original: foundPhrase.sentence,
-				marked: addMark( foundPhrase.sentence ),
-			} ) );
+		return this.foundPhrases.map( foundPhrase => {
+			const sentence = stripFullTags( foundPhrase.sentence );
+			return new Mark( {
+				original: sentence,
+				marked: addMark( sentence ),
+			} );
+		} );
 	}
 }

--- a/packages/yoastseo/src/scoring/assessments/readability/PassiveVoiceAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/readability/PassiveVoiceAssessment.js
@@ -105,10 +105,10 @@ export default class PassiveVoiceAssessment extends Assessment {
 	/**
 	 * Marks all sentences that have the passive voice.
 	 *
-	 * @param {object} paper        The paper to use for the assessment.
-	 * @param {object} researcher   The researcher used for calling research.
+	 * @param {Paper}       paper       The paper to use for the assessment.
+	 * @param {Researcher}  researcher  The researcher used for calling research.
 	 *
-	 * @returns {object} All marked sentences.
+	 * @returns {Array<Mark>} All marked sentences.
 	 */
 	getMarks( paper, researcher ) {
 		const passiveVoice = researcher.getResearch( "getPassiveVoiceResult" );

--- a/packages/yoastseo/src/scoring/assessments/readability/PassiveVoiceAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/readability/PassiveVoiceAssessment.js
@@ -5,7 +5,7 @@ import formatNumber from "../../../helpers/formatNumber";
 import { inRangeEndInclusive as inRange } from "../../helpers/assessments/inRange";
 import marker from "../../../markers/addMark";
 import { createAnchorOpeningTag } from "../../../helpers/shortlinker";
-import { stripIncompleteTags as stripTags } from "../../../languageProcessing/helpers/sanitize/stripHTMLTags";
+import { stripFullTags } from "../../../languageProcessing/helpers/sanitize/stripHTMLTags";
 import AssessmentResult from "../../../values/AssessmentResult";
 import Mark from "../../../values/Mark";
 import Assessment from "../assessment";
@@ -113,7 +113,7 @@ export default class PassiveVoiceAssessment extends Assessment {
 	getMarks( paper, researcher ) {
 		const passiveVoice = researcher.getResearch( "getPassiveVoiceResult" );
 		return map( passiveVoice.passives, function( sentence ) {
-			sentence = stripTags( sentence );
+			sentence = stripFullTags( sentence );
 			const marked = marker( sentence );
 			return new Mark( {
 				original: sentence,

--- a/packages/yoastseo/src/scoring/assessments/readability/SentenceBeginningsAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/readability/SentenceBeginningsAssessment.js
@@ -106,10 +106,10 @@ export default class SentenceBeginningsAssessment extends Assessment {
 	/**
 	 * Marks all consecutive sentences with the same beginnings.
 	 *
-	 * @param {object} paper        The paper to use for the assessment.
-	 * @param {object} researcher   The researcher used for calling research.
+	 * @param {Paper}       paper        The paper to use for the assessment.
+	 * @param {Researcher}  researcher   The researcher used for calling research.
 	 *
-	 * @returns {object} All marked sentences.
+	 * @returns {Array<Mark>} All marked sentences.
 	 */
 	getMarks( paper, researcher ) {
 		let sentenceBeginnings = researcher.getResearch( "getSentenceBeginnings" );

--- a/packages/yoastseo/src/scoring/assessments/readability/SentenceBeginningsAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/readability/SentenceBeginningsAssessment.js
@@ -3,7 +3,7 @@ import { _n, __, sprintf } from "@wordpress/i18n";
 
 import marker from "../../../markers/addMark";
 import { createAnchorOpeningTag } from "../../../helpers/shortlinker";
-import { stripIncompleteTags as stripTags } from "../../../languageProcessing/helpers/sanitize/stripHTMLTags";
+import { stripFullTags } from "../../../languageProcessing/helpers/sanitize/stripHTMLTags";
 import AssessmentResult from "../../../values/AssessmentResult";
 import Mark from "../../../values/Mark";
 import Assessment from "../assessment";
@@ -122,7 +122,7 @@ export default class SentenceBeginningsAssessment extends Assessment {
 		} );
 
 		return map( flatten( sentences ), function( sentence ) {
-			sentence = stripTags( sentence );
+			sentence = stripFullTags( sentence );
 			const marked = marker( sentence );
 			return new Mark( {
 				original: sentence,

--- a/packages/yoastseo/src/scoring/assessments/readability/SentenceLengthInTextAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/readability/SentenceLengthInTextAssessment.js
@@ -7,7 +7,7 @@ import formatNumber from "../../../helpers/formatNumber";
 import { inRangeEndInclusive as inRange } from "../../helpers/assessments/inRange";
 import addMark from "../../../markers/addMark";
 import { createAnchorOpeningTag } from "../../../helpers/shortlinker";
-import { stripIncompleteTags as stripTags } from "../../../languageProcessing/helpers/sanitize/stripHTMLTags";
+import { stripFullTags } from "../../../languageProcessing/helpers/sanitize/stripHTMLTags";
 import AssessmentResult from "../../../values/AssessmentResult";
 import Mark from "../../../values/Mark";
 
@@ -102,7 +102,7 @@ class SentenceLengthInTextAssessment extends Assessment {
 		const sentenceObjects = this.getTooLongSentences( sentenceCount );
 
 		return map( sentenceObjects, function( sentenceObject ) {
-			const sentence = stripTags( sentenceObject.sentence );
+			const sentence = stripFullTags( sentenceObject.sentence );
 			return new Mark( {
 				original: sentence,
 				marked: addMark( sentence ),

--- a/packages/yoastseo/src/scoring/assessments/readability/SentenceLengthInTextAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/readability/SentenceLengthInTextAssessment.js
@@ -89,10 +89,10 @@ class SentenceLengthInTextAssessment extends Assessment {
 	/**
 	 * Mark the sentences.
 	 *
-	 * @param {Paper} paper The paper to use for the marking.
-	 * @param {Researcher} researcher The researcher to use.
+	 * @param {Paper}       paper       The paper to use for the marking.
+	 * @param {Researcher}  researcher  The researcher to use.
 	 *
-	 * @returns {Array} Array with all the marked sentences.
+	 * @returns {Array<Mark>} Array with all the marked sentences.
 	 */
 	getMarks( paper, researcher ) {
 		const sentenceCount = researcher.getResearch( "countSentencesFromText" );

--- a/packages/yoastseo/src/scoring/assessments/readability/TransitionWordsAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/readability/TransitionWordsAssessment.js
@@ -4,7 +4,7 @@ import { map, merge } from "lodash-es";
 import formatNumber from "../../../helpers/formatNumber";
 import { inRangeStartInclusive as inRange } from "../../helpers/assessments/inRange";
 import { createAnchorOpeningTag } from "../../../helpers/shortlinker";
-import { stripIncompleteTags as stripTags } from "../../../languageProcessing/helpers/sanitize/stripHTMLTags";
+import { stripFullTags } from "../../../languageProcessing/helpers/sanitize/stripHTMLTags";
 import AssessmentResult from "../../../values/AssessmentResult";
 import Mark from "../../../values/Mark.js";
 import marker from "../../../markers/addMark.js";
@@ -168,7 +168,7 @@ export default class TransitionWordsAssessment extends Assessment {
 
 		return map( transitionWordSentences.sentenceResults, function( sentenceResult ) {
 			let sentence = sentenceResult.sentence;
-			sentence = stripTags( sentence );
+			sentence = stripFullTags( sentence );
 			return new Mark( {
 				original: sentence,
 				marked: marker( sentence ),


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* In this PR: https://github.com/Yoast/wordpress-seo/pull/19979, we've fixed the highlighting of the first sentence in the following scenarios:
   * where the highlighting would not be applied in the image captions in Classic editor when the match was found in the first sentence.
   * where the highlighting would not be applied to the first sentence in Classic editor when an image without a caption was added at the beginning of a paragraph.
* However, the aforementioned PR still hasn't fixed the following case:
   * When pasting text from google doc to Classic editor or Classic block editor (when switching to Block editor from Classic), the <span> tag will also be included. For the sentence that includes the tag at the start, the highlight is not applied.
* This issue can be reproduced in English and other languages
* It affects all assessments that highlight the sentence level: 
   * Passive voice assessment
   * Sentence length assessment
   * Transition words assessment
   * Consecutive sentences assessment
   * Inclusive language assessment

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where the highlighting would not be applied to sentences in _consecutive sentences_, _passive voice_, _transition words_,  _sentence length_, and _inclusive language_ assessments when they contained the opening of the `<span>` tag but not the closing tag.

## Relevant technical choices:

* The step to strip the full HTML tags is done at the assessment level instead of in the `getSentences.js` helper. This is because adding the step in the helper means we also strip other tags potentially needed for the analysis, such as the `<a>` tag and others.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Follow the test instructions in the following scenarios:
**NOTE**: in all scenarios below, please use CMD + V for pasting, so that the `<span>` tag is included
   * [1.2.2. Sentence length assessment](https://docs.google.com/document/d/1SGqRghwblwjDWHLeZjaeNpiSHesq1UCyvxl0i9jZUBI/edit#heading=h.h805bfmp9jsv) 
   * [1.2.3. Passive voice assessment](https://docs.google.com/document/d/1SGqRghwblwjDWHLeZjaeNpiSHesq1UCyvxl0i9jZUBI/edit#heading=h.tlvp7xj0vqfh)
   * [1.2.4. Transition words assessment](https://docs.google.com/document/d/1SGqRghwblwjDWHLeZjaeNpiSHesq1UCyvxl0i9jZUBI/edit#heading=h.11785wjqmelz)
   * [1.2.5. Consecutive sentences assessment 
](https://docs.google.com/document/d/1SGqRghwblwjDWHLeZjaeNpiSHesq1UCyvxl0i9jZUBI/edit#heading=h.72ois7gqmaq8)
   * [1.3. Inclusive language analysis](https://docs.google.com/document/d/1SGqRghwblwjDWHLeZjaeNpiSHesq1UCyvxl0i9jZUBI/edit#heading=h.452n46b12x06)
   * [Scenario 2: Test in Japanese](https://docs.google.com/document/d/1SGqRghwblwjDWHLeZjaeNpiSHesq1UCyvxl0i9jZUBI/edit#heading=h.nxklgunu8t0k)
   * [Scenario 3: Test in Hebrew](https://docs.google.com/document/d/1SGqRghwblwjDWHLeZjaeNpiSHesq1UCyvxl0i9jZUBI/edit#heading=h.2zu1izbtxyld)
   * [Scenario 7.1. Switching editors ](https://docs.google.com/document/d/1SGqRghwblwjDWHLeZjaeNpiSHesq1UCyvxl0i9jZUBI/edit#heading=h.u0yfrb9e1ffb)
      * Note: in this scenario, pleas make sure that the highlight still works for :
         * Passive voice assessment
         * Sentence length assessment
         * Transition words assessment
         * Consecutive sentences assessment
         * Inclusive language assessment 
#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [x] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The PR doesn't have additional impacts other than what have been already included in the testing instructions.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [x] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes https://github.com/Yoast/lingo-other-tasks/issues/142
