### PR TITLE
Allow indexing of author archive pages when authors have no posts and the relevant option is set to true

### DIFF
--- a/src/presentations/indexable-author-archive-presentation.php
+++ b/src/presentations/indexable-author-archive-presentation.php
@@ -119,7 +119,9 @@ class Indexable_Author_Archive_Presentation extends Indexable_Presentation {
 
 		// Safety check. The call to `get_user_data` could return false (called in `get_queried_object`).
 		if ( $current_author === false ) {
-			$robots['index'] = 'noindex';
+			if ( $this->options->get( 'noindex-author-noposts-wpseo', false ) ) {
+				$robots['index'] = 'noindex';
+			}
 			return $this->filter_robots( $robots );
 		}
 

--- a/tests/unit/presentations/indexable-author-archive-presentation/robots-test.php
+++ b/tests/unit/presentations/indexable-author-archive-presentation/robots-test.php
@@ -44,24 +44,63 @@ class Robots_Test extends TestCase {
 	}
 
 	/**
-	 * Tests don't index without a current author (safety check).
+	 * Tests don't index without a current author and no archives for authors with no posts (safety check).
 	 *
 	 * @covers ::generate_robots
 	 */
-	public function test_generate_robots_global_dont_index_without_current_author() {
-		$this->mock_global_author_option();
+	public function test_generate_robots_global_dont_index_without_current_author_and_noindex_noposts() {
 		$this->setup_get_userdata();
+
+		$this->options
+			->expects( 'get' )
+			->with( 'noindex-author-wpseo', false )
+			->once()
+			->andReturn( false );
 
 		// Should never get that far in the code.
 		$this->options
 			->expects( 'get' )
 			->with( 'noindex-author-noposts-wpseo', false )
-			->never();
+			->once()
+			->andReturn( true );
 
 		$actual   = $this->instance->generate_robots();
 		$expected = [
 			'index'  => 'noindex',
 			'follow' => 'follow',
+		];
+
+		$this->assertEquals( $expected, $actual );
+	}
+
+	/**
+	 * Tests don't index without a current author and archives for authors with no posts (safety check).
+	 *
+	 * @covers ::generate_robots
+	 */
+	public function test_generate_robots_global_dont_index_without_current_author_and_index_noposts() {
+		$this->setup_get_userdata();
+
+		$this->options
+			->expects( 'get' )
+			->with( 'noindex-author-wpseo', false )
+			->once()
+			->andReturn( false );
+
+		// Should never get that far in the code.
+		$this->options
+			->expects( 'get' )
+			->with( 'noindex-author-noposts-wpseo', false )
+			->once()
+			->andReturn( false );
+
+		$actual   = $this->instance->generate_robots();
+		$expected = [
+			'index'             => 'index',
+			'follow'            => 'follow',
+			'max-snippet'       => 'max-snippet:-1',
+			'max-image-preview' => 'max-image-preview:large',
+			'max-video-preview' => 'max-video-preview:-1',
 		];
 
 		$this->assertEquals( $expected, $actual );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Currently, when the `Show author archives without posts in search results` toggle is enabled, author archives are added to the sitemap but the archive page gets a `noindex` in the `robots` metatag, which is not the desired result.
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where, even if `Show author archives without posts in search results` is enabled, the archive page has a `noindex` in the `robots` metatag.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Add a new user and select `Author` as role
* Go to `Settings` -> `Advanced` -> `Author Archive` submenu
  * be sure `Enable author archives` is enabled
  * in the `Search appearance` section:
    * be sure `Show author archives in search results` is enabled
    * enable `Show author archives without posts in search results`
* Visit the archive page of the author you just created:
  * without this PR, the page head will contain the following metatag:
    `<meta name='robots' content='noindex, follow' />`
  * with this PR, the page head will contain the following metatag:
    `<meta name='robots' content='index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1' />`
#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
