### PR TITLE
fixed tag in translation for notification from the add-on manager

### DIFF
--- a/inc/class-addon-manager.php
+++ b/inc/class-addon-manager.php
@@ -498,13 +498,14 @@ class WPSEO_Addon_Manager {
 
 		return new Yoast_Notification(
 			sprintf(
-			/* translators: %1$s expands to a strong tag, %2$s expands to the product name, %3$s expands to a closing strong tag, %4$s expands to an a tag. %5$s expands to MyYoast with a closing a tag,  %6$s expands to the product name  */
-				__( '%1$s %2$s isn\'t working as expected %3$s and you are not receiving updates or support! Make sure to %4$s activate your product subscription in %5$s to unlock all the features of %6$s.', 'wordpress-seo' ),
+			/* translators: %1$s expands to a strong tag, %2$s expands to the product name, %3$s expands to a closing strong tag, %4$s expands to an a tag. %5$s expands to MyYoast, %6$s expands to a closing a tag,  %7$s expands to the product name  */
+				__( '%1$s %2$s isn\'t working as expected %3$s and you are not receiving updates or support! Make sure to %4$s activate your product subscription in %5$s%6$s to unlock all the features of %7$s.', 'wordpress-seo' ),
 				'<strong>',
 				$product_name,
 				'</strong>',
 				'<a href="' . WPSEO_Shortlinker::get( $short_link ) . '" target="_blank">',
-				' MyYoast</a>',
+				'MyYoast',
+				'</a>',
 				$product_name
 			),
 			$notification_options

--- a/tests/unit/doubles/inc/addon-manager-double.php
+++ b/tests/unit/doubles/inc/addon-manager-double.php
@@ -88,4 +88,16 @@ class Addon_Manager_Double extends WPSEO_Addon_Manager {
 	public function has_installed_addons() {
 		return parent::has_installed_addons();
 	}
+
+	/**
+	 * Creates an instance of Yoast_Notification.
+	 *
+	 * @param string $product_name The product to create the notification for.
+	 * @param string $short_link   The short link for the addon notification.
+	 *
+	 * @return Yoast_Notification The created notification.
+	 */
+	public function create_notification( $product_name, $short_link ) {
+		return parent::create_notification( $product_name, $short_link );
+	}
 }

--- a/tests/unit/inc/addon-manager-test.php
+++ b/tests/unit/inc/addon-manager-test.php
@@ -1103,22 +1103,53 @@ class Addon_Manager_Test extends TestCase {
 	}
 
 	/**
+	 * Data provider for create_notification
+	 *
+	 * @return array
+	 */
+	public static function data_provider_create_notification() {
+		return [
+			'Notification for Yoast SEO Premium' => [
+				'product_name' => 'Yoast SEO Premium',
+				'short_link'   => 'https://yoa.st/13j',
+			],
+			'Notification for Yoast Local SEO' => [
+				'product_name' => 'Yoast Local SEO',
+				'short_link'   => 'https://yoa.st/4xp',
+			],
+			'Notification for Yoast Video SEO' => [
+				'product_name' => 'Yoast Video SEO',
+				'short_link'   => 'https://yoa.st/4xq',
+			],
+			'Notification for Yoast News SEO' => [
+				'product_name' => 'Yoast News SEO',
+				'short_link'   => 'https://yoa.st/4xr',
+			],
+		];
+	}
+
+	/**
 	 * Tests create_notification method.
 	 *
 	 * @covers ::create_notification
+	 *
+	 * @dataProvider data_provider_create_notification
+	 *
+	 * @param string $product_name The product name.
+	 * @param string $short_link   The short link.
 	 */
-	public function test_create_notification() {
+	public function test_create_notification( $product_name, $short_link ) {
 
 		Monkey\Functions\expect( 'sanitize_title_with_dashes' )
-			->with( 'Yoast SEO Premium', null, 'save' )
+			->with( $product_name, null, 'save' )
 			->once()
-			->andReturn( 'Yoast SEO Premium' );
+			->andReturn( $product_name );
 
 		$short_link_mock = Mockery::mock( Short_Link_Helper::class );
 
 		$short_link_mock->expects( 'get' )
 			->once()
-			->andReturn( 'https://yoa.st/13j' );
+			->andReturn( $short_link );
 
 		$container = $this->create_container_with(
 			[
@@ -1133,17 +1164,17 @@ class Addon_Manager_Test extends TestCase {
 			->once()
 			->andReturn( (object) [ 'helpers' => $this->create_helper_surface( $container ) ] );
 
-		$notification = $this->instance->create_notification( 'Yoast SEO Premium', 'yoa.st/13j' );
+		$notification = $this->instance->create_notification( $product_name, $short_link );
 
 		$notification_options = [
 			'type'         => 'error',
-			'id'           => 'wpseo-dismiss-Yoast SEO Premium',
+			'id'           => 'wpseo-dismiss-' . $product_name,
 			'capabilities' => 'wpseo_manage_options',
 		];
 
 
 		$expected = new Yoast_Notification(
-			'<strong> Yoast SEO Premium isn\'t working as expected </strong> and you are not receiving updates or support! Make sure to <a href="https://yoa.st/13j" target="_blank"> activate your product subscription in MyYoast</a> to unlock all the features of Yoast SEO Premium.',
+			'<strong> ' . $product_name . ' isn\'t working as expected </strong> and you are not receiving updates or support! Make sure to <a href="' . $short_link . '" target="_blank"> activate your product subscription in MyYoast</a> to unlock all the features of ' . $product_name . '.',
 			$notification_options
 		);
 		$this->assertEquals( $expected, $notification );

--- a/tests/unit/inc/addon-manager-test.php
+++ b/tests/unit/inc/addon-manager-test.php
@@ -6,8 +6,10 @@ use Brain\Monkey;
 use Mockery;
 use stdClass;
 use WPSEO_Utils;
+use Yoast_Notification;
 use Yoast\WP\SEO\Helpers\Product_Helper;
 use Yoast\WP\SEO\Tests\Unit\Doubles\Inc\Addon_Manager_Double;
+use Yoast\WP\SEO\Helpers\Short_Link_Helper;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
@@ -45,6 +47,7 @@ class Addon_Manager_Test extends TestCase {
 	 */
 	protected function set_up() {
 		parent::set_up();
+		$this->stubTranslationFunctions();
 
 		$this->instance = Mockery::mock( Addon_Manager_Double::class )
 			->shouldAllowMockingProtectedMethods()
@@ -1097,5 +1100,52 @@ class Addon_Manager_Test extends TestCase {
 			'Page is set to null'                => $page_null,
 			'Page is something else than string' => $page_other_than_string,
 		];
+	}
+
+	/**
+	 * Tests create_notification method.
+	 *
+	 * @covers ::create_notification
+	 */
+	public function test_create_notification() {
+
+		Monkey\Functions\expect( 'sanitize_title_with_dashes' )
+			->with( 'Yoast SEO Premium', null, 'save' )
+			->once()
+			->andReturn( 'Yoast SEO Premium' );
+
+		$short_link_mock = Mockery::mock( Short_Link_Helper::class );
+
+		$short_link_mock->expects( 'get' )
+			->once()
+			->andReturn( 'https://yoa.st/13j' );
+
+		$container = $this->create_container_with(
+			[
+				Short_Link_Helper::class => $short_link_mock,
+			]
+		);
+
+		Monkey\Functions\expect( 'wp_get_current_user' )
+			->twice();
+
+		Monkey\Functions\expect( 'YoastSEO' )
+			->once()
+			->andReturn( (object) [ 'helpers' => $this->create_helper_surface( $container ) ] );
+
+		$notification = $this->instance->create_notification( 'Yoast SEO Premium', 'yoa.st/13j' );
+
+		$notification_options = [
+			'type'         => 'error',
+			'id'           => 'wpseo-dismiss-Yoast SEO Premium',
+			'capabilities' => 'wpseo_manage_options',
+		];
+
+
+		$expected = new Yoast_Notification(
+			'<strong> Yoast SEO Premium isn\'t working as expected </strong> and you are not receiving updates or support! Make sure to <a href="https://yoa.st/13j" target="_blank"> activate your product subscription in MyYoast</a> to unlock all the features of Yoast SEO Premium.',
+			$notification_options
+		);
+		$this->assertEquals( $expected, $notification );
 	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to fix some translations.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes some translations

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Follow same test instructions from #20014

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [#20468](https://github.com/Yoast/wordpress-seo/issues/20468)
