### PR TITLE
Cherry-picks the PR to exclude separator and site title replacements from title length calculations

### DIFF
--- a/packages/js/src/analysis/collectAnalysisData.js
+++ b/packages/js/src/analysis/collectAnalysisData.js
@@ -98,7 +98,9 @@ export default function collectAnalysisData( editorData, store, customAnalysisDa
 		data.wpBlocks = pluggable._applyModifications( "wpBlocks", data.wpBlocks );
 	}
 
-	data.titleWidth = measureTextWidth( data.title );
+	const filteredSEOTitle = storeData.analysisData.snippet.filteredSEOTitle;
+	// When measuring the SEO title width, we exclude the separator and the site title from the calculation.
+	data.titleWidth = measureTextWidth( filteredSEOTitle || storeData.snippetEditor.data.title );
 	data.locale = getContentLocale();
 	data.writingDirection = getWritingDirection();
 

--- a/packages/js/src/elementor/containers/SnippetEditor.js
+++ b/packages/js/src/elementor/containers/SnippetEditor.js
@@ -20,6 +20,7 @@ const { stripHTMLTags } = strings;
  * @param {string} data.title               The snippet preview title.
  * @param {string} data.url                 The snippet preview url: baseUrl with the slug.
  * @param {string} data.description         The snippet preview description.
+ * @param {string} data.filteredSEOTitle	The SEO title without separator and site title.
  * @param {Object} context                  The context surrounding the snippet editor form data.
  * @param {string} context.shortenedBaseUrl The baseUrl of the snippet preview url.
  *
@@ -57,6 +58,7 @@ const mapEditorDataToPreview = ( data, context ) => {
 		url: data.url,
 		title: stripHTMLTags( applyModifications( "data_page_title", data.title ) ),
 		description: stripHTMLTags( applyModifications( "data_meta_desc", data.description ) ),
+		filteredSEOTitle: stripHTMLTags( applyModifications( "data_page_title", data.filteredSEOTitle ) ),
 	};
 };
 

--- a/packages/js/src/helpers/replacementVariableHelpers.js
+++ b/packages/js/src/helpers/replacementVariableHelpers.js
@@ -241,10 +241,11 @@ export function excerptFromContent( content, limit = 156 ) {
 /**
  * Runs the legacy replaceVariables function on the data in the snippet preview.
  *
- * @param {Object} data             The snippet preview data object.
- * @param {string} data.title       The snippet preview title.
- * @param {string} data.url         The snippet preview url: baseUrl with the slug.
- * @param {string} data.description The snippet preview description.
+ * @param {Object} data					The snippet preview data object.
+ * @param {string} data.title			The snippet preview title.
+ * @param {string} data.url				The snippet preview url: baseUrl with the slug.
+ * @param {string} data.description		The snippet preview description.
+ * @param {string} data.filteredSEOTitle The SEO title without separator and site title.
  *
  * @returns {Object} Returns the data object in which the placeholders have been replaced.
  */
@@ -255,6 +256,7 @@ const legacyReplaceUsingPlugin = function( data ) {
 		url: data.url,
 		title: stripHTMLTags( replaceVariables( data.title ) ),
 		description: stripHTMLTags( replaceVariables( data.description ) ),
+		filteredSEOTitle: stripHTMLTags( replaceVariables( data.filteredSEOTitle ) ),
 	};
 };
 
@@ -265,6 +267,7 @@ const legacyReplaceUsingPlugin = function( data ) {
  * @param {string} data.title       The snippet preview title.
  * @param {string} data.url         The snippet preview url: baseUrl with the slug.
  * @param {string} data.description The snippet preview description.
+ * @param {string} data.filteredSEOTitle The SEO title without separator and site title.
  *
  * @returns {Object} Returns the data object in which the placeholders have been replaced.
  */
@@ -281,5 +284,6 @@ export const applyReplaceUsingPlugin = function( data ) {
 		url: data.url,
 		title: stripHTMLTags( applyModifications( "data_page_title", data.title ) ),
 		description: stripHTMLTags( applyModifications( "data_meta_desc", data.description ) ),
+		filteredSEOTitle: stripHTMLTags( applyModifications( "data_page_title", data.filteredSEOTitle ) ),
 	};
 };

