### PR TITLE
Adds defensive coding in the admin columns cache integration.

### DIFF
--- a/src/integrations/admin/admin-columns-cache-integration.php
+++ b/src/integrations/admin/admin-columns-cache-integration.php
@@ -109,7 +109,7 @@ class Admin_Columns_Cache_Integration implements Integration_Interface {
 		$indexables = $this->indexable_repository->find_by_multiple_ids_and_type( $post_ids, 'post', false );
 
 		foreach ( $indexables as $indexable ) {
-			if ( $indexable !== false ) {
+			if ( $indexable instanceof Indexable ) {
 				$this->indexable_cache[ $indexable->object_id ] = $indexable;
 			}
 		}

--- a/src/integrations/admin/admin-columns-cache-integration.php
+++ b/src/integrations/admin/admin-columns-cache-integration.php
@@ -109,7 +109,9 @@ class Admin_Columns_Cache_Integration implements Integration_Interface {
 		$indexables = $this->indexable_repository->find_by_multiple_ids_and_type( $post_ids, 'post', false );
 
 		foreach ( $indexables as $indexable ) {
-			$this->indexable_cache[ $indexable->object_id ] = $indexable;
+			if ( $indexable !== false ) {
+				$this->indexable_cache[ $indexable->object_id ] = $indexable;
+			}
 		}
 	}
 

--- a/tests/unit/integrations/admin/admin-columns-cache-integration-test.php
+++ b/tests/unit/integrations/admin/admin-columns-cache-integration-test.php
@@ -7,6 +7,7 @@ use Mockery;
 use WP_Post;
 use WP_Query;
 use Yoast\WP\SEO\Integrations\Admin\Admin_Columns_Cache_Integration;
+use Yoast\WP\SEO\Models\Indexable;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
@@ -94,6 +95,40 @@ class Admin_Columns_Cache_Integration_Test extends TestCase {
 		$results = [ (object) [ 'object_id' => 1 ] ];
 
 		$this->indexable_repository->expects( 'find_by_multiple_ids_and_type' )->once()->with( [ 1 ], 'post', false )->andReturn( $results );
+
+		$this->instance->fill_cache();
+	}
+
+	/**
+	 * Tests the fill_cache function.
+	 *
+	 * @covers ::__construct
+	 * @covers ::fill_cache
+	 */
+	public function test_fill_cache_with_broken_indexable() {
+		global $wp_query;
+
+		$posts = [ Mockery::mock( WP_Post::class ) ];
+
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$wp_query        = Mockery::mock( WP_Query::class );
+		$wp_query->posts = $posts;
+
+		Functions\expect( 'wp_list_pluck' )
+			->once()
+			->with( $posts, 'ID' )
+			->andReturn( [ 1, 2, 3, 4 ] );
+
+		$results = [
+			(object) [
+				'object_id' => 1,
+				false,
+				false,
+				'object_id' => 2,
+			],
+		];
+
+		$this->indexable_repository->expects( 'find_by_multiple_ids_and_type' )->once()->with( [ 1, 2, 3, 4 ], 'post', false )->andReturn( $results );
 
 		$this->instance->fill_cache();
 	}

--- a/tests/unit/integrations/admin/admin-columns-cache-integration-test.php
+++ b/tests/unit/integrations/admin/admin-columns-cache-integration-test.php
@@ -7,7 +7,7 @@ use Mockery;
 use WP_Post;
 use WP_Query;
 use Yoast\WP\SEO\Integrations\Admin\Admin_Columns_Cache_Integration;
-use Yoast\WP\SEO\Models\Indexable;
+use Yoast\WP\SEO\Tests\Unit\Doubles\Models\Indexable_Mock;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
@@ -65,7 +65,9 @@ class Admin_Columns_Cache_Integration_Test extends TestCase {
 			->with( $posts, 'ID' )
 			->andReturn( [ 1 ] );
 
-		$results = [ (object) [ 'object_id' => 1 ] ];
+		$indexable            = new Indexable_Mock();
+		$indexable->object_id = 1;
+		$results              = [ $indexable ];
 
 		$this->indexable_repository->expects( 'find_by_multiple_ids_and_type' )->once()->with( [ 1 ], 'post', false )->andReturn( $results );
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to add some defensive coding in our admin columns cache integration.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where an error could occur when an indexable was outdated. Props to @jaimearroyonavia.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Make sure you have ACF, Query monitor and a free version that is not this PR/RC
* Add the following filter to your functions.php
```
add_filter( "wpseo_indexable_forced_included_post_types", function($data) {
	$data[] = 'acf-field-group';

	return $data;
} );
```
* Create a new ACF field group on /wp-admin/edit.php?post_type=acf-field-group
* After saving remove the filter and run the following query:
`Update wp_yoast_indexable set version=1 where object_sub_type='acf-field-group';
* Go to /wp-admin/edit.php?post_type=acf-field-group and make sure you have a warning in query monitor.
* Checkout this branch/RC and make sure the warning is gone.


#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [X] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.
* [X] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
