### PR TITLE
Remove PHP opening tags from wpseo-functions.php

### DIFF
--- a/inc/wpseo-functions.php
+++ b/inc/wpseo-functions.php
@@ -105,7 +105,6 @@ function wpseo_replace_vars( $text, $args, $omit = [] ) {
  *
  * Example code:
  * <code>
- * <?php
  * function retrieve_var1_replacement( $var1 ) {
  *        return 'your replacement value';
  * }
@@ -115,7 +114,6 @@ function wpseo_replace_vars( $text, $args, $omit = [] ) {
  *        wpseo_register_var_replacement( 'myvar2', array( 'class', 'method_name' ), 'basic', 'this is a help text for myvar2' );
  * }
  * add_action( 'wpseo_register_extra_replacements', 'register_my_plugin_extra_replacements' );
- * ?>
  * </code>
  *
  * @since 1.5.4


### PR DESCRIPTION
## Context

Tame wild beasts 🐯 

## Summary

Popped up while generating `wordpress-seo-stubs` for static analysis.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes https://github.com/php-stubs/wordpress-seo-stubs/issues/5#issuecomment-1518056866
