### PR TITLE
CS/QA: don't pass parameter which doesn't exist

### DIFF
--- a/src/integrations/admin/crawl-settings-integration.php
+++ b/src/integrations/admin/crawl-settings-integration.php
@@ -167,7 +167,7 @@ class Crawl_Settings_Integration implements Integration_Interface {
 	 */
 	public function add_crawl_settings_tab_content( $yform ) {
 		\_deprecated_function( __METHOD__, 'Yoast SEO 20.4' );
-		$this->add_crawl_settings( $yform, false );
+		$this->add_crawl_settings( $yform );
 	}
 
 	/**
@@ -176,7 +176,7 @@ class Crawl_Settings_Integration implements Integration_Interface {
 	 * @param Yoast_Form $yform The yoast form object.
 	 */
 	public function add_crawl_settings_tab_content_network( $yform ) {
-		$this->add_crawl_settings( $yform, true );
+		$this->add_crawl_settings( $yform );
 	}
 
 	/**


### PR DESCRIPTION
## Context

* Code quality

## Summary

This PR can be summarized in the following changelog entry:

* Code quality

## Relevant technical choices:

Commit 47baef5bed4302c4bb76212339d327d462cf82fa removed support for the `$is_network` parameter, but there were still two method calls within the class passing that parameter.

Fixed now.


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality. If the build passes (linting, test runs), we're good.