### PR TITLE
PHP 8.2 | Indexable_*_Presentation: declare the property in the trait instead

### DIFF
--- a/src/presentations/archive-adjacent-trait.php
+++ b/src/presentations/archive-adjacent-trait.php
@@ -10,13 +10,16 @@ use Yoast\WP\SEO\Models\Indexable;
  *
  * Presentation object for indexables.
  *
- * @property Indexable         $model      The indexable.
- * @property Pagination_Helper $pagination The pagination helper. Should be defined in the parent
- *                                         class because of trait issues in PHP 5.6.
- *                                         For a detailed explanation of the issue, see
- *                                         {@link https://github.com/Yoast/wordpress-seo/pull/18820}.
+ * @property Indexable $model The indexable.
  */
 trait Archive_Adjacent {
+
+	/**
+	 * Holds the Pagination_Helper instance.
+	 *
+	 * @var Pagination_Helper
+	 */
+	protected $pagination;
 
 	/**
 	 * Sets the helpers for the trait.

--- a/src/presentations/indexable-author-archive-presentation.php
+++ b/src/presentations/indexable-author-archive-presentation.php
@@ -3,7 +3,6 @@
 namespace Yoast\WP\SEO\Presentations;
 
 use Yoast\WP\SEO\Helpers\Author_Archive_Helper;
-use Yoast\WP\SEO\Helpers\Pagination_Helper;
 use Yoast\WP\SEO\Helpers\Post_Type_Helper;
 
 /**
@@ -28,13 +27,6 @@ class Indexable_Author_Archive_Presentation extends Indexable_Presentation {
 	 * @var Author_Archive_Helper
 	 */
 	protected $author_archive;
-
-	/**
-	 * Holds the Pagination_Helper instance.
-	 *
-	 * @var Pagination_Helper
-	 */
-	protected $pagination;
 
 	/**
 	 * Indexable_Author_Archive_Presentation constructor.

--- a/src/presentations/indexable-home-page-presentation.php
+++ b/src/presentations/indexable-home-page-presentation.php
@@ -2,8 +2,6 @@
 
 namespace Yoast\WP\SEO\Presentations;
 
-use Yoast\WP\SEO\Helpers\Pagination_Helper;
-
 /**
  * Class Indexable_Home_Page_Presentation.
  *
@@ -12,13 +10,6 @@ use Yoast\WP\SEO\Helpers\Pagination_Helper;
 class Indexable_Home_Page_Presentation extends Indexable_Presentation {
 
 	use Archive_Adjacent;
-
-	/**
-	 * Holds the Pagination_Helper instance.
-	 *
-	 * @var Pagination_Helper
-	 */
-	protected $pagination;
 
 	/**
 	 * Generates the canonical.

--- a/src/presentations/indexable-post-type-archive-presentation.php
+++ b/src/presentations/indexable-post-type-archive-presentation.php
@@ -2,8 +2,6 @@
 
 namespace Yoast\WP\SEO\Presentations;
 
-use Yoast\WP\SEO\Helpers\Pagination_Helper;
-
 /**
  * Class Indexable_Post_Type_Archive_Presentation.
  *
@@ -12,13 +10,6 @@ use Yoast\WP\SEO\Helpers\Pagination_Helper;
 class Indexable_Post_Type_Archive_Presentation extends Indexable_Presentation {
 
 	use Archive_Adjacent;
-
-	/**
-	 * Holds the Pagination_Helper instance.
-	 *
-	 * @var Pagination_Helper
-	 */
-	protected $pagination;
 
 	/**
 	 * Generates the canonical.

--- a/src/presentations/indexable-term-archive-presentation.php
+++ b/src/presentations/indexable-term-archive-presentation.php
@@ -3,7 +3,6 @@
 namespace Yoast\WP\SEO\Presentations;
 
 use WP_Term;
-use Yoast\WP\SEO\Helpers\Pagination_Helper;
 use Yoast\WP\SEO\Helpers\Taxonomy_Helper;
 use Yoast\WP\SEO\Wrappers\WP_Query_Wrapper;
 
@@ -17,13 +16,6 @@ use Yoast\WP\SEO\Wrappers\WP_Query_Wrapper;
 class Indexable_Term_Archive_Presentation extends Indexable_Presentation {
 
 	use Archive_Adjacent;
-
-	/**
-	 * Holds the Pagination_Helper instance.
-	 *
-	 * @var Pagination_Helper
-	 */
-	protected $pagination;
 
 	/**
 	 * Holds the WP query wrapper instance.


### PR DESCRIPTION
## Context

* Code modernization

## Summary

This PR can be summarized in the following changelog entry:

* Code modernization

## Relevant technical choices:

This is a follow up PR to PR https://github.com/Yoast/wordpress-seo/pull/18820 in which we found out that this change was not possible until support for PHP 5.6 had been dropped.

As that has now happened, we can clean up the temporary work-around.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_ If the build passes, we're good.
