### PR TITLE
Assigns translation strings in Premium- and product-specific assessments to their proper domain

### DIFF
--- a/packages/yoastseo/src/scoring/assessments/readability/ListAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/readability/ListAssessment.js
@@ -90,7 +90,7 @@ export default class ListAssessment extends Assessment {
 					/* Translators: %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag */
 					__(
 						"%1$sLists%2$s: There is at least one list on this page. Great!",
-						"wordpress-seo"
+						"yoast-woo-seo"
 					),
 					this._config.urlTitle,
 					"</a>"
@@ -106,7 +106,7 @@ export default class ListAssessment extends Assessment {
 				 * %2$s expands to the anchor end tag. */
 				__(
 					"%1$sLists%3$s: No lists appear on this page. %2$sAdd at least one ordered or unordered list%3$s!",
-					"wordpress-seo"
+					"yoast-woo-seo"
 				),
 				this._config.urlTitle,
 				this._config.urlCallToAction,

--- a/packages/yoastseo/src/scoring/assessments/readability/TextAlignmentAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/readability/TextAlignmentAssessment.js
@@ -126,7 +126,7 @@ export default class TextAlignmentAssessment extends Assessment {
 							"%1$sAlignment%3$s: There are %4$s long sections of center-aligned text. " +
 							"%2$sWe recommend making them right-aligned%3$s.",
 							numberOfLongCenterAlignedTexts,
-							"wordpress-seo"
+							"wordpress-seo-premium"
 						),
 						this._config.urlTitle,
 						this._config.urlCallToAction,
@@ -145,7 +145,7 @@ export default class TextAlignmentAssessment extends Assessment {
 						"%1$sAlignment%3$s: There are %4$s long sections of center-aligned text. " +
 						"%2$sWe recommend making them left-aligned%3$s.",
 						numberOfLongCenterAlignedTexts,
-						"wordpress-seo"
+						"wordpress-seo-premium"
 					),
 					this._config.urlTitle,
 					this._config.urlCallToAction,

--- a/packages/yoastseo/src/scoring/assessments/readability/WordComplexityAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/readability/WordComplexityAssessment.js
@@ -36,7 +36,7 @@ export default class WordComplexityAssessment extends Assessment {
          * It appears before the feedback in the analysis, for example in the feedback string:
          * "Word complexity: You are not using too many complex words, which makes your text easy to read. Good job!"
          */
-		this.name = __( "Word complexity", "wordpress-seo" );
+		this.name = __( "Word complexity", "wordpress-seo-premium" );
 		this.identifier = "wordComplexity";
 		this._config = merge( defaultConfig, config );
 
@@ -85,7 +85,7 @@ export default class WordComplexityAssessment extends Assessment {
 					__(
 						// eslint-disable-next-line max-len
 						"%1$s: You are not using too many complex words, which makes your text easy to read. Good job!",
-						"wordpress-seo"
+						"wordpress-seo-premium"
 					),
 					assessmentLink
 				),
@@ -101,7 +101,7 @@ export default class WordComplexityAssessment extends Assessment {
 				__(
 					// eslint-disable-next-line max-len
 					"%1$s: %2$s of the words in your text are considered complex. %3$sTry to use shorter and more familiar words to improve readability%4$s.",
-					"wordpress-seo"
+					"wordpress-seo-premium"
 				),
 				assessmentLink,
 				complexWordsPercentage + "%",

--- a/packages/yoastseo/src/scoring/assessments/seo/ImageAltTagsAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/ImageAltTagsAssessment.js
@@ -83,7 +83,7 @@ export default class ImageAltTagsAssessment extends Assessment {
 					/* Translators: %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag */
 					__(
 						"%1$sImage alt tags%3$s: None of the images has alt attributes. %2$sAdd alt attributes to your images%3$s!",
-						"wordpress-seo"
+						"yoast-woo-seo"
 					),
 					this._config.urlTitle,
 					this._config.urlCallToAction,
@@ -104,7 +104,7 @@ export default class ImageAltTagsAssessment extends Assessment {
 						"%3$sImage alt tags%5$s: %1$d image out of %2$d doesn't have alt attributes. %4$sAdd alt attributes to your images%5$s!",
 						"%3$sImage alt tags%5$s: %1$d images out of %2$d don't have alt attributes. %4$sAdd alt attributes to your images%5$s!",
 						imagesNoAlt,
-						"wordpress-seo"
+						"yoast-woo-seo"
 					),
 					imagesNoAlt,
 					this.imageCount,
@@ -123,7 +123,7 @@ export default class ImageAltTagsAssessment extends Assessment {
 				 * %2$s expands to the anchor end tag. */
 				__(
 					"%1$sImage alt tags%2$s: All images have alt attributes. Good job!",
-					"wordpress-seo"
+					"yoast-woo-seo"
 				),
 				this._config.urlTitle,
 				"</a>"

--- a/packages/yoastseo/src/scoring/assessments/seo/KeyphraseDistributionAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/KeyphraseDistributionAssessment.js
@@ -94,7 +94,7 @@ class KeyphraseDistributionAssessment extends Assessment {
 					__(
 						// eslint-disable-next-line max-len
 						"%1$sKeyphrase distribution%3$s: %2$sInclude your keyphrase or its synonyms in the text so that we can check keyphrase distribution%3$s.",
-						"wordpress-seo"
+						"wordpress-seo-premium"
 					),
 					this._config.urlTitle,
 					this._config.urlCallToAction,
@@ -113,7 +113,7 @@ class KeyphraseDistributionAssessment extends Assessment {
 					__(
 						// eslint-disable-next-line max-len
 						"%1$sKeyphrase distribution%3$s: Very uneven. Large parts of your text do not contain the keyphrase or its synonyms. %2$sDistribute them more evenly%3$s.",
-						"wordpress-seo"
+						"wordpress-seo-premium"
 					),
 					this._config.urlTitle,
 					this._config.urlCallToAction,
@@ -134,7 +134,7 @@ class KeyphraseDistributionAssessment extends Assessment {
 					__(
 						// eslint-disable-next-line max-len
 						"%1$sKeyphrase distribution%3$s: Uneven. Some parts of your text do not contain the keyphrase or its synonyms. %2$sDistribute them more evenly%3$s.",
-						"wordpress-seo"
+						"wordpress-seo-premium"
 					),
 					this._config.urlTitle,
 					this._config.urlCallToAction,
@@ -150,7 +150,7 @@ class KeyphraseDistributionAssessment extends Assessment {
 				/* Translators: %1$s expands to links to Yoast.com articles, %2$s expands to the anchor end tag */
 				__(
 					"%1$sKeyphrase distribution%2$s: Good job!",
-					"wordpress-seo"
+					"wordpress-seo-premium"
 				),
 				this._config.urlTitle,
 				"</a>"

--- a/packages/yoastseo/src/scoring/assessments/seo/ProductIdentifiersAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/ProductIdentifiersAssessment.js
@@ -31,7 +31,7 @@ export default class ProductIdentifiersAssessment extends Assessment {
 
 		this.identifier = "productIdentifier";
 		this._config = merge( defaultConfig, config );
-		this.name = __( this._config.productIdentifierOrBarcode, "wordpress-seo" );
+		this.name = __( this._config.productIdentifierOrBarcode, "yoast-woo-seo" );
 	}
 
 	/**
@@ -101,18 +101,18 @@ export default class ProductIdentifiersAssessment extends Assessment {
 		if ( this._config.productIdentifierOrBarcode === "Product identifier" ) {
 			feedbackStrings = {
 				okNoVariants: __( "Your product is missing an identifier (like a GTIN code). " +
-					"You can add a product identifier via the \"Yoast SEO\" tab in the Product data box", "wordpress-seo" ),
-				goodNoVariants: __( "Your product has an identifier", "wordpress-seo" ),
+					"You can add a product identifier via the \"Yoast SEO\" tab in the Product data box", "yoast-woo-seo" ),
+				goodNoVariants: __( "Your product has an identifier", "yoast-woo-seo" ),
 				okWithVariants: __( "Not all your product variants have an identifier. " +
-					"You can add a product identifier via the \"Variations\" tab in the Product data box", "wordpress-seo" ),
-				goodWithVariants: __( "All your product variants have an identifier", "wordpress-seo" ),
+					"You can add a product identifier via the \"Variations\" tab in the Product data box", "yoast-woo-seo" ),
+				goodWithVariants: __( "All your product variants have an identifier", "yoast-woo-seo" ),
 			};
 		} else {
 			feedbackStrings = {
-				okNoVariants: __( "Your product is missing a barcode (like a GTIN code)", "wordpress-seo" ),
-				goodNoVariants: __( "Your product has a barcode", "wordpress-seo" ),
-				okWithVariants: __( "Not all your product variants have a barcode", "wordpress-seo" ),
-				goodWithVariants: __( "All your product variants have a barcode", "wordpress-seo" ),
+				okNoVariants: __( "Your product is missing a barcode (like a GTIN code)", "yoast-woo-seo" ),
+				goodNoVariants: __( "Your product has a barcode", "yoast-woo-seo" ),
+				okWithVariants: __( "Not all your product variants have a barcode", "yoast-woo-seo" ),
+				goodWithVariants: __( "All your product variants have a barcode", "yoast-woo-seo" ),
 			};
 		}
 
@@ -130,7 +130,7 @@ export default class ProductIdentifiersAssessment extends Assessment {
 						__(
 							"%1$s%2$s%5$s: %3$s. %4$sInclude it if you can, as it " +
 							"will help search engines to better understand your content.%5$s",
-							"wordpress-seo"
+							"yoast-woo-seo"
 						),
 						this._config.urlTitle,
 						this.name,
@@ -149,7 +149,7 @@ export default class ProductIdentifiersAssessment extends Assessment {
 					* "Your product has a product identifier" or "Your product has a barcode" */
 					__(
 						"%1$s%2$s%4$s: %3$s. Good job!",
-						"wordpress-seo"
+						"yoast-woo-seo"
 					),
 					this._config.urlTitle,
 					this.name,
@@ -170,7 +170,7 @@ export default class ProductIdentifiersAssessment extends Assessment {
 						* or "Not all your product variants have a barcode" */
 						__(
 							"%1$s%2$s%5$s: %3$s. %4$sInclude it if you can, as it will help search engines to better understand your content.%5$s",
-							"wordpress-seo"
+							"yoast-woo-seo"
 						),
 						this._config.urlTitle,
 						this.name,
@@ -188,7 +188,7 @@ export default class ProductIdentifiersAssessment extends Assessment {
 					* "All your product variants have a product identifier" or "All your product variants have a barcode" */
 					__(
 						"%1$s%2$s%4$s: %3$s. Good job!",
-						"wordpress-seo"
+						"yoast-woo-seo"
 					),
 					this._config.urlTitle,
 					this.name,

--- a/packages/yoastseo/src/scoring/assessments/seo/ProductSKUAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/ProductSKUAssessment.js
@@ -103,7 +103,7 @@ export default class ProductSKUAssessment extends Assessment {
 		let feedbackString = "";
 		if ( this._config.addSKULocation === true ) {
 			// Translators: please keep the space at the start of the sentence in your translation unless your language does not use spaces.
-			feedbackString = __( " You can add a SKU via the \"Inventory\" tab in the Product data box.", "wordpress-seo" );
+			feedbackString = __( " You can add a SKU via the \"Inventory\" tab in the Product data box.", "yoast-woo-seo" );
 		}
 
 		// Apply the following scoring conditions to products without variants.
@@ -118,7 +118,7 @@ export default class ProductSKUAssessment extends Assessment {
 						__(
 							"%1$sSKU%3$s: Your product is missing a SKU.%4$s" +
 							" %2$sInclude it if you can, as it will help search engines to better understand your content.%3$s",
-							"wordpress-seo"
+							"yoast-woo-seo"
 						),
 						this._config.urlTitle,
 						this._config.urlCallToAction,
@@ -133,7 +133,7 @@ export default class ProductSKUAssessment extends Assessment {
 					// Translators: %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag.
 					__(
 						"%1$sSKU%2$s: Your product has a SKU. Good job!",
-						"wordpress-seo"
+						"yoast-woo-seo"
 					),
 					this._config.urlTitle,
 					"</a>"
@@ -151,7 +151,7 @@ export default class ProductSKUAssessment extends Assessment {
 							"%1$sSKU%3$s: Not all your product variants have a SKU. " +
 							"You can add a SKU via the \"Variations\" tab in the Product data box." +
 							" %2$sInclude it if you can, as it will help search engines to better understand your content.%3$s",
-							"wordpress-seo"
+							"yoast-woo-seo"
 						),
 						this._config.urlTitle,
 						this._config.urlCallToAction,
@@ -165,7 +165,7 @@ export default class ProductSKUAssessment extends Assessment {
 					// Translators: %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag.
 					__(
 						"%1$sSKU%2$s: All your product variants have a SKU. Good job!",
-						"wordpress-seo"
+						"yoast-woo-seo"
 					),
 					this._config.urlTitle,
 					"</a>"

--- a/packages/yoastseo/src/scoring/assessments/seo/TextTitleAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/TextTitleAssessment.js
@@ -80,7 +80,7 @@ export default class TextTitleAssessment extends Assessment {
 					/* Translators: %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag. */
 					__(
 						"%1$sTitle%2$s: Your page has a title. Well done!",
-						"wordpress-seo"
+						"wordpress-seo-premium"
 					),
 					this._config.urlTitle,
 					"</a>"
@@ -99,7 +99,7 @@ export default class TextTitleAssessment extends Assessment {
 				__(
 					// eslint-disable-next-line max-len
 					"%1$sTitle%3$s: Your page does not have a title yet. %2$sAdd one%3$s!",
-					"wordpress-seo"
+					"wordpress-seo-premium"
 				),
 				this._config.urlTitle,
 				this._config.urlCallToAction,


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Now that Premium- and product-specific assessments are properly bundled, we should also update their translation domains. We do so in this PR. 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Assigns translation strings in Premium- and product-specific assessments to their proper domain.

## Relevant technical choices:

* None.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* See the [Premium PR](https://github.com/Yoast/wordpress-seo-premium/pull/3927) and [Yoast SEO for WooCommerce PR](https://github.com/Yoast/wpseo-woocommerce/pull/901) for testing instructions.  

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Translation strings of Premium- and product-specific assessments.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes https://github.com/Yoast/plugins-automated-testing/issues/648
