### PR TITLE
QA: various parameter name fixes

### DIFF
--- a/config/dependency-injection/deprecated-classes.php
+++ b/config/dependency-injection/deprecated-classes.php
@@ -71,5 +71,5 @@ if ( ! function_exists( '_deprecated_file' ) ) {
 	function _deprecated_file( $file, $version, $replacement = '', $message = '' ) {}
 }
 if ( ! function_exists( '_deprecated_function' ) ) {
-	function _deprecated_function( $function, $version, $replacement = '' ) {}
+	function _deprecated_function( $function_name, $version, $replacement = '' ) {}
 }

--- a/src/loader.php
+++ b/src/loader.php
@@ -279,16 +279,16 @@ class Loader {
 	/**
 	 * Gets a class from the container.
 	 *
-	 * @param string $class The class name.
+	 * @param string $class_name The class name.
 	 *
 	 * @return object|null The class or, in production environments, null if it does not exist.
 	 *
 	 * @throws Throwable If the class does not exist in development environments.
 	 * @throws Exception If the class does not exist in development environments.
 	 */
-	protected function get_class( $class ) {
+	protected function get_class( $class_name ) {
 		try {
-			return $this->container->get( $class );
+			return $this->container->get( $class_name );
 		} catch ( Throwable $e ) {
 			// In production environments do not fatal if the class could not be constructed but log and fail gracefully.
 			if ( \YOAST_ENVIRONMENT === 'production' ) {

--- a/tests/unit/integrations/admin/first-time-configuration-notice-integration-test.php
+++ b/tests/unit/integrations/admin/first-time-configuration-notice-integration-test.php
@@ -260,14 +260,14 @@ class First_Time_Configuration_Notice_Integration_Test extends TestCase {
 	/**
 	 * Expects function in should_display_first_time_configuration_notice.
 	 *
-	 * @param bool $return The expected return value of the function.
+	 * @param bool $return_value The expected return value of the function.
 	 * @return void
 	 */
-	public function expect_should_display_first_time_configuration_notice( $return ) {
+	public function expect_should_display_first_time_configuration_notice( $return_value ) {
 		$this->first_time_configuration_notice_helper
 			->expects( 'should_display_first_time_configuration_notice' )
 			->once()
-			->andReturn( $return );
+			->andReturn( $return_value );
 	}
 
 	/**


### PR DESCRIPTION
## Context

* PHP cross-version compatibility

## Summary

This PR can be summarized in the following changelog entry:

* PHP cross-version compatibility

## Relevant technical choices:

### CS/QA: don't use reserved keywords as param names

### CS/QA/Tests: don't use reserved keywords as param names

### CS/QA: match parameter name from WP Core

... to prevent (future) issues with the use of function calls with named parameters.

Ref: https://developer.wordpress.org/reference/functions/_deprecated_function/


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality. If the build passes (linting, test runs), we're good.