### PR TITLE
Add a target="_blank" parameter to the 'See who contributed to' link

### DIFF
--- a/admin/views/tabs/dashboard/dashboard.php
+++ b/admin/views/tabs/dashboard/dashboard.php
@@ -39,6 +39,6 @@ $wpseo_contributors_phrase = sprintf(
 <div class="tab-block">
 	<h2><?php esc_html_e( 'Credits', 'wordpress-seo' ); ?></h2>
 	<p>
-		<a href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/yoast-seo-credits' ); ?>"><?php echo esc_html( $wpseo_contributors_phrase ); ?></a>
+		<a href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/yoast-seo-credits' ); ?>" target="_blank"><?php echo esc_html( $wpseo_contributors_phrase ); ?></a>
 	</p>
 </div>


### PR DESCRIPTION
## Context
Applies a fix for the currently open issue [On the Yoast SEO Dashboard, "See who contributed to Yoast SEO" link opens in the same browser tab #20483](https://github.com/Yoast/wordpress-seo/issues/20483).

## Summary

This PR can be summarized in the following changelog entry:

* Adds an attribute to the link "See who contributed to" to open in a new browser tab, located in the General tab.

## Relevant technical choices:

* N/A

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install and activate Yoast SEO
* Go to Yoast SEO > General > Dashboard page
* Click on "See who contributed to Yoast SEO" link
* The [link](https://yoast.com/about-us/team/) should open within a new browser tab

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [x] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

## Impact check

This PR affects the following parts of the plugin, which may require extra testing:

* N/A

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #20483 
