### PR TITLE
20193 incorrect offsets for tokens

### DIFF
--- a/packages/yoastseo/spec/parse/build/private/tokenizeSpec.js
+++ b/packages/yoastseo/spec/parse/build/private/tokenizeSpec.js
@@ -1,0 +1,194 @@
+import tokenize from "../../../../src/parse/build/private/tokenize";
+import Paper from "../../../../src/values/Paper";
+import EnglishResearcher from "../../../../src/languageProcessing/languages/en/Researcher";
+import { buildTreeNoTokenize } from "../../../specHelpers/parse/buildTree";
+import LanguageProcessor from "../../../../src/parse/language/LanguageProcessor";
+
+describe( "A test for the tokenize function", function() {
+	it( "should correctly tokenize a paragraph of one sentence", function() {
+		const mockPaper = new Paper( "<p>This is a paragraph</p>", { locale: "en_US" } );
+		const mockResearcher = new EnglishResearcher( mockPaper );
+		const languageProcessor = new LanguageProcessor( mockResearcher );
+		buildTreeNoTokenize( mockPaper );
+		// eslint-disable-next-line max-len
+		expect( tokenize( mockPaper.getTree(), languageProcessor ) ).toEqual( { attributes: {}, childNodes: [ { attributes: {}, childNodes: [ { name: "#text", value: "This is a paragraph" } ], isImplicit: false, name: "p", sentences: [ { sourceCodeRange: { endOffset: 22, startOffset: 3 }, text: "This is a paragraph", tokens: [ { sourceCodeRange: { endOffset: 7, startOffset: 3 }, text: "This" }, { sourceCodeRange: { endOffset: 8, startOffset: 7 }, text: " " }, { sourceCodeRange: { endOffset: 10, startOffset: 8 }, text: "is" }, { sourceCodeRange: { endOffset: 11, startOffset: 10 }, text: " " }, { sourceCodeRange: { endOffset: 12, startOffset: 11 }, text: "a" }, { sourceCodeRange: { endOffset: 13, startOffset: 12 }, text: " " }, { sourceCodeRange: { endOffset: 22, startOffset: 13 }, text: "paragraph" } ] } ], sourceCodeLocation: { endOffset: 26, endTag: { endOffset: 26, startOffset: 22 }, startOffset: 0, startTag: { endOffset: 3, startOffset: 0 } } } ], name: "#document-fragment" }
+
+		);
+	} );
+
+	it( "should correctly tokenize a paragraph of two sentences", function() {
+		const mockPaper = new Paper( "<p>This is a sentence. This is another sentence.</p>", { locale: "en_US" } );
+		const mockResearcher = new EnglishResearcher( mockPaper );
+		const languageProcessor = new LanguageProcessor( mockResearcher );
+		buildTreeNoTokenize( mockPaper );
+		// eslint-disable-next-line max-len
+		expect( tokenize( mockPaper.getTree(), languageProcessor ) ).toEqual( {
+			attributes: {},
+			childNodes: [
+				{
+					attributes: {},
+					childNodes: [
+						{
+							name: "#text",
+							value: "This is a sentence. This is another sentence.",
+						},
+					],
+					isImplicit: false,
+					name: "p",
+					sentences: [
+						{
+							sourceCodeRange: {
+								endOffset: 22,
+								startOffset: 3,
+							},
+							text: "This is a sentence.",
+							tokens: [
+								{
+									sourceCodeRange: {
+										endOffset: 7,
+										startOffset: 3,
+									},
+									text: "This",
+								},
+								{
+									sourceCodeRange: {
+										endOffset: 8,
+										startOffset: 7,
+									},
+									text: " ",
+								},
+								{
+									sourceCodeRange: {
+										endOffset: 10,
+										startOffset: 8,
+									},
+									text: "is",
+								},
+								{
+									sourceCodeRange: {
+										endOffset: 11,
+										startOffset: 10,
+									},
+									text: " ",
+								},
+								{
+									sourceCodeRange: {
+										endOffset: 12,
+										startOffset: 11,
+									},
+									text: "a",
+								},
+								{
+									sourceCodeRange: {
+										endOffset: 13,
+										startOffset: 12,
+									},
+									text: " ",
+								},
+								{
+									sourceCodeRange: {
+										endOffset: 21,
+										startOffset: 13,
+									},
+									text: "sentence",
+								},
+								{
+									sourceCodeRange: {
+										endOffset: 22,
+										startOffset: 21,
+									},
+									text: ".",
+								},
+							],
+						},
+						{
+							sourceCodeRange: {
+								endOffset: 48,
+								startOffset: 22,
+							},
+							text: " This is another sentence.",
+							tokens: [
+								{
+									sourceCodeRange: {
+										endOffset: 23,
+										startOffset: 22,
+									},
+									text: " ",
+								},
+								{
+									sourceCodeRange: {
+										endOffset: 27,
+										startOffset: 23,
+									},
+									text: "This",
+								},
+								{
+									sourceCodeRange: {
+										endOffset: 28,
+										startOffset: 27,
+									},
+									text: " ",
+								},
+								{
+									sourceCodeRange: {
+										endOffset: 30,
+										startOffset: 28,
+									},
+									text: "is",
+								},
+								{
+									sourceCodeRange: {
+										endOffset: 31,
+										startOffset: 30,
+									},
+									text: " ",
+								},
+								{
+									sourceCodeRange: {
+										endOffset: 38,
+										startOffset: 31,
+									},
+									text: "another",
+								},
+								{
+									sourceCodeRange: {
+										endOffset: 39,
+										startOffset: 38,
+									},
+									text: " ",
+								},
+								{
+									sourceCodeRange: {
+										endOffset: 47,
+										startOffset: 39,
+									},
+									text: "sentence",
+								},
+								{
+									sourceCodeRange: {
+										endOffset: 48,
+										startOffset: 47,
+									},
+									text: ".",
+								},
+							],
+						},
+					],
+					sourceCodeLocation: {
+						endOffset: 52,
+						endTag: {
+							endOffset: 52,
+							startOffset: 48,
+						},
+						startOffset: 0,
+						startTag: {
+							endOffset: 3,
+							startOffset: 0,
+						},
+					},
+				},
+			],
+			name: "#document-fragment",
+		} );
+	} );
+} );

