### PR TITLE
changed the way we get the term object

### DIFF
--- a/admin/watchers/class-slug-change-watcher.php
+++ b/admin/watchers/class-slug-change-watcher.php
@@ -134,12 +134,12 @@ class WPSEO_Slug_Change_Watcher implements WPSEO_WordPress_Integration {
 	/**
 	 * Checks if the term is viewable.
 	 *
-	 * @param string $term_id The term ID to check.
+	 * @param int $term_taxonomy_id The term taxonomy ID to check.
 	 *
 	 * @return bool Whether the term is viewable or not.
 	 */
-	protected function is_term_viewable( $term_id ) {
-		$term = get_term( $term_id );
+	protected function is_term_viewable( $term_taxonomy_id ) {
+		$term = \get_term_by( 'term_taxonomy_id', (int) $term_taxonomy_id );
 
 		if ( ! $term || is_wp_error( $term ) ) {
 			return false;


### PR DESCRIPTION
We are actually getting the the term taxonomy id in this method and not the term id. The term id is not always the same as the term_taxonomy_id. Therefore the change is to avoid getting the wrong term in those cases.

## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to the way we get the term object for `delete_term_taxonomy` action.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Changes the way we get the term object for `delete_term_taxonomy` action.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Create several tags. for example `apple` and `orange`
* Modify the wp_term_taxonomy table so that the values for term_id and term_taxonomy_id don't match 
* ![image-2022-01-27-10-44-23-926](https://user-images.githubusercontent.com/7323966/235624370-504f10ab-b920-49fa-89b0-54edfd1454a0.png) In this screenshot `orange` is the line after `apple` with `term_taxonomy_id` of 57
* Go to Posts > Tags and delete one of the tags (for example, `apple`)
* Check you are getting the following notice:
![Screenshot 2023-06-07 at 11 57 56](https://github.com/Yoast/wordpress-seo/assets/65466507/d4266773-7c8c-492c-89b8-6ac4e213d59e)



#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes https://github.com/Yoast/wordpress-seo-premium/issues/3946