--- a/packages/js/tests/containers/mapEditorDataToPreview.test.js
+++ b/packages/js/tests/containers/mapEditorDataToPreview.test.js
@@ -8,6 +8,7 @@ describe( "mapEditorDataToPreview", () => {
 			title: "",
 			url: "local.wordpress.test/my URL is awesome",
 			description: "",
+			filteredSEOTitle: "",
 		};
 		context = {
 			shortenedBaseUrl: "local.wordpress.test/",
@@ -20,6 +21,7 @@ describe( "mapEditorDataToPreview", () => {
 			description: "no more spaces",
 			title: "",
 			url: "local.wordpress.test/my-URL-is-awesome",
+			filteredSEOTitle: "",
 		};
 		dataObject.description = exampleDescription;
 
@@ -34,6 +36,7 @@ describe( "mapEditorDataToPreview", () => {
 			description: "Yay for spaces",
 			title: "",
 			url: "local.wordpress.test/my-URL-is-awesome",
+			filteredSEOTitle: "",
 		};
 		dataObject.description = exampleDescription;
 
@@ -48,6 +51,7 @@ describe( "mapEditorDataToPreview", () => {
 			description: "",
 			title: "",
 			url: "local.wordpress.test/only-one-dash",
+			filteredSEOTitle: "",
 		};
 		dataObject.url = exampleUrl;
 
@@ -62,6 +66,7 @@ describe( "mapEditorDataToPreview", () => {
 			description: "",
 			title: "",
 			url: "local.wordpress.test/only-one-dash",
+			filteredSEOTitle: "",
 		};
 		dataObject.url = exampleUrl;
 

--- a/packages/search-metadata-previews/src/snippet-editor/SnippetEditor.js
+++ b/packages/search-metadata-previews/src/snippet-editor/SnippetEditor.js
@@ -46,12 +46,15 @@ const CloseEditorButton = styled( SnippetEditorButton )`
 	margin-top: 24px;
 `;
 
+// The regex for the replacement variables we want to exclude from the SEO title before we measure the width.
+const excludedVars = new RegExp( "(%%sep%%|%%sitename%%)", "g" );
+
 /**
- * Gets the title progress.
+ * Gets the SEO title progress.
  *
- * @param {string} title The title.
+ * @param {string} title The SEO title.
  *
- * @returns {Object} The title progress.
+ * @returns {Object} The SEO title progress.
  */
 function getTitleProgress( title ) {
 	const titleWidth = measureTextWidth( title );
@@ -84,7 +87,7 @@ function getTitleProgress( title ) {
 function getDescriptionProgress( description, date, isCornerstone, isTaxonomy, locale ) {
 	const descriptionLength = languageProcessing.countMetaDescriptionLength( date, description );
 
-	// Override the default config if the cornerstone content toggle is on and it is not a taxonomy page.
+	// Override the default config if the cornerstone content toggle is on, and it is not a taxonomy page.
 	const metaDescriptionLengthAssessment = ( isCornerstone && ! isTaxonomy ) ? new MetaDescriptionLengthAssessment( {
 		scores: {
 			tooLong: 3,
@@ -114,7 +117,7 @@ class SnippetEditor extends React.Component {
 	 * @param {Object[]} props.recommendedReplacementVariables   The recommended replacement variables for this editor.
 	 * @param {Object}   props.data                              The initial editor data.
 	 * @param {string}   props.keyword                           The focus keyword.
-	 * @param {string}   props.data.title                        The initial title.
+	 * @param {string}   props.data.title                        The initial SEO title.
 	 * @param {string}   props.data.slug                         The initial slug.
 	 * @param {string}   props.data.description                  The initial description.
 	 * @param {bool}     props.isCornerstone                     Whether the cornerstone content toggle is on or off.
@@ -122,7 +125,7 @@ class SnippetEditor extends React.Component {
 	 * @param {string}   props.baseUrl                           The base URL to use for the preview.
 	 * @param {string}   props.mode                              The mode the editor should be in.
 	 * @param {Function} props.onChange                          Called when the data changes.
-	 * @param {Object}   props.titleLengthProgress               The values for the title length assessment.
+	 * @param {Object}   props.titleLengthProgress               The values for the SEO title length assessment.
 	 * @param {Object}   props.descriptionLengthProgress         The values for the description length assessment.
 	 * @param {Function} props.mapEditorDataToPreview            Function to map the editor data to data for the preview.
 	 * @param {Function} props.applyReplacementVariables         Function that overrides default replacement variables application with a custom one.
@@ -143,7 +146,7 @@ class SnippetEditor extends React.Component {
 			isOpen: ! props.showCloseButton,
 			activeField: null,
 			hoveredField: null,
-			titleLengthProgress: getTitleProgress( measurementData.title ),
+			titleLengthProgress: getTitleProgress( measurementData.filteredSEOTitle ),
 			descriptionLengthProgress: getDescriptionProgress(
 				measurementData.description,
 				this.props.date,
@@ -221,7 +224,8 @@ class SnippetEditor extends React.Component {
 			const data = this.mapDataToMeasurements( nextProps.data, nextProps.replacementVariables );
 			this.setState(
 				{
-					titleLengthProgress: getTitleProgress( data.title ),
+					// Here we use the filtered SEO title for the SEO title progress calculation.
+					titleLengthProgress: getTitleProgress( data.filteredSEOTitle ),
 					descriptionLengthProgress: getDescriptionProgress(
 						data.description,
 						nextProps.date,
@@ -233,7 +237,7 @@ class SnippetEditor extends React.Component {
 
 			if ( this.haveReplaceVarsChanged( this.props.replacementVariables, nextProps.replacementVariables ) ) {
 				/*
-				 * Make sure that changes to the replace vars (e.g. title, category, tags) get reflected on the
+				 * Make sure that changes to the replacement vars (e.g. title, category, tags) get reflected on the
 				 * analysis data on the store (used in, among other things, the SEO analysis).
 				 */
 				this.props.onChangeAnalysisData( data );
@@ -448,8 +452,9 @@ class SnippetEditor extends React.Component {
 	 * Maps the data from to be suitable for measurement.
 	 *
 	 * The data that is measured is not exactly the same as the data that
-	 * is in the preview, because the metadescription placeholder shouldn't
-	 * be measured.
+	 * is in the preview, because the meta description placeholder shouldn't
+	 * be measured. Additionally, the separator and site title should also be filtered out of the SEO title
+	 * before the width is measured.
 	 *
 	 * @param {Object} originalData         The data from the form.
 	 * @param {array}  replacementVariables The replacement variables to use. Taken from the props by default.
@@ -466,10 +471,15 @@ class SnippetEditor extends React.Component {
 
 		const shortenedBaseUrl = baseUrl.replace( /^https?:\/\//i, "" );
 
+		// The filtered title is the SEO title without separator and site title.
+		// This data will be used in calculating the SEO title width.
+		const filteredTitle = originalData.title.replace( excludedVars, "" );
+
 		const mappedData = {
 			title: this.processReplacementVariables( originalData.title, replacementVariables ),
 			url: baseUrl + originalData.slug,
 			description: description,
+			filteredSEOTitle: this.processReplacementVariables( filteredTitle, replacementVariables ),
 		};
 
 		const context = {
@@ -481,7 +491,6 @@ class SnippetEditor extends React.Component {
 			return mapEditorDataToPreview( mappedData, context );
 		}
 
-
 		return mappedData;
 	}
 
@@ -489,7 +498,7 @@ class SnippetEditor extends React.Component {
 	 * Maps the passed data to be suitable for the preview.
 	 *
 	 * The data that is in the preview is not exactly the same as the data
-	 * that is measured (see above), because the metadescription placeholder
+	 * that is measured (see above), because the meta description placeholder
 	 * shouldn't be measured.
 	 *
 	 * @param {Object} originalData         The data from the form.
@@ -533,7 +542,7 @@ class SnippetEditor extends React.Component {
 	}
 
 	/**
-	 * Sets a reference to the edit button so we can move focus to it.
+	 * Sets a reference to the edit button, so we can move focus to it.
 	 *
 	 * @param {Object} ref The edit button element.
 	 *

--- a/packages/search-metadata-previews/tests/SnippetEditorTest.js
+++ b/packages/search-metadata-previews/tests/SnippetEditorTest.js
@@ -14,7 +14,6 @@ const defaultArgs = {
 	baseUrl: "http://example.org/",
 	data: defaultData,
 	onChange: () => {},
-
 };
 
 /**
@@ -251,6 +250,29 @@ describe( "SnippetEditor", () => {
 			const isDirty = editor.instance().shallowCompareData( prev, next );
 
 			expect( isDirty ).toBe( true );
+		} );
+	} );
+	describe( "mapDataToMeasurements", () => {
+		let editor, data;
+		beforeEach( () => {
+			editor = mountWithArgs( {} );
+			data = {
+				title: "Tortoiseshell cats %%sep%% %%sitename%%",
+				description: "   The cool tortie everyone loves!   ",
+				slug: "tortie-cats",
+			};
+		} );
+		it( "returns the filtered SEO title without separator and site title", () => {
+			expect( editor.instance().mapDataToMeasurements( data ).filteredSEOTitle ).toBe( "Tortoiseshell cats  " );
+			editor.unmount();
+		} );
+		it( "returns the correct url: baseURL + slug", () => {
+			expect( editor.instance().mapDataToMeasurements( data ).url ).toBe( "http://example.org/tortie-cats" );
+			editor.unmount();
+		} );
+		it( "returns the description with multiple spaces stripped", () => {
+			expect( editor.instance().mapDataToMeasurements( data ).description ).toBe( "The cool tortie everyone loves!" );
+			editor.unmount();
 		} );
 	} );
 } );

--- a/packages/yoastseo/src/scoring/assessments/SCORING SEO.md
+++ b/packages/yoastseo/src/scoring/assessments/SCORING SEO.md
@@ -289,7 +289,7 @@ With the example keyphrase `cat and dog` the following criteria would apply to c
 | Green	| 9	| All internal links are followed		| **Internal links**: You have enough internal links. Good job! |
 
 ### 4) SEO Title width
-**What it does**: Checks if the SEO title has a good length. Note that this assessment checks the SEO title as it appears in the snippet preview. Therefore, it also takes into account the content from replacement variables.
+**What it does**: Checks if the SEO title has a good length. Note that this assessment checks the SEO title as it appears in the snippet preview. Therefore, it also takes into account the content from replacement variables. However, we exclude the separator and the site title replacement variables from the calculation.
 
 **When it applies**: Always.
 

--- a/packages/yoastseo/src/scoring/assessments/seo/PageTitleWidthAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/PageTitleWidthAssessment.js
@@ -7,8 +7,9 @@ import { createAnchorOpeningTag } from "../../../helpers/shortlinker";
 import AssessmentResult from "../../../values/AssessmentResult";
 
 const maximumLength = 600;
+
 /**
- * Represents the assessment that will calculate if the width of the page title is correct.
+ * Represents the assessment that assesses the SEO title width and gives the feedback accordingly.
  */
 export default class PageTitleWidthAssessment extends Assessment {
 	/**
@@ -75,9 +76,9 @@ export default class PageTitleWidthAssessment extends Assessment {
 	}
 
 	/**
-	 * Returns the score for the pageTitleWidth
+	 * Returns the score for the SEO title width calculation.
 	 *
-	 * @param {number} pageTitleWidth The width of the pageTitle.
+	 * @param {number} pageTitleWidth The width of the SEO title.
 	 *
 	 * @returns {number} The calculated score.
 	 */
@@ -98,9 +99,9 @@ export default class PageTitleWidthAssessment extends Assessment {
 	}
 
 	/**
-	 * Translates the pageTitleWidth score to a message the user can understand.
+	 * Translates the score of the SEO title width calculation to a message the user can understand.
 	 *
-	 * @param {number} pageTitleWidth The width of the pageTitle.
+	 * @param {number} pageTitleWidth The width of the SEO title.
 	 *
 	 * @returns {string} The translated string.
 	 */


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to prepare the 20.10 RC by cherry-picking #20354 into `trunk` from the feature branch `feature/lingo-fixes`. 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Merges part of the feature branch `feature/lingo-fixes` into trunk. 

## Relevant technical choices:

* We merge only a part of the feature branch, as we do not want to yet merge other stuff on that branch. 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* See #20354 .

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes --
