### PR TITLE
Tests: `set_up()` methods cannot "cover" anything

### DIFF
--- a/tests/unit/helpers/crawl-cleanup-helper-test.php
+++ b/tests/unit/helpers/crawl-cleanup-helper-test.php
@@ -59,8 +59,6 @@ class Crawl_Cleanup_Helper_Test extends TestCase {
 
 	/**
 	 * Sets up the tests.
-	 *
-	 * @covers ::__construct
 	 */
 	protected function set_up() {
 		parent::set_up();

--- a/tests/unit/initializers/crawl-cleanup-permalinks-test.php
+++ b/tests/unit/initializers/crawl-cleanup-permalinks-test.php
@@ -59,8 +59,6 @@ class Crawl_Cleanup_Permalinks_Test extends TestCase {
 
 	/**
 	 * Sets up the tests.
-	 *
-	 * @covers ::__construct
 	 */
 	protected function set_up() {
 		parent::set_up();

--- a/tests/unit/integrations/admin/first-time-configuration-notice-integration-test.php
+++ b/tests/unit/integrations/admin/first-time-configuration-notice-integration-test.php
@@ -60,8 +60,6 @@ class First_Time_Configuration_Notice_Integration_Test extends TestCase {
 
 	/**
 	 * Sets up the tests.
-	 *
-	 * @covers __construct
 	 */
 	protected function set_up() {
 		parent::set_up();


### PR DESCRIPTION
## Context

* Improve test suite

## Summary

This PR can be summarized in the following changelog entry:

* Improve test suite

## Relevant technical choices:

`set_up()` fixtures should "set up" the environment for the test. The code in the setup should not be regarded as part of the test itself.


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a test-only change and should have no effect on the functionality. If the build passes (linting, test runs), we're good.