### PR TITLE
20221 community patch for sql query performance in indexable post indexation action

### DIFF
--- a/src/actions/indexing/indexable-post-indexation-action.php
+++ b/src/actions/indexing/indexable-post-indexation-action.php
@@ -199,8 +199,8 @@ class Indexable_Post_Indexation_Action extends Abstract_Indexing_Action {
 				AND I.object_type = 'post'
 				AND I.version = %d
 			WHERE P.post_type IN (" . \implode( ', ', \array_fill( 0, \count( $post_types ), '%s' ) ) . ')
-				AND P.post_status NOT IN (' . \implode( ', ', \array_fill( 0, \count( $excluded_post_statuses ), '%s' ) ) . ")
-				AND I.object_id IS NULL
+			AND P.post_status NOT IN (' . \implode( ', ', \array_fill( 0, \count( $excluded_post_statuses ), '%s' ) ) . ")
+			AND I.object_id IS NULL
 			$limit_query",
 			$replacements
 		);


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Improves [this community patch](https://github.com/Yoast/wordpress-seo/pull/20215/) that optimizes the queries for finding unindexed posts.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Optimizes db indexing queries improving page load times in the admin when SEO optimization hasn't been run and making the SEO optimization itself faster too.

## Relevant technical choices:

* This is a PR with a goal of improving performance of some queries. Everything should be working like before, as the new queries should return the exact same results, albeit faster.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* We have to compare this PR/RC with trunk/production version, to confirm the new queries are bringing the same results with the old ones:
  * Run SEO optimization with the production version and check the amount of rows created in the `wp_yoast_indexable` & `wp_yoast_indexable_hierarchy` tables. Reset indexables and delete transients. Do the same with this PR and confirm you're getting the same amount of rows. (Delete transients by running `wp transient delete --all` in WP CLI)
  * Once SEO optimization is complete with the production version, run `yoastIndexingData.amount` in the console of the Tools page, note that number and switch to this PR. Delete transients and run `yoastIndexingData.amount` in the console again. Confirm that you're getting the same number.
  * Once you've done that, reset indexables again and with this PR run `yoastIndexingData.amount` in the console. Note that number and switch to the production versions. Delete transients and run `yoastIndexingData.amount` in the console again. Confirm you're getting the same number.
  * Add the following filter in functions.php to exclude the pages and repeat the above tests:
```
add_filter( 'wpseo_indexable_excluded_post_types', function( $post_types ) { 
    $post_types[] = 'page'; 
    return $post_types;
} );
```

And an extra test:
* Add this filter, to make sure we don't have background indexing:
```
add_filter( 'wpseo_shutdown_indexation_limit', 'custom_limit', 1 );
function custom_limit() {
  return 1;
}
```
* Add this define to make sure we don't get cron indexation: `define( 'DISABLE_WP_CRON', true );`
* With the production version, complete the SEO optimization and then go to the indexable page and find at least 2 rows with `object_type` and `object_sub_type` equal to `post`
* Make their version column from `2` to `1`
* Delete transients and run `yoastIndexingData.amount` in the console of the Tools page. Note the number
* Switch to this PR, delete transients, refresh the Tools page, run `yoastIndexingData.amount` in the console again and confirm that you get the same number.
 
#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:
 
* SEO optimization

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
