### PR TITLE
Background cron indexation

### DIFF
--- a/src/commands/index-command.php
+++ b/src/commands/index-command.php
@@ -14,6 +14,7 @@ use Yoast\WP\SEO\Actions\Indexing\Indexation_Action_Interface;
 use Yoast\WP\SEO\Actions\Indexing\Indexing_Prepare_Action;
 use Yoast\WP\SEO\Actions\Indexing\Post_Link_Indexing_Action;
 use Yoast\WP\SEO\Actions\Indexing\Term_Link_Indexing_Action;
+use Yoast\WP\SEO\Helpers\Indexable_Helper;
 use Yoast\WP\SEO\Main;
 
 /**
@@ -78,6 +79,13 @@ class Index_Command implements Command_Interface {
 	private $prepare_indexing_action;
 
 	/**
+	 * Represents the indexable helper.
+	 *
+	 * @var Indexable_Helper
+	 */
+	protected $indexable_helper;
+
+	/**
 	 * Generate_Indexables_Command constructor.
 	 *
 	 * @param Indexable_Post_Indexation_Action              $post_indexation_action              The post indexation
@@ -96,6 +104,7 @@ class Index_Command implements Command_Interface {
 	 *                                                                                           action.
 	 * @param Term_Link_Indexing_Action                     $term_link_indexing_action           The term link indexation
 	 *                                                                                           action.
+	 * @param Indexable_Helper                              $indexable_helper                    The indexable helper.
 	 */
 	public function __construct(
 		Indexable_Post_Indexation_Action $post_indexation_action,
@@ -105,7 +114,8 @@ class Index_Command implements Command_Interface {
 		Indexable_Indexing_Complete_Action $complete_indexation_action,
 		Indexing_Prepare_Action $prepare_indexing_action,
 		Post_Link_Indexing_Action $post_link_indexing_action,
-		Term_Link_Indexing_Action $term_link_indexing_action
+		Term_Link_Indexing_Action $term_link_indexing_action,
+		Indexable_Helper $indexable_helper
 	) {
 		$this->post_indexation_action              = $post_indexation_action;
 		$this->term_indexation_action              = $term_indexation_action;
@@ -115,6 +125,7 @@ class Index_Command implements Command_Interface {
 		$this->prepare_indexing_action             = $prepare_indexing_action;
 		$this->post_link_indexing_action           = $post_link_indexing_action;
 		$this->term_link_indexing_action           = $term_link_indexing_action;
+		$this->indexable_helper                    = $indexable_helper;
 	}
 
 	/**
@@ -158,6 +169,14 @@ class Index_Command implements Command_Interface {
 	 * @return void
 	 */
 	public function index( $args = null, $assoc_args = null ) {
+		if ( ! $this->indexable_helper->should_index_indexables() ) {
+			WP_CLI::log(
+				\__( 'Your WordPress environment is running on a non-production site. Indexables can only be created on production environments. Please check your `WP_ENVIRONMENT_TYPE` settings.', 'wordpress-seo' )
+			);
+
+			return;
+		}
+
 		if ( ! isset( $assoc_args['network'] ) ) {
 			$this->run_indexation_actions( $assoc_args );
 

--- a/src/conditionals/wp-cron-enabled-conditional.php
+++ b/src/conditionals/wp-cron-enabled-conditional.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Yoast\WP\SEO\Conditionals;
+
+/**
+ * Class that checks if WP_CRON is enabled.
+ */
+class WP_CRON_Enabled_Conditional implements Conditional {
+
+	/**
+	 * Checks if WP_CRON is enabled.
+	 *
+	 * @return bool True when WP_CRON is enabled.
+	 */
+	public function is_met() {
+		return ! ( defined( 'DISABLE_WP_CRON' ) && DISABLE_WP_CRON );
+	}
+}

--- a/src/integrations/admin/background-indexing-integration.php
+++ b/src/integrations/admin/background-indexing-integration.php
@@ -11,7 +11,9 @@ use Yoast\WP\SEO\Actions\Indexing\Post_Link_Indexing_Action;
 use Yoast\WP\SEO\Actions\Indexing\Term_Link_Indexing_Action;
 use Yoast\WP\SEO\Conditionals\Get_Request_Conditional;
 use Yoast\WP\SEO\Conditionals\Migrations_Conditional;
+use Yoast\WP\SEO\Conditionals\WP_CRON_Enabled_Conditional;
 use Yoast\WP\SEO\Conditionals\Yoast_Admin_And_Dashboard_Conditional;
+use Yoast\WP\SEO\Helpers\Indexable_Helper;
 use Yoast\WP\SEO\Helpers\Indexing_Helper;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
 
@@ -79,29 +81,59 @@ class Background_Indexing_Integration implements Integration_Interface {
 	protected $indexing_helper;
 
 	/**
+	 * An object that checks if we are on the Yoast admin or on the dashboard page.
+	 *
+	 * @var Yoast_Admin_And_Dashboard_Conditional
+	 */
+	protected $yoast_admin_and_dashboard_conditional;
+
+	/**
+	 * An object that checks if we are handling a GET request.
+	 *
+	 * @var Get_Request_Conditional
+	 */
+	private $get_request_conditional;
+
+	/**
+	 * An object that checks if WP_CRON is enabled.
+	 *
+	 * @var WP_CRON_Enabled_Conditional
+	 */
+	private $wp_cron_enabled_conditional;
+
+	/**
+	 * The indexable helper
+	 *
+	 * @var Indexable_Helper
+	 */
+	private $indexable_helper;
+
+	/**
 	 * Returns the conditionals based on which this integration should be active.
 	 *
 	 * @return array The array of conditionals.
 	 */
 	public static function get_conditionals() {
 		return [
-			Yoast_Admin_And_Dashboard_Conditional::class,
 			Migrations_Conditional::class,
-			Get_Request_Conditional::class,
 		];
 	}
 
 	/**
 	 * Shutdown_Indexing_Integration constructor.
 	 *
-	 * @param Indexable_Post_Indexation_Action              $post_indexation              The post indexing action.
-	 * @param Indexable_Term_Indexation_Action              $term_indexation              The term indexing action.
-	 * @param Indexable_Post_Type_Archive_Indexation_Action $post_type_archive_indexation The post type archive indexing action.
-	 * @param Indexable_General_Indexation_Action           $general_indexation           The general indexing action.
-	 * @param Indexable_Indexing_Complete_Action            $complete_indexation_action   The complete indexing action.
-	 * @param Post_Link_Indexing_Action                     $post_link_indexing_action    The post indexing action.
-	 * @param Term_Link_Indexing_Action                     $term_link_indexing_action    The term indexing action.
-	 * @param Indexing_Helper                               $indexing_helper              The indexing helper.
+	 * @param Indexable_Post_Indexation_Action              $post_indexation                       The post indexing action.
+	 * @param Indexable_Term_Indexation_Action              $term_indexation                       The term indexing action.
+	 * @param Indexable_Post_Type_Archive_Indexation_Action $post_type_archive_indexation          The post type archive indexing action.
+	 * @param Indexable_General_Indexation_Action           $general_indexation                    The general indexing action.
+	 * @param Indexable_Indexing_Complete_Action            $complete_indexation_action            The complete indexing action.
+	 * @param Post_Link_Indexing_Action                     $post_link_indexing_action             The post indexing action.
+	 * @param Term_Link_Indexing_Action                     $term_link_indexing_action             The term indexing action.
+	 * @param Indexing_Helper                               $indexing_helper                       The indexing helper.
+	 * @param Indexable_Helper                              $indexable_helper                      The indexable helper.
+	 * @param Yoast_Admin_And_Dashboard_Conditional         $yoast_admin_and_dashboard_conditional An object that checks if we are on the Yoast admin or on the dashboard page.
+	 * @param Get_Request_Conditional                       $get_request_conditional               An object that checks if we are handling a GET request.
+	 * @param WP_CRON_Enabled_Conditional                   $wp_cron_enabled_conditional           An object that checks if WP_CRON is enabled.
 	 */
 	public function __construct(
 		Indexable_Post_Indexation_Action $post_indexation,
@@ -111,23 +143,50 @@ class Background_Indexing_Integration implements Integration_Interface {
 		Indexable_Indexing_Complete_Action $complete_indexation_action,
 		Post_Link_Indexing_Action $post_link_indexing_action,
 		Term_Link_Indexing_Action $term_link_indexing_action,
-		Indexing_Helper $indexing_helper
+		Indexing_Helper $indexing_helper,
+		Indexable_Helper $indexable_helper,
+		Yoast_Admin_And_Dashboard_Conditional $yoast_admin_and_dashboard_conditional,
+		Get_Request_Conditional $get_request_conditional,
+		WP_CRON_Enabled_Conditional $wp_cron_enabled_conditional
 	) {
-		$this->post_indexation              = $post_indexation;
-		$this->term_indexation              = $term_indexation;
-		$this->post_type_archive_indexation = $post_type_archive_indexation;
-		$this->general_indexation           = $general_indexation;
-		$this->complete_indexation_action   = $complete_indexation_action;
-		$this->post_link_indexing_action    = $post_link_indexing_action;
-		$this->term_link_indexing_action    = $term_link_indexing_action;
-		$this->indexing_helper              = $indexing_helper;
+		$this->post_indexation                       = $post_indexation;
+		$this->term_indexation                       = $term_indexation;
+		$this->post_type_archive_indexation          = $post_type_archive_indexation;
+		$this->general_indexation                    = $general_indexation;
+		$this->complete_indexation_action            = $complete_indexation_action;
+		$this->post_link_indexing_action             = $post_link_indexing_action;
+		$this->term_link_indexing_action             = $term_link_indexing_action;
+		$this->indexing_helper                       = $indexing_helper;
+		$this->indexable_helper                      = $indexable_helper;
+		$this->yoast_admin_and_dashboard_conditional = $yoast_admin_and_dashboard_conditional;
+		$this->get_request_conditional               = $get_request_conditional;
+		$this->wp_cron_enabled_conditional           = $wp_cron_enabled_conditional;
 	}
 
 	/**
 	 * Register hooks.
 	 */
 	public function register_hooks() {
-		\add_action( 'admin_init', [ $this, 'register_shutdown_indexing' ], 10 );
+		\add_action( 'admin_init', [ $this, 'register_shutdown_indexing' ] );
+		\add_action( 'wpseo_indexable_index_batch', [ $this, 'index' ] );
+		// phpcs:ignore WordPress.WP.CronInterval -- The sniff doesn't understand values with parentheses. https://github.com/WordPress/WordPress-Coding-Standards/issues/2025
+		\add_filter( 'cron_schedules', [ $this, 'add_cron_schedule' ] );
+		\add_action( 'admin_init', [ $this, 'schedule_cron_indexing' ], 11 );
+
+		$this->add_limit_filters();
+	}
+
+	/**
+	 * Adds the filters that change the indexing limits.
+	 *
+	 * @return void.
+	 */
+	public function add_limit_filters() {
+		\add_filter( 'wpseo_post_indexation_limit', [ $this, 'throttle_cron_indexing' ] );
+		\add_filter( 'wpseo_post_type_archive_indexation_limit', [ $this, 'throttle_cron_indexing' ] );
+		\add_filter( 'wpseo_term_indexation_limit', [ $this, 'throttle_cron_indexing' ] );
+		\add_filter( 'wpseo_prominent_words_indexation_limit', [ $this, 'throttle_cron_indexing' ] );
+		\add_filter( 'wpseo_link_indexing_limit', [ $this, 'throttle_cron_link_indexing' ] );
 	}
 
 	/**
@@ -137,7 +196,7 @@ class Background_Indexing_Integration implements Integration_Interface {
 	 */
 	public function register_shutdown_indexing() {
 		if ( $this->should_index_on_shutdown( $this->get_shutdown_limit() ) ) {
-			\register_shutdown_function( [ $this, 'index' ] );
+			$this->register_shutdown_function( 'index' );
 		}
 	}
 
@@ -147,13 +206,140 @@ class Background_Indexing_Integration implements Integration_Interface {
 	 * @return void
 	 */
 	public function index() {
+		if ( \wp_doing_cron() && ! $this->should_index_on_cron() ) {
+			$this->unschedule_cron_indexing();
+
+			return;
+		}
+
 		$this->post_indexation->index();
 		$this->term_indexation->index();
 		$this->general_indexation->index();
 		$this->post_type_archive_indexation->index();
 		$this->post_link_indexing_action->index();
 		$this->term_link_indexing_action->index();
-		$this->complete_indexation_action->complete();
+
+		if ( $this->indexing_helper->get_limited_filtered_unindexed_count_background( 1 ) === 0 ) {
+			// We set this as complete, even though prominent words might not be complete. But that's the way we always treated that.
+			$this->complete_indexation_action->complete();
+		}
+	}
+
+	/**
+	 * Adds the 'Every fifteen minutes' cron schedule to WP-Cron.
+	 *
+	 * @param array $schedules The existing schedules.
+	 *
+	 * @return array The schedules containing the fifteen_minutes schedule.
+	 */
+	public function add_cron_schedule( $schedules ) {
+		if ( ! \is_array( $schedules ) ) {
+			return $schedules;
+		}
+
+		$schedules['fifteen_minutes'] = [
+			'interval' => ( 15 * MINUTE_IN_SECONDS ),
+			'display'  => \esc_html__( 'Every fifteen minutes', 'wordpress-seo' ),
+		];
+
+		return $schedules;
+	}
+
+	/**
+	 * Schedule background indexing every 15 minutes if the index isn't already up to date.
+	 *
+	 * @return void
+	 */
+	public function schedule_cron_indexing() {
+		if ( ! \wp_next_scheduled( 'wpseo_indexable_index_batch' ) && $this->should_index_on_cron() ) {
+			\wp_schedule_event( ( \time() + \HOUR_IN_SECONDS ), 'fifteen_minutes', 'wpseo_indexable_index_batch' );
+		}
+	}
+
+	/**
+	 * Limit cron indexing to 15 indexables per batch instead of 25.
+	 *
+	 * @param int $indexation_limit The current limit (filter input).
+	 *
+	 * @return int The new batch limit.
+	 */
+	public function throttle_cron_indexing( $indexation_limit ) {
+		if ( \wp_doing_cron() ) {
+			/**
+			 * Filter: Adds the possibility to limit the number of items that are indexed when in cron action.
+			 *
+			 * @api int $limit Maximum number of indexables to be indexed per indexing action.
+			 */
+			return \apply_filters( 'wpseo_cron_indexing_limit_size', 15 );
+		}
+
+		return $indexation_limit;
+	}
+
+	/**
+	 * Limit cron indexing to 3 links per batch instead of 5.
+	 *
+	 * @param int $link_indexation_limit The current limit (filter input).
+	 *
+	 * @return int The new batch limit.
+	 */
+	public function throttle_cron_link_indexing( $link_indexation_limit ) {
+		if ( \wp_doing_cron() ) {
+			/**
+			 * Filter: Adds the possibility to limit the number of links that are indexed when in cron action.
+			 *
+			 * @api int $limit Maximum number of link indexables to be indexed per link indexing action.
+			 */
+			return \apply_filters( 'wpseo_cron_link_indexing_limit_size', 3 );
+		}
+
+		return $link_indexation_limit;
+	}
+
+	/**
+	 * Determine whether cron indexation should be performed.
+	 *
+	 * @return bool Should cron indexation be performed.
+	 */
+	protected function should_index_on_cron() {
+		if ( ! $this->indexable_helper->should_index_indexables() ) {
+			return false;
+		}
+
+		// The filter supersedes everything when preventing cron indexation.
+		if ( \apply_filters( 'Yoast\WP\SEO\enable_cron_indexing', true ) !== true ) {
+			return false;
+		}
+
+		return $this->indexing_helper->get_limited_filtered_unindexed_count_background( 1 ) > 0;
+	}
+
+	/**
+	 * Determine whether background indexation should be performed.
+	 *
+	 * @param int $shutdown_limit The shutdown limit used to determine whether indexation should be run.
+	 *
+	 * @return bool Should background indexation be performed.
+	 */
+	protected function should_index_on_shutdown( $shutdown_limit ) {
+		if ( ! $this->yoast_admin_and_dashboard_conditional->is_met() || ! $this->get_request_conditional->is_met() ) {
+			return false;
+		}
+
+		if ( ! $this->indexable_helper->should_index_indexables() ) {
+			return false;
+		}
+
+		if ( $this->wp_cron_enabled_conditional->is_met() ) {
+			return false;
+		}
+
+		$total_unindexed = $this->indexing_helper->get_limited_filtered_unindexed_count_background( $shutdown_limit );
+		if ( $total_unindexed === 0 || $total_unindexed > $shutdown_limit ) {
+			return false;
+		}
+
+		return true;
 	}
 
 	/**
@@ -171,15 +357,26 @@ class Background_Indexing_Integration implements Integration_Interface {
 	}
 
 	/**
-	 * Determine whether background indexation should be performed.
+	 * Removes the cron indexing job from the scheduled event queue.
 	 *
-	 * @param int $shutdown_limit The shutdown limit used to determine whether indexation should be run.
-	 *
-	 * @return bool Should background indexation be performed.
+	 * @return void
 	 */
-	public function should_index_on_shutdown( $shutdown_limit ) {
-		$total = $this->indexing_helper->get_limited_filtered_unindexed_count( $shutdown_limit );
+	protected function unschedule_cron_indexing() {
+		$scheduled = \wp_next_scheduled( 'wpseo_indexable_index_batch' );
+		if ( $scheduled ) {
+			\wp_unschedule_event( $scheduled, 'wpseo_indexable_index_batch' );
+		}
+	}
 
-		return ( $total > 0 && $total < $shutdown_limit );
+	/**
+	 * Registers a method to be executed on shutdown.
+	 * This wrapper mostly exists for making this class more unittestable.
+	 *
+	 * @param string $method_name The name of the method on the current instance to register.
+	 *
+	 * @return void
+	 */
+	protected function register_shutdown_function( $method_name ) {
+		\register_shutdown_function( [ $this, $method_name ] );
 	}
 }

--- a/tests/unit/conditionals/wp-cron-enabled-conditional-test.php
+++ b/tests/unit/conditionals/wp-cron-enabled-conditional-test.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Conditionals;
+
+use Yoast\WP\SEO\Conditionals\WP_CRON_Enabled_Conditional;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Class WP_CRON_Enabled_Conditional_Test.
+ *
+ * @group conditionals
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Conditionals\WP_CRON_Enabled_Conditional
+ */
+class WP_CRON_Enabled_Conditional_Test extends TestCase {
+
+	/**
+	 * The instance under test.
+	 *
+	 * @var WP_CRON_Enabled_Conditional
+	 */
+	protected $instance;
+
+	/**
+	 * Sets up the class under test and mock objects.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->instance = new WP_CRON_Enabled_Conditional();
+	}
+
+	/**
+	 * Tests that the condition is met when there is no DISABLE_WP_CRON define.
+	 *
+	 * @covers ::is_met
+	 */
+	public function test_is_met() {
+		$this->assertTrue( $this->instance->is_met() );
+	}
+
+	/**
+	 * Tests that the condition is not met when there is a true DISABLE_WP_CRON define.
+	 *
+	 * @covers ::is_met
+	 */
+	public function test_is_not_met() {
+		if ( ! \defined( 'DISABLE_WP_CRON' ) ) {
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound -- WP constant used in a test.
+			\define( 'DISABLE_WP_CRON', true );
+		}
+		$this->assertFalse( $this->instance->is_met() );
+	}
+}

--- a/tests/unit/generators/schema/webpage-test.php
+++ b/tests/unit/generators/schema/webpage-test.php
@@ -85,8 +85,8 @@ class WebPage_Test extends TestCase {
 		$this->meta_tags_context = Mockery::mock( Meta_Tags_Context_Mock::class );
 		$this->id                = Mockery::mock( ID_Helper::class );
 
-		$this->instance          = Mockery::mock( WebPage::class )
-			->makePartial();
+		$this->instance = new WebPage();
+
 		$this->instance->context = $this->meta_tags_context;
 		$this->instance->helpers = (object) [
 			'current_page' => $this->current_page,

--- a/tests/unit/helpers/indexing-helper-test.php
+++ b/tests/unit/helpers/indexing-helper-test.php
@@ -402,7 +402,7 @@ class Indexing_Helper_Test extends TestCase {
 	}
 
 	/**
-	 * Tests the retrieval of the filtered unindexed count with a limit.
+	 * Tests the retrieval of the filtered unindexed count with a limit enforcing success.
 	 *
 	 * @covers ::get_limited_filtered_unindexed_count
 	 * @covers ::get_limited_unindexed_count
@@ -429,5 +429,141 @@ class Indexing_Helper_Test extends TestCase {
 			->andReturn( 10 );
 
 		static::assertEquals( 30, $this->instance->get_limited_filtered_unindexed_count( 25 ) );
+	}
+
+	/**
+	 * Tests the retrieval of the filtered unindexed count with a limit.
+	 *
+	 * @covers ::get_limited_filtered_unindexed_count
+	 * @covers ::get_limited_unindexed_count
+	 */
+	public function test_get__limitedfiltered_unindexed_count_no_limit() {
+		$limit = 25;
+
+		$this->post_indexation
+			->expects( 'get_limited_unindexed_count' )
+			->with( $limit + 1 )
+			->once()
+			->andReturn( 3 );
+
+		$this->term_indexation
+			->expects( 'get_limited_unindexed_count' )
+			->with( $limit - 3 + 1 )
+			->once()
+			->andReturn( 3 );
+
+		$this->post_type_archive_indexation
+			->expects( 'get_limited_unindexed_count' )
+			->with( $limit - 6 + 1 )
+			->once()
+			->andReturn( 3 );
+
+		$this->general_indexation
+			->expects( 'get_limited_unindexed_count' )
+			->with( $limit - 9 + 1 )
+			->once()
+			->andReturn( 3 );
+
+		$this->post_link_indexing_action
+			->expects( 'get_limited_unindexed_count' )
+			->with( $limit - 12 + 1 )
+			->once()
+			->andReturn( 3 );
+
+		$this->term_link_indexing_action
+			->expects( 'get_limited_unindexed_count' )
+			->with( $limit - 15 + 1 )
+			->once()
+			->andReturn( 3 );
+
+		Monkey\Filters\expectApplied( 'wpseo_indexing_get_limited_unindexed_count' )
+			->once()
+			->with( 18, 25 )
+			->andReturn( 18 );
+
+		static::assertEquals( 18, $this->instance->get_limited_filtered_unindexed_count( 25 ) );
+	}
+
+	/**
+	 * Tests the retrieval of the background filtered unindexed count with a limit enforcing success.
+	 *
+	 * @covers ::get_limited_filtered_unindexed_count_background
+	 * @covers ::get_limited_unindexed_count
+	 */
+	public function test_get__limitedfiltered_unindexed_count_background() {
+		$limit = 25;
+
+		$this->post_indexation
+			->expects( 'get_limited_unindexed_count' )
+			->with( $limit + 1 )
+			->once()
+			->andReturn( 10 );
+
+		$this->term_indexation
+			->expects( 'get_limited_unindexed_count' )
+			->with( $limit - 10 + 1 )
+			->once()
+			->andReturn( 10 );
+
+		$this->post_type_archive_indexation
+			->expects( 'get_limited_unindexed_count' )
+			->with( $limit - 20 + 1 )
+			->once()
+			->andReturn( 10 );
+
+		static::assertEquals( 30, $this->instance->get_limited_filtered_unindexed_count_background( 25 ) );
+	}
+
+	/**
+	 * Tests the retrieval of the background filtered unindexed count with a limit.
+	 *
+	 * @covers ::get_limited_filtered_unindexed_count_background
+	 * @covers ::get_limited_unindexed_count
+	 */
+	public function test_get__limitedfiltered_unindexed_count_background_no_limit() {
+		$limit = 25;
+
+		$this->post_indexation
+			->expects( 'get_limited_unindexed_count' )
+			->with( $limit + 1 )
+			->once()
+			->andReturn( 3 );
+
+		$this->term_indexation
+			->expects( 'get_limited_unindexed_count' )
+			->with( $limit - 3 + 1 )
+			->once()
+			->andReturn( 3 );
+
+		$this->post_type_archive_indexation
+			->expects( 'get_limited_unindexed_count' )
+			->with( $limit - 6 + 1 )
+			->once()
+			->andReturn( 3 );
+
+		$this->general_indexation
+			->expects( 'get_limited_unindexed_count' )
+			->with( $limit - 9 + 1 )
+			->once()
+			->andReturn( 3 );
+
+		$this->post_link_indexing_action
+			->expects( 'get_limited_unindexed_count' )
+			->with( $limit - 12 + 1 )
+			->once()
+			->andReturn( 3 );
+
+		$this->term_link_indexing_action
+			->expects( 'get_limited_unindexed_count' )
+			->with( $limit - 15 + 1 )
+			->once()
+			->andReturn( 3 );
+
+		Monkey\Filters\expectApplied( 'wpseo_indexing_get_limited_unindexed_count_background' )
+			->once()
+			->with( 18, 25 )
+			->andReturn( 18 );
+
+		static::assertEquals( 18, $this->instance->get_limited_filtered_unindexed_count_background( 25 ) );
 	}
 }

--- a/tests/unit/integrations/admin/background-indexing-integration-test.php
+++ b/tests/unit/integrations/admin/background-indexing-integration-test.php
@@ -13,10 +13,11 @@ use Yoast\WP\SEO\Actions\Indexing\Post_Link_Indexing_Action;
 use Yoast\WP\SEO\Actions\Indexing\Term_Link_Indexing_Action;
 use Yoast\WP\SEO\Conditionals\Get_Request_Conditional;
 use Yoast\WP\SEO\Conditionals\Migrations_Conditional;
+use Yoast\WP\SEO\Conditionals\WP_CRON_Enabled_Conditional;
 use Yoast\WP\SEO\Conditionals\Yoast_Admin_And_Dashboard_Conditional;
+use Yoast\WP\SEO\Helpers\Indexable_Helper;
 use Yoast\WP\SEO\Helpers\Indexing_Helper;
 use Yoast\WP\SEO\Integrations\Admin\Background_Indexing_Integration;
-use Yoast\WP\SEO\Integrations\Admin\Indexing_Tool_Integration;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
@@ -32,7 +33,7 @@ class Background_Indexing_Integration_Test extends TestCase {
 	/**
 	 * The indexation integration under test.
 	 *
-	 * @var Indexing_Tool_Integration
+	 * @var Mockery\MockInterface|Background_Indexing_Integration
 	 */
 	protected $instance;
 
@@ -93,30 +94,72 @@ class Background_Indexing_Integration_Test extends TestCase {
 	protected $indexing_helper;
 
 	/**
+	 * Represents the indexable helper.
+	 *
+	 * @var Mockery\MockInterface|Indexable_Helper
+	 */
+	protected $indexable_helper;
+
+	/**
+	 * The Yoast_Admin_And_Dashboard_Conditional mock.
+	 *
+	 * @var Mockery\MockInterface|Yoast_Admin_And_Dashboard_Conditional
+	 */
+	protected $yoast_admin_and_dashboard_conditional;
+
+	/**
+	 * The Get_Request_Conditional mock.
+	 *
+	 * @var Mockery\MockInterface|Get_Request_Conditional
+	 */
+	private $get_request_conditional;
+
+	/**
+	 * The WP_CRON_Conditional mock.
+	 *
+	 * @var Mockery\MockInterface|WP_CRON_Enabled_Conditional
+	 */
+	private $wp_cron_enabled_conditional;
+
+	/**
 	 * Sets up the tests.
 	 */
 	protected function set_up() {
 		parent::set_up();
 
-		$this->post_indexation              = Mockery::mock( Indexable_Post_Indexation_Action::class );
-		$this->term_indexation              = Mockery::mock( Indexable_Term_Indexation_Action::class );
-		$this->post_type_archive_indexation = Mockery::mock( Indexable_Post_Type_Archive_Indexation_Action::class );
-		$this->general_indexation           = Mockery::mock( Indexable_General_Indexation_Action::class );
-		$this->complete_indexation_action   = Mockery::mock( Indexable_Indexing_Complete_Action::class );
-		$this->post_link_indexing_action    = Mockery::mock( Post_Link_Indexing_Action::class );
-		$this->term_link_indexing_action    = Mockery::mock( Term_Link_Indexing_Action::class );
-		$this->indexing_helper              = Mockery::mock( Indexing_Helper::class );
+		$this->post_indexation                       = Mockery::mock( Indexable_Post_Indexation_Action::class );
+		$this->term_indexation                       = Mockery::mock( Indexable_Term_Indexation_Action::class );
+		$this->post_type_archive_indexation          = Mockery::mock( Indexable_Post_Type_Archive_Indexation_Action::class );
+		$this->general_indexation                    = Mockery::mock( Indexable_General_Indexation_Action::class );
+		$this->complete_indexation_action            = Mockery::mock( Indexable_Indexing_Complete_Action::class );
+		$this->post_link_indexing_action             = Mockery::mock( Post_Link_Indexing_Action::class );
+		$this->term_link_indexing_action             = Mockery::mock( Term_Link_Indexing_Action::class );
+		$this->indexing_helper                       = Mockery::mock( Indexing_Helper::class );
+		$this->indexable_helper                      = Mockery::mock( Indexable_Helper::class );
+		$this->yoast_admin_and_dashboard_conditional = Mockery::mock( Yoast_Admin_And_Dashboard_Conditional::class );
+		$this->get_request_conditional               = Mockery::mock( Get_Request_Conditional::class );
+		$this->wp_cron_enabled_conditional           = Mockery::mock( WP_CRON_Enabled_Conditional::class );
 
-		$this->instance = new Background_Indexing_Integration(
-			$this->post_indexation,
-			$this->term_indexation,
-			$this->post_type_archive_indexation,
-			$this->general_indexation,
-			$this->complete_indexation_action,
-			$this->post_link_indexing_action,
-			$this->term_link_indexing_action,
-			$this->indexing_helper
-		);
+		// This is a partial mock, so we can get test the registering of the shutdown hook.
+		$this->instance = Mockery::mock(
+			Background_Indexing_Integration::class,
+			[
+				$this->post_indexation,
+				$this->term_indexation,
+				$this->post_type_archive_indexation,
+				$this->general_indexation,
+				$this->complete_indexation_action,
+				$this->post_link_indexing_action,
+				$this->term_link_indexing_action,
+				$this->indexing_helper,
+				$this->indexable_helper,
+				$this->yoast_admin_and_dashboard_conditional,
+				$this->get_request_conditional,
+				$this->wp_cron_enabled_conditional,
+			]
+		)->makePartial()->shouldAllowMockingProtectedMethods();
+
+		$this->stubTranslationFunctions();
 	}
 
 	/**
@@ -127,9 +170,7 @@ class Background_Indexing_Integration_Test extends TestCase {
 	public function test_get_conditionals() {
 		static::assertEquals(
 			[
-				Yoast_Admin_And_Dashboard_Conditional::class,
 				Migrations_Conditional::class,
-				Get_Request_Conditional::class,
 			],
 			Background_Indexing_Integration::get_conditionals()
 		);
@@ -165,6 +206,10 @@ class Background_Indexing_Integration_Test extends TestCase {
 			Indexing_Helper::class,
 			$this->getPropertyValue( $this->instance, 'indexing_helper' )
 		);
+		static::assertInstanceOf(
+			Yoast_Admin_And_Dashboard_Conditional::class,
+			$this->getPropertyValue( $this->instance, 'yoast_admin_and_dashboard_conditional' )
+		);
 	}
 
 	/**
@@ -174,31 +219,256 @@ class Background_Indexing_Integration_Test extends TestCase {
 	 */
 	public function test_register_hooks() {
 		Monkey\Actions\expectAdded( 'admin_init' );
+		Monkey\Actions\expectAdded( 'wpseo_indexable_index_batch' );
+		Monkey\Filters\expectAdded( 'cron_schedules' );
+		Monkey\Filters\expectAdded( 'wpseo_post_indexation_limit' );
+		Monkey\Filters\expectAdded( 'wpseo_post_type_archive_indexation_limit' );
+		Monkey\Filters\expectAdded( 'wpseo_term_indexation_limit' );
+		Monkey\Filters\expectAdded( 'wpseo_prominent_words_indexation_limit' );
+		Monkey\Filters\expectAdded( 'wpseo_link_indexing_limit' );
 
 		$this->instance->register_hooks();
 	}
 
 	/**
-	 * Tests the enqueue_scripts method.
+	 * Tests the add limit filters method.
+	 *
+	 * @covers ::add_limit_filters
+	 */
+	public function test_add_limit_filters() {
+		Monkey\Filters\expectAdded( 'wpseo_post_indexation_limit' );
+		Monkey\Filters\expectAdded( 'wpseo_post_type_archive_indexation_limit' );
+		Monkey\Filters\expectAdded( 'wpseo_term_indexation_limit' );
+		Monkey\Filters\expectAdded( 'wpseo_prominent_words_indexation_limit' );
+		Monkey\Filters\expectAdded( 'wpseo_link_indexing_limit' );
+
+		$this->instance->add_limit_filters();
+	}
+
+	/**
+	 * Tests the test_register_shutdown_indexing method.
 	 *
 	 * @covers ::register_shutdown_indexing
+	 * @covers ::should_index_on_shutdown
 	 * @covers ::get_shutdown_limit
 	 */
 	public function test_register_shutdown_indexing() {
 		$this->indexing_helper
-			->expects( 'get_limited_filtered_unindexed_count' )
+			->expects( 'get_limited_filtered_unindexed_count_background' )
 			->once()
 			->andReturn( 10 );
 
-		/**
-		 * We have to register the shutdown function here to prevent a fatal PHP error,
-		 * which would occur because the registered shutdown function is executed
-		 * after the unit test has already completed.
-		 */
-		\register_shutdown_function( [ $this, 'shutdown_indexation_expectations' ] );
+		$this->yoast_admin_and_dashboard_conditional
+			->expects( 'is_met' )
+			->once()
+			->andReturn( true );
+
+		$this->indexable_helper
+			->expects( 'should_index_indexables' )
+			->once()
+			->andReturn( true );
+
+		$this->get_request_conditional
+			->expects( 'is_met' )
+			->once()
+			->andReturn( true );
+
+		$this->wp_cron_enabled_conditional
+			->expects( 'is_met' )
+			->once()
+			->andReturn( false );
 
 		Monkey\Filters\expectApplied( 'wpseo_shutdown_indexation_limit' )
 			->andReturn( 25 );
+
+		$this->instance
+			->expects( 'register_shutdown_function' )
+			->once()
+			->with( 'index' );
+
+		$this->instance->register_shutdown_indexing();
+	}
+
+	/**
+	 * Tests the add cron schedule method when malformed schedules are passed.
+	 *
+	 * @covers ::add_cron_schedule
+	 */
+	public function test_add_cron_schedule_malformed() {
+		$added_schedules = $this->instance->add_cron_schedule( 'not array' );
+
+		$this->assertSame( 'not array', $added_schedules );
+	}
+
+	/**
+	 * Tests the add cron schedule method.
+	 *
+	 * @covers ::add_cron_schedule
+	 */
+	public function test_add_cron_schedule() {
+		$added_schedules          = $this->instance->add_cron_schedule( [] );
+		$expected_added_schedules = [
+			'fifteen_minutes' => [
+				'interval' => ( 15 * MINUTE_IN_SECONDS ),
+				'display'  => 'Every fifteen minutes',
+			],
+		];
+
+		$this->assertSame( $expected_added_schedules, $added_schedules );
+	}
+
+	/**
+	 * Tests the test_register_shutdown_indexing method with wp-cron enabled.
+	 *
+	 * @covers ::register_shutdown_indexing
+	 * @covers ::should_index_on_shutdown
+	 * @covers ::get_shutdown_limit
+	 */
+	public function test_register_shutdown_indexing_with_wp_cron_enabled() {
+		$this->indexing_helper
+			->expects( 'get_limited_filtered_unindexed_count_background' )
+			->never();
+
+		$this->yoast_admin_and_dashboard_conditional
+			->expects( 'is_met' )
+			->once()
+			->andReturn( true );
+
+		$this->get_request_conditional
+			->expects( 'is_met' )
+			->once()
+			->andReturn( true );
+
+		$this->indexable_helper
+			->expects( 'should_index_indexables' )
+			->once()
+			->andReturn( true );
+
+		$this->wp_cron_enabled_conditional
+			->expects( 'is_met' )
+			->once()
+			->andReturn( true );
+
+		Monkey\Filters\expectApplied( 'wpseo_shutdown_indexation_limit' )
+			->andReturn( 25 );
+
+		$this->instance
+			->expects( 'register_shutdown_function' )
+			->never();
+
+		$this->instance->register_shutdown_indexing();
+	}
+
+	/**
+	 * Tests the register_shutdown_indexing method when on a page that shouldn't receive shutdown background indexing.
+	 *
+	 * @covers ::register_shutdown_indexing
+	 * @covers ::should_index_on_shutdown
+	 * @covers ::get_shutdown_limit
+	 */
+	public function test_register_shutdown_indexing_on_invalid_pages() {
+		$this->yoast_admin_and_dashboard_conditional
+			->expects( 'is_met' )
+			->once()
+			->andReturn( false );
+
+		$this->instance
+			->expects( 'register_shutdown_function' )
+			->never();
+
+		$this->instance->register_shutdown_indexing();
+	}
+
+	/**
+	 * Tests the register_shutdown_indexing method on post requests. This should not trigger shutdown background indexing.
+	 *
+	 * @covers ::register_shutdown_indexing
+	 * @covers ::should_index_on_shutdown
+	 * @covers ::get_shutdown_limit
+	 */
+	public function test_register_shutdown_indexing_on_post_request() {
+		$this->yoast_admin_and_dashboard_conditional
+			->expects( 'is_met' )
+			->once()
+			->andReturn( true );
+
+		$this->get_request_conditional
+			->expects( 'is_met' )
+			->once()
+			->andReturn( false );
+
+		$this->instance
+			->expects( 'register_shutdown_function' )
+			->never();
+		$this->instance->register_shutdown_indexing();
+	}
+
+	/**
+	 * Tests the register_shutdown_indexing method with indexing disabled. This should not trigger shutdown background indexing.
+	 *
+	 * @covers ::register_shutdown_indexing
+	 * @covers ::should_index_on_shutdown
+	 * @covers ::get_shutdown_limit
+	 */
+	public function test_register_shutdown_indexing_with_indexing_disabled() {
+		$this->yoast_admin_and_dashboard_conditional
+			->expects( 'is_met' )
+			->once()
+			->andReturn( true );
+
+		$this->get_request_conditional
+			->expects( 'is_met' )
+			->once()
+			->andReturn( true );
+
+		$this->indexable_helper
+			->expects( 'should_index_indexables' )
+			->once()
+			->andReturn( false );
+
+		$this->instance
+			->expects( 'register_shutdown_function' )
+			->never();
+
+		$this->instance->register_shutdown_indexing();
+	}
+
+	/**
+	 * Tests the register_shutdown_indexing method with unindexed objects over limits. This should not trigger shutdown background indexing.
+	 *
+	 * @covers ::register_shutdown_indexing
+	 * @covers ::should_index_on_shutdown
+	 * @covers ::get_shutdown_limit
+	 */
+	public function test_register_shutdown_indexing_with_unindexed_objects() {
+		$this->yoast_admin_and_dashboard_conditional
+			->expects( 'is_met' )
+			->once()
+			->andReturn( true );
+
+		$this->get_request_conditional
+			->expects( 'is_met' )
+			->once()
+			->andReturn( true );
+
+		$this->indexable_helper
+			->expects( 'should_index_indexables' )
+			->once()
+			->andReturn( true );
+
+		$this->wp_cron_enabled_conditional
+			->expects( 'is_met' )
+			->once()
+			->andReturn( false );
+
+		$this->indexing_helper
+			->expects( 'get_limited_filtered_unindexed_count_background' )
+			->once()
+			->andReturn( 26 );
+
+		$this->instance
+			->expects( 'register_shutdown_function' )
+			->never();
 
 		$this->instance->register_shutdown_indexing();
 	}
@@ -209,29 +479,20 @@ class Background_Indexing_Integration_Test extends TestCase {
 	 * @covers ::index
 	 */
 	public function test_index() {
-		$this->term_indexation
-			->expects( 'index' )
-			->once();
+		Monkey\Functions\when( 'wp_doing_cron' )->justReturn( false );
 
-		$this->post_indexation
-			->expects( 'index' )
-			->once();
+		$this->term_indexation->expects( 'index' )->once();
+		$this->post_indexation->expects( 'index' )->once();
+		$this->general_indexation->expects( 'index' )->once();
+		$this->post_type_archive_indexation->expects( 'index' )->once();
+		$this->post_link_indexing_action->expects( 'index' )->once();
+		$this->term_link_indexing_action->expects( 'index' )->once();
 
-		$this->general_indexation
-			->expects( 'index' )
-			->once();
-
-		$this->post_type_archive_indexation
-			->expects( 'index' )
-			->once();
-
-		$this->post_link_indexing_action
-			->expects( 'index' )
-			->once();
-
-		$this->term_link_indexing_action
-			->expects( 'index' )
-			->once();
+		$this->indexing_helper
+			->expects( 'get_limited_filtered_unindexed_count_background' )
+			->once()
+			->with( 1 )
+			->andReturn( 0 );
 
 		$this->complete_indexation_action
 			->expects( 'complete' )
@@ -241,15 +502,304 @@ class Background_Indexing_Integration_Test extends TestCase {
 	}
 
 	/**
-	 * Sets the expectations for the shutdown indexation.
+	 * Tests the indexing method while doing wp cron.
+	 *
+	 * @covers ::index
+	 * @covers ::should_index_on_cron
 	 */
-	public function shutdown_indexation_expectations() {
-		$this->post_indexation->expects( 'index' )->once();
+	public function test_index_with_wp_cron() {
+		Monkey\Functions\when( 'wp_doing_cron' )->justReturn( true );
+
+		Monkey\Filters\expectApplied( 'Yoast\WP\SEO\enable_cron_indexing' )
+			->with( true )
+			->andReturn( true );
+
+		$this->indexable_helper
+			->expects( 'should_index_indexables' )
+			->once()
+			->andReturn( true );
+
+		$this->indexing_helper
+			->expects( 'get_limited_filtered_unindexed_count_background' )
+			->once()
+			->with( 1 )
+			->andReturn( 1 );
+
+		$this->indexing_helper
+			->expects( 'get_limited_filtered_unindexed_count_background' )
+			->once()
+			->with( 1 )
+			->andReturn( 0 );
+
+
 		$this->term_indexation->expects( 'index' )->once();
+		$this->post_indexation->expects( 'index' )->once();
 		$this->general_indexation->expects( 'index' )->once();
 		$this->post_type_archive_indexation->expects( 'index' )->once();
-		$this->complete_indexation_action->expects( 'complete' )->once();
 		$this->post_link_indexing_action->expects( 'index' )->once();
 		$this->term_link_indexing_action->expects( 'index' )->once();
+		$this->complete_indexation_action->expects( 'complete' )->once();
+
+		$this->instance->index();
+	}
+
+	/**
+	 * Tests the indexing method while doing wp cron with wp-cron-indexing disabled.
+	 *
+	 * @covers ::index
+	 * @covers ::should_index_on_cron
+	 * @covers ::unschedule_cron_indexing
+	 */
+	public function test_index_with_wp_cron_with_cron_indexing_disabled() {
+		Monkey\Functions\when( 'wp_doing_cron' )->justReturn( true );
+
+
+		$this->indexable_helper
+			->expects( 'should_index_indexables' )
+			->once()
+			->andReturn( true );
+
+		Monkey\Filters\expectApplied( 'Yoast\WP\SEO\enable_cron_indexing' )
+			->with( true )
+			->andReturn( false );
+
+		Monkey\Functions\expect( 'wp_next_scheduled' )->once()->with( 'wpseo_indexable_index_batch' )->andReturn( 12345 );
+		Monkey\Functions\expect( 'wp_unschedule_event' )->once()->with( 12345, 'wpseo_indexable_index_batch' );
+
+		$this->instance->index();
+	}
+
+	/**
+	 * Tests the indexing method while doing wp cron with indexing disabled.
+	 *
+	 * @covers ::index
+	 * @covers ::should_index_on_cron
+	 */
+	public function test_index_with_wp_cron_with_indexing_disabled() {
+		Monkey\Functions\when( 'wp_doing_cron' )->justReturn( true );
+
+		Monkey\Filters\expectApplied( 'Yoast\WP\SEO\enable_cron_indexing' )
+			->with( true )
+			->andReturn( true );
+
+		$this->indexable_helper
+			->expects( 'should_index_indexables' )
+			->once()
+			->andReturn( false );
+
+		Monkey\Functions\expect( 'wp_next_scheduled' )->once()->with( 'wpseo_indexable_index_batch' )->andReturn( 12345 );
+		Monkey\Functions\expect( 'wp_unschedule_event' )->once()->with( 12345, 'wpseo_indexable_index_batch' );
+
+		$this->instance->index();
+	}
+
+	/**
+	 * Tests the indexing method while doing wp cron with an already complete index.
+	 *
+	 * @covers ::index
+	 * @covers ::should_index_on_cron
+	 */
+	public function test_index_with_wp_cron_with_complete_index() {
+		Monkey\Functions\when( 'wp_doing_cron' )->justReturn( true );
+
+		$this->indexing_helper
+			->expects( 'get_limited_filtered_unindexed_count_background' )
+			->with( 1 )
+			->once()
+			->andReturn( 0 );
+
+		Monkey\Filters\expectApplied( 'Yoast\WP\SEO\enable_cron_indexing' )
+			->with( true )
+			->andReturn( true );
+
+		$this->indexable_helper
+			->expects( 'should_index_indexables' )
+			->once()
+			->andReturn( true );
+
+
+		Monkey\Functions\expect( 'wp_next_scheduled' )->once()->with( 'wpseo_indexable_index_batch' )->andReturn( 12345 );
+		Monkey\Functions\expect( 'wp_unschedule_event' )->once()->with( 12345, 'wpseo_indexable_index_batch' );
+
+		$this->instance->index();
+	}
+
+	/**
+	 * Tests the indexing method while doing wp cron with an already complete index but without a scheduled cron task.
+	 *
+	 * @covers ::index
+	 * @covers ::should_index_on_cron
+	 */
+	public function test_index_with_wp_cron_with_complete_index_without_scheduled_task() {
+		Monkey\Functions\when( 'wp_doing_cron' )->justReturn( true );
+
+		$this->indexing_helper
+			->expects( 'get_limited_filtered_unindexed_count_background' )
+			->with( 1 )
+			->once()
+			->andReturn( 0 );
+
+		Monkey\Filters\expectApplied( 'Yoast\WP\SEO\enable_cron_indexing' )
+			->with( true )
+			->andReturn( true );
+
+		$this->indexable_helper
+			->expects( 'should_index_indexables' )
+			->once()
+			->andReturn( true );
+
+		Monkey\Functions\expect( 'wp_next_scheduled' )->once()->with( 'wpseo_indexable_index_batch' )->andReturn( false );
+		Monkey\Functions\expect( 'wp_unschedule_event' )->never();
+
+		$this->instance->index();
+	}
+
+	/**
+	 * Tests that the schedule_cron_indexing function schedules a cron job that performs the wpseo_indexable_index_batch action.
+	 *
+	 * @covers ::schedule_cron_indexing
+	 */
+	public function test_schedule_cron_indexing() {
+		$this->indexable_helper->expects( 'should_index_indexables' )->once()->andReturn( true );
+		Monkey\Functions\expect( 'wp_next_scheduled' )->once()->with( 'wpseo_indexable_index_batch' )->andReturn( false );
+		$this->indexing_helper->expects( 'get_limited_filtered_unindexed_count_background' )->once()->andReturn( 1 );
+		Monkey\Functions\expect( 'wp_schedule_event' )->once()->with( ( \time() + \HOUR_IN_SECONDS ), 'fifteen_minutes', 'wpseo_indexable_index_batch' );
+
+		$this->instance->schedule_cron_indexing();
+	}
+
+	/**
+	 * Tests that no cron job is scheduled when the cron job is already scheduled.
+	 *
+	 * @covers ::schedule_cron_indexing
+	 */
+	public function test_schedule_cron_indexing_already_scheduled() {
+		Monkey\Functions\expect( 'wp_next_scheduled' )->once()->with( 'wpseo_indexable_index_batch' )->andReturn( 987654321 );
+		Monkey\Functions\expect( 'wp_schedule_event' )->never();
+
+		$this->instance->schedule_cron_indexing();
+	}
+
+	/**
+	 * Tests that no cron job is scheduled when the cron indexing is disabled through the Yoast\WP\SEO\enable_cron_indexing filter.
+	 *
+	 * @covers ::schedule_cron_indexing
+	 */
+	public function test_schedule_cron_indexing_cron_indexing_disabled() {
+		Monkey\Functions\expect( 'wp_next_scheduled' )->once()->with( 'wpseo_indexable_index_batch' )->andReturn( false );
+		$this->indexable_helper->expects( 'should_index_indexables' )->once()->andReturn( true );
+		Monkey\Filters\expectApplied( 'Yoast\WP\SEO\enable_cron_indexing' )->with( true )->andReturn( false );
+		Monkey\Functions\expect( 'wp_schedule_event' )->never();
+
+		$this->instance->schedule_cron_indexing();
+	}
+
+	/**
+	 * Tests that no cron job is scheduled when indexing is disabled through on the site.
+	 *
+	 * @covers ::schedule_cron_indexing
+	 */
+	public function test_schedule_cron_indexing_with_indexing_disabled() {
+		Monkey\Functions\expect( 'wp_next_scheduled' )->once()->with( 'wpseo_indexable_index_batch' )->andReturn( false );
+		$this->indexable_helper->expects( 'should_index_indexables' )->once()->andReturn( false );
+		Monkey\Functions\expect( 'wp_schedule_event' )->never();
+
+		$this->instance->schedule_cron_indexing();
+	}
+
+	/**
+	 * Tests that no cron job is scheduled when on admin and the indexing process is already complete.
+	 *
+	 * @covers ::schedule_cron_indexing
+	 */
+	public function test_schedule_cron_indexing_index_complete_on_admin() {
+		Monkey\Functions\expect( 'wp_next_scheduled' )->once()->with( 'wpseo_indexable_index_batch' )->andReturn( false );
+		$this->indexable_helper->expects( 'should_index_indexables' )->once()->andReturn( true );
+		Monkey\Functions\expect( 'wp_schedule_event' )->never();
+
+		$this->indexing_helper
+			->expects( 'get_limited_filtered_unindexed_count_background' )
+			->with( 1 )
+			->once()
+			->andReturn( 0 );
+
+		$this->instance->schedule_cron_indexing();
+	}
+
+	/**
+	 * Tests that no cron job is scheduled when on admin and the indexing process is not complete yet.
+	 *
+	 * @covers ::schedule_cron_indexing
+	 */
+	public function test_schedule_cron_indexing_index_not_complete_on_admin() {
+		Monkey\Functions\expect( 'wp_next_scheduled' )->once()->with( 'wpseo_indexable_index_batch' )->andReturn( false );
+		$this->indexable_helper->expects( 'should_index_indexables' )->once()->andReturn( true );
+		Monkey\Functions\expect( 'wp_schedule_event' )->once();
+
+		$this->indexing_helper
+			->expects( 'get_limited_filtered_unindexed_count_background' )
+			->with( 1 )
+			->once()
+			->andReturn( 1 );
+
+		$this->instance->schedule_cron_indexing();
+	}
+
+	/**
+	 * Tests that the background indexing pace stays untouched when not doing cron.
+	 *
+	 * @covers ::throttle_cron_indexing
+	 */
+	public function test_throttle_cron_indexing() {
+		Monkey\Functions\when( 'wp_doing_cron' )->justReturn( false );
+
+		Monkey\Filters\expectApplied( 'wpseo_cron_indexing_limit_size' )->never();
+
+		$this->assertSame( 25, $this->instance->throttle_cron_indexing( 25 ) );
+	}
+
+	/**
+	 * Tests that the background indexing pace is throttled to 15 when doing cron.
+	 *
+	 * @covers ::throttle_cron_indexing
+	 */
+	public function test_throttle_cron_indexing_while_doing_cron() {
+		Monkey\Functions\when( 'wp_doing_cron' )->justReturn( true );
+
+		Monkey\Filters\expectApplied( 'wpseo_cron_indexing_limit_size' )
+			->once()
+			->with( 15 )
+			->andReturn( 15 );
+
+		$this->assertSame( 15, $this->instance->throttle_cron_indexing( 25 ) );
+	}
+
+	/**
+	 * Tests that the background link indexing pace stays untouched when not doing cron.
+	 *
+	 * @covers ::throttle_cron_link_indexing
+	 */
+	public function test_throttle_cron_link_indexing() {
+		Monkey\Functions\when( 'wp_doing_cron' )->justReturn( false );
+
+		Monkey\Filters\expectApplied( 'wpseo_cron_link_indexing_limit_size' )->never();
+
+		$this->assertSame( 15, $this->instance->throttle_cron_link_indexing( 15 ) );
+	}
+
+	/**
+	 * Tests that the background link indexing pace is throttled to 15 when doing cron.
+	 *
+	 * @covers ::throttle_cron_link_indexing
+	 */
+	public function test_throttle_cron_link_indexing_while_doing_cron() {
+		Monkey\Functions\when( 'wp_doing_cron' )->justReturn( true );
+
+		Monkey\Filters\expectApplied( 'wpseo_cron_link_indexing_limit_size' )
+			->once()
+			->with( 3 )
+			->andReturn( 3 );
+
+		$this->assertSame( 3, $this->instance->throttle_cron_link_indexing( 15 ) );
 	}
 }


### PR DESCRIPTION
This reverts commit 8d8ba3636388905a825a961ca885b657a6838cd6, reversing changes made to b722cce4b8b8d5ad53c5fd312332522f32aad249.

## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Re-introduces https://github.com/Yoast/wordpress-seo/pull/20005 that got reverted because we wanted to postpone it by one release.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Sets up background indexation via WP Cron.
* Fixes a bug where indexables were created when using the wp yoast index WP CLI command on a staging site.


## Relevant technical choices:

**_Copying over the Relevant technical choices from_** [the original PR](https://github.com/Yoast/wordpress-seo/pull/20005).
* Prominent words need frontend libraries in order to be indexed, so the cron indexation doesn't cover those
* We don't deal with notifications at all, because these look to be related to the manual SEO Optimization. 
  * Even with the production version, after a user runs and completes the SEOO, the relevant notification will be cleared only for him. For any other user, that notification number (in the admin bar and the menu item) will stay until the user visits the notification center. 
  * [A task](https://github.com/Yoast/wordpress-seo/issues/20147) has been created to cover this in the future.
* Test coverage for the background indexing class is as close to 100% as possible, not covering `register_shutdown_function`. See the old PR for details around that: https://github.com/Yoast/wordpress-seo/pull/18050/files

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged

* N/A

### Test instructions for QA when the code is in the RC

**_Copying over the Test Instructions from_** [the original PR](https://github.com/Yoast/wordpress-seo/pull/20005).

This PR can be acceptance tested by following these steps:

For all tests:
* have the following snippet in functions.php to ensure we're not running any admin requests in the background (because that could mess up with our conclusions)
```
add_action( 'init', 'stop_heartbeat', 1 );
function stop_heartbeat() {
	wp_deregister_script('heartbeat');
}
```
* make sure you dont have any other plugins enabled (because we dont have any potential background admin requests to run), other than Yoast SEO (or any other Yoast plugins) and Query Monitor

**Note**:
When `selected pages` is mentioned in the instructions, we mean:
* The WP's `Dashboard->Home` page
* The WP's `Dashboard->Updates` page
* The WP's `Plugins->Installed plugins` page
* The WP's `Settings->Permalinks` page
* All of Yoast settings pages

**For the main feature**:
* Yoast SEO should not be active when installing/checking out this RC/branch.
* Also, in case you tested this in the past, delete any remaining indexation crons via WP CLI `wp cron event delete "wpseo_indexable_index_batch"`
* Use a fresh WP install or truncate the tables and transients via queries:
```
TRUNCATE wp_yoast_indexable;
TRUNCATE wp_yoast_indexable_hierarchy;
TRUNCATE wp_yoast_primary_term;
TRUNCATE wp_yoast_seo_links;
TRUNCATE wp_yoast_prominent_words;
DELETE FROM wp_options WHERE option_name LIKE ('%\_transient\_%');
```
* Make sure your site has at least 100 posts (`wp post generate --count=100 --post_author=admin` with WP CLI). Once the posts are created, add some internal links in them. A couple of them should have at least some content (for testing prominent words, when Premium is enabled, in the second run of the tests)
* Activate the plugin after you've generated some content and visit one of the `selected pages`.
* Using WP CLI, run `wp cron event list` and confirm that you see the `wpseo_indexable_index_batch` scheduled action there, that's to run in 1 hour.
* Using WP CLI, run `wp cron event run "wpseo_indexable_index_batch"`.
* This should yield output similar to this:
    ``` 
    Executed the cron event 'wpseo_indexable_index_batch' in 0.072s.
    Success: Executed a total of 1 cron event.
    ```
* Check in your database; you should see at least 15 more indexables now.
* Run `wp cron event list` and confirm that you see the `wpseo_indexable_index_batch` scheduled action there again, that's to run in 15mins now.
* Add the following line to your wp-config.php or functions.php: `add_filter( 'Yoast\WP\SEO\enable_cron_indexing', '__return_false' );`
* Repeat the WP CLI step.
* See that there are no added indexables.
* Repeat the WP CLI step.
* See that you get a different response in the terminal: `Error: Invalid cron event 'wpseo_indexable_index_batch'`
* Remove the line of code and visit one of the `selected pages` on your site.
* Keep repeating the process of running `wp cron event run "wpseo_indexable_index_batch"` and checking the database until you get a different response: `Error: Invalid cron event 'wpseo_indexable_index_batch'`
* Check that the indexable table is complete and that all your posts/pages/terms/system-pages/homepage are there.
* Disable Yoast SEO again
* Disable WP-Cron by adding the following line to your wp-config.php or functions.php `define( 'DISABLE_WP_CRON', true );`.
* Generate another 10 posts
* Delete transients - `DELETE FROM wp_options WHERE option_name LIKE ('%\_transient\_%');`
* Enable Yoast SEO
* Visit any of visit one of the `selected pages`.
* Check that the indexable table is complete and that all your posts/pages/terms/system-pages/homepage are there. If Premium is not enabled, the SEOO button should not be visible in Yoast SEO->Tools
* Repeat the whole test with Premium enabled.

**For re-enabling the cron but only upon admin page load, not on frontend load**:
* In a fresh site (or in a site with indexables/options purged)
* Using WP CLI, run `wp cron event run "wpseo_indexable_index_batch"` until you get `Error: Invalid cron event 'wpseo_indexable_index_batch'`. This means that indexables are all created and the cron is now unscheduled
* Truncate the yoast tables (aka, delete all rows there) NOT via the test helper but via a db tool and delete transients with this query:
```
TRUNCATE wp_yoast_indexable;
TRUNCATE wp_yoast_indexable_hierarchy;
TRUNCATE wp_yoast_primary_term;
TRUNCATE wp_yoast_seo_links;
TRUNCATE wp_yoast_prominent_words;
DELETE FROM wp_options WHERE option_name LIKE ('%\_transient\_%');
```
* In WP CLI, run `wp cron event list` and confirm that the `wpseo_indexable_index_batch` is NOT in that list
* Load a frontend page and again run `wp cron event list` and confirm that the `wpseo_indexable_index_batch` is NOT in that list (this means that we're not performing heavy queries on the frontend)
* Load one of the `selected pages` and again run `wp cron event list` but now confirm that the `wpseo_indexable_index_batch` IS in that list
* Run `wp cron event run "wpseo_indexable_index_batch"` until you get `Error: Invalid cron event 'wpseo_indexable_index_batch'` and repeat this test with Premium enabled and confirm the same - Note that the cron indexation will finish but the SEO optimization button will still be enabled because prominent words are not able to be indexed via background indexing
* Repeat the test but this time with `add_filter( 'Yoast\WP\SEO\enable_cron_indexing', '__return_false' );` added. This time the `wpseo_indexable_index_batch` will never be created and there's no need to check the last step (the one that begins with running `wp cron event run "wpseo_indexable_index_batch"`)

**For re-enabling the cron indexing when indexable versions are increased**:
* In a fresh site (or in a site with indexables/options purged)
* Using WP CLI, run `wp cron event run "wpseo_indexable_index_batch"` until you get `Error: Invalid cron event 'wpseo_indexable_index_batch'`. This means that indexables are all created and the cron is now unscheduled
* In WP CLI, run `wp cron event list` and confirm that the `wpseo_indexable_index_batch` is NOT in that list
* In the `Indexable_Builder_Versions` class (in the **src\values\indexables\indexable-builder-versions.php** file) increase the version of post indexables in the `indexable_builder_versions_by_type`, aka. `'post' => 3,`
* Delete transients
```
DELETE FROM wp_options WHERE option_name LIKE ('%\_transient\_%');
```
* Refresh one of the `selected pages`, run `wp cron event list` and confirm that the `wpseo_indexable_index_batch` IS in that list.
* Run `wp cron event run "wpseo_indexable_index_batch"` until you get `Error: Invalid cron event 'wpseo_indexable_index_batch'`.
* Once you save, go to the db's indexable table and confirm that the rows that have `post` as their `object_type` have `3` as their `version`
* This means that cron indexation will automatically run when a plugin upgrade brings increases in indexable versions
* (Make sure to clean up indexables and option before continuing testing in that site)

**For further checking that heavy queries will NEVER run in the frontend**:
* In a fresh site (or in a site with indexables/options purged), first add 30 posts
* Delete the indexation cron via WP CLI: `wp cron event delete "wpseo_indexable_index_batch"` and delete transients: `DELETE FROM wp_options WHERE option_name LIKE ('%\_transient\_%');`
* Load the frontend of the site and via Query monitor confirm that you don't get a query with the `Yoast\WP\SEO\Actions\Indexing\Abstract_Indexing_Action` caller.
* You can also delete transients and refresh and you still shouldnt get it.
* Repeat the test with Premium enabled.

**For the staging sites rule of not indexing there**:
* Add `define( 'WP_ENVIRONMENT_TYPE', 'staging' );` to your wp-config.php (or remove the `yoast_seo_development_mode` if you're on Local WP) 
* Run `wp yoast index`.
* You should get a notice stating that nothing will be indexed because of the staging env your site is set to.
* Check that no indexables were created in the database
* Run `wp cron event run wpseo_indexable_index_batch`
* Check that no indexables were created in the database
* Remove the WP_ENV... line or change the value to `production`. Refresh one of the `selected pages`.
* Run `wp cron event run wpseo_indexable_index_batch`
* Check that 15 indexables were created
* Run `wp yoast index`
* Check that all indexables were created.
* Now, set the site as staging and then clean up indexables via the test helper.
* Set the site as production, load the homepage and check the db to see you have created the indexable for the homepage.
* 
* Now set the site as staging.
* Run `wp cron event run wpseo_indexable_index_batch`, confirm that you got `Executed the cron event 'wpseo_indexable_index_batch'` response but also confirm that no new indexables were created in the db.
* 
* Now cleanup indexables, set the site as staging, disable cron (`DISABLE_WP_CRON` is set to `true`) and add this filter (so that we set a really large number for the shutdown indexing, so we make sure it is supposed to run on every page load):
```
add_filter( 'wpseo_shutdown_indexation_limit', 'custom_limit', 1 );
function custom_limit() {
  return 1000000;
}
```
* Refresh one of the `selected pages` and the check the db to confirm that there were no indexables created.
* Set the site as production, refresh the page and confirm that now indexables did get created.

**And a last test:**
**For testing the actual cron indexation without WP CLI**:
* Have a fresh install of WordPress without Yoast SEO
* Add the following line to your wp-config.php or functions.php: `add_filter( 'Yoast\WP\SEO\enable_cron_indexing', '__return_false' );`
* Create 100 posts for your site (`wp post generate --count=45 --post_author=admin` with WP CLI). Once the posts are created, add a couple of internal links in them.
* Activate the plugin after you've generated some content and visit one of the `selected pages`.
* After a bit over 60 minutes, visit the homepage of your site
* In the database, check that there are fewer than 15 records in the wp_yoast_indexables table. It's likely just the home-page
* Remove the line from the wp-config that you added in the second step.
* Visit the homepage of you site. And after a bit over 60 minutes, visit the homepage of your site again
* In the database, check that there are 15 more records in the wp_yoast_indexables table.
* Add the following filters in your functions.php file:
```
add_filter( 'wpseo_cron_indexing_limit_size', 'custom_cron_indexing_limit_size', 10 );
function custom_cron_indexing_limit_size() {
    return 1000;
}

add_filter( 'wpseo_cron_link_indexing_limit_size', 'custom_cron_link_indexing_limit_size', 10 );
function custom_cron_link_indexing_limit_size() {
    return 1000;
}
```
* After a bit over 15 minutes, visit the homepage of your site again.
* The indexables should now be completely built (unless you have Premium, because prominent words aren't built via the cron indexation). Confirm that in the Yoast SEO->Tools page.
#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The SEO optimization

Also:
* Installing Yoast SEO for the first time on small sites with fewer than 25 posts+authors+terms in total. This used to index the site in one go during the first wp-admin request that hits the plugin's admin pages. This is still the case when `DISABLE_WP_CRON` is set to `true`. If that is not the case, the site should be indexed gradually; 15 posts every 15 minutes (granted the site gets visitors every 15 minutes).
  * To regression test the background indexing when `define( 'DISABLE_WP_CRON', true );` add this filter (so that we set a really large number for the shutdown indexing, so we make sure it is supposed to run on every page load):
```
add_filter( 'wpseo_shutdown_indexation_limit', 'custom_limit', 1 );
function custom_limit() {
  return 1000000;
}
```
  * Clean out indexables and once the test helper page refreshes, check the db and confirm that no indexables got created.
  * Go to Dashboard->Home, check the db and confirm that some indexables got created.
  * Go to Plugins->Install plugins, check the db and confirm that some indexables got created.
  * Go to any plugin's (other than Yoast's) settings pages, check the db and confirm that no indexables got created.
  * Go to any of Yoast's settings pages, check the db and confirm that some indexables got created.
  * Repeat the test but without `define( 'DISABLE_WP_CRON', true );` and confirm that the background indexation never run (aka no indexables were created when visiting the Dashboard->Home, Plugins->Install plugins, Yoast's settings pages. But make sure you check that in under 15mins, because the cron indexation might create the indexables and mess up with our tests)
  * Also, remove the `wpseo_shutdown_indexation_limit` filter above and regression test [this PR](https://github.com/Yoast/wordpress-seo/pull/16193).
* Also regression test the notifications about the SEO optimization

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
