### PR TITLE
Improve word casing in the Yoast UI library storybook

### DIFF
--- a/packages/ui-library/.storybook/manager.js
+++ b/packages/ui-library/.storybook/manager.js
@@ -1,6 +1,10 @@
 import { addons } from "@storybook/addons";
 import theme from "./theme";
+import { lowerCase, upperFirst } from "lodash";
 
 addons.setConfig( {
 	theme,
+	sidebar: {
+		renderLabel: ( { name } ) => ( upperFirst( lowerCase( name ) ) ),
+	},
 } );

--- a/packages/ui-library/contributing.md
+++ b/packages/ui-library/contributing.md
@@ -1,4 +1,4 @@
-# Contributing to the Yoast UI Library
+# Contributing to the Yoast UI library
 The Yoast UI library is a React component library for building Yoast user interfaces. You can contribute to the UI library by adding more stories or creating new components.
 
 ## Local development

--- a/packages/ui-library/readme.md
+++ b/packages/ui-library/readme.md
@@ -1,4 +1,4 @@
-# Welcome to the Yoast UI Library
+# Welcome to the Yoast UI library
 A React component library for building Yoast user interfaces. Please visit [the Storybook](https://ui-library.yoast.com/) for an interactive overview of all available components and examples on how to use them.
 
 [View the changelog here](https://github.com/Yoast/wordpress-seo/blob/trunk/packages/ui-library/changelog.md).

--- a/packages/ui-library/src/components/autocomplete-field/stories.js
+++ b/packages/ui-library/src/components/autocomplete-field/stories.js
@@ -4,7 +4,7 @@ import { filter, find, includes, toLower, noop, map } from "lodash";
 import { VALIDATION_VARIANTS } from "../../constants";
 
 export default {
-	title: "2) Components/Autocomplete Field",
+	title: "2) Components/Autocomplete field",
 	component: StoryComponent,
 	argTypes: {
 		description: { control: "text" },
@@ -76,7 +76,7 @@ Factory.args = {
 };
 
 export const WithDescription = Template.bind( {} );
-
+WithDescription.storyName = "With description";
 WithDescription.parameters = {
 	controls: { disable: false },
 	docs: { description: { story: "An exampe with description message using `description`." } },
@@ -89,7 +89,7 @@ WithDescription.args = {
 };
 
 export const WithSelectedLabel = Template.bind( {} );
-
+WithSelectedLabel.storyName = "With selected label";
 WithSelectedLabel.parameters = {
 	controls: { disable: false },
 	docs: { description: { story: "When using `children` prop, `selectedLabel` prop is used to set default/selected value." } },
@@ -108,7 +108,7 @@ WithSelectedLabel.args = {
 };
 
 export const WithPlaceholder = Template.bind( {} );
-
+WithPlaceholder.storyName = "With placeholder";
 WithPlaceholder.parameters = {
 	controls: { disable: false },
 	docs: { description: { story: "An example with placeholder." } },
@@ -122,6 +122,7 @@ WithPlaceholder.args = {
 };
 
 export const ChildrenProp = Template.bind();
+ChildrenProp.storyName = "Children prop";
 ChildrenProp.args = {
 	id: "with-children-prop",
 	name: "with-children-prop",

--- a/packages/ui-library/src/components/card/stories.js
+++ b/packages/ui-library/src/components/card/stories.js
@@ -49,7 +49,7 @@ Factory.args = {
 };
 
 export const WithoutHeader = Template.bind( {} );
-
+WithoutHeader.storyName = "Without header";
 WithoutHeader.args = {
 	children: (
 		<>

--- a/packages/ui-library/src/components/checkbox-group/stories.js
+++ b/packages/ui-library/src/components/checkbox-group/stories.js
@@ -2,7 +2,7 @@ import { useCallback, useState } from "@wordpress/element";
 import CheckboxGroup from ".";
 
 export default {
-	title: "2) Components/Checkbox Group",
+	title: "2) Components/Checkbox group",
 	component: CheckboxGroup,
 	argTypes: {
 		children: { control: "text" },
@@ -43,7 +43,7 @@ Factory.args = {
 };
 
 export const WithLabelAndDescription = Template.bind( {} );
-
+WithLabelAndDescription.storyName = "With label and description";
 WithLabelAndDescription.args = {
 	id: "checkbox-group-1",
 	name: "name-1",
@@ -58,7 +58,7 @@ WithLabelAndDescription.args = {
 };
 
 export const WithValues = Template.bind( {} );
-
+WithValues.storyName = "With values";
 WithValues.args = {
 	id: "checkbox-group-2",
 	name: "name-2",
@@ -73,7 +73,7 @@ WithValues.args = {
 };
 
 export const ChildrenProp = Template.bind( {} );
-
+ChildrenProp.storyName = "Children prop";
 ChildrenProp.args = {
 	id: "checkbox-group-3",
 	name: "name-3",

--- a/packages/ui-library/src/components/checkbox-group/stories.js
+++ b/packages/ui-library/src/components/checkbox-group/stories.js
@@ -39,7 +39,7 @@ Factory.args = {
 		{ value: "3", label: "Option 3" },
 		{ value: "4", label: "Option 4" },
 	],
-	label: "A Checkbox Group",
+	label: "A checkbox group",
 };
 
 export const WithLabelAndDescription = Template.bind( {} );

--- a/packages/ui-library/src/components/children-limiter/stories.js
+++ b/packages/ui-library/src/components/children-limiter/stories.js
@@ -4,7 +4,7 @@ import ChildrenLimiter from ".";
 import { Button } from "../../";
 
 export default {
-	title: "2) Components/Children Limiter",
+	title: "2) Components/Children limiter",
 	component: ChildrenLimiter,
 	parameters: {
 		docs: {

--- a/packages/ui-library/src/components/feature-upsell/stories.js
+++ b/packages/ui-library/src/components/feature-upsell/stories.js
@@ -1,7 +1,7 @@
 import FeatureUpsell from ".";
 
 export default {
-	title: "2) Components/Feature Upsell",
+	title: "2) Components/Feature upsell",
 	component: FeatureUpsell,
 	parameters: {
 		docs: {

--- a/packages/ui-library/src/components/file-import/stories.js
+++ b/packages/ui-library/src/components/file-import/stories.js
@@ -5,7 +5,7 @@ import Alert from "../../elements/alert";
 import FileImport, { FILE_IMPORT_STATUS, StoryComponent } from ".";
 
 export default {
-	title: "2) Components/File Import",
+	title: "2) Components/File import",
 	component: StoryComponent,
 	argTypes: {
 		children: { control: "text" },

--- a/packages/ui-library/src/components/modal/stories.js
+++ b/packages/ui-library/src/components/modal/stories.js
@@ -94,6 +94,7 @@ export const Factory = {
 
 export const WithPanel = {
 	component: Factory.component.bind( {} ),
+	storyName: "With panel",
 	parameters: {
 		docs: {
 			description: {
@@ -117,6 +118,7 @@ export const WithPanel = {
 
 export const WithTitleAndDescription = {
 	component: Factory.component.bind( {} ),
+	storyName: "With title and description",
 	parameters: {
 		docs: {
 			description: {
@@ -159,5 +161,5 @@ const InitialFocusComponent = () => {
 };
 
 export const InitialFocus = () => <InitialFocusComponent />;
-
+InitialFocus.storyName = "Initial focus";
 InitialFocus.parameters = { docs: { description: { story: "The `initialFocus` prop accepts ref object and once the modal is open, the focus will be applied to the element with the ref. <br>By default, the focus will go to the first focusable element in the modal." } } };

--- a/packages/ui-library/src/components/notifications/stories.js
+++ b/packages/ui-library/src/components/notifications/stories.js
@@ -32,12 +32,12 @@ export default {
 		title: { control: "text", type: "string" },
 		description: { control: "text", type: "string" },
 		onDismiss: { control: { disable: false } },
-		autoDismiss: { type: "number", description: "Miliseconds for Notification to dissapear." },
+		autoDismiss: { type: "number", description: "Milliseconds for Notification to disappear." },
 		dismissScreenReaderLabel: { control: "text", type: "string" },
 	},
 	args: {
 		title: "Notification title",
-		description: "Notifiation description",
+		description: "Notification description",
 		dismissScreenReaderLabel: "Dismiss",
 	},
 	parameters: {

--- a/packages/ui-library/src/components/notifications/stories.js
+++ b/packages/ui-library/src/components/notifications/stories.js
@@ -92,6 +92,7 @@ Error.args = {
 };
 
 export const DescriptionList = Template.bind( {} );
+DescriptionList.storyName = "Description list";
 DescriptionList.args = {
 	variant: "info",
 	id: "notification-info",
@@ -101,7 +102,7 @@ DescriptionList.args = {
 DescriptionList.parameters = { docs: { description: { story: "Description can be an array of strings." } } };
 
 export const ChildrenNotification = Template.bind( {} );
-
+ChildrenNotification.storyName = "Children notification";
 const DescriptionChild = () => <b>Notification description as a component.</b>;
 
 ChildrenNotification.args = {

--- a/packages/ui-library/src/components/radio-group/stories.js
+++ b/packages/ui-library/src/components/radio-group/stories.js
@@ -57,7 +57,7 @@ export const Variants = ( args ) => (
 				{ value: "3", label: "3", screenReaderLabel: "Option #3" },
 				{ value: "4", label: "4", screenReaderLabel: "Option #4" },
 			] }
-			label="Default Radio Group"
+			label="Default radio group"
 			onChange={ noop }
 		/>
 		<hr />
@@ -65,7 +65,7 @@ export const Variants = ( args ) => (
 			id="radio-group-2"
 			name="name-2"
 			value="2"
-			label="Inline-block Radio Group"
+			label="Inline-block radio group"
 			description="Radio group with a description."
 			options={ [
 				{ value: "1", label: "1", screenReaderLabel: "Option #1" },

--- a/packages/ui-library/src/components/radio-group/stories.js
+++ b/packages/ui-library/src/components/radio-group/stories.js
@@ -4,7 +4,7 @@ import { noop } from "lodash";
 import RadioGroup from ".";
 
 export default {
-	title: "2) Components/Radio Group",
+	title: "2) Components/Radio group",
 	component: RadioGroup,
 	argTypes: {
 		children: { control: "text" },
@@ -83,6 +83,7 @@ Variants.parameters = {
 };
 
 export const WithLabelAndDescription = Template.bind();
+WithLabelAndDescription.storyName = "With label and description";
 WithLabelAndDescription.args = {
 	id: "radio-group-3",
 	name: "name-3",
@@ -97,6 +98,7 @@ WithLabelAndDescription.args = {
 };
 
 export const WithValue = Template.bind();
+WithValue.storyName = "With value";
 WithValue.args = {
 	id: "radio-group-4",
 	name: "name-4",
@@ -111,6 +113,7 @@ WithValue.args = {
 };
 
 export const ChildrenProp = Template.bind();
+ChildrenProp.storyName = "Children prop";
 ChildrenProp.args = {
 	id: "radio-group-5",
 	name: "name-5",

--- a/packages/ui-library/src/components/root/stories.js
+++ b/packages/ui-library/src/components/root/stories.js
@@ -8,7 +8,7 @@ export default {
 			description: {
 				component:
                     "The `Root` component provides your React tree with a `RootContext` which contains general options such as `isRtl` to indicate right to left language direction. " +
-                    "It also provides a `.yst-root` CSS class for scoping our CSS in opiniated environments. " +
+                    "It also provides a `.yst-root` CSS class for scoping our CSS in opinionated environments. " +
                     "You can use the `RootContext` by using the `useRootContext` hook exported from `@yoast/ui-library/hooks`." +
 					"\n\n" +
 					"Please note that the CSS scoping adds one level of CSS specificity. Therefore `@yoast/tailwindcss-preset` does the following:\n" +

--- a/packages/ui-library/src/components/select-field/stories.js
+++ b/packages/ui-library/src/components/select-field/stories.js
@@ -12,7 +12,7 @@ const options = [
 ];
 
 export default {
-	title: "2) Components/Select Field",
+	title: "2) Components/Select field",
 	component: StoryComponent,
 	argTypes: {
 		description: { control: "text" },
@@ -62,6 +62,7 @@ Factory.args = {
 };
 
 export const WithLabelAndDescription = Template.bind( {} );
+WithLabelAndDescription.storyName = "With label and description";
 WithLabelAndDescription.args = {
 	id: "select-field-1",
 	name: "name-1",
@@ -72,6 +73,7 @@ WithLabelAndDescription.args = {
 };
 
 export const WithError = Template.bind( {} );
+WithError.storyName = "With error";
 WithError.args = {
 	id: "select-field-2",
 	name: "name-2",
@@ -82,6 +84,7 @@ WithError.args = {
 
 
 export const WithLabelSuffix = Template.bind( {} );
+WithLabelSuffix.storyName = "With label suffix";
 WithLabelSuffix.args = {
 	id: "select-field-3",
 	name: "name-3",
@@ -91,6 +94,7 @@ WithLabelSuffix.args = {
 };
 
 export const OptionsProp = Template.bind( {} );
+OptionsProp.storyName = "Options prop";
 OptionsProp.args = {
 	id: "select-field-4",
 	name: "name-4",
@@ -103,6 +107,7 @@ OptionsProp.parameters = {
 };
 
 export const SelectFieldOption = Template.bind( {} );
+SelectFieldOption.storyName = "Select field option";
 SelectFieldOption.args = {
 	id: "select-field-5",
 	name: "name-5",

--- a/packages/ui-library/src/components/select-field/stories.js
+++ b/packages/ui-library/src/components/select-field/stories.js
@@ -58,7 +58,7 @@ Factory.args = {
 	name: "name-0",
 	value: "1",
 	children: options.map( option => <SelectField.Option key={ option.value } { ...option } /> ),
-	label: "A Select Field",
+	label: "A select field",
 };
 
 export const WithLabelAndDescription = Template.bind( {} );

--- a/packages/ui-library/src/components/sidebar-navigation/stories.js
+++ b/packages/ui-library/src/components/sidebar-navigation/stories.js
@@ -183,7 +183,7 @@ Mobile.args = {
 		openButtonScreenReaderText="Open sidebar"
 		closeButtonScreenReaderText="Close sidebar"
 	>
-		<div className="yst-m-4">MobileMenu</div>
+		<div className="yst-m-4">Mobile menu</div>
 		<SidebarNavigation.MenuItem
 			id={ "submenuitem-mobile" }
 			icon={ AdjustmentsIcon }

--- a/packages/ui-library/src/components/sidebar-navigation/stories.js
+++ b/packages/ui-library/src/components/sidebar-navigation/stories.js
@@ -3,7 +3,7 @@ import SidebarNavigation from ".";
 import Table from "../../elements/table";
 
 export default {
-	title: "2) Components/Sidebar Navigation",
+	title: "2) Components/Sidebar navigation",
 	component: SidebarNavigation,
 	argTypes: {
 		children: { control: "text" },
@@ -120,7 +120,7 @@ Factory.args = {
 };
 
 export const MenuItem = Template.bind( {} );
-
+MenuItem.storyName = "Menu item";
 MenuItem.parameters = { docs: { description: { story: "The subcomponent `SidebarNavigation.MenuItem` accepts the subcomponents `SidebarNavigation.SubmenuItem` as children." } } };
 
 MenuItem.args = {
@@ -200,7 +200,7 @@ Mobile.args = {
 
 
 export const NavigationContext = Template.bind( {} );
-
+NavigationContext.storyName = "Navigation context";
 NavigationContext.parameters = {
 	docs: {
 		description: {

--- a/packages/ui-library/src/components/sidebar-navigation/stories.js
+++ b/packages/ui-library/src/components/sidebar-navigation/stories.js
@@ -45,14 +45,14 @@ export default {
 		},
 		openButtonScreenReaderText: {
 			control: "text",
-			description: "Accesability for `Mobile`",
+			description: "Accessibility for `Mobile`",
 			table: {
 				type: { summary: "string" },
 			},
 		},
 		closeButtonScreenReaderText: {
 			control: "text",
-			description: "Accesability for `Mobile`",
+			description: "Accessibility for `Mobile`",
 			table: {
 				type: { summary: "string" },
 			},

--- a/packages/ui-library/src/components/tag-field/stories.js
+++ b/packages/ui-library/src/components/tag-field/stories.js
@@ -4,7 +4,7 @@ import { VALIDATION_VARIANTS } from "../../constants";
 import { StoryComponent } from ".";
 
 export default {
-	title: "2) Components/Tag Field",
+	title: "2) Components/Tag field",
 	component: StoryComponent,
 	parameters: {
 		docs: {
@@ -44,6 +44,7 @@ Factory.parameters = {
 };
 
 export const WithLabelAndDescription = Template.bind( {} );
+WithLabelAndDescription.storyName = "With label and description";
 WithLabelAndDescription.args = {
 	id: "tag-field-1",
 	label: "Tag field with a label",

--- a/packages/ui-library/src/components/text-field/stories.js
+++ b/packages/ui-library/src/components/text-field/stories.js
@@ -5,7 +5,7 @@ import { VALIDATION_VARIANTS } from "../../constants";
 import { StoryComponent } from ".";
 
 export default {
-	title: "2) Components/Text Field",
+	title: "2) Components/Text field",
 	component: StoryComponent,
 	argTypes: {
 		description: { control: "text" },
@@ -40,6 +40,7 @@ export const Factory = {
 };
 
 export const WithLabelAndDescription = {
+	storyName: "With label and description",
 	component: Factory.component.bind( {} ),
 	args: {
 		id: "input-field-1",

--- a/packages/ui-library/src/components/text-field/stories.js
+++ b/packages/ui-library/src/components/text-field/stories.js
@@ -21,7 +21,7 @@ export default {
 	args: {
 		id: "input-field",
 		onChange: noop,
-		label: "A Text Field",
+		label: "A text field",
 	},
 };
 

--- a/packages/ui-library/src/components/textarea-field/stories.js
+++ b/packages/ui-library/src/components/textarea-field/stories.js
@@ -18,7 +18,7 @@ export default {
 	},
 	args: {
 		id: "textarea-field",
-		label: "A Textarea Field",
+		label: "A textarea field",
 	},
 };
 

--- a/packages/ui-library/src/components/textarea-field/stories.js
+++ b/packages/ui-library/src/components/textarea-field/stories.js
@@ -4,7 +4,7 @@ import { VALIDATION_VARIANTS } from "../../constants";
 import { StoryComponent } from ".";
 
 export default {
-	title: "2) Components/Textarea Field",
+	title: "2) Components/Textarea field",
 	component: StoryComponent,
 	argTypes: {
 		description: { control: "text" },
@@ -31,6 +31,7 @@ export const Factory = {
 
 export const WithLabelAndDescription = {
 	component: Factory.component.bind( {} ),
+	storyName: "With label and description",
 	args: {
 		id: "textarea-field-1",
 		label: "Textarea field with a label",

--- a/packages/ui-library/src/components/toggle-field/stories.js
+++ b/packages/ui-library/src/components/toggle-field/stories.js
@@ -35,7 +35,7 @@ Factory.parameters = {
 
 Factory.args = {
 	id: "factory-id",
-	label: "A Toggle Field",
+	label: "A toggle field",
 };
 
 export const WithLabelAndDescription = Template.bind( {} );

--- a/packages/ui-library/src/components/toggle-field/stories.js
+++ b/packages/ui-library/src/components/toggle-field/stories.js
@@ -3,7 +3,7 @@ import { StoryComponent } from ".";
 import Badge from "../../elements/badge";
 
 export default {
-	title: "2) Components/Toggle Field",
+	title: "2) Components/Toggle field",
 	component: StoryComponent,
 	argTypes: {
 		children: { control: "text" },
@@ -39,6 +39,7 @@ Factory.args = {
 };
 
 export const WithLabelAndDescription = Template.bind( {} );
+WithLabelAndDescription.storyName = "With label and description";
 WithLabelAndDescription.args = {
 	id: "id-1",
 	name: "name-1",
@@ -55,6 +56,7 @@ Checked.args = {
 };
 
 export const WithLabelSuffix = Template.bind( {} );
+WithLabelSuffix.storyName = "With label suffix";
 WithLabelSuffix.args = {
 	id: "id-3",
 	name: "name-3",

--- a/packages/ui-library/src/elements/alert/stories.js
+++ b/packages/ui-library/src/elements/alert/stories.js
@@ -38,7 +38,7 @@ Factory.parameters = {
 	controls: { disable: false },
 };
 Factory.args = {
-	children: "Alert Factory",
+	children: "Alert factory",
 };
 
 export const Variants = ( args ) => {

--- a/packages/ui-library/src/elements/autocomplete/stories.js
+++ b/packages/ui-library/src/elements/autocomplete/stories.js
@@ -75,6 +75,8 @@ Factory.args = {
 
 export const WithLabel = Template.bind( {} );
 
+WithLabel.storyName = "With label";
+
 WithLabel.parameters = {
 	controls: { disable: false },
 	docs: { description: { story: "An example with a label using `label` prop." } },
@@ -88,6 +90,8 @@ WithLabel.args = {
 
 export const WithPlaceholder = Template.bind( {} );
 
+WithPlaceholder.storyName = "With placeholder";
+
 WithPlaceholder.parameters = {
 	controls: { disable: false },
 	docs: { description: { story: "An example with placeholder using `placeholder` prop." } },
@@ -100,6 +104,8 @@ WithPlaceholder.args = {
 };
 
 export const WithSelectedLabel = Template.bind( {} );
+
+WithSelectedLabel.storyName = "With selected label";
 
 WithSelectedLabel.parameters = {
 	controls: { disable: false },

--- a/packages/ui-library/src/elements/badge/stories.js
+++ b/packages/ui-library/src/elements/badge/stories.js
@@ -23,7 +23,7 @@ Factory.parameters = {
 	controls: { disable: false },
 };
 Factory.args = {
-	children: "Badge Factory",
+	children: "Badge factory",
 };
 
 export const Variants = ( args ) => (

--- a/packages/ui-library/src/elements/button/stories.js
+++ b/packages/ui-library/src/elements/button/stories.js
@@ -36,7 +36,7 @@ Factory.parameters = {
 	controls: { disable: false },
 };
 Factory.args = {
-	children: "Button Factory",
+	children: "Button factory",
 };
 
 export const Variants = ( args ) => (

--- a/packages/ui-library/src/elements/code/stories.js
+++ b/packages/ui-library/src/elements/code/stories.js
@@ -22,7 +22,7 @@ export const Factory = {
 		controls: { disable: false },
 	},
 	args: {
-		children: "Code Factory",
+		children: "Code factory",
 		variant: "default",
 	},
 };

--- a/packages/ui-library/src/elements/error-boundary/stories.js
+++ b/packages/ui-library/src/elements/error-boundary/stories.js
@@ -3,7 +3,7 @@ import { Alert, Button } from "../../";
 import { useToggleState } from "../../hooks";
 
 export default {
-	title: "1) Elements/Error Boundary",
+	title: "1) Elements/Error boundary",
 	component: ErrorBoundary,
 	argTypes: {
 		children: { control: "text" },

--- a/packages/ui-library/src/elements/file-input/stories.js
+++ b/packages/ui-library/src/elements/file-input/stories.js
@@ -3,7 +3,7 @@ import { StoryComponent } from ".";
 import { DesktopComputerIcon } from "@heroicons/react/outline";
 
 export default {
-	title: "1) Elements/File Input",
+	title: "1) Elements/File input",
 	component: StoryComponent,
 	argTypes: {},
 	parameters: {
@@ -37,6 +37,8 @@ Factory.args = {
 
 export const WithDescription = Template.bind( {} );
 
+WithDescription.storyName = "With description";
+
 WithDescription.parameters = {
 	controls: { disable: false },
 	docs: { description: { story: "A file input with a description using `selectDescription` prop." } },
@@ -64,7 +66,7 @@ Disabled.args = {
 };
 
 export const DifferentIcon = Template.bind( {} );
-
+DifferentIcon.storyName = "Different icon";
 DifferentIcon.parameters = {
 	controls: { disable: false },
 	docs: { description: { story: "A file input with different icon using `iconAs` prop. The icon should be a react component." } },

--- a/packages/ui-library/src/elements/file-input/stories.js
+++ b/packages/ui-library/src/elements/file-input/stories.js
@@ -69,7 +69,7 @@ export const DifferentIcon = Template.bind( {} );
 DifferentIcon.storyName = "Different icon";
 DifferentIcon.parameters = {
 	controls: { disable: false },
-	docs: { description: { story: "A file input with different icon using `iconAs` prop. The icon should be a Rlabeact component." } },
+	docs: { description: { story: "A file input with different icon using `iconAs` prop. The icon should be a React component." } },
 };
 
 DifferentIcon.args = {

--- a/packages/ui-library/src/elements/file-input/stories.js
+++ b/packages/ui-library/src/elements/file-input/stories.js
@@ -69,7 +69,7 @@ export const DifferentIcon = Template.bind( {} );
 DifferentIcon.storyName = "Different icon";
 DifferentIcon.parameters = {
 	controls: { disable: false },
-	docs: { description: { story: "A file input with different icon using `iconAs` prop. The icon should be a react component." } },
+	docs: { description: { story: "A file input with different icon using `iconAs` prop. The icon should be a Rlabeact component." } },
 };
 
 DifferentIcon.args = {

--- a/packages/ui-library/src/elements/label/stories.js
+++ b/packages/ui-library/src/elements/label/stories.js
@@ -22,5 +22,5 @@ Factory.parameters = {
 	controls: { disable: false },
 };
 Factory.args = {
-	label: "Label Factory",
+	label: "Label factory",
 };

--- a/packages/ui-library/src/elements/link/stories.js
+++ b/packages/ui-library/src/elements/link/stories.js
@@ -93,3 +93,5 @@ export const CustomComponent = {
 		children: "component",
 	},
 };
+
+CustomComponent.storyName = "Custom component";

--- a/packages/ui-library/src/elements/progress-bar/stories.js
+++ b/packages/ui-library/src/elements/progress-bar/stories.js
@@ -1,7 +1,7 @@
 import { StoryComponent } from ".";
 
 export default {
-	title: "1) Elements/Progress Bar",
+	title: "1) Elements/Progress bar",
 	component: StoryComponent,
 	parameters: {
 		docs: {

--- a/packages/ui-library/src/elements/radio/stories.js
+++ b/packages/ui-library/src/elements/radio/stories.js
@@ -44,6 +44,7 @@ export const DangerousLabel = ( args ) => (
 		<StoryComponent id="radio-dangerous" name="option-dangerous" value="D" label={ "&bull; Dangerous label." } isLabelDangerousHtml={ true } />
 	</div>
 );
+DangerousLabel.storyName = "Dangerous label";
 DangerousLabel.parameters = {
 	docs: { description: { story: "This Radio element has `isLabelDangerousHtml` prop set to true, the bullet is encoded (&bull;)." } },
 };

--- a/packages/ui-library/src/elements/select/stories.js
+++ b/packages/ui-library/src/elements/select/stories.js
@@ -69,12 +69,13 @@ OptionsProp.args = {
 		{ value: "4", label: "Option 4" },
 	],
 };
-
+OptionsProp.storyName = "Options prop";
 OptionsProp.parameters = {
 	docs: { description: { story: "Add options as an array of objects with `options` prop. Each object must contain `value` and `label` parameters. The displayed selected label will be updated automatically on change." } },
 };
 
 export const ChildrenProp = Template.bind( {} );
+ChildrenProp.storyName = "Children prop";
 ChildrenProp.args = {
 	id: "select-field-5",
 	name: "name-5",
@@ -82,6 +83,7 @@ ChildrenProp.args = {
 	label: "Select field with options as exposed React components",
 	children: options.map( option => <Select.Option key={ option.value } { ...option } /> ),
 };
+
 
 ChildrenProp.parameters = {
 	docs: { description: { story: "Add options as an array of React components with `children` prop, using the exposed option component `Select.Option`. In this case changing the `selectedLabel` should be done manually in the handleChange function" } },

--- a/packages/ui-library/src/elements/table/stories.js
+++ b/packages/ui-library/src/elements/table/stories.js
@@ -56,6 +56,7 @@ Factory.args = {
 };
 
 export const TableHead = Template.bind( {} );
+TableHead.storyName = "Table head";
 
 TableHead.parameters = {
 	controls: { disable: false },
@@ -89,6 +90,7 @@ TableHead.args = {
 };
 
 export const TableRow = Template.bind( {} );
+TableRow.storyName = "Table row";
 
 TableRow.parameters = {
 	controls: { disable: false },
@@ -122,6 +124,7 @@ TableRow.args = {
 };
 
 export const TableHeader = Template.bind( {} );
+TableHeader.storyName = "Table header";
 
 TableHeader.parameters = {
 	controls: { disable: false },
@@ -155,6 +158,7 @@ TableHeader.args = {
 };
 
 export const TableBody = Template.bind( {} );
+TableBody.storyName = "Table body";
 
 TableBody.parameters = {
 	controls: { disable: false },
@@ -188,6 +192,7 @@ TableBody.args = {
 };
 
 export const TableCell = Template.bind( {} );
+TableCell.storyName = "Table cell";
 
 TableCell.parameters = {
 	controls: { disable: false },

--- a/packages/ui-library/src/elements/tag-input/stories.js
+++ b/packages/ui-library/src/elements/tag-input/stories.js
@@ -2,7 +2,7 @@ import { StoryComponent } from ".";
 import { useCallback, useState } from "@wordpress/element";
 
 export default {
-	title: "1) Elements/Tag Input",
+	title: "1) Elements/Tag input",
 	component: StoryComponent,
 	parameters: {
 		docs: {

--- a/packages/ui-library/src/elements/text-input/stories.js
+++ b/packages/ui-library/src/elements/text-input/stories.js
@@ -7,7 +7,7 @@ export default {
 	parameters: {
 		docs: {
 			description: {
-				component: "A simple text input component. Aceept all props of a regular input element.",
+				component: "A simple text input component. Accept all props of a regular input element.",
 			},
 		},
 	},

--- a/packages/ui-library/src/elements/text-input/stories.js
+++ b/packages/ui-library/src/elements/text-input/stories.js
@@ -2,7 +2,7 @@
 import { StoryComponent } from ".";
 
 export default {
-	title: "1) Elements/Text Input",
+	title: "1) Elements/Text input",
 	component: StoryComponent,
 	parameters: {
 		docs: {

--- a/packages/ui-library/src/elements/title/stories.js
+++ b/packages/ui-library/src/elements/title/stories.js
@@ -23,7 +23,7 @@ Factory.parameters = {
 	controls: { disable: false },
 };
 Factory.args = {
-	children: "Title Factory",
+	children: "Title factory",
 };
 
 export const As = args => (
@@ -36,7 +36,7 @@ export const As = args => (
 	</div>
 );
 As.parameters = {
-	docs: { description: { story: "Control the Title Component using the `as` prop. Using a heading component without the `size` prop will infer the size from the heading component, ie. `as=\"h1\"` will automagically add size 1." } },
+	docs: { description: { story: "Control the Title component using the `as` prop. Using a heading component without the `size` prop will infer the size from the heading component, ie. `as=\"h1\"` will automagically add size 1." } },
 };
 
 export const Sizes = args => (

--- a/packages/ui-library/src/hooks/readme.md
+++ b/packages/ui-library/src/hooks/readme.md
@@ -93,9 +93,9 @@ The `useRootContext` hook returns the root context.
 import { useRootContext } from from "@yoast/ui-library";
 
 const Component = () => {
-    const rootContext = useRootContext();
+    const { isRtl } = useRootContext();
 
-    return <div />
+    return <div className={ isRtl ? "yst-ml-4" : "yst-mr-4" } />
 
 };
 ~~~  

--- a/packages/ui-library/src/installation.md
+++ b/packages/ui-library/src/installation.md
@@ -1,4 +1,4 @@
-# Installation of the Yoast UI Library
+# Installation of the Yoast UI library
 To install the Yoast UI library, start with installing the package and its peer dependencies from NPM.
 
 ```shell

--- a/packages/ui-library/src/introduction.md
+++ b/packages/ui-library/src/introduction.md
@@ -1,4 +1,4 @@
-# Welcome to the Yoast UI Library
+# Welcome to the Yoast UI library
 The Yoast UI library is a React component library for building Yoast user interfaces. This Storybook provides an interactive overview of all available components and examples on how to use them.
 
 [View the changelog here](https://github.com/Yoast/wordpress-seo/blob/trunk/packages/ui-library/changelog.md).


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

Fixes https://github.com/Yoast/ui-library-storybook/issues/11.

* Our content guidelines advise to not use any unnecessary capitalization. Storybook introduces a lot of this capitalization when generating names. This change hard-codes those names, so Storybook does not need to generate them. The given names then have the right casing already.
* This brings configuration to ensure proper casing in the future **for the sidebar**, by changing the generator. Sadly, there is no such configuration for the individual stories. There's an existing report for Storybook to add configuration option to add this. https://github.com/storybookjs/storybook/issues/21395.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Ensures proper casing in the Yoast UI library storybook by reducing excessive capitalization.

## Relevant technical choices:

* Ensures proper casing in the future **for the sidebar**, by changing the generator.
* I've only hardcoded the `storyName` for all relevant stories with multiple words in their story name.
* After changing the `storyName` for all relevant stories, the sidebar configuration became redundant. I opted to keep it, hoping it might trigger awareness of the casing style for such new stories when they differ from the sidebar.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Checkout this PR.
* Create the storybook with `$ yarn workspace @yoast/ui-library storybook`.
* Go through the Storybook and verify there are no excessive capitals.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [x] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
