### PR TITLE
Dependency injection: fix `Loader_Pass` being broken on Windows

### DIFF
--- a/config/dependency-injection/loader-pass.php
+++ b/config/dependency-injection/loader-pass.php
@@ -52,28 +52,31 @@ class Loader_Pass implements CompilerPassInterface {
 	private function process_definition( Definition $definition, Definition $loader_definition ) {
 		$class = $definition->getClass();
 
+
 		try {
 			$reflect = new ReflectionClass( $class );
 			$path    = $this->normalize_slashes( $reflect->getFileName() );
-			if ( strpos( $path, 'wordpress-seo/src/helpers' )
-				|| strpos( $path, 'wordpress-seo/src/actions' )
-				|| strpos( $path, 'wordpress-seo/src/builders' )
-				|| strpos( $path, 'wordpress-seo/src/config' )
-				|| strpos( $path, 'wordpress-seo/src/context' )
-				|| strpos( $path, 'wordpress-seo/src/generators' )
-				|| strpos( $path, 'wordpress-seo/src/surfaces' )
-				|| strpos( $path, 'wordpress-seo/src/integrations' )
-				|| strpos( $path, 'wordpress-seo/src/loggers' )
-				|| strpos( $path, 'wordpress-seo/src/memoizers' )
-				|| strpos( $path, 'wordpress-seo/src/models' )
-				|| strpos( $path, 'wordpress-seo/src/presentations' )
-				|| strpos( $path, 'wordpress-seo/src/repositories' )
-				|| strpos( $path, 'wordpress-seo/src/services' )
-				|| strpos( $path, 'wordpress-seo/src/values' )
-				|| strpos( $path, 'wordpress-seo/src/wrappers' )
-				|| strpos( $path, 'wordpress-seo/src/wordpress' )
-				|| strpos( $path, 'wordpress-seo/src/loader' )
-				) {
+			if (
+				strpos( $path, 'src/helpers' ) !== false
+				|| strpos( $path, 'src/actions' ) !== false
+				|| strpos( $path, 'src/builders' ) !== false
+				|| strpos( $path, 'src/config' ) !== false
+				|| strpos( $path, 'src/context' ) !== false
+				|| strpos( $path, 'src/generators' ) !== false
+				|| strpos( $path, 'src/surfaces' ) !== false
+				|| strpos( $path, 'src/integrations' ) !== false
+				|| strpos( $path, 'src/loggers' ) !== false
+				|| strpos( $path, 'src/memoizers' ) !== false
+				|| strpos( $path, 'src/models' ) !== false
+				|| strpos( $path, 'src/presentations' ) !== false
+				|| strpos( $path, 'src/repositories' ) !== false
+				|| strpos( $path, 'src/services' ) !== false
+				|| strpos( $path, 'src/values' ) !== false
+				|| strpos( $path, 'src/wrappers' ) !== false
+				|| strpos( $path, 'src/wordpress' ) !== false
+				|| strpos( $path, 'src/loader' ) !== false
+			) {
+
 				$definition->setPublic( true );
 			}
 		} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch

--- a/config/dependency-injection/loader-pass.php
+++ b/config/dependency-injection/loader-pass.php
@@ -54,7 +54,7 @@ class Loader_Pass implements CompilerPassInterface {
 
 		try {
 			$reflect = new ReflectionClass( $class );
-			$path    = $reflect->getFileName();
+			$path    = $this->normalize_slashes( $reflect->getFileName() );
 			if ( strpos( $path, 'wordpress-seo/src/helpers' )
 				|| strpos( $path, 'wordpress-seo/src/actions' )
 				|| strpos( $path, 'wordpress-seo/src/builders' )
@@ -160,5 +160,16 @@ class Loader_Pass implements CompilerPassInterface {
 		$doc_comment = $reflection_class->getDocComment();
 
 		return ( $doc_comment === false ) ? '' : $doc_comment;
+	}
+
+	/**
+	 * Normalizes all slashes in a file path to forward slashes.
+	 *
+	 * @param string $path File path.
+	 *
+	 * @return string The file path with normalized slashes.
+	 */
+	private function normalize_slashes( $path ) {
+		return \str_replace( '\\', '/', $path );
 	}
 }


### PR DESCRIPTION
## Context

* Bug fix: building DI container was broken for Windows.

## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where building the DI container would silently fail when running on Windows.

## Relevant technical choices:

Follow up on #20074, which changed the `Loader_Pass` class to compare paths against (other) paths with hard-coded forward slashes.

This silently broke the Dependency injection layer for anyone compiling on Windows, i.e. the DI container scripts would run without errors, but once the DI container is attempted to be used, everything breaks.

This commit should fix that in a similar way as a previous similar issue was fixed in another part of the DI container setup (PR #16364).


## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

Easiest way to reproduce the original issue is as follows:
0. On a Windows computer....
1. Check out `trunk`.
2. Run `composer install` - the DI container will appear to be build without errors.
3. Try running the integration tests `vendor/bin/phpunit -c phpunit-integration.xml.dist` and see it fail in the bootstrap before the test run even gets started.

Rinse & repeat with this branch & see things working again.

Recommendation: also test this PR on Mac and Linux just to make sure there is no regression on that side of things.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* N/A this is a fix only for devs using a Windows environment

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
