### PR TITLE
CS/QA: use the appropriate PHP native function

### DIFF
--- a/inc/class-wpseo-meta.php
+++ b/inc/class-wpseo-meta.php
@@ -1029,12 +1029,7 @@ class WPSEO_Meta {
 			->find_array();
 
 		// Get object_id from each subarray in $post_ids.
-		$post_ids = array_map(
-			function( $row ) {
-				return $row['object_id'];
-			},
-			$post_ids
-		);
+		$post_ids = array_column( $post_ids, 'object_id' );
 
 		/*
 		 * If Premium is installed, get the additional keywords as well.
@@ -1081,12 +1076,7 @@ class WPSEO_Meta {
 				->find_array();
 
 			// Get object_sub_type from each subarray in $post_ids.
-			$post_types = array_map(
-				function( $row ) {
-					return $row['object_sub_type'];
-				},
-				$post_types
-			);
+			$post_types = array_column( $post_types, 'object_sub_type' );
 		}
 		else {
 			$post_types = [];


### PR DESCRIPTION
## Context

* Code modernization

## Summary

This PR can be summarized in the following changelog entry:

* Code modernization

## Relevant technical choices:

No need to use `array_map()` with a closure when there is a PHP (5.5+) native function to do exactly the same.

Ref: https://www.php.net/manual/en/function.array-column.php


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality. If the build passes (linting, test runs), we're good.