### PR TITLE
Improve SQL query performance in Indexable_Post_Indexation_Action

### DIFF
--- a/src/actions/indexing/indexable-post-indexation-action.php
+++ b/src/actions/indexing/indexable-post-indexation-action.php
@@ -154,12 +154,13 @@ class Indexable_Post_Indexation_Action extends Abstract_Indexing_Action {
 			"
 			SELECT COUNT(P.ID)
 			FROM {$this->wpdb->posts} AS P
+			LEFT JOIN $indexable_table AS I
+				ON P.ID = I.object_id
+				AND I.object_type = 'post'
+				AND I.version = %d
 			WHERE P.post_type IN (" . \implode( ', ', \array_fill( 0, \count( $post_types ), '%s' ) ) . ')
 			AND P.post_status NOT IN (' . \implode( ', ', \array_fill( 0, \count( $excluded_post_statuses ), '%s' ) ) . ")
-			AND P.ID not in (
-				SELECT I.object_id from $indexable_table as I
-				WHERE I.object_type = 'post'
-				AND I.version = %d )",
+			AND I.object_id IS NULL",
 			$replacements
 		);
 	}
@@ -194,12 +195,13 @@ class Indexable_Post_Indexation_Action extends Abstract_Indexing_Action {
 			"
 			SELECT P.ID
 			FROM {$this->wpdb->posts} AS P
+			LEFT JOIN $indexable_table AS I
+				ON P.ID = I.object_id
+				AND I.object_type = 'post'
+				AND I.version = %d
 			WHERE P.post_type IN (" . \implode( ', ', \array_fill( 0, \count( $post_types ), '%s' ) ) . ')
-			AND P.post_status NOT IN (' . \implode( ', ', \array_fill( 0, \count( $excluded_post_statuses ), '%s' ) ) . ")
-			AND P.ID not in (
-				SELECT I.object_id from $indexable_table as I
-				WHERE I.object_type = 'post'
-				AND I.version = %d )
+				AND P.post_status NOT IN (' . \implode( ', ', \array_fill( 0, \count( $excluded_post_statuses ), '%s' ) ) . ")
+				AND I.object_id IS NULL
 			$limit_query",
 			$replacements
 		);


### PR DESCRIPTION
## Context
Improve performance of Yoast on wp-admin dashboard, when working with indexables, on sites with large number of posts.

## Summary
The following query in `get_select_query()` method in the `Indexable_Post_Indexation_Action` class can be improved:

```
return $this->wpdb->prepare(
	"
	SELECT P.ID
	FROM {$this->wpdb->posts} AS P
	WHERE P.post_type IN (" . \implode( ', ', \array_fill( 0, \count( $post_types ), '%s' ) ) . ')
	AND P.post_status NOT IN (' . \implode( ', ', \array_fill( 0, \count( $excluded_post_statuses ), '%s' ) ) . ")
	AND P.ID not in (
		SELECT I.object_id from $indexable_table as I
		WHERE I.object_type = 'post'
		AND I.version = %d )
	$limit_query",
	$replacements
);
```

When running `EXPLAIN` on the query, the subquery goes over all the rows, which makes this significantly slower on larger data sets:

![EXPLAIN results before](https://s3.amazonaws.com/tw-inlineimages/239776/0/0/e516bf4da5a8827967b8744196d987f4.png)

If the query is changed to:

```
return $this->wpdb->prepare(
	"
	SELECT P.ID
	FROM {$this->wpdb->posts} AS P
	LEFT JOIN $indexable_table AS I
		ON P.ID = I.object_id
		AND I.object_type = 'post'
		AND I.version = %d
	WHERE P.post_type IN (" . \implode( ', ', \array_fill( 0, \count( $post_types ), '%s' ) ) . ')
		AND P.post_status NOT IN (' . \implode( ', ', \array_fill( 0, \count( $excluded_post_statuses ), '%s' ) ) . ")
		AND I.object_id IS NULL
	$limit_query",
	$replacements
);
```

we can simplify the query and get rid of the scan across the whole table:

![EXPLAIN results after](https://s3.amazonaws.com/tw-inlineimages/239776/0/0/e5182c78adb8331f8e8ed65f51f63069.png)

This PR can be summarized in the following changelog entry:

* Improve SQL performance on wp-admin

### Test instructions for QA when the code is in the RC
Make sure that the output results from old and new queries match.

## Impact check
This PR affects how unindexed posts are selected.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.
