### PR TITLE
GH Actions: run workflows more selectively

### DIFF
--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -1,11 +1,25 @@
 name: CS
 
 on:
-  # Run on all pushes (except to main) and on all pull requests.
+  # Run on all relevant pushes (except to main) and on all relevant pull requests.
   push:
     branches-ignore:
       - 'main'
+    paths:
+      - '**.php' # Includes config/*.php files.
+      - 'composer.json'
+      - 'composer.lock'
+      - '.phpcs.xml.dist'
+      - 'phpcs.xml.dist'
+      - '.github/workflows/cs.yml'
   pull_request:
+    paths:
+      - '**.php' # Includes config/*.php files.
+      - 'composer.json'
+      - 'composer.lock'
+      - '.phpcs.xml.dist'
+      - 'phpcs.xml.dist'
+      - '.github/workflows/cs.yml'
   # Allow manually triggering the workflow.
   workflow_dispatch:
 

--- a/.github/workflows/jslint.yml
+++ b/.github/workflows/jslint.yml
@@ -1,7 +1,7 @@
 name: LintJS
 
 on:
-  # Run on pushes to select branches and on all pull requests.
+  # Run on relevant pushes to select branches and on all relevant pull requests.
   push:
     branches:
       - main
@@ -9,7 +9,37 @@ on:
       - 'release/**'
       - 'hotfix/[0-9]+.[0-9]+*'
       - 'feature/**'
+    paths:
+      - '**.js' # Includes Gruntfile.js.
+      - '.browserslistrc'
+      - '.eslintignore'
+      - '.eslintrc'
+      - '.nvmrc'
+      - '.yarnrc'
+      - 'lerna.json'
+      - 'package.json'
+      - 'yarn.lock'
+      - '.github/workflows/jslint.yml'
+      - '.yarn/**'
+      - 'apps/**'
+      - 'config/grunt/**'
+      - 'packages/**'
   pull_request:
+    paths:
+      - '**.js' # Includes Gruntfile.js.
+      - '.browserslistrc'
+      - '.eslintignore'
+      - '.eslintrc'
+      - '.nvmrc'
+      - '.yarnrc'
+      - 'lerna.json'
+      - 'package.json'
+      - 'yarn.lock'
+      - '.github/workflows/jslint.yml'
+      - '.yarn/**'
+      - 'apps/**'
+      - 'config/grunt/**'
+      - 'packages/**'
   # Allow manually triggering the workflow.
   workflow_dispatch:
 

--- a/.github/workflows/jstest.yml
+++ b/.github/workflows/jstest.yml
@@ -1,7 +1,7 @@
 name: TestJS
 
 on:
-  # Run on pushes to select branches and on all pull requests.
+  # Run on relevant pushes to select branches and on all relevant pull requests.
   push:
     branches:
       - main
@@ -9,7 +9,37 @@ on:
       - 'release/**'
       - 'hotfix/[0-9]+.[0-9]+*'
       - 'feature/**'
+    paths:
+      - '**.js' # Includes Gruntfile.js.
+      - '.browserslistrc'
+      - '.eslintignore'
+      - '.eslintrc'
+      - '.nvmrc'
+      - '.yarnrc'
+      - 'lerna.json'
+      - 'package.json'
+      - 'yarn.lock'
+      - '.github/workflows/jstest.yml'
+      - '.yarn/**'
+      - 'apps/**'
+      - 'config/grunt/**'
+      - 'packages/**'
   pull_request:
+    paths:
+      - '**.js' # Includes Gruntfile.js.
+      - '.browserslistrc'
+      - '.eslintignore'
+      - '.eslintrc'
+      - '.nvmrc'
+      - '.yarnrc'
+      - 'lerna.json'
+      - 'package.json'
+      - 'yarn.lock'
+      - '.github/workflows/jstest.yml'
+      - '.yarn/**'
+      - 'apps/**'
+      - 'config/grunt/**'
+      - 'packages/**'
   # Allow manually triggering the workflow.
   workflow_dispatch:
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,7 +1,7 @@
 name: Lint
 
 on:
-  # Run on pushes to select branches and on all pull requests.
+  # Run on relevant pushes to select branches and on all relevant pull requests.
   push:
     branches:
       - main
@@ -9,7 +9,17 @@ on:
       - "release/**"
       - "hotfix/[0-9]+.[0-9]+*"
       - "feature/**"
+    paths:
+      - '**.php'
+      - 'composer.json'
+      - 'composer.lock'
+      - '.github/workflows/lint.yml'
   pull_request:
+    paths:
+      - '**.php'
+      - 'composer.json'
+      - 'composer.lock'
+      - '.github/workflows/lint.yml'
   # Allow manually triggering the workflow.
   workflow_dispatch:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 name: Test
 
 on:
-  # Run on pushes to select branches and on all pull requests.
+  # Run on relevant pushes to select branches and on all relevant pull requests.
   push:
     branches:
       - main
@@ -9,7 +9,29 @@ on:
       - "release/**"
       - "hotfix/[0-9]+.[0-9]+*"
       - "feature/**"
+    paths:
+      - '**.php' # Includes config/*.php and lib/*.php files.
+      - '**.xsl'
+      - 'composer.json'
+      - 'composer.lock'
+      - 'phpunit.xml.dist'
+      - 'phpunit-integration.xml.dist'
+      - 'wpml-config.xml'
+      - '.github/workflows/test.yml'
+      - 'config/scripts/install-wp-tests.sh'
+      - 'tests/**'
   pull_request:
+    paths:
+      - '**.php' # Includes config/*.php and lib/*.php files.
+      - '**.xsl'
+      - 'composer.json'
+      - 'composer.lock'
+      - 'phpunit.xml.dist'
+      - 'phpunit-integration.xml.dist'
+      - 'wpml-config.xml'
+      - '.github/workflows/test.yml'
+      - 'config/scripts/install-wp-tests.sh'
+      - 'tests/**'
   # Allow manually triggering the workflow.
   workflow_dispatch:
 


### PR DESCRIPTION
## Context

* CI maintenance

## Summary

This PR can be summarized in the following changelog entry:

* CI maintenance

## Relevant technical choices:

Only run the workflows when there is a chance that the result of the workflow run will be different from before.

The path selection is set up to cast a wide net to make the risk of the workflows not running when the build could potentially break as small as possible.

This means that, aside from files of the type being checked in the workflow changing, the workflow will also run when:
* The configuration used changes.
* Dependencies used in the workflow may potentially have changed.
* Composer scripts used in the workflow may potentially have changed.
* Shell scripts used in the workflow have changed.
* The workflow itself changes.
* Miscellaneous related files have changed.

Note: the lists of files _may_ include some files which don't currently exist in the repo (like `.eslintignore`) for consistency across workflows and to prevent issues if/when such file(s) would be introduced to the repo.


## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_