### PR TITLE
Deleting tags has prompt showing "posts" instead of "tags"#20575

### DIFF
--- a/admin/watchers/class-slug-change-watcher.php
+++ b/admin/watchers/class-slug-change-watcher.php
@@ -65,7 +65,7 @@ class WPSEO_Slug_Change_Watcher implements WPSEO_WordPress_Integration {
 
 		/* translators: %1$s expands to the translated name of the post type. */
 		$first_sentence = sprintf( __( 'You just trashed a %1$s.', 'wordpress-seo' ), $post_type );
-		$message        = $this->get_message( $first_sentence, 'trashed',  $post_type );
+		$message        = $this->get_message( $first_sentence, 'trashed', $post_type );
 
 		$this->add_notification( $message );
 	}
@@ -85,7 +85,7 @@ class WPSEO_Slug_Change_Watcher implements WPSEO_WordPress_Integration {
 		$post_type = $this->get_post_type_label( get_post_type( $post_id ) );
 
 		/* translators: %1$s expands to the translated name of the post type. */
-		$first_sentence = sprintf( __( 'You just deleted a %1$s.', 'wordpress-seo' ),  $post_type );
+		$first_sentence = sprintf( __( 'You just deleted a %1$s.', 'wordpress-seo' ), $post_type );
 		$message        = $this->get_message( $first_sentence, 'deleted', $post_type );
 
 		$this->add_notification( $message );
@@ -103,7 +103,7 @@ class WPSEO_Slug_Change_Watcher implements WPSEO_WordPress_Integration {
 			return;
 		}
 
-		$term = \get_term_by( 'term_taxonomy_id', (int) $term_taxonomy_id );
+		$term       = \get_term_by( 'term_taxonomy_id', (int) $term_taxonomy_id );
 		$term_label = $this->get_taxonomy_label_for_term( $term->term_id );
 
 		$first_sentence = sprintf(

--- a/admin/watchers/class-slug-change-watcher.php
+++ b/admin/watchers/class-slug-change-watcher.php
@@ -50,7 +50,7 @@ class WPSEO_Slug_Change_Watcher implements WPSEO_WordPress_Integration {
 	}
 
 	/**
-	 * Shows an message when a post is about to get trashed.
+	 * Shows a message when a post is about to get trashed.
 	 *
 	 * @param int $post_id The current post ID.
 	 *
@@ -61,17 +61,17 @@ class WPSEO_Slug_Change_Watcher implements WPSEO_WordPress_Integration {
 			return;
 		}
 
-		$post_type = $this->get_post_type_label( get_post_type( $post_id ) );
+		$post_label = $this->get_post_type_label( get_post_type( $post_id ) );
 
 		/* translators: %1$s expands to the translated name of the post type. */
-		$first_sentence = sprintf( __( 'You just trashed a %1$s.', 'wordpress-seo' ), $post_type );
-		$message        = $this->get_message( $first_sentence, 'trashed', $post_type );
+		$first_sentence = sprintf( __( 'You just trashed a %1$s.', 'wordpress-seo' ), $post_label );
+		$message        = $this->get_message( $first_sentence, 'trashed', $post_label );
 
 		$this->add_notification( $message );
 	}
 
 	/**
-	 * Shows an message when a post is about to get trashed.
+	 * Shows a message when a post is about to get trashed.
 	 *
 	 * @param int $post_id The current post ID.
 	 *
@@ -82,11 +82,11 @@ class WPSEO_Slug_Change_Watcher implements WPSEO_WordPress_Integration {
 			return;
 		}
 
-		$post_type = $this->get_post_type_label( get_post_type( $post_id ) );
+		$post_label = $this->get_post_type_label( get_post_type( $post_id ) );
 
 		/* translators: %1$s expands to the translated name of the post type. */
-		$first_sentence = sprintf( __( 'You just deleted a %1$s.', 'wordpress-seo' ), $post_type );
-		$message        = $this->get_message( $first_sentence, 'deleted', $post_type );
+		$first_sentence = sprintf( __( 'You just deleted a %1$s.', 'wordpress-seo' ), $post_label );
+		$message        = $this->get_message( $first_sentence, 'deleted', $post_label );
 
 		$this->add_notification( $message );
 	}
