### PR TITLE
Add yoast woo ad in google preview on the product pages and in the "schema" tab in the sidebar/metabox 

### DIFF
--- a/admin/formatter/class-metabox-formatter.php
+++ b/admin/formatter/class-metabox-formatter.php
@@ -61,51 +61,51 @@ class WPSEO_Metabox_Formatter {
 		$host                        = YoastSEO()->helpers->url->get_url_host( get_site_url() );
 
 		return [
-			'author_name'                       => get_the_author_meta( 'display_name' ),
-			'site_name'                         => YoastSEO()->meta->for_current_page()->site_name,
-			'sitewide_social_image'             => WPSEO_Options::get( 'og_default_image' ),
-			'search_url'                        => '',
-			'post_edit_url'                     => '',
-			'base_url'                          => '',
-			'contentTab'                        => __( 'Readability', 'wordpress-seo' ),
-			'keywordTab'                        => __( 'Keyphrase:', 'wordpress-seo' ),
-			'removeKeyword'                     => __( 'Remove keyphrase', 'wordpress-seo' ),
-			'contentLocale'                     => get_locale(),
-			'userLocale'                        => \get_user_locale(),
-			'translations'                      => $this->get_translations(),
-			'keyword_usage'                     => [],
-			'title_template'                    => '',
-			'metadesc_template'                 => '',
-			'contentAnalysisActive'             => $analysis_readability->is_enabled() ? 1 : 0,
-			'keywordAnalysisActive'             => $analysis_seo->is_enabled() ? 1 : 0,
-			'inclusiveLanguageAnalysisActive'   => $analysis_inclusive_language->is_enabled() ? 1 : 0,
-			'cornerstoneActive'                 => WPSEO_Options::get( 'enable_cornerstone_content', false ) ? 1 : 0,
-			'semrushIntegrationActive'          => WPSEO_Options::get( 'semrush_integration_active', true ) ? 1 : 0,
-			'intl'                              => $this->get_content_analysis_component_translations(),
-			'isRtl'                             => is_rtl(),
-			'isPremium'                         => YoastSEO()->helpers->product->is_premium(),
-			'wordFormRecognitionActive'         => YoastSEO()->helpers->language->is_word_form_recognition_active( WPSEO_Language_Utils::get_language( get_locale() ) ),
-			'siteIconUrl'                       => get_site_icon_url(),
-			'countryCode'                       => WPSEO_Options::get( 'semrush_country_code', false ),
-			'SEMrushLoginStatus'                => WPSEO_Options::get( 'semrush_integration_active', true ) ? $this->get_semrush_login_status() : false,
-			'showSocial'                        => [
+			'author_name'                        => get_the_author_meta( 'display_name' ),
+			'site_name'                          => YoastSEO()->meta->for_current_page()->site_name,
+			'sitewide_social_image'              => WPSEO_Options::get( 'og_default_image' ),
+			'search_url'                         => '',
+			'post_edit_url'                      => '',
+			'base_url'                           => '',
+			'contentTab'                         => __( 'Readability', 'wordpress-seo' ),
+			'keywordTab'                         => __( 'Keyphrase:', 'wordpress-seo' ),
+			'removeKeyword'                      => __( 'Remove keyphrase', 'wordpress-seo' ),
+			'contentLocale'                      => get_locale(),
+			'userLocale'                         => \get_user_locale(),
+			'translations'                       => $this->get_translations(),
+			'keyword_usage'                      => [],
+			'title_template'                     => '',
+			'metadesc_template'                  => '',
+			'contentAnalysisActive'              => $analysis_readability->is_enabled() ? 1 : 0,
+			'keywordAnalysisActive'              => $analysis_seo->is_enabled() ? 1 : 0,
+			'inclusiveLanguageAnalysisActive'    => $analysis_inclusive_language->is_enabled() ? 1 : 0,
+			'cornerstoneActive'                  => WPSEO_Options::get( 'enable_cornerstone_content', false ) ? 1 : 0,
+			'semrushIntegrationActive'           => WPSEO_Options::get( 'semrush_integration_active', true ) ? 1 : 0,
+			'intl'                               => $this->get_content_analysis_component_translations(),
+			'isRtl'                              => is_rtl(),
+			'isPremium'                          => YoastSEO()->helpers->product->is_premium(),
+			'wordFormRecognitionActive'          => YoastSEO()->helpers->language->is_word_form_recognition_active( WPSEO_Language_Utils::get_language( get_locale() ) ),
+			'siteIconUrl'                        => get_site_icon_url(),
+			'countryCode'                        => WPSEO_Options::get( 'semrush_country_code', false ),
+			'SEMrushLoginStatus'                 => WPSEO_Options::get( 'semrush_integration_active', true ) ? $this->get_semrush_login_status() : false,
+			'showSocial'                         => [
 				'facebook' => WPSEO_Options::get( 'opengraph', false ),
 				'twitter'  => WPSEO_Options::get( 'twitter', false ),
 			],
-			'schema'                            => [
+			'schema'                             => [
 				'displayFooter'      => WPSEO_Capability_Utils::current_user_can( 'wpseo_manage_options' ),
 				'pageTypeOptions'    => $schema_types->get_page_type_options(),
 				'articleTypeOptions' => $schema_types->get_article_type_options(),
 			],
-			'twitterCardType'                   => 'summary_large_image',
+			'twitterCardType'                    => 'summary_large_image',
 
 			/**
 			 * Filter to determine if the markers should be enabled or not.
 			 *
 			 * @param bool $showMarkers Should the markers being enabled. Default = true.
 			 */
-			'show_markers'                      => apply_filters( 'wpseo_enable_assessment_markers', true ),
-			'publish_box'                       => [
+			'show_markers'                       => apply_filters( 'wpseo_enable_assessment_markers', true ),
+			'publish_box'                        => [
 				'labels' => [
 					'keyword'            => [
 						'na'   => sprintf(
@@ -199,25 +199,27 @@ class WPSEO_Metabox_Formatter {
 					],
 				],
 			],
-			'markdownEnabled'                   => $this->is_markdown_enabled(),
-			'analysisHeadingTitle'              => __( 'Analysis', 'wordpress-seo' ),
-			'zapierIntegrationActive'           => WPSEO_Options::get( 'zapier_integration_active', false ) ? 1 : 0,
-			'zapierConnectedStatus'             => ! empty( WPSEO_Options::get( 'zapier_subscription', [] ) ) ? 1 : 0,
-			'wincherIntegrationActive'          => ( $is_wincher_active ) ? 1 : 0,
-			'wincherLoginStatus'                => ( $is_wincher_active ) ? YoastSEO()->helpers->wincher->login_status() : false,
-			'wincherWebsiteId'                  => WPSEO_Options::get( 'wincher_website_id', '' ),
-			'wincherAutoAddKeyphrases'          => WPSEO_Options::get( 'wincher_automatically_add_keyphrases', false ),
-			'wordproofIntegrationActive'        => YoastSEO()->helpers->wordproof->is_active() ? 1 : 0,
-			'multilingualPluginActive'          => $this->multilingual_plugin_active(),
+			'markdownEnabled'                    => $this->is_markdown_enabled(),
+			'analysisHeadingTitle'               => __( 'Analysis', 'wordpress-seo' ),
+			'zapierIntegrationActive'            => WPSEO_Options::get( 'zapier_integration_active', false ) ? 1 : 0,
+			'zapierConnectedStatus'              => ! empty( WPSEO_Options::get( 'zapier_subscription', [] ) ) ? 1 : 0,
+			'wincherIntegrationActive'           => ( $is_wincher_active ) ? 1 : 0,
+			'wincherLoginStatus'                 => ( $is_wincher_active ) ? YoastSEO()->helpers->wincher->login_status() : false,
+			'wincherWebsiteId'                   => WPSEO_Options::get( 'wincher_website_id', '' ),
+			'wincherAutoAddKeyphrases'           => WPSEO_Options::get( 'wincher_automatically_add_keyphrases', false ),
+			'wordproofIntegrationActive'         => YoastSEO()->helpers->wordproof->is_active() ? 1 : 0,
+			'multilingualPluginActive'           => $this->multilingual_plugin_active(),
 
 			/**
 			 * Filter to determine whether the PreviouslyUsedKeyword assessment should run.
 			 *
 			 * @param bool $previouslyUsedKeywordActive Whether the PreviouslyUsedKeyword assessment should run.
 			 */
-			'previouslyUsedKeywordActive'       => apply_filters( 'wpseo_previously_used_keyword_active', true ),
-			'getJetpackBoostPrePublishLink'     => WPSEO_Shortlinker::get( 'https://yoa.st/jetpack-boost-get-prepublish?domain=' . $host ),
-			'upgradeJetpackBoostPrePublishLink' => WPSEO_Shortlinker::get( 'https://yoa.st/jetpack-boost-upgrade-prepublish?domain=' . $host ),
+			'previouslyUsedKeywordActive'        => apply_filters( 'wpseo_previously_used_keyword_active', true ),
+			'getJetpackBoostPrePublishLink'      => WPSEO_Shortlinker::get( 'https://yoa.st/jetpack-boost-get-prepublish?domain=' . $host ),
+			'upgradeJetpackBoostPrePublishLink'  => WPSEO_Shortlinker::get( 'https://yoa.st/jetpack-boost-upgrade-prepublish?domain=' . $host ),
+			'woocommerceUpsellSchemaLink'        => WPSEO_Shortlinker::get( 'https://yoa.st/product-schema-metabox' ),
+			'woocommerceUpsellGooglePreviewLink' => WPSEO_Shortlinker::get( 'https://yoa.st/product-google-preview-metabox' ),
 		];
 	}
 

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -10,6 +10,7 @@ use Yoast\WP\SEO\Conditionals\Third_Party\Jetpack_Boost_Active_Conditional;
 use Yoast\WP\SEO\Conditionals\Third_Party\Jetpack_Boost_Not_Premium_Conditional;
 use Yoast\WP\SEO\Presenters\Admin\Alert_Presenter;
 use Yoast\WP\SEO\Presenters\Admin\Meta_Fields_Presenter;
+use Yoast\WP\SEO\Conditionals\WooCommerce_Conditional;
 
 /**
  * This class generates the metabox on the edit post / page as well as contains all page analysis functionality.
@@ -903,8 +904,13 @@ class WPSEO_Metabox extends WPSEO_Meta {
 			'log_level'               => WPSEO_Utils::get_analysis_worker_log_level(),
 		];
 
-		$alert_dismissal_action = YoastSEO()->classes->get( Alert_Dismissal_Action::class );
-		$dismissed_alerts       = $alert_dismissal_action->all_dismissed();
+		$alert_dismissal_action            = YoastSEO()->classes->get( Alert_Dismissal_Action::class );
+		$dismissed_alerts                  = $alert_dismissal_action->all_dismissed();
+		$woocommerce_conditional           = new WooCommerce_Conditional();
+		$woocommerce_active                = $woocommerce_conditional->is_met();
+		$wpseo_plugin_availability_checker = new WPSEO_Plugin_Availability();
+		$woocommerce_seo_file              = 'wpseo-woocommerce/wpseo-woocommerce.php';
+		$woocommerce_seo_active            = $wpseo_plugin_availability_checker->is_active( $woocommerce_seo_file );
 
 		$script_data = [
 			// @todo replace this translation with JavaScript translations.

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -863,6 +863,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 		$asset_manager->enqueue_style( 'metabox-css' );
 		$asset_manager->enqueue_style( 'scoring' );
 		$asset_manager->enqueue_style( 'monorepo' );
+		$asset_manager->enqueue_style( 'tailwind' );
 
 		$is_block_editor  = WP_Screen::get()->is_block_editor();
 		$post_edit_handle = 'post-edit';
@@ -923,6 +924,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 			'webinarIntroBlockEditorUrl' => WPSEO_Shortlinker::get( 'https://yoa.st/webinar-intro-block-editor' ),
 			'isJetpackBoostActive'       => ( $is_block_editor ) ? YoastSEO()->classes->get( Jetpack_Boost_Active_Conditional::class )->is_met() : false,
 			'isJetpackBoostNotPremium'   => ( $is_block_editor ) ? YoastSEO()->classes->get( Jetpack_Boost_Not_Premium_Conditional::class )->is_met() : false,
+			'woocommerceUpsell'          => get_post_type( $post_id ) === 'product' && ! $woocommerce_seo_active && $woocommerce_active,
 		];
 
 		if ( post_type_supports( get_post_type(), 'thumbnail' ) ) {

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -8,9 +8,9 @@
 use Yoast\WP\SEO\Actions\Alert_Dismissal_Action;
 use Yoast\WP\SEO\Conditionals\Third_Party\Jetpack_Boost_Active_Conditional;
 use Yoast\WP\SEO\Conditionals\Third_Party\Jetpack_Boost_Not_Premium_Conditional;
+use Yoast\WP\SEO\Conditionals\WooCommerce_Conditional;
 use Yoast\WP\SEO\Presenters\Admin\Alert_Presenter;
 use Yoast\WP\SEO\Presenters\Admin\Meta_Fields_Presenter;
-use Yoast\WP\SEO\Conditionals\WooCommerce_Conditional;
 
 /**
  * This class generates the metabox on the edit post / page as well as contains all page analysis functionality.

--- a/packages/js/src/components/SchemaTab.js
+++ b/packages/js/src/components/SchemaTab.js
@@ -5,6 +5,8 @@ import { makeOutboundLink, join } from "@yoast/helpers";
 import interpolateComponents from "interpolate-components";
 import PropTypes from "prop-types";
 import styled from "styled-components";
+import WooCommerceUpsell from "./WooCommerceUpsell";
+import { get } from "lodash";
 
 const NewsLandingPageLink = makeOutboundLink();
 
@@ -156,7 +158,8 @@ function isNewsArticleType( selectedValue, defaultValue ) {
 const Content = ( props ) => {
 	const schemaPageTypeOptions = getSchemaTypeOptions( props.pageTypeOptions, props.defaultPageType, props.postTypeName );
 	const schemaArticleTypeOptions = getSchemaTypeOptions( props.articleTypeOptions, props.defaultArticleType, props.postTypeName );
-
+	const woocommerceUpsellLink = get( window, "wpseoScriptData.metabox.woocommerceUpsellSchemaLink", "" );
+	const woocommerceUpsell = get( window, "wpseoScriptData.woocommerceUpsell", "" );
 	const [ focusedArticleType, setFocusedArticleType ] = useState( props.schemaArticleTypeSelected );
 
 	const handleOptionChange = useCallback(
@@ -179,6 +182,7 @@ const Content = ( props ) => {
 				linkTo={ props.additionalHelpTextLink }
 				linkText={ __( "Learn more about page or content types", "wordpress-seo" ) }
 			/>
+			{ woocommerceUpsell && <WooCommerceUpsell link={ woocommerceUpsellLink } /> }
 			<Select
 				id={ join( [ "yoast-schema-page-type", props.location ] ) }
 				options={ schemaPageTypeOptions }

--- a/packages/js/src/components/SchemaTab.js
+++ b/packages/js/src/components/SchemaTab.js
@@ -161,6 +161,7 @@ const Content = ( props ) => {
 	const woocommerceUpsellLink = get( window, "wpseoScriptData.metabox.woocommerceUpsellSchemaLink", "" );
 	const woocommerceUpsell = get( window, "wpseoScriptData.woocommerceUpsell", "" );
 	const [ focusedArticleType, setFocusedArticleType ] = useState( props.schemaArticleTypeSelected );
+	const woocommerceUpsellText = __( "Want your products stand out in search results with rich results like price, reviews and more?", "wordpress-seo" );
 
 	const handleOptionChange = useCallback(
 		( _, value ) => {
@@ -182,7 +183,7 @@ const Content = ( props ) => {
 				linkTo={ props.additionalHelpTextLink }
 				linkText={ __( "Learn more about page or content types", "wordpress-seo" ) }
 			/>
-			{ woocommerceUpsell && <WooCommerceUpsell link={ woocommerceUpsellLink } /> }
+			{ woocommerceUpsell && <WooCommerceUpsell link={ woocommerceUpsellLink } text={ woocommerceUpsellText } /> }
 			<Select
 				id={ join( [ "yoast-schema-page-type", props.location ] ) }
 				options={ schemaPageTypeOptions }

--- a/packages/js/src/components/WooCommerceUpsell.js
+++ b/packages/js/src/components/WooCommerceUpsell.js
@@ -1,0 +1,37 @@
+import { __, sprintf } from "@wordpress/i18n";
+import PropTypes from "prop-types";
+import { LockOpenIcon } from "@heroicons/react/outline";
+import { Button, Root } from "@yoast/ui-library";
+
+/**
+ *
+ * @returns {React.Component} The Y.
+ */
+const WooCommerceUpsell = ( { link } ) => {
+	return (
+		<Root>
+			<p>{ __( "Want an enhanced Google preview of how your WooCommerce products look in the search results?", "wordpress-seo" ) }</p>
+			<Button
+				href={ link }
+				as="a"
+				className="yst-gap-2 yst-mb-5 yst-mt-2"
+				variant="upsell"
+				target="_blank"
+				rel="noopener"
+			>
+				<LockOpenIcon className="yst-w-4 yst-h-4 yst--ml-1 yst-shrink-0" />
+				{ sprintf(
+				/* translators: %1$s expands to Yoast WooCommerce SEO. */
+					__( "Unlock with %1$s", "wordpress-seo" ),
+					"Yoast WooCommerce SEO"
+				) }
+			</Button>
+		</Root>
+	);
+};
+
+WooCommerceUpsell.propTypes = {
+	link: PropTypes.string,
+};
+
+export default WooCommerceUpsell;

--- a/packages/js/src/components/WooCommerceUpsell.js
+++ b/packages/js/src/components/WooCommerceUpsell.js
@@ -5,12 +5,12 @@ import { Button, Root } from "@yoast/ui-library";
 
 /**
  *
- * @returns {React.Component} The Y.
+ * @returns {React.Component} The react component for woocommerce upsell ads.
  */
-const WooCommerceUpsell = ( { link } ) => {
+const WooCommerceUpsell = ( { link, text } ) => {
 	return (
 		<Root>
-			<p>{ __( "Want an enhanced Google preview of how your WooCommerce products look in the search results?", "wordpress-seo" ) }</p>
+			<p>{ text }</p>
 			<Button
 				href={ link }
 				as="a"
@@ -31,7 +31,8 @@ const WooCommerceUpsell = ( { link } ) => {
 };
 
 WooCommerceUpsell.propTypes = {
-	link: PropTypes.string,
+	link: PropTypes.string.isRequired,
+	text: PropTypes.string.isRequired,
 };
 
 export default WooCommerceUpsell;

--- a/packages/js/src/containers/SnippetEditor.js
+++ b/packages/js/src/containers/SnippetEditor.js
@@ -6,6 +6,8 @@ import { LocationConsumer } from "@yoast/externals/contexts";
 import SnippetPreviewSection from "../components/SnippetPreviewSection";
 import { applyReplaceUsingPlugin } from "../helpers/replacementVariableHelpers";
 import getMemoizedFindCustomFields from "../helpers/getMemoizedFindCustomFields";
+import WooCommerceUpsell from "../components/WooCommerceUpsell";
+import { get } from "lodash";
 
 /**
  * Process the snippet editor form data before it's being displayed in the snippet preview.
@@ -47,24 +49,29 @@ export const mapEditorDataToPreview = function( data, context ) {
  *
  * @returns {wp.Element} The component.
  */
-const SnippetEditorWrapper = ( props ) => (
-	<LocationConsumer>
+const SnippetEditorWrapper = ( props ) => {
+	const woocommerceUpsellLink = get( window, "wpseoScriptData.metabox.woocommerceUpsellGooglePreviewLink", "" );
+	const woocommerceUpsell = get( window, "wpseoScriptData.woocommerceUpsell", "" );
+	return <LocationConsumer>
 		{ location =>
 			<SnippetPreviewSection
 				icon="eye"
 				hasPaperStyle={ props.hasPaperStyle }
 			>
-				<SnippetEditor
-					{ ...props }
-					descriptionPlaceholder={ __( "Please provide a meta description by editing the snippet below.", "wordpress-seo" ) }
-					mapEditorDataToPreview={ mapEditorDataToPreview }
-					showCloseButton={ false }
-					idSuffix={ location }
-				/>
+				<>
+					{ woocommerceUpsell && <WooCommerceUpsell link={ woocommerceUpsellLink } /> }
+					<SnippetEditor
+						{ ...props }
+						descriptionPlaceholder={ __( "Please provide a meta description by editing the snippet below.", "wordpress-seo" ) }
+						mapEditorDataToPreview={ mapEditorDataToPreview }
+						showCloseButton={ false }
+						idSuffix={ location }
+					/>
+				</>
 			</SnippetPreviewSection>
 		}
-	</LocationConsumer>
-);
+	</LocationConsumer>;
+};
 
 /**
  * Maps the select function to props.

--- a/packages/js/src/containers/SnippetEditor.js
+++ b/packages/js/src/containers/SnippetEditor.js
@@ -52,6 +52,8 @@ export const mapEditorDataToPreview = function( data, context ) {
 const SnippetEditorWrapper = ( props ) => {
 	const woocommerceUpsellLink = get( window, "wpseoScriptData.metabox.woocommerceUpsellGooglePreviewLink", "" );
 	const woocommerceUpsell = get( window, "wpseoScriptData.woocommerceUpsell", "" );
+	const woocommerceUpsellText = __( "Want an enhanced Google preview of how your WooCommerce products look in the search results?", "wordpress-seo" );
+
 	return <LocationConsumer>
 		{ location =>
 			<SnippetPreviewSection
@@ -59,7 +61,7 @@ const SnippetEditorWrapper = ( props ) => {
 				hasPaperStyle={ props.hasPaperStyle }
 			>
 				<>
-					{ woocommerceUpsell && <WooCommerceUpsell link={ woocommerceUpsellLink } /> }
+					{ woocommerceUpsell && <WooCommerceUpsell link={ woocommerceUpsellLink } text={ woocommerceUpsellText } /> }
 					<SnippetEditor
 						{ ...props }
 						descriptionPlaceholder={ __( "Please provide a meta description by editing the snippet below.", "wordpress-seo" ) }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Add an ad to metabox schema tab and google preview section on product pages when WooCommerce is active and WooCommerce SEO addon is not active.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds an ad to metabox schema tab and google preview section on product pages when WooCommerce is active and WooCommerce SEO addon is either not installed or not active.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install Woocommerce
* Create a product
* Go to the meta box and check Google Preview has an upsell add:
![Screenshot 2023-07-10 at 13 54 25](https://github.com/Yoast/wordpress-seo/assets/65466507/db7e1e0f-1e9c-45a9-9aa6-8e55152d73d1)
* Check the link on the upsell button is yoa.st/product-google-preview-metabox
* Click on the upsell button and check that your are redirected to the upsell page in a new tab and the url contains the platform parameters.
* Go to Schema tab and check the same ad is there:
![Screenshot 2023-07-10 at 17 06 34](https://github.com/Yoast/wordpress-seo/assets/65466507/30b4cc89-4e2f-4f37-a346-8e9d965546ed)

* Check the link on the upsell button is yoa.st/product-schema-metabox
* Click on the upsell button and check that your are redirected to the upsell page in a new tab and the url contains the platform parameters.
* Edit other post type/taxonomies in block editor/elementor check you don't see the ads.
* Install Woocommerce SEO plugin and activate, check you don't see the ads when editing a product.
* Deactivate Woocommerce SEO plugin
* Check you see the ads again when editing a product.


#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [X] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [#23](https://github.com/Yoast/growth/issues/23)
Fixes [#25](https://github.com/Yoast/growth/issues/25)
