### PR TITLE
Enables creating filters for other scores

### DIFF
--- a/admin/class-meta-columns.php
+++ b/admin/class-meta-columns.php
@@ -291,7 +291,7 @@ class WPSEO_Meta_Columns {
 	 *
 	 * @return string The generated <option> element.
 	 */
-	protected function generate_option( $value, $label, $selected = '' ) {
+	public static function generate_option( $value, $label, $selected = '' ) {
 		return '<option ' . $selected . ' value="' . esc_attr( $value ) . '">' . esc_html( $label ) . '</option>';
 	}
 
@@ -364,7 +364,7 @@ class WPSEO_Meta_Columns {
 	 *
 	 * @return bool Whether the filter is considered valid.
 	 */
-	protected function is_valid_filter( $filter ) {
+	public static function is_valid_filter( $filter ) {
 		return ! empty( $filter ) && is_string( $filter );
 	}
 
@@ -418,7 +418,14 @@ class WPSEO_Meta_Columns {
 			}
 		}
 
-		return $active_filters;
+		/**
+		 * Adapt the active applicable filters on the posts overview.
+		 *
+		 * @internal
+		 *
+		 * @api array $active_filters The current applicable filters.
+		 */
+		return \apply_filters( 'wpseo_change_applicable_filters', $active_filters );
 	}
 
 	/**
@@ -431,8 +438,22 @@ class WPSEO_Meta_Columns {
 	public function column_sort_orderby( $vars ) {
 		$collected_filters = $this->collect_filters();
 
-		if ( isset( $vars['orderby'] ) ) {
-			$vars = array_merge( $vars, $this->filter_order_by( $vars['orderby'] ) );
+		$order_by_column = $vars['orderby'];
+		if ( isset( $order_by_column ) ) {
+			// Based on the selected column, create a meta query.
+			$order_by = $this->filter_order_by( $order_by_column );
+
+			/**
+			 * Adapt the order by part of the query on the posts overview.
+			 *
+			 * @internal
+			 *
+			 * @api array $order_by The current order by.
+			 * @api string $order_by_column The current order by column.
+			 */
+			$order_by = \apply_filters( 'wpseo_change_order_by', $order_by, $order_by_column );
+
+			$vars = array_merge( $vars, $order_by );
 		}
 
 		return $this->build_filter_query( $vars, $collected_filters );

--- a/inc/class-wpseo-rank.php
+++ b/inc/class-wpseo-rank.php
@@ -223,6 +223,33 @@ class WPSEO_Rank {
 	}
 
 	/**
+	 * Gets the drop down labels for the inclusive language score.
+	 *
+	 * @return string The inclusive language rank label.
+	 */
+	public function get_drop_down_inclusive_language_labels() {
+		$labels = [
+			self::BAD => sprintf(
+			/* translators: %s expands to the inclusive language score */
+				__( 'Inclusive language: %s', 'wordpress-seo' ),
+				__( 'Needs improvement', 'wordpress-seo' )
+			),
+			self::OK => sprintf(
+			/* translators: %s expands to the inclusive language score */
+				__( 'Inclusive language: %s', 'wordpress-seo' ),
+				__( 'Potentially non-inclusive', 'wordpress-seo' )
+			),
+			self::GOOD => sprintf(
+			/* translators: %s expands to the inclusive language score */
+				__( 'Inclusive language: %s', 'wordpress-seo' ),
+				__( 'Good', 'wordpress-seo' )
+			),
+		];
+
+		return $labels[ $this->rank ];
+	}
+
+	/**
 	 * Get the starting score for this rank.
 	 *
 	 * @return int The start score.
@@ -286,6 +313,15 @@ class WPSEO_Rank {
 	 * @return WPSEO_Rank[]
 	 */
 	public static function get_all_readability_ranks() {
+		return array_map( [ 'WPSEO_Rank', 'create_rank' ], [ self::BAD, self::OK, self::GOOD ] );
+	}
+
+	/**
+	 * Returns a list of all possible Inclusive Language Ranks.
+	 *
+	 * @return WPSEO_Rank[]
+	 */
+	public static function get_all_inclusive_language_ranks() {
 		return array_map( [ 'WPSEO_Rank', 'create_rank' ], [ self::BAD, self::OK, self::GOOD ] );
 	}
 

--- a/tests/integration/test-class-wpseo-rank.php
+++ b/tests/integration/test-class-wpseo-rank.php
@@ -121,7 +121,7 @@ class WPSEO_Rank_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	 * Tests whether the correct label for the drop down is returned.
+	 * Tests whether the correct label for the SEO drop down is returned.
 	 *
 	 * @dataProvider provider_get_drop_down_label
 	 * @covers       WPSEO_Rank::get_drop_down_label
@@ -147,6 +147,62 @@ class WPSEO_Rank_Test extends WPSEO_UnitTestCase {
 			[ WPSEO_Rank::OK, 'SEO: OK' ],
 			[ WPSEO_Rank::GOOD, 'SEO: Good' ],
 			[ WPSEO_Rank::NO_INDEX, 'SEO: Post Noindexed' ],
+		];
+	}
+
+	/**
+	 * Tests whether the correct label for the readability drop down is returned.
+	 *
+	 * @dataProvider provider_get_drop_down_readability_labels
+	 * @covers       WPSEO_Rank::get_drop_down_readability_labels
+	 *
+	 * @param int    $rank     Ranking.
+	 * @param string $expected Expected drop-down label.
+	 */
+	public function test_get_drop_down_readability_labels( $rank, $expected ) {
+		$rank = new WPSEO_Rank( $rank );
+
+		$this->assertEquals( $expected, $rank->get_drop_down_readability_labels() );
+	}
+
+	/**
+	 * Data provider for test_get_drop_down_readability_labels().
+	 *
+	 * @return array
+	 */
+	public function provider_get_drop_down_readability_labels() {
+		return [
+			[ WPSEO_Rank::BAD, 'Readability: Needs improvement' ],
+			[ WPSEO_Rank::OK, 'Readability: OK' ],
+			[ WPSEO_Rank::GOOD, 'Readability: Good' ],
+		];
+	}
+
+	/**
+	 * Tests whether the correct label for the inclusive language drop down is returned.
+	 *
+	 * @dataProvider provider_get_drop_down_inclusive_language_labels
+	 * @covers       WPSEO_Rank::get_drop_down_inclusive_language_labels
+	 *
+	 * @param int    $rank     Ranking.
+	 * @param string $expected Expected drop-down label.
+	 */
+	public function test_get_drop_down_inclusive_language_labels( $rank, $expected ) {
+		$rank = new WPSEO_Rank( $rank );
+
+		$this->assertEquals( $expected, $rank->get_drop_down_inclusive_language_labels() );
+	}
+
+	/**
+	 * Data provider for test_get_drop_down_inclusive_language_labels().
+	 *
+	 * @return array
+	 */
+	public function provider_get_drop_down_inclusive_language_labels() {
+		return [
+			[ WPSEO_Rank::BAD, 'Inclusive language: Needs improvement' ],
+			[ WPSEO_Rank::OK, 'Inclusive language: Potentially non-inclusive' ],
+			[ WPSEO_Rank::GOOD, 'Inclusive language: Good' ],
 		];
 	}
 
@@ -246,12 +302,38 @@ class WPSEO_Rank_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	 * Tests whether all the ranks are instances of the WPSEO_Rank class.
+	 * Tests whether all the SEO ranks are instances of the WPSEO_Rank class.
 	 *
 	 * @covers WPSEO_Rank::get_all_ranks
 	 */
 	public function test_get_all_ranks() {
 		$ranks = WPSEO_Rank::get_all_ranks();
+
+		foreach ( $ranks as $rank ) {
+			$this->assertInstanceOf( 'WPSEO_Rank', $rank );
+		}
+	}
+
+	/**
+	 * Tests whether all the readability ranks are instances of the WPSEO_Rank class.
+	 *
+	 * @covers WPSEO_Rank::get_all_readability_ranks
+	 */
+	public function test_get_all_readability_ranks() {
+		$ranks = WPSEO_Rank::get_all_readability_ranks();
+
+		foreach ( $ranks as $rank ) {
+			$this->assertInstanceOf( 'WPSEO_Rank', $rank );
+		}
+	}
+
+	/**
+	 * Tests whether all the inclusive language ranks are instances of the WPSEO_Rank class.
+	 *
+	 * @covers WPSEO_Rank::get_all_inclusive_language_ranks
+	 */
+	public function test_get_all_inclusive_language_ranks() {
+		$ranks = WPSEO_Rank::get_all_inclusive_language_ranks();
 
 		foreach ( $ranks as $rank ) {
 			$this->assertInstanceOf( 'WPSEO_Rank', $rank );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* This PR enables the creation of filters for scores, like the inclusive language score, outside of the `wordpress-seo` plugin, through the creation of two `apply_filters` functions. 
* This PR also adds functionality in `WPSEO_Rank` to support inclusive language scores.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Enables creating filters for other scores, like the inclusive language score. 

## Relevant technical choices:

* We turned a few methods into static methods to allow them to be more easily included outside the scope of `wordpress-seo`. 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* This PR contains no user-facing changes and should be tested in combination with ...

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* This PR affects the score filters (SEO and readability) on the posts overview. 

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [x] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes https://github.com/Yoast/plugins-automated-testing/issues/725
