### PR TITLE
Update cleanup to be allow multisites.

### DIFF
--- a/src/analytics/application/to-be-cleaned-indexables-collector.php
+++ b/src/analytics/application/to-be-cleaned-indexables-collector.php
@@ -43,7 +43,7 @@ class To_Be_Cleaned_Indexables_Collector implements WPSEO_Collection {
 			'indexables_for_non_publicly_viewable_post_type_archive_pages' => $this->indexable_cleanup_repository->count_indexables_for_non_publicly_post_type_archive_pages(),
 			'indexables_for_authors_archive_disabled'           => $this->indexable_cleanup_repository->count_indexables_for_authors_archive_disabled(),
 			'indexables_for_authors_without_archive'            => $this->indexable_cleanup_repository->count_indexables_for_authors_without_archive(),
-			'indexables_for_object_type_and_source_table_users' => $this->indexable_cleanup_repository->count_indexables_for_object_type_and_source_table( 'users', 'ID', 'user' ),
+			'indexables_for_object_type_and_source_table_users' => $this->indexable_cleanup_repository->count_indexables_for_orphaned_users(),
 			'indexables_for_object_type_and_source_table_posts' => $this->indexable_cleanup_repository->count_indexables_for_object_type_and_source_table( 'posts', 'ID', 'post' ),
 			'indexables_for_object_type_and_source_table_terms' => $this->indexable_cleanup_repository->count_indexables_for_object_type_and_source_table( 'terms', 'term_id', 'term' ),
 			'orphaned_from_table_indexable_hierarchy'           => $this->indexable_cleanup_repository->count_orphaned_from_table( 'Indexable_Hierarchy', 'indexable_id' ),

--- a/src/integrations/cleanup-integration.php
+++ b/src/integrations/cleanup-integration.php
@@ -125,7 +125,7 @@ class Cleanup_Integration implements Integration_Interface {
 					return $this->cleanup_repository->update_indexables_author_to_reassigned( $limit );
 				},
 				'clean_orphaned_user_indexables_without_wp_user' => function ( $limit ) {
-					return $this->cleanup_repository->clean_indexables_for_object_type_and_source_table( 'users', 'ID', 'user', $limit );
+					return $this->cleanup_repository->clean_indexables_for_orphaned_users( $limit );
 				},
 				'clean_orphaned_user_indexables_without_wp_post' => function ( $limit ) {
 					return $this->cleanup_repository->clean_indexables_for_object_type_and_source_table( 'posts', 'ID', 'post', $limit );

--- a/tests/unit/analytics/application/to-be-cleaned-indexables-collector-test.php
+++ b/tests/unit/analytics/application/to-be-cleaned-indexables-collector-test.php
@@ -51,8 +51,10 @@ class To_Be_Cleaned_Indexables_Collector_Test extends TestCase {
 		$indexable_cleanup_repository_mock->shouldReceive( 'count_indexables_for_authors_without_archive' )
 				->once()
 					->andReturn( 0 );
+		$indexable_cleanup_repository_mock->shouldReceive( 'count_indexables_for_orphaned_users' )
+			->andReturn( 0 );
 		$indexable_cleanup_repository_mock->shouldReceive( 'count_indexables_for_object_type_and_source_table' )
-				->times( 3 )
+				->times( 2 )
 					->andReturn( 0 );
 		$indexable_cleanup_repository_mock->shouldReceive( 'count_orphaned_from_table' )
 				->times( 3 )

--- a/tests/unit/integrations/cleanup-integration-test.php
+++ b/tests/unit/integrations/cleanup-integration-test.php
@@ -57,7 +57,8 @@ class Cleanup_Integration_Test extends TestCase {
 		$wpdb         = Mockery::mock( wpdb::class );
 		$wpdb->prefix = 'wp_';
 
-		$this->wpdb = $wpdb;
+		$this->wpdb        = $wpdb;
+		$this->wpdb->users = 'users';
 	}
 
 	/**
@@ -111,7 +112,8 @@ class Cleanup_Integration_Test extends TestCase {
 		$this->indexable_repository->shouldReceive( 'clean_indexables_for_authors_archive_disabled' )->once();
 		$this->indexable_repository->shouldReceive( 'clean_indexables_for_authors_without_archive' )->once();
 		$this->indexable_repository->shouldReceive( 'update_indexables_author_to_reassigned' )->once();
-		$this->indexable_repository->shouldReceive( 'clean_indexables_for_object_type_and_source_table' )->times( 3 );
+		$this->indexable_repository->shouldReceive( 'clean_indexables_for_orphaned_users' )->once();
+		$this->indexable_repository->shouldReceive( 'clean_indexables_for_object_type_and_source_table' )->times( 2 );
 		$this->indexable_repository->shouldReceive( 'cleanup_orphaned_from_table' )->times( 3 );
 
 		$this->instance->run_cleanup();


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want our cleanup routine to work also on multisites.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the cleanup routine would throw an error when on multisites.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

To test if the count query still shows the right amount do the following:

Before testing, install WP control plugin.

* Start up a multisite.
* Do the following in one of the subsites.
* Go to `Yoast SEO`->`Settings`->`Advanced`->`Author archives` and make sure Author archives are enabled.
* Create a new author user, and assign the author to a post. 
* Visit the post to make sure there is a indexable made with object_type `user`
* Go to `My sites`->`Network Admin`->`Users` and remove that author user.
* Add the following code to `/wordpress-seo/admin/class-admin.php` at the end of the constructor at around line 118.
* Notice the closing `}` after the admin init this is to close out the constructor.
```
		add_action( 'admin_init', [ $this, 'send' ], 1 );
	}

	public function send() {
		if ( filter_input( INPUT_GET, 'action' ) === 'test' ) {
			$collector = new WPSEO_Collector();

			$collector->add_collection(
				YoastSEO()->classes->get( To_Be_Cleaned_Indexables_Collector::class )
			);
			echo '<pre>';
			print_r( $collector->collect() );
			echo '</pre>';
			die;
		}
	}

```
And add the following use statement at the top of file with the other use statements.
```
use Yoast\WP\SEO\Analytics\Application\To_Be_Cleaned_Indexables_Collector;
```

*Go to {yoursubtsite}/wp-admin/admin.php?page=wpseo_dashboard&action=test

* Make sure the following entry has at least 1 in the count.
``` 
 [7] => Array
                (
                    [cleanup_name] => indexables_for_object_type_and_source_table_users
                    [count] => 1
                )
```

* Go to `Tools`->`Cron events` and look for `wpseo_start_cleanup_indexables`, hover it and click `Run now`.
* Go back to ` {yoursubtsite}/wp-admin/admin.php?page=wpseo_dashboard&action=test` and check the count for `indexables_for_object_type_and_source_table_users` again and make sure it is now 0.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [X] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:


## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [X] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.
* [X] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