@@ -106,13 +106,9 @@ class WPSEO_Slug_Change_Watcher implements WPSEO_WordPress_Integration {
 		$term       = \get_term_by( 'term_taxonomy_id', (int) $term_taxonomy_id );
 		$term_label = $this->get_taxonomy_label_for_term( $term->term_id );
 
-		$first_sentence = sprintf(
-			/* translators: 1: term label */
-			__( 'You just deleted a %1$s.', 'wordpress-seo' ),
-			$term_label
-		);
-
-		$message = $this->get_message( $first_sentence, 'deleted', $term_label );
+		/* translators: %1$s expands to the translated name of the term. */
+		$first_sentence = sprintf( __( 'You just deleted a %1$s.', 'wordpress-seo' ), $term_label );
+		$message        = $this->get_message( $first_sentence, 'deleted', $term_label );
 
 		$this->add_notification( $message );
 	}
@@ -214,16 +210,16 @@ class WPSEO_Slug_Change_Watcher implements WPSEO_WordPress_Integration {
 	 *
 	 * @param string $first_sentence The first sentence of the notification.
 	 * @param string $action The action performed, either "deleted" or "trashed".
-	 * @param string $object_type The label of the object that was deleted or trashed.
+	 * @param string $object_label The label of the object that was deleted or trashed.
 	 *
 	 * @return string The full notification.
 	 */
-	protected function get_message( $first_sentence, $action, $object_type ) {
+	protected function get_message( $first_sentence, $action, $object_label ) {
 		return '<h2>' . __( 'Make sure you don\'t miss out on traffic!', 'wordpress-seo' ) . '</h2>'
 			. '<p>'
 			. $first_sentence
 			/* translators: %1$s expands to either "deleted" or "trashed". %2$s expands to the name of the post or term. */
-			. ' ' . sprintf( __( 'Search engines and other websites can still send traffic to your %1$s %2$s.', 'wordpress-seo' ), $action, $object_type )
+			. ' ' . sprintf( __( 'Search engines and other websites can still send traffic to your %1$s %2$s.', 'wordpress-seo' ), $action, $object_label )
 			. ' ' . __( 'You should create a redirect to ensure your visitors do not get a 404 error when they click on the no longer working URL.', 'wordpress-seo' )
 			/* translators: %s expands to Yoast SEO Premium */
 			. ' ' . sprintf( __( 'With %s, you can easily create such redirects.', 'wordpress-seo' ), 'Yoast SEO Premium' )

--- a/admin/watchers/class-slug-change-watcher.php
+++ b/admin/watchers/class-slug-change-watcher.php
@@ -222,7 +222,7 @@ class WPSEO_Slug_Change_Watcher implements WPSEO_WordPress_Integration {
 		return '<h2>' . __( 'Make sure you don\'t miss out on traffic!', 'wordpress-seo' ) . '</h2>'
 			. '<p>'
 			. $first_sentence
-			/* translators: %1$s expands to the translated name of action. %1$s expand to translated name of object type */
+			/* translators: %1$s expands to either "deleted" or "trashed". %2$s expands to the name of the post or term. */
 			. ' ' . sprintf( __( 'Search engines and other websites can still send traffic to your %1$s %2$s.', 'wordpress-seo' ), $action, $object_type )
 			. ' ' . __( 'You should create a redirect to ensure your visitors do not get a 404 error when they click on the no longer working URL.', 'wordpress-seo' )
 			/* translators: %s expands to Yoast SEO Premium */

--- a/admin/watchers/class-slug-change-watcher.php
+++ b/admin/watchers/class-slug-change-watcher.php
@@ -213,8 +213,8 @@ class WPSEO_Slug_Change_Watcher implements WPSEO_WordPress_Integration {
 	 * Returns the message around changed URLs.
 	 *
 	 * @param string $first_sentence The first sentence of the notification.
-	 * @param string $action The action done.
-	 * @param string $object_type The object type action done for.
+	 * @param string $action The action performed, either "deleted" or "trashed".
+	 * @param string $object_type The label of the object that was deleted or trashed.
 	 *
 	 * @return string The full notification.
 	 */

--- a/admin/watchers/class-slug-change-watcher.php
+++ b/admin/watchers/class-slug-change-watcher.php
@@ -61,9 +61,11 @@ class WPSEO_Slug_Change_Watcher implements WPSEO_WordPress_Integration {
 			return;
 		}
 
+		$post_type = $this->get_post_type_label( get_post_type( $post_id ) );
+
 		/* translators: %1$s expands to the translated name of the post type. */
-		$first_sentence = sprintf( __( 'You just trashed a %1$s.', 'wordpress-seo' ), $this->get_post_type_label( get_post_type( $post_id ) ) );
-		$message        = $this->get_message( $first_sentence );
+		$first_sentence = sprintf( __( 'You just trashed a %1$s.', 'wordpress-seo' ), $post_type );
+		$message        = $this->get_message( $first_sentence, 'trashed',  $post_type );
 
 		$this->add_notification( $message );
 	}
@@ -80,9 +82,11 @@ class WPSEO_Slug_Change_Watcher implements WPSEO_WordPress_Integration {
 			return;
 		}
 
+		$post_type = $this->get_post_type_label( get_post_type( $post_id ) );
+
 		/* translators: %1$s expands to the translated name of the post type. */
-		$first_sentence = sprintf( __( 'You just deleted a %1$s.', 'wordpress-seo' ), $this->get_post_type_label( get_post_type( $post_id ) ) );
-		$message        = $this->get_message( $first_sentence );
+		$first_sentence = sprintf( __( 'You just deleted a %1$s.', 'wordpress-seo' ),  $post_type );
+		$message        = $this->get_message( $first_sentence, 'deleted', $post_type );
 
 		$this->add_notification( $message );
 	}
@@ -98,15 +102,17 @@ class WPSEO_Slug_Change_Watcher implements WPSEO_WordPress_Integration {
 		if ( ! $this->is_term_viewable( $term_taxonomy_id ) ) {
 			return;
 		}
+
 		$term = \get_term_by( 'term_taxonomy_id', (int) $term_taxonomy_id );
+		$term_label = $this->get_taxonomy_label_for_term( $term->term_id );
 
 		$first_sentence = sprintf(
 			/* translators: 1: term label */
 			__( 'You just deleted a %1$s.', 'wordpress-seo' ),
-			$this->get_taxonomy_label_for_term( $term->term_id )
+			$term_label
 		);
 
-		$message = $this->get_message( $first_sentence );
+		$message = $this->get_message( $first_sentence, 'deleted', $term_label );
 
 		$this->add_notification( $message );
 	}
@@ -207,14 +213,17 @@ class WPSEO_Slug_Change_Watcher implements WPSEO_WordPress_Integration {
 	 * Returns the message around changed URLs.
 	 *
 	 * @param string $first_sentence The first sentence of the notification.
+	 * @param string $action The action done.
+	 * @param string $object_type The object type action done for.
 	 *
 	 * @return string The full notification.
 	 */
-	protected function get_message( $first_sentence ) {
+	protected function get_message( $first_sentence, $action, $object_type ) {
 		return '<h2>' . __( 'Make sure you don\'t miss out on traffic!', 'wordpress-seo' ) . '</h2>'
 			. '<p>'
 			. $first_sentence
-			. ' ' . __( 'Search engines and other websites can still send traffic to your deleted post.', 'wordpress-seo' )
+			/* translators: %1$s expands to the translated name of action. %1$s expand to translated name of object type */
+			. ' ' . sprintf( __( 'Search engines and other websites can still send traffic to your %1$s %2$s.', 'wordpress-seo' ), $action, $object_type )
 			. ' ' . __( 'You should create a redirect to ensure your visitors do not get a 404 error when they click on the no longer working URL.', 'wordpress-seo' )
 			/* translators: %s expands to Yoast SEO Premium */
 			. ' ' . sprintf( __( 'With %s, you can easily create such redirects.', 'wordpress-seo' ), 'Yoast SEO Premium' )


### PR DESCRIPTION
Implemented

## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Fixing prompt showing "posts" instead of "tags" when tags is deleting.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the redirect notification would mention "posts" when a tag was deleted or trashed.

## Relevant technical choices:

* 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

**Trash post**
 * Yoast SEO premium plugin should be switched off.
 * Create and publish post with any content.
 * Trash the post.
 * Make sure that on top the following message is displayed 'You just trashed a Post. Search engines and other websites can still send traffic to your trashed Post. You should create a redirect to ensure your visitors do not get a 404 error when they click on the no longer working URL. With Yoast SEO Premium, you can easily create such redirects.'.

**Delete tag**
 * Yoast SEO premium plugin should be switched off.
 * Create new tag.
 * Delete the tag.
 * Make sure that on top the following message is displayed 'You just deleted a Tag. Search engines and other websites can still send traffic to your deleted Tag. You should create a redirect to ensure your visitors do not get a 404 error when they click on the no longer working URL. With Yoast SEO Premium, you can easily create such redirects.'.

**Delete category**
 * Yoast SEO premium plugin should be switched off.
 * Create new category.
 * Delete the category.
 * Make sure that on top the following message is displayed 'You just deleted a Category. Search engines and other websites can still send traffic to your deleted Category. You should create a redirect to ensure your visitors do not get a 404 error when they click on the no longer working URL. With Yoast SEO Premium, you can easily create such redirects.'.
 
#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* It can impact any place where we delete object.

## UI changes

* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #20575 
