### PR TITLE
Docs: various fixes

### DIFF
--- a/admin/ajax.php
+++ b/admin/ajax.php
@@ -367,6 +367,7 @@ new WPSEO_Shortcode_Filter();
 new WPSEO_Taxonomy_Columns();
 
 /* ********************* DEPRECATED FUNCTIONS ********************* */
+
 /**
  * Retrieves the keyword for the keyword doubles.
  */

--- a/admin/formatter/class-metabox-formatter.php
+++ b/admin/formatter/class-metabox-formatter.php
@@ -209,6 +209,7 @@ class WPSEO_Metabox_Formatter {
 			'wincherAutoAddKeyphrases'          => WPSEO_Options::get( 'wincher_automatically_add_keyphrases', false ),
 			'wordproofIntegrationActive'        => YoastSEO()->helpers->wordproof->is_active() ? 1 : 0,
 			'multilingualPluginActive'          => $this->multilingual_plugin_active(),
+
 			/**
 			 * Filter to determine whether the PreviouslyUsedKeyword assessment should run.
 			 *

--- a/inc/class-wpseo-image-utils.php
+++ b/inc/class-wpseo-image-utils.php
@@ -202,7 +202,7 @@ class WPSEO_Image_Utils {
 	 * Find the right version of an image based on size.
 	 *
 	 * @param int          $attachment_id Attachment ID.
-	 * @param string|array $size     Size name, or array of width and height in pixels (e.g [800,400]).
+	 * @param string|array $size          Size name, or array of width and height in pixels (e.g [800,400]).
 	 *
 	 * @return array|false Returns an array with image data on success, false on failure.
 	 */

--- a/src/actions/indexing/abstract-indexing-action.php
+++ b/src/actions/indexing/abstract-indexing-action.php
@@ -90,6 +90,7 @@ abstract class Abstract_Indexing_Action implements Indexation_Action_Interface, 
 		}
 
 		\set_transient( static::UNINDEXED_COUNT_TRANSIENT, $count, \DAY_IN_SECONDS );
