### PR TITLE
Prevents metabox crashing when the additional keywords objects are malformed

### DIFF
--- a/packages/js/src/redux/selectors/WincherSEOPerformance.js
+++ b/packages/js/src/redux/selectors/WincherSEOPerformance.js
@@ -52,7 +52,8 @@ export function getWincherTrackableKeyphrases( state ) {
 	const keyphrases = [ state.focusKeyword.trim(), ...tracked ];
 
 	if ( isPremium && premiumStore ) {
-		keyphrases.push( ...premiumStore.getKeywords().map( k => k.keyword.trim() ) );
+		// eslint-disable-next-line no-undefined
+		keyphrases.push( ...premiumStore.getKeywords().filter( k => k.keyword !== undefined ).map( k => k.keyword.trim() ) );
 	}
 
 	return uniq( keyphrases.filter( k => !! k ).map(


### PR DESCRIPTION

## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* On certain pathological situations, additional keyphrases can be stored in a wrong way in the DB. This can lead to a fatal error for the Wincher integration which cannot be solved except by editing the DB. We should add defensive coding for it.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the Yoast SEO metabox would crash in conjunction with Yoast SEO Premium when additional keyphrases are stored in the DB in a malformed way.

## Relevant technical choices:

* It was found while working on https://github.com/Yoast/wordpress-seo-premium/issues/3872

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* use Premium with [this fix](https://github.com/Yoast/wordpress-seo-premium/pull/3975)
* create a post
* Set the _yoast_wpseo_focuskeywords field for that post to [""] in the wp_postmeta table in the WordPress database.
* Go to the editor for the post

without this fix:
* you should see the metabox disappear and find an error in the JS console `Uncaught TypeError: k.keyword is undefined`

with this fix:
* you should see the metabox working, with an empty additional keyphrase that can be easily removed or replaced


#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [x] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

should be working in both the Classic and Block editor

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
