### PR TITLE
239 update the copy of existing ads so that it mentions ai

### DIFF
--- a/admin/class-premium-upsell-admin-block.php
+++ b/admin/class-premium-upsell-admin-block.php
@@ -51,10 +51,12 @@ class WPSEO_Premium_Upsell_Admin_Block {
 		$url = WPSEO_Shortlinker::get( 'https://yoa.st/17h' );
 
 		$arguments = [
-			'<strong>' . esc_html__( 'Multiple keyphrases', 'wordpress-seo' ) . '</strong>: ' . esc_html__( 'Increase your SEO reach', 'wordpress-seo' ),
+			'<strong>' . esc_html__( 'Use AI', 'wordpress-seo' ) . '</strong>: ' . esc_html__( 'Quickly create titles & meta descriptions', 'wordpress-seo' ),
 			'<strong>' . esc_html__( 'No more dead links', 'wordpress-seo' ) . '</strong>: ' . esc_html__( 'Easy redirect manager', 'wordpress-seo' ),
 			'<strong>' . esc_html__( 'Superfast internal linking suggestions', 'wordpress-seo' ) . '</strong>',
 			'<strong>' . esc_html__( 'Social media preview', 'wordpress-seo' ) . '</strong>: ' . esc_html__( 'Facebook & Twitter', 'wordpress-seo' ),
+			'<strong>' . esc_html__( 'Multiple keyphrases', 'wordpress-seo' ) . '</strong>: ' . esc_html__( 'Increase your SEO reach', 'wordpress-seo' ),
+			'<strong>' . esc_html__( 'SEO Workouts', 'wordpress-seo' ) . '</strong>: ' . esc_html__( 'Get guided in routine SEO tasks', 'wordpress-seo' ),
 			'<strong>' . esc_html__( '24/7 email support', 'wordpress-seo' ) . '</strong>',
 			'<strong>' . esc_html__( 'No ads!', 'wordpress-seo' ) . '</strong>',
 		];

--- a/admin/views/licenses.php
+++ b/admin/views/licenses.php
@@ -151,6 +151,10 @@ $new_tab_message         = sprintf(
 				?>
 				<ul class="yoast-seo-premium-benefits yoast-list--usp">
 					<li class="yoast-seo-premium-benefits__item">
+						<span class="yoast-seo-premium-benefits__title"><?php esc_html_e( 'Be more efficient in creating content', 'wordpress-seo' ); ?></span>
+						<span class="yoast-seo-premium-benefits__description"><?php esc_html_e( 'Use AI to create high-quality titles and meta descriptions for posts and pages', 'wordpress-seo' ); ?></span>
+					</li>
+					<li class="yoast-seo-premium-benefits__item">
 						<span class="yoast-seo-premium-benefits__title"><?php esc_html_e( 'Reach bigger audiences', 'wordpress-seo' ); ?></span>
 						<span class="yoast-seo-premium-benefits__description"><?php esc_html_e( 'Optimize a single post for synonyms and related keyphrases and get extra checks with the Premium SEO analysis', 'wordpress-seo' ); ?></span>
 					</li>

--- a/packages/js/src/components/modals/KeywordSynonyms.js
+++ b/packages/js/src/components/modals/KeywordSynonyms.js
@@ -27,6 +27,12 @@ const KeywordSynonyms = ( props ) => {
 	} );
 
 	const benefits = [
+		sprintf(
+			/* translators: %1$s expands to a 'strong' start tag, %2$s to a 'strong' end tag. */
+			__( "%1$sCreate content faster%2$s: Use AI to create titles & meta descriptions", "wordpress-seo" ),
+			"<strong>",
+			"</strong>"
+		),
 		`<strong>${ __( "Rank better with synonyms & related keyphrases", "wordpress-seo" ) }</strong>`,
 		sprintf(
 			/* translators: %1$s expands to a 'strong' start tag, %2$s to a 'strong' end tag. */

--- a/packages/js/src/components/modals/MultipleKeywords.js
+++ b/packages/js/src/components/modals/MultipleKeywords.js
@@ -25,6 +25,12 @@ const MultipleKeywords = ( props ) => {
 	const benefits = [
 		sprintf(
 			/* translators: %1$s expands to a 'strong' start tag, %2$s to a 'strong' end tag. */
+			__( "%1$sCreate content faster%2$s: Use AI to create titles & meta descriptions", "wordpress-seo" ),
+			"<strong>",
+			"</strong>"
+		),
+		sprintf(
+			/* translators: %1$s expands to a 'strong' start tag, %2$s to a 'strong' end tag. */
 			__( "%1$sNo more dead links%2$s: easy redirect manager", "wordpress-seo" ),
 			"<strong>",
 			"</strong>"

--- a/packages/js/src/components/modals/PremiumSEOAnalysisUpsell.js
+++ b/packages/js/src/components/modals/PremiumSEOAnalysisUpsell.js
@@ -17,6 +17,7 @@ const PremiumSEOAnalysisUpsell = ( props ) => {
 	const intro = __( "Get extra, smarter recommendations about your site’s structure, content, and SEO opportunities.", "wordpress-seo" );
 
 	const benefits = [
+		__( "Use AI to create titles & meta descriptions", "wordpress-seo" ),
 		__( "Target multiple focus keyphrases", "wordpress-seo" ),
 		__( "Use synonyms, plurals, and variations", "wordpress-seo" ),
 		__( "Unlock expert workouts and workflows", "wordpress-seo" ),

--- a/packages/js/src/settings/app.js
+++ b/packages/js/src/settings/app.js
@@ -174,9 +174,9 @@ const PremiumUpsellList = () => {
 			</Title>
 			<ul className="yst-grid yst-grid-cols-1 sm:yst-grid-cols-2 yst-gap-x-6 yst-list-disc yst-pl-[1em] yst-list-outside yst-text-slate-800 yst-mt-6">
 				<li>
-					<span className="yst-font-semibold">{ __( "Multiple keyphrases", "wordpress-seo" ) }</span>
+					<span className="yst-font-semibold">{ __( "Use AI", "wordpress-seo" ) }</span>
 					:&nbsp;
-					{ __( "Increase your SEO reach", "wordpress-seo" ) }
+					{ __( "Quickly create titles & meta descriptions", "wordpress-seo" ) }
 				</li>
 				<li>
 					<span className="yst-font-semibold">{ __( "No more dead links", "wordpress-seo" ) }</span>
@@ -188,6 +188,16 @@ const PremiumUpsellList = () => {
 					<span className="yst-font-semibold">{ __( "Social media preview", "wordpress-seo" ) }</span>
 					:&nbsp;
 					{ __( "Facebook & Twitter", "wordpress-seo" ) }
+				</li>
+				<li>
+					<span className="yst-font-semibold">{ __( "Multiple keyphrases", "wordpress-seo" ) }</span>
+					:&nbsp;
+					{ __( "Increase your SEO reach", "wordpress-seo" ) }
+				</li>
+				<li>
+					<span className="yst-font-semibold">{ __( "SEO Workouts", "wordpress-seo" ) }</span>
+					:&nbsp;
+					{ __( "Get guided in routine SEO tasks", "wordpress-seo" ) }
 				</li>
 				<li><span className="yst-font-semibold">{ __( "24/7 email support", "wordpress-seo" ) }</span></li>
 				<li><span className="yst-font-semibold">{ __( "No ads!", "wordpress-seo" ) }</span></li>

--- a/packages/js/src/shared-admin/components/premium-upsell-card.js
+++ b/packages/js/src/shared-admin/components/premium-upsell-card.js
@@ -18,7 +18,7 @@ export const PremiumUpsellCard = ( { link, linkProps } ) => {
 	const info = useMemo( () => createInterpolateElement(
 		sprintf(
 			/* translators: %1$s and %2$s expand to opening and closing <strong> tags. */
-			__( "Be the first to get %1$snew features & tools%2$s, before everyone else. Get %1$s24/7 support%2$s and boost your website’s visibility.", "wordpress-seo" ),
+			__( "Be more efficient in creating titles and meta descriptions with the help of AI. %1$sGet 24/7 support%2$s and boost your website’s visibility.", "wordpress-seo" ),
 			"<strong>",
 			"</strong>"
 		),

--- a/src/presenters/admin/sidebar-presenter.php
+++ b/src/presenters/admin/sidebar-presenter.php
@@ -51,7 +51,7 @@ class Sidebar_Presenter extends Abstract_Presenter {
 						<p>
 							<?php
 							/* translators: %1$s expands to an opening strong tag, %2$s expands to a closing strong tag */
-							\printf( \esc_html__( 'Be the first to get %1$snew features & tools%2$s, before everyone else. Get %1$s 24/7 support%2$s and boost your website’s visibility.', 'wordpress-seo' ), '<strong>', '</strong>' );
+							\printf( \esc_html__( 'Be more efficient in creating titles and meta descriptions with the help of AI. %1$sGet 24/7 support%2$s and boost your website’s visibility.', 'wordpress-seo' ), '<strong>', '</strong>' );
 							?>
 						</p>
 						<p class="plugin-buy-button">


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Update copy for premium ads to promote AI feature.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Updates premium ads copy to promote AI feature.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install Yoast SEO free plugin and disable Yoast premium or do not install premium.
* Go to `Yoast SEO`->`General`
* Check the ad in the bottom of the page and sidebar have the same copy and design as:
  * Sidebar (copy changed): 
  `Be more efficient in creating titles and meta descriptions with the help of AI. Get 24/7 support and boost your website’s visibility.`
  * Footer ( copy added): 
  `Use AI: Quickly create titles & meta descriptions`

<img width="1510" alt="Screenshot 2023-08-02 at 13 51 12" src="https://github.com/Yoast/wordpress-seo/assets/65466507/a8bf7e6d-7375-4c3f-afa8-8bd631951c0a">

* Go to `Yoast SEO`->`Settings` and check the same as above.
* Go to `Yoast SEO`->`Support` and check sidebar has changed the same as above.
* Go to `Yoast SEO`->`Premium` and check copy was added:
  * `Be more efficient in creating content Use AI to create high-quality titles and meta descriptions for posts and pages`
<img width="1263" alt="Screenshot 2023-08-02 at 13 58 33" src="https://github.com/Yoast/wordpress-seo/assets/65466507/e707515f-ff3f-4081-acf7-0ef84e6a6022">

* Edit a post or a page in block editor and go to `Yoast` tab.
* Click on `Premium SEO analysis` and check copy was added:
   * `Use AI to create titles & meta descriptions`
  <img width="481" alt="Screenshot 2023-08-01 at 10 14 26" src="https://github.com/Yoast/roadmap/assets/83759531/2e11f401-3f85-464a-9a6c-fd34f88a56d5">
* Click on `Add related keyphrase` and check copy was added:
   * `Create content faster: Use AI to create titles & meta descriptions`
   <img width="200" alt="Screenshot 2023-08-01 at 10 16 21" src="https://github.com/Yoast/roadmap/assets/83759531/c7045f9e-8897-4b87-a97e-37104e7bd4b1"> 
* Click on `SEO analysis`->`+ Add synonyms` and check copy was added to the modal:
  * `Create content faster: Use AI to create titles & meta descriptions`
* Click on `SEO analysis`->`+ Add related keyphrase` and check the same copy was added to the modal.
  <img width="729" alt="Screenshot 2023-08-02 at 14 13 37" src="https://github.com/Yoast/wordpress-seo/assets/65466507/9f8b3cc6-62db-4d3c-800e-9a58e9094ee2"> 

* Repeat those check for the metabox when using classic editor.
* Repeat those check when editing a post in elementor.

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [X] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [X] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.
* [X] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/roadmap/issues/239
