### PR TITLE
Add JS tests for issue 4036

### DIFF
--- a/packages/js/src/shared-admin/store/wistia-embed-permission.js
+++ b/packages/js/src/shared-admin/store/wistia-embed-permission.js
@@ -38,12 +38,15 @@ const slice = createSlice( {
 		} );
 		builder.addCase( `${ WISTIA_EMBED_PERMISSION_NAME }/${ ASYNC_ACTION_NAMES.success }`, ( state, { payload } ) => {
 			state.status = ASYNC_ACTION_STATUS.success;
-			state.value = Boolean( payload.value );
+			state.value = Boolean( payload && payload.value );
 		} );
 		builder.addCase( `${ WISTIA_EMBED_PERMISSION_NAME }/${ ASYNC_ACTION_NAMES.error }`, ( state, { payload } ) => {
 			state.status = ASYNC_ACTION_STATUS.error;
-			state.value = Boolean( payload.value );
-			state.error = payload.error;
+			state.value = Boolean( payload && payload.value );
+			state.error = {
+				code: get( payload, "error.code", 500 ),
+				message: get( payload, "error.message", "Unknown" ),
+			};
 		} );
 	},
 } );
@@ -63,10 +66,10 @@ export const wistiaEmbedPermissionActions = {
 };
 
 export const wistiaEmbedPermissionControls = {
-	[ WISTIA_EMBED_PERMISSION_NAME ]: async( { payload = true } ) => apiFetch( {
+	[ WISTIA_EMBED_PERMISSION_NAME ]: async( { payload } ) => apiFetch( {
 		path: "/yoast/v1/wistia_embed_permission",
 		method: "POST",
-		data: { value: payload },
+		data: { value: Boolean( payload ) },
 	} ),
 };
 

--- a/packages/js/src/shared-admin/store/wistia-embed-permission.js
+++ b/packages/js/src/shared-admin/store/wistia-embed-permission.js
@@ -41,7 +41,6 @@ const slice = createSlice( {
 			state.value = Boolean( payload.value );
 		} );
 		builder.addCase( `${ WISTIA_EMBED_PERMISSION_NAME }/${ ASYNC_ACTION_NAMES.error }`, ( state, { payload } ) => {
-			console.error( `${ payload.error?.code }: ${ payload.error?.message }` );
 			state.status = ASYNC_ACTION_STATUS.error;
 			state.value = Boolean( payload.value );
 			state.error = payload.error;

--- a/packages/js/tests/__mocks__/@wordpress/api-fetch.js
+++ b/packages/js/tests/__mocks__/@wordpress/api-fetch.js
@@ -1,3 +1,1 @@
-module.exports = () => ( {
-	response: {},
-} );
+module.exports = jest.fn();

--- a/packages/js/tests/components/SEMrushCountrySelector.test.js
+++ b/packages/js/tests/components/SEMrushCountrySelector.test.js
@@ -3,6 +3,11 @@ import { noop } from "lodash";
 import React from "react";
 import SEMrushCountrySelector from "../../../js/src/components/modals/SEMrushCountrySelector";
 
+jest.mock( "@wordpress/api-fetch", () => ( {
+	__esModule: true,
+	"default": () => ( { response: {} } ),
+} ) );
+
 window.jQuery = () => ( { on: noop } );
 
 describe( "SEMrushCountrySelector", () => {

--- a/packages/js/tests/components/SEMrushRelatedKeyphrasesModal.test.js
+++ b/packages/js/tests/components/SEMrushRelatedKeyphrasesModal.test.js
@@ -1,6 +1,6 @@
-import { shallow, mount } from "enzyme";
+import apiFetch from "@wordpress/api-fetch";
+import { mount, shallow } from "enzyme";
 import SEMrushRelatedKeyphrasesModal from "../../src/components/SEMrushRelatedKeyphrasesModal";
-import apiFetch from "../__mocks__/@wordpress/api-fetch";
 
 jest.mock( "@wordpress/api-fetch", () => {
 	return {

--- a/packages/js/tests/shared-admin/store/wistia-embed-permission.test.js
+++ b/packages/js/tests/shared-admin/store/wistia-embed-permission.test.js
@@ -1,0 +1,359 @@
+import apiFetch from "@wordpress/api-fetch";
+import { ASYNC_ACTION_NAMES, ASYNC_ACTION_STATUS } from "../../../src/shared-admin/constants";
+import {
+	getInitialWistiaEmbedPermissionState,
+	WISTIA_EMBED_PERMISSION_NAME,
+	wistiaEmbedPermissionActions,
+	wistiaEmbedPermissionControls,
+	wistiaEmbedPermissionReducer,
+	wistiaEmbedPermissionSelectors,
+} from "../../../src/shared-admin/store";
+
+describe( "wistiaEmbedPermission", () => {
+	it( "WISTIA_EMBED_PERMISSION_NAME is wistiaEmbedPermission", () => {
+		expect( WISTIA_EMBED_PERMISSION_NAME ).toBe( "wistiaEmbedPermission" );
+	} );
+
+	describe( "actions", () => {
+		describe( "setWistiaEmbedPermission", () => {
+			it( "exists", () => {
+				expect( wistiaEmbedPermissionActions.setWistiaEmbedPermission ).toBeTruthy();
+			} );
+
+			it( "creates multiple setWistiaEmbedPermission action objects", () => {
+				const generator = wistiaEmbedPermissionActions.setWistiaEmbedPermission( true );
+
+				let result = generator.next();
+				expect( result.done ).toBe( false );
+				expect( result.value ).toEqual( {
+					type: `${ WISTIA_EMBED_PERMISSION_NAME }/${ ASYNC_ACTION_NAMES.request }`,
+				} );
+
+				result = generator.next();
+				expect( result.done ).toBe( false );
+				expect( result.value ).toEqual( {
+					payload: true,
+					type: `${ WISTIA_EMBED_PERMISSION_NAME }`,
+				} );
+
+				result = generator.next();
+				expect( result.done ).toBe( true );
+				expect( result.value ).toEqual( {
+					payload: { value: true },
+					type: `${ WISTIA_EMBED_PERMISSION_NAME }/${ ASYNC_ACTION_NAMES.success }`,
+				} );
+			} );
+
+			it( "creates multiple setWistiaEmbedPermission action objects and fails", () => {
+				const generator = wistiaEmbedPermissionActions.setWistiaEmbedPermission( true );
+
+				let result = generator.next();
+				expect( result.done ).toBe( false );
+				expect( result.value ).toEqual( {
+					type: `${ WISTIA_EMBED_PERMISSION_NAME }/${ ASYNC_ACTION_NAMES.request }`,
+				} );
+
+				result = generator.next();
+				expect( result.done ).toBe( false );
+				expect( result.value ).toEqual( {
+					payload: true,
+					type: `${ WISTIA_EMBED_PERMISSION_NAME }`,
+				} );
+
+				result = generator.throw( "foo" );
+				expect( result.done ).toBe( true );
+				expect( result.value ).toEqual( {
+					payload: { error: "foo", value: true },
+					type: `${ WISTIA_EMBED_PERMISSION_NAME }/${ ASYNC_ACTION_NAMES.error }`,
+				} );
+			} );
+		} );
+
+		describe( "setWistiaEmbedPermissionValue", () => {
+			it( "exists", () => {
+				expect( wistiaEmbedPermissionActions.setWistiaEmbedPermissionValue ).toBeTruthy();
+			} );
+
+			it( "creates a setWistiaEmbedPermissionValue action object", () => {
+				expect( wistiaEmbedPermissionActions.setWistiaEmbedPermissionValue( true ) ).toEqual( {
+					payload: true,
+					type: `${ WISTIA_EMBED_PERMISSION_NAME }/setWistiaEmbedPermissionValue`,
+				} );
+			} );
+		} );
+	} );
+
+	describe( "initial state", () => {
+		it( "has a default state", () => {
+			expect( getInitialWistiaEmbedPermissionState() ).toEqual( {
+				value: false,
+				status: ASYNC_ACTION_STATUS.idle,
+				error: {},
+			} );
+		} );
+	} );
+
+	describe( "reducer", () => {
+		it( "returns the initial state", () => {
+			// eslint-disable-next-line no-undefined
+			expect( wistiaEmbedPermissionReducer( undefined, {} ) ).toEqual( getInitialWistiaEmbedPermissionState() );
+		} );
+
+		describe( "setWistiaEmbedPermissionValue", () => {
+			test.each( [
+				// Happy path with boolean.
+				[ true, true ],
+				[ false, false ],
+				// Truthy with different types.
+				[ true, "string" ],
+				[ true, {} ],
+				[ true, [] ],
+				[ true, Object ],
+				// Falsy with different types.
+				[ false, "" ],
+				[ false, null ],
+				// eslint-disable-next-line no-undefined
+				[ false, undefined ],
+			] )( "returns the value %p when the input value is %p", ( expected, input ) => {
+				expect( wistiaEmbedPermissionReducer( {}, wistiaEmbedPermissionActions.setWistiaEmbedPermissionValue( input ) ) )
+					.toEqual( { value: expected } );
+			} );
+		} );
+
+		describe( "wistiaEmbedPermission/request", () => {
+			it( "returns the loading status", () => {
+				expect( wistiaEmbedPermissionReducer( {}, { type: `${ WISTIA_EMBED_PERMISSION_NAME }/${ ASYNC_ACTION_NAMES.request }` } ) )
+					.toEqual( { status: ASYNC_ACTION_STATUS.loading } );
+			} );
+		} );
+
+		describe( "wistiaEmbedPermission/success", () => {
+			test.each( [
+				// Happy path with boolean.
+				[ true, { value: true } ],
+				[ false, { value: false } ],
+				// Truthy with different types.
+				[ true, { value: "string" } ],
+				[ true, { value: {} } ],
+				[ true, { value: [] } ],
+				[ true, { value: Object } ],
+				// Falsy with different types.
+				[ false, { value: "" } ],
+				[ false, { value: null } ],
+				// eslint-disable-next-line no-undefined
+				[ false, { value: undefined } ],
+				// The above, but without the object with value key.
+				[ false, true ],
+				[ false, false ],
+				[ false, "string" ],
+				[ false, {} ],
+				[ false, [] ],
+				[ false, Object ],
+				[ false, "" ],
+				[ false, null ],
+				// eslint-disable-next-line no-undefined
+				[ false, undefined ],
+			] )( "returns the value %p when the input value is %p", ( expected, input ) => {
+				expect( wistiaEmbedPermissionReducer( {}, {
+					type: `${ WISTIA_EMBED_PERMISSION_NAME }/${ ASYNC_ACTION_NAMES.success }`,
+					payload: input,
+				} ) )
+					.toEqual( { status: ASYNC_ACTION_STATUS.success, value: expected } );
+			} );
+		} );
+
+		describe( "wistiaEmbedPermission/error", () => {
+			test.each( [
+				// Happy path with boolean.
+				[ true, { value: true } ],
+				[ false, { value: false } ],
+				// Truthy with different types.
+				[ true, { value: "string" } ],
+				[ true, { value: {} } ],
+				[ true, { value: [] } ],
+				[ true, { value: Object } ],
+				// Falsy with different types.
+				[ false, { value: "" } ],
+				[ false, { value: null } ],
+				// eslint-disable-next-line no-undefined
+				[ false, { value: undefined } ],
+				// The above, but without the object with value key.
+				[ false, true ],
+				[ false, false ],
+				[ false, "string" ],
+				[ false, {} ],
+				[ false, [] ],
+				[ false, Object ],
+				[ false, "" ],
+				[ false, null ],
+				// eslint-disable-next-line no-undefined
+				[ false, undefined ],
+			] )( "returns the value %p when the input value is %p", ( expectedValue, inputValue ) => {
+				expect( wistiaEmbedPermissionReducer( {}, {
+					type: `${ WISTIA_EMBED_PERMISSION_NAME }/${ ASYNC_ACTION_NAMES.error }`,
+					payload: inputValue,
+				} ) )
+					.toEqual( { status: ASYNC_ACTION_STATUS.error, value: expectedValue, error: { code: 500, message: "Unknown" } } );
+			} );
+
+			test.each( [
+				// Happy path with code and message.
+				[ { code: 401, message: "Unauthorized" }, { error: { code: 401, message: "Unauthorized" } } ],
+				// Only code, only message, no code or message.
+				[ { code: 404, message: "Unknown" }, { error: { code: 404 } } ],
+				[ { code: 500, message: "foo" }, { error: { message: "foo" } } ],
+				[ { code: 500, message: "Unknown" }, { error: {} } ],
+				// Different types as value.
+				[ { code: 500, message: "Unknown" }, { error: "string" } ],
+				[ { code: 500, message: "Unknown" }, { error: true } ],
+				[ { code: 500, message: "Unknown" }, { error: [] } ],
+				[ { code: 500, message: "Unknown" }, { error: Object } ],
+				[ { code: 500, message: "Unknown" }, { error: null } ],
+				// Different type altogether.
+				[ { code: 500, message: "Unknown" }, "string" ],
+				[ { code: 500, message: "Unknown" }, true ],
+				[ { code: 500, message: "Unknown" }, {} ],
+				[ { code: 500, message: "Unknown" }, [] ],
+				[ { code: 500, message: "Unknown" }, Object ],
+				[ { code: 500, message: "Unknown" }, null ],
+			] )( "returns the error %p when the input error is %p", ( expectedError, inputError ) => {
+				expect( wistiaEmbedPermissionReducer( {}, {
+					type: `${ WISTIA_EMBED_PERMISSION_NAME }/${ ASYNC_ACTION_NAMES.error }`,
+					payload: inputError,
+				} ) )
+					.toEqual( { status: ASYNC_ACTION_STATUS.error, value: false, error: expectedError } );
+			} );
+		} );
+	} );
+
+	describe( "selectors", () => {
+		const mockState = {
+			[ WISTIA_EMBED_PERMISSION_NAME ]: {
+				value: true,
+				status: ASYNC_ACTION_STATUS.success,
+				error: {
+					code: 500,
+					message: "Error",
+				},
+			},
+		};
+
+		describe( "selectWistiaEmbedPermission", () => {
+			it( "exists", () => {
+				expect( wistiaEmbedPermissionSelectors.selectWistiaEmbedPermission ).toBeTruthy();
+			} );
+
+			it( "returns a value and status by default", () => {
+				expect( wistiaEmbedPermissionSelectors.selectWistiaEmbedPermission( {} ) )
+					.toEqual( { value: false, status: ASYNC_ACTION_STATUS.idle } );
+			} );
+
+			it( "returns the full state", () => {
+				expect( wistiaEmbedPermissionSelectors.selectWistiaEmbedPermission( mockState ) )
+					.toEqual( mockState[ WISTIA_EMBED_PERMISSION_NAME ] );
+			} );
+		} );
+
+		describe( "selectWistiaEmbedPermissionValue", () => {
+			it( "exists", () => {
+				expect( wistiaEmbedPermissionSelectors.selectWistiaEmbedPermissionValue ).toBeTruthy();
+			} );
+
+			it( "return false by default", () => {
+				expect( wistiaEmbedPermissionSelectors.selectWistiaEmbedPermissionValue( {} ) ).toBe( false );
+			} );
+
+			it( "returns the value", () => {
+				expect( wistiaEmbedPermissionSelectors.selectWistiaEmbedPermissionValue( mockState ) )
+					.toBe( mockState[ WISTIA_EMBED_PERMISSION_NAME ].value );
+			} );
+		} );
+
+		describe( "selectWistiaEmbedPermissionStatus", () => {
+			it( "exists", () => {
+				expect( wistiaEmbedPermissionSelectors.selectWistiaEmbedPermissionStatus ).toBeTruthy();
+			} );
+
+			it( "returns idle by default", () => {
+				expect( wistiaEmbedPermissionSelectors.selectWistiaEmbedPermissionStatus( {} ) ).toBe( ASYNC_ACTION_STATUS.idle );
+			} );
+
+			it( "returns the status", () => {
+				expect( wistiaEmbedPermissionSelectors.selectWistiaEmbedPermissionStatus( mockState ) )
+					.toBe( mockState[ WISTIA_EMBED_PERMISSION_NAME ].status );
+			} );
+		} );
+
+		describe( "selectWistiaEmbedPermissionError", () => {
+			it( "exists", () => {
+				expect( wistiaEmbedPermissionSelectors.selectWistiaEmbedPermissionError ).toBeTruthy();
+			} );
+
+			it( "returns an empty object by default", () => {
+				expect( wistiaEmbedPermissionSelectors.selectWistiaEmbedPermissionError( {} ) ).toEqual( {} );
+			} );
+
+			it( "returns the error object", () => {
+				expect( wistiaEmbedPermissionSelectors.selectWistiaEmbedPermissionError( mockState ) )
+					.toEqual( mockState[ WISTIA_EMBED_PERMISSION_NAME ].error );
+			} );
+		} );
+	} );
+
+	describe( "controls", () => {
+		describe( "wistiaEmbedPermission", () => {
+			beforeEach( () => {
+				apiFetch.mockClear();
+			} );
+
+			it( "exists", () => {
+				expect( wistiaEmbedPermissionControls.wistiaEmbedPermission ).toBeTruthy();
+			} );
+
+			test.each( [
+				// Happy path with boolean.
+				[ true, { payload: true } ],
+				[ false, { payload: false } ],
+				// Truthy with different types.
+				[ true, { payload: "string" } ],
+				[ true, { payload: {} } ],
+				[ true, { payload: [] } ],
+				[ true, { payload: Object } ],
+				// Falsy with different types.
+				[ false, { payload: "" } ],
+				[ false, { payload: null } ],
+				// eslint-disable-next-line no-undefined
+				[ false, { payload: undefined } ],
+				// The above, but without the object with payload key.
+				[ false, true ],
+				[ false, false ],
+				[ false, "string" ],
+				[ false, {} ],
+				[ false, [] ],
+				[ false, Object ],
+				[ false, "" ],
+			] )( "calls apiFetch with the value %p when passing %p", ( expected, input ) => {
+				wistiaEmbedPermissionControls.wistiaEmbedPermission( input );
+				expect( apiFetch ).toBeCalledWith( {
+					path: "/yoast/v1/wistia_embed_permission",
+					method: "POST",
+					data: { value: expected },
+				} );
+			} );
+
+			test.each( [
+				[ null ],
+				// eslint-disable-next-line no-undefined
+				[ undefined ],
+			] )( "throws a TypeError when passing %p", async( input ) => {
+				expect.assertions( 2 );
+				try {
+					await wistiaEmbedPermissionControls.wistiaEmbedPermission( input );
+				} catch ( e ) {
+					expect( e ).toBeInstanceOf( TypeError );
+				}
+				expect( apiFetch ).toHaveBeenCalledTimes( 0 );
+			} );
+		} );
+	} );
+} );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Add JS tests for #4036 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds tests for the Wistia embed permission slice.

## Relevant technical choices:

* Changing the global mock for WP api-fetch. Let's not return an object by default, moved that to the SemRush test.
* Removed the error log, after looking at it from the perspective of the tests: logging there is a strange side effect of a slice I no longer agree with
* Choose to add some type coercion for the value. Is that better than throwing errors? We should use it proper in the first place. Now testing the expected results either way.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Verify the tests make sense
* Verify the tests pass
* Verify the tests have 100% coverage

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* No need for QA, CI should tell if the tests pass

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/wordpress-seo-premium/issues/4044
