### PR TITLE
Tests: add missing assertions

### DIFF
--- a/tests/unit/builders/indexable-term-builder-test.php
+++ b/tests/unit/builders/indexable-term-builder-test.php
@@ -484,6 +484,8 @@ class Indexable_Term_Builder_Test extends TestCase {
 			'source' => 'first-content-image',
 		];
 		$actual   = $this->instance->find_alternative_image( $indexable_mock );
+
+		$this->assertSame( $expected, $actual );
 	}
 
 	/**

--- a/tests/unit/repositories/seo-links-repository-test.php
+++ b/tests/unit/repositories/seo-links-repository-test.php
@@ -150,7 +150,6 @@ class SEO_Links_Repository_Test extends TestCase {
 	public function test_update_target_indexable_id() {
 		$link_id             = 1;
 		$target_indexable_id = 2;
-		$expected_result     = true;
 
 		$this->instance->expects( $this->once() )
 			->method( 'query' )
@@ -160,7 +159,7 @@ class SEO_Links_Repository_Test extends TestCase {
 		$this->orm_mock->shouldReceive( 'where' )->with( 'id', $link_id )->andReturn( $this->orm_mock );
 		$this->orm_mock->shouldReceive( 'update_many' )->andReturn( 1 );
 
-		$this->assertSame( $expected_result, $this->instance->update_target_indexable_id( $link_id, $target_indexable_id ) );
+		$this->assertTrue( $this->instance->update_target_indexable_id( $link_id, $target_indexable_id ) );
 	}
 
 	/**
@@ -169,8 +168,7 @@ class SEO_Links_Repository_Test extends TestCase {
 	 * @covers ::delete_all_by_post_id
 	 */
 	public function test_delete_all_by_post_id() {
-		$post_id         = 1;
-		$expected_result = true;
+		$post_id = 1;
 
 		$this->instance->expects( $this->once() )
 			->method( 'query' )
@@ -179,7 +177,7 @@ class SEO_Links_Repository_Test extends TestCase {
 		$this->orm_mock->shouldReceive( 'where' )->with( 'post_id', $post_id )->andReturn( $this->orm_mock );
 		$this->orm_mock->shouldReceive( 'delete_many' )->andReturn( true );
 
-		$this->assertSame( $expected_result, $this->instance->delete_all_by_post_id( $post_id ) );
+		$this->instance->delete_all_by_post_id( $post_id );
 	}
 
 	/**
@@ -188,8 +186,7 @@ class SEO_Links_Repository_Test extends TestCase {
 	 * @covers ::delete_all_by_post_id_where_indexable_id_null
 	 */
 	public function test_delete_all_by_post_id_where_indexable_id_null() {
-		$post_id         = 1;
-		$expected_result = true;
+		$post_id = 1;
 
 		$this->instance->expects( $this->once() )
 			->method( 'query' )
@@ -199,7 +196,7 @@ class SEO_Links_Repository_Test extends TestCase {
 		$this->orm_mock->shouldReceive( 'where_null' )->with( 'indexable_id' )->andReturn( $this->orm_mock );
 		$this->orm_mock->shouldReceive( 'delete_many' )->andReturn( true );
 
-		$this->assertSame( $expected_result, $this->instance->delete_all_by_post_id_where_indexable_id_null( $post_id ) );
+		$this->instance->delete_all_by_post_id_where_indexable_id_null( $post_id );
 	}
 
 	/**
@@ -208,8 +205,7 @@ class SEO_Links_Repository_Test extends TestCase {
 	 * @covers ::delete_all_by_indexable_id
 	 */
 	public function test_delete_all_by_indexable_id() {
-		$indexable_id    = 1;
-		$expected_result = true;
+		$indexable_id = 1;
 
 		$this->instance->expects( $this->once() )
 			->method( 'query' )
@@ -218,7 +214,7 @@ class SEO_Links_Repository_Test extends TestCase {
 		$this->orm_mock->shouldReceive( 'where' )->with( 'indexable_id', $indexable_id )->andReturn( $this->orm_mock );
 		$this->orm_mock->shouldReceive( 'delete_many' )->andReturn( true );
 
-		$this->assertSame( $expected_result, $this->instance->delete_all_by_indexable_id( $indexable_id ) );
+		$this->instance->delete_all_by_indexable_id( $indexable_id );
 	}
 
 	/**
@@ -322,8 +318,7 @@ class SEO_Links_Repository_Test extends TestCase {
 	 * @covers ::delete_many_by_id
 	 */
 	public function test_delete_many_by_id() {
-		$ids             = [ 1, 2 ];
-		$expected_result = true;
+		$ids = [ 1, 2 ];
 
 		$this->instance->expects( $this->once() )
 			->method( 'query' )
@@ -332,7 +327,7 @@ class SEO_Links_Repository_Test extends TestCase {
 		$this->orm_mock->shouldReceive( 'where_in' )->with( 'id', $ids )->andReturn( $this->orm_mock );
 		$this->orm_mock->shouldReceive( 'delete_many' )->andReturn( true );
 
-		$this->assertSame( $expected_result, $this->instance->delete_many_by_id( $ids ) );
+		$this->instance->delete_many_by_id( $ids );
 	}
 
 	/**
@@ -341,9 +336,7 @@ class SEO_Links_Repository_Test extends TestCase {
 	 * @covers ::insert_many
 	 */
 	public function test_insert_many() {
-
-		$links           = [ new SEO_Links(), new SEO_Links() ];
-		$expected_result = true;
+		$links = [ new SEO_Links(), new SEO_Links() ];
 
 		$this->instance->expects( $this->once() )
 			->method( 'query' )
@@ -351,6 +344,6 @@ class SEO_Links_Repository_Test extends TestCase {
 
 		$this->orm_mock->shouldReceive( 'insert_many' )->with( $links )->andReturn( true );
 
-		$this->assertSame( $expected_result, $this->instance->insert_many( $links ) );
+		$this->instance->insert_many( $links );
 	}
 }

--- a/tests/unit/repositories/seo-links-repository-test.php
+++ b/tests/unit/repositories/seo-links-repository-test.php
@@ -160,7 +160,7 @@ class SEO_Links_Repository_Test extends TestCase {
 		$this->orm_mock->shouldReceive( 'where' )->with( 'id', $link_id )->andReturn( $this->orm_mock );
 		$this->orm_mock->shouldReceive( 'update_many' )->andReturn( 1 );
 
-		$this->instance->update_target_indexable_id( $link_id, $target_indexable_id );
+		$this->assertSame( $expected_result, $this->instance->update_target_indexable_id( $link_id, $target_indexable_id ) );
 	}
 
 	/**
@@ -179,7 +179,7 @@ class SEO_Links_Repository_Test extends TestCase {
 		$this->orm_mock->shouldReceive( 'where' )->with( 'post_id', $post_id )->andReturn( $this->orm_mock );
 		$this->orm_mock->shouldReceive( 'delete_many' )->andReturn( true );
 
-		$this->instance->delete_all_by_post_id( $post_id );
+		$this->assertSame( $expected_result, $this->instance->delete_all_by_post_id( $post_id ) );
 	}
 
 	/**
@@ -199,7 +199,7 @@ class SEO_Links_Repository_Test extends TestCase {
 		$this->orm_mock->shouldReceive( 'where_null' )->with( 'indexable_id' )->andReturn( $this->orm_mock );
 		$this->orm_mock->shouldReceive( 'delete_many' )->andReturn( true );
 
-		$this->instance->delete_all_by_post_id_where_indexable_id_null( $post_id );
+		$this->assertSame( $expected_result, $this->instance->delete_all_by_post_id_where_indexable_id_null( $post_id ) );
 	}
 
 	/**
@@ -218,7 +218,7 @@ class SEO_Links_Repository_Test extends TestCase {
 		$this->orm_mock->shouldReceive( 'where' )->with( 'indexable_id', $indexable_id )->andReturn( $this->orm_mock );
 		$this->orm_mock->shouldReceive( 'delete_many' )->andReturn( true );
 
-		$this->instance->delete_all_by_indexable_id( $indexable_id );
+		$this->assertSame( $expected_result, $this->instance->delete_all_by_indexable_id( $indexable_id ) );
 	}
 
 	/**
@@ -332,7 +332,7 @@ class SEO_Links_Repository_Test extends TestCase {
 		$this->orm_mock->shouldReceive( 'where_in' )->with( 'id', $ids )->andReturn( $this->orm_mock );
 		$this->orm_mock->shouldReceive( 'delete_many' )->andReturn( true );
 
-		$this->instance->delete_many_by_id( $ids );
+		$this->assertSame( $expected_result, $this->instance->delete_many_by_id( $ids ) );
 	}
 
 	/**
@@ -351,6 +351,6 @@ class SEO_Links_Repository_Test extends TestCase {
 
 		$this->orm_mock->shouldReceive( 'insert_many' )->with( $links )->andReturn( true );
 
-		$this->instance->insert_many( $links );
+		$this->assertSame( $expected_result, $this->instance->insert_many( $links ) );
 	}
 }

--- a/tests/unit/repositories/seo-links-repository-test.php
+++ b/tests/unit/repositories/seo-links-repository-test.php
@@ -313,7 +313,7 @@ class SEO_Links_Repository_Test extends TestCase {
 		$this->orm_mock->shouldReceive( 'group_by' )->with( 'target_indexable_id' )->andReturn( $this->orm_mock );
 		$this->orm_mock->shouldReceive( 'find_array' )->andReturn( $indexable_counts );
 
-		$this->instance->get_incoming_link_counts_for_indexable_ids( $indexable_ids );
+		$this->assertSame( $expected, $this->instance->get_incoming_link_counts_for_indexable_ids( $indexable_ids ) );
 	}
 
 	/**


### PR DESCRIPTION
## Context

* Improve test suite

## Summary

This PR can be summarized in the following changelog entry:

* Improve test suite

## Relevant technical choices:

### Tests: add missing assertion [1]

Both the `$expected` variable, as well as the `$actual` variable were unused, which gives me the impression the intention was to test that those are the same.

### Tests: add missing assertion [2]

The `$expected` parameter received from the data provider was unused, which gives me the impression the intention was to also test the function call result.

### Tests: add missing assertion [3]

In each of these tests, an `$expected_result` variable is being set, but subsequently never used, which gives me the impression the intention was to also test the function call result.


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a test-only change and should have no effect on the functionality. If the build passes (linting, test runs), we're good.