### PR TITLE
Remove calls to logged-in-only Wincher apis when user is not logged in

### DIFF
--- a/packages/js/src/components/WincherPerformanceReport.js
+++ b/packages/js/src/components/WincherPerformanceReport.js
@@ -445,6 +445,15 @@ WincherSEOPerformanceTable.propTypes = {
 };
 
 /**
+ * Checks whether Wincher performance data has results.
+ *
+ * @param {Object} data the Wincher performance data.
+ *
+ * @returns {boolean} Whether Wincher performance data has results.
+ */
+const checkHasResults = ( data ) => data && ! isEmpty( data ) && ! isEmpty( data.results );
+
+/**
  * The Dashboard Wincher SEO Performance component.
  *
  * @param {Object} props The component props.
@@ -455,16 +464,17 @@ const WincherPerformanceReport = ( props ) => {
 	const { className, websiteId, isLoggedIn, onConnectAction, isConnectSuccess } = props;
 	const data = isLoggedIn ? props.data : fakeWincherPerformanceData;
 	const isBlurred = ! isLoggedIn;
+	const hasResults = checkHasResults( data );
 
 	return (
 		<WicnherSEOPerformanceContainer
 			className={ className }
 		>
-			<WincherUpgradeCallout isTitleShortened={ true } />
+			{ isLoggedIn && <WincherUpgradeCallout isTitleShortened={ true } /> }
 
 			<GetUserMessage { ...props } data={ data } isConnectSuccess={ isConnectSuccess && isLoggedIn } />
 
-			{ data && ! isEmpty( data ) && ! isEmpty( data.results ) && <Fragment>
+			{ hasResults && <Fragment>
 				<TableExplanation isLoggedIn={ isLoggedIn } />
 
 				<WincherSEOPerformanceTableWrapper>

--- a/packages/js/src/components/WincherSEOPerformance.js
+++ b/packages/js/src/components/WincherSEOPerformance.js
@@ -287,7 +287,7 @@ export default function WincherSEOPerformance( props ) {
 	return (
 		<Wrapper>
 			{ isNewlyAuthenticated && <WincherConnectedAlert /> }
-			<WincherUpgradeCallout />
+			{ isLoggedIn && <WincherUpgradeCallout /> }
 
 			<Title>
 				{ __( "SEO performance", "wordpress-seo" ) }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Remove calls to wincher APIs when wincher integration is active but user is not logged in to a wincher account.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Removes calls to wincher APIs when wincher integration is active but user is not logged in to a wincher account.

## Test instructions

* Go to Yoast SEO->Integration
* Enable Wincher integration if it is disabled.
* Go to Dashboard
* Check in the Wincher block it is not connected to a Wincher account.
* Inspect page
* Check no console errors related to Wincher apis

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] During testing, I had activated all plugins Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #20424
