### PR TITLE
Add a link to the taxonomy edit page when there are no public post types associated to it

### DIFF
--- a/packages/js/src/settings/routes/templates/taxonomy.js
+++ b/packages/js/src/settings/routes/templates/taxonomy.js
@@ -41,6 +41,8 @@ const Taxonomy = ( { name, label, postTypes: postTypeNames, showUi } ) => {
 	const initialPostTypeValues = useMemo( () => initial( postTypeValues ), [ postTypeValues ] );
 	const lastPostTypeValue = useMemo( () => last( postTypeValues ), [ postTypeValues ] );
 
+	console.log( { name, label, postTypeValues, initialPostTypeValues, lastPostTypeValue } );
+
 	const recommendedSize = useMemo( () => createInterpolateElement(
 		sprintf(
 			/**
@@ -132,6 +134,22 @@ const Taxonomy = ( { name, label, postTypes: postTypeNames, showUi } ) => {
 		/>;
 	}, [ name, stripCategoryBaseDescription ] );
 
+	const taxonomyNameMessage = useMemo( () => {
+		return createInterpolateElement(
+			sprintf(
+				/**
+				 * translators: %1$s expands to the name of the taxonomy.
+				 */
+				__( "The name of this category is %1$s.", "wordpress-seo" ),
+				"<link />"
+			), {
+				link: <Link href={ `edit-tags.php?taxonomy=${ name }` }>
+					{ name }
+				</Link>,
+			}
+		);
+	}, [ label, postTypeValues, name ] );
+
 	return (
 		<RouteLayout
 			title={ label }
@@ -141,12 +159,8 @@ const Taxonomy = ( { name, label, postTypes: postTypeNames, showUi } ) => {
 					__( "Determine how your %1$s should look in search engines and on social media.", "wordpress-seo" ),
 					labelLower
 				) }
-				{ ! isEmpty( postTypeValues ) && (
-					<>
-						<br />
-						{ taxonomyMessage }
-					</>
-				) }
+				<br />
+				{ isEmpty( postTypeValues ) ? taxonomyNameMessage : taxonomyMessage }
 			</> }
 		>
 			<FormLayout>

--- a/packages/js/src/settings/routes/templates/taxonomy.js
+++ b/packages/js/src/settings/routes/templates/taxonomy.js
@@ -34,6 +34,8 @@ const Taxonomy = ( { name, label, postTypes: postTypeNames, showUi } ) => {
 	const noIndexInfoLink = useSelectSettings( "selectLink", [], "https://yoa.st/show-x" );
 	const isPremium = useSelectSettings( "selectPreference", [], "isPremium" );
 	const userLocale = useSelectSettings( "selectPreference", [], "userLocale" );
+	const editTaxonomyUrl = useSelectSettings( "selectPreference", [], "editTaxonomyUrl" );
+
 	const socialAppearancePremiumLink = useSelectSettings( "selectLink", [], "https://yoa.st/4e0" );
 
 	const labelLower = useMemo( () => safeToLocaleLower( label, userLocale ), [ label, userLocale ] );
@@ -141,7 +143,7 @@ const Taxonomy = ( { name, label, postTypes: postTypeNames, showUi } ) => {
 				__( "The name of this category is %1$s.", "wordpress-seo" ),
 				"<link />"
 			), {
-				link: <Link href={ `edit-tags.php?taxonomy=${ name }` }>
+				link: <Link href={ `${ editTaxonomyUrl }?taxonomy=${ name }` }>
 					{ name }
 				</Link>,
 			}

--- a/packages/js/src/settings/routes/templates/taxonomy.js
+++ b/packages/js/src/settings/routes/templates/taxonomy.js
@@ -41,8 +41,6 @@ const Taxonomy = ( { name, label, postTypes: postTypeNames, showUi } ) => {
 	const initialPostTypeValues = useMemo( () => initial( postTypeValues ), [ postTypeValues ] );
 	const lastPostTypeValue = useMemo( () => last( postTypeValues ), [ postTypeValues ] );
 
-	console.log( { name, label, postTypeValues, initialPostTypeValues, lastPostTypeValue } );
-
 	const recommendedSize = useMemo( () => createInterpolateElement(
 		sprintf(
 			/**

--- a/packages/js/src/settings/routes/templates/taxonomy.js
+++ b/packages/js/src/settings/routes/templates/taxonomy.js
@@ -146,7 +146,7 @@ const Taxonomy = ( { name, label, postTypes: postTypeNames, showUi } ) => {
 				</Link>,
 			}
 		);
-	}, [ label, postTypeValues, name ] );
+	}, [ name ] );
 
 	return (
 		<RouteLayout

--- a/src/integrations/settings-integration.php
+++ b/src/integrations/settings-integration.php
@@ -441,6 +441,7 @@ class Settings_Integration implements Integration_Interface {
 			'homepagePostsEditUrl'          => \get_edit_post_link( $page_for_posts, 'js' ),
 			'createUserUrl'                 => \admin_url( 'user-new.php' ),
 			'editUserUrl'                   => \admin_url( 'user-edit.php' ),
+			'editTaxonomyUrl'               => \admin_url( 'edit-tags.php' ),
 			'generalSettingsUrl'            => \admin_url( 'options-general.php' ),
 			'companyOrPersonMessage'        => \apply_filters( 'wpseo_knowledge_graph_setting_msg', '' ),
 			'currentUserId'                 => \get_current_user_id(),


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* In each page related to a taxonomy without a public post type associated we want to add a link to its edit page. 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds a link to a taxonomy edit page in its settings section when the taxonomy has no public post types associated.

## Relevant technical choices:

* N/A

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Make sure you have installed and activated [CPT UI](https://wordpress.org/plugins/custom-post-type-ui/)
* Go to `CPT UI` -> `Add/Edit Post Types
  * specify the slug, e.g. `my-post-type`
  * specify the singular and plural labels, e.g. `My post type` and `My Post Types`
  * click `Save Post Type`
*   Go to `CPT UI` -> `Add/Edit Taxonomies`
  * specify the slug, e.g. `my-taxonomy`
  * specify the singular and plural labels, e.g. `My Taxonomy` and `My Taxonomies`
  * in the `Attach to Post Types` checkbox list select `My Post Type`
  * click `Save Taxonomy`
* Go to `Yoast SEO` -> `Settings`
  * in the `Category & Tags` section, click on `My Taxonomy`
  * verify that in the introduction the following text is shown: 
    > This taxonomy is used for `My Post Types`
* Go to `CPT UI` -> `Add/Edit Post Types
  * in the `Edit Post Types`, select `My Post Type` from the upper drop-down menu
  * in the `Settings` section, set `Public` to false
  * click `Save Post Type`
* Go to `Yoast SEO` -> `Settings`
  * in the `Category & Tags` section, click on `My Taxonomy` and verify that:
  * in the introduction the following text is shown: 
    > The name of this category is [my-taxonomy](faux).
  * the link points to the taxonomy's edit page

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* N/A

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [X] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes https://github.com/Yoast/wordpress-seo/issues/19836
