### PR TITLE
20015 difficulty in adding a link in the editor as the box positioning is off

### DIFF
--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "test": "jest -u",
-    "lint": "eslint src tests --max-warnings=108"
+    "lint": "eslint src tests --max-warnings=85"
   },
   "dependencies": {
     "@draft-js-plugins/mention": "^5.0.0",

--- a/packages/js/src/inline-links/inline.js
+++ b/packages/js/src/inline-links/inline.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { uniqueId } from "lodash";
+import PropTypes from "prop-types";
 
 /**
  * WordPress dependencies
@@ -283,5 +284,15 @@ function InlineLinkUI( {
 		</Popover>
 	);
 }
+
+InlineLinkUI.propTypes = {
+	isActive: PropTypes.bool,
+	activeAttributes: PropTypes.object,
+	addingLink: PropTypes.bool,
+	value: PropTypes.object,
+	onChange: PropTypes.func,
+	speak: PropTypes.func.isRequired,
+	stopAddingLink: PropTypes.func.isRequired,
+};
 
 export default withSpokenMessages( InlineLinkUI );

--- a/packages/js/src/inline-links/inline.js
+++ b/packages/js/src/inline-links/inline.js
@@ -7,7 +7,7 @@ import PropTypes from "prop-types";
 /**
  * WordPress dependencies
  */
-import { useMemo, useState } from "@wordpress/element";
+import { useMemo, useState, useCallback } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
 import { withSpokenMessages, Popover } from "@wordpress/components";
 import { prependHTTP } from "@wordpress/url";
@@ -204,6 +204,7 @@ function InlineLinkUI( {
 		}
 	};
 
+	const onChangeLink = useCallback( ( nextValue ) =>{
 		/*
 		 * Merge with values from state, both for the purpose of assigning the next state value, and for use in constructing the new link format if
 		 * the link is ready to be applied.
@@ -270,7 +271,6 @@ function InlineLinkUI( {
 
 		actionCompleteMessage( newUrl );
 	}, [] );
-	}
 
 	const NoFollowHelpLink = <HelpLink
 		href={ window.wpseoAdminL10n[ "shortlinks.nofollow_sponsored" ] }

--- a/packages/js/src/inline-links/inline.js
+++ b/packages/js/src/inline-links/inline.js
@@ -184,6 +184,14 @@ function InlineLinkUI( {
 		return nextValue.title ? nextValue.title : newUrl;
 	};
 
+	/**
+	 * Should insert new link.
+	 * @returns {boolean} Whether the link rel should be sponsored.
+	 */
+	const shouldInsertLink = () => {
+		return isCollapsed( value ) && ! isActive;
+	};
+
 		/*
 		 * Merge with values from state, both for the purpose of assigning the next state value, and for use in constructing the new link format if
 		 * the link is ready to be applied.
@@ -232,7 +240,7 @@ function InlineLinkUI( {
 			sponsored: nextValue.sponsored,
 		} );
 
-		if ( isCollapsed( value ) && ! isActive ) {
+		if ( shouldInsertLink() ) {
 			const newText = getNewText( nextValue.title, newUrl );
 			const toInsert = applyFormat(
 				create( { text: newText } ),

--- a/packages/js/src/inline-links/inline.js
+++ b/packages/js/src/inline-links/inline.js
@@ -107,6 +107,20 @@ function InlineLinkUI( {
 	};
 
 	/**
+	 * LinkControl calls `onChange` immediately upon the toggling a setting.
+	 *
+	 * @param {object} nextValue The next link URL.
+	 *
+	 * @returns {boolean} Whether the link rel should be sponsored.
+	 */
+	const isToggleSetting = ( nextValue ) =>{
+		return linkValue.url === nextValue.url &&
+		linkValue.opensInNewTab !== nextValue.opensInNewTab ||
+		linkValue.noFollow !== nextValue.noFollow ||
+		linkValue.sponsored !== nextValue.sponsored;
+	};
+
+	/**
 	 * Checks if link rel should be nofollow.
 	 *
 	 * @param {boolean} didToggleSetting Whether the user toggled a setting.
@@ -130,11 +144,7 @@ function InlineLinkUI( {
 		};
 
 		/* LinkControl calls `onChange` immediately upon the toggling a setting. */
-		const didToggleSetting =
-			linkValue.url === nextValue.url &&
-			linkValue.opensInNewTab !== nextValue.opensInNewTab ||
-			linkValue.noFollow !== nextValue.noFollow ||
-			linkValue.sponsored !== nextValue.sponsored;
+		const didToggleSetting = isToggleSetting( linkValue, nextValue );
 
 		/*
 		 * A link rel can only be one of three combinations:

--- a/packages/js/src/inline-links/inline.js
+++ b/packages/js/src/inline-links/inline.js
@@ -19,6 +19,22 @@ import { createLinkFormat, isValidHref } from "./utils";
 import HelpLink from "../components/HelpLink";
 import createInterpolateElement from "../helpers/createInterpolateElement";
 
+/**
+ * Component to render the inline link UI.
+ * This component is rendered when adding or editing a
+ * link.
+ *
+ * @param {Object} props Component props.
+ * @param {boolean} props.isActive Whether a link is active.
+ * @param {Object} props.activeAttributes The attributes of the active link.
+ * @param {boolean} props.addingLink Whether a link is being added or edited.
+ * @param {object} props.value The current value of the rich text.
+ * @param {Function} props.onChange The rich text change handler.
+ * @param {Function} props.speak The speak function.
+ * @param {Function} props.stopAddingLink The stop adding link handler.
+ *
+ * @returns {WPElement} The inline link UI.
+ */
 function InlineLinkUI( {
 	isActive,
 	activeAttributes,

--- a/packages/js/src/inline-links/inline.js
+++ b/packages/js/src/inline-links/inline.js
@@ -174,6 +174,16 @@ function InlineLinkUI( {
 		}
 	};
 
+	/**
+	 * Gets the new text for the link.
+	 * @param {object} nextValue The next link URL.
+	 * @param {string} newUrl The new link URL.
+	 * @returns {string} The new text for the link.
+	 */
+	const getNewText = ( nextValue, newUrl ) =>{
+		return nextValue.title ? nextValue.title : newUrl;
+	};
+
 		/*
 		 * Merge with values from state, both for the purpose of assigning the next state value, and for use in constructing the new link format if
 		 * the link is ready to be applied.
@@ -223,7 +233,7 @@ function InlineLinkUI( {
 		} );
 
 		if ( isCollapsed( value ) && ! isActive ) {
-			const newText = nextValue.title || newUrl;
+			const newText = getNewText( nextValue.title, newUrl );
 			const toInsert = applyFormat(
 				create( { text: newText } ),
 				format,

--- a/packages/js/src/inline-links/inline.js
+++ b/packages/js/src/inline-links/inline.js
@@ -192,6 +192,18 @@ function InlineLinkUI( {
 		return isCollapsed( value ) && ! isActive;
 	};
 
+	/**
+	 * Validates the link id is not null or undefined and cast it to string.
+	 *
+	 * @param {string} id The link id.
+	 * @returns {string} The validated link id.
+	 */
+	const validateLinkId = ( id ) => {
+		if ( typeof id === "number" || typeof id === "string" ) {
+			return String( id );
+		}
+	};
+
 		/*
 		 * Merge with values from state, both for the purpose of assigning the next state value, and for use in constructing the new link format if
 		 * the link is ready to be applied.
@@ -229,12 +241,7 @@ function InlineLinkUI( {
 		const format = createLinkFormat( {
 			url: newUrl,
 			type: nextValue.type,
-			id:
-			// eslint-disable-next-line no-undefined
-				nextValue.id !== undefined && nextValue.id !== null
-					? String( nextValue.id )
-					// eslint-disable-next-line no-undefined
-					: undefined,
+			id: validateLinkId( nextValue.id ),
 			opensInNewWindow: nextValue.opensInNewTab,
 			noFollow: nextValue.noFollow,
 			sponsored: nextValue.sponsored,

--- a/packages/js/src/inline-links/inline.js
+++ b/packages/js/src/inline-links/inline.js
@@ -262,18 +262,7 @@ function InlineLinkUI( {
 		}
 
 		actionCompleteMessage( newUrl );
-			speak(
-				__(
-					"Warning: the link has been inserted but may have errors. Please test it.",
-					"wordpress-seo"
-				),
-				"assertive"
-			);
-		} else if ( isActive ) {
-			speak( __( "Link edited.", "wordpress-seo" ), "assertive" );
-		} else {
-			speak( __( "Link inserted.", "wordpress-seo" ), "assertive" );
-		}
+	}, [] );
 	}
 
 	const NoFollowHelpLink = <HelpLink

--- a/packages/js/src/inline-links/inline.js
+++ b/packages/js/src/inline-links/inline.js
@@ -130,6 +130,17 @@ function InlineLinkUI( {
 		return isToggleSetting( nextValue ) && nextValue.sponsored === true && linkValue.Sponsored !== true;
 	};
 
+	/**
+	 * Checks if link rel should be sponsored.
+	 * This handler is called when the user changes the link URL.
+	 * LinkControl calls `onChange` immediately upon the toggling a setting.
+	 * @param {boolean} nextValue The next link URL.
+	 * @returns {boolean} Whether the link rel should be sponsored.
+	 */
+	const isSponsored = ( nextValue ) => {
+		return isToggleSetting( nextValue ) && nextValue.noFollow === false && linkValue.noFollow !== false;
+	};
+
 	 *
 	 * @returns {boolean} Whether the link rel should be nofollow.
 	 */
@@ -160,7 +171,7 @@ function InlineLinkUI( {
 		if ( isLinkNoFollow( nextValue ) ) {
 			nextValue.noFollow = true;
 		}
-		if ( didToggleSetting && nextValue.noFollow === false && linkValue.noFollow !== false ) {
+		if ( isSponsored( nextValue ) ) {
 			nextValue.sponsored = false;
 		}
 

--- a/packages/js/src/inline-links/inline.js
+++ b/packages/js/src/inline-links/inline.js
@@ -106,6 +106,19 @@ function InlineLinkUI( {
 		...nextLinkValue,
 	};
 
+	/**
+	 * Checks if link rel should be nofollow.
+	 *
+	 * @param {boolean} didToggleSetting Whether the user toggled a setting.
+	 * @param {boolean} nextValueSponsored Whether the next link is sponsored.
+	 * @param {boolean} linkValueSponsored Whether the current link is sponsored.
+	 *
+	 * @returns {boolean} Whether the link rel should be nofollow.
+	 */
+	const isLinkNoFollow = ( didToggleSetting, nextValueSponsored, linkValueSponsored ) => {
+		return didToggleSetting && nextValueSponsored === true && linkValueSponsored !== true;
+	};
+
 	function onChangeLink( nextValue ) {
 		/*
 		 * Merge with values from state, both for the purpose of assigning the next state value, and for use in constructing the new link format if
@@ -130,7 +143,7 @@ function InlineLinkUI( {
 		 * - neither nofollow or sponsored
 		 * On first toggle there is no linkValue. We need to compare with what it should be instead of what it is.
 		 */
-		if ( didToggleSetting && nextValue.sponsored === true && linkValue.sponsored !== true ) {
+		if ( isLinkNoFollow( didToggleSetting, nextValue.sponsored, linkValue.sponsored ) ) {
 			nextValue.noFollow = true;
 		}
 		if ( didToggleSetting && nextValue.noFollow === false && linkValue.noFollow !== false ) {

--- a/packages/js/src/inline-links/inline.js
+++ b/packages/js/src/inline-links/inline.js
@@ -153,7 +153,27 @@ function InlineLinkUI( {
 		return isToggleSetting( nextValue ) && ! nextValue.url;
 	};
 
-	function onChangeLink( nextValue ) {
+	/**
+	 * Speaks a message after a link is inserted or edited.
+	 * @param {string} newUrl The new link URL.
+	 * @returns {void}
+	 */
+	const actionCompleteMessage = ( newUrl ) => {
+		if ( ! isValidHref( newUrl ) ) {
+			speak(
+				__(
+					"Warning: the link has been inserted but may have errors. Please test it.",
+					"wordpress-seo"
+				),
+				"assertive"
+			);
+		} else if ( isActive ) {
+			speak( __( "Link edited.", "wordpress-seo" ), "assertive" );
+		} else {
+			speak( __( "Link inserted.", "wordpress-seo" ), "assertive" );
+		}
+	};
+
 		/*
 		 * Merge with values from state, both for the purpose of assigning the next state value, and for use in constructing the new link format if
 		 * the link is ready to be applied.
@@ -223,7 +243,7 @@ function InlineLinkUI( {
 			stopAddingLink();
 		}
 
-		if ( ! isValidHref( newUrl ) ) {
+		actionCompleteMessage( newUrl );
 			speak(
 				__(
 					"Warning: the link has been inserted but may have errors. Please test it.",

--- a/packages/js/src/inline-links/inline.js
+++ b/packages/js/src/inline-links/inline.js
@@ -141,11 +141,16 @@ function InlineLinkUI( {
 		return isToggleSetting( nextValue ) && nextValue.noFollow === false && linkValue.noFollow !== false;
 	};
 
+	/**
+	 * Checks if toggle setting for new link is valid.
+	 * If change handler was called as a result of a settings change during link insertion,
+	 * it must be held in state until the link is ready to be applied.
 	 *
-	 * @returns {boolean} Whether the link rel should be nofollow.
+	 * @param {boolean} nextValue The next link URL.
+	 * @returns {boolean} Whether the link rel should be sponsored.
 	 */
-	const isLinkNoFollow = ( didToggleSetting, nextValueSponsored, linkValueSponsored ) => {
-		return didToggleSetting && nextValueSponsored === true && linkValueSponsored !== true;
+	const didToggleSettingForNewLink = ( nextValue ) => {
+		return isToggleSetting( nextValue ) && ! nextValue.url;
 	};
 
 	function onChangeLink( nextValue ) {
@@ -175,19 +180,9 @@ function InlineLinkUI( {
 			nextValue.sponsored = false;
 		}
 
-		/*
-		 * If change handler was called as a result of a settings change during link insertion, it must be held in state until the link is ready to
-		 * be applied.
- 		 */
-		const didToggleSettingForNewLink =
-			// eslint-disable-next-line no-undefined
-			didToggleSetting && nextValue.url === undefined;
-
-		/* If link will be assigned, the state value can be considered flushed. Otherwise, persist the pending changes. */
-		// eslint-disable-next-line no-undefined
-		setNextLinkValue( didToggleSettingForNewLink ? nextValue : undefined );
-
-		if ( didToggleSettingForNewLink ) {
+		if ( didToggleSettingForNewLink( nextValue ) ) {
+			/* If link will be assigned, the state value can be considered flushed. Otherwise, persist the pending changes. */
+			setNextLinkValue( nextValue );
 			return;
 		}
 

--- a/packages/js/src/inline-links/inline.js
+++ b/packages/js/src/inline-links/inline.js
@@ -255,6 +255,8 @@ function InlineLinkUI( {
 			focusOnMount={ addingLink ? "firstElement" : false }
 			onClose={ stopAddingLink }
 			position="bottom center"
+			placement="bottom"
+			shift={ true }
 		>
 			<LinkControl
 				value={ linkValue }

--- a/packages/js/src/inline-links/inline.js
+++ b/packages/js/src/inline-links/inline.js
@@ -123,9 +123,13 @@ function InlineLinkUI( {
 	/**
 	 * Checks if link rel should be nofollow.
 	 *
-	 * @param {boolean} didToggleSetting Whether the user toggled a setting.
-	 * @param {boolean} nextValueSponsored Whether the next link is sponsored.
-	 * @param {boolean} linkValueSponsored Whether the current link is sponsored.
+	 * @param {boolean} nextValue The next link URL.
+	 * @returns {boolean} Whether the link rel should be nofollow.
+	 */
+	const isLinkNoFollow = ( nextValue ) => {
+		return isToggleSetting( nextValue ) && nextValue.sponsored === true && linkValue.Sponsored !== true;
+	};
+
 	 *
 	 * @returns {boolean} Whether the link rel should be nofollow.
 	 */
@@ -153,7 +157,7 @@ function InlineLinkUI( {
 		 * - neither nofollow or sponsored
 		 * On first toggle there is no linkValue. We need to compare with what it should be instead of what it is.
 		 */
-		if ( isLinkNoFollow( didToggleSetting, nextValue.sponsored, linkValue.sponsored ) ) {
+		if ( isLinkNoFollow( nextValue ) ) {
 			nextValue.noFollow = true;
 		}
 		if ( didToggleSetting && nextValue.noFollow === false && linkValue.noFollow !== false ) {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Fix position of the popover box when editing a link in block editor. 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the link popover position in the block editor would be positioned incorrectly when adding or creating links.

## Relevant technical choices:

* Refactored the component to reduce complexity and remove es lint warnings.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Open a post or page in the block editor.
* Add a link to the first word in the text.
* A popover would appear for the link.
* Check popover is fully visible when increasing screen resolution to 150%.
How it shouldn't look:
![image](https://user-images.githubusercontent.com/65466507/236805848-d7cee221-58d3-4fb7-a6e8-038811f098c6.png)
How it should look:
![image](https://user-images.githubusercontent.com/65466507/236806004-7d040296-a9a0-41df-970a-744126a259c5.png)

* Toggle `Open in new Tab` add a url and save.
  * View page and inspect the link.
  * Check it has `target="_blank"` attribute.
* Toggle `Mark as nofollow` and save
   * View page and inspect link.
   * Check it has `rel="nofollow"` attribute.
* Toggle `Mark as sponsored` and save
   * View page and inspect link.
   * Check it has `rel="sponsored nofollow"` attribute.
 
Uncheck all those options and check they are removed from the link.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes https://github.com/Yoast/wordpress-seo/issues/20015
