### PR TITLE
4009 improve site policies select menu

### DIFF
--- a/packages/js/src/settings/components/formik-page-select-field.js
+++ b/packages/js/src/settings/components/formik-page-select-field.js
@@ -87,6 +87,7 @@ const FormikPageSelectField = ( { name, id, className = "", ...props } ) => {
 			onQueryChange={ handleQueryChange }
 			className={ classNames( className, props.disabled && "yst-autocomplete--disabled" ) }
 			nullable={ true }
+			clearButtonScreenReaderText={ __( "Clear selection", "wordpress-seo" ) }
 			{ ...props }
 		>
 			<>

--- a/packages/js/src/settings/components/formik-page-select-field.js
+++ b/packages/js/src/settings/components/formik-page-select-field.js
@@ -49,14 +49,6 @@ const FormikPageSelectField = ( { name, id, className = "", ...props } ) => {
 	}, [ value, pages ] );
 
 	const debouncedFetchPages = useCallback( debounce( async search => {
-		if ( search === "" ) {
-			// No need to fetch pages if there is no search term.
-			setQueriedPageIds( map( pages, "id" ) );
-			setValue( 0 );
-			setStatus( ASYNC_ACTION_STATUS.success );
-			return;
-		}
-
 		try {
 			setStatus( ASYNC_ACTION_STATUS.loading );
 			// eslint-disable-next-line camelcase
@@ -90,10 +82,10 @@ const FormikPageSelectField = ( { name, id, className = "", ...props } ) => {
 			// Hack to force re-render of Headless UI Combobox.Input component when selectedPage changes.
 			value={ selectedPage ? value : 0 }
 			onChange={ handleChange }
-			placeholder={ __( "Select a page...", "wordpress-seo" ) }
+			placeholder={ __( "None", "wordpress-seo" ) }
 			selectedLabel={ selectedPage?.name }
 			onQueryChange={ handleQueryChange }
-			className={ className && props.disabled && "yst-autocomplete--disabled" }
+			className={ classNames( className, props.disabled && "yst-autocomplete--disabled" ) }
 			nullable={ true }
 			{ ...props }
 		>

--- a/packages/js/src/settings/store/pages.js
+++ b/packages/js/src/settings/store/pages.js
@@ -1,7 +1,7 @@
 /* eslint-disable camelcase, complexity */
 import { createEntityAdapter, createSelector, createSlice } from "@reduxjs/toolkit";
 import apiFetch from "@wordpress/api-fetch";
-import { __ } from "@wordpress/i18n";
+import { decodeEntities } from "@wordpress/html-entities";
 import { buildQueryString } from "@wordpress/url";
 import { map, trim, pickBy } from "lodash";
 import { ASYNC_ACTION_NAMES, ASYNC_ACTION_STATUS } from "../constants";
@@ -33,13 +33,13 @@ export function* fetchPages( queryData ) {
 
 /**
  * @param {Object} page The page.
- * @returns {Object} The prepared and predictable user.
+ * @returns {Object} The prepared and predictable page.
  */
 const preparePage = page => (
 	{
 		id: page?.id,
 		// Fallbacks for page title, because we always need something to show.
-		name: trim( page?.title.rendered ) || page?.slug || page.id,
+		name: decodeEntities( trim( page?.title.rendered ) ) || page?.slug || page.id,
 		slug: page?.slug,
 		"protected": page?.content?.protected,
 	} );
@@ -90,8 +90,7 @@ pageSelectors.selectPagesWith = createSelector(
 		( state, additionalPage = {} ) => additionalPage,
 	],
 	( pages, additionalPage ) => {
-		const none = { id: 0, name: __( "None", "wordpress-seo" ), slug: null, "protected": null };
-		const additionalPages = { 0: none };
+		const additionalPages = {};
 		additionalPage.forEach( page => {
 			if ( page?.id && ! pages[ page.id ] ) {
 				// Add the additional page.

--- a/packages/ui-library/src/elements/autocomplete/index.js
+++ b/packages/ui-library/src/elements/autocomplete/index.js
@@ -54,16 +54,17 @@ Option.propTypes = optionPropType;
  *
  * @param {Function} onChange Change callback.
  * @param {Object} svgAriaProps SVG aria props.
+ * @param {string} screenReaderText Screen reader text.
 * @returns {JSX.Element} Select component.
  */
-const ClearSelection = ( { onChange, svgAriaProps } ) => {
+const ClearSelection = ( { onChange, svgAriaProps, screenReaderText } ) => {
 	const clear = useCallback( ( e )=> {
 		e.preventDefault();
 		onChange( 0 );
 	}, [ onChange ] );
 
 	return <button className="yst-mr-4 yst-flex yst-items-center" onClick={ clear }>
-		<span className="yst-sr-only">Clear</span>
+		<span className="yst-sr-only">{ screenReaderText }</span>
 		<XIcon className="yst-slate-400 yst-w-5 yst-h-5" { ...svgAriaProps } />
 		<div className="yst-w-2 yst-mr-2 yst-border-r-slate-200 yst-border-r yst-h-7" />
 	</button>;
@@ -72,6 +73,7 @@ const ClearSelection = ( { onChange, svgAriaProps } ) => {
 ClearSelection.propTypes = {
 	onChange: PropTypes.func.isRequired,
 	svgAriaProps: PropTypes.object.isRequired,
+	screenReaderText: PropTypes.string.isRequired,
 };
 
 /**
@@ -105,6 +107,7 @@ const Autocomplete = forwardRef( ( {
 	placeholder,
 	className,
 	buttonProps,
+	clearButtonScreenReaderText,
 	...props
 }, ref ) => {
 	const getDisplayValue = useCallback( constant( selectedLabel ), [ selectedLabel ] );
@@ -137,7 +140,8 @@ const Autocomplete = forwardRef( ( {
 						displayValue={ getDisplayValue }
 						onChange={ onQueryChange }
 					/>
-					{ props.nullable && selectedLabel && <ClearSelection onChange={ onChange } svgAriaProps={ svgAriaProps } /> }
+					{ props.nullable && selectedLabel &&
+					<ClearSelection onChange={ onChange } svgAriaProps={ svgAriaProps } screenReaderText={ clearButtonScreenReaderText } /> }
 					{ ! validation?.message && (
 						<SelectorIcon className="yst-autocomplete__button-icon" { ...svgAriaProps } />
 					) }
@@ -181,6 +185,7 @@ const propTypes = {
 	placeholder: PropTypes.string,
 	className: PropTypes.string,
 	buttonProps: PropTypes.object,
+	clearButtonScreenReaderText: PropTypes.string,
 };
 Autocomplete.propTypes = propTypes;
 
@@ -194,6 +199,7 @@ Autocomplete.defaultProps = {
 	placeholder: "",
 	className: "",
 	buttonProps: {},
+	clearButtonScreenReaderText: "Clear",
 };
 
 export default Autocomplete;

--- a/packages/ui-library/src/elements/autocomplete/index.js
+++ b/packages/ui-library/src/elements/autocomplete/index.js
@@ -65,7 +65,7 @@ const ClearSelection = ( { onChange, svgAriaProps, screenReaderText } ) => {
 
 	return <button className="yst-mr-4 yst-flex yst-items-center" onClick={ clear }>
 		<span className="yst-sr-only">{ screenReaderText }</span>
-		<XIcon className="yst-slate-400 yst-w-5 yst-h-5" { ...svgAriaProps } />
+		<XIcon className="yst-text-slate-400 yst-w-5 yst-h-5" { ...svgAriaProps } />
 		<div className="yst-w-2 yst-mr-2 yst-border-r-slate-200 yst-border-r yst-h-7" />
 	</button>;
 };
@@ -136,6 +136,7 @@ const Autocomplete = forwardRef( ( {
 				>
 					<Combobox.Input
 						className="yst-autocomplete__input"
+						autoComplete="off"
 						placeholder={ placeholder }
 						displayValue={ getDisplayValue }
 						onChange={ onQueryChange }

--- a/packages/ui-library/src/elements/autocomplete/index.js
+++ b/packages/ui-library/src/elements/autocomplete/index.js
@@ -2,6 +2,7 @@ import PropTypes from "prop-types";
 import { forwardRef, Fragment, useCallback } from "@wordpress/element";
 import { Combobox, Transition } from "@headlessui/react";
 import { SelectorIcon, CheckIcon } from "@heroicons/react/solid";
+import { XIcon } from "@heroicons/react/outline";
 import classNames from "classnames";
 import { constant } from "lodash";
 import { useSvgAria } from "../../hooks";
@@ -49,6 +50,26 @@ const optionPropType = {
 
 Option.propTypes = optionPropType;
 
+/**
+ *
+ * @param {Function} onChange Change callback.
+* @returns {JSX.Element} Select component.
+ */
+const ClearSelection = ( { onChange } ) => {
+	const clear = useCallback( ( e )=> {
+		e.preventDefault();
+		onChange( 0 );
+	}, [ onChange ] );
+
+	return <button className="yst-mr-4 yst-flex yst-items-center" onClick={ clear }>
+		<XIcon className="yst-slate-400 yst-w-5 yst-h-5" />
+		<div className="yst-w-2 yst-mr-2 yst-border-r-slate-200 yst-border-r yst-h-7" />
+	</button>;
+};
+
+ClearSelection.propTypes = {
+	onChange: PropTypes.func.isRequired,
+};
 
 /**
  * @param {string} id Identifier.
@@ -113,6 +134,7 @@ const Autocomplete = forwardRef( ( {
 						displayValue={ getDisplayValue }
 						onChange={ onQueryChange }
 					/>
+					{ props.nullable && selectedLabel && <ClearSelection onChange={ onChange } /> }
 					{ ! validation?.message && (
 						<SelectorIcon className="yst-autocomplete__button-icon" { ...svgAriaProps } />
 					) }

--- a/packages/ui-library/src/elements/autocomplete/index.js
+++ b/packages/ui-library/src/elements/autocomplete/index.js
@@ -60,7 +60,7 @@ Option.propTypes = optionPropType;
 const ClearSelection = ( { onChange, svgAriaProps, screenReaderText } ) => {
 	const clear = useCallback( ( e )=> {
 		e.preventDefault();
-		onChange( 0 );
+		onChange( null );
 	}, [ onChange ] );
 
 	return <button className="yst-mr-4 yst-flex yst-items-center" onClick={ clear }>
@@ -170,7 +170,7 @@ Autocomplete.Option.displayName = "Autocomplete.Option";
 
 const propTypes = {
 	id: PropTypes.string.isRequired,
-	value: PropTypes.oneOfType( [ PropTypes.string, PropTypes.number, PropTypes.bool ] ).isRequired,
+	value: PropTypes.oneOfType( [ PropTypes.string, PropTypes.number, PropTypes.bool ] ),
 	children: PropTypes.node,
 	selectedLabel: PropTypes.string,
 	label: PropTypes.string,
@@ -191,6 +191,7 @@ Autocomplete.propTypes = propTypes;
 
 Autocomplete.defaultProps = {
 	children: null,
+	value: null,
 	selectedLabel: "",
 	label: "",
 	labelProps: {},

--- a/packages/ui-library/src/elements/autocomplete/index.js
+++ b/packages/ui-library/src/elements/autocomplete/index.js
@@ -53,22 +53,25 @@ Option.propTypes = optionPropType;
 /**
  *
  * @param {Function} onChange Change callback.
+ * @param {Object} svgAriaProps SVG aria props.
 * @returns {JSX.Element} Select component.
  */
-const ClearSelection = ( { onChange } ) => {
+const ClearSelection = ( { onChange, svgAriaProps } ) => {
 	const clear = useCallback( ( e )=> {
 		e.preventDefault();
 		onChange( 0 );
 	}, [ onChange ] );
 
 	return <button className="yst-mr-4 yst-flex yst-items-center" onClick={ clear }>
-		<XIcon className="yst-slate-400 yst-w-5 yst-h-5" />
+		<span className="yst-sr-only">Clear</span>
+		<XIcon className="yst-slate-400 yst-w-5 yst-h-5" { ...svgAriaProps } />
 		<div className="yst-w-2 yst-mr-2 yst-border-r-slate-200 yst-border-r yst-h-7" />
 	</button>;
 };
 
 ClearSelection.propTypes = {
 	onChange: PropTypes.func.isRequired,
+	svgAriaProps: PropTypes.object.isRequired,
 };
 
 /**
@@ -134,7 +137,7 @@ const Autocomplete = forwardRef( ( {
 						displayValue={ getDisplayValue }
 						onChange={ onQueryChange }
 					/>
-					{ props.nullable && selectedLabel && <ClearSelection onChange={ onChange } /> }
+					{ props.nullable && selectedLabel && <ClearSelection onChange={ onChange } svgAriaProps={ svgAriaProps } /> }
 					{ ! validation?.message && (
 						<SelectorIcon className="yst-autocomplete__button-icon" { ...svgAriaProps } />
 					) }

--- a/packages/ui-library/src/elements/autocomplete/stories.js
+++ b/packages/ui-library/src/elements/autocomplete/stories.js
@@ -9,6 +9,7 @@ export default {
 	argTypes: {
 		children: { control: "text" },
 		labelSuffix: { control: "text" },
+		nullable: { control: "boolean" },
 	},
 	parameters: {
 		docs: {
@@ -86,6 +87,23 @@ WithLabel.args = {
 	id: "with-label",
 	value: "",
 	label: "Example label",
+};
+
+export const Nullable = Template.bind( {} );
+
+Nullable.storyName = "Nullable";
+
+Nullable.parameters = {
+	controls: { disable: false },
+	docs: { description: { story: "Allow empty values with reset button `X` or deleting the option and clicking outside the field." } },
+};
+
+Nullable.args = {
+	id: "with-label",
+	value: "",
+	label: "Example label",
+	nullable: true,
+	placeholder: "None...",
 };
 
 export const WithPlaceholder = Template.bind( {} );

--- a/packages/ui-library/src/elements/autocomplete/style.css
+++ b/packages/ui-library/src/elements/autocomplete/style.css
@@ -57,7 +57,8 @@
 			yst-pr-10
 			yst-shadow-none
 			yst-text-sm
-			focus:yst-ring-0;
+			focus:yst-ring-0
+			yst-text-slate-800;
 		}
 
 		.yst-autocomplete__options {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Add an easer way to reset autocomplete field with an X button.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [@yoast/ui-library 0.1.0] Add a clear button to nullable autocomplete field.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install and activate `Yoast Premium`
* Add some sample pages.
* Go to `Yoast SEO`->`Settings`->`Site representation`
* Add logo and name to the organisation.  
* Go to `Site basics`
* Scroll to `Site policies`
* Check you see the default is "None"
* Add some pages to the different policies.
* Check you see an `X` to clear the selection
* Use a screen reader and check the text for the `X` is `Clear selection`.
* Go to home page and check the policy page appears in the schema.
* Go back to `Site policies`
* Click on the `X` of the policy page you added and check that the selection was cleared and the `X` is gone.
* Save changes and refresh.
* Check that the page is not selected.
* Go to home page and check the policy page doesn't appears in the schema.

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/wordpress-seo-premium/issues/4009
Fixes https://github.com/Yoast/wordpress-seo-premium/issues/4010