### PR TITLE
Add `None` option to site policies

### DIFF
--- a/inc/options/class-wpseo-option-titles.php
+++ b/inc/options/class-wpseo-option-titles.php
@@ -93,13 +93,13 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 		'open_graph_frontpage_image'       => '', // Text field.
 		'open_graph_frontpage_image_id'    => 0,
 
-		'publishing_principles_id'         => false,
-		'ownership_funding_info_id'        => false,
-		'actionable_feedback_policy_id'    => false,
-		'corrections_policy_id'            => false,
-		'ethics_policy_id'                 => false,
-		'diversity_policy_id'              => false,
-		'diversity_staffing_report_id'     => false,
+		'publishing_principles_id'         => 0,
+		'ownership_funding_info_id'        => 0,
+		'actionable_feedback_policy_id'    => 0,
+		'corrections_policy_id'            => 0,
+		'ethics_policy_id'                 => 0,
+		'diversity_policy_id'              => 0,
+		'diversity_staffing_report_id'     => 0,
 
 		/*
 		 * Uses enrich_defaults to add more along the lines of:

--- a/packages/js/src/settings/components/formik-page-select-field.js
+++ b/packages/js/src/settings/components/formik-page-select-field.js
@@ -49,6 +49,14 @@ const FormikPageSelectField = ( { name, id, className = "", ...props } ) => {
 	}, [ value, pages ] );
 
 	const debouncedFetchPages = useCallback( debounce( async search => {
+		if ( search === "" ) {
+			// No need to fetch pages if there is no search term.
+			setQueriedPageIds( map( pages, "id" ) );
+			setValue( 0 );
+			setStatus( ASYNC_ACTION_STATUS.success );
+			return;
+		}
+
 		try {
 			setStatus( ASYNC_ACTION_STATUS.loading );
 			// eslint-disable-next-line camelcase

--- a/packages/js/src/settings/store/pages.js
+++ b/packages/js/src/settings/store/pages.js
@@ -1,6 +1,7 @@
 /* eslint-disable camelcase, complexity */
 import { createEntityAdapter, createSelector, createSlice } from "@reduxjs/toolkit";
 import apiFetch from "@wordpress/api-fetch";
+import { __ } from "@wordpress/i18n";
 import { buildQueryString } from "@wordpress/url";
 import { map, trim, pickBy } from "lodash";
 import { ASYNC_ACTION_NAMES, ASYNC_ACTION_STATUS } from "../constants";
@@ -89,7 +90,8 @@ pageSelectors.selectPagesWith = createSelector(
 		( state, additionalPage = {} ) => additionalPage,
 	],
 	( pages, additionalPage ) => {
-		const additionalPages = {};
+		const none = { id: 0, name: __( "None", "wordpress-seo" ), slug: null, "protected": null };
+		const additionalPages = { 0: none };
 		additionalPage.forEach( page => {
 			if ( page?.id && ! pages[ page.id ] ) {
 				// Add the additional page.

--- a/src/integrations/settings-integration.php
+++ b/src/integrations/settings-integration.php
@@ -542,8 +542,8 @@ class Settings_Integration implements Integration_Interface {
 	 */
 	private function maybe_add_policy( $policies, $policy, $key ) {
 		$policy_array = [
-			'id'   => false,
-			'name' => '',
+			'id'   => 0,
+			'name' => \__( 'None', 'wordpress-seo' ),
 		];
 
 		if ( isset( $policy ) && \is_int( $policy ) ) {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Changes the default value for the site policies options to `0` and adds `None`  as a selectable option in the settings.

## Relevant technical choices:

* Important: this sets the default value to `0` while it used to be `false`. since the feature has not been released yet, no upgrade code has been added. It's very important then to test this PR on a clean environment where the values has not been set yet.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* **install on a clean environment** (see above the technical reason)
* Install and activate the latest Premium RC
* Go to `Yoast SEO` -> `Settings` -> `Site representation`
* Select organisation and add name and logo.
* Visit `Site basics` -> `Site policies` and check they are all set to `None` by default
* Check the Schema in the home page and see that you don't see any site policy property
* Visit Site basics > Site policies once more
* Set one or more fields to a page and save
   * While you are there, check the autocomplete works as expected
   * Check that if you empty the field, you get the a list of pages + `None` which is pre-selected and gets displayed even if you click outside the control
* Check the Schema in the home page and see that you see the expected site policy properties
* Visit Site basics > Site policies once more
* Set one or more fields to `None` and save
* Check the Schema in the home page and see that you see the expected site policy properties (the ones, if any, which you didn't set back to `None`

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #https://github.com/Yoast/ux/issues/50
