### PR TITLE
20271 fix incorrect covers tags

### DIFF
--- a/tests/unit/actions/importing/aioseo-cleanup-action-test.php
+++ b/tests/unit/actions/importing/aioseo-cleanup-action-test.php
@@ -120,7 +120,6 @@ class Aioseo_Cleanup_Action_Test extends TestCase {
 	 * @covers ::cleanup_postmeta_query
 	 * @covers ::truncate_query
 	 * @covers ::get_postmeta_table
-	 * @covers ::get_aioseo_table
 	 *
 	 * @param array     $completed_option   The persistent completed option.
 	 * @param int       $query_times        The times we're gonna run the cleanup queries.

--- a/tests/unit/actions/indexing/abstract-link-indexing-action-test.php
+++ b/tests/unit/actions/indexing/abstract-link-indexing-action-test.php
@@ -17,7 +17,7 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  * @group actions
  * @group indexing
  *
- * @coversDefaultClass \Yoast\WP\SEO\Actions\Indexation\Abstract_Link_Indexing_Action
+ * @coversDefaultClass \Yoast\WP\SEO\Actions\Indexing\Abstract_Link_Indexing_Action
  */
 class Abstract_Link_Indexing_Action_Test extends TestCase {
 

--- a/tests/unit/actions/indexing/indexable-post-indexation-action-test.php
+++ b/tests/unit/actions/indexing/indexable-post-indexation-action-test.php
@@ -101,7 +101,6 @@ class Indexable_Post_Indexation_Action_Test extends TestCase {
 	 * @covers ::__construct
 	 * @covers ::get_total_unindexed
 	 * @covers ::get_count_query
-	 * @covers ::get_post_types
 	 */
 	public function test_get_total_unindexed() {
 		$expected_query = "
@@ -133,7 +132,6 @@ class Indexable_Post_Indexation_Action_Test extends TestCase {
 	 * Tests the get_limited_unindexed_count method with a limit.
 	 *
 	 * @covers ::__construct
-	 * @covers ::get_post_types
 	 * @covers ::get_select_query
 	 */
 	public function test_get_limited_unindexed_count() {
@@ -175,7 +173,6 @@ class Indexable_Post_Indexation_Action_Test extends TestCase {
 	 *
 	 * @covers ::__construct
 	 * @covers ::get_total_unindexed
-	 * @covers ::get_post_types
 	 */
 	public function test_get_total_unindexed_cached() {
 		Functions\expect( 'get_transient' )->once()->with( 'wpseo_total_unindexed_posts' )->andReturn( '10' );
@@ -211,7 +208,6 @@ class Indexable_Post_Indexation_Action_Test extends TestCase {
 	 *
 	 * @covers ::__construct
 	 * @covers ::get_total_unindexed
-	 * @covers ::get_post_types
 	 */
 	public function test_get_total_unindexed_with_excluded_post_types() {
 		$public_post_types = [ 'public_post_type' ];
@@ -248,7 +244,6 @@ class Indexable_Post_Indexation_Action_Test extends TestCase {
 	 * @covers ::__construct
 	 * @covers ::index
 	 * @covers ::get_limit
-	 * @covers ::get_post_types
 	 */
 	public function test_index() {
 		$expected_query = "
@@ -328,7 +323,6 @@ class Indexable_Post_Indexation_Action_Test extends TestCase {
 	 * @covers ::__construct
 	 * @covers ::index
 	 * @covers ::get_limit
-	 * @covers ::get_post_types
 	 */
 	public function test_index_with_excluded_post_types() {
 		$public_post_types = [ 'public_post_type' ];
@@ -384,7 +378,6 @@ class Indexable_Post_Indexation_Action_Test extends TestCase {
 	 * @covers ::__construct
 	 * @covers ::index
 	 * @covers ::get_limit
-	 * @covers ::get_post_types
 	 */
 	public function test_index_no_indexables_created() {
 		$expected_query = "

--- a/tests/unit/actions/indexing/post-link-indexing-action-test.php
+++ b/tests/unit/actions/indexing/post-link-indexing-action-test.php
@@ -100,7 +100,7 @@ class Post_Link_Indexing_Action_Test extends TestCase {
 	 * Tests getting the total unindexed.
 	 *
 	 * @covers ::get_count_query
-	 * @covers \Yoast\WP\SEO\Actions\Indexation\Abstract_Link_Indexing_Action::get_total_unindexed
+	 * @covers \Yoast\WP\SEO\Actions\Indexing\Abstract_Link_Indexing_Action::get_total_unindexed
 	 */
 	public function test_get_total_unindexed() {
 		Functions\expect( 'get_transient' )
@@ -156,7 +156,6 @@ class Post_Link_Indexing_Action_Test extends TestCase {
 	 * @covers ::get_count_query
 	 * @covers ::get_total_unindexed
 	 * @covers ::get_limited_unindexed_count
-	 * @covers \Yoast\WP\SEO\Actions\Indexation\Abstract_Link_Indexing_Action::get_total_unindexed
 	 */
 	public function test_get_limited_unindexed_count() {
 		Functions\expect( 'get_transient' )
@@ -283,7 +282,6 @@ class Post_Link_Indexing_Action_Test extends TestCase {
 	 * Tests the index function.
 	 *
 	 * @covers ::get_objects
-	 * @covers \Yoast\WP\SEO\Actions\Indexation\Abstract_Link_Indexing_Action::index
 	 */
 	public function test_index_without_link_count() {
 		Filters\expectApplied( 'wpseo_link_indexing_limit' );

--- a/tests/unit/actions/indexing/term-link-indexing-action-test.php
+++ b/tests/unit/actions/indexing/term-link-indexing-action-test.php
@@ -100,7 +100,7 @@ class Term_Link_Indexing_Action_Test extends TestCase {
 	 * Tests getting the unindexed count with a limit.
 	 *
 	 * @covers ::get_count_query
-	 * @covers \Yoast\WP\SEO\Actions\Indexation\Abstract_Link_Indexing_Action::get_total_unindexed
+	 * @covers \Yoast\WP\SEO\Actions\Indexing\Abstract_Link_Indexing_Action::get_total_unindexed
 	 */
 	public function test_get_total_unindexed() {
 		$expected_query = "
@@ -148,7 +148,7 @@ class Term_Link_Indexing_Action_Test extends TestCase {
 	 *
 	 * @covers ::get_count_query
 	 * @covers ::get_total_unindexed
-	 * @covers \Yoast\WP\SEO\Actions\Indexation\Abstract_Link_Indexing_Action::get_limited_unindexed_count
+	 * @covers \Yoast\WP\SEO\Actions\Indexing\Abstract_Link_Indexing_Action::get_limited_unindexed_count
 	 */
 	public function test_get_limited_unindexed_count() {
 		$expected_query = "
@@ -195,7 +195,7 @@ class Term_Link_Indexing_Action_Test extends TestCase {
 	/**
 	 * Tests getting the total unindexed.
 	 *
-	 * @covers \Yoast\WP\SEO\Actions\Indexation\Abstract_Link_Indexing_Action::get_total_unindexed
+	 * @covers \Yoast\WP\SEO\Actions\Indexing\Abstract_Link_Indexing_Action::get_total_unindexed
 	 */
 	public function test_get_total_unindexed_cached() {
 		Functions\expect( 'get_transient' )
@@ -209,7 +209,7 @@ class Term_Link_Indexing_Action_Test extends TestCase {
 	/**
 	 * Tests getting the total unindexed.
 	 *
-	 * @covers \Yoast\WP\SEO\Actions\Indexation\Abstract_Link_Indexing_Action::get_total_unindexed
+	 * @covers \Yoast\WP\SEO\Actions\Indexing\Abstract_Link_Indexing_Action::get_total_unindexed
 	 */
 	public function test_get_total_unindexed_failed_query() {
 		Functions\expect( 'get_transient' )
@@ -256,7 +256,7 @@ class Term_Link_Indexing_Action_Test extends TestCase {
 	 * Tests the index function.
 	 *
 	 * @covers ::get_objects
-	 * @covers \Yoast\WP\SEO\Actions\Indexation\Abstract_Link_Indexing_Action::index
+	 * @covers \Yoast\WP\SEO\Actions\Indexing\Abstract_Link_Indexing_Action::index
 	 */
 	public function test_index() {
 		Filters\expectApplied( 'wpseo_link_indexing_limit' );
@@ -323,7 +323,7 @@ class Term_Link_Indexing_Action_Test extends TestCase {
 	 * Tests the index function.
 	 *
 	 * @covers ::get_objects
-	 * @covers \Yoast\WP\SEO\Actions\Indexation\Abstract_Link_Indexing_Action::index
+	 * @covers \Yoast\WP\SEO\Actions\Indexing\Abstract_Link_Indexing_Action::index
 	 */
 	public function test_index_without_link_count() {
 		Filters\expectApplied( 'wpseo_link_indexing_limit' );

--- a/tests/unit/conditionals/front-end-conditional-test.php
+++ b/tests/unit/conditionals/front-end-conditional-test.php
@@ -32,15 +32,6 @@ class Front_End_Conditional_Test extends TestCase {
 	}
 
 	/**
-	 * Tests if the needed attributes are set correctly.
-	 *
-	 * @covers ::__construct
-	 */
-	public function test_construct() {
-		$this->assertInstanceOf( Front_End_Conditional::class, $this->instance );
-	}
-
-	/**
 	 * Tests that the conditional is met when is_admin is false.
 	 *
 	 * @covers ::is_met

--- a/tests/unit/exceptions/importing/aioseo-validation-exception-test.php
+++ b/tests/unit/exceptions/importing/aioseo-validation-exception-test.php
@@ -10,7 +10,7 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  *
  * @group exceptions
  *
- * @coversDefaultClass \Yoast\WP\SEO\Exceptions\Indexable\Aioseo_Validation_Exception
+ * @coversDefaultClass \Yoast\WP\SEO\Exceptions\Importing\Aioseo_Validation_Exception
  */
 class Aioseo_Validation_Exception_Test extends TestCase {
 

--- a/tests/unit/helpers/crawl-cleanup-helper-test.php
+++ b/tests/unit/helpers/crawl-cleanup-helper-test.php
@@ -16,7 +16,7 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
 /**
  * Class Crawl_Cleanup_Helper_Test.
  *
- * @coversDefaultClass \Yoast\WP\SEO\Initializers\Crawl_Cleanup_Helper
+ * @coversDefaultClass \Yoast\WP\SEO\Helpers\Crawl_Cleanup_Helper
  *
  * @group integrations
  */

--- a/tests/unit/initializers/woocommerce-test.php
+++ b/tests/unit/initializers/woocommerce-test.php
@@ -33,7 +33,6 @@ class Woocommerce_Test extends TestCase {
 	/**
 	 * Tests the initialization.
 	 *
-	 * @covers ::__construct
 	 * @covers ::initialize
 	 */
 	public function test_initialize() {

--- a/tests/unit/integrations/cleanup-integration-test.php
+++ b/tests/unit/integrations/cleanup-integration-test.php
@@ -4,16 +4,10 @@ namespace Yoast\WP\SEO\Tests\Unit\Integrations;
 
 use Brain\Monkey;
 use Mockery;
-use stdClass;
 use wpdb;
-use Yoast\WP\Lib\Model;
 
-use Yoast\WP\SEO\Helpers\Author_Archive_Helper;
-use Yoast\WP\SEO\Helpers\Post_Type_Helper;
-use Yoast\WP\SEO\Helpers\Taxonomy_Helper;
 use Yoast\WP\SEO\Integrations\Cleanup_Integration;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
-use Yoast\WP\SEO\Tests\Unit\Doubles\Models\Indexable_Mock;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 use Yoast\WP\SEO\Repositories\Indexable_Cleanup_Repository;
 
@@ -93,9 +87,6 @@ class Cleanup_Integration_Test extends TestCase {
 	 *
 	 * @covers ::run_cleanup
 	 * @covers ::get_cleanup_tasks
-	 * @covers ::clean_indexables_with_object_type_and_object_sub_type
-	 * @covers ::clean_indexables_with_post_status
-	 * @covers ::cleanup_orphaned_from_table
 	 * @covers ::get_limit
 	 * @covers ::reset_cleanup
 	 */
@@ -132,9 +123,6 @@ class Cleanup_Integration_Test extends TestCase {
 	 *
 	 * @covers ::run_cleanup
 	 * @covers ::get_cleanup_tasks
-	 * @covers ::clean_indexables_with_object_type_and_object_sub_type
-	 * @covers ::clean_indexables_with_post_status
-	 * @covers ::cleanup_orphaned_from_table
 	 * @covers ::get_limit
 	 * @covers ::reset_cleanup
 	 */
@@ -164,7 +152,6 @@ class Cleanup_Integration_Test extends TestCase {
 	 * @covers ::get_cleanup_tasks
 	 * @covers ::get_limit
 	 * @covers ::reset_cleanup
-	 * @covers ::clean_indexables_with_object_type_and_object_sub_type
 	 * @covers ::start_cron_job
 	 */
 	public function test_run_cleanup_starts_cron_job() {
@@ -233,7 +220,6 @@ class Cleanup_Integration_Test extends TestCase {
 	 * @covers ::run_cleanup_cron
 	 * @covers ::get_cleanup_tasks
 	 * @covers ::get_limit
-	 * @covers ::cleanup_orphaned_from_table
 	 * @covers ::start_cron_job
 	 */
 	public function test_run_cleanup_cron_last_task() {

--- a/tests/unit/integrations/front-end/robots-txt-integration-test.php
+++ b/tests/unit/integrations/front-end/robots-txt-integration-test.php
@@ -119,8 +119,7 @@ class Robots_Txt_Integration_Test extends TestCase {
 	 * Tests the robots filter for a public site, with sitemaps.
 	 *
 	 * @covers ::filter_robots
-	 * @covers ::change_default_robots
-	 * @covers ::add_xml_sitemap
+	 * @covers ::maybe_add_xml_sitemap
 	 */
 	public function test_public_site_with_sitemaps() {
 		global $wp_rewrite;
@@ -174,8 +173,7 @@ class Robots_Txt_Integration_Test extends TestCase {
 	 * @dataProvider multisite_provider
 	 *
 	 * @covers ::filter_robots
-	 * @covers ::change_default_robots
-	 * @covers ::add_xml_sitemap
+	 * @covers ::maybe_add_xml_sitemap
 	 * @covers ::add_subdirectory_multisite_xml_sitemaps
 	 * @covers ::get_xml_sitemaps_enabled
 	 * @covers ::is_sitemap_allowed
@@ -300,8 +298,7 @@ class Robots_Txt_Integration_Test extends TestCase {
 	 * Tests the robots filter for multisite installations, other site without Yoast SEO activated.
 	 *
 	 * @covers ::filter_robots
-	 * @covers ::change_default_robots
-	 * @covers ::add_xml_sitemap
+	 * @covers ::maybe_add_xml_sitemap
 	 * @covers ::add_subdirectory_multisite_xml_sitemaps
 	 * @covers ::get_xml_sitemaps_enabled
 	 * @covers ::is_sitemap_allowed
@@ -382,8 +379,7 @@ class Robots_Txt_Integration_Test extends TestCase {
 	 * Tests the robots filter for a multisite subdirectory installation without any existing option rows.
 	 *
 	 * @covers ::filter_robots
-	 * @covers ::change_default_robots
-	 * @covers ::add_xml_sitemap
+	 * @covers ::maybe_add_xml_sitemap
 	 * @covers ::add_subdirectory_multisite_xml_sitemaps
 	 * @covers ::get_xml_sitemaps_enabled
 	 * @covers ::is_sitemap_allowed
@@ -463,8 +459,7 @@ class Robots_Txt_Integration_Test extends TestCase {
 	 * Tests the robots filter for a public site, without sitemaps.
 	 *
 	 * @covers ::filter_robots
-	 * @covers ::change_default_robots
-	 * @covers ::add_xml_sitemap
+	 * @covers ::maybe_add_xml_sitemap
 	 */
 	public function test_public_site_without_sitemaps() {
 		$this->options_helper

--- a/tests/unit/integrations/settings-integration-test.php
+++ b/tests/unit/integrations/settings-integration-test.php
@@ -83,7 +83,7 @@ class Settings_Integration_Test extends TestCase {
 	/**
 	 * Tests the addition of a submenu page.
 	 *
-	 * @covers ::add_submenu_page
+	 * @covers ::add_settings_saved_page
 	 */
 	public function test_add_submenu_page() {
 

--- a/tests/unit/integrations/third-party/woocommerce-test.php
+++ b/tests/unit/integrations/third-party/woocommerce-test.php
@@ -232,7 +232,6 @@ class WooCommerce_Test extends TestCase {
 	 * Tests the situation where the WooCommerce function doesn't exist (for some reason).
 	 *
 	 * @covers ::get_page_id
-	 * @covers ::get_shop_page_id
 	 */
 	public function test_get_page_id_when_woocommerce_function_does_not_exist() {
 		// Sets the stubs.
@@ -250,7 +249,6 @@ class WooCommerce_Test extends TestCase {
 	 * Tests the happy path where we have a page id.
 	 *
 	 * @covers ::get_page_id
-	 * @covers ::get_shop_page_id
 	 */
 	public function test_get_page_id() {
 		$this->woocommerce_helper->expects( 'is_shop_page' )
@@ -270,8 +268,6 @@ class WooCommerce_Test extends TestCase {
 	 * @dataProvider meta_value_provider
 	 *
 	 * @covers ::title
-	 * @covers ::is_shop_page
-	 * @covers ::get_shop_page_id
 	 *
 	 * @param string   $expected       The expected value.
 	 * @param string   $model_value    Value that is set as indexable title.
@@ -315,8 +311,6 @@ class WooCommerce_Test extends TestCase {
 	 * @dataProvider meta_value_provider
 	 *
 	 * @covers ::description
-	 * @covers ::is_shop_page
-	 * @covers ::get_shop_page_id
 	 *
 	 * @param string   $expected       The expected value.
 	 * @param string   $model_value    Value that is set as indexable title.

--- a/tests/unit/presentations/indexable-presentation/permalink-test.php
+++ b/tests/unit/presentations/indexable-presentation/permalink-test.php
@@ -53,7 +53,6 @@ class Permalink_Test extends TestCase {
 	 * Tests the permalink getter method with dynamic permalinks enabled.
 	 *
 	 * @covers ::generate_permalink
-	 * @covers ::get_permalink
 	 */
 	public function test_get_permalink_with_dynamic_permalinks() {
 		$this->indexable->permalink = 'https://example.com/permalink/';

--- a/tests/unit/surfaces/helpers-surface-test.php
+++ b/tests/unit/surfaces/helpers-surface-test.php
@@ -65,7 +65,7 @@ class Helpers_Surface_Test extends TestCase {
 	/**
 	 * The get method should rethrow exceptions from the container.
 	 *
-	 * @covers ::get
+	 * @covers ::__get
 	 * @dataProvider provide_classes
 	 *
 	 * @param string $helper_name Helper name.

--- a/tests/unit/surfaces/open-graph-helpers-surface-test.php
+++ b/tests/unit/surfaces/open-graph-helpers-surface-test.php
@@ -65,7 +65,7 @@ class Open_Graph_Helpers_Surface_Test extends TestCase {
 	/**
 	 * The get method should rethrow exceptions from the container.
 	 *
-	 * @covers ::get
+	 * @covers ::__get
 	 * @dataProvider provide_classes
 	 *
 	 * @param string $helper_name Helper name.

--- a/tests/unit/surfaces/schema-helpers-surface-test.php
+++ b/tests/unit/surfaces/schema-helpers-surface-test.php
@@ -65,7 +65,7 @@ class Schema_Helpers_Surface_Test extends TestCase {
 	/**
 	 * The get method should rethrow exceptions from the container.
 	 *
-	 * @covers ::get
+	 * @covers ::__get
 	 * @dataProvider provide_classes
 	 *
 	 * @param string $helper_name Helper name.

--- a/tests/unit/surfaces/twitter-helpers-surface-test.php
+++ b/tests/unit/surfaces/twitter-helpers-surface-test.php
@@ -65,7 +65,7 @@ class Twitter_Helpers_Surface_Test extends TestCase {
 	/**
 	 * The get method should rethrow exceptions from the container.
 	 *
-	 * @covers ::get
+	 * @covers ::__get
 	 * @dataProvider provide_classes
 	 *
 	 * @param string $helper_name Helper name.


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Fix incorrect covers tags in tests.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes incorrect covers tags in tests.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Make sure you have phpunit 9 installed.
* Create test coverage report on the command line `./vendor/bin/phpunit --coverage-html ~/Desktop/coverage-report`
* Check you get no warnings on the command line.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes https://github.com/Yoast/wordpress-seo/issues/20271
