### PR TITLE
Performance improvement for author_has_public_posts_wp

### DIFF
--- a/src/helpers/author-archive-helper.php
+++ b/src/helpers/author-archive-helper.php
@@ -89,7 +89,7 @@ class Author_Archive_Helper {
 		$post_types        = \array_intersect( $this->get_author_archive_post_types(), $this->post_type_helper->get_indexable_post_types() );
 		$public_post_stati = \array_values( \array_filter( \get_post_stati(), 'is_post_status_viewable' ) );
 
-		$args  = [
+		$args = [
 			'post_type'              => $post_types,
 			'post_status'            => $public_post_stati,
 			'author'                 => $user_id,

--- a/src/helpers/author-archive-helper.php
+++ b/src/helpers/author-archive-helper.php
@@ -90,13 +90,19 @@ class Author_Archive_Helper {
 		$public_post_stati = \array_values( \array_filter( \get_post_stati(), 'is_post_status_viewable' ) );
 
 		$args  = [
-			'post_type'   => $post_types,
-			'post_status' => $public_post_stati,
-			'author'      => $user_id,
+			'post_type'              => $post_types,
+			'post_status'            => $public_post_stati,
+			'author'                 => $user_id,
+			'update_post_term_cache' => false,
+			'update_post_meta_cache' => false,
+			'no_found_rows'          => true,
+			'fields'                 => 'ids',
+			'posts_per_page'         => 1,
 		];
+
 		$query = new WP_Query( $args );
 
-		if ( ! empty( $query->posts ) ) {
+		if ( $query->have_posts() ) {
 			return true;
 		}
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The WP_Query used in the `author_has_public_posts_wp()` function can be improved so as to not run unnecessary queries.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves performance when SEO optimization hasn't been completed. Props to @PypWalters.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

In order to benchmark the performance improvement of the change:
* To have a website with a lot of posts, run the following command in the WP CLI: `wp post generate --count=100000 --post_author=admin` (it assumes that you have a user with ID=1 - let's say it has the `admin` username)
  * Or use [this zip](https://drive.google.com/file/d/1PnqKjeRcjxQ8Oy3qTnDSGUy1eztteS_-/view?usp=sharing) to import in your Local WP.
  * If after importing, you get a Database error, make sure to use the Test Helper to Reset Indexables.
* Have debug enabled in your site. That is, add these in your wp-config:
```
define( 'WP_DEBUG', true );
define( 'WP_DEBUG_LOG', true );
define( 'WP_DEBUG_DISPLAY', false );
```
* Add this in your functions.php code (it assumes that you have a user with ID=1 - let's say it has the `admin` username):
```
add_filter( 'shutdown', 'benchmark_yoast_code', 10 );
function benchmark_yoast_code() {
    if ( ! get_option( 'benchmark_ran' ) ) {
        update_option( 'benchmark_ran', true );
        $author_archive_helper = YoastSEO()->helpers->author_archive;
        $start_time = microtime(TRUE);
        // Define the number of times the function should be executed
        $numRuns = 100;
        
        // Start the benchmark
        $start = microtime(true);
        
        // Execute the function multiple times
        for ($i = 0; $i < $numRuns; $i++) {
            $author_archive_helper->author_has_public_posts_wp(1);
        }
        
        // End the benchmark
        $end = microtime(true);
        
        // Calculate the elapsed time
        $elapsed = $end - $start;
        
        error_log( "Average time per run: " . ($elapsed / $numRuns) . " seconds\n" );
    }
}
```
* With the previous Yoast SEO version, refresh any page and go to your wp-content/debug.log and check what that `Average time per run` is.
* Install this RC to repeat the test.
* Anytime you want to repeat the test, you have to delete the `benchmark_ran` option from wp_options. Once you do that, refresh any page.
* Go to your wp-content/debug.log and check what that `Average time per run` is. It should be lower than the one from the previous test. Provided that your site is big enough, it will be **significantly** lower.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Regression test https://github.com/Yoast/wordpress-seo/pull/19146

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
