### PR TITLE
Indexable attachment watcher unit tests

### DIFF
--- a/src/integrations/watchers/indexable-attachment-watcher.php
+++ b/src/integrations/watchers/indexable-attachment-watcher.php
@@ -119,8 +119,6 @@ class Indexable_Attachment_Watcher implements Integration_Interface {
 						\wp_schedule_single_event( ( time() + ( MINUTE_IN_SECONDS * 5 ) ), Cleanup_Integration::START_HOOK );
 					}
 					return;
-				default:
-					return;
 			}
 		}
 	}

--- a/tests/unit/integrations/watchers/indexable-attachment-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-attachment-watcher-test.php
@@ -23,7 +23,6 @@ use Yoast\WP\SEO\Integrations\Watchers\Indexable_Attachment_Watcher;
  * @group watchers
  *
  * @coversDefaultClass Yoast\WP\SEO\Integrations\Watchers\Indexable_Attachment_Watcher
- * @covers Yoast\WP\SEO\Integrations\Watchers\Indexable_Attachment_Watcher
  */
 class Indexable_Attachment_Watcher_Test extends TestCase {
 

--- a/tests/unit/integrations/watchers/indexable-attachment-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-attachment-watcher-test.php
@@ -78,7 +78,7 @@ class Indexable_Attachment_Watcher_Test extends TestCase {
 	 * @covers ::get_conditionals
 	 */
 	public function test_get_conditionals() {
-		$this->assertSame( [ Migrations_Conditional::class ], $this->instance->get_conditionals() );
+		$this->assertSame( [ Migrations_Conditional::class ], Indexable_Attachment_Watcher::get_conditionals() );
 	}
 
 	/**

--- a/tests/unit/integrations/watchers/indexable-attachment-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-attachment-watcher-test.php
@@ -1,7 +1,8 @@
 <?php
 
-use Brain\Monkey;
+namespace Yoast\WP\SEO\Tests\Unit\Integrations\Watchers;
 
+use Brain\Monkey;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 use Yoast\WP\SEO\Config\Indexing_Reasons;
 use Yoast\WP\SEO\Helpers\Indexing_Helper;
@@ -57,10 +58,6 @@ class Indexable_Attachment_Watcher_Test extends TestCase {
 	 */
 	protected function set_up() {
 		parent::set_up();
-
-		if ( ! defined( 'MINUTE_IN_SECONDS' ) ) {
-			define( 'MINUTE_IN_SECONDS', 60 );
-		}
 
 		$this->indexing_helper     = Mockery::mock( Indexing_Helper::class );
 		$this->attachment_cleanup  = Mockery::mock( Attachment_Cleanup_Helper::class );
@@ -158,7 +155,7 @@ class Indexable_Attachment_Watcher_Test extends TestCase {
 			->andReturn( $wp_next_scheduled );
 
 			Monkey\Functions\expect( 'wp_schedule_single_event' )
-				->with( ( time() + ( MINUTE_IN_SECONDS * 5 ) ), Cleanup_Integration::START_HOOK )
+				->with( ( time() + ( \MINUTE_IN_SECONDS * 5 ) ), Cleanup_Integration::START_HOOK )
 				->times( $schedule_event_times );
 
 		$this->instance->check_option( $old_value, $new_value );

--- a/tests/unit/integrations/watchers/indexable-attachment-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-attachment-watcher-test.php
@@ -102,104 +102,88 @@ class Indexable_Attachment_Watcher_Test extends TestCase {
 	 */
 	public function check_option_provider() {
 		return [
-			[
-				[
-					'old_value'                => 1,
-					'new_value'                => 2,
-					'delete_transient_times'   => 0,
-					'set_reason_times'         => 0,
-					'attachment_cleanup_times' => 0,
-					'wp_next_scheduled'        => null,
-					'schedule_event_times'     => 0,
-				],
+
+			'Old and new values are not arrays' => [
+				'old_value'                => 1,
+				'new_value'                => 2,
+				'delete_transient_times'   => 0,
+				'set_reason_times'         => 0,
+				'attachment_cleanup_times' => 0,
+				'wp_next_scheduled'        => null,
+				'schedule_event_times'     => 0,
 			],
-			[
-				[
-					'old_value'                => [],
-					'new_value'                => [],
-					'delete_transient_times'   => 0,
-					'set_reason_times'         => 0,
-					'attachment_cleanup_times' => 0,
-					'wp_next_scheduled'        => null,
-					'schedule_event_times'     => 0,
-				],
+
+			'Old and new values are empty arrays' => [
+				'old_value'                => [],
+				'new_value'                => [],
+				'delete_transient_times'   => 0,
+				'set_reason_times'         => 0,
+				'attachment_cleanup_times' => 0,
+				'wp_next_scheduled'        => null,
+				'schedule_event_times'     => 0,
 			],
-			[
-				[
-					'old_value'                => [],
-					'new_value'                => [ 'test' => 'test' ],
-					'delete_transient_times'   => 0,
-					'set_reason_times'         => 0,
-					'attachment_cleanup_times' => 0,
-					'wp_next_scheduled'        => null,
-					'schedule_event_times'     => 0,
-				],
+			'Old value is empty array and new doesnt have disable-attachment key' => [
+				'old_value'                => [],
+				'new_value'                => [ 'test' => 'test' ],
+				'delete_transient_times'   => 0,
+				'set_reason_times'         => 0,
+				'attachment_cleanup_times' => 0,
+				'wp_next_scheduled'        => null,
+				'schedule_event_times'     => 0,
 			],
-			[
-				[
-					'old_value'                => [ 'test' => 'test' ],
-					'new_value'                => [],
-					'delete_transient_times'   => 0,
-					'set_reason_times'         => 0,
-					'attachment_cleanup_times' => 0,
-					'wp_next_scheduled'        => null,
-					'schedule_event_times'     => 0,
-				],
+			'Old value doesnt have disable-attachment key and new value is empty array' => [
+				'old_value'                => [ 'test' => 'test' ],
+				'new_value'                => [],
+				'delete_transient_times'   => 0,
+				'set_reason_times'         => 0,
+				'attachment_cleanup_times' => 0,
+				'wp_next_scheduled'        => null,
+				'schedule_event_times'     => 0,
 			],
-			[
-				[
-					'old_value'                => [ 'test' => 'test' ],
-					'new_value'                => [ 'test' => 'test' ],
-					'delete_transient_times'   => 0,
-					'set_reason_times'         => 0,
-					'attachment_cleanup_times' => 0,
-					'wp_next_scheduled'        => null,
-					'schedule_event_times'     => 0,
-				],
+			'Old and new values doesnt have disable-attachment key' => [
+				'old_value'                => [ 'test' => 'test' ],
+				'new_value'                => [ 'test' => 'test' ],
+				'delete_transient_times'   => 0,
+				'set_reason_times'         => 0,
+				'attachment_cleanup_times' => 0,
+				'wp_next_scheduled'        => null,
+				'schedule_event_times'     => 0,
 			],
-			[
-				[
-					'old_value'                => false,
-					'new_value'                => [ 'test' => 'test' ],
-					'delete_transient_times'   => 0,
-					'set_reason_times'         => 0,
-					'attachment_cleanup_times' => 0,
-					'wp_next_scheduled'        => null,
-					'schedule_event_times'     => 0,
-				],
+			'Old value is false and new value doesnt have disable-attachment key' => [
+				'old_value'                => false,
+				'new_value'                => [ 'test' => 'test' ],
+				'delete_transient_times'   => 0,
+				'set_reason_times'         => 0,
+				'attachment_cleanup_times' => 0,
+				'wp_next_scheduled'        => null,
+				'schedule_event_times'     => 0,
 			],
-			[
-				[
-					'old_value'                => [ 'disable-attachment' => true ],
-					'new_value'                => [ 'disable-attachment' => false ],
-					'delete_transient_times'   => 1,
-					'set_reason_times'         => 1,
-					'attachment_cleanup_times' => 0,
-					'wp_next_scheduled'        => null,
-					'schedule_event_times'     => 0,
-				],
+			'Old and new values have disable-attachment key, old true, new false' => [
+				'old_value'                => [ 'disable-attachment' => true ],
+				'new_value'                => [ 'disable-attachment' => false ],
+				'delete_transient_times'   => 1,
+				'set_reason_times'         => 1,
+				'attachment_cleanup_times' => 0,
+				'wp_next_scheduled'        => null,
+				'schedule_event_times'     => 0,
 			],
-			[
-				[
-					'old_value'                => [ 'disable-attachment' => false ],
-					'new_value'                => [ 'disable-attachment' => true ],
-					'delete_transient_times'   => 1,
-					'set_reason_times'         => 0,
-					'attachment_cleanup_times' => 1,
-					'wp_next_scheduled'        => true,
-					'schedule_event_times'     => 0,
-				],
+			'Old and new values have disable-attachment key, old false, new true' => [
+				'old_value'                => [ 'disable-attachment' => false ],
+				'new_value'                => [ 'disable-attachment' => true ],
+				'delete_transient_times'   => 1,
+				'set_reason_times'         => 0,
+				'attachment_cleanup_times' => 1,
+				'wp_next_scheduled'        => true,
+				'schedule_event_times'     => 0,
 			],
-			[
-				[
-					'old_value'                => [ 'disable-attachment' => false ],
-					'new_value'                => [ 'disable-attachment' => true ],
-					'delete_transient_times'   => 1,
-					'set_reason_times'         => 0,
-					'attachment_cleanup_times' => 1,
-					'wp_next_scheduled'        => false,
-					'schedule_event_times'     => 1,
-				],
+			'Old and new values have disable-attachment key, old false, new true' => [
+				'old_value'                => [ 'disable-attachment' => false ],
+				'new_value'                => [ 'disable-attachment' => true ],
+				'delete_transient_times'   => 1,
+				'set_reason_times'         => 0,
+				'attachment_cleanup_times' => 1,
+				'wp_next_scheduled'        => false,
+				'schedule_event_times'     => 1,
 			],
 		];
 	}
@@ -211,42 +195,48 @@ class Indexable_Attachment_Watcher_Test extends TestCase {
 	 *
 	 * @dataProvider check_option_provider
 	 *
-	 * @param array $expected An array of expected results.
+	 * @param mixed $old_value                Old value.
+	 * @param mixed $new_value                New value.
+	 * @param int   $delete_transient_times   Number of times delete_transient should be called.
+	 * @param int   $set_reason_times         Number of times set_reason should be called.
+	 * @param int   $attachment_cleanup_times Number of times attachment_cleanup should be called.
+	 * @param mixed $wp_next_scheduled        Value of wp_next_scheduled.
+	 * @param int   $schedule_event_times     Number of times schedule_event should be called.
 	 */
-	public function test_check_option( $expected ) {
+	public function test_check_option( $old_value, $new_value, $delete_transient_times, $set_reason_times, $attachment_cleanup_times, $wp_next_scheduled, $schedule_event_times ) {
 
 		Monkey\Functions\expect( 'delete_transient' )
 			->with( Indexable_Post_Indexation_Action::UNINDEXED_COUNT_TRANSIENT )
-			->times( $expected['delete_transient_times'] );
+			->times( $delete_transient_times );
 
 		Monkey\Functions\expect( 'delete_transient' )
 			->with( Indexable_Post_Indexation_Action::UNINDEXED_LIMITED_COUNT_TRANSIENT )
-			->times( $expected['delete_transient_times'] );
+			->times( $delete_transient_times );
 
 		$this->indexing_helper
 			->expects( 'set_reason' )
 			->with( Indexing_Reasons::REASON_ATTACHMENTS_MADE_ENABLED )
-			->times( $expected['set_reason_times'] );
+			->times( $set_reason_times );
 
 		$this->attachment_cleanup
 			->expects( 'remove_attachment_indexables' )
 			->with( false )
-			->times( $expected['attachment_cleanup_times'] );
+			->times( $attachment_cleanup_times );
 
 		$this->attachment_cleanup
 			->expects( 'clean_attachment_links_from_target_indexable_ids' )
 			->with( false )
-			->times( $expected['attachment_cleanup_times'] );
+			->times( $attachment_cleanup_times );
 
 		Monkey\Functions\expect( 'wp_next_scheduled' )
 			->with( Cleanup_Integration::START_HOOK )
-			->times( $expected['attachment_cleanup_times'] )
-			->andReturn( $expected['wp_next_scheduled'] );
+			->times( $attachment_cleanup_times )
+			->andReturn( $wp_next_scheduled );
 
 			Monkey\Functions\expect( 'wp_schedule_single_event' )
 				->with( ( time() + ( \MINUTE_IN_SECONDS * 5 ) ), Cleanup_Integration::START_HOOK )
-				->times( $expected['schedule_event_times'] );
+				->times( $schedule_event_times );
 
-		$this->instance->check_option( $expected['old_value'], $expected['new_value'] );
+		$this->instance->check_option( $old_value, $new_value );
 	}
 }

--- a/tests/unit/integrations/watchers/indexable-attachment-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-attachment-watcher-test.php
@@ -87,7 +87,7 @@ class Indexable_Attachment_Watcher_Test extends TestCase {
 	 * @covers ::register_hooks
 	 */
 	public function test_register_hooks() {
-	
+
 		$this->instance->register_hooks();
 
 		$this->assertNotFalse( \has_action( 'update_option_wpseo_titles', [ $this->instance, 'check_option' ] ) );

--- a/tests/unit/integrations/watchers/indexable-attachment-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-attachment-watcher-test.php
@@ -3,6 +3,8 @@
 namespace Yoast\WP\SEO\Tests\Unit\Integrations\Watchers;
 
 use Brain\Monkey;
+use Mockery;
+use Yoast_Notification_Center;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 use Yoast\WP\SEO\Config\Indexing_Reasons;
 use Yoast\WP\SEO\Helpers\Indexing_Helper;

--- a/tests/unit/integrations/watchers/indexable-attachment-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-attachment-watcher-test.php
@@ -102,7 +102,6 @@ class Indexable_Attachment_Watcher_Test extends TestCase {
 	 */
 	public function check_option_provider() {
 		return [
-
 			'Old and new values are not arrays' => [
 				'old_value'                => 1,
 				'new_value'                => 2,
@@ -233,9 +232,9 @@ class Indexable_Attachment_Watcher_Test extends TestCase {
 			->times( $attachment_cleanup_times )
 			->andReturn( $wp_next_scheduled );
 
-			Monkey\Functions\expect( 'wp_schedule_single_event' )
-				->with( ( time() + ( \MINUTE_IN_SECONDS * 5 ) ), Cleanup_Integration::START_HOOK )
-				->times( $schedule_event_times );
+		Monkey\Functions\expect( 'wp_schedule_single_event' )
+			->with( ( time() + ( \MINUTE_IN_SECONDS * 5 ) ), Cleanup_Integration::START_HOOK )
+			->times( $schedule_event_times );
 
 		$this->instance->check_option( $old_value, $new_value );
 	}

--- a/tests/unit/integrations/watchers/indexable-attachment-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-attachment-watcher-test.php
@@ -1,0 +1,166 @@
+<?php
+
+use Brain\Monkey;
+
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+use Yoast\WP\SEO\Config\Indexing_Reasons;
+use Yoast\WP\SEO\Helpers\Indexing_Helper;
+use Yoast\WP\SEO\Integrations\Cleanup_Integration;
+use Yoast\WP\SEO\Helpers\Attachment_Cleanup_Helper;
+use Yoast\WP\SEO\Conditionals\Migrations_Conditional;
+use Yoast\WP\SEO\Actions\Indexing\Indexable_Post_Indexation_Action;
+use Yoast\WP\SEO\Integrations\Watchers\Indexable_Attachment_Watcher;
+
+
+/**
+ * Class Indexable_Attachment_Watcher_Test.
+ *
+ * @group indexables
+ * @group integrations
+ * @group watchers
+ *
+ * @coversDefaultClass Yoast\WP\SEO\Integrations\Watchers\Indexable_Attachment_Watcher
+ * @covers Yoast\WP\SEO\Integrations\Watchers\Indexable_Attachment_Watcher
+ */
+class Indexable_Attachment_Watcher_Test extends TestCase {
+
+	/**
+	 * The indexing helper.
+	 *
+	 * @var Indexing_Helper
+	 */
+	protected $indexing_helper;
+
+	/**
+	 * The attachment cleanup helper.
+	 *
+	 * @var Attachment_Cleanup_Helper
+	 */
+	protected $attachment_cleanup;
+
+	/**
+	 * The notifications center.
+	 *
+	 * @var Yoast_Notification_Center
+	 */
+	protected $notification_center;
+
+	/**
+	 * The Indexable_Attachment_Watcher instance.
+	 *
+	 * @var Indexable_Attachment_Watcher
+	 */
+	protected $instance;
+
+	/**
+	 * Sets up the tests.
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		if ( ! defined( 'MINUTE_IN_SECONDS' ) ) {
+			define( 'MINUTE_IN_SECONDS', 60 );
+		}
+
+		$this->indexing_helper     = Mockery::mock( Indexing_Helper::class );
+		$this->attachment_cleanup  = Mockery::mock( Attachment_Cleanup_Helper::class );
+		$this->notification_center = Mockery::mock( Yoast_Notification_Center::class );
+
+		$this->instance = new Indexable_Attachment_Watcher(
+			$this->indexing_helper,
+			$this->attachment_cleanup,
+			$this->notification_center
+		);
+	}
+
+	/**
+	 * Tests the get_conditionals method.
+	 *
+	 * @covers ::get_conditionals
+	 */
+	public function test_get_conditionals() {
+		$this->assertSame( [ Migrations_Conditional::class ], $this->instance->get_conditionals() );
+	}
+
+	/**
+	 * Tests the register_hooks method.
+	 *
+	 * @covers ::register_hooks
+	 */
+	public function test_register_hooks() {
+
+		Monkey\Actions\expectAdded( 'update_option_wpseo_titles' )
+			->with( [ $this->instance, 'check_option' ] )
+			->once();
+
+		$this->instance->register_hooks();
+	}
+
+	/**
+	 * Data provider for test_check_option.
+	 *
+	 * @return array $old_value,$new_value, $delete_transient_times, $set_reason_times, $attachment_cleanup_times, wp_next_scheduled, $schedule_event_times.
+	 */
+	public function check_option_provider() {
+		return [
+			[ 1, 2, 0, 0, 0, null, 0 ],
+			[ [ 'test' => 'test' ], [ 'test' => 'test' ], 0, 0, 0, null, 0 ],
+			[ false, [ 'test' => 'test' ], 0, 0, 0, null, 0 ],
+			[ [ 'disable-attachment' => true ], [ 'disable-attachment' => false ], 1, 1, 0, null, 0 ],
+			[ [ 'disable-attachment' => false ], [ 'disable-attachment' => true ], 1, 0, 1, true, 0 ],
+			[ [ 'disable-attachment' => false ], [ 'disable-attachment' => true ], 1, 0, 1, false, 1 ],
+		];
+	}
+
+	/**
+	 * Tests the check_option method.
+	 *
+	 * @covers ::check_option
+	 *
+	 * @dataProvider check_option_provider
+	 *
+	 * @param array|bool $old_value The old value.
+	 * @param array|bool $new_value The new value.
+	 * @param int        $delete_transient_times Whether to delete the transient.
+	 * @param int        $set_reason_times Whether to set the reason.
+	 * @param int        $attachment_cleanup_times Whether to clean up the attachment.
+	 * @param bool       $wp_next_scheduled Whether to schedule the cleanup.
+	 * @param int        $schedule_event_times Whether to schedule the cleanup.
+	 */
+	public function test_check_option( $old_value, $new_value, $delete_transient_times, $set_reason_times, $attachment_cleanup_times, $wp_next_scheduled, $schedule_event_times ) {
+
+		Monkey\Functions\expect( 'delete_transient' )
+			->with( Indexable_Post_Indexation_Action::UNINDEXED_COUNT_TRANSIENT )
+			->times( $delete_transient_times );
+
+		Monkey\Functions\expect( 'delete_transient' )
+			->with( Indexable_Post_Indexation_Action::UNINDEXED_LIMITED_COUNT_TRANSIENT )
+			->times( $delete_transient_times );
+
+		$this->indexing_helper
+			->expects( 'set_reason' )
+			->with( Indexing_Reasons::REASON_ATTACHMENTS_MADE_ENABLED )
+			->times( $set_reason_times );
+
+		$this->attachment_cleanup
+			->expects( 'remove_attachment_indexables' )
+			->with( false )
+			->times( $attachment_cleanup_times );
+
+		$this->attachment_cleanup
+			->expects( 'clean_attachment_links_from_target_indexable_ids' )
+			->with( false )
+			->times( $attachment_cleanup_times );
+
+		Monkey\Functions\expect( 'wp_next_scheduled' )
+			->with( Cleanup_Integration::START_HOOK )
+			->times( $attachment_cleanup_times )
+			->andReturn( $wp_next_scheduled );
+
+			Monkey\Functions\expect( 'wp_schedule_single_event' )
+				->with( ( time() + ( MINUTE_IN_SECONDS * 5 ) ), Cleanup_Integration::START_HOOK )
+				->times( $schedule_event_times );
+
+		$this->instance->check_option( $old_value, $new_value );
+	}
+}

--- a/tests/unit/integrations/watchers/indexable-attachment-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-attachment-watcher-test.php
@@ -87,12 +87,10 @@ class Indexable_Attachment_Watcher_Test extends TestCase {
 	 * @covers ::register_hooks
 	 */
 	public function test_register_hooks() {
-
-		Monkey\Actions\expectAdded( 'update_option_wpseo_titles' )
-			->with( [ $this->instance, 'check_option' ] )
-			->once();
-
+	
 		$this->instance->register_hooks();
+
+		$this->assertNotFalse( \has_action( 'update_option_wpseo_titles', [ $this->instance, 'check_option' ] ) );
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Add unit test to Indexable attachment watcher class

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* adds unit tests to indexable attachment watcher.

## Relevant technical choices:

* Removed default from original class that couldn't be reached. 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Generate test coverage report and check `Indexable_Attachment_Watcher` is 100% covered.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes [Add more unit tests for the #19388 PR](https://github.com/Yoast/wordpress-seo/issues/19747)
