### PR TITLE
Add information about the allowlist for users.

### DIFF
--- a/packages/js/src/settings/routes/crawl-optimization.js
+++ b/packages/js/src/settings/routes/crawl-optimization.js
@@ -232,11 +232,11 @@ const CrawlOptimization = () => {
 				"<code2/>",
 				"<code3/>"
 			) + " " +
-			/**
-			 * translators:
-			 * %1$s through %7$s each expand to a parameter name within a <code> tag.
-			 */
 			sprintf(
+				/**
+				 * translators:
+				 * %1$s through %7$s each expand to a parameter name within a <code> tag. For example <code>gclid</code>.
+				 */
 				__( "Note that the following commonly-used parameters will not be removed: %1$s, %2$s, %3$s, %4$s, %5$s, %6$s, and %7$s.",
 					"wordpress-seo" ),
 				"<code4/>",

--- a/packages/js/src/settings/routes/crawl-optimization.js
+++ b/packages/js/src/settings/routes/crawl-optimization.js
@@ -226,15 +226,31 @@ const CrawlOptimization = () => {
 				 * %1$s expands to `<code>301</code>`.
 				 * %2$s and %3$s both expand to an example within a <code> tag.
 				 */
-				__( "Removes unknown URL parameters via a %1$s redirect. E.g., %2$s will be redirected to %3$s", "wordpress-seo" ),
+				__( "Removes unknown URL parameters via a %1$s redirect. " +
+					"E.g., %2$s will be redirected to %3$s " +
+					"Note that the following commonly-used parameters will not be removed: %4$s, %5$s, %6$s, %7$s, %8$s, %9$s, and %10$s.", "wordpress-seo" ),
 				"<code1/>",
 				"<code2/>",
-				"<code3/>"
+				"<code3/>",
+				"<code4/>",
+				"<code5/>",
+				"<code6/>",
+				"<code7/>",
+				"<code8/>",
+				"<code9/>",
+				"<code10/>"
 			),
 			{
 				code1: <Code>301</Code>,
 				code2: <Code variant="block">https://www.example.com/?unknown_parameter=yes</Code>,
 				code3: <Code variant="block">https://www.example.com</Code>,
+				code4: <Code>utm_source</Code>,
+				code5: <Code>utm_medium</Code>,
+				code6: <Code>utm_campaign</Code>,
+				code7: <Code>utm_term</Code>,
+				code8: <Code>utm_content</Code>,
+				code9: <Code>gclid</Code>,
+				code10: <Code>gtm_debug</Code>,
 			}
 		),
 		cleanPermalinksExtraVariables: createInterpolateElement(

--- a/packages/js/src/settings/routes/crawl-optimization.js
+++ b/packages/js/src/settings/routes/crawl-optimization.js
@@ -234,7 +234,7 @@ const CrawlOptimization = () => {
 			sprintf(
 				/**
 				 * translators:
-				 * %1$s through %7$s each expand to a parameter name within a <code> tag. For example <code>gclid</code>.
+				 * %1$s through %7$s each expand to a parameter name within a <code> tag. For example, <code>gclid</code>.
 				 */
 				__( "Note that the following commonly-used parameters will not be removed: %1$s, %2$s, %3$s, %4$s, %5$s, %6$s, and %7$s.",
 					"wordpress-seo" ),

--- a/packages/js/src/settings/routes/crawl-optimization.js
+++ b/packages/js/src/settings/routes/crawl-optimization.js
@@ -234,7 +234,7 @@ const CrawlOptimization = () => {
 			) +
 			/**
 			 * translators:
-			 * %1$s through %7$s all expand to a parameter name within a <code> tag.
+			 * %1$s through %7$s each expand to a parameter name within a <code> tag.
 			 */
 			sprintf(
 				__( "Note that the following commonly-used parameters will not be removed: %1$s, %2$s, %3$s, %4$s, %5$s, %6$s, and %7$s.",

--- a/packages/js/src/settings/routes/crawl-optimization.js
+++ b/packages/js/src/settings/routes/crawl-optimization.js
@@ -226,8 +226,7 @@ const CrawlOptimization = () => {
 				 * %1$s expands to `<code>301</code>`.
 				 * %2$s and %3$s both expand to an example within a <code> tag.
 				 */
-				__( "Removes unknown URL parameters via a %1$s redirect. " +
-					"E.g., %2$s will be redirected to %3$s", "wordpress-seo" ),
+				__( "Removes unknown URL parameters via a %1$s redirect. E.g., %2$s will be redirected to %3$s", "wordpress-seo" ),
 				"<code1/>",
 				"<code2/>",
 				"<code3/>"

--- a/packages/js/src/settings/routes/crawl-optimization.js
+++ b/packages/js/src/settings/routes/crawl-optimization.js
@@ -230,7 +230,7 @@ const CrawlOptimization = () => {
 				"<code1/>",
 				"<code2/>",
 				"<code3/>"
-			) + " " +
+			) +
 			sprintf(
 				/**
 				 * translators:

--- a/packages/js/src/settings/routes/crawl-optimization.js
+++ b/packages/js/src/settings/routes/crawl-optimization.js
@@ -227,11 +227,18 @@ const CrawlOptimization = () => {
 				 * %2$s and %3$s both expand to an example within a <code> tag.
 				 */
 				__( "Removes unknown URL parameters via a %1$s redirect. " +
-					"E.g., %2$s will be redirected to %3$s " +
-					"Note that the following commonly-used parameters will not be removed: %4$s, %5$s, %6$s, %7$s, %8$s, %9$s, and %10$s.", "wordpress-seo" ),
+					"E.g., %2$s will be redirected to %3$s ", "wordpress-seo" ),
 				"<code1/>",
 				"<code2/>",
-				"<code3/>",
+				"<code3/>"
+			) +
+			/**
+			 * translators:
+			 * %1$s through %7$s all expand to a parameter name within a <code> tag.
+			 */
+			sprintf(
+				__( "Note that the following commonly-used parameters will not be removed: %1$s, %2$s, %3$s, %4$s, %5$s, %6$s, and %7$s.",
+					"wordpress-seo" ),
 				"<code4/>",
 				"<code5/>",
 				"<code6/>",
@@ -244,13 +251,13 @@ const CrawlOptimization = () => {
 				code1: <Code>301</Code>,
 				code2: <Code variant="block">https://www.example.com/?unknown_parameter=yes</Code>,
 				code3: <Code variant="block">https://www.example.com</Code>,
-				code4: <Code>utm_source</Code>,
-				code5: <Code>utm_medium</Code>,
+				code4: <Code>gclid</Code>,
+				code5: <Code>gtm_debug</Code>,
 				code6: <Code>utm_campaign</Code>,
-				code7: <Code>utm_term</Code>,
-				code8: <Code>utm_content</Code>,
-				code9: <Code>gclid</Code>,
-				code10: <Code>gtm_debug</Code>,
+				code7: <Code>utm_content</Code>,
+				code8: <Code>utm_medium</Code>,
+				code9: <Code>utm_source</Code>,
+				code10: <Code>utm_term</Code>,
 			}
 		),
 		cleanPermalinksExtraVariables: createInterpolateElement(

--- a/packages/js/src/settings/routes/crawl-optimization.js
+++ b/packages/js/src/settings/routes/crawl-optimization.js
@@ -227,11 +227,11 @@ const CrawlOptimization = () => {
 				 * %2$s and %3$s both expand to an example within a <code> tag.
 				 */
 				__( "Removes unknown URL parameters via a %1$s redirect. " +
-					"E.g., %2$s will be redirected to %3$s ", "wordpress-seo" ),
+					"E.g., %2$s will be redirected to %3$s", "wordpress-seo" ),
 				"<code1/>",
 				"<code2/>",
 				"<code3/>"
-			) +
+			) + " " +
 			/**
 			 * translators:
 			 * %1$s through %7$s each expand to a parameter name within a <code> tag.


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* In [a previous PR](https://github.com/Yoast/wordpress-seo/pull/20452) we added an allowlist for the "Remove unregistered URL parameters" setting. In this PR we forgot to provide information to the user about the defaultly allowed url parameters. In the current PR we add feedback to the user.
* Search team was notified of this change as well as of the change in the previous PR in [this thread](https://yoast.slack.com/archives/C012CJJ46P7/p1688045368543239).

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds information to the "Remove unregistered URL parameters" setting in the crawl settings about which URL parameters are always allowed.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Open Yoast SEO -> Settings -> Advanced -> Crawl optimization.
* Scroll till section _Advanced: URL cleanup_.
* Make sure that the following sentence appears there: "Note that the following commonly-used parameters will not be removed: gclid, gtm_debug, utm_campaign, utm_content, utm_medium, utm_source, and utm_term."

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* This PR only changes text in the admin UI. Nothing functional is changed, so impact should be low.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #20463 