+
 		/**
 		 * Action: 'wpseo_indexables_unindexed_calculated' - sets an option to timestamp when there are no unindexed indexables left.
 		 *

--- a/src/actions/indexing/indexable-post-type-archive-indexation-action.php
+++ b/src/actions/indexing/indexable-post-type-archive-indexation-action.php
@@ -53,9 +53,9 @@ class Indexable_Post_Type_Archive_Indexation_Action implements Indexation_Action
 	 * Indexation_Post_Type_Archive_Action constructor.
 	 *
 	 * @param Indexable_Repository       $repository The indexable repository.
-	 * @param Indexable_Builder          $builder The indexable builder.
-	 * @param Post_Type_Helper           $post_type The post type helper.
-	 * @param Indexable_Builder_Versions $versions The current versions of all indexable builders.
+	 * @param Indexable_Builder          $builder    The indexable builder.
+	 * @param Post_Type_Helper           $post_type  The post type helper.
+	 * @param Indexable_Builder_Versions $versions   The current versions of all indexable builders.
 	 */
 	public function __construct(
 		Indexable_Repository $repository,

--- a/src/actions/integrations-action.php
+++ b/src/actions/integrations-action.php
@@ -28,8 +28,8 @@ class Integrations_Action {
 	/**
 	 * Sets an integration state.
 	 *
-	 * @param string  $integration_name The name of the integration to activate/deactivate.
-	 * @param boolean $value            The value to store.
+	 * @param string $integration_name The name of the integration to activate/deactivate.
+	 * @param bool   $value            The value to store.
 	 *
 	 * @return object The response object.
 	 */

--- a/src/analytics/application/missing-indexables-collector.php
+++ b/src/analytics/application/missing-indexables-collector.php
@@ -15,7 +15,7 @@ class Missing_Indexables_Collector implements WPSEO_Collection {
 	/**
 	 * All the indexation actions.
 	 *
-	 * @var array<Indexation_Action_Interface> $indexation_actions
+	 * @var array<Indexation_Action_Interface>
 	 */
 	private $indexation_actions;
 

--- a/src/analytics/domain/missing-indexable-bucket.php
+++ b/src/analytics/domain/missing-indexable-bucket.php
@@ -10,7 +10,7 @@ class Missing_Indexable_Bucket {
 	/**
 	 * All the missing indexable count objects.
 	 *
-	 * @var array<Missing_Indexable_Count> $missing_indexable_counts
+	 * @var array<Missing_Indexable_Count>
 	 */
 	private $missing_indexable_counts;
 

--- a/src/analytics/domain/missing-indexable-count.php
+++ b/src/analytics/domain/missing-indexable-count.php
@@ -10,14 +10,14 @@ class Missing_Indexable_Count {
 	/**
 	 * The indexable type that is represented by this.
 	 *
-	 * @var string $indexable_type
+	 * @var string
 	 */
 	private $indexable_type;
 
 	/**
 	 * The amount of missing indexables.
 	 *
-	 * @var int $count
+	 * @var int
 	 */
 	private $count;
 

--- a/src/analytics/domain/to-be-cleaned-indexable-bucket.php
+++ b/src/analytics/domain/to-be-cleaned-indexable-bucket.php
@@ -10,7 +10,7 @@ class To_Be_Cleaned_Indexable_Bucket {
 	/**
 	 * All the to be cleaned indexable count objects.
 	 *
-	 * @var array<To_Be_Cleaned_Indexable_Count> $to_be_cleaned_indexable_counts
+	 * @var array<To_Be_Cleaned_Indexable_Count>
 	 */
 	private $to_be_cleaned_indexable_counts;
 

--- a/src/analytics/domain/to-be-cleaned-indexable-count.php
+++ b/src/analytics/domain/to-be-cleaned-indexable-count.php
@@ -10,14 +10,14 @@ class To_Be_Cleaned_Indexable_Count {
 	/**
 	 * The cleanup task that is represented by this.
 	 *
-	 * @var string $cleanup_name
+	 * @var string
 	 */
 	private $cleanup_name;
 
 	/**
 	 * The amount of missing indexables.
 	 *
-	 * @var int $count
+	 * @var int
 	 */
 	private $count;
 

--- a/src/analytics/domain/to-be-cleaned-indexable-count.php
+++ b/src/analytics/domain/to-be-cleaned-indexable-count.php
@@ -25,7 +25,7 @@ class To_Be_Cleaned_Indexable_Count {
 	 * The constructor.
 	 *
 	 * @param string $cleanup_name The indexable type that is represented by this.
-	 * @param int    $count          The amount of missing indexables.
+	 * @param int    $count        The amount of missing indexables.
 	 */
 	public function __construct( string $cleanup_name, int $count ) {
 		$this->cleanup_name = $cleanup_name;

--- a/src/analytics/user-interface/last-completed-indexation-integration.php
+++ b/src/analytics/user-interface/last-completed-indexation-integration.php
@@ -16,7 +16,7 @@ class Last_Completed_Indexation_Integration implements Integration_Interface {
 	/**
 	 * The options helper.
 	 *
-	 * @var Options_Helper $options_helper The options helper.
+	 * @var Options_Helper The options helper.
 	 */
 	private $options_helper;
 

--- a/src/analytics/user-interface/last-completed-indexation-integration.php
+++ b/src/analytics/user-interface/last-completed-indexation-integration.php
@@ -50,7 +50,7 @@ class Last_Completed_Indexation_Integration implements Integration_Interface {
 	 * Saves a timestamp option when there are no unindexed indexables.
 	 *
 	 * @param string $indexable_name The name of the indexable that is being checked.
-	 * @param int    $count The amount of missing indexables.
+	 * @param int    $count          The amount of missing indexables.
 	 *
 	 * @return void
 	 */

--- a/src/builders/indexable-builder.php
+++ b/src/builders/indexable-builder.php
@@ -428,6 +428,7 @@ class Indexable_Builder {
 			if ( ! $this->is_type_with_no_id( $indexable->object_type ) && ( ! isset( $indexable->object_id ) || \is_null( $indexable->object_id ) ) ) {
 				return false;
 			}
+
 			/**
 			 * The current indexable could not be indexed. Create a placeholder indexable, so we can
 			 * skip this indexable in future indexing runs.

--- a/src/builders/indexable-post-type-archive-builder.php
+++ b/src/builders/indexable-post-type-archive-builder.php
@@ -55,11 +55,11 @@ class Indexable_Post_Type_Archive_Builder {
 	/**
 	 * Indexable_Post_Type_Archive_Builder constructor.
 	 *
-	 * @param Options_Helper             $options The options helper.
-	 * @param Indexable_Builder_Versions $versions The latest version of each Indexable builder.
-	 * @param Post_Helper                $post_helper The post helper.
+	 * @param Options_Helper             $options          The options helper.
+	 * @param Indexable_Builder_Versions $versions         The latest version of each Indexable builder.
+	 * @param Post_Helper                $post_helper      The post helper.
 	 * @param Post_Type_Helper           $post_type_helper The post type helper.
-	 * @param wpdb                       $wpdb The WPDB instance.
+	 * @param wpdb                       $wpdb             The WPDB instance.
 	 */
 	public function __construct(
 		Options_Helper $options,

--- a/src/conditionals/primary-category-conditional.php
+++ b/src/conditionals/primary-category-conditional.php
@@ -37,6 +37,7 @@ class Primary_Category_Conditional implements Conditional {
 		if ( ! \is_admin() ) {
 			return true;
 		}
+
 		/**
 		 * Filter: Adds the possibility to use primary category at additional admin pages.
 		 *

--- a/src/deprecated/admin/views/class-view-utils.php
+++ b/src/deprecated/admin/views/class-view-utils.php
@@ -38,12 +38,12 @@ class Yoast_View_Utils {
 	 *
 	 * Used for all the Help sections for indexable objects like post types, taxonomies, or archives.
 	 *
-	 * @param string|object $post_type        The post type to show the search results help for.
-	 * @param string        $help_text_switch Switch the help text to one that's more appropriate
-	 *                                        for the indexable object type the help section is for.
 	 * @deprecated 20.3
 	 * @codeCoverageIgnore
 	 *
+	 * @param string|object $post_type        The post type to show the search results help for.
+	 * @param string        $help_text_switch Switch the help text to one that's more appropriate
+	 *                                        for the indexable object type the help section is for.
 	 * @return object The help panel instance.
 	 */
 	public function search_results_setting_help( $post_type, $help_text_switch = '' ) {
@@ -79,10 +79,10 @@ class Yoast_View_Utils {
 	/**
 	 * Generates the OpenGraph disabled alert, depending on whether the OpenGraph feature is disabled.
 	 *
-	 * @param string $type The type of message. Can be altered to homepage, taxonomies or archives. Empty string by default.
-	 *
 	 * @deprecated 20.3
 	 * @codeCoverageIgnore
+	 *
+	 * @param string $type The type of message. Can be altered to homepage, taxonomies or archives. Empty string by default.
 	 *
 	 * @return string The alert. Returns an empty string if the setting is enabled.
 	 */

--- a/src/deprecated/frontend/breadcrumbs.php
+++ b/src/deprecated/frontend/breadcrumbs.php
@@ -132,6 +132,7 @@ class WPSEO_Breadcrumbs {
 	private function render() {
 		$presenter = new Breadcrumbs_Presenter();
 		$context   = $this->context_memoizer->for_current_page();
+
 		/** This filter is documented in src/integrations/front-end-integration.php */
 		$presentation            = apply_filters( 'wpseo_frontend_presentation', $context->presentation, $context );
 		$presenter->presentation = $presentation;

--- a/src/deprecated/frontend/frontend.php
+++ b/src/deprecated/frontend/frontend.php
@@ -113,6 +113,7 @@ class WPSEO_Frontend {
 
 		$presentation = $this->get_current_page_presentation();
 		$presenter    = new Canonical_Presenter();
+
 		/** This filter is documented in src/integrations/front-end-integration.php */
 		$presenter->presentation = $presentation;
 		$presenter->helpers      = $this->helpers;
@@ -270,6 +271,7 @@ class WPSEO_Frontend {
 	 */
 	private function get_current_page_presentation() {
 		$context = $this->context_memoizer->for_current_page();
+
 		/** This filter is documented in src/integrations/front-end-integration.php */
 		return apply_filters( 'wpseo_frontend_presentation', $context->presentation, $context );
 	}

--- a/src/deprecated/i18n/i18n-v3.php
+++ b/src/deprecated/i18n/i18n-v3.php
@@ -49,8 +49,6 @@ class Yoast_I18n_v3 {
 	 * @deprecated 19.12
 	 * @codeCoverageIgnore
 	 *
-	 * @access public
-	 *
 	 * @return string The i18n promo message.
 	 */
 	public function get_promo_message() {
@@ -64,8 +62,6 @@ class Yoast_I18n_v3 {
 	 * @deprecated 19.12
 	 * @codeCoverageIgnore
 	 *
-	 * @access private
-	 *
 	 * @return string
 	 */
 	public function get_dismiss_i18n_message_button() {
@@ -78,8 +74,6 @@ class Yoast_I18n_v3 {
 	 *
 	 * @deprecated 19.12
 	 * @codeCoverageIgnore
-	 *
-	 * @access public
 	 */
 	public function promo() {
 		\_deprecated_function( __METHOD__, 'Yoast SEO 19.12' );

--- a/src/deprecated/src/actions/indexables-page-action.php
+++ b/src/deprecated/src/actions/indexables-page-action.php
@@ -80,6 +80,7 @@ class Indexables_Page_Action {
 		$object_sub_types = \array_values( $this->post_type_helper->get_public_post_types() );
 
 		$excluded_post_types = \apply_filters( 'wpseo_indexable_excluded_post_types', [ 'attachment' ] );
+
 		/**
 		 * Filter: 'wpseo_indexable_included_post_types' - Allow developers to specify which post types will
 		 * be shown in the indexables overview cards.

--- a/src/deprecated/src/actions/settings-introduction-action.php
+++ b/src/deprecated/src/actions/settings-introduction-action.php
@@ -30,10 +30,10 @@ class Settings_Introduction_Action {
 	/**
 	 * Constructs Settings_Introduction_Action.
 	 *
-	 * @param User_Helper $user_helper The User_Helper.
-	 *
 	 * @deprecated 20.7
 	 * @codeCoverageIgnore
+	 *
+	 * @param User_Helper $user_helper The User_Helper.
 	 */
 	public function __construct( User_Helper $user_helper ) {
 		\_deprecated_function( __METHOD__, 'Yoast SEO 20.7' );
@@ -44,12 +44,12 @@ class Settings_Introduction_Action {
 	/**
 	 * Retrieves the Wistia embed permission value.
 	 *
-	 * @throws Exception If an invalid user ID is supplied.
-	 *
 	 * @deprecated 20.7
 	 * @codeCoverageIgnore
 	 *
 	 * @return bool The value of the Wistia embed permission.
+	 *
+	 * @throws Exception If an invalid user ID is supplied.
 	 */
 	public function get_wistia_embed_permission() {
 		\_deprecated_function( __METHOD__, 'Yoast SEO 20.7' );
@@ -63,14 +63,14 @@ class Settings_Introduction_Action {
 	/**
 	 * Sets the Wistia embed permission value.
 	 *
-	 * @param bool $value The value.
-	 *
-	 * @throws Exception If an invalid user ID is supplied.
-	 *
 	 * @deprecated 20.7
 	 * @codeCoverageIgnore
 	 *
+	 * @param bool $value The value.
+	 *
 	 * @return bool Whether the update was successful.
+	 *
+	 * @throws Exception If an invalid user ID is supplied.
 	 */
 	public function set_wistia_embed_permission( $value ) {
 		\_deprecated_function( __METHOD__, 'Yoast SEO 20.7' );
@@ -91,12 +91,12 @@ class Settings_Introduction_Action {
 	/**
 	 * Retrieves the show value.
 	 *
-	 * @throws Exception If an invalid user ID is supplied.
-	 *
 	 * @deprecated 20.7
 	 * @codeCoverageIgnore
 	 *
 	 * @return bool The value of show.
+	 *
+	 * @throws Exception If an invalid user ID is supplied.
 	 */
 	public function get_show() {
 		\_deprecated_function( __METHOD__, 'Yoast SEO 20.7' );
@@ -110,14 +110,14 @@ class Settings_Introduction_Action {
 	/**
 	 * Sets the show value.
 	 *
-	 * @param bool $value The value.
-	 *
-	 * @throws Exception If an invalid user ID is supplied.
-	 *
 	 * @deprecated 20.7
 	 * @codeCoverageIgnore
 	 *
+	 * @param bool $value The value.
+	 *
 	 * @return bool Whether the update was successful.
+	 *
+	 * @throws Exception If an invalid user ID is supplied.
 	 */
 	public function set_show( $value ) {
 		\_deprecated_function( __METHOD__, 'Yoast SEO 20.7' );
@@ -140,9 +140,9 @@ class Settings_Introduction_Action {
 	 *
 	 * @param int $user_id User ID.
 	 *
-	 * @throws Exception If an invalid user ID is supplied.
-	 *
 	 * @return array The (meta) values.
+	 *
+	 * @throws Exception If an invalid user ID is supplied.
 	 */
 	private function get_values_for_user( $user_id ) {
 		$values = $this->user_helper->get_meta( $user_id, self::USER_META_KEY, true );

--- a/src/deprecated/src/integrations/schema-blocks.php
+++ b/src/deprecated/src/integrations/schema-blocks.php
@@ -69,10 +69,10 @@ class Schema_Blocks implements Integration_Interface {
 	/**
 	 * Initializes the integration.
 	 *
+	 * This is the place to register hooks and filters.
+	 *
 	 * @deprecated 20.5
 	 * @codeCoverageIgnore
-	 *
-	 * This is the place to register hooks and filters.
 	 *
 	 * @return void
 	 */

--- a/src/deprecated/src/integrations/third-party/the-events-calendar.php
+++ b/src/deprecated/src/integrations/third-party/the-events-calendar.php
@@ -44,11 +44,11 @@ class The_Events_Calendar implements Integration_Interface {
 	/**
 	 * Adds the events graph pieces to the schema collector.
 	 *
-	 * @param array  $pieces  The current graph pieces.
-	 * @param string $context The current context.
-	 *
 	 * @deprecated 19.12
 	 * @codeCoverageIgnore
+	 *
+	 * @param array  $pieces  The current graph pieces.
+	 * @param string $context The current context.
 	 *
 	 * @return array Extended graph pieces.
 	 */

--- a/src/deprecated/src/routes/settings-introduction-route.php
+++ b/src/deprecated/src/routes/settings-introduction-route.php
@@ -49,10 +49,10 @@ class Settings_Introduction_Route implements Route_Interface {
 	/**
 	 * Constructs Settings_Introduction_Route.
 	 *
-	 * @param Settings_Introduction_Action $settings_introduction_action The $settings_introduction_action.
-	 *
 	 * @deprecated 20.7
 	 * @codeCoverageIgnore
+	 *
+	 * @param Settings_Introduction_Action $settings_introduction_action The $settings_introduction_action.
 	 */
 	public function __construct( Settings_Introduction_Action $settings_introduction_action ) {
 		\_deprecated_function( __METHOD__, 'Yoast SEO 20.7' );
@@ -177,10 +177,10 @@ class Settings_Introduction_Route implements Route_Interface {
 	/**
 	 * Sets the value of the wistia embed permission.
 	 *
-	 * @param WP_REST_Request $request The request object.
-	 *
 	 * @deprecated 20.7
 	 * @codeCoverageIgnore
+	 *
+	 * @param WP_REST_Request $request The request object.
 	 *
 	 * @return WP_REST_Response|WP_Error The success or failure response.
 	 */
@@ -243,10 +243,10 @@ class Settings_Introduction_Route implements Route_Interface {
 	/**
 	 * Sets the value of show.
 	 *
-	 * @param WP_REST_Request $request The request object.
-	 *
 	 * @deprecated 20.7
 	 * @codeCoverageIgnore
+	 *
+	 * @param WP_REST_Request $request The request object.
 	 *
 	 * @return WP_REST_Response|WP_Error The success or failure response.
 	 */

--- a/src/deprecated/src/schema-templates/assets/icons.php
+++ b/src/deprecated/src/schema-templates/assets/icons.php
@@ -7,10 +7,10 @@ namespace Yoast\WP\SEO\Schema_Templates\Assets;
 /**
  * Class Icons.
  *
+ * Provides SVG icons as strings.
+ *
  * @deprecated 20.5
  * @codeCoverageIgnore
- *
- * Provides SVG icons as strings.
  */
 class Icons {
 

--- a/src/generators/schema-generator.php
+++ b/src/generators/schema-generator.php
@@ -184,6 +184,7 @@ class Schema_Generator implements Generator_Interface {
 		foreach ( $context->blocks as $block_type => $blocks ) {
 			foreach ( $blocks as $block ) {
 				$block_type = \strtolower( $block['blockName'] );
+
 				/**
 				 * Filter: 'wpseo_schema_block_<block-type>'.
 				 * This filter is documented in the `generate_graph()` function in this class.

--- a/src/helpers/crawl-cleanup-helper.php
+++ b/src/helpers/crawl-cleanup-helper.php
@@ -248,7 +248,7 @@ class Crawl_Cleanup_Helper {
 	 * Redirects clean permalink.
 	 *
 	 * @param string $proper_url The proper URL.
-	 * @return void.
+	 * @return void
 	 */
 	public function do_clean_redirect( $proper_url ) {
 		$this->redirect_helper->set_header( 'Content-Type: redirect', true );

--- a/src/helpers/image-helper.php
+++ b/src/helpers/image-helper.php
@@ -297,8 +297,8 @@ class Image_Helper {
 	/**
 	 * Find an attachment ID for a given URL.
 	 *
-	 * @param string $url             The URL to find the attachment for.
-	 * @param bool   $use_link_table  Whether the SEO Links table will be used to retrieve the id.
+	 * @param string $url            The URL to find the attachment for.
+	 * @param bool   $use_link_table Whether the SEO Links table will be used to retrieve the id.
 	 *
 	 * @return int The found attachment ID, or 0 if none was found.
 	 */

--- a/src/helpers/schema/image-helper.php
+++ b/src/helpers/schema/image-helper.php
@@ -48,11 +48,11 @@ class Image_Helper {
 	/**
 	 * Find an image based on its URL and generate a Schema object for it.
 	 *
-	 * @param string $schema_id       The `@id` to use for the returned image.
-	 * @param string $url             The image URL to base our object on.
-	 * @param string $caption         An optional caption.
-	 * @param bool   $add_hash        Whether a hash will be added as a suffix in the @id.
-	 * @param bool   $use_link_table  Whether the SEO Links table will be used to retrieve the id.
+	 * @param string $schema_id      The `@id` to use for the returned image.
+	 * @param string $url            The image URL to base our object on.
+	 * @param string $caption        An optional caption.
+	 * @param bool   $add_hash       Whether a hash will be added as a suffix in the @id.
+	 * @param bool   $use_link_table Whether the SEO Links table will be used to retrieve the id.
 	 *
 	 * @return array Schema ImageObject array.
 	 */

--- a/src/helpers/social-profiles-helper.php
+++ b/src/helpers/social-profiles-helper.php
@@ -328,7 +328,7 @@ class Social_Profiles_Helper {
 		return [ $twitter_setting ];
 	}
 
-	/*** DEPRECATED METHODS ***/
+	/* DEPRECATED METHODS */
 
 	/**
 	 * Gets the person social profile fields supported by us after WP filtering.

--- a/src/initializers/crawl-cleanup-permalinks.php
+++ b/src/initializers/crawl-cleanup-permalinks.php
@@ -44,9 +44,9 @@ class Crawl_Cleanup_Permalinks implements Initializer_Interface {
 	/**
 	 * Crawl Cleanup Basic integration constructor.
 	 *
-	 * @param Options_Helper       $options_helper      The option helper.
-	 * @param Url_Helper           $url_helper          The URL helper.
-	 * @param Redirect_Helper      $redirect_helper     The Redirect Helper.
+	 * @param Options_Helper       $options_helper       The option helper.
+	 * @param Url_Helper           $url_helper           The URL helper.
+	 * @param Redirect_Helper      $redirect_helper      The Redirect Helper.
 	 * @param Crawl_Cleanup_Helper $crawl_cleanup_helper The Crawl_Cleanup_Helper.
 	 */
 	public function __construct(

--- a/src/integrations/admin/crawl-settings-integration.php
+++ b/src/integrations/admin/crawl-settings-integration.php
@@ -182,7 +182,7 @@ class Crawl_Settings_Integration implements Integration_Interface {
 	/**
 	 * Print the settings sections.
 	 *
-	 * @param Yoast_Form $yform      The Yoast form class.
+	 * @param Yoast_Form $yform The Yoast form class.
 	 *
 	 * @return void
 	 */
@@ -223,11 +223,11 @@ class Crawl_Settings_Integration implements Integration_Interface {
 	/**
 	 * Prints a list of toggles for an array of settings with labels.
 	 *
-	 * @param array      $settings    The settings being displayed.
-	 * @param Yoast_Form $yform       The Yoast form class.
-	 * @param string     $title       Optional title for the settings being displayed.
-	 * @param array      $toggles     Optional naming of the toggle buttons.
-	 * @param string     $warning     Optional warning to be displayed above the toggles.
+	 * @param array      $settings The settings being displayed.
+	 * @param Yoast_Form $yform    The Yoast form class.
+	 * @param string     $title    Optional title for the settings being displayed.
+	 * @param array      $toggles  Optional naming of the toggle buttons.
+	 * @param string     $warning  Optional warning to be displayed above the toggles.
 	 *
 	 * @return void
 	 */

--- a/src/integrations/admin/first-time-configuration-notice-integration.php
+++ b/src/integrations/admin/first-time-configuration-notice-integration.php
@@ -45,9 +45,9 @@ class First_Time_Configuration_Notice_Integration implements Integration_Interfa
 	/**
 	 * First_Time_Configuration_Notice_Integration constructor.
 	 *
-	 * @param Options_Helper                         $options_helper      The options helper.
-	 * @param First_Time_Configuration_Notice_Helper $first_time_configuration_notice_helper      The first time configuration notice helper.
-	 * @param WPSEO_Admin_Asset_Manager              $admin_asset_manager The admin asset manager.
+	 * @param Options_Helper                         $options_helper                         The options helper.
+	 * @param First_Time_Configuration_Notice_Helper $first_time_configuration_notice_helper The first time configuration notice helper.
+	 * @param WPSEO_Admin_Asset_Manager              $admin_asset_manager                    The admin asset manager.
 	 */
 	public function __construct(
 		Options_Helper $options_helper,

--- a/src/integrations/cleanup-integration.php
+++ b/src/integrations/cleanup-integration.php
@@ -35,7 +35,7 @@ class Cleanup_Integration implements Integration_Interface {
 	/**
 	 * The constructor.
 	 *
-	 * @param Indexable_Cleanup_Repository $cleanup_repository   The cleanup repository.
+	 * @param Indexable_Cleanup_Repository $cleanup_repository The cleanup repository.
 	 */
 	public function __construct( Indexable_Cleanup_Repository $cleanup_repository ) {
 		$this->cleanup_repository = $cleanup_repository;

--- a/src/integrations/settings-integration.php
+++ b/src/integrations/settings-integration.php
@@ -166,17 +166,17 @@ class Settings_Integration implements Integration_Interface {
 	/**
 	 * Constructs Settings_Integration.
 	 *
-	 * @param WPSEO_Admin_Asset_Manager $asset_manager                The WPSEO_Admin_Asset_Manager.
-	 * @param WPSEO_Replace_Vars        $replace_vars                 The WPSEO_Replace_Vars.
-	 * @param Schema_Types              $schema_types                 The Schema_Types.
-	 * @param Current_Page_Helper       $current_page_helper          The Current_Page_Helper.
-	 * @param Post_Type_Helper          $post_type_helper             The Post_Type_Helper.
-	 * @param Language_Helper           $language_helper              The Language_Helper.
-	 * @param Taxonomy_Helper           $taxonomy_helper              The Taxonomy_Helper.
-	 * @param Product_Helper            $product_helper               The Product_Helper.
-	 * @param Woocommerce_Helper        $woocommerce_helper           The Woocommerce_Helper.
-	 * @param Article_Helper            $article_helper               The Article_Helper.
-	 * @param User_Helper               $user_helper                  The User_Helper.
+	 * @param WPSEO_Admin_Asset_Manager $asset_manager       The WPSEO_Admin_Asset_Manager.
+	 * @param WPSEO_Replace_Vars        $replace_vars        The WPSEO_Replace_Vars.
+	 * @param Schema_Types              $schema_types        The Schema_Types.
+	 * @param Current_Page_Helper       $current_page_helper The Current_Page_Helper.
+	 * @param Post_Type_Helper          $post_type_helper    The Post_Type_Helper.
+	 * @param Language_Helper           $language_helper     The Language_Helper.
+	 * @param Taxonomy_Helper           $taxonomy_helper     The Taxonomy_Helper.
+	 * @param Product_Helper            $product_helper      The Product_Helper.
+	 * @param Woocommerce_Helper        $woocommerce_helper  The Woocommerce_Helper.
+	 * @param Article_Helper            $article_helper      The Article_Helper.
+	 * @param User_Helper               $user_helper         The User_Helper.
 	 */
 	public function __construct(
 		WPSEO_Admin_Asset_Manager $asset_manager,

--- a/src/integrations/third-party/elementor.php
+++ b/src/integrations/third-party/elementor.php
@@ -110,9 +110,9 @@ class Elementor implements Integration_Interface {
 	/**
 	 * Constructor.
 	 *
-	 * @param WPSEO_Admin_Asset_Manager $asset_manager                      The asset manager.
-	 * @param Options_Helper            $options                            The options helper.
-	 * @param Capability_Helper         $capability                         The capability helper.
+	 * @param WPSEO_Admin_Asset_Manager $asset_manager The asset manager.
+	 * @param Options_Helper            $options       The options helper.
+	 * @param Capability_Helper         $capability    The capability helper.
 	 */
 	public function __construct(
 		WPSEO_Admin_Asset_Manager $asset_manager,

--- a/src/loader.php
+++ b/src/loader.php
@@ -2,7 +2,6 @@
 
 namespace Yoast\WP\SEO;
 
-use Exception;
 use Throwable;
 use WP_CLI;
 use YoastSEO_Vendor\Symfony\Component\DependencyInjection\ContainerInterface;
@@ -284,7 +283,6 @@ class Loader {
 	 * @return object|null The class or, in production environments, null if it does not exist.
 	 *
 	 * @throws Throwable If the class does not exist in development environments.
-	 * @throws Exception If the class does not exist in development environments.
 	 */
 	protected function get_class( $class_name ) {
 		try {

--- a/src/presenters/open-graph/title-presenter.php
+++ b/src/presenters/open-graph/title-presenter.php
@@ -31,6 +31,7 @@ class Title_Presenter extends Abstract_Indexable_Tag_Presenter {
 	 */
 	public function get() {
 		$title = $this->replace_vars( $this->presentation->open_graph_title );
+
 		/**
 		 * Filter: 'wpseo_opengraph_title' - Allow changing the Yoast SEO generated title.
 		 *

--- a/src/repositories/indexable-cleanup-repository.php
+++ b/src/repositories/indexable-cleanup-repository.php
@@ -38,9 +38,9 @@ class Indexable_Cleanup_Repository {
 	/**
 	 * The constructor.
 	 *
-	 * @param Taxonomy_Helper       $taxonomy             A helper for taxonomies.
-	 * @param Post_Type_Helper      $post_type            A helper for post types.
-	 * @param Author_Archive_Helper $author_archive       A helper for author archives.
+	 * @param Taxonomy_Helper       $taxonomy       A helper for taxonomies.
+	 * @param Post_Type_Helper      $post_type      A helper for post types.
+	 * @param Author_Archive_Helper $author_archive A helper for author archives.
 	 */
 	public function __construct( Taxonomy_Helper $taxonomy, Post_Type_Helper $post_type, Author_Archive_Helper $author_archive ) {
 		$this->taxonomy       = $taxonomy;
@@ -81,7 +81,7 @@ class Indexable_Cleanup_Repository {
 	/**
 	 * Counts amount of indexables by object type and object sub type.
 	 *
-	 * @param string $object_type The object type to check.
+	 * @param string $object_type     The object type to check.
 	 * @param string $object_sub_type The object sub type to check.
 	 *
 	 * @return float|int

--- a/src/routes/first-time-configuration-route.php
+++ b/src/routes/first-time-configuration-route.php
@@ -320,7 +320,7 @@ class First_Time_Configuration_Route implements Route_Interface {
 		return new WP_REST_Response( $data, $data->status );
 	}
 
-	/*** DEPRECATED METHODS ***/
+	/* DEPRECATED METHODS */
 
 	/**
 	 * Gets a person's social profiles values.

--- a/tests/integration/repositories/seo-links-repository-test.php
+++ b/tests/integration/repositories/seo-links-repository-test.php
@@ -249,10 +249,10 @@ class SEO_Links_Repository_Test extends WPSEO_UnitTestCase {
 	 *
 	 * @dataProvider data_provider_test_update_target_indexable_id
 	 *
-	 * @param int  $link_id The link id.
+	 * @param int  $link_id             The link id.
 	 * @param int  $target_indexable_id The target indexable id to update.
-	 * @param bool $expected_result The expected result.
-	 * @param int  $in_db The expected result in the database.
+	 * @param bool $expected_result     The expected result.
+	 * @param int  $in_db               The expected result in the database.
 	 */
 	public function test_update_target_indexable_id( $link_id, $target_indexable_id, $expected_result, $in_db ) {
 		global $wpdb;
@@ -290,7 +290,7 @@ class SEO_Links_Repository_Test extends WPSEO_UnitTestCase {
 	 *
 	 * @dataProvider data_provider_test_delete_all_by_post_id
 	 *
-	 * @param int $post_id The post id.
+	 * @param int $post_id         The post id.
 	 * @param int $expected_result The expected result.
 	 */
 	public function test_delete_all_by_post_id( $post_id, $expected_result ) {
@@ -343,7 +343,7 @@ class SEO_Links_Repository_Test extends WPSEO_UnitTestCase {
 	 *
 	 * @dataProvider data_provider_test_delete_all_by_post_id_where_indexable_id_null
 	 *
-	 * @param int $post_id The post id.
+	 * @param int $post_id         The post id.
 	 * @param int $expected_result The number of links deleted.
 	 */
 	public function test_delete_all_by_post_id_where_indexable_id_null( $post_id, $expected_result ) {
@@ -407,7 +407,7 @@ class SEO_Links_Repository_Test extends WPSEO_UnitTestCase {
 	 *
 	 * @dataProvider data_provider_test_delete_all_by_indexable_id
 	 *
-	 * @param int $indexable_id The indexable id.
+	 * @param int $indexable_id    The indexable id.
 	 * @param int $expected_result The number of links deleted.
 	 */
 	public function test_delete_all_by_indexable_id( $indexable_id, $expected_result ) {
@@ -477,7 +477,7 @@ class SEO_Links_Repository_Test extends WPSEO_UnitTestCase {
 	 *
 	 * @dataProvider data_provider_get_incoming_link_counts_for_post_ids
 	 *
-	 * @param array $post_ids The post ids.
+	 * @param array $post_ids        The post ids.
 	 * @param array $expected_result The expected result.
 	 */
 	public function test_get_incoming_link_counts_for_post_ids( $post_ids, $expected_result ) {
@@ -525,7 +525,7 @@ class SEO_Links_Repository_Test extends WPSEO_UnitTestCase {
 	 *
 	 * @dataProvider data_provider_test_delete_many_by_id
 	 *
-	 * @param array $ids The ids.
+	 * @param array $ids             The ids.
 	 * @param int   $expected_result The number of links deleted.
 	 */
 	public function test_delete_many_by_id( $ids, $expected_result ) {
@@ -606,7 +606,7 @@ class SEO_Links_Repository_Test extends WPSEO_UnitTestCase {
 	 *
 	 * @dataProvider data_provider_test_get_incoming_link_counts_for_indexable_ids
 	 *
-	 * @param array $indexable_ids The indexable ids.
+	 * @param array $indexable_ids   The indexable ids.
 	 * @param array $expected_result The expected result.
 	 */
 	public function test_get_incoming_link_counts_for_indexable_ids( $indexable_ids, $expected_result ) {

--- a/tests/integration/sitemaps/test-class-wpseo-sitemaps-router.php
+++ b/tests/integration/sitemaps/test-class-wpseo-sitemaps-router.php
@@ -58,11 +58,11 @@ class WPSEO_Sitemaps_Router_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests retrieval of the base url.
 	 *
-	 * @param string $home_url The home URL to set.
-	 * @param string $expected The expected test result.
-	 *
 	 * @covers WPSEO_Sitemaps_Router::get_base_url
 	 * @dataProvider data_get_base_url
+	 *
+	 * @param string $home_url The home URL to set.
+	 * @param string $expected The expected test result.
 	 */
 	public function test_get_base_url( $home_url, $expected ) {
 		update_option( 'home', $home_url );

--- a/tests/unit/analytics/application/missing-indexables-collector-test.php
+++ b/tests/unit/analytics/application/missing-indexables-collector-test.php
@@ -25,8 +25,8 @@ class Missing_Indexables_Collector_Test extends TestCase {
 	 * @dataProvider collector_get_data
 	 *
 	 * @param array                           $additional_indexation_actions All the indexations actions that are added via the filter.
-	 * @param Abstract_Indexing_Action_Double $initial_indexation_actions The initial indexation actions available in free.
-	 * @param array                           $expected_result The expected result.
+	 * @param Abstract_Indexing_Action_Double $initial_indexation_actions    The initial indexation actions available in free.
+	 * @param array                           $expected_result               The expected result.
 	 *
 	 * @return void
 	 */

--- a/tests/unit/analytics/user-interface/last-completed-indexation-integration-test.php
+++ b/tests/unit/analytics/user-interface/last-completed-indexation-integration-test.php
@@ -26,7 +26,7 @@ class Last_Completed_Indexation_Integration_Test extends TestCase {
 	/**
 	 * The options helper mock.
 	 *
-	 * @var Mockery\MockInterface|Options_Helper $options_helper_mock
+	 * @var Mockery\MockInterface|Options_Helper
 	 */
 	private $options_helper_mock;
 

--- a/tests/unit/builders/indexable-builder/build-for-id-and-type-test.php
+++ b/tests/unit/builders/indexable-builder/build-for-id-and-type-test.php
@@ -32,11 +32,11 @@ class Build_For_Id_And_Type_Test extends Abstract_Indexable_Builder_TestCase {
 		$this->assertSame( $this->indexable, $this->instance->build_for_id_and_type( 1337, 'post' ) );
 	}
 
-		/**
-		 * Expectation for build method.
-		 *
-		 * @param array $defaults The defaults to expect.
-		 */
+	/**
+	 * Expectation for build method.
+	 *
+	 * @param array $defaults The defaults to expect.
+	 */
 	public function expect_build( $defaults ) {
 		$this->expect_ensure_indexable( $defaults, $this->indexable );
 

--- a/tests/unit/builders/indexable-builder/build-test.php
+++ b/tests/unit/builders/indexable-builder/build-test.php
@@ -198,12 +198,12 @@ class Build_Test extends Abstract_Indexable_Builder_TestCase {
 		$this->assertFalse( $this->instance->build( $this->indexable ) );
 	}
 
-		/**
-		 * Tests building an indexable for a post when the post builder throws an exception because the post does not exist.
-		 *
-		 * @covers ::build_for_id_and_type
-		 * @covers ::ensure_indexable
-		 */
+	/**
+	 * Tests building an indexable for a post when the post builder throws an exception because the post does not exist.
+	 *
+	 * @covers ::build_for_id_and_type
+	 * @covers ::ensure_indexable
+	 */
 	public function test_build_for_id_and_type_with_post_given_and_no_indexable_build() {
 		$empty_indexable = Mockery::mock( Indexable_Mock::class );
 

--- a/tests/unit/builders/indexable-builder/is-type-with-no-id-test.php
+++ b/tests/unit/builders/indexable-builder/is-type-with-no-id-test.php
@@ -75,7 +75,7 @@ class Is_Type_With_No_Id_Test extends Abstract_Indexable_Builder_TestCase {
 	 *
 	 * @dataProvider is_type_with_no_id_provider
 	 *
-	 * @param string $type The type to test.
+	 * @param string $type     The type to test.
 	 * @param bool   $expected The expected result.
 	 * @return void
 	 */

--- a/tests/unit/builders/indexable-builder/save-indexable-test.php
+++ b/tests/unit/builders/indexable-builder/save-indexable-test.php
@@ -104,11 +104,11 @@ class Save_Indexable_Test extends Abstract_Indexable_Builder_TestCase {
 	 *
 	 * @dataProvider save_indexable_provider
 	 *
-	 * @param Indexable_Mock $indexable_before The indexable to expect.
-	 * @param bool           $should_index The return value of should_index_indexables method.
+	 * @param Indexable_Mock $indexable_before  The indexable to expect.
+	 * @param bool           $should_index      The return value of should_index_indexables method.
 	 * @param bool           $wpseo_should_save The return value for wpseo_should_save_indexable.
-	 * @param int            $save_times The times save method should be executed.
-	 * @param int            $action_times The times wpseo_save_indexable action should be executed.
+	 * @param int            $save_times        The times save method should be executed.
+	 * @param int            $action_times      The times wpseo_save_indexable action should be executed.
 	 * @return void
 	 */
 	public function test_save_indexable( $indexable_before, $should_index, $wpseo_should_save, $save_times, $action_times ) {

--- a/tests/unit/builders/indexable-link-builder/abstract-indexable-link-builder-testcase.php
+++ b/tests/unit/builders/indexable-link-builder/abstract-indexable-link-builder-testcase.php
@@ -114,8 +114,8 @@ abstract class Abstract_Indexable_Link_Builder_TestCase extends TestCase {
 	/**
 	 * Expectations for update_related_indexables.
 	 *
-	 * @param int   $indexable_id The indexable id.
-	 * @param array $insert_links The links to insert.
+	 * @param int   $indexable_id          The indexable id.
+	 * @param array $insert_links          The links to insert.
 	 * @param array $links_by_indexable_id The links by indexable id.
 	 */
 	public function expect_update_related_indexables_with_links_to_add( $indexable_id, $insert_links, $links_by_indexable_id = [] ) {
@@ -158,7 +158,7 @@ abstract class Abstract_Indexable_Link_Builder_TestCase extends TestCase {
 	 * Expectations for seo_links_repository->query->create.
 	 *
 	 * @param object $indexable The indexable.
-	 * @param object $seo_link The seo link.
+	 * @param object $seo_link  The seo link.
 	 */
 	public function expect_seo_links_repository_query_create( $indexable, $seo_link ) {
 

--- a/tests/unit/builders/indexable-link-builder/build-test.php
+++ b/tests/unit/builders/indexable-link-builder/build-test.php
@@ -314,10 +314,10 @@ class Build_Test extends Abstract_Indexable_Link_Builder_TestCase {
 	/**
 	 * Expectation for update_related_indexables.
 	 *
-	 * @param object $indexable The indexable object.
+	 * @param object $indexable    The indexable object.
 	 * @param array  $new_seo_link The new seo link.
 	 * @param array  $old_seo_link The old seo link.
-	 * @param array  $delete_ids The delete ids.
+	 * @param array  $delete_ids   The delete ids.
 	 */
 	public function expect_update_related_indexables( $indexable, $new_seo_link, $old_seo_link, $delete_ids ) {
 

--- a/tests/unit/builders/indexable-link-builder/create-internal-link-test.php
+++ b/tests/unit/builders/indexable-link-builder/create-internal-link-test.php
@@ -308,18 +308,18 @@ class Create_Internal_Link_Test extends Abstract_Indexable_Link_Builder_TestCase
 		$this->instance->build( $indexable, '<img width="640" height="480" src="' . $this->image_url . '" class="attachment-post-thumbnail size-post-thumbnail wp-post-image" alt="" decoding="async" loading="lazy" srcset="http://basic.wordpress.test/wp-content/uploads/2022/11/WordPress8.jpg 640w, http://basic.wordpress.test/wp-content/uploads/2022/11/WordPress8-300x225.jpg 300w" sizes="(max-width: 640px) 100vw, 640px">' );
 	}
 
-		/**
-		 * Tests the build in case of an image link and 'disable attachment` option is true.
-		 *
-		 * @covers ::build
-		 * @covers ::create_links
-		 * @covers ::create_internal_link
-		 * @covers ::build_permalink
-		 * @covers ::get_permalink
-		 * @covers ::enhance_link_from_indexable
-		 * @covers ::get_post_id
-		 * @covers ::update_related_indexables
-		 */
+	/**
+	 * Tests the build in case of an image link and 'disable attachment` option is true.
+	 *
+	 * @covers ::build
+	 * @covers ::create_links
+	 * @covers ::create_internal_link
+	 * @covers ::build_permalink
+	 * @covers ::get_permalink
+	 * @covers ::enhance_link_from_indexable
+	 * @covers ::get_post_id
+	 * @covers ::update_related_indexables
+	 */
 	public function test_build_create_internal_link_disable_attachment_true_get_attachment_by_url_not_empty() {
 
 		$indexable              = Mockery::mock( Indexable_Mock::class );

--- a/tests/unit/builders/indexable-link-builder/get-permalink-test.php
+++ b/tests/unit/builders/indexable-link-builder/get-permalink-test.php
@@ -91,10 +91,10 @@ class Get_Permalink_Test extends Abstract_Indexable_Link_Builder_TestCase {
 	 *
 	 * @dataProvider data_provider_get_permalink
 	 *
-	 * @param string $link The link to test.
-	 * @param array  $home_url The home URL schema and host.
+	 * @param string $link           The link to test.
+	 * @param array  $home_url       The home URL schema and host.
 	 * @param string $set_url_scheme The URL scheme.
-	 * @param string $expected The expected permalink.
+	 * @param string $expected       The expected permalink.
 	 */
 	public function test_get_permalink( $link, $home_url, $set_url_scheme, $expected ) {
 

--- a/tests/unit/builders/indexable-link-builder/patch-seo-links-test.php
+++ b/tests/unit/builders/indexable-link-builder/patch-seo-links-test.php
@@ -19,7 +19,7 @@ class Patch_Seo_Links_Test extends Abstract_Indexable_Link_Builder_TestCase {
 	/**
 	 * Data provider for test_patch_seo_links;
 	 *
-	 * @return array $indexable_id, $object_id, $links_times, $links, $update_target_indexable_id_times.
+	 * @return array
 	 */
 	public function patch_seo_links_provider() {
 		$object                                  = (object) [ 'type' => 'not SEO_Links' ];

--- a/tests/unit/builders/indexable-link-builder/patch-seo-links-test.php
+++ b/tests/unit/builders/indexable-link-builder/patch-seo-links-test.php
@@ -88,10 +88,10 @@ class Patch_Seo_Links_Test extends Abstract_Indexable_Link_Builder_TestCase {
 	 *
 	 * @dataProvider patch_seo_links_provider
 	 *
-	 * @param int|null $indexable_id The indexable id.
-	 * @param int|null $object_id The object id.
-	 * @param int      $links_times The times that find_all_by_target_post_id is executed.
-	 * @param array    $links The links.
+	 * @param int|null $indexable_id                     The indexable id.
+	 * @param int|null $object_id                        The object id.
+	 * @param int      $links_times                      The times that find_all_by_target_post_id is executed.
+	 * @param array    $links                            The links.
 	 * @param int      $update_target_indexable_id_times The times that update_target_indexable_id is executed.
 	 */
 	public function test_patch_seo_links( $indexable_id, $object_id, $links_times, $links, $update_target_indexable_id_times ) {

--- a/tests/unit/builders/indexable-link-builder/update-incoming-links-for-related-test.php
+++ b/tests/unit/builders/indexable-link-builder/update-incoming-links-for-related-test.php
@@ -81,8 +81,8 @@ class Update_Incoming_Links_For_Related_Test extends Abstract_Indexable_Link_Bui
 	 *
 	 * @dataProvider data_provider_update_incoming_links_for_related_indexables
 	 *
-	 * @param int[] $related_indexable_ids The IDs of all related indexables.
-	 * @param array $expected_counts The expected counts.
+	 * @param int[] $related_indexable_ids                            The IDs of all related indexables.
+	 * @param array $expected_counts                                  The expected counts.
 	 * @param int   $get_incoming_link_counts_for_indexable_ids_times The number of times the method should be called.
 	 */
 	public function test_update_incoming_links_for_related_indexables( $related_indexable_ids, $expected_counts, $get_incoming_link_counts_for_indexable_ids_times ) {

--- a/tests/unit/conditionals/third-party/elementor-edit-conditional-test.php
+++ b/tests/unit/conditionals/third-party/elementor-edit-conditional-test.php
@@ -35,15 +35,15 @@ class Elementor_Edit_Conditional_Test extends TestCase {
 	/**
 	 * Tests that the condition is not met when the Elementor plugin is not active.
 	 *
+	 * @dataProvider is_met_dataprovider
+	 *
+	 * @covers ::is_met
+	 *
 	 * @param string    $pagenow_new  The value of global pagenow.
 	 * @param mixed     $get_action   The value of action in $_GET['action'].
 	 * @param mixed     $post_action  The value of action in $_POST['action'].
 	 * @param bool|null $doing_ajax   What wp_doing_ajax should return, if false it should not be called.
 	 * @param bool      $return_value The expected return value.
-	 *
-	 * @dataProvider is_met_dataprovider
-	 *
-	 * @covers ::is_met
 	 */
 	public function test_is_met( $pagenow_new, $get_action, $post_action, $doing_ajax, $return_value ) {
 		global $pagenow;

--- a/tests/unit/helpers/crawl-cleanup-helper-test.php
+++ b/tests/unit/helpers/crawl-cleanup-helper-test.php
@@ -85,11 +85,11 @@ class Crawl_Cleanup_Helper_Test extends TestCase {
 	 *
 	 * @dataProvider should_avoid_redirect_provider
 	 *
-	 * @param boolean $is_robots is_robots return value.
-	 * @param string  $sitemap get_query_var return value.
-	 * @param array   $get_response get_response value.
+	 * @param boolean $is_robots         is_robots return value.
+	 * @param string  $sitemap           get_query_var return value.
+	 * @param array   $get_response      get_response value.
 	 * @param boolean $is_user_logged_in is_user_logged_in return value.
-	 * @param int     $expected The return value from the should_avoid_redirect function.
+	 * @param int     $expected          The return value from the should_avoid_redirect function.
 	 */
 	public function test_should_avoid_redirect( $is_robots, $sitemap, $get_response, $is_user_logged_in, $expected ) {
 
@@ -142,8 +142,8 @@ class Crawl_Cleanup_Helper_Test extends TestCase {
 	 * @dataProvider get_allowed_extravars_provider
 	 *
 	 * @param string $clean_permalinks_extra_variables return value.
-	 * @param array  $permalink_vars The return value from the filter to add extra vars.
-	 * @param array  $expeted The allowed extra vars (is set in settings under 'Additional URL parameters to allow').
+	 * @param array  $permalink_vars                   The return value from the filter to add extra vars.
+	 * @param array  $expeted                          The allowed extra vars (is set in settings under 'Additional URL parameters to allow').
 	 */
 	public function test_get_allowed_extravars( $clean_permalinks_extra_variables, $permalink_vars, $expeted ) {
 
@@ -182,12 +182,12 @@ class Crawl_Cleanup_Helper_Test extends TestCase {
 	 *
 	 * @dataProvider front_page_url_provider
 	 *
-	 * @param boolean $is_home_posts_page is_home_posts_page return value.
+	 * @param boolean $is_home_posts_page  is_home_posts_page return value.
 	 * @param boolean $is_home_static_page is_home_static_page return value.
-	 * @param int     $static_times The times is_home_static_page function is called.
-	 * @param int     $home_url_times home_url times called.
-	 * @param int     $permalink_times get_permalink times called.
-	 * @param string  $expected expected return value.
+	 * @param int     $static_times        The times is_home_static_page function is called.
+	 * @param int     $home_url_times      home_url times called.
+	 * @param int     $permalink_times     get_permalink times called.
+	 * @param string  $expected            expected return value.
 	 */
 	public function test_front_page_url( $is_home_posts_page, $is_home_static_page, $static_times, $home_url_times, $permalink_times, $expected ) {
 
@@ -236,16 +236,16 @@ class Crawl_Cleanup_Helper_Test extends TestCase {
 	 *
 	 * @dataProvider page_not_found_url_provider
 	 *
-	 * @param bool   $is_multisite is_multisite return value.
-	 * @param bool   $is_subdomain_install is_subdomain_install return value.
-	 * @param bool   $is_main_site is_main_site return value.
-	 * @param string $home_url home_url return value.
-	 * @param bool   $is_home_static_page The return value from is_home_static_page function.
+	 * @param bool   $is_multisite           is_multisite return value.
+	 * @param bool   $is_subdomain_install   is_subdomain_install return value.
+	 * @param bool   $is_main_site           is_main_site return value.
+	 * @param string $home_url               home_url return value.
+	 * @param bool   $is_home_static_page    The return value from is_home_static_page function.
 	 * @param int    $home_static_page_times The times is_home_static_page function is called.
-	 * @param int    $get_permalink_times get_permalink times called.
-	 * @param int    $page_for_posts_times times get_option(page_for_posts) is called.
-	 * @param string $current_url current_url return value.
-	 * @param string $expected expected return value.
+	 * @param int    $get_permalink_times    get_permalink times called.
+	 * @param int    $page_for_posts_times   times get_option(page_for_posts) is called.
+	 * @param string $current_url            current_url return value.
+	 * @param string $expected               expected return value.
 	 */
 	public function test_page_not_found_url( $is_multisite, $is_subdomain_install, $is_main_site, $home_url, $is_home_static_page, $home_static_page_times, $get_permalink_times, $page_for_posts_times, $current_url, $expected ) {
 
@@ -300,10 +300,10 @@ class Crawl_Cleanup_Helper_Test extends TestCase {
 	 *
 	 * @dataProvider taxonomy_url_provider
 	 *
-	 * @param bool   $is_feed is_feed return value.
+	 * @param bool   $is_feed                  is_feed return value.
 	 * @param int    $get_term_feed_link_times times get_term_feed_link is called.
-	 * @param int    $get_term_link_times times get_term_link is called.
-	 * @param string $expected expected return value.
+	 * @param int    $get_term_link_times      times get_term_link is called.
+	 * @param string $expected                 expected return value.
 	 */
 	public function test_taxonomy_url( $is_feed, $get_term_feed_link_times, $get_term_link_times, $expected ) {
 
@@ -378,11 +378,11 @@ class Crawl_Cleanup_Helper_Test extends TestCase {
 	 *
 	 * @dataProvider query_var_page_url_provider
 	 *
-	 * @param bool   $is_search is_search return value.
-	 * @param string $proper_url proper url.
-	 * @param int    $home_url times home_url is called.
+	 * @param bool   $is_search        is_search return value.
+	 * @param string $proper_url       proper url.
+	 * @param int    $home_url         times home_url is called.
 	 * @param int    $get_search_query times get_search_query is called.
-	 * @param string $expected expected return value.
+	 * @param string $expected         expected return value.
 	 */
 	public function test_query_var_page_url( $is_search, $proper_url, $home_url, $get_search_query, $expected ) {
 		global $wp_query;
@@ -426,10 +426,10 @@ class Crawl_Cleanup_Helper_Test extends TestCase {
 	 *
 	 * @dataProvider is_query_var_page_provider
 	 *
-	 * @param string $proper_url proper url.
+	 * @param string $proper_url       proper url.
 	 * @param string $query_vars_paged query_vars_paged.
-	 * @param int    $post_count post_count.
-	 * @param bool   $expected expected return value.
+	 * @param int    $post_count       post_count.
+	 * @param bool   $expected         expected return value.
 	 */
 	public function test_is_query_var_page( $proper_url, $query_vars_paged, $post_count, $expected ) {
 		global $wp_query;
@@ -484,16 +484,16 @@ class Crawl_Cleanup_Helper_Test extends TestCase {
 	 *
 	 * @dataProvider get_url_type_provider
 	 *
-	 * @param bool   $singular is_singular return value.
-	 * @param bool   $front is_front_page return value.
-	 * @param bool   $category is_category return value.
-	 * @param bool   $tag is_tag return value.
-	 * @param bool   $tax is_tax return value.
-	 * @param bool   $search is_search return value.
-	 * @param bool   $is404 is_404 return value.
-	 * @param bool   $post_page is_posts_page return value.
+	 * @param bool   $singular        is_singular return value.
+	 * @param bool   $front           is_front_page return value.
+	 * @param bool   $category        is_category return value.
+	 * @param bool   $tag             is_tag return value.
+	 * @param bool   $tax             is_tax return value.
+	 * @param bool   $search          is_search return value.
+	 * @param bool   $is404           is_404 return value.
+	 * @param bool   $post_page       is_posts_page return value.
 	 * @param int    $post_page_times times is_posts_page is called.
-	 * @param string $expected expected return value.
+	 * @param string $expected        expected return value.
 	 */
 	public function test_get_url_type( $singular, $front, $category, $tag, $tax, $search, $is404, $post_page, $post_page_times, $expected ) {
 

--- a/tests/unit/helpers/crawl-cleanup-helper-test.php
+++ b/tests/unit/helpers/crawl-cleanup-helper-test.php
@@ -110,7 +110,6 @@ class Crawl_Cleanup_Helper_Test extends TestCase {
 	}
 
 	/**
-	 *
 	 * Data provider for test_clean_permalinks_avoid_redirect.
 	 *
 	 * @return array is_robots, get_query_var( 'sitemap' ), $_GET, is_user_logged_in(), $expected.
@@ -162,7 +161,6 @@ class Crawl_Cleanup_Helper_Test extends TestCase {
 	}
 
 	/**
-	 *
 	 * Data provider for test_clean_permalinks.
 	 *
 	 * @return array avoid_redirect, expected.
@@ -342,7 +340,6 @@ class Crawl_Cleanup_Helper_Test extends TestCase {
 	}
 
 	/**
-	 *
 	 * Data provider for test_taxonomy_url.
 	 *
 	 * @return array $is_feed, $get_term_feed_link_times, $get_term_link_times, $expected

--- a/tests/unit/helpers/crawl-cleanup-helper-test.php
+++ b/tests/unit/helpers/crawl-cleanup-helper-test.php
@@ -85,11 +85,11 @@ class Crawl_Cleanup_Helper_Test extends TestCase {
 	 *
 	 * @dataProvider should_avoid_redirect_provider
 	 *
-	 * @param bool   $is_robots         is_robots return value.
-	 * @param string $sitemap           get_query_var return value.
-	 * @param array  $get_response      get_response value.
-	 * @param bool   $is_user_logged_in is_user_logged_in return value.
-	 * @param int    $expected          The return value from the should_avoid_redirect function.
+	 * @param bool   $is_robots         Mock return value for is_robots().
+	 * @param string $sitemap           Mock return value for get_query_var().
+	 * @param array  $get_response      Mock $_GET data.
+	 * @param bool   $is_user_logged_in Mock return value for is_user_logged_in().
+	 * @param int    $expected          Expected return value from the should_avoid_redirect() method.
 	 */
 	public function test_should_avoid_redirect( $is_robots, $sitemap, $get_response, $is_user_logged_in, $expected ) {
 
@@ -140,7 +140,7 @@ class Crawl_Cleanup_Helper_Test extends TestCase {
 	 *
 	 * @dataProvider get_allowed_extravars_provider
 	 *
-	 * @param string $clean_permalinks_extra_variables return value.
+	 * @param string $clean_permalinks_extra_variables Mock return value for clean_permalinks_extra_variables().
 	 * @param array  $permalink_vars                   The return value from the filter to add extra vars.
 	 * @param array  $expeted                          The allowed extra vars (is set in settings under 'Additional URL parameters to allow').
 	 */
@@ -180,12 +180,12 @@ class Crawl_Cleanup_Helper_Test extends TestCase {
 	 *
 	 * @dataProvider front_page_url_provider
 	 *
-	 * @param bool   $is_home_posts_page  is_home_posts_page return value.
-	 * @param bool   $is_home_static_page is_home_static_page return value.
-	 * @param int    $static_times        The times is_home_static_page function is called.
-	 * @param int    $home_url_times      home_url times called.
-	 * @param int    $permalink_times     get_permalink times called.
-	 * @param string $expected            expected return value.
+	 * @param bool   $is_home_posts_page  Mock return value for is_home_posts_page().
+	 * @param bool   $is_home_static_page Mock return value for is_home_static_page().
+	 * @param int    $static_times        The number of times is_home_static_page() is expected to be called.
+	 * @param int    $home_url_times      The number of times home_url() is expected to be called.
+	 * @param int    $permalink_times     The number of times get_permalink() is expected to be called.
+	 * @param string $expected            Expected return value.
 	 */
 	public function test_front_page_url( $is_home_posts_page, $is_home_static_page, $static_times, $home_url_times, $permalink_times, $expected ) {
 
@@ -234,16 +234,16 @@ class Crawl_Cleanup_Helper_Test extends TestCase {
 	 *
 	 * @dataProvider page_not_found_url_provider
 	 *
-	 * @param bool   $is_multisite           is_multisite return value.
-	 * @param bool   $is_subdomain_install   is_subdomain_install return value.
-	 * @param bool   $is_main_site           is_main_site return value.
-	 * @param string $home_url               home_url return value.
-	 * @param bool   $is_home_static_page    The return value from is_home_static_page function.
-	 * @param int    $home_static_page_times The times is_home_static_page function is called.
-	 * @param int    $get_permalink_times    get_permalink times called.
-	 * @param int    $page_for_posts_times   times get_option(page_for_posts) is called.
-	 * @param string $current_url            current_url return value.
-	 * @param string $expected               expected return value.
+	 * @param bool   $is_multisite           Mock return value for is_multisite().
+	 * @param bool   $is_subdomain_install   Mock return value for is_subdomain_install().
+	 * @param bool   $is_main_site           Mock return value for is_main_site().
+	 * @param string $home_url               Mock return value for home_url().
+	 * @param bool   $is_home_static_page    Mock return value for is_home_static_page().
+	 * @param int    $home_static_page_times The number of times is_home_static_page() is expected to be called.
+	 * @param int    $get_permalink_times    The number of times get_permalink() is expected to be called.
+	 * @param int    $page_for_posts_times   The number of times times get_option(page_for_posts) is expected to be called.
+	 * @param string $current_url            Input value for $current_url parameter.
+	 * @param string $expected               Expected return value.
 	 */
 	public function test_page_not_found_url( $is_multisite, $is_subdomain_install, $is_main_site, $home_url, $is_home_static_page, $home_static_page_times, $get_permalink_times, $page_for_posts_times, $current_url, $expected ) {
 
@@ -298,10 +298,10 @@ class Crawl_Cleanup_Helper_Test extends TestCase {
 	 *
 	 * @dataProvider taxonomy_url_provider
 	 *
-	 * @param bool   $is_feed                  is_feed return value.
-	 * @param int    $get_term_feed_link_times times get_term_feed_link is called.
-	 * @param int    $get_term_link_times      times get_term_link is called.
-	 * @param string $expected                 expected return value.
+	 * @param bool   $is_feed                  Mock return value for is_feed().
+	 * @param int    $get_term_feed_link_times The number of times get_term_feed_link() is expected to be called.
+	 * @param int    $get_term_link_times      The number of times get_term_link() is expected to be called.
+	 * @param string $expected                 Expected return value.
 	 */
 	public function test_taxonomy_url( $is_feed, $get_term_feed_link_times, $get_term_link_times, $expected ) {
 
@@ -375,11 +375,11 @@ class Crawl_Cleanup_Helper_Test extends TestCase {
 	 *
 	 * @dataProvider query_var_page_url_provider
 	 *
-	 * @param bool   $is_search        is_search return value.
-	 * @param string $proper_url       proper url.
-	 * @param int    $home_url         times home_url is called.
-	 * @param int    $get_search_query times get_search_query is called.
-	 * @param string $expected         expected return value.
+	 * @param bool   $is_search        Mock return value for is_search().
+	 * @param string $proper_url       Input value for $proper_url parameter.
+	 * @param int    $home_url         The number of times home_url() is expected to be called.
+	 * @param int    $get_search_query The number of times get_search_query() is expected to be called.
+	 * @param string $expected         Expected return value.
 	 */
 	public function test_query_var_page_url( $is_search, $proper_url, $home_url, $get_search_query, $expected ) {
 		global $wp_query;
@@ -423,10 +423,10 @@ class Crawl_Cleanup_Helper_Test extends TestCase {
 	 *
 	 * @dataProvider is_query_var_page_provider
 	 *
-	 * @param string $proper_url       proper url.
-	 * @param string $query_vars_paged query_vars_paged.
-	 * @param int    $post_count       post_count.
-	 * @param bool   $expected         expected return value.
+	 * @param string $proper_url       Input value for $proper_url parameter.
+	 * @param string $query_vars_paged WP_Query query_vars_paged input.
+	 * @param int    $post_count       WP_Query post_count input.
+	 * @param bool   $expected         Expected return value.
 	 */
 	public function test_is_query_var_page( $proper_url, $query_vars_paged, $post_count, $expected ) {
 		global $wp_query;
@@ -481,16 +481,16 @@ class Crawl_Cleanup_Helper_Test extends TestCase {
 	 *
 	 * @dataProvider get_url_type_provider
 	 *
-	 * @param bool   $singular        is_singular return value.
-	 * @param bool   $front           is_front_page return value.
-	 * @param bool   $category        is_category return value.
-	 * @param bool   $tag             is_tag return value.
-	 * @param bool   $tax             is_tax return value.
-	 * @param bool   $search          is_search return value.
-	 * @param bool   $is404           is_404 return value.
-	 * @param bool   $post_page       is_posts_page return value.
-	 * @param int    $post_page_times times is_posts_page is called.
-	 * @param string $expected        expected return value.
+	 * @param bool   $singular        Mock return value for is_singular().
+	 * @param bool   $front           Mock return value for is_front_page().
+	 * @param bool   $category        Mock return value for is_category().
+	 * @param bool   $tag             Mock return value for is_tag().
+	 * @param bool   $tax             Mock return value for is_tax().
+	 * @param bool   $search          Mock return value for is_search().
+	 * @param bool   $is404           Mock return value for is_404().
+	 * @param bool   $post_page       Mock return value for is_posts_page().
+	 * @param int    $post_page_times The number of times is_posts_page() is expected to be called.
+	 * @param string $expected        Expected return value.
 	 */
 	public function test_get_url_type( $singular, $front, $category, $tag, $tax, $search, $is404, $post_page, $post_page_times, $expected ) {
 

--- a/tests/unit/helpers/crawl-cleanup-helper-test.php
+++ b/tests/unit/helpers/crawl-cleanup-helper-test.php
@@ -85,11 +85,11 @@ class Crawl_Cleanup_Helper_Test extends TestCase {
 	 *
 	 * @dataProvider should_avoid_redirect_provider
 	 *
-	 * @param boolean $is_robots         is_robots return value.
-	 * @param string  $sitemap           get_query_var return value.
-	 * @param array   $get_response      get_response value.
-	 * @param boolean $is_user_logged_in is_user_logged_in return value.
-	 * @param int     $expected          The return value from the should_avoid_redirect function.
+	 * @param bool   $is_robots         is_robots return value.
+	 * @param string $sitemap           get_query_var return value.
+	 * @param array  $get_response      get_response value.
+	 * @param bool   $is_user_logged_in is_user_logged_in return value.
+	 * @param int    $expected          The return value from the should_avoid_redirect function.
 	 */
 	public function test_should_avoid_redirect( $is_robots, $sitemap, $get_response, $is_user_logged_in, $expected ) {
 
@@ -180,12 +180,12 @@ class Crawl_Cleanup_Helper_Test extends TestCase {
 	 *
 	 * @dataProvider front_page_url_provider
 	 *
-	 * @param boolean $is_home_posts_page  is_home_posts_page return value.
-	 * @param boolean $is_home_static_page is_home_static_page return value.
-	 * @param int     $static_times        The times is_home_static_page function is called.
-	 * @param int     $home_url_times      home_url times called.
-	 * @param int     $permalink_times     get_permalink times called.
-	 * @param string  $expected            expected return value.
+	 * @param bool   $is_home_posts_page  is_home_posts_page return value.
+	 * @param bool   $is_home_static_page is_home_static_page return value.
+	 * @param int    $static_times        The times is_home_static_page function is called.
+	 * @param int    $home_url_times      home_url times called.
+	 * @param int    $permalink_times     get_permalink times called.
+	 * @param string $expected            expected return value.
 	 */
 	public function test_front_page_url( $is_home_posts_page, $is_home_static_page, $static_times, $home_url_times, $permalink_times, $expected ) {
 

--- a/tests/unit/helpers/crawl-cleanup-helper-test.php
+++ b/tests/unit/helpers/crawl-cleanup-helper-test.php
@@ -112,7 +112,7 @@ class Crawl_Cleanup_Helper_Test extends TestCase {
 	/**
 	 * Data provider for test_clean_permalinks_avoid_redirect.
 	 *
-	 * @return array is_robots, get_query_var( 'sitemap' ), $_GET, is_user_logged_in(), $expected.
+	 * @return array
 	 */
 	public function should_avoid_redirect_provider() {
 		return [
@@ -163,7 +163,7 @@ class Crawl_Cleanup_Helper_Test extends TestCase {
 	/**
 	 * Data provider for test_clean_permalinks.
 	 *
-	 * @return array avoid_redirect, expected.
+	 * @return array
 	 */
 	public function get_allowed_extravars_provider() {
 		return [
@@ -217,7 +217,7 @@ class Crawl_Cleanup_Helper_Test extends TestCase {
 	/**
 	 * Provider for test_front_page_url.
 	 *
-	 * @return array is_home_posts_page, is_home_static_page, static_times, home_url_times,permalink_times, expected.
+	 * @return array
 	 */
 	public function front_page_url_provider() {
 		return [
@@ -277,7 +277,7 @@ class Crawl_Cleanup_Helper_Test extends TestCase {
 	/**
 	 * Data provider for test_page_not_found_url.
 	 *
-	 * @return array is_multisite,is_subdomain_install,is_main_site,home_url,is_home_static_page,home_static_page_times,get_permalink_times,page_for_posts_times, current_url, expected.
+	 * @return array
 	 */
 	public function page_not_found_url_provider() {
 		return [
@@ -342,7 +342,7 @@ class Crawl_Cleanup_Helper_Test extends TestCase {
 	/**
 	 * Data provider for test_taxonomy_url.
 	 *
-	 * @return array $is_feed, $get_term_feed_link_times, $get_term_link_times, $expected
+	 * @return array
 	 */
 	public function taxonomy_url_provider() {
 		return [
@@ -405,7 +405,7 @@ class Crawl_Cleanup_Helper_Test extends TestCase {
 	/**
 	 * Data provider for test_query_var_page_url.
 	 *
-	 * @return array $is_search, $expected
+	 * @return array
 	 */
 	public function query_var_page_url_provider() {
 		$proper_url = 'http://basic.wordpress.test';
@@ -443,7 +443,7 @@ class Crawl_Cleanup_Helper_Test extends TestCase {
 	/**
 	 * Data provider for test_is_query_var_page.
 	 *
-	 * @return array $is_search, $expected
+	 * @return array
 	 */
 	public function is_query_var_page_provider() {
 		$proper_url = 'http://basic.wordpress.test';
@@ -518,7 +518,7 @@ class Crawl_Cleanup_Helper_Test extends TestCase {
 	/**
 	 * Data provider for test_get_url_type.
 	 *
-	 * @return array $singular,$front,$category,$tag,$tax,$search,$is404,$post_page,$post_page_times, $expected
+	 * @return array
 	 */
 	public function get_url_type_provider() {
 		return [

--- a/tests/unit/helpers/post-type-helper-test.php
+++ b/tests/unit/helpers/post-type-helper-test.php
@@ -44,10 +44,10 @@ class Post_Type_Helper_Test extends TestCase {
 	 *
 	 * @dataProvider post_type_archive_provider
 	 *
-	 * @param stdClass $return_object The object returned by the get_post_type_object function.
-	 * @param array    $post_types A list of post_types.
+	 * @param stdClass $return_object      The object returned by the get_post_type_object function.
+	 * @param array    $post_types         A list of post_types.
 	 * @param string   $post_type_to_check The post type to check.
-	 * @param bool     $expected_result The expected result if the archive is indexable.
+	 * @param bool     $expected_result    The expected result if the archive is indexable.
 	 *
 	 * @return void
 	 */
@@ -91,8 +91,8 @@ class Post_Type_Helper_Test extends TestCase {
 	 *
 	 * @dataProvider post_type_archive_object_provider
 	 *
-	 * @param stdClass $return_object The object returned by the get_post_type_object function.
-	 * @param array    $post_types A list of post_types.
+	 * @param stdClass $return_object   The object returned by the get_post_type_object function.
+	 * @param array    $post_types      A list of post_types.
 	 * @param array    $expected_result The expected list of indexable post archives.
 	 *
 	 * @return void

--- a/tests/unit/helpers/short-link-helper-test.php
+++ b/tests/unit/helpers/short-link-helper-test.php
@@ -67,12 +67,12 @@ class Short_Link_Helper_Test extends TestCase {
 	 *
 	 * @dataProvider build_dataprovider
 	 *
-	 * @param bool   $is_premium Whether the plugin is premium or not.
+	 * @param bool   $is_premium         Whether the plugin is premium or not.
 	 * @param string $first_activated_on The date (in days) the plugin was first activated.
-	 * @param string $locale The locale of the user.
-	 * @param string $link The link to build upon.
-	 * @param array  $args_list The list of arguments to add to the link.
-	 * @param string $expected The expected url.
+	 * @param string $locale             The locale of the user.
+	 * @param string $link               The link to build upon.
+	 * @param array  $args_list          The list of arguments to add to the link.
+	 * @param string $expected           The expected url.
 	 */
 	public function test_build( $is_premium, $first_activated_on, $locale, $link, $args_list, $expected ) {
 		$this->product_helper
@@ -149,11 +149,11 @@ class Short_Link_Helper_Test extends TestCase {
 	 *
 	 * @dataProvider get_query_params_dataprovider
 	 *
-	 * @param bool   $is_premium Whether the plugin is premium or not.
+	 * @param bool   $is_premium         Whether the plugin is premium or not.
 	 * @param string $first_activated_on The date (in days) the plugin was first activated.
-	 * @param string $locale The locale of the user.
-	 * @param string $page The page to get the query params for.
-	 * @param array  $expected The expected query params values.
+	 * @param string $locale             The locale of the user.
+	 * @param string $page               The page to get the query params for.
+	 * @param array  $expected           The expected query params values.
 	 */
 	public function test_get_query_params( $is_premium, $first_activated_on, $locale, $page, $expected ) {
 		$_GET['page'] = $page;

--- a/tests/unit/inc/addon-manager-test.php
+++ b/tests/unit/inc/addon-manager-test.php
@@ -1022,15 +1022,15 @@ class Addon_Manager_Test extends TestCase {
 	 *
 	 * Note that this only tests when a transient can be retrieved.
 	 *
+	 * @dataProvider get_myyoast_site_information_dataprovider
+	 *
+	 * @covers ::get_myyoast_site_information
+	 *
 	 * @param string $pagenow_new What the value of global pagenow should be.
 	 * @param mixed  $page What the value of $_GET['page'] should be.
 	 * @param bool   $call_quick Whether the quick transient will be used.
 	 * @param mixed  $transient_return The value the transient should return.
 	 * @param mixed  $return_value The return value.
-	 *
-	 * @dataProvider get_myyoast_site_information_dataprovider
-	 *
-	 * @covers ::get_myyoast_site_information
 	 */
 	public function test_get_myyoast_site_information( $pagenow_new, $page, $call_quick, $transient_return, $return_value ) {
 		global $pagenow;

--- a/tests/unit/inc/addon-manager-test.php
+++ b/tests/unit/inc/addon-manager-test.php
@@ -1026,11 +1026,11 @@ class Addon_Manager_Test extends TestCase {
 	 *
 	 * @covers ::get_myyoast_site_information
 	 *
-	 * @param string $pagenow_new What the value of global pagenow should be.
-	 * @param mixed  $page What the value of $_GET['page'] should be.
-	 * @param bool   $call_quick Whether the quick transient will be used.
+	 * @param string $pagenow_new      What the value of global pagenow should be.
+	 * @param mixed  $page             What the value of $_GET['page'] should be.
+	 * @param bool   $call_quick       Whether the quick transient will be used.
 	 * @param mixed  $transient_return The value the transient should return.
-	 * @param mixed  $return_value The return value.
+	 * @param mixed  $return_value     The return value.
 	 */
 	public function test_get_myyoast_site_information( $pagenow_new, $page, $call_quick, $transient_return, $return_value ) {
 		global $pagenow;

--- a/tests/unit/initializers/crawl-cleanup-permalinks-test.php
+++ b/tests/unit/initializers/crawl-cleanup-permalinks-test.php
@@ -97,10 +97,10 @@ class Crawl_Cleanup_Permalinks_Test extends TestCase {
 	 *
 	 * @dataProvider register_hooks_provider
 	 *
-	 * @param string $permalink_structure permalink_structure value returned from get_option.
-	 * @param string $campaign_tracking_urls Returned value from option_helper.
-	 * @param string $clean_permalinks Returned value from option_helper.
-	 * @param int    $expected_utm_redirect Is action fired.
+	 * @param string $permalink_structure       permalink_structure value returned from get_option.
+	 * @param string $campaign_tracking_urls    Returned value from option_helper.
+	 * @param string $clean_permalinks          Returned value from option_helper.
+	 * @param int    $expected_utm_redirect     Is action fired.
 	 * @param int    $expected_clean_permalinks Is action fired.
 	 */
 	public function test_register_hooks( $permalink_structure, $campaign_tracking_urls, $clean_permalinks, $expected_utm_redirect, $expected_clean_permalinks ) {
@@ -166,8 +166,8 @@ class Crawl_Cleanup_Permalinks_Test extends TestCase {
 	 *
 	 * @dataProvider utm_redirect_provider
 	 *
-	 * @param string $request_uri $_SERVER['REQUEST_URI'].
-	 * @param array  $wp_parse_url wp_parse_url return value.
+	 * @param string $request_uri         $_SERVER['REQUEST_URI'].
+	 * @param array  $wp_parse_url        wp_parse_url return value.
 	 * @param int    $is_wp_safe_redirect Is wp_safe_redirect called.
 	 */
 	public function test_utm_redirect( $request_uri, $wp_parse_url, $is_wp_safe_redirect ) {
@@ -229,11 +229,11 @@ class Crawl_Cleanup_Permalinks_Test extends TestCase {
 	 *
 	 * @dataProvider clean_permalinks_no_redirect_provider
 	 *
-	 * @param bool   $avoid_redirect should avoid redirect.
+	 * @param bool   $avoid_redirect             should avoid redirect.
 	 * @param int    $recreate_current_url_times times recreate_current_url is called.
-	 * @param string $current_url current url.
-	 * @param array  $allowed_params allowed params.
-	 * @param int    $expected times redirect is done.
+	 * @param string $current_url                current url.
+	 * @param array  $allowed_params             allowed params.
+	 * @param int    $expected                   times redirect is done.
 	 */
 	public function test_clean_permalinks_no_redirect( $avoid_redirect, $recreate_current_url_times, $current_url, $allowed_params, $expected ) {
 
@@ -284,11 +284,11 @@ class Crawl_Cleanup_Permalinks_Test extends TestCase {
 	 *
 	 * @dataProvider clean_permalinks_provider
 	 *
-	 * @param string $current_url current url.
+	 * @param string $current_url    current url.
 	 * @param array  $allowed_params allowed params.
-	 * @param string $url_type is url type and the function name in the helper.
-	 * @param string $proper_url proper url.
-	 * @param int    $expected times redirect is done.
+	 * @param string $url_type       is url type and the function name in the helper.
+	 * @param string $proper_url     proper url.
+	 * @param int    $expected       times redirect is done.
 	 */
 	public function test_clean_permalinks( $current_url, $allowed_params, $url_type, $proper_url, $expected ) {
 
@@ -399,10 +399,10 @@ class Crawl_Cleanup_Permalinks_Test extends TestCase {
 	 *
 	 * @dataProvider clean_permalinks_with_page_var_provider
 	 *
-	 * @param string $current_url current url.
+	 * @param string $current_url    current url.
 	 * @param array  $allowed_params allowed params.
-	 * @param string $proper_url proper url.
-	 * @param int    $expected times redirect is done.
+	 * @param string $proper_url     proper url.
+	 * @param int    $expected       times redirect is done.
 	 */
 	public function test_clean_permalinks_with_page_var( $current_url, $allowed_params, $proper_url, $expected ) {
 

--- a/tests/unit/initializers/crawl-cleanup-permalinks-test.php
+++ b/tests/unit/initializers/crawl-cleanup-permalinks-test.php
@@ -97,11 +97,11 @@ class Crawl_Cleanup_Permalinks_Test extends TestCase {
 	 *
 	 * @dataProvider register_hooks_provider
 	 *
-	 * @param string $permalink_structure       permalink_structure value returned from get_option.
-	 * @param string $campaign_tracking_urls    Returned value from option_helper.
-	 * @param string $clean_permalinks          Returned value from option_helper.
-	 * @param int    $expected_utm_redirect     Is action fired.
-	 * @param int    $expected_clean_permalinks Is action fired.
+	 * @param string $permalink_structure       Mock return value for get_option(permalink_structure).
+	 * @param string $campaign_tracking_urls    Mock return value for option_helper.
+	 * @param string $clean_permalinks          Mock return value for option_helper.
+	 * @param int    $expected_utm_redirect     The number of times the utm_redirect action is expected to be added.
+	 * @param int    $expected_clean_permalinks The number of times the clean_permalinks action is expected to be added.
 	 */
 	public function test_register_hooks( $permalink_structure, $campaign_tracking_urls, $clean_permalinks, $expected_utm_redirect, $expected_clean_permalinks ) {
 
@@ -166,9 +166,9 @@ class Crawl_Cleanup_Permalinks_Test extends TestCase {
 	 *
 	 * @dataProvider utm_redirect_provider
 	 *
-	 * @param string $request_uri         $_SERVER['REQUEST_URI'].
-	 * @param array  $wp_parse_url        wp_parse_url return value.
-	 * @param int    $is_wp_safe_redirect Is wp_safe_redirect called.
+	 * @param string $request_uri         Mock $_SERVER['REQUEST_URI'] data.
+	 * @param array  $wp_parse_url        Mock return value for wp_parse_url().
+	 * @param int    $is_wp_safe_redirect The number of times wp_safe_redirect() is expected to be called.
 	 */
 	public function test_utm_redirect( $request_uri, $wp_parse_url, $is_wp_safe_redirect ) {
 		$_SERVER['REQUEST_URI'] = $request_uri;
@@ -229,11 +229,11 @@ class Crawl_Cleanup_Permalinks_Test extends TestCase {
 	 *
 	 * @dataProvider clean_permalinks_no_redirect_provider
 	 *
-	 * @param bool   $avoid_redirect             should avoid redirect.
-	 * @param int    $recreate_current_url_times times recreate_current_url is called.
-	 * @param string $current_url                current url.
-	 * @param array  $allowed_params             allowed params.
-	 * @param int    $expected                   times redirect is done.
+	 * @param bool   $avoid_redirect             Mock return value for should avoid redirect().
+	 * @param int    $recreate_current_url_times The number of times recreate_current_url() is expected to be called.
+	 * @param string $current_url                Mock return value for recreate_current_url().
+	 * @param array  $allowed_params             Mock return value for allowed_params().
+	 * @param int    $expected                   The number of times do_clean_redirect() is expected to be called.
 	 */
 	public function test_clean_permalinks_no_redirect( $avoid_redirect, $recreate_current_url_times, $current_url, $allowed_params, $expected ) {
 
@@ -284,11 +284,11 @@ class Crawl_Cleanup_Permalinks_Test extends TestCase {
 	 *
 	 * @dataProvider clean_permalinks_provider
 	 *
-	 * @param string $current_url    current url.
-	 * @param array  $allowed_params allowed params.
-	 * @param string $url_type       is url type and the function name in the helper.
-	 * @param string $proper_url     proper url.
-	 * @param int    $expected       times redirect is done.
+	 * @param string $current_url    Mock return value for recreate_current_url().
+	 * @param array  $allowed_params Mock return value for allowed_params().
+	 * @param string $url_type       Mock return value for get_url_type() and the function name in the helper.
+	 * @param string $proper_url     Mock return value for helper.
+	 * @param int    $expected       The number of times do_clean_redirect() is expected to be called.
 	 */
 	public function test_clean_permalinks( $current_url, $allowed_params, $url_type, $proper_url, $expected ) {
 
@@ -399,10 +399,10 @@ class Crawl_Cleanup_Permalinks_Test extends TestCase {
 	 *
 	 * @dataProvider clean_permalinks_with_page_var_provider
 	 *
-	 * @param string $current_url    current url.
-	 * @param array  $allowed_params allowed params.
-	 * @param string $proper_url     proper url.
-	 * @param int    $expected       times redirect is done.
+	 * @param string $current_url    Mock return value for recreate_current_url().
+	 * @param array  $allowed_params Mock return value for allowed_params().
+	 * @param string $proper_url     Mock return value for query_var_page_url().
+	 * @param int    $expected       The number of times do_clean_redirect() is expected to be called.
 	 */
 	public function test_clean_permalinks_with_page_var( $current_url, $allowed_params, $proper_url, $expected ) {
 

--- a/tests/unit/initializers/crawl-cleanup-permalinks-test.php
+++ b/tests/unit/initializers/crawl-cleanup-permalinks-test.php
@@ -196,7 +196,7 @@ class Crawl_Cleanup_Permalinks_Test extends TestCase {
 	/**
 	 * Data provider for utm_redirect.
 	 *
-	 * @return array $_SERVER['REQUEST_URI'], wp_parse_url return value, is wp_safe_redirect.
+	 * @return array
 	 */
 	public function utm_redirect_provider() {
 		return [
@@ -268,7 +268,7 @@ class Crawl_Cleanup_Permalinks_Test extends TestCase {
 	 * 1. If avoid_redirect is true then do_clean_redirect shouldn't be called.
 	 * 2. If avoid_redirect is false and 'query' is empty then do_clean_redirect shouldn't be called.
 	 *
-	 * @return array avoid_redirect, recreate_current_url_times, current_url, allowed_params, expected.
+	 * @return array
 	 */
 	public function clean_permalinks_no_redirect_provider() {
 		return [
@@ -345,7 +345,7 @@ class Crawl_Cleanup_Permalinks_Test extends TestCase {
 	 * 4. If url type is search, then search_url should be called and do_clean_redirect should be called.
 	 * 5. If url type is page_not_found_url, then page_not_found_url should be called and do_clean_redirect should be called.
 	 *
-	 * @return array avoid_redirect, recreate_current_url_times, allowed_params, current_url,$url_type,$proper_url,get_url_type_times, expected.
+	 * @return array
 	 */
 	public function clean_permalinks_provider() {
 		$allowed_params = [
@@ -457,7 +457,7 @@ class Crawl_Cleanup_Permalinks_Test extends TestCase {
 	 * 2. If $proper_url is empty, then do_clean_redirect should not be called.
 	 * 3. If $proper_url is equal to $current_url, then do_clean_redirect should not be called.
 	 *
-	 * @return array  current_url, allowed_params, $proper_url, expected.
+	 * @return array
 	 */
 	public function clean_permalinks_with_page_var_provider() {
 		$allowed_params = [

--- a/tests/unit/initializers/crawl-cleanup-permalinks-test.php
+++ b/tests/unit/initializers/crawl-cleanup-permalinks-test.php
@@ -154,7 +154,7 @@ class Crawl_Cleanup_Permalinks_Test extends TestCase {
 	 * Tests get_conditionals.
 	 *
 	 * @covers ::get_conditionals
-	 **/
+	 */
 	public function test_get_conditionals() {
 		$this->assertEquals( [ Front_End_Conditional::class ], $this->instance->get_conditionals() );
 	}

--- a/tests/unit/integrations/admin/crawl-settings-integration-test.php
+++ b/tests/unit/integrations/admin/crawl-settings-integration-test.php
@@ -88,8 +88,8 @@ class Crawl_Settings_Integration_Test extends TestCase {
 	 * @dataProvider enqueue_assets_provider
 	 *
 	 * @param bool   $is_network_admin Whether the current page is a network admin page.
-	 * @param string $get_response The response of the GET request.
-	 * @param int    $expected The times admin_asset_manager->enqueue_script( 'crawl-settings' ) is called.
+	 * @param string $get_response     The response of the GET request.
+	 * @param int    $expected         The times admin_asset_manager->enqueue_script( 'crawl-settings' ) is called.
 	 */
 	public function test_enqueue_assets( $is_network_admin, $get_response, $expected ) {
 

--- a/tests/unit/integrations/admin/first-time-configuration-notice-integration-test.php
+++ b/tests/unit/integrations/admin/first-time-configuration-notice-integration-test.php
@@ -133,7 +133,7 @@ class First_Time_Configuration_Notice_Integration_Test extends TestCase {
 	 *
 	 * @dataProvider dismiss_first_time_configuration_notice_provider
 	 *
-	 * @param bool $check_ajax_referer The value for the check_ajax_referer function.
+	 * @param bool $check_ajax_referer                         The value for the check_ajax_referer function.
 	 * @param int  $dismiss_configuration_workout_notice_times The value for the dismiss_configuration_workout_notice option.
 	 */
 	public function test_dismiss_first_time_configuration_notice( $check_ajax_referer, $dismiss_configuration_workout_notice_times ) {
@@ -220,7 +220,7 @@ class First_Time_Configuration_Notice_Integration_Test extends TestCase {
 	 *
 	 * @dataProvider first_time_configuration_notice_provider
 	 * @param bool   $should_show_alternate_message Indicate what message to render.
-	 * @param string $message The string that will be rendered.
+	 * @param string $message                       The string that will be rendered.
 	 */
 	public function test_first_time_configuration_notice( $should_show_alternate_message, $message ) {
 		$this->expect_should_display_first_time_configuration_notice( true );

--- a/tests/unit/integrations/watchers/indexable-attachment-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-attachment-watcher-test.php
@@ -95,7 +95,7 @@ class Indexable_Attachment_Watcher_Test extends TestCase {
 	/**
 	 * Data provider for test_check_option.
 	 *
-	 * @return array $old_value,$new_value, $delete_transient_times, $set_reason_times, $attachment_cleanup_times, wp_next_scheduled, $schedule_event_times.
+	 * @return array
 	 */
 	public function check_option_provider() {
 		return [

--- a/tests/unit/repositories/indexable-cleanup-repository-test.php
+++ b/tests/unit/repositories/indexable-cleanup-repository-test.php
@@ -62,7 +62,7 @@ class Indexable_Cleanup_Repository_Test extends TestCase {
 	/**
 	 * The query limit.
 	 *
-	 * @var int $limit
+	 * @var int
 	 */
 	private $limit = 1000;
 

--- a/tests/unit/repositories/seo-links-repository-test.php
+++ b/tests/unit/repositories/seo-links-repository-test.php
@@ -255,7 +255,7 @@ class SEO_Links_Repository_Test extends TestCase {
 	/**
 	 * Data provider for test_get_incoming_link_counts_for_indexable_ids method.
 	 *
-	 * @return array $indexable_counts, $expected_return.
+	 * @return array
 	 */
 	public function get_incoming_link_counts_for_indexable_ids_provider() {
 		return [

--- a/tests/unit/repositories/seo-links-repository-test.php
+++ b/tests/unit/repositories/seo-links-repository-test.php
@@ -298,7 +298,7 @@ class SEO_Links_Repository_Test extends TestCase {
 	 *
 	 * @dataProvider get_incoming_link_counts_for_indexable_ids_provider
 	 * @param array $indexable_counts The indexable counts.
-	 * @param array $expected The expected result.
+	 * @param array $expected         The expected result.
 	 */
 	public function test_get_incoming_link_counts_for_indexable_ids( $indexable_counts, $expected ) {
 		$indexable_ids = [ 1, 2 ];

--- a/tests/unit/services/importing/conflicting-plugins-service-test.php
+++ b/tests/unit/services/importing/conflicting-plugins-service-test.php
@@ -115,13 +115,13 @@ class Conflicting_Plugins_Service_Test extends TestCase {
 	/**
 	 * Test the ignore_deactivating_plugin when GET variables are not set correctly.
 	 *
-	 * @param mixed $action The value of $_GET['action'].
-	 * @param mixed $plugin The value of $_GET['plugin'].
-	 * @param array $expected The expected return value of detect_conflicting_plugins.
-	 *
 	 * @dataProvider detect_deactivating_conflicting_plugins_dataprovider
 	 *
 	 * @covers ::ignore_deactivating_plugin
+	 *
+	 * @param mixed $action The value of $_GET['action'].
+	 * @param mixed $plugin The value of $_GET['plugin'].
+	 * @param array $expected The expected return value of detect_conflicting_plugins.
 	 */
 	public function test_detect_deactivating_conflicting_plugins_plugin_is_int( $action, $plugin, $expected ) {
 		Monkey\Functions\expect( 'get_option' )

--- a/tests/unit/services/importing/conflicting-plugins-service-test.php
+++ b/tests/unit/services/importing/conflicting-plugins-service-test.php
@@ -119,8 +119,8 @@ class Conflicting_Plugins_Service_Test extends TestCase {
 	 *
 	 * @covers ::ignore_deactivating_plugin
 	 *
-	 * @param mixed $action The value of $_GET['action'].
-	 * @param mixed $plugin The value of $_GET['plugin'].
+	 * @param mixed $action   The value of $_GET['action'].
+	 * @param mixed $plugin   The value of $_GET['plugin'].
 	 * @param array $expected The expected return value of detect_conflicting_plugins.
 	 */
 	public function test_detect_deactivating_conflicting_plugins_plugin_is_int( $action, $plugin, $expected ) {


### PR DESCRIPTION
## Context

* Code documentation consistency 

## Summary

This PR can be summarized in the following changelog entry:

* Code documentation consistency 

## Relevant technical choices:

* Docs: remove redundant `@throws` tag
    Follow up on #19948, commit c5a257c
* Docs: use consistent tag order
* Docs: fix incorrect @param tag alignment
* Docs: minor formatting fixes
* Docs: property `@var` tags should not include the property name
* Docs: remove annotation which shouldn't be used
    The `@access` annotation should only ever be used for functions declared in the global namespace where visibility modifiers are not available.
* Docs: use short form type keywords
* Docs: fix invalid @return tag descriptions
    PHP does not return a named entity, so variable names have no place in `@return` tags.
    Either provide a proper description or leave the description out.
* Docs: fix capitalization and punctuation
    ... by actually describing the parameter.


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a docs-only change and should have no effect on the functionality. If the build passes (linting, test runs), we're good.