### PR TITLE
Fixes removal of unstableOnFocus prop

### DIFF
--- a/packages/js/src/structured-data-blocks/faq/components/Question.js
+++ b/packages/js/src/structured-data-blocks/faq/components/Question.js
@@ -332,6 +332,9 @@ export default class Question extends Component {
 			answer,
 		} = attributes;
 
+		// The unstableOnFocus prop is added for backwards compatibility with Gutenberg versions <= 15.1 (WordPress 6.2).
+		const focusQuestion = { onFocus: this.onFocusQuestion, unstableOnFocus: this.onFocusQuestion };
+		const focusAnswer = { onFocus: this.onFocusAnswer, unstableOnFocus: this.onFocusAnswer };
 
 		return (
 			<div className="schema-faq-section" key={ id }>
@@ -342,9 +345,9 @@ export default class Question extends Component {
 					key={ id + "-question" }
 					value={ question }
 					onChange={ this.onChangeQuestion }
-					unstableOnFocus={ this.onFocusQuestion }
 					placeholder={ __( "Enter a question", "wordpress-seo" ) }
 					allowedFormats={ [ "core/italic", "core/strikethrough", "core/link", "core/annotation" ] }
+					{ ...focusQuestion }
 				/>
 				<RichText
 					identifier={ id + "-answer" }
@@ -353,8 +356,8 @@ export default class Question extends Component {
 					key={ id + "-answer" }
 					value={ answer }
 					onChange={ this.onChangeAnswer }
-					unstableOnFocus={ this.onFocusAnswer }
 					placeholder={ __( "Enter the answer to the question", "wordpress-seo" ) }
+					{ ...focusAnswer }
 				/>
 				{ isSelected &&
 					<div className="schema-faq-section-controls-container">

--- a/packages/js/src/structured-data-blocks/how-to/components/HowTo.js
+++ b/packages/js/src/structured-data-blocks/how-to/components/HowTo.js
@@ -726,6 +726,9 @@ export default class HowTo extends Component {
 		const classNames     = [ "schema-how-to", className ].filter( ( item ) => item ).join( " " );
 		const listClassNames = [ "schema-how-to-steps", attributes.additionalListCssClasses ].filter( ( item ) => item ).join( " " );
 
+		// The unstableOnFocus prop is added for backwards compatibility with Gutenberg versions <= 15.1 (WordPress 6.2).
+		const focusDescription = { onFocus: this.focusDescription, unstableOnFocus: this.focusDescription };
+
 		return (
 			<div className={ classNames }>
 				{ this.getDuration() }
@@ -734,9 +737,9 @@ export default class HowTo extends Component {
 					tagName="p"
 					className="schema-how-to-description"
 					value={ attributes.description }
-					unstableOnFocus={ this.focusDescription }
 					onChange={ this.onChangeDescription }
 					placeholder={ __( "Enter a description", "wordpress-seo" ) }
+					{ ...focusDescription }
 				/>
 				<ul className={ listClassNames }>
 					{ this.getSteps() }

--- a/packages/js/src/structured-data-blocks/how-to/components/HowToStep.js
+++ b/packages/js/src/structured-data-blocks/how-to/components/HowToStep.js
@@ -314,6 +314,11 @@ export default class HowToStep extends Component {
 		} = this.props;
 
 		const { id, name, text } = step;
+
+		// The unstableOnFocus prop is added for backwards compatibility with Gutenberg versions <= 15.1 (WordPress 6.2).
+		const focusTitle = { onFocus: this.onFocusTitle, unstableOnFocus: this.onFocusTitle };
+		const focusText = { onFocus: this.onFocusText, unstableOnFocus: this.onFocusText };
+
 		return (
 			<li className="schema-how-to-step" key={ id }>
 				<span className="schema-how-to-step-number">
@@ -330,8 +335,8 @@ export default class HowToStep extends Component {
 					value={ name }
 					onChange={ this.onChangeTitle }
 					placeholder={ __( "Enter a step title", "wordpress-seo" ) }
-					unstableOnFocus={ this.onFocusTitle }
 					allowedFormats={ [ "core/italic", "core/strikethrough", "core/link", "core/annotation" ] }
+					{ ...focusTitle }
 				/>
 				<RichTextWithAppendedSpace
 					identifier={ `${ id }-text` }
@@ -341,7 +346,7 @@ export default class HowToStep extends Component {
 					value={ text }
 					onChange={ this.onChangeText }
 					placeholder={ __( "Enter a step description", "wordpress-seo" ) }
-					unstableOnFocus={ this.onFocusText }
+					{ ...focusText }
 				/>
 				{ isSelected &&
 					<div className="schema-how-to-step-controls-container">


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* In Gutenberg 15.2, in this PR, the prop `unstableOnFocus` was removed. As the Gutenberg version for WordPress 6.3 will be upgraded to 16.1, in this PR, we prepare ourselves for the WP 6.3 release by addressing this issue.
* By using both the `unstableOnFocus` and the `onFocus` prop, we will continue to support Gutenberg versions below 15.2 (and consequently, WordPress version below 6.3).

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the controls for the _FAQ_ and _how-to_ blocks would be not shown when running Gutenberg versions >= 15.2.

## Relevant technical choices:

* By using both the `unstableOnFocus` and the `onFocus` prop, we will continue to support Gutenberg versions below 15.2 (and consequently, WordPress version below 6.3). We might decide to remove `unstableOnFocus` at some future point in time, though, but we should be wary to do that once we no longer support WP 6.2.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

*

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The FAQ and How-To structured data blocks.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/plugins-automated-testing/issues/843
