### PR TITLE
Use the Addon_Manager to check if addons are activated

### DIFF
--- a/src/integrations/academy-integration.php
+++ b/src/integrations/academy-integration.php
@@ -2,8 +2,8 @@
 
 namespace Yoast\WP\SEO\Integrations;
 
+use WPSEO_Addon_Manager;
 use WPSEO_Admin_Asset_Manager;
-use WPSEO_Plugin_Availability;
 use Yoast\WP\SEO\Helpers\Short_Link_Helper;
 use Yoast\WP\SEO\Conditionals\Admin_Conditional;
 use Yoast\WP\SEO\Conditionals\User_Can_Manage_Wpseo_Options_Conditional;
@@ -158,12 +158,10 @@ class Academy_Integration implements Integration_Interface {
 	 * @return array The script data.
 	 */
 	public function get_script_data() {
-		$woocommerce_seo_file = 'wpseo-woocommerce/wpseo-woocommerce.php';
-		$local_seo_file       = 'wordpress-seo-local/local-seo.php';
+		$addon_manager = new WPSEO_Addon_Manager();
 
-		$wpseo_plugin_availability_checker = new WPSEO_Plugin_Availability();
-		$woocommerce_seo_active            = $wpseo_plugin_availability_checker->is_active( $woocommerce_seo_file );
-		$local_seo_active                  = $wpseo_plugin_availability_checker->is_active( $local_seo_file );
+		$woocommerce_seo_active = $addon_manager->is_installed( WPSEO_Addon_Manager::WOOCOMMERCE_SLUG );
+		$local_seo_active       = $addon_manager->is_installed( WPSEO_Addon_Manager::LOCAL_SLUG );
 
 		return [
 			'preferences' => [

--- a/tests/unit/integrations/academy-integration-test.php
+++ b/tests/unit/integrations/academy-integration-test.php
@@ -5,6 +5,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Integrations;
 use Brain\Monkey;
 use Mockery;
 use WPSEO_Admin_Asset_Manager;
+use WPSEO_Addon_Manager;
 use Yoast\WP\SEO\Conditionals\Admin_Conditional;
 use Yoast\WP\SEO\Conditionals\User_Can_Manage_Wpseo_Options_Conditional;
 use Yoast\WP\SEO\Helpers\Current_Page_Helper;
@@ -264,16 +265,6 @@ class Academy_Integration_Test extends TestCase {
 			'user_language'    => 'en_US',
 		];
 
-		Monkey\Functions\expect( 'is_plugin_active' )
-			->with( 'wpseo-woocommerce/wpseo-woocommerce.php' )
-			->once()
-			->andReturn( false );
-
-		Monkey\Functions\expect( 'is_plugin_active' )
-			->with( 'wordpress-seo-local/local-seo.php' )
-			->once()
-			->andReturn( true );
-
 		$this->product_helper
 				->expects( 'is_premium' )
 				->once()
@@ -297,13 +288,14 @@ class Academy_Integration_Test extends TestCase {
 	 * @covers ::get_script_data
 	 */
 	public function test_get_script_data() {
-		$link_params = $this->expect_get_script_data();
+		$link_params   = $this->expect_get_script_data();
+		$addon_manager = new WPSEO_Addon_Manager();
 
 		$expected = [
 			'preferences' => [
 				'isPremium'      => false,
-				'isWooActive'    => false,
-				'isLocalActive'  => true,
+				'isWooActive'    => $addon_manager->is_installed( WPSEO_Addon_Manager::WOOCOMMERCE_SLUG ),
+				'isLocalActive'  => $addon_manager->is_installed( WPSEO_Addon_Manager::LOCAL_SLUG ),
 				'isRtl'          => false,
 				'pluginUrl'      => 'http://basic.wordpress.test/wp-content/worspress-seo',
 				'upsellSettings' => [


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Previously we were using the `WPSEO_Plugin_Availability` class to check if Yoast SEO Local is active, but this does not work in production environments. We switched to the `WPSEO_Addon_Manager` class instead.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where the `Local SEO` course in the `Academy` page would not be active when Yoast SEO Local is active.

## Relevant technical choices:

* N/A

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Please check this PR by uploading an artifact to your WordPress installation (or the latest RC)
* Install `Yoast SEO Local` and don't activate it
* Go to `Yoast SEO` -> `Academy` and verify the `Local SEO` course:
  * has no `Premium` badge
  * shows the `Start free trial lesson →` link
  * shows the `Unlock with Premium` button
* Now activate `Yoast SEO Local`
* Go to `Yoast SEO` -> `Academy` and verify the `Local SEO` course:
  * has a `Premium` badge
  * doesn't show the `Start free trial lesson →` link
  * shows the `Start the course` button
* Do the same test with `Yoast SEO WooCommerce`

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The Academy page should work as expected; see [this PR](https://github.com/Yoast/wordpress-seo/pull/20238) for regression-testing the relevant functionality.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes https://github.com/Yoast/wordpress-seo/issues/20247
