### PR TITLE
CS/QA: use `self` when refering to current class

### DIFF
--- a/src/exceptions/indexable/author-not-built-exception.php
+++ b/src/exceptions/indexable/author-not-built-exception.php
@@ -16,7 +16,7 @@ class Author_Not_Built_Exception extends Not_Built_Exception {
 	 * @return Author_Not_Built_Exception The exception.
 	 */
 	public static function author_archives_are_not_indexed_for_users_without_posts( $user_id ) {
-		return new Author_Not_Built_Exception(
+		return new self(
 			'Indexable for author with id ' . $user_id . ' is not being built, since author archives are not indexed for users without posts.'
 		);
 	}
@@ -30,7 +30,7 @@ class Author_Not_Built_Exception extends Not_Built_Exception {
 	 * @return Author_Not_Built_Exception The exception.
 	 */
 	public static function author_archives_are_disabled( $user_id ) {
-		return new Author_Not_Built_Exception(
+		return new self(
 			'Indexable for author with id ' . $user_id . ' is not being built, since author archives are disabled.'
 		);
 	}
@@ -44,7 +44,7 @@ class Author_Not_Built_Exception extends Not_Built_Exception {
 	 * @return Author_Not_Built_Exception The exception.
 	 */
 	public static function author_not_built_because_of_filter( $user_id ) {
-		return new Author_Not_Built_Exception(
+		return new self(
 			'Indexable for author with id ' . $user_id . ' is not being built, since it is excluded because of the \'wpseo_should_build_and_save_user_indexable\' filter.'
 		);
 	}

--- a/src/exceptions/indexable/not-built-exception.php
+++ b/src/exceptions/indexable/not-built-exception.php
@@ -16,7 +16,7 @@ class Not_Built_Exception extends Indexable_Exception {
 	 * @return Not_Built_Exception The exception.
 	 */
 	public static function invalid_object_id( $object_id ) {
-		return new Not_Built_Exception(
+		return new self(
 			"Indexable was not built because it had an invalid object id of $object_id."
 		);
 	}

--- a/src/exceptions/indexable/post-not-built-exception.php
+++ b/src/exceptions/indexable/post-not-built-exception.php
@@ -17,7 +17,7 @@ class Post_Not_Built_Exception extends Not_Built_Exception {
 	 */
 	public static function because_not_indexable( $post_id ) {
 		/* translators: %s: expands to the post id */
-		return new Post_Not_Built_Exception( \sprintf( \__( 'The post %s could not be indexed because it does not meet indexing requirements.', 'wordpress-seo' ), $post_id ) );
+		return new self( \sprintf( \__( 'The post %s could not be indexed because it does not meet indexing requirements.', 'wordpress-seo' ), $post_id ) );
 	}
 
 	/**
@@ -29,6 +29,6 @@ class Post_Not_Built_Exception extends Not_Built_Exception {
 	 */
 	public static function because_post_type_excluded( $post_id ) {
 		/* translators: %s: expands to the post id */
-		return new Post_Not_Built_Exception( \sprintf( \__( 'The post %s could not be indexed because it\'s post type is excluded from indexing.', 'wordpress-seo' ), $post_id ) );
+		return new self( \sprintf( \__( 'The post %s could not be indexed because it\'s post type is excluded from indexing.', 'wordpress-seo' ), $post_id ) );
 	}
 }

--- a/src/exceptions/indexable/post-type-not-built-exception.php
+++ b/src/exceptions/indexable/post-type-not-built-exception.php
@@ -17,6 +17,6 @@ class Post_Type_Not_Built_Exception extends Not_Built_Exception {
 	 */
 	public static function because_not_indexable( $post_type ) {
 		/* translators: %s: expands to the post type */
-		return new Post_Type_Not_Built_Exception( \sprintf( \__( 'The post type %s could not be indexed because it does not meet indexing requirements.', 'wordpress-seo' ), $post_type ) );
+		return new self( \sprintf( \__( 'The post type %s could not be indexed because it does not meet indexing requirements.', 'wordpress-seo' ), $post_type ) );
 	}
 }

--- a/src/exceptions/indexable/term-not-built-exception.php
+++ b/src/exceptions/indexable/term-not-built-exception.php
@@ -17,6 +17,6 @@ class Term_Not_Built_Exception extends Not_Built_Exception {
 	 */
 	public static function because_not_indexable( $term_id ) {
 		/* translators: %s: expands to the term id */
-		return new Term_Not_Built_Exception( \sprintf( \__( 'The term %s could not be built because it\'s not indexable.', 'wordpress-seo' ), $term_id ) );
+		return new self( \sprintf( \__( 'The term %s could not be built because it\'s not indexable.', 'wordpress-seo' ), $term_id ) );
 	}
 }


### PR DESCRIPTION
## Context

* Code style consistency
* Code quality

## Summary

This PR can be summarized in the following changelog entry:

* Code style consistency

## Relevant technical choices:

* 


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality. If the build passes (linting, test runs), we're good.