### PR TITLE
used WP core function to flush rewrite rules

### DIFF
--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -429,7 +429,7 @@ class WPSEO_Utils {
 	 */
 	public static function clear_rewrites() {
 		// Flush the rewrite rules to immediately propagate the change through the site.
-		\add_action( 'shutdown', 'flush_rewrite_rules' );
+		add_action( 'shutdown', 'flush_rewrite_rules' );
 	}
 
 	/**

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -428,7 +428,8 @@ class WPSEO_Utils {
 	 * @since 1.8.0
 	 */
 	public static function clear_rewrites() {
-		update_option( 'rewrite_rules', '' );
+		// Flush the rewrite rules to immediately propagate the change through the site.
+		\add_action( 'shutdown', 'flush_rewrite_rules' );
 	}
 
 	/**

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -202,7 +202,8 @@ function _wpseo_activate() {
 	WPSEO_Options::ensure_options_exist();
 
 	if ( is_multisite() && ms_is_switched() ) {
-		update_option( 'rewrite_rules', '' );
+		add_action( 'shutdown', 'flush_rewrite_rules' );
+
 	}
 	else {
 		if ( WPSEO_Options::get( 'stripcategorybase' ) === true ) {
@@ -244,7 +245,7 @@ function _wpseo_deactivate() {
 	require_once WPSEO_PATH . 'inc/wpseo-functions.php';
 
 	if ( is_multisite() && ms_is_switched() ) {
-		update_option( 'rewrite_rules', '' );
+		add_action( 'shutdown', 'flush_rewrite_rules' );
 	}
 	else {
 		add_action( 'shutdown', 'flush_rewrite_rules' );

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -201,17 +201,14 @@ function _wpseo_activate() {
 	}
 	WPSEO_Options::ensure_options_exist();
 
-	if ( is_multisite() && ms_is_switched() ) {
-		add_action( 'shutdown', 'flush_rewrite_rules' );
+	$is_multisite_deactivation = is_multisite() && ms_is_switched();
 
+	if ( !$is_multisite_deactivation && WPSEO_Options::get( 'stripcategorybase' ) === true ) {
+		// Constructor has side effects so this registers all hooks.
+		$GLOBALS['wpseo_rewrite'] = new WPSEO_Rewrite();
 	}
-	else {
-		if ( WPSEO_Options::get( 'stripcategorybase' ) === true ) {
-			// Constructor has side effects so this registers all hooks.
-			$GLOBALS['wpseo_rewrite'] = new WPSEO_Rewrite();
-		}
-		add_action( 'shutdown', 'flush_rewrite_rules' );
-	}
+	
+	add_action( 'shutdown', 'flush_rewrite_rules' );
 
 	WPSEO_Options::set( 'indexing_reason', 'first_install' );
 	WPSEO_Options::set( 'first_time_install', true );
@@ -244,13 +241,8 @@ function _wpseo_activate() {
 function _wpseo_deactivate() {
 	require_once WPSEO_PATH . 'inc/wpseo-functions.php';
 
-	if ( is_multisite() && ms_is_switched() ) {
-		add_action( 'shutdown', 'flush_rewrite_rules' );
-	}
-	else {
-		add_action( 'shutdown', 'flush_rewrite_rules' );
-	}
-
+	add_action( 'shutdown', 'flush_rewrite_rules' );
+	
 	// Register capabilities, to make sure they are cleaned up.
 	do_action( 'wpseo_register_roles' );
 	do_action( 'wpseo_register_capabilities' );

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -203,11 +203,11 @@ function _wpseo_activate() {
 
 	$is_multisite_deactivation = is_multisite() && ms_is_switched();
 
-	if ( !$is_multisite_deactivation && WPSEO_Options::get( 'stripcategorybase' ) === true ) {
+	if ( ! $is_multisite_deactivation && WPSEO_Options::get( 'stripcategorybase' ) === true ) {
 		// Constructor has side effects so this registers all hooks.
 		$GLOBALS['wpseo_rewrite'] = new WPSEO_Rewrite();
 	}
-	
+
 	add_action( 'shutdown', 'flush_rewrite_rules' );
 
 	WPSEO_Options::set( 'indexing_reason', 'first_install' );
@@ -242,7 +242,7 @@ function _wpseo_deactivate() {
 	require_once WPSEO_PATH . 'inc/wpseo-functions.php';
 
 	add_action( 'shutdown', 'flush_rewrite_rules' );
-	
+
 	// Register capabilities, to make sure they are cleaned up.
 	do_action( 'wpseo_register_roles' );
 	do_action( 'wpseo_register_capabilities' );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to replace our custom way we flush rewrite rules with WP core `flush_rewrite_rules` method.
* The difference is that the WP method updates the `rewrite_rules` and other safeguards while the custom methods deletes the content of the rewrite rules option in the data base.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where 404 responses would occur when updating or deactivating the plugin because of incorrect flushing of the rewrite rules.

## Relevant technical choices:

* WP core function `flush_rewrite_rules` has a lot of safeguards, like:
  * Making sure all plugins have registered their rewrites
  * Clearing rewrites from the Apache .htaccess if needed
  * Actually re-populating the rewrite rules in the same call (and not just leaving it empty for the next call)
* This PR is an improvement of [Dupp 413 fix rewrite_rules performance problem](https://github.com/Yoast/wordpress-seo/pull/18352)

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

*  There are 3 scenarios where `rewrite_rules` option was emptied:
    1. In a multisite wp installation, when network-activating wpseo
    2. In a multisite wp installation, when network-deactivating wpseo
    3. Every time an option is being updated

_Scenario 1_
* Start with a fresh wp multisite installation
* Without applying this patch:
  * Check database `wp_options`->`rewrite_rules` has content. If not visit homepage and check again.
  * From the upper admin bar, Visit `My Sites` -> `Network Admin `-> `Dashboard`
  * Go to `Plugins` and (network) activate `Yoast SEO`
  * From the database check `rewrite_rules` got emptied.
  * Visit the homepage of your sites (this makes `rewrite_rules` to be filled)
  * From the database, copy the value of `rewrite_rules` and past it in one of the two sides [of compare](https://text-compare.com/) (or in any other tool which lets you compare texts)
* Now apply the patch and perform the same steps as above.
  * From the database check `rewrite_rules` was not emptied.
  * Copy the content of `rewrite_rules` and past the text into the other side of the text comparison tool and verify the two texts are the same

_Scenario 2_
* Without applying this patch:
  * Check database `wp_options`->`rewrite_rules` has content. If not visit homepage and check again.
  * Deactivate (network-)deactivate `Yoast SEO`
  * From the database check `rewrite_rules` got emptied.
  * Visit the homepage of your sites (this makes `rewrite_rules` to be filled)
  * From the database, copy the value of `rewrite_rules` and past it in one of the two sides [of compare](https://text-compare.com/) (or in any other tool which lets you compare texts)
  * Activate again
   * Visit the homepage of your sites (this makes `rewrite_rules` to be filled)
* With patch
  * Deactivate (network-)deactivate `Yoast SEO`
  * From the database check `rewrite_rules` was not emptied.
  * Copy the value of `rewrite_rules` from the database
  * Past the text into the other side of the text comparison tool and verify the two texts are the same

_Scenario 3_
* Without this PR with a single site settings:
  * Check database `wp_options`->`rewrite_rules` has content.
  * Go to one of your site's Dashboard
  * Visit `SEO` -> `Search Appearance`
  * In Knowledge Graph & Schema.org section, edit `Organization name` and save the changes
  * From the database check `rewrite_rules` got emptied.
  * Go to `Settings`->`Permalinks` and save
  * Check `rewrite_rules` has value and copy and past it in one of the two sides [of compare](https://text-compare.com/) (or in any other tool which lets you compare texts)
* Re-apply this patch
  * Edit again the `Organization name` (change the name, save it, and restore the name from previous stage) and save the changes
  * Check database `wp_options`->`rewrite_rules` in not empty and has content.
  * Copy the value of `rewrite_rules` from the database
  * Past the text into the other side of the text comparison tool and verify the two texts are the same


#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [#87](https://github.com/Yoast/reserved-tasks/issues/87)
