### PR TITLE
Adds a grouping array around the new indexable tracking info.

### DIFF
--- a/src/analytics/application/missing-indexables-collector.php
+++ b/src/analytics/application/missing-indexables-collector.php
@@ -41,7 +41,7 @@ class Missing_Indexables_Collector implements WPSEO_Collection {
 			$missing_indexable_bucket->add_missing_indexable_count( $missing_indexable_count );
 		}
 
-		return $missing_indexable_bucket->to_array();
+		return [ 'missing_indexables' => $missing_indexable_bucket->to_array() ];
 	}
 
 	/**

--- a/src/analytics/application/to-be-cleaned-indexables-collector.php
+++ b/src/analytics/application/to-be-cleaned-indexables-collector.php
@@ -55,7 +55,7 @@ class To_Be_Cleaned_Indexables_Collector implements WPSEO_Collection {
 
 		$this->add_additional_counts( $to_be_cleaned_indexable_bucket );
 
-		return $to_be_cleaned_indexable_bucket->to_array();
+		return [ 'to_be_cleaned_indexables' => $to_be_cleaned_indexable_bucket->to_array() ];
 	}
 
 	/**

--- a/tests/unit/analytics/application/missing-indexables-collector-test.php
+++ b/tests/unit/analytics/application/missing-indexables-collector-test.php
@@ -53,13 +53,15 @@ class Missing_Indexables_Collector_Test extends TestCase {
 				[ $indexation_action, $indexation_action ],
 				$indexation_action,
 				[
-					[
-						'indexable_type' => Abstract_Indexing_Action_Double::class,
-						'count'          => 15,
-					],
-					[
-						'indexable_type' => Abstract_Indexing_Action_Double::class,
-						'count'          => 15,
+					'missing_indexables' => [
+						[
+							'indexable_type' => Abstract_Indexing_Action_Double::class,
+							'count'          => 15,
+						],
+						[
+							'indexable_type' => Abstract_Indexing_Action_Double::class,
+							'count'          => 15,
+						],
 					],
 				],
 			],
@@ -68,9 +70,11 @@ class Missing_Indexables_Collector_Test extends TestCase {
 				[ $indexation_action, 'somerandomobject' ],
 				$indexation_action,
 				[
-					[
-						'indexable_type' => Abstract_Indexing_Action_Double::class,
-						'count'          => 15,
+					'missing_indexables' => [
+						[
+							'indexable_type' => Abstract_Indexing_Action_Double::class,
+							'count'          => 15,
+						],
 					],
 				],
 
@@ -79,7 +83,7 @@ class Missing_Indexables_Collector_Test extends TestCase {
 
 				null,
 				$indexation_action,
-				[],
+				[ 'missing_indexables' => [] ],
 
 			],
 		];

--- a/tests/unit/analytics/application/to-be-cleaned-indexables-collector-test.php
+++ b/tests/unit/analytics/application/to-be-cleaned-indexables-collector-test.php
@@ -56,7 +56,7 @@ class To_Be_Cleaned_Indexables_Collector_Test extends TestCase {
 					->andReturn( 0 );
 		$this->sut = new To_Be_Cleaned_Indexables_Collector( $indexable_cleanup_repository_mock );
 
-		$this->assertEquals(
+		$this->assertSame(
 			[
 				'to_be_cleaned_indexables' => [
 					[

--- a/tests/unit/analytics/application/to-be-cleaned-indexables-collector-test.php
+++ b/tests/unit/analytics/application/to-be-cleaned-indexables-collector-test.php
@@ -2,10 +2,10 @@
 
 namespace Yoast\WP\SEO\Tests\Unit\Analytics\Application;
 
+use Mockery;
 use Yoast\WP\SEO\Analytics\Application\To_Be_Cleaned_Indexables_Collector;
 use Yoast\WP\SEO\Repositories\Indexable_Cleanup_Repository;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
-use Mockery;
 
 /**
  * Class To_Be_Cleaned_Indexables_Collector_Test.
@@ -58,55 +58,57 @@ class To_Be_Cleaned_Indexables_Collector_Test extends TestCase {
 
 		$this->assertEquals(
 			[
-				[
-					'cleanup_name' => 'indexables_with_post_object_type_and_shop_order_object_sub_type',
-					'count'        => 0,
-				],
-				[
-					'cleanup_name' => 'indexables_with_auto-draft_post_status',
-					'count'        => 0,
-				],
-				[
-					'cleanup_name' => 'indexables_for_non_publicly_viewable_post',
-					'count'        => 0,
-				],
-				[
-					'cleanup_name' => 'indexables_for_non_publicly_viewable_taxonomies',
-					'count'        => 0,
-				],
-				[
-					'cleanup_name' => 'indexables_for_authors_archive_disabled',
-					'count'        => 0,
-				],
-				[
-					'cleanup_name' => 'indexables_for_authors_without_archive',
-					'count'        => 0,
-				],
+				'to_be_cleaned_indexables' => [
+					[
+						'cleanup_name' => 'indexables_with_post_object_type_and_shop_order_object_sub_type',
+						'count'        => 0,
+					],
+					[
+						'cleanup_name' => 'indexables_with_auto-draft_post_status',
+						'count'        => 0,
+					],
+					[
+						'cleanup_name' => 'indexables_for_non_publicly_viewable_post',
+						'count'        => 0,
+					],
+					[
+						'cleanup_name' => 'indexables_for_non_publicly_viewable_taxonomies',
+						'count'        => 0,
+					],
+					[
+						'cleanup_name' => 'indexables_for_authors_archive_disabled',
+						'count'        => 0,
+					],
+					[
+						'cleanup_name' => 'indexables_for_authors_without_archive',
+						'count'        => 0,
+					],
 
-				[
-					'cleanup_name' => 'indexables_for_object_type_and_source_table_users',
-					'count'        => 0,
-				],
-				[
-					'cleanup_name' => 'indexables_for_object_type_and_source_table_posts',
-					'count'        => 0,
-				],
-				[
-					'cleanup_name' => 'indexables_for_object_type_and_source_table_terms',
-					'count'        => 0,
-				],
+					[
+						'cleanup_name' => 'indexables_for_object_type_and_source_table_users',
+						'count'        => 0,
+					],
+					[
+						'cleanup_name' => 'indexables_for_object_type_and_source_table_posts',
+						'count'        => 0,
+					],
+					[
+						'cleanup_name' => 'indexables_for_object_type_and_source_table_terms',
+						'count'        => 0,
+					],
 
-				[
-					'cleanup_name' => 'orphaned_from_table_indexable_hierarchy',
-					'count'        => 0,
-				],
-				[
-					'cleanup_name' => 'orphaned_from_table_indexable_id',
-					'count'        => 0,
-				],
-				[
-					'cleanup_name' => 'orphaned_from_table_target_indexable_id',
-					'count'        => 0,
+					[
+						'cleanup_name' => 'orphaned_from_table_indexable_hierarchy',
+						'count'        => 0,
+					],
+					[
+						'cleanup_name' => 'orphaned_from_table_indexable_id',
+						'count'        => 0,
+					],
+					[
+						'cleanup_name' => 'orphaned_from_table_target_indexable_id',
+						'count'        => 0,
+					],
 				],
 			],
 			$this->sut->get()


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We need to add a grouping array around the indexable tracking, so we can pick them up in our back-end.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds a grouping array around our new non-released tracking data.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Add the following code to `/wordpress-seo/admin/class-admin.php` at the end of the constructor at around line 118.
* Notice the closing `}` after the admin init this is to close out the constructor.
```
		add_action( 'admin_init', [ $this, 'send' ], 1 );
	}

	public function send() {
		if ( filter_input( INPUT_GET, 'action' ) === 'test' ) {
			$collector = new WPSEO_Collector();

			$collector->add_collection( new WPSEO_Tracking_Default_Data() );
			$collector->add_collection( new WPSEO_Tracking_Server_Data() );
			$collector->add_collection( new WPSEO_Tracking_Theme_Data() );
			$collector->add_collection( new WPSEO_Tracking_Plugin_Data() );
			$collector->add_collection( new WPSEO_Tracking_Settings_Data() );
			$collector->add_collection( new WPSEO_Tracking_Addon_Data() );
			$collector->add_collection( YoastSEO()->classes->get( Yoast\WP\SEO\Analytics\Application\Missing_Indexables_Collector::class ) );
			$collector->add_collection( YoastSEO()->classes->get( Yoast\WP\SEO\Analytics\Application\To_Be_Cleaned_Indexables_Collector::class ) );

			echo '<pre>';
			print_r( $collector->collect() );
			echo '</pre>';
			die;
		}
	}

```
* Go to wp-admin/admin.php?page=wpseo_dashboard&action=test
* Verify that you see an array key `missing_indexables` with arrays in there.
* Verify that you see an array key `to_be_cleaned_indexables` with arrays in there.
* Read through the rest of the data and make sure there is nothing else about missing indexables or to be cleaned indexables not in those groups.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [X] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
