### PR TITLE
Seo links repository tests

### DIFF
--- a/tests/integration/repositories/seo-links-repository-test.php
+++ b/tests/integration/repositories/seo-links-repository-test.php
@@ -1,0 +1,634 @@
+<?php
+/**
+ * WPSEO plugin integration test file.
+ *
+ * @package Yoast\Tests\Repositories
+ */
+
+use Yoast\WP\SEO\Repositories\SEO_Links_Repository;
+use Yoast\WP\SEO\Models\SEO_Links;
+
+
+/**
+ * Class SEO_Links_Repository_Test.
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Repositories\SEO_Links_Repository
+ */
+class SEO_Links_Repository_Test extends WPSEO_UnitTestCase {
+
+	/**
+	 * The instance to test.
+	 *
+	 * @var SEO_Links_Repository
+	 */
+	private $instance;
+
+	/**
+	 * Sets up the test class.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		global $wpdb;
+
+		$wpdb->insert(
+			$wpdb->prefix . 'yoast_seo_links',
+			[
+				'url'                 => 'https://example.com/test',
+				'type'                => 'internal',
+				'indexable_id'        => '101',
+				'post_id'             => '110',
+				'target_post_id'      => '112',
+				'target_indexable_id' => '344',
+				'id'                  => '113',
+			]
+		);
+
+		$this->instance = new SEO_Links_Repository();
+	}
+
+	/**
+	 * Tears down the test class.
+	 */
+	public function tearDown(): void {
+		global $wpdb;
+
+		$wpdb->query( "TRUNCATE TABLE {$wpdb->prefix}yoast_seo_links" );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Tests the query method.
+	 *
+	 * @covers ::query
+	 */
+	public function test_query() {
+
+		$this->assertIsObject( $this->instance->query() );
+	}
+
+	/**
+	 * Tests the find_all_by_post_id method.
+	 *
+	 * @covers ::find_all_by_post_id
+	 */
+	public function test_find_all_by_post_id_no_result() {
+
+		$post_id = 1;
+
+		$result = $this->instance->find_all_by_post_id( $post_id );
+
+		$this->assertIsArray( $result, 'The result should be an array.' );
+		$this->assertEmpty( $result, 'The result should be empty.' );
+	}
+
+	/**
+	 * Tests the find_all_by_post_id method.
+	 *
+	 * @covers ::find_all_by_post_id
+	 */
+	public function test_find_all_by_post_id_with_result() {
+
+		$post_id = 110;
+
+		$result = $this->instance->find_all_by_post_id( $post_id );
+
+		$this->assertIsArray( $result, 'The result should be an array.' );
+		$this->assertContainsOnlyInstancesOf(
+			SEO_Links::class,
+			$result,
+			'The result should only contain SEO_Links instances.'
+		);
+
+		$this->assertCount( 1, $result, 'The result should contain 1 items.' );
+
+		$this->assertEquals( 'https://example.com/test', $result[0]->url, 'The url should be the same for first link.' );
+		$this->assertEquals( 'internal', $result[0]->type, 'The type should be the same  for first link.' );
+		$this->assertEquals( '101', $result[0]->indexable_id, 'The indexable_id should be the same for first link.' );
+		$this->assertEquals( '110', $result[0]->post_id, 'The post_id should be the same for first link.' );
+	}
+
+	/**
+	 * Tests the insert_many method.
+	 *
+	 * @covers ::insert_many
+	 */
+	public function test_insert_many() {
+		global $wpdb;
+		$post_id = 11;
+		$link_1  = $this->instance->query()->create(
+			[
+				'url'          => 'https://example.com/test1',
+				'type'         => 'external',
+				'indexable_id' => 1,
+				'post_id'      => $post_id,
+			]
+		);
+		$link_2  = $this->instance->query()->create(
+			[
+				'url'          => 'https://example.com/test2',
+				'type'         => 'internal',
+				'indexable_id' => 2,
+				'post_id'      => $post_id,
+			]
+		);
+
+		$links = [ $link_1, $link_2 ];
+
+		$this->instance->insert_many( $links );
+
+		$result = $wpdb->get_results(
+			$wpdb->prepare( "SELECT * FROM {$wpdb->prefix}yoast_seo_links WHERE post_id = %d", $post_id )
+		);
+
+		$this->assertCount( 2, $result, 'The result should contain 2 items.' );
+
+		$this->assertEquals( $links[0]->url, $result[0]->url, 'The url should be the same for first link.' );
+		$this->assertEquals( $links[0]->type, $result[0]->type, 'The type should be the same  for first link.' );
+		$this->assertEquals( $links[0]->indexable_id, $result[0]->indexable_id, 'The indexable_id should be the same for first link.' );
+		$this->assertEquals( $links[0]->post_id, $result[0]->post_id, 'The post_id should be the same for first link.' );
+
+		$this->assertEquals( $links[1]->url, $result[1]->url, 'The url should be the same for second link.' );
+		$this->assertEquals( $links[1]->type, $result[1]->type, 'The type should be the same for second link.' );
+		$this->assertEquals( $links[1]->indexable_id, $result[1]->indexable_id, 'The indexable_id should be the same for second link.' );
+		$this->assertEquals( $links[1]->post_id, $result[1]->post_id, 'The post_id should be the same for second link.' );
+
+		$this->assertIsArray( $result, 'The result should be an array.' );
+	}
+
+	/**
+	 * Tests the find_all_by_indexable_id method.
+	 *
+	 * @covers ::find_all_by_indexable_id
+	 */
+	public function test_find_all_by_indexable_id_no_results_found() {
+		$indexable_id = '1';
+
+		$result = $this->instance->find_all_by_indexable_id( 3 );
+
+		$this->assertIsArray( $result, 'The result should be an array when there are no result.' );
+		$this->assertEmpty( $result, 'The result should be empty.' );
+	}
+
+	/**
+	 * Tests the find_all_by_indexable_id method.
+	 *
+	 * @covers ::find_all_by_indexable_id
+	 */
+	public function test_find_all_by_indexable_id_with_results_found() {
+
+		$result = $this->instance->find_all_by_indexable_id( 101 );
+
+		$this->assertIsArray( $result, 'The result should be an array.' );
+
+		$this->assertCount( 1, $result, 'The result should contain one item.' );
+	}
+
+	/**
+	 * Tests find_one_by_url method.
+	 *
+	 * @covers ::find_one_by_url
+	 */
+	public function test_find_one_by_url() {
+
+		$result = $this->instance->find_one_by_url( 'https://example.com/test' );
+
+		$this->assertInstanceOf( SEO_Links::class, $result, 'The result should SEO_Links type.' );
+		$this->assertSame( $result->target_post_id, 112, 'The target_post_id should be 112.' );
+	}
+
+	/**
+	 * Tests find_all_by_target_post_id.
+	 *
+	 * @covers ::find_all_by_target_post_id
+	 */
+	public function test_find_all_by_target_post_id() {
+		$result = $this->instance->find_all_by_target_post_id( '112' );
+
+		$this->assertIsArray( $result, 'The result should be an array.' );
+
+		$this->assertContainsOnlyInstancesOf(
+			SEO_Links::class,
+			$result,
+			'The result should only contain SEO_Links instances.'
+		);
+
+		$this->assertCount( 1, $result, 'The result should contain one item.' );
+	}
+
+	/**
+	 * Data provider for test_update_target_indexable_id.
+	 *
+	 * @return array
+	 */
+	public function data_provider_test_update_target_indexable_id() {
+		return [
+			'The update should be succesful, with no change' => [
+				'link_id'             => 113,
+				'target_indexable_id' => '112',
+				'expected_result'     => true,
+				'in_db'               => 1,
+			],
+			'The update should be succesful with update' => [
+				'link_id'             => 113,
+				'target_indexable_id' => '155',
+				'expected_result'     => true,
+				'in_db'               => 1,
+			],
+			'No update, id is invalid' => [
+				'link_id'             => 115,
+				'target_indexable_id' => 112,
+				'expected_result'     => false,
+				'in_db'               => 0,
+			],
+		];
+	}
+
+	/**
+	 * Tests update_target_indexable_id.
+	 *
+	 * @covers ::update_target_indexable_id
+	 *
+	 * @dataProvider data_provider_test_update_target_indexable_id
+	 *
+	 * @param int  $link_id The link id.
+	 * @param int  $target_indexable_id The target indexable id to update.
+	 * @param bool $expected_result The expected result.
+	 * @param int  $in_db The expected result in the database.
+	 */
+	public function test_update_target_indexable_id( $link_id, $target_indexable_id, $expected_result, $in_db ) {
+		global $wpdb;
+		$result = $this->instance->update_target_indexable_id( $link_id, $target_indexable_id );
+
+		$this->assertSame( $expected_result, $result );
+
+		$db = $wpdb->get_var( $wpdb->prepare( 'SELECT COUNT(*) FROM `' . $wpdb->prefix . 'yoast_seo_links` WHERE `id` = %d AND `target_indexable_id` = %d', [ $link_id, $target_indexable_id ] ) );
+
+		$this->assertEquals( $in_db, $db, 'The result should be the same in the database.' );
+	}
+
+	/**
+	 * Data provider for test_delete_all_by_post_id.
+	 *
+	 * @return array
+	 */
+	public function data_provider_test_delete_all_by_post_id() {
+		return [
+			'The delete should be succesful' => [
+				'post_id'         => 110,
+				'expected_result' => 2,
+			],
+			'The delete should fail, no post id' => [
+				'post_id'         => 111,
+				'expected_result' => 0,
+			],
+		];
+	}
+
+	/**
+	 * Tests delete_all_by_post_id.
+	 *
+	 * @covers ::delete_all_by_post_id
+	 *
+	 * @dataProvider data_provider_test_delete_all_by_post_id
+	 *
+	 * @param int $post_id The post id.
+	 * @param int $expected_result The expected result.
+	 */
+	public function test_delete_all_by_post_id( $post_id, $expected_result ) {
+		global $wpdb;
+
+		// Adding another link with indexable_id null.
+		$wpdb->insert(
+			$wpdb->prefix . 'yoast_seo_links',
+			[
+				'url'            => 'https://example.com/test/1',
+				'type'           => 'internal',
+				'indexable_id'   => '101',
+				'post_id'        => '110',
+				'target_post_id' => '159',
+				'id'             => '223',
+			]
+		);
+
+		$result = $this->instance->delete_all_by_post_id( $post_id );
+
+		$db = $wpdb->get_var( $wpdb->prepare( 'SELECT COUNT(*) FROM `' . $wpdb->prefix . 'yoast_seo_links` WHERE `post_id`=%d', $post_id ) );
+
+		$this->assertEquals( 0, $db, 'The result should be the same in the database.' );
+
+		$this->assertSame( $expected_result, $result, 'How many links were deleted should be the result' );
+	}
+
+	/**
+	 * Data provider for test test_delete_all_by_post_id_where_indexable_id_null
+	 *
+	 * @return array
+	 */
+	public function data_provider_test_delete_all_by_post_id_where_indexable_id_null() {
+		return [
+			'The delete should be succesful' => [
+				'post_id'         => 110,
+				'expected_result' => 2,
+			],
+			'The delete should fail, no post id' => [
+				'post_id'         => 111,
+				'expected_result' => 0,
+			],
+		];
+	}
+
+	/**
+	 * Tests delete_all_by_post_id_where_indexable_id_null.
+	 *
+	 * @covers ::delete_all_by_post_id_where_indexable_id_null
+	 *
+	 * @dataProvider data_provider_test_delete_all_by_post_id_where_indexable_id_null
+	 *
+	 * @param int $post_id The post id.
+	 * @param int $expected_result The number of links deleted.
+	 */
+	public function test_delete_all_by_post_id_where_indexable_id_null( $post_id, $expected_result ) {
+		global $wpdb;
+
+		// Adding another link with indexable_id null.
+		$wpdb->insert(
+			$wpdb->prefix . 'yoast_seo_links',
+			[
+				'url'            => 'https://example.com/test/1',
+				'type'           => 'internal',
+				'indexable_id'   => null,
+				'post_id'        => '110',
+				'target_post_id' => '154',
+				'id'             => '222',
+			]
+		);
+		$wpdb->insert(
+			$wpdb->prefix . 'yoast_seo_links',
+			[
+				'url'            => 'https://example.com/test/2',
+				'type'           => 'internal',
+				'indexable_id'   => null,
+				'post_id'        => '110',
+				'target_post_id' => '159',
+				'id'             => '229',
+			]
+		);
+
+		$result = $this->instance->delete_all_by_post_id_where_indexable_id_null( $post_id );
+
+		$db = $wpdb->get_var( $wpdb->prepare( 'SELECT COUNT(*) FROM `' . $wpdb->prefix . 'yoast_seo_links` WHERE `post_id`=%d AND `indexable_id` IS NULL', $post_id ) );
+
+		$this->assertEquals( 0, $db, 'The result should be the same in the database.' );
+
+		$this->assertSame( $expected_result, $result, 'How many links were deleted should be the result' );
+	}
+
+	/**
+	 * Data provider for test test_delete_all_by_indexable_id
+	 *
+	 * @return array
+	 */
+	public function data_provider_test_delete_all_by_indexable_id() {
+		return [
+			'The delete should be succesful' => [
+				'indexable_id'    => 101,
+				'expected_result' => 2,
+			],
+			'The delete should fail, no indexable id' => [
+				'indexable_id'    => 999,
+				'expected_result' => 0,
+			],
+		];
+	}
+
+	/**
+	 * Tests delete_all_by_indexable_id.
+	 *
+	 * @covers ::delete_all_by_indexable_id
+	 *
+	 * @dataProvider data_provider_test_delete_all_by_indexable_id
+	 *
+	 * @param int $indexable_id The indexable id.
+	 * @param int $expected_result The number of links deleted.
+	 */
+	public function test_delete_all_by_indexable_id( $indexable_id, $expected_result ) {
+		global $wpdb;
+		// Adding another link with same indexable_id.
+		$wpdb->insert(
+			$wpdb->prefix . 'yoast_seo_links',
+			[
+				'url'            => 'https://example.com/test/1',
+				'type'           => 'internal',
+				'indexable_id'   => '101',
+				'post_id'        => '110',
+				'target_post_id' => '154',
+				'id'             => '222',
+			]
+		);
+
+		$result = $this->instance->delete_all_by_indexable_id( $indexable_id );
+
+		$db = $wpdb->get_var( $wpdb->prepare( 'SELECT COUNT(*) FROM `' . $wpdb->prefix . 'yoast_seo_links` WHERE `indexable_id`=%d', $indexable_id ) );
+
+		$this->assertEquals( 0, $db, 'The result should be the same in the database.' );
+
+		$this->assertSame( $expected_result, $result, 'How many links were deleted should be the result' );
+	}
+
+	/**
+	 * Data provider for get_incoming_link_counts_for_post_ids
+	 *
+	 * @return array
+	 */
+	public function data_provider_get_incoming_link_counts_for_post_ids() {
+		return [
+			'The result should be succesful' => [
+				'target_post_id'  => [ 154 ],
+				'expected_result' => [
+					[
+						'incoming' => '1',
+						'post_id'  => '154',
+					],
+				],
+			],
+			'The result should be empty, no post ids' => [
+				'post_ids'        => [ 100 ],
+				'expected_result' => [],
+			],
+			'The Result should have two arrays' => [
+				'post_ids'        => [ 112, 154 ],
+				'expected_result' => [
+					[
+						'incoming' => '1',
+						'post_id'  => '112',
+					],
+					[
+						'incoming' => '1',
+						'post_id'  => '154',
+					],
+				],
+			],
+		];
+	}
+
+	/**
+	 * Tests get_incoming_link_counts_for_post_ids.
+	 *
+	 * @covers ::get_incoming_link_counts_for_post_ids
+	 *
+	 * @dataProvider data_provider_get_incoming_link_counts_for_post_ids
+	 *
+	 * @param array $post_ids The post ids.
+	 * @param array $expected_result The expected result.
+	 */
+	public function test_get_incoming_link_counts_for_post_ids( $post_ids, $expected_result ) {
+		global $wpdb;
+		// Adding another link with same indexable_id.
+		$wpdb->insert(
+			$wpdb->prefix . 'yoast_seo_links',
+			[
+				'url'            => 'https://example.com/test/1',
+				'type'           => 'internal',
+				'indexable_id'   => '101',
+				'post_id'        => '108',
+				'target_post_id' => '154',
+				'id'             => '222',
+			]
+		);
+
+		$result = $this->instance->get_incoming_link_counts_for_post_ids( $post_ids );
+
+		$this->assertSame( $expected_result, $result, 'The result should be the same' );
+	}
+
+	/**
+	 * Data provider for test_delete_many_by_id
+	 *
+	 * @return array
+	 */
+	public function data_provider_test_delete_many_by_id() {
+		return [
+			'The delete should be succesful' => [
+				'ids'             => [ 222, 113 ],
+				'expected_result' => 2,
+			],
+			'The delete should fail, no ids' => [
+				'ids'             => [ 999 ],
+				'expected_result' => 0,
+			],
+		];
+	}
+
+	/**
+	 * Tests delete_many_by_id
+	 *
+	 * @covers ::delete_many_by_id
+	 *
+	 * @dataProvider data_provider_test_delete_many_by_id
+	 *
+	 * @param array $ids The ids.
+	 * @param int   $expected_result The number of links deleted.
+	 */
+	public function test_delete_many_by_id( $ids, $expected_result ) {
+		global $wpdb;
+		// Adding another link.
+		$wpdb->insert(
+			$wpdb->prefix . 'yoast_seo_links',
+			[
+				'url'            => 'https://example.com/test/1',
+				'type'           => 'internal',
+				'indexable_id'   => '101',
+				'post_id'        => '108',
+				'target_post_id' => '154',
+				'id'             => '222',
+			]
+		);
+
+		$result = $this->instance->delete_many_by_id( $ids );
+
+		$in = implode( ',', $ids );
+
+		$db = $wpdb->get_var( $wpdb->prepare( 'SELECT COUNT(*) FROM `' . $wpdb->prefix . 'yoast_seo_links` WHERE `id`IN (%s)', $in ) );
+
+		$this->assertEquals( 0, $db, 'The result should be the same in the database.' );
+
+		$this->assertSame( $expected_result, $result, 'How many links were deleted should be the result' );
+	}
+
+	/**
+	 * Data provider for test_get_incoming_link_counts_for_indexable_ids
+	 *
+	 * @return array
+	 */
+	public function data_provider_test_get_incoming_link_counts_for_indexable_ids() {
+		return [
+			'One target indexable id' => [
+				'indexable_ids'   => [ 355 ],
+				'expected_result' => [
+					[
+						'incoming'            => '1',
+						'target_indexable_id' => '355',
+					],
+				],
+			],
+			'No target indexable ids' => [
+				'indexable_ids'   => [ 102 ],
+				'expected_result' => [
+					[
+						'incoming'            => '0',
+						'target_indexable_id' => '102',
+					],
+				],
+			],
+			'The Result should have two arrays' => [
+				'indexable_ids'   => [ 344, 355 ],
+				'expected_result' => [
+					[
+						'incoming'            => '1',
+						'target_indexable_id' => '344',
+					],
+					[
+						'incoming'            => '1',
+						'target_indexable_id' => '355',
+					],
+				],
+			],
+			'Query fails' => [
+				'indexable_ids'   => [],
+				'expected_result' => [],
+			],
+		];
+	}
+
+	/**
+	 * Tests get_incoming_link_counts_for_indexable_ids
+	 *
+	 * @covers ::get_incoming_link_counts_for_indexable_ids
+	 *
+	 * @dataProvider data_provider_test_get_incoming_link_counts_for_indexable_ids
+	 *
+	 * @param array $indexable_ids The indexable ids.
+	 * @param array $expected_result The expected result.
+	 */
+	public function test_get_incoming_link_counts_for_indexable_ids( $indexable_ids, $expected_result ) {
+		global $wpdb;
+		// Adding another link with same indexable_id.
+		$wpdb->insert(
+			$wpdb->prefix . 'yoast_seo_links',
+			[
+				'url'                 => 'https://example.com/test/1',
+				'type'                => 'internal',
+				'indexable_id'        => '102',
+				'post_id'             => '108',
+				'target_post_id'      => '154',
+				'id'                  => '222',
+				'target_indexable_id' => '355',
+			]
+		);
+
+		$result = $this->instance->get_incoming_link_counts_for_indexable_ids( $indexable_ids );
+
+		$this->assertSame( $expected_result, $result, 'The result should be the same' );
+	}
+}

--- a/tests/integration/repositories/seo-links-repository-test.php
+++ b/tests/integration/repositories/seo-links-repository-test.php
@@ -443,8 +443,8 @@ class SEO_Links_Repository_Test extends WPSEO_UnitTestCase {
 	 */
 	public function data_provider_get_incoming_link_counts_for_post_ids() {
 		return [
-			'The result should be succesful' => [
-				'target_post_id'  => [ 154 ],
+			'One item in post_ids array with result' => [
+				'post_ids'        => [ 154 ],
 				'expected_result' => [
 					[
 						'incoming' => '1',
@@ -452,11 +452,11 @@ class SEO_Links_Repository_Test extends WPSEO_UnitTestCase {
 					],
 				],
 			],
-			'The result should be empty, no post ids' => [
+			'One item in post_ids array without result' => [
 				'post_ids'        => [ 100 ],
 				'expected_result' => [],
 			],
-			'The Result should have two arrays' => [
+			'Two items in post_ids array with result' => [
 				'post_ids'        => [ 112, 154 ],
 				'expected_result' => [
 					[

--- a/tests/unit/integrations/academy-integration-test.php
+++ b/tests/unit/integrations/academy-integration-test.php
@@ -116,11 +116,11 @@ class Academy_Integration_Test extends TestCase {
 	public function register_hooks_provider() {
 		return [
 			'Not on academy page' => [
-				'current_page'          => 'not academy page',
+				'current_page' => 'not academy page',
 				'action_times' => 0,
 			],
 			'On academy page' => [
-				'current_page'          => 'wpseo_page_academy',
+				'current_page' => 'wpseo_page_academy',
 				'action_times' => 1,
 			],
 		];

--- a/tests/unit/repositories/seo-links-repository-test.php
+++ b/tests/unit/repositories/seo-links-repository-test.php
@@ -1,0 +1,356 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Repositories;
+
+use Mockery;
+use wpdb;
+use Yoast\WP\SEO\Models\SEO_Links;
+use Yoast\WP\SEO\Repositories\SEO_Links_Repository;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+use Yoast\WP\Lib\ORM;
+
+/**
+ * Class SEO_Links_Repository_Test.
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Repositories\SEO_Links_Repository
+ */
+class SEO_Links_Repository_Test extends TestCase {
+
+	/**
+	 * The instance to test.
+	 *
+	 * @var SEO_Links_Repository
+	 */
+	private $instance;
+
+	/**
+	 * The ORM Mock.
+	 *
+	 * @var Mockery\MockInterface|ORM
+	 */
+	private $orm_mock;
+
+	/**
+	 * The wpdb mock.
+	 *
+	 * @var wpdb|Mockery\MockInterface
+	 */
+	protected $wpdb;
+
+	/**
+	 * Sets up the test class.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		global $wpdb;
+		$wpdb = (object) [ 'prefix' => 'wp_' ];
+
+		$this->orm_mock = Mockery::mock( ORM::class );
+
+		$this->instance = $this
+			->getMockBuilder( SEO_Links_Repository::class )
+			->setMethods( [ 'query' ] )
+			->getMock();
+	}
+
+	/**
+	 * Tests the query method.
+	 *
+	 * @covers ::query
+	 */
+	public function test_query() {
+		$seo_links_repository = new SEO_Links_Repository();
+
+		$this->assertInstanceOf( ORM::class, $seo_links_repository->query() );
+	}
+
+	/**
+	 * Tests the find_all_by_post_id method.
+	 *
+	 * @covers ::find_all_by_post_id
+	 */
+	public function test_find_all_by_post_id() {
+		$this->instance->expects( $this->once() )
+			->method( 'query' )
+			->will( $this->returnValue( $this->orm_mock ) );
+
+		$post_id         = 1;
+		$expected_result = [ new SEO_Links(), new SEO_Links() ];
+
+		$this->orm_mock->shouldReceive( 'where' )->with( 'post_id', $post_id )->andReturn( $this->orm_mock );
+		$this->orm_mock->shouldReceive( 'find_many' )->andReturn( $expected_result );
+
+		$this->instance->find_all_by_post_id( $post_id );
+	}
+
+	/**
+	 * Tests the find_all_by_indexable_id method.
+	 *
+	 * @covers ::find_all_by_indexable_id
+	 */
+	public function test_find_all_by_indexable_id() {
+		$indexable_id    = 1;
+		$expected_result = [ new SEO_Links(), new SEO_Links() ];
+
+		$this->instance->expects( $this->once() )
+			->method( 'query' )
+			->will( $this->returnValue( $this->orm_mock ) );
+
+		$this->orm_mock->shouldReceive( 'where' )->with( 'indexable_id', $indexable_id )->andReturn( $this->orm_mock );
+		$this->orm_mock->shouldReceive( 'find_many' )->andReturn( $expected_result );
+
+		$this->instance->find_all_by_indexable_id( $indexable_id );
+	}
+
+	/**
+	 * Tests the find_one_by_url method.
+	 *
+	 * @covers ::find_one_by_url
+	 */
+	public function test_find_one_by_url() {
+		$url             = 'https://example.com';
+		$expected_result = new SEO_Links();
+
+		$this->instance->expects( $this->once() )
+			->method( 'query' )
+			->will( $this->returnValue( $this->orm_mock ) );
+
+		$this->orm_mock->shouldReceive( 'select' )->with( 'target_post_id' )->andReturn( $this->orm_mock );
+		$this->orm_mock->shouldReceive( 'where' )->with( 'url', $url )->andReturn( $this->orm_mock );
+		$this->orm_mock->shouldReceive( 'find_one' )->andReturn( $expected_result );
+
+		$this->instance->find_one_by_url( $url );
+	}
+
+	/**
+	 * Tests the find_all_by_target_post_id.
+	 *
+	 * @covers ::find_all_by_target_post_id
+	 */
+	public function test_find_all_by_target_post_id() {
+		$target_post_id  = 5;
+		$expected_result = [ new SEO_Links(), new SEO_Links() ];
+
+		$this->instance->expects( $this->once() )
+			->method( 'query' )
+			->will( $this->returnValue( $this->orm_mock ) );
+
+		$this->orm_mock->shouldReceive( 'where' )->with( 'target_post_id', $target_post_id )->andReturn( $this->orm_mock );
+		$this->orm_mock->shouldReceive( 'find_many' )->andReturn( $expected_result );
+
+		$this->instance->find_all_by_target_post_id( $target_post_id );
+	}
+
+	/**
+	 * Tests the update_target_indexable_id method.
+	 *
+	 * @covers ::update_target_indexable_id
+	 */
+	public function test_update_target_indexable_id() {
+		$link_id             = 1;
+		$target_indexable_id = 2;
+		$expected_result     = true;
+
+		$this->instance->expects( $this->once() )
+			->method( 'query' )
+			->will( $this->returnValue( $this->orm_mock ) );
+
+		$this->orm_mock->shouldReceive( 'set' )->with( 'target_indexable_id', $target_indexable_id )->andReturn( $this->orm_mock );
+		$this->orm_mock->shouldReceive( 'where' )->with( 'id', $link_id )->andReturn( $this->orm_mock );
+		$this->orm_mock->shouldReceive( 'update_many' )->andReturn( 1 );
+
+		$this->instance->update_target_indexable_id( $link_id, $target_indexable_id );
+	}
+
+	/**
+	 * Tests the delete_all_by_post_id method.
+	 *
+	 * @covers ::delete_all_by_post_id
+	 */
+	public function test_delete_all_by_post_id() {
+		$post_id         = 1;
+		$expected_result = true;
+
+		$this->instance->expects( $this->once() )
+			->method( 'query' )
+			->will( $this->returnValue( $this->orm_mock ) );
+
+		$this->orm_mock->shouldReceive( 'where' )->with( 'post_id', $post_id )->andReturn( $this->orm_mock );
+		$this->orm_mock->shouldReceive( 'delete_many' )->andReturn( true );
+
+		$this->instance->delete_all_by_post_id( $post_id );
+	}
+
+	/**
+	 * Tests the delete_all_by_post_id_where_indexable_id_null method.
+	 *
+	 * @covers ::delete_all_by_post_id_where_indexable_id_null
+	 */
+	public function test_delete_all_by_post_id_where_indexable_id_null() {
+		$post_id         = 1;
+		$expected_result = true;
+
+		$this->instance->expects( $this->once() )
+			->method( 'query' )
+			->will( $this->returnValue( $this->orm_mock ) );
+
+		$this->orm_mock->shouldReceive( 'where' )->with( 'post_id', $post_id )->andReturn( $this->orm_mock );
+		$this->orm_mock->shouldReceive( 'where_null' )->with( 'indexable_id' )->andReturn( $this->orm_mock );
+		$this->orm_mock->shouldReceive( 'delete_many' )->andReturn( true );
+
+		$this->instance->delete_all_by_post_id_where_indexable_id_null( $post_id );
+	}
+
+	/**
+	 * Tests the delete_all_by_indexable_id method.
+	 *
+	 * @covers ::delete_all_by_indexable_id
+	 */
+	public function test_delete_all_by_indexable_id() {
+		$indexable_id    = 1;
+		$expected_result = true;
+
+		$this->instance->expects( $this->once() )
+			->method( 'query' )
+			->will( $this->returnValue( $this->orm_mock ) );
+
+		$this->orm_mock->shouldReceive( 'where' )->with( 'indexable_id', $indexable_id )->andReturn( $this->orm_mock );
+		$this->orm_mock->shouldReceive( 'delete_many' )->andReturn( true );
+
+		$this->instance->delete_all_by_indexable_id( $indexable_id );
+	}
+
+	/**
+	 * Tests the get_incoming_link_counts_for_post_ids method.
+	 *
+	 * @covers ::get_incoming_link_counts_for_post_ids
+	 */
+	public function test_get_incoming_link_counts_for_post_ids() {
+		$post_ids        = [ 1, 2 ];
+		$expected_result = [
+			[
+				'post_id'  => 1,
+				'incoming' => 2,
+			],
+			[
+				'post_id'  => 2,
+				'incoming' => 1,
+			],
+		];
+
+		$this->instance->expects( $this->once() )
+			->method( 'query' )
+			->will( $this->returnValue( $this->orm_mock ) );
+
+		$this->orm_mock->shouldReceive( 'select_expr' )->with( 'COUNT( id )', 'incoming' )->andReturn( $this->orm_mock );
+		$this->orm_mock->shouldReceive( 'select' )->with( 'target_post_id', 'post_id' )->andReturn( $this->orm_mock );
+		$this->orm_mock->shouldReceive( 'where_in' )->with( 'target_post_id', $post_ids )->andReturn( $this->orm_mock );
+		$this->orm_mock->shouldReceive( 'group_by' )->with( 'target_post_id' )->andReturn( $this->orm_mock );
+		$this->orm_mock->shouldReceive( 'find_array' )->andReturn( $expected_result );
+
+		$this->instance->get_incoming_link_counts_for_post_ids( $post_ids );
+	}
+
+	/**
+	 * Data provider for test_get_incoming_link_counts_for_indexable_ids method.
+	 *
+	 * @return array $indexable_counts, $expected_return.
+	 */
+	public function get_incoming_link_counts_for_indexable_ids_provider() {
+		return [
+			'Indexable counts is false' => [
+				'indexable_counts' => false,
+				'expected_return'  => [],
+			],
+			'Indexable count is empty array' => [
+				'indexable_counts' => [],
+				'expected_return'  => [
+					[
+						'incoming'            => '0',
+						'target_indexable_id' => '1',
+
+					],
+					[
+						'incoming'            => '0',
+						'target_indexable_id' => '2',
+
+					],
+				],
+			],
+			'Indexable count is array of arrays with target_ondexable_id' => [
+				'indexable_counts' => [
+					[ 'target_indexable_id' => '1' ],
+					[ 'target_indexable_id' => '2' ],
+				],
+				'expected_return' => [
+					[ 'target_indexable_id' => '1' ],
+					[ 'target_indexable_id' => '2' ],
+				],
+			],
+		];
+	}
+
+	/**
+	 * Tests the get_incoming_link_counts_for_indexable_ids method.
+	 *
+	 * @covers ::get_incoming_link_counts_for_indexable_ids
+	 *
+	 * @dataProvider get_incoming_link_counts_for_indexable_ids_provider
+	 * @param array $indexable_counts The indexable counts.
+	 * @param array $expected The expected result.
+	 */
+	public function test_get_incoming_link_counts_for_indexable_ids( $indexable_counts, $expected ) {
+		$indexable_ids = [ 1, 2 ];
+
+		$this->instance->expects( $this->once() )
+			->method( 'query' )
+			->will( $this->returnValue( $this->orm_mock ) );
+
+		$this->orm_mock->shouldReceive( 'select_expr' )->with( 'COUNT( id )', 'incoming' )->andReturn( $this->orm_mock );
+		$this->orm_mock->shouldReceive( 'select' )->with( 'target_indexable_id' )->andReturn( $this->orm_mock );
+		$this->orm_mock->shouldReceive( 'where_in' )->with( 'target_indexable_id', $indexable_ids )->andReturn( $this->orm_mock );
+		$this->orm_mock->shouldReceive( 'group_by' )->with( 'target_indexable_id' )->andReturn( $this->orm_mock );
+		$this->orm_mock->shouldReceive( 'find_array' )->andReturn( $indexable_counts );
+
+		$this->instance->get_incoming_link_counts_for_indexable_ids( $indexable_ids );
+	}
+
+	/**
+	 * Tests the delete_many_by_id.
+	 *
+	 * @covers ::delete_many_by_id
+	 */
+	public function test_delete_many_by_id() {
+		$ids             = [ 1, 2 ];
+		$expected_result = true;
+
+		$this->instance->expects( $this->once() )
+			->method( 'query' )
+			->will( $this->returnValue( $this->orm_mock ) );
+
+		$this->orm_mock->shouldReceive( 'where_in' )->with( 'id', $ids )->andReturn( $this->orm_mock );
+		$this->orm_mock->shouldReceive( 'delete_many' )->andReturn( true );
+
+		$this->instance->delete_many_by_id( $ids );
+	}
+
+	/**
+	 * Tests the insert_many method.
+	 *
+	 * @covers ::insert_many
+	 */
+	public function test_insert_many() {
+
+		$links           = [ new SEO_Links(), new SEO_Links() ];
+		$expected_result = true;
+
+		$this->instance->expects( $this->once() )
+			->method( 'query' )
+			->will( $this->returnValue( $this->orm_mock ) );
+
+		$this->orm_mock->shouldReceive( 'insert_many' )->with( $links )->andReturn( true );
+
+		$this->instance->insert_many( $links );
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Add unit tests and integration tests for `SEO_Links_Repository` class.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds unit tests and integration tests for `SEO_Links_Repository` class.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Produce test coverage report and check this class has 100% coverage.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [X] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.
