### PR TITLE
fixing contact our support team button when tracking is disabled

### DIFF
--- a/packages/js/src/support/app.js
+++ b/packages/js/src/support/app.js
@@ -18,11 +18,14 @@ import { useSelectSupport } from "./hooks";
  * @returns {void}
  */
 const openHelpScoutBeacon = () => {
-	document.querySelector( "#beacon-container .BeaconFabButtonFrame iframe" )
-		?.contentWindow
-		?.document
-		?.querySelector( "button[aria-controls='HSBeaconContainerFrame']" )
-		?.click();
+	const beaconButtonNeedsHelp = document.querySelector( "#beacon-container .BeaconFabButtonFrame iframe" );
+
+	if ( beaconButtonNeedsHelp ) {
+		// eslint-disable-next-line new-cap
+		window.Beacon( "open" );
+	} else {
+		document.querySelector( "#yoast-helpscout-beacon button" ).click();
+	}
 };
 
 /**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to trigger the help scout beacon also when the tracking is disabled.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Updates the `contact our support team` button when tracking is disabled.

## Relevant technical choices:

* 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install also Yoast premium and activate
* Got to `Yoast SEO`->`General`->`First time configuration`->`PERSONAL PREFERENCES` and disable tracking:
![Screenshot 2023-06-12 at 14 34 21](https://github.com/Yoast/wordpress-seo/assets/65466507/3bd358eb-bfcb-4207-a7e5-3a84f6868d3f)
* Go to `Yoast SEO`->`Support` and check the beacon has a question mark instead of `Need help?`
![Screenshot 2023-06-12 at 10 47 45](https://github.com/Yoast/wordpress-seo/assets/65466507/9464e816-8839-4ef0-a301-34df27188d64)
* Click on `Contact our support team` button
* Check you see a popup and click ok
![Screenshot 2023-06-12 at 10 47 53](https://github.com/Yoast/wordpress-seo/assets/65466507/837373f5-3151-411c-ac97-f6cbfe0ec010)
* Check you see the form in the beacon and it's button is `Need help?`

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:


*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes [Investigate "Contact our support team" button in support page potentially doing nothing on a new site](https://github.com/Yoast/wordpress-seo/issues/20395)
