### PR TITLE
Fix Elementor 3.13 compatibility

### DIFF
--- a/css/src/elementor.css
+++ b/css/src/elementor.css
@@ -44,7 +44,9 @@
 	font-weight: 400;
 }
 
-.elementor-panel .elementor-tab-control-yoast-tab a:before, .yoast-element-menu-icon:before {
+.elementor-panel .elementor-tab-control-yoast-tab a:before,
+.elementor-panel .elementor-tab-control-yoast-tab span:before,
+.yoast-element-menu-icon:before {
 	mask-image: var(--yoast-svg-icon-yoast);
 	-webkit-mask-image: var(--yoast-svg-icon-yoast);
 	mask-size: 100% 100%;
@@ -249,7 +251,7 @@
 
 /* All hover effects */
 @media(hover:hover) {
-	
+
 	.yoast a:hover, .yoast a:hover p, .yoast-elementor-panel__fills p a:hover, .button-link:hover {
 		color: var(--yoast-color-primary-darker);
 	}

--- a/packages/js/src/initializers/elementor-editor-integration.js
+++ b/packages/js/src/initializers/elementor-editor-integration.js
@@ -293,7 +293,7 @@ export default function initElementEditorIntegration() {
 	 * Listen for Yoast tab activation from within settings panel to start rendering the Yoast tab React content.
 	 * Note the `.not` in the selector, this is to prevent rendering the React content multiple times.
 	 */
-	jQuery( document ).on( "click", "[data-tab=\"yoast-tab\"]:not(.elementor-active) > a", renderYoastTabReactContent );
+	jQuery( document ).on( "click", "[data-tab=\"yoast-tab\"]:not(.elementor-active)", renderYoastTabReactContent );
 
 	yoastInputs = document.querySelectorAll( "input[name^='yoast']" );
 	storeAllValuesAsOldValues();

--- a/packages/js/src/initializers/elementor-editor-integration.js
+++ b/packages/js/src/initializers/elementor-editor-integration.js
@@ -293,7 +293,16 @@ export default function initElementEditorIntegration() {
 	 * Listen for Yoast tab activation from within settings panel to start rendering the Yoast tab React content.
 	 * Note the `.not` in the selector, this is to prevent rendering the React content multiple times.
 	 */
-	jQuery( document ).on( "click", "[data-tab=\"yoast-tab\"]:not(.elementor-active)", renderYoastTabReactContent );
+	jQuery( document )
+		.on( "click", "[data-tab=\"yoast-tab\"]:not(.elementor-active)", renderYoastTabReactContent )
+		.on( "keyup", "[data-tab=\"yoast-tab\"]:not(.elementor-active)", ( event ) => {
+			const ENTER_KEY = 13;
+			const SPACE_KEY = 32;
+
+			if ( ENTER_KEY === event.keyCode || SPACE_KEY === event.keyCode ) {
+				event.currentTarget.click();
+			}
+		} );
 
 	yoastInputs = document.querySelectorAll( "input[name^='yoast']" );
 	storeAllValuesAsOldValues();


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Elementor 3.13 beta 1 changes the markup in their sidebar with [this PR](https://github.com/elementor/elementor/pull/21733), resulting in a broken Yoast SEO tab. It will be reverted in a following beta but it's going to be part of 3.14 so we want to be prepared.
* We also want make sure the Yoast tab can be accessed via keyboard.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Ensures compatibility with upcoming Elementor accessibility improvements.

## Relevant technical choices:

* The relevant markup is going to change from `div > a` to `button > span` for a11y reasons. The rendering event used to be attached to the `a` tag. I've decided to target the `button` tag instead, via the `data-tab` attribute, for 2 reasons:
  1. backwards compatibility
  2. consistency with the other tabs, where the event is attached to the `button`, not the inner `span`
* The PR also includes the improvement from [this patch](https://github.com/Yoast/wordpress-seo/pull/20229)


## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install the beta from Elementor with the a11y changes (find it [here](https://github.com/elementor/elementor/releases/tag/v3.13.0-beta-rc))
* edit a post with Elementor
* check that the Yoast tab displays the icon correctly:
![image](https://user-images.githubusercontent.com/12400734/235078267-75660c9a-ed89-4751-b4fc-df16985c35ea.png)

* check that by clicking on the tab the sidebar is rendered correctly
  * with the production version of Yoast, you get an empty tab instead:
 
![image](https://user-images.githubusercontent.com/12400734/235077529-56a1d62d-e18a-448d-9f1f-381ab7250601.png)

* try to access the tab by navigating with the keyboard
  * with the production version of Yoast, you should not be able to switch to the Yoast tab

* install the 3.12.1 version of Elementor 
* repeat the tests above

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [x] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

* Install the beta from Elementor with the a11y changes (find it [here](https://github.com/elementor/elementor/releases/tag/v3.13.0-beta-rc))
* edit a post with Elementor
* check that the Yoast tab displays the icon correctly:
![image](https://user-images.githubusercontent.com/12400734/235078267-75660c9a-ed89-4751-b4fc-df16985c35ea.png)

* check that by clicking on the tab the sidebar is rendered correctly
  * with the production version of Yoast, you get an empty tab instead:
 
![image](https://user-images.githubusercontent.com/12400734/235077529-56a1d62d-e18a-448d-9f1f-381ab7250601.png)

* try to access the tab by navigating with the keyboard
  * with the production version of Yoast, you should not be able to switch to the Yoast tab

* install the 3.12.1 version of Elementor 
* repeat the tests above

* install the latest beta from Elementor (should be out since May 3, has the changes reverted)
* repeat the tests above


<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes https://github.com/Yoast/plugins-automated-testing/issues/653
