### PR TITLE
GH Actions: fix coveralls reporting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,6 +90,8 @@ jobs:
           php-version: ${{ matrix.php_version }}
           ini-values: zend.assertions=1, error_reporting=-1, display_errors=On
           coverage: ${{ matrix.coverage == true && 'xdebug' || 'none' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.YOASTBOT_CI_PAT_DIST }}
 
       # The PHP platform requirement would prevent updating the test utilities to the appropriate versions.
       # As long as the `composer update` is run selectively to only update the test utils, removing this is fine.
@@ -121,7 +123,9 @@ jobs:
       # Global install is used to prevent a conflict with the local composer.lock in PHP 8.0+.
       - name: Install Coveralls
         if: ${{ success() && matrix.coverage == true }}
-        run: composer global require php-coveralls/php-coveralls:"^2.5.3" --no-interaction
+        run: |
+          composer global config repositories.foo vcs https://github.com/jrfnl/php-coveralls
+          composer global require php-coveralls/php-coveralls:"dev-feature/fix-php-8.1-compatibility" --no-interaction
 
       - name: Upload coverage results to Coveralls
         if: ${{ success() && matrix.coverage == true }}
@@ -217,6 +221,8 @@ jobs:
           php-version: ${{ matrix.php_version }}
           ini-values: zend.assertions=1, error_reporting=-1, display_errors=On
           coverage: ${{ matrix.coverage == true && 'xdebug' || 'none' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.YOASTBOT_CI_PAT_DIST }}
 
       # The PHP platform requirement would prevent updating the test utilities to the appropriate versions.
       # As long as the `composer update` is run selectively to only update the test utils, removing this is fine.
@@ -260,7 +266,9 @@ jobs:
       # Global install is used to prevent a conflict with the local composer.lock in PHP 8.0+.
       - name: Install Coveralls
         if: ${{ success() && matrix.coverage == true }}
-        run: composer global require php-coveralls/php-coveralls:"^2.5.3" --no-interaction
+        run: |
+          composer global config repositories.foo vcs https://github.com/jrfnl/php-coveralls
+          composer global require php-coveralls/php-coveralls:"dev-feature/fix-php-8.1-compatibility" --no-interaction
 
       - name: Upload coverage results to Coveralls - single site
         if: ${{ success() && matrix.coverage == true }}


### PR DESCRIPTION
## Context

* Fix Coveralls reporting

## Summary

This PR can be summarized in the following changelog entry:

* Fix Coveralls reporting

## Relevant technical choices:

Looks like _some_ of the Coveralls builds were hitting an edge case PHP 8.1 bug in the php-coveralls package.

This is a [known issue](https://github.com/php-coveralls/php-coveralls/pull/361) for which a PR is already open to fix it.

In most other repos we don't run the risk of hitting the bug as we switch to PHP 7.4 before running PHP Coveralls (deliberately to avoid the bug).

Unfortunately, last time I checked, there still were restrictions on how often the `setup-php` action can run in a workflow (twice) and we are already at that limit for the Free workflow.

So.... to fix this issue until the PR for `php-coveralls` has been merged and a new release has been tagged, we are switching to the branch containing the patch for `php-coveralls`.

For now, it looks like that fixed things.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Verify that the coveralls build result is back to ~40% instead of round ~9%.