### PR TITLE
Tests: sync `Addon_Manager_Double` with parent class

### DIFF
--- a/tests/unit/doubles/inc/addon-manager-double.php
+++ b/tests/unit/doubles/inc/addon-manager-double.php
@@ -39,6 +39,7 @@ class Addon_Manager_Double extends WPSEO_Addon_Manager {
 	 * @param stdClass      $subscription    The subscription to convert.
 	 * @param stdClass|null $yoast_free_data The Yoast Free's data.
 	 * @param bool          $plugin_info     Whether we're in the plugin information modal.
+	 * @param string        $plugin_file     The plugin filename.
 	 *
 	 * @return stdClass The converted subscription.
 	 */
@@ -47,7 +48,7 @@ class Addon_Manager_Double extends WPSEO_Addon_Manager {
 			->withAnyArgs()
 			->andReturn( (object) $subscription );
 
-		return parent::convert_subscription_to_plugin( $subscription, $yoast_free_data, $plugin_info );
+		return parent::convert_subscription_to_plugin( $subscription, $yoast_free_data, $plugin_info, $plugin_file );
 	}
 
 	/**

--- a/tests/unit/inc/addon-manager-test.php
+++ b/tests/unit/inc/addon-manager-test.php
@@ -860,7 +860,7 @@ class Addon_Manager_Test extends TestCase {
 							'new_version'      => '10.0',
 							'name'             => 'Extension',
 							'slug'             => 'yoast-seo-wordpress-premium',
-							'plugin'           => '',
+							'plugin'           => 'wp-seo-premium.php',
 							'url'              => 'https://example.org/store',
 							'last_update'      => 'yesterday',
 							'homepage'         => 'https://example.org/store',


### PR DESCRIPTION
## Context

* Improve test suite

## Summary

This PR can be summarized in the following changelog entry:

* Improve test suite

## Relevant technical choices:

The `Addon_Manager::convert_subscription_to_plugin()` parent method received a new `$plugin_file` parameter over a year ago and while the parameter _was_ added to the `Addon_Manager_Double::convert_subscription_to_plugin()`, the parameter was not passed to the parent class, nor documented.

This fixes it and updates the associated test expectation.


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a test-only change and should have no effect on the functionality. If the build passes (linting, test runs), we're good.