### PR TITLE
Set the minimum supported WordPress version to 6.1

### DIFF
--- a/.github/workflows/integrationtest.yml
+++ b/.github/workflows/integrationtest.yml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         include:
           - php_version: "7.2"
-            wp_version: "6.0"
+            wp_version: "6.1"
             multisite: true
 
           - php_version: "7.3"
@@ -40,7 +40,7 @@ jobs:
 
           # WP 5.6 is the earliest version which (sort of) supports PHP 8.0.
           - php_version: "8.0"
-            wp_version: "6.0"
+            wp_version: "6.1"
             multisite: false
 
           # WP 5.9 is the earliest version which (sort of) supports PHP 8.1.
@@ -50,7 +50,7 @@ jobs:
 
           # WP 6.1 is the earliest version which supports PHP 8.2.
           - php_version: "8.2"
-            wp_version: "6.1"
+            wp_version: "6.2"
             multisite: true
 
     name: "Integration Test: PHP ${{ matrix.php_version }} | WP ${{ matrix.wp_version }}${{ matrix.multisite == true && ' (+ ms)' || '' }}"

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -37,7 +37,7 @@ define( 'YOAST_VENDOR_PREFIX_DIRECTORY', 'vendor_prefixed' );
 
 define( 'YOAST_SEO_PHP_REQUIRED', '7.2.5' );
 define( 'YOAST_SEO_WP_TESTED', '6.2' );
-define( 'YOAST_SEO_WP_REQUIRED', '6.0' );
+define( 'YOAST_SEO_WP_REQUIRED', '6.1' );
 
 if ( ! defined( 'WPSEO_NAMESPACES' ) ) {
 	define( 'WPSEO_NAMESPACES', true );

--- a/tests/unit/inc/addon-manager-test.php
+++ b/tests/unit/inc/addon-manager-test.php
@@ -533,7 +533,7 @@ class Addon_Manager_Test extends TestCase {
 				[
 					'wordpress-seo/wp-seo.php' => [
 						'update' => [
-							'tested'       => '6.0',
+							'tested'       => \YOAST_SEO_WP_REQUIRED,
 							'requires_php' => '7.2.5',
 						],
 					],
@@ -541,12 +541,12 @@ class Addon_Manager_Test extends TestCase {
 			);
 
 		global $wp_version;
-		$wp_version = '6.0';
+		$wp_version = \YOAST_SEO_WP_REQUIRED;
 		$this->assertEquals( $expected, $this->instance->check_for_updates( $data ), $message );
 
 		// Now check that the Premium plugin won't show updates, if the requirement for the WP version coming from Yoast free, is not met.
 		if ( isset( $addons['wp-seo-premium.php'] ) ) {
-			$wp_version = '5.9';
+			$wp_version = '6.0';
 			$updates    = $this->instance->check_for_updates( $data );
 
 			$this->assertTrue( isset( $updates->no_update['wp-seo-premium.php'] ) );

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -36,7 +36,7 @@ define( 'YOAST_VENDOR_PREFIX_DIRECTORY', 'vendor_prefixed' );
 
 define( 'YOAST_SEO_PHP_REQUIRED', '7.2.5' );
 define( 'YOAST_SEO_WP_TESTED', '6.2' );
-define( 'YOAST_SEO_WP_REQUIRED', '6.0' );
+define( 'YOAST_SEO_WP_REQUIRED', '6.1' );
 
 if ( ! defined( 'WPSEO_NAMESPACES' ) ) {
 	define( 'WPSEO_NAMESPACES', true );

--- a/wp-seo.php
+++ b/wp-seo.php
@@ -16,7 +16,7 @@
  * Text Domain: wordpress-seo
  * Domain Path: /languages/
  * License:     GPL v3
- * Requires at least: 6.0
+ * Requires at least: 6.1
  * Requires PHP: 7.2.5
  *
  * WC requires at least: 3.0


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Sets the minimum supported WordPress version to 6.1

## Relevant technical choices:

* I changed the test for the Addon Manager to use the `YOAST_SEO_WP_REQUIRED` constant and reduce the number of lines to edit manually.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* N/A

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* N/A

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #