### PR TITLE
20505 notification for new content type not excluding

### DIFF
--- a/src/content-type-visibility/application/content-type-visibility-dismiss-notifications.php
+++ b/src/content-type-visibility/application/content-type-visibility-dismiss-notifications.php
@@ -42,7 +42,7 @@ class Content_Type_Visibility_Dismiss_Notifications {
 			$success          = $this->options->set( 'new_post_types', $new_needs_review );
 			$message          = ( $success ) ? __( 'Post type is no longer new.', 'wordpress-seo' ) : __( 'Error: Post type was not removed from new_post_types list.', 'wordpress-seo' );
 			if ( $success ) {
-				$this->maybe_dismiss_notifications();
+				$this->maybe_dismiss_notifications( [ 'new_post_types' => $new_needs_review ] );
 			}
 		}
 
@@ -72,7 +72,7 @@ class Content_Type_Visibility_Dismiss_Notifications {
 			$success          = $this->options->set( 'new_taxonomies', $new_needs_review );
 			$message          = ( $success ) ? __( 'Taxonomy is no longer new.', 'wordpress-seo' ) : __( 'Error: Taxonomy was not removed from new_taxonomies list.', 'wordpress-seo' );
 			if ( $success ) {
-				$this->maybe_dismiss_notifications();
+				$this->maybe_dismiss_notifications( [ 'new_taxonomies' => $new_needs_review ] );
 			}
 		}
 
@@ -88,11 +88,14 @@ class Content_Type_Visibility_Dismiss_Notifications {
 	/**
 	 * Checks if there are new content types or taxonomies.
 	 *
+	 * @param array $new_content_types The new content types.
 	 * @return bool
 	 */
-	public function maybe_dismiss_notifications() {
-		$taxonomies_needs_review = $this->options->get( 'new_taxonomies', [] );
-		$post_types_needs_review = $this->options->get( 'new_post_types', [] );
+	public function maybe_dismiss_notifications( $new_content_types = [] ) {
+
+		$post_types_needs_review = ( array_key_exists( 'new_post_types', $new_content_types ) ) ? $new_content_types['new_post_types'] : $this->options->get( 'new_post_types', [] );
+		$taxonomies_needs_review = ( array_key_exists( 'new_taxonomies', $new_content_types ) ) ? $new_content_types['new_taxonomies'] : $this->options->get( 'new_taxonomies', [] );
+
 		if ( $post_types_needs_review || $taxonomies_needs_review ) {
 			return;
 		}

--- a/src/content-type-visibility/application/content-type-visibility-watcher-actions.php
+++ b/src/content-type-visibility/application/content-type-visibility-watcher-actions.php
@@ -103,7 +103,7 @@ class Content_Type_Visibility_Watcher_Actions implements Integration_Interface {
 		$new_needs_review = \array_diff( $needs_review, $newly_made_non_public_post_types );
 		if ( \count( $new_needs_review ) !== \count( $needs_review ) ) {
 			$this->options->set( 'new_post_types', $new_needs_review );
-			$this->content_type_dismiss_notifications->maybe_dismiss_notifications();
+			$this->content_type_dismiss_notifications->maybe_dismiss_notifications( [ 'new_post_types' => $new_needs_review ] );
 		}
 	}
 
@@ -131,7 +131,7 @@ class Content_Type_Visibility_Watcher_Actions implements Integration_Interface {
 		$new_needs_review = \array_diff( $needs_review, $newly_made_non_public_taxonomies );
 		if ( \count( $new_needs_review ) !== \count( $needs_review ) ) {
 			$this->options->set( 'new_taxonomies', $new_needs_review );
-			$this->content_type_dismiss_notifications->maybe_dismiss_notifications();
+			$this->content_type_dismiss_notifications->maybe_dismiss_notifications( [ 'new_taxonomies' => $new_needs_review ] );
 		}
 	}
 

--- a/src/integrations/watchers/indexable-post-type-change-watcher.php
+++ b/src/integrations/watchers/indexable-post-type-change-watcher.php
@@ -108,8 +108,9 @@ class Indexable_Post_Type_Change_Watcher implements Integration_Interface {
 			return;
 		}
 
+		$excluded_post_types = $this->post_type_helper->get_excluded_post_types_for_indexables();
 		// We look for new public post types.
-		$newly_made_public_post_types = \array_diff( $public_post_types, $last_known_public_post_types );
+		$newly_made_public_post_types = \array_diff( $public_post_types, $last_known_public_post_types, $excluded_post_types );
 		// We look for post types that from public have been made private.
 		$newly_made_non_public_post_types = \array_diff( $last_known_public_post_types, $public_post_types );
 

--- a/src/integrations/watchers/indexable-post-type-change-watcher.php
+++ b/src/integrations/watchers/indexable-post-type-change-watcher.php
@@ -99,8 +99,7 @@ class Indexable_Post_Type_Change_Watcher implements Integration_Interface {
 			return;
 		}
 
-		$excluded_post_types = $this->post_type_helper->get_excluded_post_types_for_indexables();
-		$public_post_types   = \array_diff( \array_keys( $this->post_type_helper->get_public_post_types() ), $excluded_post_types );
+		$public_post_types = $this->post_type_helper->get_indexable_post_types();
 
 		$last_known_public_post_types = $this->options->get( 'last_known_public_post_types', [] );
 

--- a/src/integrations/watchers/indexable-taxonomy-change-watcher.php
+++ b/src/integrations/watchers/indexable-taxonomy-change-watcher.php
@@ -101,8 +101,7 @@ class Indexable_Taxonomy_Change_Watcher implements Integration_Interface {
 			return;
 		}
 
-		$excluded_taxonomies = $this->taxonomy_helper->get_excluded_taxonomies_for_indexables();
-		$public_taxonomies   = \array_diff( \array_keys( $this->taxonomy_helper->get_public_taxonomies() ), $excluded_taxonomies );
+		$public_taxonomies = $this->taxonomy_helper->get_indexable_taxonomies();
 
 		$last_known_public_taxonomies = $this->options->get( 'last_known_public_taxonomies', [] );
 
@@ -113,7 +112,7 @@ class Indexable_Taxonomy_Change_Watcher implements Integration_Interface {
 		}
 
 		// We look for new public taxonomies.
-		$newly_made_public_taxonomies = \array_diff( $public_taxonomies, $last_known_public_taxonomies, $excluded_taxonomies );
+		$newly_made_public_taxonomies = \array_diff( $public_taxonomies, $last_known_public_taxonomies );
 
 		// We look fortaxonomies that from public have been made private.
 		$newly_made_non_public_taxonomies = \array_diff( $last_known_public_taxonomies, $public_taxonomies );

--- a/src/integrations/watchers/indexable-taxonomy-change-watcher.php
+++ b/src/integrations/watchers/indexable-taxonomy-change-watcher.php
@@ -103,6 +103,7 @@ class Indexable_Taxonomy_Change_Watcher implements Integration_Interface {
 
 		$public_taxonomies            = \array_keys( $this->taxonomy_helper->get_public_taxonomies() );
 		$last_known_public_taxonomies = $this->options->get( 'last_known_public_taxonomies', [] );
+		$excluded_taxonomies          = $this->taxonomy_helper->get_excluded_taxonomies_for_indexables();
 
 		// Initializing the option on the first run.
 		if ( empty( $last_known_public_taxonomies ) ) {
@@ -111,7 +112,8 @@ class Indexable_Taxonomy_Change_Watcher implements Integration_Interface {
 		}
 
 		// We look for new public taxonomies.
-		$newly_made_public_taxonomies = \array_diff( $public_taxonomies, $last_known_public_taxonomies );
+		$newly_made_public_taxonomies = \array_diff( $public_taxonomies, $last_known_public_taxonomies, $excluded_taxonomies );
+
 		// We look fortaxonomies that from public have been made private.
 		$newly_made_non_public_taxonomies = \array_diff( $last_known_public_taxonomies, $public_taxonomies );
 

--- a/src/integrations/watchers/indexable-taxonomy-change-watcher.php
+++ b/src/integrations/watchers/indexable-taxonomy-change-watcher.php
@@ -101,9 +101,10 @@ class Indexable_Taxonomy_Change_Watcher implements Integration_Interface {
 			return;
 		}
 
-		$public_taxonomies            = \array_keys( $this->taxonomy_helper->get_public_taxonomies() );
+		$excluded_taxonomies = $this->taxonomy_helper->get_excluded_taxonomies_for_indexables();
+		$public_taxonomies   = \array_diff( \array_keys( $this->taxonomy_helper->get_public_taxonomies() ), $excluded_taxonomies );
+
 		$last_known_public_taxonomies = $this->options->get( 'last_known_public_taxonomies', [] );
-		$excluded_taxonomies          = $this->taxonomy_helper->get_excluded_taxonomies_for_indexables();
 
 		// Initializing the option on the first run.
 		if ( empty( $last_known_public_taxonomies ) ) {

--- a/tests/unit/content-type-visibility/application/content-type-visibility-dismiss-notifications-test.php
+++ b/tests/unit/content-type-visibility/application/content-type-visibility-dismiss-notifications-test.php
@@ -68,23 +68,50 @@ class Content_Type_Visibility_Dismiss_Notifications_Test extends TestCase {
 				'new_post_types'              => [],
 				'new_taxonomies'              => [],
 				'dismiss_notifications_times' => 1,
+				'new_content_type'            => [],
+				'get_new_post_types_times'    => 1,
+				'get_new_taxonomies_times'    => 1,
 			],
 			'New post types and taxonomies' => [
 				'new_post_types'              => [ 'book', 'movie' ],
 				'new_taxonomies'              => [ 'books-category', 'movie-category' ],
 				'dismiss_notifications_times' => 0,
+				'new_content_type'            => [],
+				'get_new_post_types_times'    => 1,
+				'get_new_taxonomies_times'    => 1,
 			],
 			'New post types' => [
 				'new_post_types'              => [ 'book', 'movie' ],
 				'new_taxonomies'              => [],
 				'dismiss_notifications_times' => 0,
+				'new_content_type'            => [],
+				'get_new_post_types_times'    => 1,
+				'get_new_taxonomies_times'    => 1,
 			],
 			'New taxonomies' => [
 				'new_post_types'              => [],
 				'new_taxonomies'              => [ 'books-category', 'movie-category' ],
 				'dismiss_notifications_times' => 0,
+				'new_content_type'            => [],
+				'get_new_post_types_times'    => 1,
+				'get_new_taxonomies_times'    => 1,
 			],
-
+			'New taxonomies in param' => [
+				'new_post_types'              => [],
+				'new_taxonomies'              => [],
+				'dismiss_notifications_times' => 0,
+				'new_content_type'            => [ 'new_taxonomies' => [ 'books-category', 'movie-category' ] ],
+				'get_new_post_types_times'    => 1,
+				'get_new_taxonomies_times'    => 0,
+			],
+			'New post types in param' => [
+				'new_post_types'              => [],
+				'new_taxonomies'              => [],
+				'dismiss_notifications_times' => 0,
+				'new_content_type'            => [ 'new_post_types' => [ 'book', 'movie' ] ],
+				'get_new_post_types_times'    => 0,
+				'get_new_taxonomies_times'    => 1,
+			],
 		];
 	}
 
@@ -98,25 +125,28 @@ class Content_Type_Visibility_Dismiss_Notifications_Test extends TestCase {
 	 * @param array $new_post_types The new post types.
 	 * @param array $new_taxonomies The new taxonomies.
 	 * @param int   $dismiss_notifications_times The number of times the dismiss_notifications method should be called.
+	 * @param array $new_content_type The new content type.
+	 * @param int   $get_new_post_types_times The number of times the get method should be called.
+	 * @param int   $get_new_taxonomies_times The number of times the get method should be called.
 	 * @return void
 	 */
-	public function test_maybe_dismiss_notifications( $new_post_types, $new_taxonomies, $dismiss_notifications_times ) {
+	public function test_maybe_dismiss_notifications( $new_post_types, $new_taxonomies, $dismiss_notifications_times, $new_content_type, $get_new_post_types_times, $get_new_taxonomies_times ) {
 
 		$this->options
 			->expects( 'get' )
 			->with( 'new_post_types', [] )
-			->once()
+			->times( $get_new_post_types_times )
 			->andReturn( $new_post_types );
 
 		$this->options
 			->expects( 'get' )
 			->with( 'new_taxonomies', [] )
-			->once()
+			->times( $get_new_taxonomies_times )
 			->andReturn( $new_taxonomies );
 
 		$this->expect_dismiss_notifications( $dismiss_notifications_times );
 
-		$this->instance->maybe_dismiss_notifications();
+		$this->instance->maybe_dismiss_notifications( $new_content_type );
 	}
 
 	/**
@@ -243,12 +273,6 @@ class Content_Type_Visibility_Dismiss_Notifications_Test extends TestCase {
 			->once()
 			->andReturn( [] );
 
-		$this->options
-			->expects( 'get' )
-			->with( 'new_post_types', [] )
-			->once()
-			->andReturn( [ 'movie' ] );
-
 		$response = $this->instance->post_type_dismiss( 'book' );
 		$expected = [
 			'message' => 'Post type is no longer new.',
@@ -330,15 +354,9 @@ class Content_Type_Visibility_Dismiss_Notifications_Test extends TestCase {
 
 		$this->options
 			->expects( 'get' )
-			->with( 'new_taxonomies', [] )
-			->once()
-			->andReturn( [] );
-
-		$this->options
-			->expects( 'get' )
 			->with( 'new_post_types', [] )
 			->once()
-			->andReturn( [ 'movie-category' ] );
+			->andReturn( [ 'movie' ] );
 
 		$response = $this->instance->taxonomy_dismiss( 'book-category' );
 		$expected = [

--- a/tests/unit/integrations/watchers/indexable-post-type-change-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-post-type-change-watcher-test.php
@@ -120,31 +120,23 @@ class Indexable_Post_Type_Change_Watcher_Test extends TestCase {
 	 * @covers ::check_post_types_public_availability
 	 *
 	 * @param bool  $is_json_request              Whether it's a JSON request.
-	 * @param array $get_public_post_types        The raw public post types.
 	 * @param array $public_post_types            The public post types.
 	 * @param int   $get_public_post_types_times  The times we get the public post types.
 	 * @param array $last_known_public_post_types The last known public post types.
 	 * @param int   $set_public_post_types_times  The times we get the last known public post types.
 	 * @param int   $delete_transient_times       The times we delete the transients.
-	 * @param int   $schedule_cleanup_times       The times we schedule cleanup.
-	 * @param int   $excluded_times               The times we get the excluded post types.
 	 */
 	public function test_check_post_types_public_availability(
-		$is_json_request, $get_public_post_types, $public_post_types, $get_public_post_types_times, $last_known_public_post_types, $set_public_post_types_times, $delete_transient_times, $schedule_cleanup_times, $excluded_times
+		$is_json_request, $public_post_types, $get_public_post_types_times, $last_known_public_post_types, $set_public_post_types_times, $delete_transient_times, $schedule_cleanup_times
 	) {
 		Functions\expect( 'wp_is_json_request' )
 			->once()
 			->andReturn( $is_json_request );
 
 		$this->post_type_helper
-			->expects( 'get_public_post_types' )
+			->expects( 'get_indexable_post_types' )
 			->times( $get_public_post_types_times )
-			->andReturn( $get_public_post_types );
-
-		$this->post_type_helper
-			->expects( 'get_excluded_post_types_for_indexables' )
-			->times( $excluded_times )
-			->andReturn( [ 'elementor_library', 'shop_order' ] );
+			->andReturn( $public_post_types );
 
 		$this->options
 			->expects( 'get' )
@@ -197,43 +189,24 @@ class Indexable_Post_Type_Change_Watcher_Test extends TestCase {
 		return [
 			'When it is ajax request' => [
 				'is_json_request'              => true,
-				'get_public_post_types'        => [ 'irrelevant' => 'irrelevant' ],
 				'public_post_types'            => [ 'irrelevant' ],
 				'get_public_post_types_times'  => 0,
 				'last_known_public_post_types' => [ 'irrelevant' ],
 				'set_public_post_types_times'  => 0,
 				'delete_transient_times'       => 0,
 				'schedule_cleanup_times'       => 0,
-				'excluded_times'               => 0,
 			],
 			'When there are no new public content types' => [
 				'is_json_request'              => false,
-				'get_public_post_types'        => [],
 				'public_post_types'            => [],
 				'get_public_post_types_times'  => 1,
 				'last_known_public_post_types' => [],
 				'set_public_post_types_times'  => 1,
 				'delete_transient_times'       => 0,
 				'schedule_cleanup_times'       => 0,
-				'excluded_times'               => 1,
-			],
-			'When the new public content types are excluded' => [
-				'is_json_request'              => false,
-				'get_public_post_types'        => [ 'elementor_library' => 'elementor_library' ],
-				'public_post_types'            => [],
-				'get_public_post_types_times'  => 1,
-				'last_known_public_post_types' => [],
-				'set_public_post_types_times'  => 1,
-				'delete_transient_times'       => 0,
-				'schedule_cleanup_times'       => 0,
-				'excluded_times'               => 1,
 			],
 			'When the new post types are already saved in cache' => [
 				'is_json_request'              => false,
-				'get_public_post_types'        => [
-					'post' => 'post',
-					'page' => 'page',
-				],
 				'public_post_types'            => [ 'post', 'page' ],
 				'get_public_post_types_times'  => 1,
 				'last_known_public_post_types' => [
@@ -243,14 +216,9 @@ class Indexable_Post_Type_Change_Watcher_Test extends TestCase {
 				'set_public_post_types_times'  => 0,
 				'delete_transient_times'       => 0,
 				'schedule_cleanup_times'       => 0,
-				'excluded_times'               => 1,
 			],
 			'When new post type is added' => [
 				'is_json_request'              => false,
-				'get_public_post_types'        => [
-					'post' => 'post',
-					'page' => 'page',
-				],
 				'public_post_types'            => [ 'post', 'page' ],
 				'get_public_post_types_times'  => 1,
 				'last_known_public_post_types' => [
@@ -259,13 +227,9 @@ class Indexable_Post_Type_Change_Watcher_Test extends TestCase {
 				'set_public_post_types_times'  => 1,
 				'delete_transient_times'       => 1,
 				'schedule_cleanup_times'       => 0,
-				'excluded_times'               => 1,
 			],
 			'when post type is removed' => [
 				'is_json_request'              => false,
-				'get_public_post_types'        => [
-					'post' => 'post',
-				],
 				'public_post_types'            => [ 'post' ],
 				'get_public_post_types_times'  => 1,
 				'last_known_public_post_types' => [
@@ -275,7 +239,6 @@ class Indexable_Post_Type_Change_Watcher_Test extends TestCase {
 				'set_public_post_types_times'  => 1,
 				'delete_transient_times'       => 0,
 				'schedule_cleanup_times'       => 1,
-				'excluded_times'               => 1,
 			],
 		];
 	}

--- a/tests/unit/integrations/watchers/indexable-post-type-change-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-post-type-change-watcher-test.php
@@ -125,6 +125,7 @@ class Indexable_Post_Type_Change_Watcher_Test extends TestCase {
 	 * @param array $last_known_public_post_types The last known public post types.
 	 * @param int   $set_public_post_types_times  The times we get the last known public post types.
 	 * @param int   $delete_transient_times       The times we delete the transients.
+	 * @param int   $schedule_cleanup_times       The times we schedule the cleanup.
 	 */
 	public function test_check_post_types_public_availability(
 		$is_json_request, $public_post_types, $get_public_post_types_times, $last_known_public_post_types, $set_public_post_types_times, $delete_transient_times, $schedule_cleanup_times

--- a/tests/unit/integrations/watchers/indexable-taxonomy-change-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-taxonomy-change-watcher-test.php
@@ -120,15 +120,17 @@ class Indexable_Taxonomy_Change_Watcher_Test extends TestCase {
 	 * @covers ::check_taxonomy_public_availability
 	 *
 	 * @param bool  $is_json_request              Whether it's a JSON request.
+	 * @param array $get_public_taxonomies        The raw public taxonomies.
 	 * @param array $public_taxonomies            The public taxonomies.
 	 * @param int   $get_public_taxonomies_times  The times we get the public taxonomies.
 	 * @param array $last_known_public_taxonomies The last known public taxonomies.
 	 * @param int   $set_public_taxonomies_times  The times we get the last known public taxonomies.
 	 * @param int   $delete_transient_times       The times we delete the transients.
 	 * @param int   $schedule_cleanup_times       The times we schedule cleanup.
+	 * @param int   $excluded_times               The times we get the excluded taxonomies.
 	 */
 	public function test_check_taxonomy_public_availability(
-		$is_json_request, $public_taxonomies, $get_public_taxonomies_times, $last_known_public_taxonomies, $set_public_taxonomies_times, $delete_transient_times, $schedule_cleanup_times
+		$is_json_request, $get_public_taxonomies, $public_taxonomies, $get_public_taxonomies_times, $last_known_public_taxonomies, $set_public_taxonomies_times, $delete_transient_times, $schedule_cleanup_times, $excluded_times
 	) {
 		Functions\expect( 'wp_is_json_request' )
 			->once()
@@ -137,7 +139,7 @@ class Indexable_Taxonomy_Change_Watcher_Test extends TestCase {
 		$this->taxonomy_helper
 			->expects( 'get_public_taxonomies' )
 			->times( $get_public_taxonomies_times )
-			->andReturn( $public_taxonomies );
+			->andReturn( $get_public_taxonomies );
 
 		$this->options
 			->expects( 'get' )
@@ -145,10 +147,15 @@ class Indexable_Taxonomy_Change_Watcher_Test extends TestCase {
 			->with( 'last_known_public_taxonomies', [] )
 			->andReturn( $last_known_public_taxonomies );
 
+		$this->taxonomy_helper
+			->expects( 'get_excluded_taxonomies_for_indexables' )
+			->times( $excluded_times )
+			->andReturn( [ 'post_format' ] );
+
 		$this->options
 			->expects( 'set' )
 			->times( $set_public_taxonomies_times )
-			->with( 'last_known_public_taxonomies', \array_keys( $public_taxonomies ) );
+			->with( 'last_known_public_taxonomies', $public_taxonomies );
 
 		Functions\expect( 'delete_transient' )
 			->times( $delete_transient_times )
@@ -189,29 +196,45 @@ class Indexable_Taxonomy_Change_Watcher_Test extends TestCase {
 
 		return [
 			'When it is ajax request' => [
-				'is_json_request'                                => true,
-				'public_taxonomies'                              => [ 'irrelevant' ],
-				'get_public_taxonomies_times'                    => 0,
-				'last_known_public_taxonomies'                   => [ 'irrelevant' ],
-				'set_public_taxonomies_times'                    => 0,
-				'delete_transient_times'                         => 0,
-				'schedule_cleanup_times'                         => 0,
+				'is_json_request'              => true,
+				'get_public_taxonomies'        => [ 'irrelevant' => 'irrelevant' ],
+				'public_taxonomies'            => [ 'irrelevant' ],
+				'get_public_taxonomies_times'  => 0,
+				'last_known_public_taxonomies' => [ 'irrelevant' ],
+				'set_public_taxonomies_times'  => 0,
+				'delete_transient_times'       => 0,
+				'schedule_cleanup_times'       => 0,
+				'excluded_times'               => 0,
 			],
 			'When there are no new public taxonomies' => [
 				'is_json_request'              => false,
+				'get_public_taxonomies'        => [],
 				'public_taxonomies'            => [],
 				'get_public_taxonomies_times'  => 1,
 				'last_known_public_taxonomies' => [],
 				'set_public_taxonomies_times'  => 1,
 				'delete_transient_times'       => 0,
 				'schedule_cleanup_times'       => 0,
+				'excluded_times'               => 1,
+			],
+			'When the new public content types was excluded' => [
+				'is_json_request'              => false,
+				'get_public_taxonomies'        => [ 'post_format' => 'post_format' ],
+				'public_taxonomies'            => [],
+				'get_public_taxonomies_times'  => 1,
+				'last_known_public_taxonomies' => [],
+				'set_public_taxonomies_times'  => 1,
+				'delete_transient_times'       => 0,
+				'schedule_cleanup_times'       => 0,
+				'excluded_times'               => 1,
 			],
 			'When the new taxonomies are already saved in cache' => [
 				'is_json_request'              => false,
-				'public_taxonomies'            => [
+				'get_public_taxonomies'        => [
 					'category' => 'category',
 					'post_tag' => 'post_tag',
 				],
+				'public_taxonomies'            => [ 'category', 'post_tag' ],
 				'get_public_taxonomies_times'  => 1,
 				'last_known_public_taxonomies' => [
 					'category' => 'category',
@@ -220,12 +243,17 @@ class Indexable_Taxonomy_Change_Watcher_Test extends TestCase {
 				'set_public_taxonomies_times'  => 0,
 				'delete_transient_times'       => 0,
 				'schedule_cleanup_times'       => 0,
+				'excluded_times'               => 1,
 			],
 			'When new taxonomy is added' => [
 				'is_json_request'              => false,
-				'public_taxonomies'            => [
+				'get_public_taxonomies'        => [
 					'category' => 'category',
 					'post_tag' => 'post_tag',
+				],
+				'public_taxonomies'            => [
+					'category',
+					'post_tag',
 				],
 				'get_public_taxonomies_times'  => 1,
 				'last_known_public_taxonomies' => [
@@ -234,12 +262,14 @@ class Indexable_Taxonomy_Change_Watcher_Test extends TestCase {
 				'set_public_taxonomies_times'  => 1,
 				'delete_transient_times'       => 1,
 				'schedule_cleanup_times'       => 0,
+				'excluded_times'               => 1,
 			],
 			'when taxonomy is removed' => [
 				'is_json_request'              => false,
-				'public_taxonomies'            => [
+				'get_public_taxonomies'        => [
 					'category' => 'category',
 				],
+				'public_taxonomies'            => [ 'category' ],
 				'get_public_taxonomies_times'  => 1,
 				'last_known_public_taxonomies' => [
 					'category' => 'category',
@@ -248,6 +278,7 @@ class Indexable_Taxonomy_Change_Watcher_Test extends TestCase {
 				'set_public_taxonomies_times'  => 1,
 				'delete_transient_times'       => 0,
 				'schedule_cleanup_times'       => 1,
+				'excluded_times'               => 1,
 			],
 		];
 	}

--- a/tests/unit/integrations/watchers/indexable-taxonomy-change-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-taxonomy-change-watcher-test.php
@@ -120,37 +120,30 @@ class Indexable_Taxonomy_Change_Watcher_Test extends TestCase {
 	 * @covers ::check_taxonomy_public_availability
 	 *
 	 * @param bool  $is_json_request              Whether it's a JSON request.
-	 * @param array $get_public_taxonomies        The raw public taxonomies.
 	 * @param array $public_taxonomies            The public taxonomies.
 	 * @param int   $get_public_taxonomies_times  The times we get the public taxonomies.
 	 * @param array $last_known_public_taxonomies The last known public taxonomies.
 	 * @param int   $set_public_taxonomies_times  The times we get the last known public taxonomies.
 	 * @param int   $delete_transient_times       The times we delete the transients.
 	 * @param int   $schedule_cleanup_times       The times we schedule cleanup.
-	 * @param int   $excluded_times               The times we get the excluded taxonomies.
 	 */
 	public function test_check_taxonomy_public_availability(
-		$is_json_request, $get_public_taxonomies, $public_taxonomies, $get_public_taxonomies_times, $last_known_public_taxonomies, $set_public_taxonomies_times, $delete_transient_times, $schedule_cleanup_times, $excluded_times
+		$is_json_request, $public_taxonomies, $get_public_taxonomies_times, $last_known_public_taxonomies, $set_public_taxonomies_times, $delete_transient_times, $schedule_cleanup_times
 	) {
 		Functions\expect( 'wp_is_json_request' )
 			->once()
 			->andReturn( $is_json_request );
 
 		$this->taxonomy_helper
-			->expects( 'get_public_taxonomies' )
+			->expects( 'get_indexable_taxonomies' )
 			->times( $get_public_taxonomies_times )
-			->andReturn( $get_public_taxonomies );
+			->andReturn( $public_taxonomies );
 
 		$this->options
 			->expects( 'get' )
 			->times( $get_public_taxonomies_times )
 			->with( 'last_known_public_taxonomies', [] )
 			->andReturn( $last_known_public_taxonomies );
-
-		$this->taxonomy_helper
-			->expects( 'get_excluded_taxonomies_for_indexables' )
-			->times( $excluded_times )
-			->andReturn( [ 'post_format' ] );
 
 		$this->options
 			->expects( 'set' )
@@ -197,43 +190,24 @@ class Indexable_Taxonomy_Change_Watcher_Test extends TestCase {
 		return [
 			'When it is ajax request' => [
 				'is_json_request'              => true,
-				'get_public_taxonomies'        => [ 'irrelevant' => 'irrelevant' ],
 				'public_taxonomies'            => [ 'irrelevant' ],
 				'get_public_taxonomies_times'  => 0,
 				'last_known_public_taxonomies' => [ 'irrelevant' ],
 				'set_public_taxonomies_times'  => 0,
 				'delete_transient_times'       => 0,
 				'schedule_cleanup_times'       => 0,
-				'excluded_times'               => 0,
 			],
 			'When there are no new public taxonomies' => [
 				'is_json_request'              => false,
-				'get_public_taxonomies'        => [],
 				'public_taxonomies'            => [],
 				'get_public_taxonomies_times'  => 1,
 				'last_known_public_taxonomies' => [],
 				'set_public_taxonomies_times'  => 1,
 				'delete_transient_times'       => 0,
 				'schedule_cleanup_times'       => 0,
-				'excluded_times'               => 1,
-			],
-			'When the new public content types was excluded' => [
-				'is_json_request'              => false,
-				'get_public_taxonomies'        => [ 'post_format' => 'post_format' ],
-				'public_taxonomies'            => [],
-				'get_public_taxonomies_times'  => 1,
-				'last_known_public_taxonomies' => [],
-				'set_public_taxonomies_times'  => 1,
-				'delete_transient_times'       => 0,
-				'schedule_cleanup_times'       => 0,
-				'excluded_times'               => 1,
 			],
 			'When the new taxonomies are already saved in cache' => [
 				'is_json_request'              => false,
-				'get_public_taxonomies'        => [
-					'category' => 'category',
-					'post_tag' => 'post_tag',
-				],
 				'public_taxonomies'            => [ 'category', 'post_tag' ],
 				'get_public_taxonomies_times'  => 1,
 				'last_known_public_taxonomies' => [
@@ -243,14 +217,9 @@ class Indexable_Taxonomy_Change_Watcher_Test extends TestCase {
 				'set_public_taxonomies_times'  => 0,
 				'delete_transient_times'       => 0,
 				'schedule_cleanup_times'       => 0,
-				'excluded_times'               => 1,
 			],
 			'When new taxonomy is added' => [
 				'is_json_request'              => false,
-				'get_public_taxonomies'        => [
-					'category' => 'category',
-					'post_tag' => 'post_tag',
-				],
 				'public_taxonomies'            => [
 					'category',
 					'post_tag',
@@ -262,13 +231,9 @@ class Indexable_Taxonomy_Change_Watcher_Test extends TestCase {
 				'set_public_taxonomies_times'  => 1,
 				'delete_transient_times'       => 1,
 				'schedule_cleanup_times'       => 0,
-				'excluded_times'               => 1,
 			],
 			'when taxonomy is removed' => [
 				'is_json_request'              => false,
-				'get_public_taxonomies'        => [
-					'category' => 'category',
-				],
 				'public_taxonomies'            => [ 'category' ],
 				'get_public_taxonomies_times'  => 1,
 				'last_known_public_taxonomies' => [
@@ -278,7 +243,6 @@ class Indexable_Taxonomy_Change_Watcher_Test extends TestCase {
 				'set_public_taxonomies_times'  => 1,
 				'delete_transient_times'       => 0,
 				'schedule_cleanup_times'       => 1,
-				'excluded_times'               => 1,
 			],
 		];
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to exclude some post types and taxonomies in the indexable watchers.
* Improve the `maybe_dismiss_notification` method to reduce DB queries.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where notification for new content type in the notification center would not be dismissed when installing elementor and reviewing the new content types.

## Relevant technical choices:

* No need for upgrade routine since the watcher is hooked to `admin_init`.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install and activate Elementor.
* Check a for notification for new content type appears in the notification center
* Click on the link of that notification to review the new content.
* You will be redirected to the `Yoast SEO`->`Settings` page
* Check for a notification in the bottom of the screen for new content type
* Check for a badge of the `Landing pages` content type.
* Click on that content type
* Check the badge disappear 
* Go to the notification center and check there are no notification for new content type.

Without this PR:
* Deactivate Elementor
* Activate it again
* Check you see the notification in the notification center
* Review the new content type in the settings, and the badge will disappear
* Go back to the notification center and check the notification for new content type is still there even though there are no new badges in the settings.
With this PR: 
* Check the notification for new content type is gone from the notification center

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [X] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [X] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #20505 
