### PR TITLE
20231 html parser token positions incorrect when sentence starts with html tag

### DIFF
--- a/packages/yoastseo/spec/parse/build/buildSpec.js
+++ b/packages/yoastseo/spec/parse/build/buildSpec.js
@@ -98,12 +98,12 @@ describe( "The parse function", () => {
 					attributes: {},
 					sentences: [ {
 						text: "Hello World!",
-						sourceCodeRange: { startOffset: 5, endOffset: 30 },
+						sourceCodeRange: { startOffset: 5, endOffset: 23 },
 						tokens: [
 							{ text: "Hello", sourceCodeRange: { startOffset: 5, endOffset: 10 } },
 							{ text: " ", sourceCodeRange: { startOffset: 10, endOffset: 11 } },
-							{ text: "World", sourceCodeRange: { startOffset: 11, endOffset: 22 } },
-							{ text: "!", sourceCodeRange: { startOffset: 22, endOffset: 30 } },
+							{ text: "World", sourceCodeRange: { startOffset: 17, endOffset: 22 } },
+							{ text: "!", sourceCodeRange: { startOffset: 22, endOffset: 23 } },
 						],
 					} ],
 					childNodes: [
@@ -337,7 +337,7 @@ describe( "The parse function", () => {
 								tokens: [
 									{ text: "So", sourceCodeRange: { startOffset: 5, endOffset: 7 } },
 									{ text: " ", sourceCodeRange: { startOffset: 7, endOffset: 8 } },
-									{ text: "long", sourceCodeRange: { startOffset: 8, endOffset: 21 } },
+									{ text: "long", sourceCodeRange: { startOffset: 12, endOffset: 16 } },
 									{ text: ",", sourceCodeRange: { startOffset: 21, endOffset: 22 } },
 									{ text: " ", sourceCodeRange: { startOffset: 22, endOffset: 23 } },
 									{ text: "and", sourceCodeRange: { startOffset: 23, endOffset: 26 } },
@@ -476,7 +476,7 @@ describe( "The parse function", () => {
 									{ text: " ", sourceCodeRange: { startOffset: 55, endOffset: 56 } },
 									{ text: "the", sourceCodeRange: { startOffset: 56, endOffset: 59 } },
 									{ text: " ", sourceCodeRange: { startOffset: 59, endOffset: 60 } },
-									{ text: "fish", sourceCodeRange: { startOffset: 60, endOffset: 81 } },
+									{ text: "fish", sourceCodeRange: { startOffset: 68, endOffset: 72 } },
 									{ text: "!", sourceCodeRange: { startOffset: 81, endOffset: 82 } },
 								],
 							} ],

--- a/packages/yoastseo/spec/parse/build/private/getTextElementPositionsSpec.js
+++ b/packages/yoastseo/spec/parse/build/private/getTextElementPositionsSpec.js
@@ -1,6 +1,9 @@
 import getTextElementPositions from "../../../../src/parse/build/private/getTextElementPositions";
 import Paragraph from "../../../../src/parse/structure/Paragraph";
 import Heading from "../../../../src/parse/structure/Heading";
+import Token from "../../../../src/parse/structure/Token";
+import { parseFragment } from "parse5";
+import adapt from "../../../../src/parse/build/private/adapt";
 
 describe( "A test for getting positions of sentences", () => {
 	it( "gets the sentence positions from a node that doesn't have descendants other than the Text node", function() {
@@ -26,249 +29,198 @@ describe( "A test for getting positions of sentences", () => {
 		expect( getTextElementPositions( node, sentences ) ).toEqual( sentencesWithPositions );
 	} );
 
-	it( "gets the sentence positions from a node that has a `span` descendant node", function() {
+	it( "gets the token and sentence positions from a node that has a `span` descendant node", function() {
 		// HTML: <p>Hello, <span>world!</span> Hello, yoast!</p>.
-		const node = new Paragraph( {}, [ { name: "#text", value: "Hello, world! Hello, yoast!" },
-			{
-				name: "span",
-				attributes: {},
-				childNodes: [ {
-					name: "#text",
-					value: "world!",
-				} ],
-				sourceCodeLocation: {
-					startOffset: 15,
-					endOffset: 34,
-					startTag: {
-						startOffset: 15,
-						endOffset: 21,
-					},
-					endTag: {
-						startOffset: 27,
-						endOffset: 34,
-					},
-				},
-			} ],
-		{
-			startOffset: 5,
-			endOffset: 39,
-			startTag: {
-				startOffset: 5,
-				endOffset: 8,
-			},
-			endTag: {
-				startOffset: 48,
-				endOffset: 52,
-			},
-		} );
+		const html = "<p>Hello, <span>world!</span> Hello, yoast!</p>";
+		const tree = adapt( parseFragment( html, { sourceCodeLocationInfo: true } ) );
+		const paragraph = tree.childNodes[ 0 ];
+		const tokens = [ "Hello", ",", " ", "world", "!", " ", "Hello", ",", " ", "yoast", "!" ].map( string => new Token( string ) );
+
+		const [ hello, comma, space, world, bang, space2, hello2, comma2, space3, yoast, bang2 ] = getTextElementPositions( paragraph, tokens );
+
+		expect( hello.sourceCodeRange ).toEqual( { startOffset: 3, endOffset: 8 } );
+		expect( comma.sourceCodeRange ).toEqual( { startOffset: 8, endOffset: 9 } );
+		expect( space.sourceCodeRange ).toEqual( { startOffset: 9, endOffset: 10 } );
+		expect( world.sourceCodeRange ).toEqual( { startOffset: 16, endOffset: 21 } );
+		expect( bang.sourceCodeRange ).toEqual( { startOffset: 21, endOffset: 22 } );
+		expect( space2.sourceCodeRange ).toEqual( { startOffset: 29, endOffset: 30 } );
+		expect( hello2.sourceCodeRange ).toEqual( { startOffset: 30, endOffset: 35 } );
+		expect( comma2.sourceCodeRange ).toEqual( { startOffset: 35, endOffset: 36 } );
+		expect( space3.sourceCodeRange ).toEqual( { startOffset: 36, endOffset: 37 } );
+		expect( yoast.sourceCodeRange ).toEqual( { startOffset: 37, endOffset: 42 } );
+		expect( bang2.sourceCodeRange ).toEqual( { startOffset: 42, endOffset: 43 } );
 
 		const sentences = [ { text: "Hello, world!" }, { text: " Hello, yoast!" } ];
-		const sentencesWithPositions = [ { text: "Hello, world!", sourceCodeRange: { startOffset: 8, endOffset: 34 } },
-			{ text: " Hello, yoast!", sourceCodeRange: { startOffset: 34, endOffset: 48 } } ];
-
-		expect( getTextElementPositions( node, sentences ) ).toEqual( sentencesWithPositions );
+		const [ helloSentence, yoastSentence ] = getTextElementPositions( paragraph, sentences );
+		expect( helloSentence.sourceCodeRange ).toEqual( { startOffset: 3, endOffset: 22 } );
+		expect( yoastSentence.sourceCodeRange ).toEqual( { startOffset: 29, endOffset: 43 } );
 	} );
 
-	it( "gets the sentence positions from a node that has a descendant node without a closing tag (img)", function() {
+	it( "gets the token and sentence positions from a node that has a descendant node without a closing tag (img)", function() {
 		// HTML: <p>Hello, world!<img src="image.jpg" alt="this is an image" width="500" height="600"> Hello, yoast!</p>
-		const node = new Paragraph( {}, [ { name: "#text", value: "Hello, world! Hello, yoast!" },
-			{
-				name: "img",
-				attributes: {
-					src: "image.jpg",
-					alt: "this is an image",
-					width: "500",
-					height: "600",
-				},
-				childNodes: [],
-				sourceCodeLocation: {
-					startOffset: 21,
-					endOffset: 90,
-					startTag: {
-						startOffset: 21,
-						endOffset: 90,
-					},
-				},
-			} ],
-		{
-			startOffset: 5,
-			endOffset: 108,
-			startTag: {
-				startOffset: 5,
-				endOffset: 8,
-			},
-			endTag: {
-				startOffset: 104,
-				endOffset: 108,
-			},
-		} );
+		const html = "<p>Hello, world!<img src=\"image.jpg\" alt=\"this is an image\" width=\"500\" height=\"600\"> Hello, yoast!</p>";
+		const tree = adapt( parseFragment( html, { sourceCodeLocationInfo: true } ) );
+		const paragraph = tree.childNodes[ 0 ];
+		const tokens = [ "Hello", ",", " ", "world", "!", " ", "Hello", ",", " ", "yoast", "!" ].map( string => new Token( string ) );
+
+		const [ hello, comma, space, world, bang, space2, hello2, comma2, space3, yoast, bang2 ] = getTextElementPositions( paragraph, tokens );
+
+		expect( hello.sourceCodeRange ).toEqual( { startOffset: 3, endOffset: 8 } );
+		expect( comma.sourceCodeRange ).toEqual( { startOffset: 8, endOffset: 9 } );
+		expect( space.sourceCodeRange ).toEqual( { startOffset: 9, endOffset: 10 } );
+		expect( world.sourceCodeRange ).toEqual( { startOffset: 10, endOffset: 15 } );
+		expect( bang.sourceCodeRange ).toEqual( { startOffset: 15, endOffset: 16 } );
+		expect( space2.sourceCodeRange ).toEqual( { startOffset: 85, endOffset: 86 } );
+		expect( hello2.sourceCodeRange ).toEqual( { startOffset: 86, endOffset: 91 } );
+		expect( comma2.sourceCodeRange ).toEqual( { startOffset: 91, endOffset: 92 } );
+		expect( space3.sourceCodeRange ).toEqual( { startOffset: 92, endOffset: 93 } );
+		expect( yoast.sourceCodeRange ).toEqual( { startOffset: 93, endOffset: 98 } );
+		expect( bang2.sourceCodeRange ).toEqual( { startOffset: 98, endOffset: 99 } );
 
 		const sentences = [ { text: "Hello, world!" }, { text: " Hello, yoast!" } ];
-		const sentencesWithPositions = [ { text: "Hello, world!", sourceCodeRange: { startOffset: 8, endOffset: 21 } },
-			{ text: " Hello, yoast!", sourceCodeRange: { startOffset: 21, endOffset: 104 } } ];
-
-		expect( getTextElementPositions( node, sentences ) ).toEqual( sentencesWithPositions );
+		const [ helloSentence, yoastSentence ] = getTextElementPositions( paragraph, sentences );
+		expect( helloSentence.sourceCodeRange ).toEqual( { startOffset: 3, endOffset: 16 } );
+		expect( yoastSentence.sourceCodeRange ).toEqual( { startOffset: 85, endOffset: 99 } );
 	} );
 
 	it( "gets the sentence positions from a node that has a `span` and an `em` descendant node", function() {
 		// HTML: <p>Hello, <span>world!</span> Hello, <em>yoast!</em></p>.
-		const node = new Paragraph( {}, [ { name: "#text", value: "Hello, world! Hello, yoast!" },
-			{
-				name: "span",
-				attributes: {},
-				childNodes: [ {
-					name: "#text",
-					value: "world!",
-				} ],
-				sourceCodeLocation: {
-					startOffset: 15,
-					endOffset: 34,
-					startTag: {
-						startOffset: 15,
-						endOffset: 21,
-					},
-					endTag: {
-						startOffset: 27,
-						endOffset: 34,
-					},
-				},
-			},
-			{
-				name: "em",
-				attributes: {},
-				childNodes: [ {
-					name: "#text",
-					value: "world!",
-				} ],
-				sourceCodeLocation: {
-					startOffset: 42,
-					endOffset: 57,
-					startTag: {
-						startOffset: 42,
-						endOffset: 46,
-					},
-					endTag: {
-						startOffset: 52,
-						endOffset: 57,
-					},
-				},
-			} ],
-		{
-			startOffset: 5,
-			endOffset: 61,
-			startTag: {
-				startOffset: 5,
-				endOffset: 8,
-			},
-			endTag: {
-				startOffset: 57,
-				endOffset: 61,
-			},
-		} );
+		// It is decided as follows: The following sentence boundaries:
+		// Sentences:
+		// <p>|Hello, <span>world!|</span>| Hello, <em>yoast!|</em></p>.
+		//    ^ start             ^ end   ^ start            ^ end
+		// Tokens:
+		// <p>|Hello|,| |<span>|world|!|</span>| |Hello|,| |<em>|yoast|!|</em>|</p>.
+
+		const html = "<p>Hello, <span>world!</span> Hello, <em>yoast!</em></p>";
+		const tree = adapt( parseFragment( html, { sourceCodeLocationInfo: true } ) );
+		const paragraph = tree.childNodes[ 0 ];
+		const tokens = [ "Hello", ",", " ", "world", "!", " ", "Hello", ",", " ", "yoast", "!" ].map( string => new Token( string ) );
+
+		const [ hello, comma, space, world, bang, space2, hello2, comma2, space3, yoast, bang2 ] = getTextElementPositions( paragraph, tokens );
+
+		expect( hello.sourceCodeRange ).toEqual( { startOffset: 3, endOffset: 8 } );
+		expect( comma.sourceCodeRange ).toEqual( { startOffset: 8, endOffset: 9 } );
+		expect( space.sourceCodeRange ).toEqual( { startOffset: 9, endOffset: 10 } );
+		expect( world.sourceCodeRange ).toEqual( { startOffset: 16, endOffset: 21 } );
+		expect( bang.sourceCodeRange ).toEqual( { startOffset: 21, endOffset: 22 } );
+		expect( space2.sourceCodeRange ).toEqual( { startOffset: 29, endOffset: 30 } );
+		expect( hello2.sourceCodeRange ).toEqual( { startOffset: 30, endOffset: 35 } );
+		expect( comma2.sourceCodeRange ).toEqual( { startOffset: 35, endOffset: 36 } );
+		expect( space3.sourceCodeRange ).toEqual( { startOffset: 36, endOffset: 37 } );
+		expect( yoast.sourceCodeRange ).toEqual( { startOffset: 41, endOffset: 46 } );
+		expect( bang2.sourceCodeRange ).toEqual( { startOffset: 46, endOffset: 47 } );
 
 		const sentences = [ { text: "Hello, world!" }, { text: " Hello, yoast!" } ];
-		const sentencesWithPositions = [ { text: "Hello, world!", sourceCodeRange: { startOffset: 8, endOffset: 34 } },
-			{ text: " Hello, yoast!", sourceCodeRange: { startOffset: 34, endOffset: 57 } } ];
-
-		expect( getTextElementPositions( node, sentences ) ).toEqual( sentencesWithPositions );
+		const [ helloSentence, yoastSentence ] = getTextElementPositions( paragraph, sentences );
+		expect( helloSentence.sourceCodeRange ).toEqual( { startOffset: 3, endOffset: 22 } );
+		expect( yoastSentence.sourceCodeRange ).toEqual( { startOffset: 29, endOffset: 47 } );
 	} );
+
+	it( "gets the sentence positions from a node that has a `span` and an `em` descendant node when the em-tags are directly bordering a word ",
+		function() {
+		// HTML: <p>Hello, <span>world!</span> Hello, <em>yoast</em>!</p>.
+			const html = "<p>Hello, <span>world!</span> Hello, <em>yoast</em>!</p>";
+			const tree = adapt( parseFragment( html, { sourceCodeLocationInfo: true } ) );
+			const paragraph = tree.childNodes[ 0 ];
+			const tokens = [ "Hello", ",", " ", "world", "!", " ", "Hello", ",", " ", "yoast", "!" ].map( string => new Token( string ) );
+
+			const [ hello, comma, space, world, bang, space2, hello2, comma2, space3, yoast, bang2 ] = getTextElementPositions( paragraph, tokens );
+
+			expect( hello.sourceCodeRange ).toEqual( { startOffset: 3, endOffset: 8 } );
+			expect( comma.sourceCodeRange ).toEqual( { startOffset: 8, endOffset: 9 } );
+			expect( space.sourceCodeRange ).toEqual( { startOffset: 9, endOffset: 10 } );
+			expect( world.sourceCodeRange ).toEqual( { startOffset: 16, endOffset: 21 } );
+			expect( bang.sourceCodeRange ).toEqual( { startOffset: 21, endOffset: 22 } );
+			expect( space2.sourceCodeRange ).toEqual( { startOffset: 29, endOffset: 30 } );
+			expect( hello2.sourceCodeRange ).toEqual( { startOffset: 30, endOffset: 35 } );
+			expect( comma2.sourceCodeRange ).toEqual( { startOffset: 35, endOffset: 36 } );
+			expect( space3.sourceCodeRange ).toEqual( { startOffset: 36, endOffset: 37 } );
+			expect( yoast.sourceCodeRange ).toEqual( { startOffset: 41, endOffset: 46 } );
+			expect( bang2.sourceCodeRange ).toEqual( { startOffset: 51, endOffset: 52 } );
+
+			const sentences = [ { text: "Hello, world!" }, { text: " Hello, yoast!" } ];
+			const [ helloSentence, yoastSentence ] = getTextElementPositions( paragraph, sentences );
+			expect( helloSentence.sourceCodeRange ).toEqual( { startOffset: 3, endOffset: 22 } );
+			expect( yoastSentence.sourceCodeRange ).toEqual( { startOffset: 29, endOffset: 52 } );
+		} );
 
 	it( "doesn't include an opening tag at the end of a sentence when calculating the end position", function() {
 		// HTML: <p>Hello, world!<span> Hello, <em>yoast!</em></span></p>.
-		const node = new Paragraph( {}, [ { name: "#text", value: "Hello, world! Hello, yoast!" },
-			{
-				name: "span",
-				attributes: {},
-				childNodes: [ {
-					name: "#text",
-					value: "world!",
-				} ],
-				sourceCodeLocation: {
-					startOffset: 21,
-					endOffset: 57,
-					startTag: {
-						startOffset: 21,
-						endOffset: 27,
-					},
-					endTag: {
-						startOffset: 50,
-						endOffset: 57,
-					},
-				},
-			},
-			{
-				name: "em",
-				attributes: {},
-				childNodes: [ {
-					name: "#text",
-					value: "world!",
-				} ],
-				sourceCodeLocation: {
-					startOffset: 35,
-					endOffset: 50,
-					startTag: {
-						startOffset: 35,
-						endOffset: 39,
-					},
-					endTag: {
-						startOffset: 45,
-						endOffset: 50,
-					},
-				},
-			} ],
-		{
-			startOffset: 5,
-			endOffset: 39,
-			startTag: {
-				startOffset: 5,
-				endOffset: 8,
-			},
-			endTag: {
-				startOffset: 57,
-				endOffset: 61,
-			},
-		} );
+		const html = "<p>Hello, world!<span> Hello, <em>yoast!</em></span></p>";
+		const tree = adapt( parseFragment( html, { sourceCodeLocationInfo: true } ) );
+		const paragraph = tree.childNodes[ 0 ];
+		const tokens = [ "Hello", ",", " ", "world", "!", " ", "Hello", ",", " ", "yoast", "!" ].map( string => new Token( string ) );
+
+		const [ hello, comma, space, world, bang, space2, hello2, comma2, space3, yoast, bang2 ] = getTextElementPositions( paragraph, tokens );
+
+		expect( hello.sourceCodeRange ).toEqual( { startOffset: 3, endOffset: 8 } );
+		expect( comma.sourceCodeRange ).toEqual( { startOffset: 8, endOffset: 9 } );
+		expect( space.sourceCodeRange ).toEqual( { startOffset: 9, endOffset: 10 } );
+		expect( world.sourceCodeRange ).toEqual( { startOffset: 10, endOffset: 15 } );
+		expect( bang.sourceCodeRange ).toEqual( { startOffset: 15, endOffset: 16 } );
+		expect( space2.sourceCodeRange ).toEqual( { startOffset: 22, endOffset: 23 } );
+		expect( hello2.sourceCodeRange ).toEqual( { startOffset: 23, endOffset: 28 } );
+		expect( comma2.sourceCodeRange ).toEqual( { startOffset: 28, endOffset: 29 } );
+		expect( space3.sourceCodeRange ).toEqual( { startOffset: 29, endOffset: 30 } );
+		expect( yoast.sourceCodeRange ).toEqual( { startOffset: 34, endOffset: 39 } );
+		expect( bang2.sourceCodeRange ).toEqual( { startOffset: 39, endOffset: 40 } );
 
 		const sentences = [ { text: "Hello, world!" }, { text: " Hello, yoast!" } ];
-		const sentencesWithPositions = [ { text: "Hello, world!", sourceCodeRange: { startOffset: 8, endOffset: 21 } },
-			{ text: " Hello, yoast!", sourceCodeRange: { startOffset: 21, endOffset: 57 } } ];
-
-		expect( getTextElementPositions( node, sentences ) ).toEqual( sentencesWithPositions );
+		const [ helloSentence, yoastSentence ] = getTextElementPositions( paragraph, sentences );
+		expect( helloSentence.sourceCodeRange ).toEqual( { startOffset: 3, endOffset: 16 } );
+		expect( yoastSentence.sourceCodeRange ).toEqual( { startOffset: 22, endOffset: 40 } );
 	} );
 
 	it( "gets the sentence positions from an implicit paragraph", function() {
 		// HTML: <div>Hello <em>World!</em></div>.
-		const node = new Paragraph( {}, [ { name: "#text", value: "Hello, World!" },
-			{
-				name: "em",
-				attributes: {},
-				childNodes: [ {
-					name: "#text",
-					value: "World!",
-				} ],
-				sourceCodeLocation: {
-					startOffset: 11,
-					endOffset: 26,
-					startTag: {
-						startOffset: 11,
-						endOffset: 15,
-					},
-					endTag: {
-						startOffset: 21,
-						endOffset: 26,
-					},
-				},
-			} ],
-		{
-			startOffset: 5,
-			endOffset: 32,
-		},
-		true );
+
+		const html = "<div>Hello <em>World!</em></div>";
+		const tree = adapt( parseFragment( html, { sourceCodeLocationInfo: true } ) );
+		const paragraph = tree.childNodes[ 0 ];
+		const tokens = [ "Hello", " ", "World", "!" ].map( string => new Token( string ) );
+
+		const [ hello, space, world, bang ] = getTextElementPositions( paragraph, tokens );
+
+		expect( hello.sourceCodeRange ).toEqual( { startOffset: 5, endOffset: 10 } );
+		expect( space.sourceCodeRange ).toEqual( { startOffset: 10, endOffset: 11 } );
+		expect( world.sourceCodeRange ).toEqual( { startOffset: 15, endOffset: 20 } );
+		expect( bang.sourceCodeRange ).toEqual( { startOffset: 20, endOffset: 21 } );
 
 		const sentences = [ { text: "Hello World!" } ];
-		const sentencesWithPositions = [ { text: "Hello World!", sourceCodeRange: { startOffset: 5, endOffset: 26 } } ];
+		const [ helloSentence ] = getTextElementPositions( paragraph, sentences );
+		expect( helloSentence.sourceCodeRange ).toEqual( { startOffset: 5, endOffset: 21 } );
+	} );
 
-		expect( getTextElementPositions( node, sentences ) ).toEqual( sentencesWithPositions );
+	it( "should get the correct sentence position for a sentence in an image caption", function() {
+		// html: "<p><img class='size-medium wp-image-33' src='http://basic.wordpress.test/wp-content/uploads/2021/08/" +
+		// 			"cat-3957861_1280-211x300.jpeg' alt='a different cat with toy' width='211' height='300'></img> " +
+		// 			"A flamboyant cat with a toy<br></br>\n" +
+		// 			"</p>"
+
+		const html = "<p><img class='size-medium wp-image-33' src='http://basic.wordpress.test/wp-content/uploads/2021/08/cat-3957861_1280-211x300.jpeg' alt='a different cat with toy' width='211' height='300'></img>A flamboyant cat with a toy<br></br>\n</p>";
+
+		const tree = adapt( parseFragment( html, { sourceCodeLocationInfo: true } ) );
+		const paragraph = tree.childNodes[ 0 ];
+		const tokens = [ "A", " ", "flamboyant", " ", "cat", " ", "with", " ", "a", " ", "toy" ].map( string => new Token( string ) );
+
+		const [ a, space, flamboyant, space2, cat, space3, withWord, space4, a2, space5, toy ] = getTextElementPositions( paragraph, tokens );
+
+		expect( a.sourceCodeRange ).toEqual( { startOffset: 193, endOffset: 194 } );
+		expect( space.sourceCodeRange ).toEqual( { startOffset: 194, endOffset: 195 } );
+		expect( flamboyant.sourceCodeRange ).toEqual( { startOffset: 195, endOffset: 205 } );
+		expect( space2.sourceCodeRange ).toEqual( { startOffset: 205, endOffset: 206 } );
+		expect( cat.sourceCodeRange ).toEqual( { startOffset: 206, endOffset: 209 } );
+		expect( space3.sourceCodeRange ).toEqual( { startOffset: 209, endOffset: 210 } );
+		expect( withWord.sourceCodeRange ).toEqual( { startOffset: 210, endOffset: 214 } );
+		expect( space4.sourceCodeRange ).toEqual( { startOffset: 214, endOffset: 215 } );
+		expect( a2.sourceCodeRange ).toEqual( { startOffset: 215, endOffset: 216 } );
+		expect( space5.sourceCodeRange ).toEqual( { startOffset: 216, endOffset: 217 } );
+		expect( toy.sourceCodeRange ).toEqual( { startOffset: 217, endOffset: 220 } );
+
+		const sentences = [ { text: "A flamboyant cat with a toy" } ];
+		const [ aSentence ] = getTextElementPositions( paragraph, sentences );
+		expect( aSentence.sourceCodeRange ).toEqual( { startOffset: 193, endOffset: 220 } );
 	} );
 
 	it( "gets the sentence positions from a heading", function() {
@@ -413,77 +365,94 @@ describe( "A test for getting positions of sentences", () => {
 
 	it( "gets the token positions from a node that has multiple descendants", function() {
 		// HTML: <p><strong>Hello</strong>, <em>world</em>!</p>.
+		const html = "<p><strong>Hello</strong>, <em>world</em>!</p>";
+		const tree = adapt( parseFragment( html, { sourceCodeLocationInfo: true } ) );
+		const paragraph = tree.childNodes[ 0 ];
+		const tokens = [ "Hello", ",", " ", "World", "!" ].map( string => new Token( string ) );
 
-		const node = new Paragraph( {}, [
-			{ name: "#text", value: "Hello, world!" },
-			{
-				name: "strong",
-				attributes: {},
-				childNodes: [
-					{
-						name: "#text",
-						value: "Hello",
-					},
-				],
-				sourceCodeLocation: {
-					startTag: {
-						startOffset: 3,
-						endOffset: 11,
-					},
-					endTag: {
-						startOffset: 16,
-						endOffset: 25,
-					},
-					startOffset: 3,
-					endOffset: 25,
-				},
-			},
-			{
-				name: "em",
-				attributes: {},
-				childNodes: [
-					{
-						name: "#text",
-						value: "world",
-					},
-				],
-				sourceCodeLocation: {
-					startTag: {
-						startOffset: 27,
-						endOffset: 31,
-					},
-					endTag: {
-						startOffset: 36,
-						endOffset: 41,
-					},
-					startOffset: 27,
-					endOffset: 41,
-				},
-			},
-		],
-		{
-			startTag: {
-				startOffset: 0,
-				endOffset: 3,
-			},
-			endTag: {
-				startOffset: 42,
-				endOffset: 46,
-			},
-			startOffset: 0,
-			endOffset: 46,
-		} );
+		const [ hello, comma, space, world, bang ] = getTextElementPositions( paragraph, tokens );
 
-		const tokens = [ { text: "Hello" }, { text: "," }, { text: " " }, { text: "world" }, { text: "!" } ];
-		const tokensWithPositions = [
-			{ text: "Hello", sourceCodeRange: { startOffset: 3, endOffset: 25 } },
-			{ text: ",", sourceCodeRange: { startOffset: 25, endOffset: 26 } },
-			{ text: " ", sourceCodeRange: { startOffset: 26, endOffset: 27 } },
-			{ text: "world", sourceCodeRange: { startOffset: 27, endOffset: 41 } },
-			{ text: "!", sourceCodeRange: { startOffset: 41, endOffset: 42 } },
-		];
+		expect( hello.sourceCodeRange ).toEqual( { startOffset: 11, endOffset: 16 } );
+		expect( comma.sourceCodeRange ).toEqual( { startOffset: 25, endOffset: 26 } );
+		expect( space.sourceCodeRange ).toEqual( { startOffset: 26, endOffset: 27 } );
+		expect( world.sourceCodeRange ).toEqual( { startOffset: 31, endOffset: 36 } );
+		expect( bang.sourceCodeRange ).toEqual( { startOffset: 41, endOffset: 42 } );
 
-		expect( getTextElementPositions( node, tokens ) ).toEqual( tokensWithPositions );
+		const sentences = [ { text: "Hello, World!" } ];
+		const [ helloSentence ] = getTextElementPositions( paragraph, sentences );
+		expect( helloSentence.sourceCodeRange ).toEqual( { startOffset: 11, endOffset: 42 } );
+
+		//
+		// const node = new Paragraph( {}, [
+		// 	{ name: "#text", value: "Hello, world!" },
+		// 	{
+		// 		name: "strong",
+		// 		attributes: {},
+		// 		childNodes: [
+		// 			{
+		// 				name: "#text",
+		// 				value: "Hello",
+		// 			},
+		// 		],
+		// 		sourceCodeLocation: {
+		// 			startTag: {
+		// 				startOffset: 3,
+		// 				endOffset: 11,
+		// 			},
+		// 			endTag: {
+		// 				startOffset: 16,
+		// 				endOffset: 25,
+		// 			},
+		// 			startOffset: 3,
+		// 			endOffset: 25,
+		// 		},
+		// 	},
+		// 	{
+		// 		name: "em",
+		// 		attributes: {},
+		// 		childNodes: [
+		// 			{
+		// 				name: "#text",
+		// 				value: "world",
+		// 			},
+		// 		],
+		// 		sourceCodeLocation: {
+		// 			startTag: {
+		// 				startOffset: 27,
+		// 				endOffset: 31,
+		// 			},
+		// 			endTag: {
+		// 				startOffset: 36,
+		// 				endOffset: 41,
+		// 			},
+		// 			startOffset: 27,
+		// 			endOffset: 41,
+		// 		},
+		// 	},
+		// ],
+		// {
+		// 	startTag: {
+		// 		startOffset: 0,
+		// 		endOffset: 3,
+		// 	},
+		// 	endTag: {
+		// 		startOffset: 42,
+		// 		endOffset: 46,
+		// 	},
+		// 	startOffset: 0,
+		// 	endOffset: 46,
+		// } );
+		//
+		// const tokens = [ { text: "Hello" }, { text: "," }, { text: " " }, { text: "world" }, { text: "!" } ];
+		// const tokensWithPositions = [
+		// 	{ text: "Hello", sourceCodeRange: { startOffset: 3, endOffset: 25 } },
+		// 	{ text: ",", sourceCodeRange: { startOffset: 25, endOffset: 26 } },
+		// 	{ text: " ", sourceCodeRange: { startOffset: 26, endOffset: 27 } },
+		// 	{ text: "world", sourceCodeRange: { startOffset: 27, endOffset: 41 } },
+		// 	{ text: "!", sourceCodeRange: { startOffset: 41, endOffset: 42 } },
+		// ];
+		//
+		// expect( getTextElementPositions( node, tokens ) ).toEqual( tokensWithPositions );
 	} );
 
 	it( "don't calculate sentence position if the source code location of the node is unknown", function() {
@@ -492,5 +461,20 @@ describe( "A test for getting positions of sentences", () => {
 		const sentences = [ { text: "Hello, world!" }, { text: " Hello, yoast!" } ];
 
 		expect( getTextElementPositions( node, sentences ) ).toEqual( sentences );
+	} );
+
+	it( "calculates the position of tokens correctly", () => {
+		const html = "<p><span>Hello, world!</span></p>";
+		const tree = adapt( parseFragment( html, { sourceCodeLocationInfo: true } ) );
+		const paragraph = tree.childNodes[ 0 ];
+		const tokens = [ "Hello", ",", " ", "world", "!" ].map( string => new Token( string ) );
+
+		const [ hello, comma, space, world, bang ] = getTextElementPositions( paragraph, tokens );
+
+		expect( hello.sourceCodeRange ).toEqual( { startOffset: 9, endOffset: 14 } );
+		expect( comma.sourceCodeRange ).toEqual( { startOffset: 14, endOffset: 15 } );
+		expect( space.sourceCodeRange ).toEqual( { startOffset: 15, endOffset: 16 } );
+		expect( world.sourceCodeRange ).toEqual( { startOffset: 16, endOffset: 21 } );
+		expect( bang.sourceCodeRange ).toEqual( { startOffset: 21, endOffset: 22 } );
 	} );
 } );

--- a/packages/yoastseo/src/parse/build/private/getTextElementPositions.js
+++ b/packages/yoastseo/src/parse/build/private/getTextElementPositions.js
@@ -53,16 +53,7 @@ function adjustElementEnd( descendantNodes, descendantTagPositions, textElementS
 			textElementEnd += ( position.endOffset - position.startOffset );
 		}
 	} );
-	/*
-	 * If the length of a start tag at the end of the text element was added to the textElementEnd in the step above,
-	 * remove it. We are using the data from the original descendantNodes array for this check, as the
-	 * descendantTagPositions array doesn't specify whether each tag is an opening or closing tag.
-	 */
-	const startTagAtEndOfTextElement = descendantNodes.find( node => node.sourceCodeLocation.startTag.endOffset === textElementEnd );
-	if ( startTagAtEndOfTextElement ) {
-		const startTagLocation = startTagAtEndOfTextElement.sourceCodeLocation.startTag;
-		textElementEnd = textElementEnd - ( startTagLocation.endOffset - startTagLocation.startOffset );
-	}
+
 
 	return textElementEnd;
 }

--- a/packages/yoastseo/src/parse/build/private/getTextElementPositions.js
+++ b/packages/yoastseo/src/parse/build/private/getTextElementPositions.js
@@ -49,7 +49,7 @@ function adjustElementEnd( descendantNodes, descendantTagPositions, textElementS
 	 * the same as the start/end position of the text element, add the tag's length to the end position of the text element.
 	 */
 	descendantTagPositions.forEach( ( position ) => {
-		if ( position.startOffset >= textElementStart && position.startOffset <= textElementEnd ) {
+		if ( position.startOffset >= textElementStart && position.startOffset < textElementEnd ) {
 			textElementEnd += ( position.endOffset - position.startOffset );
 		}
 	} );

--- a/packages/yoastseo/src/parse/build/private/getTextElementPositions.js
+++ b/packages/yoastseo/src/parse/build/private/getTextElementPositions.js
@@ -114,7 +114,7 @@ export default function getTextElementPositions( node, textElements, startOffset
 	 * should have this property). If such nodes exist, store the positions of each node's opening and closing tags in
 	 * an array. These positions will have to be taken into account when calculating the position of the text elements.
 	 */
-	const descendantNodes = node.findAll( descendantNode => descendantNode.sourceCodeLocation );
+	const descendantNodes = node.findAll( descendantNode => descendantNode.sourceCodeLocation, true );
 	if ( descendantNodes.length > 0 ) {
 		descendantTagPositions = getDescendantPositions( descendantNodes );
 	}
@@ -126,6 +126,9 @@ export default function getTextElementPositions( node, textElements, startOffset
 		// If there are descendant tags, possibly adjust the textElementEnd to account for tags within/next to the text element.
 		if ( descendantTagPositions.length > 0 ) {
 			textElementEnd = adjustElementEnd( descendantNodes, descendantTagPositions, textElementStart, textElementEnd );
+
+			textElementStart = adjustTextElementStart( descendantNodes, descendantTagPositions, textElementStart, textElementEnd );
+
 		}
 
 		// Add the start and end positions to the textElement object.

--- a/packages/yoastseo/src/parse/build/private/getTextElementPositions.js
+++ b/packages/yoastseo/src/parse/build/private/getTextElementPositions.js
@@ -59,6 +59,25 @@ function adjustElementEnd( descendantNodes, descendantTagPositions, textElementS
 }
 
 /**
+ * Adjusts the start position of the text element to account for any descendant node tags that overlap with the text element.
+ * @param {Node[]} descendantNodes The descendant nodes.
+ * @param {SourceCodeRange[]} descendantTagPositions The positions of the descendant nodes' tags.
+ * @param {Number} textElementStart The start position of a text element.
+ */
+function adjustTextElementStart( descendantNodes, descendantTagPositions, textElementStart ) {
+	/*
+	 * If the start position of a descendant's node tag is between the start and end position of the text element, or is
+	 * the same as the start/end position of the text element, add the tag's length to the end position of the text element.
+	 */
+	descendantTagPositions.forEach( ( position ) => {
+		if ( position.startOffset >= textElementStart && position.startOffset <= textElementStart ) {
+			textElementStart += ( position.endOffset - position.startOffset );
+		}
+	} );
+	return textElementStart;
+}
+
+/**
  * Gets the start and end positions of text elements (sentences or tokens) in the source code.
  *
  * @param {Paragraph|Heading} 		node  			The paragraph or heading node.

--- a/packages/yoastseo/src/parse/build/private/getTextElementPositions.js
+++ b/packages/yoastseo/src/parse/build/private/getTextElementPositions.js
@@ -63,6 +63,8 @@ function adjustElementEnd( descendantNodes, descendantTagPositions, textElementS
  * @param {Node[]} descendantNodes The descendant nodes.
  * @param {SourceCodeRange[]} descendantTagPositions The positions of the descendant nodes' tags.
  * @param {Number} textElementStart The start position of a text element.
+ *
+ * @returns {Number} The adjusted start position of the text element.
  */
 function adjustTextElementStart( descendantNodes, descendantTagPositions, textElementStart ) {
 	/*

--- a/packages/yoastseo/src/parse/build/private/getTextElementPositions.js
+++ b/packages/yoastseo/src/parse/build/private/getTextElementPositions.js
@@ -14,7 +14,9 @@ import { Paragraph } from "../../structure";
 function getDescendantPositions( descendantNodes ) {
 	const descendantTagPositions = [];
 	descendantNodes.forEach( ( node ) => {
-		descendantTagPositions.push( node.sourceCodeLocation.startTag );
+		if ( node.sourceCodeLocation.startTag ) {
+			descendantTagPositions.push( node.sourceCodeLocation.startTag );
+		}
 		if ( node.sourceCodeLocation.endTag ) {
 			descendantTagPositions.push( node.sourceCodeLocation.endTag );
 		}

--- a/packages/yoastseo/src/parse/structure/Node.js
+++ b/packages/yoastseo/src/parse/structure/Node.js
@@ -47,11 +47,13 @@ class Node {
 	 * Finds all nodes in the tree that satisfies the given condition.
 	 *
 	 * @param {function} condition The condition that a node should satisfy to end up in the list.
+	 * @param {boolean} recurseFoundNodes=false Whether to recurse into found nodes
+	 * to see if the condition also applies to sub-nodes of the found node.
 	 *
 	 * @returns {(Node|Text|Paragraph|Heading)[]} The list of nodes that satisfy the condition.
 	 */
-	findAll( condition ) {
-		return findAllInTree( this, condition );
+	findAll( condition, recurseFoundNodes = false ) {
+		return findAllInTree( this, condition, recurseFoundNodes );
 	}
 
 	/**

--- a/packages/yoastseo/src/parse/traverse/findAllInTree.js
+++ b/packages/yoastseo/src/parse/traverse/findAllInTree.js
@@ -3,10 +3,11 @@
  *
  * @param {Object} tree The tree.
  * @param {function} condition The condition that a node should satisfy to end up in the list.
+ * @param {boolean} recurseFoundNodes=false Whether to recurse into found nodes to see if the condition also applies to sub-nodes of the found node.
  *
  * @returns {Object[]} The list of nodes that satisfy the condition.
  */
-export default function findAllInTree( tree, condition ) {
+export default function findAllInTree( tree, condition, recurseFoundNodes = false ) {
 	const nodes = [];
 
 	if ( ! tree.childNodes ) {
@@ -16,6 +17,9 @@ export default function findAllInTree( tree, condition ) {
 	tree.childNodes.forEach( child => {
 		if ( condition( child ) ) {
 			nodes.push( child );
+			if ( recurseFoundNodes ) {
+				nodes.push( ...findAllInTree( child, condition ) );
+			}
 		} else {
 			nodes.push( ...findAllInTree( child, condition ) );
 		}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

*

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

*

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
