### PR TITLE
Removes typing and adds null check.

### DIFF
--- a/src/analytics/application/missing-indexables-collector.php
+++ b/src/analytics/application/missing-indexables-collector.php
@@ -34,7 +34,7 @@ class Missing_Indexables_Collector implements WPSEO_Collection {
 	 *
 	 * @return array The list of missing indexables.
 	 */
-	public function get(): array {
+	public function get() {
 		$missing_indexable_bucket = new Missing_Indexable_Bucket();
 		foreach ( $this->indexation_actions as $indexation_action ) {
 			$missing_indexable_count = new Missing_Indexable_Count( \get_class( $indexation_action ), $indexation_action->get_total_unindexed() );
@@ -49,7 +49,7 @@ class Missing_Indexables_Collector implements WPSEO_Collection {
 	 *
 	 * @return void
 	 */
-	private function add_additional_indexing_actions(): void {
+	private function add_additional_indexing_actions() {
 		/**
 		 * Filter: Adds the possibility to add additional indexation actions to be included in the count routine.
 		 *

--- a/src/analytics/application/to-be-cleaned-indexables-collector.php
+++ b/src/analytics/application/to-be-cleaned-indexables-collector.php
@@ -31,7 +31,7 @@ class To_Be_Cleaned_Indexables_Collector implements WPSEO_Collection {
 	/**
 	 * Gets the data for the collector.
 	 */
-	public function get(): array {
+	public function get() {
 		$to_be_cleaned_indexable_bucket = new To_Be_Cleaned_Indexable_Bucket();
 		$cleanup_tasks                  = [
 			'indexables_with_post_object_type_and_shop_order_object_sub_type' => $this->indexable_cleanup_repository->count_indexables_with_object_type_and_object_sub_type( 'post', 'shop_order' ),
@@ -68,7 +68,7 @@ class To_Be_Cleaned_Indexables_Collector implements WPSEO_Collection {
 	 *
 	 * @return void
 	 */
-	private function add_additional_counts( To_Be_Cleaned_Indexable_Bucket $to_be_cleaned_indexable_bucket ): void {
+	private function add_additional_counts( $to_be_cleaned_indexable_bucket ) {
 		/**
 		 * Action: Adds the possibility to add additional to be cleaned objects.
 		 *

--- a/src/analytics/application/to-be-cleaned-indexables-collector.php
+++ b/src/analytics/application/to-be-cleaned-indexables-collector.php
@@ -50,8 +50,10 @@ class To_Be_Cleaned_Indexables_Collector implements WPSEO_Collection {
 		];
 
 		foreach ( $cleanup_tasks as $name => $count ) {
-			$count_object = new To_Be_Cleaned_Indexable_Count( $name, $count );
-			$to_be_cleaned_indexable_bucket->add_to_be_cleaned_indexable_count( $count_object );
+			if ( $count !== null ) {
+				$count_object = new To_Be_Cleaned_Indexable_Count( $name, $count );
+				$to_be_cleaned_indexable_bucket->add_to_be_cleaned_indexable_count( $count_object );
+			}
 		}
 
 		$this->add_additional_counts( $to_be_cleaned_indexable_bucket );

--- a/src/analytics/domain/missing-indexable-bucket.php
+++ b/src/analytics/domain/missing-indexable-bucket.php
@@ -37,7 +37,7 @@ class Missing_Indexable_Bucket {
 	 *
 	 * @return array
 	 */
-	public function to_array(): array {
+	public function to_array() {
 		return \array_map(
 			static function ( $item ) {
 				return $item->to_array();

--- a/src/analytics/domain/missing-indexable-count.php
+++ b/src/analytics/domain/missing-indexable-count.php
@@ -27,7 +27,7 @@ class Missing_Indexable_Count {
 	 * @param string $indexable_type The indexable type that is represented by this.
 	 * @param int    $count          The amount of missing indexables.
 	 */
-	public function __construct( string $indexable_type, int $count ) {
+	public function __construct( $indexable_type, $count ) {
 		$this->indexable_type = $indexable_type;
 		$this->count          = $count;
 	}
@@ -37,7 +37,7 @@ class Missing_Indexable_Count {
 	 *
 	 * @return array Returns both values in an array format.
 	 */
-	public function to_array(): array {
+	public function to_array() {
 		return [
 			'indexable_type' => $this->get_indexable_type(),
 			'count'          => $this->get_count(),
@@ -49,7 +49,7 @@ class Missing_Indexable_Count {
 	 *
 	 * @return string Returns the indexable type.
 	 */
-	public function get_indexable_type(): string {
+	public function get_indexable_type() {
 		return $this->indexable_type;
 	}
 
@@ -58,7 +58,7 @@ class Missing_Indexable_Count {
 	 *
 	 * @return int Returns the amount of missing indexables.
 	 */
-	public function get_count(): int {
+	public function get_count() {
 		return $this->count;
 	}
 }

--- a/src/analytics/domain/to-be-cleaned-indexable-bucket.php
+++ b/src/analytics/domain/to-be-cleaned-indexable-bucket.php
@@ -28,7 +28,7 @@ class To_Be_Cleaned_Indexable_Bucket {
 	 *
 	 * @return void
 	 */
-	public function add_to_be_cleaned_indexable_count( To_Be_Cleaned_Indexable_Count $to_be_cleaned_indexable_counts ): void {
+	public function add_to_be_cleaned_indexable_count( To_Be_Cleaned_Indexable_Count $to_be_cleaned_indexable_counts ) {
 		$this->to_be_cleaned_indexable_counts[] = $to_be_cleaned_indexable_counts;
 	}
 
@@ -37,7 +37,7 @@ class To_Be_Cleaned_Indexable_Bucket {
 	 *
 	 * @return array
 	 */
-	public function to_array(): array {
+	public function to_array() {
 		return \array_map(
 			static function ( $item ) {
 				return $item->to_array();

--- a/src/analytics/domain/to-be-cleaned-indexable-count.php
+++ b/src/analytics/domain/to-be-cleaned-indexable-count.php
@@ -27,7 +27,7 @@ class To_Be_Cleaned_Indexable_Count {
 	 * @param string $cleanup_name The indexable type that is represented by this.
 	 * @param int    $count        The amount of missing indexables.
 	 */
-	public function __construct( string $cleanup_name, int $count ) {
+	public function __construct( $cleanup_name, $count ) {
 		$this->cleanup_name = $cleanup_name;
 		$this->count        = $count;
 	}
@@ -37,7 +37,7 @@ class To_Be_Cleaned_Indexable_Count {
 	 *
 	 * @return array Returns both values in an array format.
 	 */
-	public function to_array(): array {
+	public function to_array() {
 		return [
 			'cleanup_name' => $this->get_cleanup_name(),
 			'count'        => $this->get_count(),
@@ -49,7 +49,7 @@ class To_Be_Cleaned_Indexable_Count {
 	 *
 	 * @return string
 	 */
-	public function get_cleanup_name(): string {
+	public function get_cleanup_name() {
 		return $this->cleanup_name;
 	}
 
@@ -58,7 +58,7 @@ class To_Be_Cleaned_Indexable_Count {
 	 *
 	 * @return int Returns the amount of missing indexables.
 	 */
-	public function get_count(): int {
+	public function get_count() {
 		return $this->count;
 	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Fixes an edge case where the tracking would fatal when the query fails to get a result.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where a fatal occurs after updating the plugin due to a failed query

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Add the following code to `class-admin`: The add_action part should be at the end of the `__construct` method at around line 116.
``` 
	add_action( 'admin_init', [ $this, 'send' ], 1 );
	}

	public function send() {
		if ( filter_input( INPUT_GET, 'action' ) === 'test' ) {
			$collector = new WPSEO_Collector();

			  $collector->add_collection( YoastSEO()->classes->get( Yoast\WP\SEO\Analytics\Application\To_Be_Cleaned_Indexables_Collector::class ) );

			echo '<pre>';
			print_r( WPSEO_Utils::format_json_encode( $collector->collect() ) );
			echo '</pre>';
			die;
		}
	}
```
* Without this PR/RC:
	* Rename your indexables database table and go to https://basic.wordpress.test/wp-admin/admin.php?page=wpseo_dashboard&action=test. Verify this gives a fatal error.
* Checkout this PR/RC and make sure the fatal error is gone.
* Rename the indexables table back and make sure the collector still works and now gives more results.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
