### PR TITLE
20105 add nonce verification to ftc notice dismissal

### DIFF
--- a/src/integrations/admin/first-time-configuration-notice-integration.php
+++ b/src/integrations/admin/first-time-configuration-notice-integration.php
@@ -101,12 +101,14 @@ class First_Time_Configuration_Notice_Integration implements Integration_Interfa
 
 		$this->admin_asset_manager->enqueue_style( 'monorepo' );
 
-		$title = $this->first_time_configuration_notice_helper->get_first_time_configuration_title();
+		$title    = $this->first_time_configuration_notice_helper->get_first_time_configuration_title();
+		$link_url = \esc_url( \self_admin_url( 'admin.php?page=wpseo_dashboard#top#first-time-configuration' ) );
+
 		if ( ! $this->first_time_configuration_notice_helper->should_show_alternate_message() ) {
 			$content = \sprintf(
 				/* translators: 1: Link start tag to the first-time configuration, 2: Yoast SEO, 3: Link closing tag. */
 				\__( 'Get started quickly with the %1$s%2$s First-time configuration%3$s and configure Yoast SEO with the optimal SEO settings for your site!', 'wordpress-seo' ),
-				'<a href="' . \esc_url( \self_admin_url( 'admin.php?page=wpseo_dashboard#top#first-time-configuration' ) ) . '">',
+				'<a href="' . $link_url . '">',
 				'Yoast SEO',
 				'</a>'
 			);
@@ -115,7 +117,7 @@ class First_Time_Configuration_Notice_Integration implements Integration_Interfa
 			$content = \sprintf(
 				/* translators: 1: Link start tag to the first-time configuration, 2: Link closing tag. */
 				\__( 'We noticed that you haven\'t fully configured Yoast SEO yet. Optimize your SEO settings even further by using our improved %1$s First-time configuration%2$s.', 'wordpress-seo' ),
-				'<a href="' . \esc_url( \self_admin_url( 'admin.php?page=wpseo_dashboard#top#first-time-configuration' ) ) . '">',
+				'<a href="' . $link_url . '">',
 				'</a>'
 			);
 		}
@@ -133,19 +135,18 @@ class First_Time_Configuration_Notice_Integration implements Integration_Interfa
 		echo $notice->present();
 
 		// Enable permanently dismissing the notice.
