### PR TITLE
added default color for placeholder text

### DIFF
--- a/css/src/tailwind.css
+++ b/css/src/tailwind.css
@@ -55,7 +55,7 @@
 
 		/* Override aggressive WordPress inputs styling */
 		.yst-input {
-			@apply yst-py-2 yst-px-3 yst-border yst-bg-white yst-rounded-md yst-shadow-sm yst-text-sm yst-placeholder-gray-400 !important;
+			@apply yst-py-2 yst-px-3 yst-border yst-bg-white yst-rounded-md yst-shadow-sm yst-text-sm yst-placeholder-slate-500 !important;
 		}
 
 		.yst-radio {

--- a/packages/tailwindcss-preset/index.js
+++ b/packages/tailwindcss-preset/index.js
@@ -42,6 +42,13 @@ module.exports = {
 		require( "@tailwindcss/forms" )( {
 			strategy: "class",
 		} ),
+		function( { addBase, theme } ) {
+			addBase( {
+			  "::placeholder": {
+					color: theme( "colors.slate.500" ),
+			  },
+			} );
+		  },
 	],
 	corePlugins: {
 		preflight: false,


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Fix the default color for placeholder text throughout the plugin.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [@yoast/tailwindcss-preset 0.1.0]  Fixes the default color for placeholder text throughout the plugin.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Go to `Yoast SEO`->`Settings`->`Site connections`
* Inspect placeholder for `Add verification code` for input fields, you can do that by check the `Show user agent shadow Dom` in the inspect Developer Tools settings in chrome.
![Screenshot 2023-06-13 at 12 21 58](https://github.com/Yoast/wordpress-seo/assets/65466507/31a7beb2-d554-4019-8455-a8868debac5a)
* Check the color of the placeholder is `rgb(100 116 139 / var(--tw-placeholder-opacity));`
* Go to `Yoast SEO`->`General`->`First time configuration`->`SOCIAL PROFILES`
* Check the color of the placeholder text in the input fields is `rgb(100 116 139 / var(--tw-placeholder-opacity));`

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes [Check placeholder text color#20120](https://github.com/Yoast/wordpress-seo/issues/20120)
