### PR TITLE
Add new setting for AdsBot crawling

### DIFF
--- a/admin/tracking/class-tracking-settings-data.php
+++ b/admin/tracking/class-tracking-settings-data.php
@@ -222,6 +222,7 @@ class WPSEO_Tracking_Settings_Data implements WPSEO_Collection {
 		'indexables_overview_state',
 		'deny_search_crawling',
 		'deny_wp_json_crawling',
+		'deny_adsbot_crawling',
 		'last_known_no_unindexed',
 	];
 

--- a/inc/options/class-wpseo-option-wpseo.php
+++ b/inc/options/class-wpseo-option-wpseo.php
@@ -126,6 +126,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 		'search_character_limit'                   => 50,
 		'deny_search_crawling'                     => false,
 		'deny_wp_json_crawling'                    => false,
+		'deny_adsbot_crawling'                     => false,
 		'redirect_search_pretty_urls'              => false,
 		'least_readability_ignore_list'            => [],
 		'least_seo_score_ignore_list'              => [],
@@ -505,6 +506,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 				 *  'search_cleanup_emoji'
 				 *  'search_cleanup_patterns'
 				 *  'deny_wp_json_crawling'
+				 *  'deny_adsbot_crawling'
 				 *  'redirect_search_pretty_urls'
 				 *  'should_redirect_after_install_free'
 				 *  and most of the feature variables.

--- a/packages/js/src/settings/helpers/search.js
+++ b/packages/js/src/settings/helpers/search.js
@@ -519,7 +519,14 @@ export const createSearchIndex = ( postTypes, taxonomies, { userLocale } = {} ) 
 			routeLabel: __( "Crawl optimization", "wordpress-seo" ),
 			fieldId: "input-wpseo-deny_wp_json_crawling",
 			fieldLabel: __( "Remove WP-JSON API", "wordpress-seo" ),
-			keywords: [],
+			keywords: [ 'robots' ],
+		},
+		deny_adsbot_crawling: {
+			route: "/crawl-optimization",
+			routeLabel: __( "Crawl optimization", "wordpress-seo" ),
+			fieldId: "input-wpseo-deny_adsbot_crawling",
+			fieldLabel: __( "Prevent Google AdsBot from crawling", "wordpress-seo" ),
+			keywords: [ 'robots' ],
 		},
 		search_cleanup: {
 			route: "/crawl-optimization",
@@ -561,7 +568,7 @@ export const createSearchIndex = ( postTypes, taxonomies, { userLocale } = {} ) 
 			routeLabel: __( "Crawl optimization", "wordpress-seo" ),
 			fieldId: "input-wpseo-deny_search_crawling",
 			fieldLabel: __( "Prevent crawling of internal site search URLs", "wordpress-seo" ),
-			keywords: [],
+			keywords: [ 'robots' ],
 		},
 		clean_campaign_tracking_urls: {
 			route: "/crawl-optimization",

--- a/packages/js/src/settings/routes/crawl-optimization.js
+++ b/packages/js/src/settings/routes/crawl-optimization.js
@@ -518,6 +518,15 @@ const CrawlOptimization = () => {
 								&nbsp;
 							{ descriptions.denyWpJsonCrawling }
 						</FormikValueChangeFieldWithDisabledMessage>
+						<FormikValueChangeFieldWithDisabledMessage
+							as={ ToggleField }
+							type="checkbox"
+							name="wpseo.deny_adsbot_crawling"
+							id="input-wpseo-deny_adsbot_crawling"
+							label={ __( "Prevent Google AdsBot from crawling", "wordpress-seo" ) }
+							description={ __( "Add a 'disallow' rule to your robots.txt file to prevent crawling by Google's AdsBot. You should only enable this setting if you're not using Google Ads on your site.", "wordpress-seo" ) }
+							className="yst-max-w-2xl"
+						/>
 					</FieldsetLayout>
 					<hr className="yst-my-8" />
 					<FieldsetLayout

--- a/src/integrations/admin/crawl-settings-integration.php
+++ b/src/integrations/admin/crawl-settings-integration.php
@@ -154,6 +154,7 @@ class Crawl_Settings_Integration implements Integration_Interface {
 		$this->unused_resources_settings = [
 			'remove_emoji_scripts'  => \__( 'Emoji scripts', 'wordpress-seo' ),
 			'deny_wp_json_crawling' => \__( 'Prevent search engines from crawling /wp-json/', 'wordpress-seo' ),
+			'deny_adsbot_crawling'  => \__( 'Prevent Google AdsBot from crawling', 'wordpress-seo' ),
 		];
 	}
 
@@ -323,7 +324,7 @@ class Crawl_Settings_Integration implements Integration_Interface {
 	 */
 	protected function should_feature_be_disabled_multisite( $setting ) {
 		return (
-			\in_array( $setting, [ 'deny_search_crawling', 'deny_wp_json_crawling' ], true )
+			\in_array( $setting, [ 'deny_search_crawling', 'deny_wp_json_crawling', 'deny_adsbot_crawling' ], true )
 			&& \is_multisite()
 		);
 	}

--- a/src/integrations/settings-integration.php
+++ b/src/integrations/settings-integration.php
@@ -83,6 +83,7 @@ class Settings_Integration implements Integration_Interface {
 		'wpseo' => [
 			'deny_search_crawling',
 			'deny_wp_json_crawling',
+			'deny_adsbot_crawling',
 		],
 	];
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Introduces a new setting for crawl optimization, that disallows AdsBot crawling when enabled.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

*

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