--- a/packages/yoastseo/spec/specHelpers/parse/buildTree.js
+++ b/packages/yoastseo/spec/specHelpers/parse/buildTree.js
@@ -1,5 +1,9 @@
 import LanguageProcessor from "../../../src/parse/language/LanguageProcessor";
 import { build } from "../../../src/parse/build";
+import adapt from "../../../src/parse/build/private/adapt";
+import { parseFragment } from "parse5";
+import filterTree from "../../../src/parse/build/private/filterTree";
+import permanentFilters from "../../../src/parse/build/private/alwaysFilterElements";
 
 /**
  * Builds an HTML tree for a given paper and researcher, and adds it to the paper.
@@ -11,4 +15,27 @@ import { build } from "../../../src/parse/build";
 export default function buildTree( paper, researcher ) {
 	const languageProcessor = new LanguageProcessor( researcher );
 	paper.setTree( build( paper.getText(), languageProcessor ) );
+}
+
+/**
+ * Parses the HTML string to a tree representation of
+ * the HTML document.
+ *
+ * @param {string} htmlString The HTML string.
+ *
+ * @returns {Node} The tree representation of the HTML string.
+ */
+function buildWithoutTokenize( htmlString ) {
+	let tree = adapt( parseFragment( htmlString, { sourceCodeLocationInfo: true } ) );
+	tree = filterTree( tree, permanentFilters );
+	return tree;
+}
+
+/**
+ * Builds an HTML tree for a given paper and researcher, and adds it to the paper.
+ * @param {Paper} paper The paper to which the tree will be added.
+ * @returns {void}
+ */
+export function buildTreeNoTokenize( paper ) {
+	paper.setTree( buildWithoutTokenize( paper.getText() ) );
 }

--- a/packages/yoastseo/src/parse/build/private/getTextElementPositions.js
+++ b/packages/yoastseo/src/parse/build/private/getTextElementPositions.js
@@ -70,22 +70,28 @@ function adjustElementEnd( descendantNodes, descendantTagPositions, textElementS
  *
  * @param {Paragraph|Heading} 		node  			The paragraph or heading node.
  * @param {Sentence[]|Token[]} 		textElements 	The sentences or tokens in the node.
+ * @param {number} 					startOffset 	The start position of the node in the source code.
+ * Defaults to -1 which signals that it should not be used.
  *
  * @returns {Sentence[]|Token[]} The sentences or tokens, with their positions in the source code.
  */
-export default function getTextElementPositions( node, textElements ) {
+export default function getTextElementPositions( node, textElements, startOffset = -1 ) {
 	// We cannot calculate positions if there are no text elements, or if we don't know the node's source code location.
 	if (  textElements.length === 0 || ! node.sourceCodeLocation ) {
 		return textElements;
 	}
+
 	/*
 	 * Set the start position of the first element. If the node is an implicit paragraph, which don't have start and
 	 * end tags, set the start position to the start of the node. Otherwise, set the start position to the end of the
 	 * node's start tag.
 	 */
-	let textElementStart = node instanceof Paragraph && node.isImplicit
-		? node.sourceCodeLocation.startOffset
-		: node.sourceCodeLocation.startTag.endOffset;
+	let textElementStart;
+	if ( node instanceof Paragraph && node.isImplicit ) {
+		textElementStart = node.sourceCodeLocation.startOffset;
+	} else {
+		textElementStart = startOffset >= 0 ? startOffset : node.sourceCodeLocation.startTag.endOffset;
+	}
 	let textElementEnd;
 	let descendantTagPositions = [];
 

--- a/packages/yoastseo/src/parse/build/private/tokenize.js
+++ b/packages/yoastseo/src/parse/build/private/tokenize.js
@@ -12,7 +12,7 @@ import getTextElementPositions from "./getTextElementPositions";
  */
 function getTokens( node, sentence, splitIntoTokens ) {
 	sentence.tokens = splitIntoTokens( sentence );
-	sentence.tokens = getTextElementPositions( node, sentence.tokens );
+	sentence.tokens = getTextElementPositions( node, sentence.tokens, sentence.sourceCodeRange.startOffset );
 	return sentence;
 }
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* In https://github.com/Yoast/wordpress-seo/pull/20131 position information was added to tokens. This position information is incorrect if a paragraph contains multiple sentences, it would give offsets to the tokens of this sentence as if they were in the first sentence.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where tokens would get the incorrect offsets if they were not in the first sentence of the paragraph.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Is not connected to frontend yet, so cannot be tested. Instead make sure that all specs pass.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [x] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
