### PR TITLE
Fix console error related to translations for English sites

### DIFF
--- a/packages/yoastseo/src/worker/AnalysisWebWorker.js
+++ b/packages/yoastseo/src/worker/AnalysisWebWorker.js
@@ -702,7 +702,7 @@ export default class AnalysisWebWorker {
 		if ( has( configuration, "translations" ) ) {
 			Object.values( configuration.translations ).forEach( translation => {
 				// Don't proceed if translation object is null or otherwise falsy.
-				if( translation ) {
+				if ( translation ) {
 					const { domain, locale_data: localeData } = translation;
 					setLocaleData( localeData[ domain ], domain );
 				}

--- a/packages/yoastseo/src/worker/AnalysisWebWorker.js
+++ b/packages/yoastseo/src/worker/AnalysisWebWorker.js
@@ -700,11 +700,13 @@ export default class AnalysisWebWorker {
 		);
 
 		if ( has( configuration, "translations" ) ) {
-			Object.values( configuration.translations ).forEach(
-				( { domain, locale_data: localeData } ) => {
+			Object.values( configuration.translations ).forEach( translation => {
+				// Don't proceed if translation object is null or otherwise falsy.
+				if( translation ) {
+					const { domain, locale_data: localeData } = translation;
 					setLocaleData( localeData[ domain ], domain );
 				}
-			);
+			} );
 		}
 
 		if ( has( configuration, "researchData" ) ) {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* A console error related to translations appeared when opening a post on a site that's in a language that doesn't have translations, i.e. English.
* This was caused by the change in [this PR](https://github.com/Yoast/wordpress-seo/pull/20204/files) which tries to get the domain from each translation object without checking whether that object is null.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [wordpress-seo-premium] Fixes a bug where a console error would appear when opening a post on English sites.

## Relevant technical choices:

* A safeguard was added that checks whether each translation object within the `translations` object is truthy before retrieving the translation.
* An alternative would be to avoid passing an empty translations objects to the worker in the first place. But this would require us to make changes in multiple places (wherever we pass a translations object to the worker), and remember to add the safeguard whenever we add new code that passes translations.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Activate Free and Premium (run `composer require yoast/wordpress-seo:dev-3941-fix-console-error-related-to-translations@dev` when building Premium)
* Set your site language to English
* Open a new post and confirm there are no console errors
* Change your site language to Spanish
* Open a new post and confirm there are no console errors
* Confirm that the (Premium) title assessment appears in the SEO tab with the feedback in Spanish (`Título: Tu página todavía no tiene título. ¡Añade uno!` in case of a red traffic light)
* Confirm that the (Free) images assessment appears in the SEO tab with the feedback in Spanish( `Imágenes: No hay imágenes en esta página. ¡Añade algunash!`)
* Build and activate Yoast WooCommerce, create a product and confirm that the strings for Woo-specific assessments are also translated to Spanish. For example: `SKU: A la imagen de tu producto le falta el SKU. Puedes añadir un SKU desde la pestaña de «Inventario» en la caja de datos del producto. Inclúyelo si puedes, ya que ayudará a los motores de búsqueda a comprender mejor tu contenido.`
* Change site language back to English, open a product and confirm there are no console errors.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [x] Changes should be tested on different editors (Block/Classic/Elementor/other)
     * Check in Elementor
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* This PR touches code related to assessment feedback translations in Free, Premium, and Woo.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes https://github.com/Yoast/wordpress-seo-premium/issues/3941
