### PR TITLE
Fix fatal error on Yoast admin pages with WooCommerce SEO

### DIFF
--- a/admin/tracking/class-tracking-addon-data.php
+++ b/admin/tracking/class-tracking-addon-data.php
@@ -85,7 +85,10 @@ class WPSEO_Tracking_Addon_Data implements WPSEO_Collection {
 	 * @return array
 	 */
 	public function get_addon_settings( array $addon_settings, $source_name, $slug, $option_include_list ) {
-		$source_options          = \get_option( $source_name );
+		$source_options = \get_option( $source_name, [] );
+		if ( ! \is_array( $source_options ) || empty( $source_options ) ) {
+			return $addon_settings;
+		}
 		$addon_settings[ $slug ] = \array_intersect_key( $source_options, \array_flip( $option_include_list ) );
 
 		return $addon_settings;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* In certain rare conditions we might get a fatal error on the Yoast SEO admin pages in conjunction with WooCommerce SEO if it hasn't been able yet to save its options in the DB.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where a fatal error would be thrown when visiting Yoast SEO admin pages while Yoast SEO for WooCommerce is active but never executed.

## Relevant technical choices:

* very similar to https://github.com/Yoast/wordpress-seo/pull/20090 but that one occurred only on upgrade, so the fix was proactive for the future. In this case, it will already work in the current version.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* create an instaWP site with PHP >= 8.0 or use our docker env (the issue doesn't happen on Local by Flywheel because tracking collection doesn't run, probably)
* install and activate Yoast SEO 20.6 (but any version from 19.10 would work)
* install and activate Yoast SEO for WooCommerce (latest version or one matching the Yoast SEO one)
  * note that it doesn't run and just throws a notice about missing WooCommerce - this is why the wpseo_woo options are not saved in the DB
* visit any Yoast SEO admin page
* You should get a fatal error:
```
Fatal error: Uncaught TypeError: array_intersect_key(): Argument #1 ($array) must be of type array, bool given in /home/fonofuyewi1200/web/pebeach-man-vaka.instawp.xyz/public_html/wp-content/plugins/wordpress-seo/admin/tracking/class-tracking-addon-data.php:89 Stack trace: #0 /home/fonofuyewi1200/web/pebeach-man-vaka.instawp.xyz/public_html/wp-content/plugins/wordpress-seo/admin/tracking/class-tracking-addon-data.php(89): array_intersect_key() #1 /home/fonofuyewi1200/web/pebeach-man-vaka.instawp.xyz/public_html/wp-content/plugins/wordpress-seo/admin/tracking/class-tracking-addon-data.php(63): WPSEO_Tracking_Addon_Data->get_addon_settings() #2 /home/fonofuyewi1200/web/pebeach-man-vaka.instawp.xyz/public_html/wp-content/plugins/wordpress-seo/admin/class-collector.php(38): WPSEO_Tracking_Addon_Data->get() #3 /home/fonofuyewi1200/web/pebeach-man-vaka.instawp.xyz/public_html/wp-content/plugins/wordpress-seo/admin/class-collector.php(50): WPSEO_Collector->collect() #4 /home/fonofuyewi1200/web/pebeach-man-vaka.instawp.xyz/public_html/wp-content/plugins/wordpress-seo/admin/tracking/class-tracking.php(126): WPSEO_Collector->get_as_json() #5 /home/fonofuyewi1200/web/pebeach-man-vaka.instawp.xyz/public_html/wp-includes/class-wp-hook.php(308): WPSEO_Tracking->send() #6 /home/fonofuyewi1200/web/pebeach-man-vaka.instawp.xyz/public_html/wp-includes/class-wp-hook.php(332): WP_Hook->apply_filters() #7 /home/fonofuyewi1200/web/pebeach-man-vaka.instawp.xyz/public_html/wp-includes/plugin.php(517): WP_Hook->do_action() #8 /home/fonofuyewi1200/web/pebeach-man-vaka.instawp.xyz/public_html/wp-admin/admin.php(175): do_action() #9 {main} thrown in /home/fonofuyewi1200/web/pebeach-man-vaka.instawp.xyz/public_html/wp-content/plugins/wordpress-seo/admin/tracking/class-tracking-addon-data.php on line 89
```
* if you are upgrading by zip upload, **deactivate Yoast SEO** (very important or the upgrade will fail with the above error)
* switch to this PR (or the RC containing it)
* visit any Yoast admin page
* see that you don't get the error anymore.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes https://github.com/Yoast/wpseo-woocommerce/issues/906
