### PR TITLE
HTML parser: Make it possible to get sentences from nodes that have descendant nodes without a closing tag

### DIFF
--- a/packages/yoastseo/spec/parse/build/private/getSentencePositionsSpec.js
+++ b/packages/yoastseo/spec/parse/build/private/getSentencePositionsSpec.js
@@ -70,32 +70,36 @@ describe( "A test for getting positions of sentences", () => {
 	it( "gets the sentence positions from a node that has a descendant node without a closing tag (img)", function() {
 		// HTML: <p>Hello, world!<img src="image.jpg" alt="this is an image" width="500" height="600"> Hello, yoast!</p>
 		const node = new Paragraph( {}, [ { name: "#text", value: "Hello, world! Hello, yoast!" },
-				{
-					name: "img",
-					attributes: { "src": new Set( [ "image.jpg" ] ), "alt": new Set( [ "this is an image" ] ),
-					"width": new Set( [ "500" ] ), "height": new Set( [ "600" ] ) },
-					childNodes: [],
-					sourceCodeLocation: {
+			{
+				name: "img",
+				attributes: {
+					src: "image.jpg",
+					alt: "this is an image",
+					width: "500",
+					height: "600",
+				},
+				childNodes: [],
+				sourceCodeLocation: {
+					startOffset: 21,
+					endOffset: 90,
+					startTag: {
 						startOffset: 21,
 						endOffset: 90,
-						startTag: {
-							startOffset: 21,
-							endOffset: 90,
-						},
 					},
-				} ],
-			{
+				},
+			} ],
+		{
+			startOffset: 5,
+			endOffset: 108,
+			startTag: {
 				startOffset: 5,
+				endOffset: 8,
+			},
+			endTag: {
+				startOffset: 104,
 				endOffset: 108,
-				startTag: {
-					startOffset: 5,
-					endOffset: 8,
-				},
-				endTag: {
-					startOffset: 104,
-					endOffset: 108,
-				},
-			} );
+			},
+		} );
 
 		const sentences = [ { text: "Hello, world!" }, { text: " Hello, yoast!" } ];
 		const sentencesWithPositions = [ { text: "Hello, world!", sourceCodeRange: { startOffset: 8, endOffset: 21 } },

--- a/packages/yoastseo/spec/parse/build/private/getSentencePositionsSpec.js
+++ b/packages/yoastseo/spec/parse/build/private/getSentencePositionsSpec.js
@@ -67,6 +67,42 @@ describe( "A test for getting positions of sentences", () => {
 
 		expect( getSentencePositions( node, sentences ) ).toEqual( sentencesWithPositions );
 	} );
+	it( "gets the sentence positions from a node that has a descendant node without a closing tag (img)", function() {
+		// HTML: <p>Hello, world!<img src="image.jpg" alt="this is an image" width="500" height="600"> Hello, yoast!</p>
+		const node = new Paragraph( {}, [ { name: "#text", value: "Hello, world! Hello, yoast!" },
+				{
+					name: "img",
+					attributes: { "src": new Set( [ "image.jpg" ] ), "alt": new Set( [ "this is an image" ] ),
+					"width": new Set( [ "500" ] ), "height": new Set( [ "600" ] ) },
+					childNodes: [],
+					sourceCodeLocation: {
+						startOffset: 21,
+						endOffset: 90,
+						startTag: {
+							startOffset: 21,
+							endOffset: 90,
+						},
+					},
+				} ],
+			{
+				startOffset: 5,
+				endOffset: 108,
+				startTag: {
+					startOffset: 5,
+					endOffset: 8,
+				},
+				endTag: {
+					startOffset: 104,
+					endOffset: 108,
+				},
+			} );
+
+		const sentences = [ { text: "Hello, world!" }, { text: " Hello, yoast!" } ];
+		const sentencesWithPositions = [ { text: "Hello, world!", sourceCodeRange: { startOffset: 8, endOffset: 21 } },
+			{ text: " Hello, yoast!", sourceCodeRange: { startOffset: 21, endOffset: 104 } } ];
+
+		expect( getSentencePositions( node, sentences ) ).toEqual( sentencesWithPositions );
+	} );
 	it( "gets the sentence positions from a node that has a `span` and an `em` descendant node", function() {
 		// HTML: <p>Hello, <span>world!</span> Hello, <em>yoast!</em></p>.
 		const node = new Paragraph( {}, [ { name: "#text", value: "Hello, world! Hello, yoast!" },

--- a/packages/yoastseo/src/parse/build/private/getSentencePositions.js
+++ b/packages/yoastseo/src/parse/build/private/getSentencePositions.js
@@ -15,7 +15,9 @@ function getDescendantPositions( descendantNodes ) {
 	const descendantTagPositions = [];
 	descendantNodes.forEach( ( node ) => {
 		descendantTagPositions.push( node.sourceCodeLocation.startTag );
-		descendantTagPositions.push( node.sourceCodeLocation.endTag );
+		if ( node.sourceCodeLocation.endTag ) {
+			descendantTagPositions.push( node.sourceCodeLocation.endTag );
+		}
 	} );
 	// Sort the tag position objects by the start tag position in ascending order.
 	descendantTagPositions.sort( ( a, b ) => a.startOffset - b.startOffset );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The `getSentencePositions` function was failing for texts that had sentences with HTML tags that don't have a closing tag, such as `<img>`. This is because the function was trying to get each node's end tag which would return `undefined` for nodes without end tags and break the functionality. This is fixed by only getting the end tag if the node has one.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [yoastseo] Do not try to get a descendant node's end tag in the `getSentencePositions` function if the node doesn't have an end tag.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Make sure all unit tests pass.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [x] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes https://github.com/Yoast/lingo-other-tasks/issues/153
