### PR TITLE
20103 tighten crawl optimization site search blocking rules

### DIFF
--- a/packages/js/src/settings/routes/crawl-optimization.js
+++ b/packages/js/src/settings/routes/crawl-optimization.js
@@ -171,14 +171,16 @@ const CrawlOptimization = () => {
 		),
 		denySearchCrawling: createInterpolateElement(
 			sprintf(
-				/* translators: %1$s and %2$s expand to example parts of a URL, surrounded by <code> tags. */
-				__( "Add a ‘disallow’ rule to your robots.txt file to prevent crawling of %1$s and %2$s URLs.", "wordpress-seo" ),
+				/* translators: %1$s, %2$s and %3$s expand to example parts of a URL, surrounded by <code> tags. */
+				__( "Add a 'disallow' rule to your robots.txt file to prevent crawling of URLs like %1$s, %2$s and %3$s.", "wordpress-seo" ),
 				"<code1/>",
-				"<code2/>"
+				"<code2/>",
+				"<code3/>"
 			),
 			{
 				code1: <Code>?s=</Code>,
 				code2: <Code>/search/</Code>,
+				code3: <Code>/page/*/?s=</Code>,
 			}
 		),
 

--- a/packages/js/src/settings/routes/crawl-optimization.js
+++ b/packages/js/src/settings/routes/crawl-optimization.js
@@ -172,7 +172,7 @@ const CrawlOptimization = () => {
 		denySearchCrawling: createInterpolateElement(
 			sprintf(
 				/* translators: %1$s, %2$s and %3$s expand to example parts of a URL, surrounded by <code> tags. */
-				__( "Add a 'disallow' rule to your robots.txt file to prevent crawling of URLs like %1$s, %2$s and %3$s.", "wordpress-seo" ),
+				__( "Add a ‘disallow’ rule to your robots.txt file to prevent crawling of URLs like %1$s, %2$s and %3$s.", "wordpress-seo" ),
 				"<code1/>",
 				"<code2/>",
 				"<code3/>"

--- a/src/integrations/front-end/robots-txt-integration.php
+++ b/src/integrations/front-end/robots-txt-integration.php
@@ -116,6 +116,7 @@ class Robots_Txt_Integration implements Integration_Interface {
 	 */
 	public function add_disallow_search_to_robots( Robots_Txt_Helper $robots_txt_helper ) {
 		$robots_txt_helper->add_disallow( '*', '/?s=' );
+		$robots_txt_helper->add_disallow( '*', '/page/*/?s=' );
 		$robots_txt_helper->add_disallow( '*', '/search/' );
 	}
 

--- a/tests/unit/integrations/front-end/robots-txt-integration-test.php
+++ b/tests/unit/integrations/front-end/robots-txt-integration-test.php
@@ -569,6 +569,12 @@ class Robots_Txt_Integration_Test extends TestCase {
 
 		$robots_txt_helper
 			->expects( 'add_disallow' )
+			->with( '*', '/page/*/?s=' )
+			->once()
+			->andReturn();
+
+		$robots_txt_helper
+			->expects( 'add_disallow' )
 			->with( '*', '/search/' )
 			->once()
 			->andReturn();


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Add `/page/*/?s=` pattern when preventing crawling of internal site search URLs.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Tightens crawl optimization site search blocking rules.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Go to `Yoast SEO`->`Settings`->`Advanced`->`Crawl optimisation`
* Toggle `Prevent crawling of internal site search URLs`
* Check description of the toggle contain `/page/*/?s=`
* Go to http://basic.wordpress.test/robots.txt
* Check you see: 
```
Disallow: /?s=
Disallow: /page/*/?s=
Disallow: /search/
```

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes [Tighten crawl optimization site search blocking rules#20103](https://github.com/Yoast/wordpress-seo/issues/20103)