-		echo "<script>
-			jQuery( document ).ready( function() {
-				jQuery( 'body' ).on( 'click', '#yoast-first-time-configuration-notice .notice-dismiss', function() {
-					var data = {
-						'action': 'dismiss_first_time_configuration_notice',
-						'nonce': '" . \esc_js( \wp_create_nonce( 'wpseo-dismiss-first-time-configuration-notice' ) ) . "'
+		echo '<script>
+				jQuery( document ).ready( function() {
+					jQuery( "body" ).on( "click", "#yoast-first-time-configuration-notice .notice-dismiss", function() {
+						const data = {
+							"action": "dismiss_first_time_configuration_notice",
+							"nonce": "' . \esc_js( \wp_create_nonce( 'wpseo-dismiss-first-time-configuration-notice' ) ) . '"
 						};
-		
-					jQuery.post( ajaxurl, data, function( response ) {
-						jQuery( this ).parent( '#yoast-first-time-configuration-notice' ).hide();
-					});
+						jQuery.post( ajaxurl, data, function( response ) {
+							jQuery( this ).parent( "#yoast-first-time-configuration-notice" ).hide();
+						});
+					} );
 				} );
-			} );
-			</script>";
+				</script>';
 	}
 }

--- a/src/integrations/admin/first-time-configuration-notice-integration.php
+++ b/src/integrations/admin/first-time-configuration-notice-integration.php
@@ -4,7 +4,6 @@ namespace Yoast\WP\SEO\Integrations\Admin;
 
 use WPSEO_Admin_Asset_Manager;
 use Yoast\WP\SEO\Conditionals\Admin_Conditional;
-use Yoast\WP\SEO\Helpers\Indexing_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
 use Yoast\WP\SEO\Presenters\Admin\Notice_Presenter;
@@ -74,6 +73,10 @@ class First_Time_Configuration_Notice_Integration implements Integration_Interfa
 	 * @return bool
 	 */
 	public function dismiss_first_time_configuration_notice() {
+		// Check for nonce.
+		if ( ! \check_ajax_referer( 'wpseo-dismiss-first-time-configuration-notice', 'nonce', false ) ) {
+			return false;
+		}
 		return $this->options_helper->set( 'dismiss_configuration_workout_notice', true );
 	}
 
@@ -131,19 +134,16 @@ class First_Time_Configuration_Notice_Integration implements Integration_Interfa
 
 		// Enable permanently dismissing the notice.
 		echo "<script>
-			function dismiss_first_time_configuration_notice(){
-				var data = {
-				'action': 'dismiss_first_time_configuration_notice',
-				};
-
-				jQuery.post( ajaxurl, data, function( response ) {
-					jQuery( '#yoast-first-time-configuration-notice' ).hide();
-				});
-			}
-
 			jQuery( document ).ready( function() {
 				jQuery( 'body' ).on( 'click', '#yoast-first-time-configuration-notice .notice-dismiss', function() {
-					dismiss_first_time_configuration_notice();
+					var data = {
+						'action': 'dismiss_first_time_configuration_notice',
+						'nonce': '" . \esc_js( \wp_create_nonce( 'wpseo-dismiss-first-time-configuration-notice' ) ) . "'
+						};
+		
+					jQuery.post( ajaxurl, data, function( response ) {
+						jQuery( this ).parent( '#yoast-first-time-configuration-notice' ).hide();
+					});
 				} );
 			} );
 			</script>";

--- a/tests/unit/integrations/admin/first-time-configuration-notice-integration-test.php
+++ b/tests/unit/integrations/admin/first-time-configuration-notice-integration-test.php
@@ -1,0 +1,298 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Integrations\Admin;
+
+use Brain\Monkey;
+use Mockery;
+use WPSEO_Admin_Asset_Manager;
+use Yoast\WP\SEO\Conditionals\Admin_Conditional;
+use Yoast\WP\SEO\Helpers\Options_Helper;
+use Yoast\WP\SEO\Presenters\Admin\Notice_Presenter;
+use Yoast\WP\SEO\Helpers\First_Time_Configuration_Notice_Helper;
+use Yoast\WP\SEO\Integrations\Admin\First_Time_Configuration_Notice_Integration;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+
+/**
+ * Class First_Time_Configuration_Notice_Integration_Test.
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Integrations\Admin\First_Time_Configuration_Notice_Integration
+ * @covers \Yoast\WP\SEO\Integrations\Admin\First_Time_Configuration_Notice_Integration
+ *
+ * @group integrations
+ */
+class First_Time_Configuration_Notice_Integration_Test extends TestCase {
+
+	/**
+	 * The options' helper.
+	 *
+	 * @var Mockery\MockInterface|Options_Helper
+	 */
+	private $options_helper;
+
+	/**
+	 * The admin asset manager.
+	 *
+	 * @var WPSEO_Admin_Asset_Manager
+	 */
+	private $admin_asset_manager;
+
+	/**
+	 * The first time configuration notice helper.
+	 *
+	 * @var \Yoast\WP\SEO\Helpers\First_Time_Configuration_Notice_Helper
+	 */
+	private $first_time_configuration_notice_helper;
+
+	/**
+	 * The the mock for a notice.
+	 *
+	 * @var Yoast\WP\SEO\Presenters\Admin\Notice_Presenter
+	 */
+	private $notice_presenter;
+
+	/**
+	 * The instance under test.
+	 *
+	 * @var First_Time_Configuration_Notice_Integration
+	 */
+	protected $instance;
+
+	/**
+	 * Sets up the tests.
+	 *
+	 * @covers __construct
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->stubEscapeFunctions();
+		$this->stubTranslationFunctions();
+
+		$this->options_helper                         = Mockery::mock( Options_Helper::class );
+		$this->admin_asset_manager                    = Mockery::mock( WPSEO_Admin_Asset_Manager::class );
+		$this->first_time_configuration_notice_helper = Mockery::mock( First_Time_Configuration_Notice_Helper::class );
+
+		$this->instance = new First_Time_Configuration_Notice_Integration(
+			$this->options_helper,
+			$this->first_time_configuration_notice_helper,
+			$this->admin_asset_manager
+		);
+
+		$this->notice_presenter = Mockery::mock( Notice_Presenter::class );
+	}
+
+	/**
+	 * Tests get_conditionals.
+	 *
+	 * @covers ::get_conditionals
+	 */
+	public function test_get_conditionals() {
+		$this->assertEquals(
+			[ Admin_Conditional::class ],
+			$this->instance->get_conditionals()
+		);
+	}
+
+	/**
+	 * Tests the registration of the hooks.
+	 *
+	 * @covers ::register_hooks
+	 */
+	public function test_register_hooks() {
+
+		Monkey\Actions\expectAdded( 'wp_ajax_dismiss_first_time_configuration_notice' );
+		Monkey\Actions\expectAdded( 'admin_notices' );
+
+		$this->instance->register_hooks();
+
+		$this->assertNotFalse( Monkey\Actions\has( 'wp_ajax_dismiss_first_time_configuration_notice', [ $this->instance, 'dismiss_first_time_configuration_notice' ] ) );
+		$this->assertNotFalse( Monkey\Actions\has( 'admin_notices', [ $this->instance, 'first_time_configuration_notice' ] ) );
+	}
+
+	/**
+	 * Data provider for the test_first_time_configuration_notice method.
+	 *
+	 * @return array The data for the test.
+	 */
+	public function dismiss_first_time_configuration_notice_provider() {
+		return [
+			[
+				'check_ajax_referer'                   => true,
+				'dismiss_configuration_workout_notice' => 1,
+			],
+			[
+				'check_ajax_referer'                   => false,
+				'dismiss_configuration_workout_notice' => 0,
+			],
+		];
+	}
+
+	/**
+	 * Tests the dismiss_first_time_configuration_notice method.
+	 *
+	 * @covers ::dismiss_first_time_configuration_notice
+	 *
+	 * @dataProvider dismiss_first_time_configuration_notice_provider
+	 *
+	 * @param bool $check_ajax_referer The value for the check_ajax_referer function.
+	 * @param int  $dismiss_configuration_workout_notice_times The value for the dismiss_configuration_workout_notice option.
+	 */
+	public function test_dismiss_first_time_configuration_notice( $check_ajax_referer, $dismiss_configuration_workout_notice_times ) {
+
+		Monkey\Functions\expect( 'check_ajax_referer' )
+			->once()
+			->with( 'wpseo-dismiss-first-time-configuration-notice', 'nonce', false )
+			->andReturn( $check_ajax_referer );
+
+		$this->options_helper
+			->expects( 'set' )
+			->times( $dismiss_configuration_workout_notice_times )
+			->with( 'dismiss_configuration_workout_notice', true );
+
+		$this->instance->dismiss_first_time_configuration_notice();
+	}
+
+	/**
+	 * Test should_display_first_time_configuration_notice.
+	 *
+	 * @covers ::should_display_first_time_configuration_notice
+	 */
+	public function test_should_display_first_time_configuration_notice() {
+
+		$this->first_time_configuration_notice_helper
+			->expects( 'should_display_first_time_configuration_notice' )
+			->once();
+
+		$this->instance->should_display_first_time_configuration_notice();
+	}
+
+	/**
+	 * Data provider for test_first_time_configuration_notice.
+	 *
+	 * @return array The data for the test.
+	 */
+	public function first_time_configuration_notice_provider() {
+
+		// In case of change in js, make sure to match the tabs and line breaks for this test to pass (avoid 4 spaces as tab).
+		$default_message = '<div id="yoast-first-time-configuration-notice" class="notice notice-yoast yoast is-dismissible"><div class="notice-yoast__container"><div><div class="notice-yoast__header"><span class="yoast-icon"></span><h2 class="notice-yoast__header-heading">First-time SEO configuration</h2></div><p>Get started quickly with the <a href="">Yoast SEO First-time configuration</a> and configure Yoast SEO with the optimal SEO settings for your site!</p></div><img src="images/mirrored_fit_bubble_woman_1_optim.svg" alt="" height="60" width="75"/></div></div><script>
+				jQuery( document ).ready( function() {
+					jQuery( "body" ).on( "click", "#yoast-first-time-configuration-notice .notice-dismiss", function() {
+						const data = {
+							"action": "dismiss_first_time_configuration_notice",
+							"nonce": "123456"
+						};
+						jQuery.post( ajaxurl, data, function( response ) {
+							jQuery( this ).parent( "#yoast-first-time-configuration-notice" ).hide();
+						});
+					} );
+				} );
+				</script>';
+
+		$alternate_message = '<div id="yoast-first-time-configuration-notice" class="notice notice-yoast yoast is-dismissible"><div class="notice-yoast__container"><div><div class="notice-yoast__header"><span class="yoast-icon"></span><h2 class="notice-yoast__header-heading">First-time SEO configuration</h2></div><p>We noticed that you haven\'t fully configured Yoast SEO yet. Optimize your SEO settings even further by using our improved <a href=""> First-time configuration</a>.</p></div><img src="images/mirrored_fit_bubble_woman_1_optim.svg" alt="" height="60" width="75"/></div></div><script>
+				jQuery( document ).ready( function() {
+					jQuery( "body" ).on( "click", "#yoast-first-time-configuration-notice .notice-dismiss", function() {
+						const data = {
+							"action": "dismiss_first_time_configuration_notice",
+							"nonce": "123456"
+						};
+						jQuery.post( ajaxurl, data, function( response ) {
+							jQuery( this ).parent( "#yoast-first-time-configuration-notice" ).hide();
+						});
+					} );
+				} );
+				</script>';
+
+		return [
+			[
+				'should_show_alternate_message' => false,
+				'message'                       => $default_message,
+			],
+			[
+				'should_show_alternate_message' => true,
+				'message'                       => $alternate_message,
+			],
+		];
+	}
+
+	/**
+	 * Tests first_time_configuration_notice.
+	 *
+	 * @covers ::first_time_configuration_notice
+	 *
+	 * @dataProvider first_time_configuration_notice_provider
+	 * @param bool   $should_show_alternate_message Indicate what message to render.
+	 * @param string $message The string that will be rendered.
+	 */
+	public function test_first_time_configuration_notice( $should_show_alternate_message, $message ) {
+		$this->expect_should_display_first_time_configuration_notice( true );
+
+		$this->admin_asset_manager
+			->expects( 'enqueue_style' )
+			->once()
+			->with( 'monorepo' );
+
+		$this->first_time_configuration_notice_helper
+			->expects( 'get_first_time_configuration_title' )
+			->once()
+			->andReturn( 'First-time SEO configuration' );
+
+		$this->first_time_configuration_notice_helper
+			->expects( 'should_show_alternate_message' )
+			->once()
+			->andReturn( $should_show_alternate_message );
+
+		Monkey\Functions\expect( 'self_admin_url' )
+			->once()
+			->with( 'admin.php?page=wpseo_dashboard#top#first-time-configuration' );
+
+		$this->expect_notice_presenter();
+
+		Monkey\Functions\expect( 'wp_create_nonce' )
+			->once()
+			->with( 'wpseo-dismiss-first-time-configuration-notice' )
+			->andReturn( '123456' );
+
+		$this->instance->first_time_configuration_notice();
+		$this->expectOutputString( $message );
+	}
+
+	/**
+	 * Expects function in should_display_first_time_configuration_notice.
+	 *
+	 * @param bool $return The expected return value of the function.
+	 * @return void
+	 */
+	public function expect_should_display_first_time_configuration_notice( $return ) {
+		$this->first_time_configuration_notice_helper
+			->expects( 'should_display_first_time_configuration_notice' )
+			->once()
+			->andReturn( $return );
+	}
+
+	/**
+	 * Expects functions in new Notice_Presenter.
+	 *
+	 * @return void
+	 */
+	public function expect_notice_presenter() {
+		Monkey\Functions\expect( 'wp_enqueue_style' )
+			->once();
+
+		Monkey\Functions\expect( 'plugin_dir_url' )
+			->once();
+	}
+
+	/**
+	 * Tests first_time_configuration_notice when it is aborted.
+	 *
+	 * @covers ::first_time_configuration_notice
+	 */
+	public function test_first_time_configuration_notice_aborted() {
+		$this->expect_should_display_first_time_configuration_notice( false );
+
+		$this->instance->first_time_configuration_notice();
+
+		$this->expectOutputString( '' );
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to add nonce verification to the dismissal of the first time configuration notice.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:
 
* Adds nonce verification to the dismissal of the first time configuration notice.
* Adds unit tests to the `First_Time_Configuration_Notice_Integration` class.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Set a new site and install `Yoast SEO` or reset options and notifications with `Yoast Test` plugin.
* Go to `Yoast SEO` -> `General` 
* Make sure you see the notice to start the first time configuration or to complete it.
* With the browser console open on the `Network` tab, dismiss the notice
  * In the browser console select the `POST` request to `admin-ajax.php` and make sure the request contains the `nonce` parameter
* Refresh the page and check the notice is not reappearing.

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [X] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes [Add nonce verification to FTC notice dismissal](https://github.com/Yoast/wordpress-seo/issues/20105)
