### PR TITLE
20066 add default allowlis to remove unregistered url parameters

### DIFF
--- a/src/helpers/crawl-cleanup-helper.php
+++ b/src/helpers/crawl-cleanup-helper.php
@@ -76,6 +76,16 @@ class Crawl_Cleanup_Helper {
 	 * @return array The list of the allowed extra vars.
 	 */
 	public function get_allowed_extravars() {
+		$default_allowed_extravars = [
+			'utm_source',
+			'utm_medium',
+			'utm_campaign',
+			'utm_term',
+			'utm_content',
+			'gclid',
+			'gtm_debug'
+		];
+
 		/**
 		 * Filter: 'Yoast\WP\SEO\allowlist_permalink_vars' - Allows plugins to register their own variables not to clean.
 		 *
@@ -83,7 +93,8 @@ class Crawl_Cleanup_Helper {
 		 *
 		 * @param array $allowed_extravars The list of the allowed vars (empty by default).
 		 */
-		$allowed_extravars = \apply_filters( 'Yoast\WP\SEO\allowlist_permalink_vars', [] );
+
+		$allowed_extravars = \apply_filters('Yoast\WP\SEO\allowlist_permalink_vars', $default_allowed_extravars);
 
 		$clean_permalinks_extra_variables = $this->options_helper->get( 'clean_permalinks_extra_variables' );
 

--- a/src/helpers/crawl-cleanup-helper.php
+++ b/src/helpers/crawl-cleanup-helper.php
@@ -83,7 +83,7 @@ class Crawl_Cleanup_Helper {
 			'utm_term',
 			'utm_content',
 			'gclid',
-			'gtm_debug'
+			'gtm_debug',
 		];
 
 		/**
@@ -94,7 +94,7 @@ class Crawl_Cleanup_Helper {
 		 * @param array $allowed_extravars The list of the allowed vars (empty by default).
 		 */
 
-		$allowed_extravars = \apply_filters('Yoast\WP\SEO\allowlist_permalink_vars', $default_allowed_extravars);
+		$allowed_extravars = \apply_filters( 'Yoast\WP\SEO\allowlist_permalink_vars', $default_allowed_extravars );
 
 		$clean_permalinks_extra_variables = $this->options_helper->get( 'clean_permalinks_extra_variables' );
 

--- a/tests/unit/helpers/crawl-cleanup-helper-test.php
+++ b/tests/unit/helpers/crawl-cleanup-helper-test.php
@@ -147,7 +147,7 @@ class Crawl_Cleanup_Helper_Test extends TestCase {
 
 		Monkey\Functions\expect( 'apply_filters' )
 			->once()
-			->with( 'Yoast\WP\SEO\allowlist_permalink_vars', [] )
+			->with( 'Yoast\WP\SEO\allowlist_permalink_vars', ['utm_source', 'utm_medium', 'utm_campaign', 'utm_term', 'utm_content', 'gclid', 'gtm_debug'] )
 			->andReturn( $permalink_vars );
 
 		$this->options_helper

--- a/tests/unit/helpers/crawl-cleanup-helper-test.php
+++ b/tests/unit/helpers/crawl-cleanup-helper-test.php
@@ -147,7 +147,7 @@ class Crawl_Cleanup_Helper_Test extends TestCase {
 
 		Monkey\Functions\expect( 'apply_filters' )
 			->once()
-			->with( 'Yoast\WP\SEO\allowlist_permalink_vars', ['utm_source', 'utm_medium', 'utm_campaign', 'utm_term', 'utm_content', 'gclid', 'gtm_debug'] )
+			->with( 'Yoast\WP\SEO\allowlist_permalink_vars', [ 'utm_source', 'utm_medium', 'utm_campaign', 'utm_term', 'utm_content', 'gclid', 'gtm_debug' ] )
 			->andReturn( $permalink_vars );
 
 		$this->options_helper


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Adds  default allowlist to "Remove unregistered URL parameters" in Advanced: URL cleanup settings.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds utm_source, utm_medium, utm_campaign, utm_term, utm_content, gclid and 
 gtm_debug to the default allowlist for the "Remove unregistered URL parameters" setting.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Open Yoast Seo->Settings->Advanced->Crawl optimization 
* Scroll till section Advanced: URL cleanup
* Check "Remove unregistered URL parameters"
* Save settings.
* Logout from current user or open site in incognito mode.
* Append test parameter in site - for example unknown_parameter=yes so you site url will be https://www.example.com/?unknown_parameter=yes
* page should be redirected and the parameter removed.
* add any parameter from the allow list: utm_source, utm_medium, utm_campaign, utm_term, utm_content, gclid, 
 gtm_debug
* it should not be removed.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [#20066](https://github.com/Yoast/wordpress-seo/issues/20066)
