### PR TITLE
Fix Transition words assessment result discrepancy of text containing `<strong>` tag

### DIFF
--- a/packages/yoastseo/spec/scoring/assessments/readability/TransitionWordsAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/readability/TransitionWordsAssessmentSpec.js
@@ -113,6 +113,87 @@ describe( "An assessment for transition word percentage", function() {
 		expect( result.getText() ).toEqual( "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Well done!" );
 	} );
 
+	it( "should return the same score for text with and without <strong> tags in English", function() {
+		const paper = new Paper( "<p dir=\"auto\"><strong>Lorem however ipsum dolor sit amet, ex vel harum iisque, " +
+			"cum nonumy vulputate dissentiet cu." +
+			" Id mei feugait constituam scriptorem, posse labitur vis cu, ad mel rebum saepe. No vix diam dolores. " +
+			"Eos id vidisse posidonium, veniam denique efficiendi te nec. Mea id legere prompta comprehensam. " +
+			"Ex errem docendi detraxit quo. Dicit viris in cum, unum modus voluptaria no eam. Id nonumes accusata qui," +
+			" blandit delectus cu sed. Ex saepe prodesset interesset vel, hence vel docendi percipit delicatissimi ad.</strong></p>" +
+			"<p dir=\"auto\">His ut laudem reprimique, id vis nisl dicta argumentum, has aeque partem ea. " +
+			"Nihil aliquam adipiscing has ex, ea atqui accusata reprimique sed, vix legimus accumsan salutatus in. " +
+			"Ceteros ancillae sapientem ei eam, bonorum insolens salutandi ei sit, soleat voluptatibus eu est. " +
+			"Cum porro dicit delicatissimi et, qui quis diam deleniti id, altera ornatus pericula usu ex." +
+			" Debitis suscipit aliquando an vis. Nam clita ignota ut, errem fierent mea te, eu sit falli meliore perpetua. </p> " );
+		const researcher = new EnglishResearcher( paper );
+		const result = new TransitionWordsAssessment().getResult( paper, researcher );
+
+		expect( result.getScore() ).toEqual( 3 );
+		expect( result.getText() ).toEqual( "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 12.5% of the sentences " +
+			"contain transition words, which is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more of them</a>." );
+	} );
+
+	it( "should return the same score for text with and without <strong> tags in English", function() {
+		const paper = new Paper( "<p dir=\"auto\">Lorem however ipsum dolor sit amet, ex vel harum iisque, " +
+			"cum nonumy vulputate dissentiet cu." +
+			" Id mei feugait constituam scriptorem, posse labitur vis cu, ad mel rebum saepe. No vix diam dolores. " +
+			"Eos id vidisse posidonium, veniam denique efficiendi te nec. Mea id legere prompta comprehensam. " +
+			"Ex errem docendi detraxit quo. Dicit viris in cum, unum modus voluptaria no eam. Id nonumes accusata qui," +
+			" blandit delectus cu sed. Ex saepe prodesset interesset vel, hence vel docendi percipit delicatissimi ad.</p>" +
+			"<p dir=\"auto\">His ut laudem reprimique, id vis nisl dicta argumentum, has aeque partem ea. " +
+			"Nihil aliquam adipiscing has ex, ea atqui accusata reprimique sed, vix legimus accumsan salutatus in. " +
+			"Ceteros ancillae sapientem ei eam, bonorum insolens salutandi ei sit, soleat voluptatibus eu est. " +
+			"Cum porro dicit delicatissimi et, qui quis diam deleniti id, altera ornatus pericula usu ex." +
+			" Debitis suscipit aliquando an vis. Nam clita ignota ut, errem fierent mea te, eu sit falli meliore perpetua. </p> " );
+		const researcher = new EnglishResearcher( paper );
+		const result = new TransitionWordsAssessment().getResult( paper, researcher );
+
+		expect( result.getScore() ).toEqual( 3 );
+		expect( result.getText() ).toEqual( "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 12.5% of the sentences " +
+			"contain transition words, which is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more of them</a>." );
+	} );
+
+	it( "should return the same score for text with and without <strong> tags in Japanese", function() {
+		const paper = new Paper( "<p dir=\"auto\"><strong>しかし半数の7名は幼少時に様々な病気で死亡し 第一子（長男）のイージドールも早世しており、" +
+			"グスタフはいわば長男として育てられた。そのなか心臓水腫に長期間苦しんだ弟エルンストは、少年期のグスタフにとって悲しい体験となった。" +
+			"グスタフは盲目のエルンストを愛し、彼が死去するまで数ヶ月間ベッドから離れずに世話をしたという。</strong></p>" +
+			"<p dir=\"auto\">母マリーもユダヤ人で、石鹸製造業者の娘だった。ベルンハルトとは20歳の時に結婚している。家柄は良かったが心臓が悪" +
+			"く生まれつき片足が不自由であり、自分の望む結婚はできなかったという。アルマ・マーラーは「あきらめの心境でベルンハルトと愛のない結婚をし、" +
+			"結婚生活は初日から不幸であった」と書き記している。その結婚自体は理想的な形で実現したとは言えないものの、夫妻の間には前述の通り多く" +
+			"の子供が生まれている。ただし身体の不自由なマリーは、教育熱心な夫ベルンハルトと違い母親としての理想的な教育を子供たちに施すことができなかった。" +
+			"グスタフは生涯この母親に対し「固定観念と言えるほど強い愛情」を持ち続けた。</p> " +
+			"<p dir=\"auto\">ベルンハルトの母（グスタフの祖母）も、行商を生業とする剛毅な人間だった。18歳の頃から大きな籠を背に売り歩いていた。" +
+			"晩年には、行商を規制したある法律に触れる事件を起こし、重刑を言い渡されたが、刑に服する気はなく、ただちにウィーンへ赴き皇帝フランツ・" +
+			"ヨーゼフ1世に直訴する。皇帝は彼女の体力と80歳という高齢に感動し、特赦した。グスタフ・マーラーの一徹な性格はこの祖母譲りだとアルマは語っている。</p>" );
+		const researcher = new JapaneseResearcher( paper );
+		const result = new TransitionWordsAssessment().getResult( paper, researcher );
+
+		expect( result.getScore() ).toEqual( 6 );
+		expect( result.getText() ).toEqual( "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: " +
+			"Only 25% of the sentences contain transition words, which is not enough. <a href='https://yoa.st/35a' " +
+			"target='_blank'>Use more of them</a>." );
+	} );
+
+	it( "should match transition word in image caption", function() {
+		const paper = new Paper( "<p dir=\"auto\">しかし半数の7名は幼少時に様々な病気で死亡し 第一子（長男）のイージドールも早世しており、" +
+			"グスタフはいわば長男として育てられた。そのなか心臓水腫に長期間苦しんだ弟エルンストは、少年期のグスタフにとって悲しい体験となった。" +
+			"グスタフは盲目のエルンストを愛し、彼が死去するまで数ヶ月間ベッドから離れずに世話をしたという。</p>" +
+			"<p dir=\"auto\">母マリーもユダヤ人で、石鹸製造業者の娘だった。ベルンハルトとは20歳の時に結婚している。家柄は良かったが心臓が悪" +
+			"く生まれつき片足が不自由であり、自分の望む結婚はできなかったという。アルマ・マーラーは「あきらめの心境でベルンハルトと愛のない結婚をし、" +
+			"結婚生活は初日から不幸であった」と書き記している。その結婚自体は理想的な形で実現したとは言えないものの、夫妻の間には前述の通り多く" +
+			"の子供が生まれている。ただし身体の不自由なマリーは、教育熱心な夫ベルンハルトと違い母親としての理想的な教育を子供たちに施すことができなかった。" +
+			"グスタフは生涯この母親に対し「固定観念と言えるほど強い愛情」を持ち続けた。</p> " +
+			"<p dir=\"auto\">ベルンハルトの母（グスタフの祖母）も、行商を生業とする剛毅な人間だった。18歳の頃から大きな籠を背に売り歩いていた。" +
+			"晩年には、行商を規制したある法律に触れる事件を起こし、重刑を言い渡されたが、刑に服する気はなく、ただちにウィーンへ赴き皇帝フランツ・" +
+			"ヨーゼフ1世に直訴する。皇帝は彼女の体力と80歳という高齢に感動し、特赦した。グスタフ・マーラーの一徹な性格はこの祖母譲りだとアルマは語っている。</p>" );
+		const researcher = new JapaneseResearcher( paper );
+		const result = new TransitionWordsAssessment().getResult( paper, researcher );
+
+		expect( result.getScore() ).toEqual( 6 );
+		expect( result.getText() ).toEqual( "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: " +
+			"Only 25% of the sentences contain transition words, which is not enough. <a href='https://yoa.st/35a' " +
+			"target='_blank'>Use more of them</a>." );
+	} );
 	it( "is not applicable for empty papers", function() {
 		const mockPaper = new Paper();
 		const assessment = new TransitionWordsAssessment().isApplicable( mockPaper, new EnglishResearcher( mockPaper ) );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

*

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

*

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
