### PR TITLE
QA: fix various unused/undeclared variable issues

### DIFF
--- a/admin/import/plugins/class-import-seopressor.php
+++ b/admin/import/plugins/class-import-seopressor.php
@@ -45,7 +45,7 @@ class WPSEO_Import_SEOPressor extends WPSEO_Plugin_Importer {
 	protected function import() {
 		// Query for all the posts that have an _seop_settings meta set.
 		$query_posts = new WP_Query( 'post_type=any&meta_key=_seop_settings&order=ASC&fields=ids&nopaging=true' );
-		foreach ( $query_posts->posts as $key => $post_id ) {
+		foreach ( $query_posts->posts as $post_id ) {
 			$this->import_post_focus_keywords( $post_id );
 			$this->import_seopressor_post_settings( $post_id );
 		}

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -1574,7 +1574,7 @@ class WPSEO_Upgrade {
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Reason: No user input, just a table name.
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery -- Reason: Most performant way.
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching -- Reason: No relevant caches.
-		$delete_query = $wpdb->query(
+		$wpdb->query(
 			"DELETE FROM $indexable_table
 			WHERE post_status = 'unindexed'
 			AND object_type NOT IN ( 'home-page', 'date-archive', 'post-type-archive', 'system-page' )

--- a/inc/class-wpseo-meta.php
+++ b/inc/class-wpseo-meta.php
@@ -383,8 +383,6 @@ class WPSEO_Meta {
 					unset( $field_defs['bctitle'] );
 				}
 
-				global $post;
-
 				if ( empty( $post->ID ) || ( ! empty( $post->ID ) && self::get_value( 'redirect', $post->ID ) === '' ) ) {
 					unset( $field_defs['redirect'] );
 				}

--- a/inc/options/class-wpseo-options.php
+++ b/inc/options/class-wpseo-options.php
@@ -59,7 +59,7 @@ class WPSEO_Options {
 	protected function __construct() {
 		$this->register_hooks();
 
-		foreach ( static::$options as $option_name => $option_class ) {
+		foreach ( static::$options as $option_class ) {
 			static::register_option( call_user_func( [ $option_class, 'get_instance' ] ) );
 		}
 	}

--- a/inc/sitemaps/class-sitemap-image-parser.php
+++ b/inc/sitemaps/class-sitemap-image-parser.php
@@ -457,7 +457,7 @@ class WPSEO_Sitemap_Image_Parser {
 		);
 
 		$gallery_attachments = [];
-		foreach ( $attachments as $key => $val ) {
+		foreach ( $attachments as $val ) {
 			$gallery_attachments[ $val->ID ] = $val;
 		}
 

--- a/inc/sitemaps/class-sitemaps-renderer.php
+++ b/inc/sitemaps/class-sitemaps-renderer.php
@@ -232,7 +232,7 @@ class WPSEO_Sitemaps_Renderer {
 			$output .= "\t\t\t<image:loc>" . $this->encode_and_escape( $img['src'] ) . "</image:loc>\n";
 			$output .= "\t\t</image:image>\n";
 		}
-		unset( $img, $title, $alt );
+		unset( $img );
 
 		$output .= "\t</url>\n";
 

--- a/lib/migrations/table.php
+++ b/lib/migrations/table.php
@@ -224,7 +224,6 @@ class Table {
 	 * @return string The SQL.
 	 */
 	private function columns_to_str() {
-		$str    = '';
 		$fields = [];
 		$len    = \count( $this->columns );
 		for ( $i = 0; $i < $len; $i++ ) {

--- a/lib/model.php
+++ b/lib/model.php
@@ -402,7 +402,7 @@ class Model implements JsonSerializable {
 		$associated_table_name = static::get_table_name_for_class( static::$auto_prefix_models . $associated_class_name );
 		$foreign_key_name      = static::build_foreign_key_name( $foreign_key_name, $associated_table_name );
 		$associated_object_id  = $this->{$foreign_key_name};
-		$desired_record        = null;
+
 		if ( $foreign_key_name_in_associated_models_table === null ) {
 			/*
 			 * Comparison: "{$associated_table_name}.primary_key = {$associated_object_id}".

--- a/src/actions/wincher/wincher-keyphrases-action.php
+++ b/src/actions/wincher/wincher-keyphrases-action.php
@@ -275,8 +275,6 @@ class Wincher_Keyphrases_Action {
 	 * @return array
 	 */
 	protected function collect_all_keyphrases() {
-		global $wpdb;
-
 		// Collect primary keyphrases first.
 		$keyphrases = \array_column(
 			$this->indexable_repository

--- a/src/generators/schema/faq.php
+++ b/src/generators/schema/faq.php
@@ -34,7 +34,7 @@ class FAQ extends Abstract_Schema_Piece {
 	private function generate_ids() {
 		$ids = [];
 		foreach ( $this->context->blocks['yoast/faq-block'] as $block ) {
-			foreach ( $block['attrs']['questions'] as $index => $question ) {
+			foreach ( $block['attrs']['questions'] as $question ) {
 				if ( ! isset( $question['jsonAnswer'] ) || empty( $question['jsonAnswer'] ) ) {
 					continue;
 				}

--- a/src/presenters/open-graph/image-presenter.php
+++ b/src/presenters/open-graph/image-presenter.php
@@ -41,7 +41,7 @@ class Image_Presenter extends Abstract_Indexable_Presenter {
 		}
 
 		$return = '';
-		foreach ( $images as $image_index => $image_meta ) {
+		foreach ( $images as $image_meta ) {
 			$image_url = $image_meta['url'];
 
 			if ( \is_attachment() ) {

--- a/tests/integration/admin/test-class-database-proxy.php
+++ b/tests/integration/admin/test-class-database-proxy.php
@@ -431,7 +431,6 @@ class WPSEO_Database_Proxy_Test extends WPSEO_UnitTestCase {
 		global $wpdb;
 
 		$proxy_table_name = self::$proxy_table_name . '_duplicate';
-		$proxy            = new WPSEO_Database_Proxy( $wpdb, $proxy_table_name, true );
 
 		$this->assertTrue( in_array( $proxy_table_name, $wpdb->tables, true ) );
 	}
@@ -445,7 +444,6 @@ class WPSEO_Database_Proxy_Test extends WPSEO_UnitTestCase {
 		global $wpdb;
 
 		$proxy_table_name = self::$proxy_table_name . '_duplicate';
-		$proxy            = new WPSEO_Database_Proxy( $wpdb, $proxy_table_name, true, true );
 
 		$this->assertTrue( in_array( $proxy_table_name, $wpdb->ms_global_tables, true ) );
 	}

--- a/tests/integration/repositories/seo-links-repository-test.php
+++ b/tests/integration/repositories/seo-links-repository-test.php
@@ -162,8 +162,6 @@ class SEO_Links_Repository_Test extends WPSEO_UnitTestCase {
 	 * @covers ::find_all_by_indexable_id
 	 */
 	public function test_find_all_by_indexable_id_no_results_found() {
-		$indexable_id = '1';
-
 		$result = $this->instance->find_all_by_indexable_id( 3 );
 
 		$this->assertIsArray( $result, 'The result should be an array when there are no result.' );

--- a/tests/integration/test-class-rewrite.php
+++ b/tests/integration/test-class-rewrite.php
@@ -130,7 +130,6 @@ class WPSEO_Rewrite_Test extends WPSEO_UnitTestCase {
 
 		$c = self::$class_instance;
 
-		$categories          = get_categories( [ 'hide_empty' => false ] );
 		$permalink_structure = get_option( 'permalink_structure' );
 
 		if ( ! ( is_multisite() && strpos( $permalink_structure, '/blog/' ) === 0 ) ) {

--- a/tests/unit/actions/importing/abstract-aioseo-importing-action-test.php
+++ b/tests/unit/actions/importing/abstract-aioseo-importing-action-test.php
@@ -157,7 +157,7 @@ class Abstract_Aioseo_Importing_Action_Test extends TestCase {
 			->once()
 			->with( 'importing_completed', $expected_arg );
 
-		$completed = $this->mock_instance->set_completed( false );
+		$this->mock_instance->set_completed( false );
 	}
 
 	/**
@@ -182,6 +182,6 @@ class Abstract_Aioseo_Importing_Action_Test extends TestCase {
 			->once()
 			->with( 'importing_completed', $expected_arg );
 
-		$completed = $this->mock_instance->set_completed( true );
+		$this->mock_instance->set_completed( true );
 	}
 }

--- a/tests/unit/actions/importing/aioseo-general-settings-importing-action-test.php
+++ b/tests/unit/actions/importing/aioseo-general-settings-importing-action-test.php
@@ -209,7 +209,7 @@ class Aioseo_General_Settings_Importing_Action_Test extends TestCase {
 	 */
 	public function test_map( $setting, $setting_value, $times, $transform_times, $image_times, $set_image_times ) {
 		$this->mock_instance->build_mapping();
-		$aioseo_options_to_yoast_map = $this->mock_instance->get_aioseo_options_to_yoast_map();
+		$this->mock_instance->get_aioseo_options_to_yoast_map();
 
 		$this->options->shouldReceive( 'get_default' )
 			->times( $times )

--- a/tests/unit/admin/admin-features-test.php
+++ b/tests/unit/admin/admin-features-test.php
@@ -8,12 +8,10 @@ use WP_User;
 use WPSEO_Admin;
 use WPSEO_Primary_Term_Admin;
 use Yoast\WP\SEO\Helpers\Current_Page_Helper;
-use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Product_Helper;
 use Yoast\WP\SEO\Helpers\Short_Link_Helper;
 
 use Yoast\WP\SEO\Helpers\Url_Helper;
-use Yoast\WP\SEO\Tests\Unit\Doubles\Helpers\Short_Link_Helper_Double;
 
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 use Yoast_Dashboard_Widget;
@@ -26,40 +24,11 @@ use Yoast_Dashboard_Widget;
 class Admin_Features_Test extends TestCase {
 
 	/**
-	 * The options helper.
-	 *
-	 * @var Mockery\MockInterface
-	 */
-	private $options_helper;
-
-	/**
-	 * The product helper.
-	 *
-	 * @var Mockery\MockInterface
-	 */
-	private $product_helper;
-
-	/**
-	 * Sets up the class under test and mock objects.
-	 */
-	public function set_up() {
-		parent::set_up();
-
-		$this->options_helper = Mockery::mock( Options_Helper::class );
-		$this->product_helper = Mockery::mock( Product_Helper::class );
-	}
-
-	/**
 	 * Returns an instance with set expectations for the dependencies.
 	 *
 	 * @return WPSEO_Admin Instance to test against.
 	 */
 	private function get_admin_with_expectations() {
-		$shortlinker = new Short_Link_Helper_Double(
-			$this->options_helper,
-			$this->product_helper
-		);
-
 		Monkey\Functions\expect( 'admin_url' )
 			->once()
 			->with( '?page=' . WPSEO_Admin::PAGE_IDENTIFIER . '&yoast_dismiss=upsell' )

--- a/tests/unit/builders/indexable-builder/maybe-build-author-indexable-test.php
+++ b/tests/unit/builders/indexable-builder/maybe-build-author-indexable-test.php
@@ -100,12 +100,6 @@ class Maybe_Build_Author_Indexable_Test extends Abstract_Indexable_Builder_TestC
 		$author_indexable->object_type = 'user';
 		$author_indexable->object_id   = $author_id;
 
-
-		$author_defaults = [
-			'object_type' => 'user',
-			'object_id'   => $author_id,
-		];
-
 		$this->indexable_repository
 			->expects( 'find_by_id_and_type' )
 			->once()

--- a/tests/unit/helpers/crawl-cleanup-helper-test.php
+++ b/tests/unit/helpers/crawl-cleanup-helper-test.php
@@ -388,8 +388,8 @@ class Crawl_Cleanup_Helper_Test extends TestCase {
 	 */
 	public function test_query_var_page_url( $is_search, $proper_url, $home_url, $get_search_query, $expected ) {
 		global $wp_query;
-		$wp_query = Mockery::mock( WP_Query::class );
-
+		$wp_query                      = Mockery::mock( WP_Query::class );
+		$wp_query->query_vars['paged'] = 'test';
 
 		Monkey\Functions\expect( 'is_search' )
 			->once()
@@ -403,12 +403,6 @@ class Crawl_Cleanup_Helper_Test extends TestCase {
 			Monkey\Functions\expect( 'get_search_query' )
 				->times( $get_search_query )
 				->andReturn( 'test' );
-
-		global $wp_query;
-
-		$wp_query = Mockery::mock( WP_Query::class );
-
-		$wp_query->query_vars['paged'] = 'test';
 
 		$this->assertSame( $expected, $this->instance->query_var_page_url( $proper_url ) );
 	}

--- a/tests/unit/helpers/social-profiles-helper-test.php
+++ b/tests/unit/helpers/social-profiles-helper-test.php
@@ -208,8 +208,7 @@ class Social_Profiles_Helper_Test extends TestCase {
 	 * @param array $expected                    The expected field names which failed to be saved in the db.
 	 */
 	public function test_set_organization_social_profiles( $social_profiles, $validate_social_url_results, $validate_social_url_times, $validate_twitter_id_results, $validate_twitter_id_times, $set_option_times, $expected ) {
-		$person_id = 123;
-		$fields    = [
+		$fields = [
 			'facebook_site',
 			'twitter_site',
 			'other_social_urls',

--- a/tests/unit/repositories/orm-test.php
+++ b/tests/unit/repositories/orm-test.php
@@ -43,9 +43,7 @@ class Orm_Test extends TestCase {
 		$this->expectException( InvalidArgumentException::class );
 
 		// Act.
-		$result = $this->instance->insert_many( $models );
-
-		// Assert.
+		$this->instance->insert_many( $models );
 	}
 
 	/**
@@ -85,8 +83,6 @@ class Orm_Test extends TestCase {
 		$this->expectException( InvalidArgumentException::class );
 
 		// Act.
-		$result = $this->instance->insert_many( $models );
-
-		// Assert.
+		$this->instance->insert_many( $models );
 	}
 }

--- a/tests/unit/surfaces/helpers-surface-test.php
+++ b/tests/unit/surfaces/helpers-surface-test.php
@@ -73,7 +73,7 @@ class Helpers_Surface_Test extends TestCase {
 	public function test_get_invalid_service( $helper_name ) {
 		$this->expectException( ServiceNotFoundException::class );
 
-		$_ = $this->instance->$helper_name;
+		$this->instance->$helper_name;
 	}
 
 	/**

--- a/tests/unit/surfaces/open-graph-helpers-surface-test.php
+++ b/tests/unit/surfaces/open-graph-helpers-surface-test.php
@@ -73,7 +73,7 @@ class Open_Graph_Helpers_Surface_Test extends TestCase {
 	public function test_get_invalid_service( $helper_name ) {
 		$this->expectException( ServiceNotFoundException::class );
 
-		$_ = $this->instance->$helper_name;
+		$this->instance->$helper_name;
 	}
 
 	/**

--- a/tests/unit/surfaces/schema-helpers-surface-test.php
+++ b/tests/unit/surfaces/schema-helpers-surface-test.php
@@ -73,7 +73,7 @@ class Schema_Helpers_Surface_Test extends TestCase {
 	public function test_get_invalid_service( $helper_name ) {
 		$this->expectException( ServiceNotFoundException::class );
 
-		$_ = $this->instance->$helper_name;
+		$this->instance->$helper_name;
 	}
 
 	/**

--- a/tests/unit/surfaces/twitter-helpers-surface-test.php
+++ b/tests/unit/surfaces/twitter-helpers-surface-test.php
@@ -73,7 +73,7 @@ class Twitter_Helpers_Surface_Test extends TestCase {
 	public function test_get_invalid_service( $helper_name ) {
 		$this->expectException( ServiceNotFoundException::class );
 
-		$_ = $this->instance->$helper_name;
+		$this->instance->$helper_name;
 	}
 
 	/**


### PR DESCRIPTION
## Context

* Code quality

## Summary

This PR can be summarized in the following changelog entry:

* Code quality

## Relevant technical choices:

### CS/QA: remove global statement for unused var

### CS/QA: remove duplicate global variable import

Variable is already being imported earlier on in the same function.

### CS/QA: no need to unset non-existent vars

### CS/QA: remove some unused variable assignments

The results of a function call do not need to be assigned to a variable, unless that variable will be used later on.

Along the same lines, when looping through an array, the key of the array item does not need to be assigned unless it will be used.

### CS/QA: remove unused variables

Variables which are not being used have no business existing. All of these are variables which are being assigned a value, but are subsequently never used.


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality. If the build passes (linting, test runs), we're good.