### PR TITLE
Update the google search console verification link

### DIFF
--- a/packages/js/src/settings/routes/site-connections.js
+++ b/packages/js/src/settings/routes/site-connections.js
@@ -90,7 +90,7 @@ const SiteConnections = () => {
 									"<a>",
 									"</a>"
 								),
-								addQueryArgs( "https://www.google.com/webmasters/verification/verification", { hl: "en", tid: "alternate", siteUrl } ),
+								addQueryArgs( "https://search.google.com/search-console/users", { hl: "en", tid: "alternate", siteUrl } ),
 								"link-google-search-console"
 							) }
 							placeholder={ __( "Add verification code", "wordpress-seo" ) }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The URL of the Google Search Console was updated from `https://www.google.com/webmasters/verification/verification` to `https://search.google.com/search-console/users`. After [the original task](https://github.com/Yoast/wordpress-seo/issues/20404) was created, the old URL started to redirect to the new one, but it was still preferable that our link gets updated.
* This task has a complementary one for Shopify: [here](https://github.com/Yoast/shopify-seo/pull/1237)

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Updates the verification link to the Google Search Console in the Site connections section in Settings.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

##### Upgrade routine & Current changes
* Activate the currently released version of Free
  * On the left-side menu go to Yoast SEO > Settings > Site Connections > Google 
  * Hover over the link in the `Get your verification code in Google Search Console` message
  * Look at the link that appears in the bottom left corner, confirm it's the one to `https://www.google.com/webmasters/verification/verification`
<img width="386" alt="Screenshot 2023-07-04 at 15 14 50" src="https://github.com/Yoast/wordpress-seo/assets/90325221/6f4c730f-49de-4b33-9d65-9ae813c34a85">

  * Click on the link and confirm you get redirected to the new Google Search Console page
<img width="1310" alt="Screenshot 2023-07-04 at 16 18 37" src="https://github.com/Yoast/wordpress-seo/assets/90325221/d64e0cce-2e1b-4f69-9052-47dd8f69258c">

* Update to this branch/ this RC
  * Again, go to Yoast SEO > Settings > Site Connections 
  * Hover over the link in the `Get your verification code in Google Search Console` message
  * Look at the link that appears in the bottom left corner, confirm now it shows the new URL `https://search.google.com/search-console/users`
<img width="318" alt="Screenshot 2023-07-04 at 15 15 04" src="https://github.com/Yoast/wordpress-seo/assets/90325221/cd01e750-863b-4b5b-a71c-e67d443fd75c">

  * Click on the link and confirm you get redirected to the same Google Search Console page
<img width="1310" alt="Screenshot 2023-07-04 at 16 18 37" src="https://github.com/Yoast/wordpress-seo/assets/90325221/75884aea-cab3-4927-b72e-181f32ad7d53">

##### Only for the code reviewer
* Just to double check, search for the old URL in `wordpress-seo` `https://www.google.com/webmasters/verification/verification` and make sure it's not used anywhere anymore. 

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* It's a ridiculously small change, nothing else is affected.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [#20404](https://github.com/Yoast/wordpress-seo/issues/20404)
