### PR TITLE
add filter to allow building hierarchy

### DIFF
--- a/src/builders/indexable-hierarchy-builder.php
+++ b/src/builders/indexable-hierarchy-builder.php
@@ -132,7 +132,19 @@ class Indexable_Hierarchy_Builder {
 	 * @return bool True when indexable has a built hierarchy.
 	 */
 	protected function hierarchy_is_built( Indexable $indexable ) {
-		if ( \in_array( $indexable->id, $this->saved_ancestors, true ) ) {
+
+		/**
+		 * Filters the parameter to allow building hierarchy.
+		 *
+		 * Used when adding term with `wp_set_object_terms` together with `wp_insert_post`.
+		 *
+		 * @since 21.2
+		 *
+		 * @return bool The filtered value of the `in_saved_ancestors` parameter.
+		 */
+		$in_saved_ancestors = apply_filters( 'Yoast\WP\SEO\manual_set_object_terms', \in_array( $indexable->id, $this->saved_ancestors, true ) );
+
+		if ( $in_saved_ancestors ) {
 			return true;
 		}
 

--- a/src/builders/indexable-hierarchy-builder.php
+++ b/src/builders/indexable-hierarchy-builder.php
@@ -132,19 +132,22 @@ class Indexable_Hierarchy_Builder {
 	 * @return bool True when indexable has a built hierarchy.
 	 */
 	protected function hierarchy_is_built( Indexable $indexable ) {
-
 		/**
-		 * Filters the parameter to allow building hierarchy.
+		 * Filters ignoring checking if the hierarchy is already built.
 		 *
 		 * Used when adding term with `wp_set_object_terms` together with `wp_insert_post`.
 		 *
+		 * @api bool If the hierarchy already saved check should be ignored.
 		 * @since 21.2
 		 *
 		 * @return bool The filtered value of the `in_saved_ancestors` parameter.
 		 */
-		$in_saved_ancestors = apply_filters( 'Yoast\WP\SEO\manual_set_object_terms', \in_array( $indexable->id, $this->saved_ancestors, true ) );
+		$ignore_already_saved = apply_filters( 'wpseo_hierarchy_ignore_already_saved', false );
+		if ( $ignore_already_saved ) {
+			return false;
+		}
 
-		if ( $in_saved_ancestors ) {
+		if ( \in_array( $indexable->id, $this->saved_ancestors, true ) ) {
 			return true;
 		}
 

--- a/src/builders/indexable-hierarchy-builder.php
+++ b/src/builders/indexable-hierarchy-builder.php
@@ -140,7 +140,7 @@ class Indexable_Hierarchy_Builder {
 		 * @api bool If the hierarchy already saved check should be ignored.
 		 * @since 21.2
 		 *
-		 * @return bool The filtered value of the `in_saved_ancestors` parameter.
+		 * @return bool The filtered value of the `$ignore_already_saved` parameter.
 		 */
 		$ignore_already_saved = apply_filters( 'wpseo_hierarchy_ignore_already_saved', false );
 		if ( $ignore_already_saved ) {

--- a/src/builders/indexable-hierarchy-builder.php
+++ b/src/builders/indexable-hierarchy-builder.php
@@ -137,9 +137,9 @@ class Indexable_Hierarchy_Builder {
 		 *
 		 * Used when adding term with `wp_set_object_terms` together with `wp_insert_post`.
 		 *
-		 * @api bool If the hierarchy already saved check should be ignored.
 		 * @since 21.2
 		 *
+		 * @param bool $ignore_already_saved If the hierarchy already saved check should be ignored.
 		 * @return bool The filtered value of the `$ignore_already_saved` parameter.
 		 */
 		$ignore_already_saved = apply_filters( 'wpseo_hierarchy_ignore_already_saved', false );

--- a/src/integrations/watchers/indexable-ancestor-watcher.php
+++ b/src/integrations/watchers/indexable-ancestor-watcher.php
@@ -92,6 +92,32 @@ class Indexable_Ancestor_Watcher implements Integration_Interface {
 	 */
 	public function register_hooks() {
 		\add_action( 'wpseo_save_indexable', [ $this, 'reset_children' ], \PHP_INT_MAX, 2 );
+		if ( ! \check_ajax_referer( 'inlineeditnonce', '_inline_edit', false ) ) {
+			\add_action( 'set_object_terms', [ $this, 'validate_primary_category' ], 10, 6 );
+		}
+	}
+
+	/**
+	 * Validates if the current primary category is still present. If not just remove the post meta for it.
+	 *
+	 * @param int    $object_id Object ID.
+	 * @param array  $terms     Unused. An array of object terms.
+	 * @param array  $tt_ids    An array of term taxonomy IDs.
+	 * @param string $taxonomy  Taxonomy slug.
+	 * @param bool   $append     Whether to append new terms to the old terms.
+	 * @param array  $old_tt_ids Old array of term taxonomy IDs.
+	 */
+	public function validate_primary_category( $object_id, $terms, $tt_ids, $taxonomy, $append, $old_tt_ids ) {
+		$post = \get_post( $object_id );
+		if ( $this->post_type_helper->is_excluded( $post->post_type ) ) {
+			return;
+		}
+
+		$indexable = $this->indexable_repository->find_by_id_and_type( $post->ID, 'post' );
+
+		if ( $indexable instanceof Indexable ) {
+			$this->indexable_hierarchy_builder->build( $indexable );
+		}
 	}
 
 	/**

--- a/src/integrations/watchers/primary-category-quick-edit-watcher.php
+++ b/src/integrations/watchers/primary-category-quick-edit-watcher.php
@@ -85,7 +85,7 @@ class Primary_Category_Quick_Edit_Watcher implements Integration_Interface {
 	 * @return void
 	 */
 	public function register_hooks() {
-		\add_action( 'set_object_terms', [ $this, 'validate_primary_category' ], 10, 4 );
+		\add_action( 'set_object_terms', [ $this, 'validate_primary_category' ], 10, 6 );
 	}
 
 	/**
@@ -94,7 +94,7 @@ class Primary_Category_Quick_Edit_Watcher implements Integration_Interface {
 	 * @return array The conditionals.
 	 */
 	public static function get_conditionals() {
-		return [ Migrations_Conditional::class, Doing_Post_Quick_Edit_Save_Conditional::class ];
+		return [ Migrations_Conditional::class ];
 	}
 
 	/**
@@ -104,8 +104,10 @@ class Primary_Category_Quick_Edit_Watcher implements Integration_Interface {
 	 * @param array  $terms     Unused. An array of object terms.
 	 * @param array  $tt_ids    An array of term taxonomy IDs.
 	 * @param string $taxonomy  Taxonomy slug.
+	 * @param bool   $append     Whether to append new terms to the old terms.
+	 * @param array  $old_tt_ids Old array of term taxonomy IDs.
 	 */
-	public function validate_primary_category( $object_id, $terms, $tt_ids, $taxonomy ) {
+	public function validate_primary_category( $object_id, $terms, $tt_ids, $taxonomy, $append, $old_tt_ids ) {
 		$post = \get_post( $object_id );
 		if ( $post === null ) {
 			return;

--- a/src/integrations/watchers/primary-category-quick-edit-watcher.php
+++ b/src/integrations/watchers/primary-category-quick-edit-watcher.php
@@ -85,7 +85,7 @@ class Primary_Category_Quick_Edit_Watcher implements Integration_Interface {
 	 * @return void
 	 */
 	public function register_hooks() {
-		\add_action( 'set_object_terms', [ $this, 'validate_primary_category' ], 10, 6 );
+		\add_action( 'set_object_terms', [ $this, 'validate_primary_category' ], 10, 4 );
 	}
 
 	/**
@@ -94,7 +94,7 @@ class Primary_Category_Quick_Edit_Watcher implements Integration_Interface {
 	 * @return array The conditionals.
 	 */
 	public static function get_conditionals() {
-		return [ Migrations_Conditional::class ];
+		return [ Migrations_Conditional::class, Doing_Post_Quick_Edit_Save_Conditional::class ];
 	}
 
 	/**
@@ -104,10 +104,8 @@ class Primary_Category_Quick_Edit_Watcher implements Integration_Interface {
 	 * @param array  $terms     Unused. An array of object terms.
 	 * @param array  $tt_ids    An array of term taxonomy IDs.
 	 * @param string $taxonomy  Taxonomy slug.
-	 * @param bool   $append     Whether to append new terms to the old terms.
-	 * @param array  $old_tt_ids Old array of term taxonomy IDs.
 	 */
-	public function validate_primary_category( $object_id, $terms, $tt_ids, $taxonomy, $append, $old_tt_ids ) {
+	public function validate_primary_category( $object_id, $terms, $tt_ids, $taxonomy ) {
 		$post = \get_post( $object_id );
 		if ( $post === null ) {
 			return;

--- a/tests/unit/integrations/watchers/indexable-ancestor-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-ancestor-watcher-test.php
@@ -206,7 +206,78 @@ class Indexable_Ancestor_Watcher_Test extends TestCase {
 		$this->instance->register_hooks();
 
 		self::assertNotFalse( \has_action( 'wpseo_save_indexable', [ $this->instance, 'reset_children' ] ) );
-		self::assertSame( $set_object_terms_action, \has_action( 'set_object_terms', [ $this->instance, 'validate_primary_category' ] ) );
+		self::assertSame( $set_object_terms_action, \has_action( 'set_object_terms', [ $this->instance, 'build_post_hierarchy' ] ) );
+	}
+
+	/**
+	 * Data provider for the build_post_hierarchy test.
+	 *
+	 * @return array The data.
+	 */
+	public static function data_provider_build_post_hierarchy() {
+		$indexable = Mockery::mock( Indexable_Mock::class );
+		return [
+			'Building hierarchy' => [
+				'is_excluded'               => false,
+				'find_by_id_and_type_times' => 1,
+				'indexable'                 => $indexable,
+				'build_times'               => 1,
+			],
+			'Not building hierarchy because no indexable' => [
+				'is_excluded'               => false,
+				'find_by_id_and_type_times' => 1,
+				'indexable'                 => (object) [ 'ID' => 5 ],
+				'build_times'               => 0,
+			],
+			'Not building because excluded post type' => [
+				'is_excluded'               => true,
+				'find_by_id_and_type_times' => 0,
+				'indexable'                 => (object) [ 'ID' => 5 ],
+				'build_times'               => 0,
+			],
+		];
+	}
+
+	/**
+	 * Tests the build_post_hierarchy.
+	 *
+	 * @covers ::build_post_hierarchy
+	 *
+	 * @dataProvider data_provider_build_post_hierarchy
+	 *
+	 * @param bool           $is_excluded Whether or not the post type is excluded.
+	 * @param int            $find_by_id_and_type_times The number of times the find_by_id_and_type method is called.
+	 * @param Indexable_Mock $indexable The indexable.
+	 * @param int            $build_times The number of times the build method is called.
+	 */
+	public function test_build_post_hierarchy( $is_excluded, $find_by_id_and_type_times, $indexable, $build_times ) {
+		$post            = Mockery::mock( \WP_Post::class );
+		$post->post_type = 'post';
+		$post->ID        = 5;
+
+		Functions\expect( 'get_post' )
+			->once()
+			->with( 5 )
+			->andReturn( $post );
+
+		$this->post_type_helper
+			->expects( 'is_excluded' )
+			->once()
+			->with( $post->post_type )
+			->andReturn( $is_excluded );
+
+		$this->indexable_repository
+			->expects( 'find_by_id_and_type' )
+			->times( $find_by_id_and_type_times )
+			->with( $post->ID, $post->post_type )
+			->andReturn( $indexable );
+
+		$this->indexable_hierarchy_builder
+			->expects( 'build' )
+			->times( $build_times )
+			->with( $indexable );
+
+		$this->instance->build_post_hierarchy( 5, [ 'test_term' ], [ 7 ], 'category', false, [] );
 	}
 
 	/**

--- a/tests/unit/integrations/watchers/indexable-ancestor-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-ancestor-watcher-test.php
@@ -169,14 +169,44 @@ class Indexable_Ancestor_Watcher_Test extends TestCase {
 	}
 
 	/**
+	 * Data provider for the register_hooks test.
+	 *
+	 * @return array The data.
+	 */
+	public function data_provider_register_hooks() {
+		return [
+			'When ancestor is changes inline edit' => [
+				'is_inline_edit'          => true,
+				'set_object_terms_action' => false,
+			],
+			'When ancestor is changes not inline edit' => [
+				'is_inline_edit'          => false,
+				'set_object_terms_action' => 10,
+			],
+		];
+	}
+
+	/**
 	 * Tests if the expected hooks are registered.
 	 *
 	 * @covers ::register_hooks
+	 *
+	 * @dataProvider data_provider_register_hooks
+	 *
+	 * @param bool     $is_inline_edit      Whether or not the request is an inline edit.
+	 * @param bool|int $set_object_terms_action The set_object_terms action return value.
 	 */
-	public function test_register_hooks() {
+	public function test_register_hooks( $is_inline_edit, $set_object_terms_action ) {
+
+		Functions\expect( 'check_ajax_referer' )
+			->once()
+			->with( 'inlineeditnonce', '_inline_edit', false )
+			->andReturn( $is_inline_edit );
+
 		$this->instance->register_hooks();
 
 		self::assertNotFalse( \has_action( 'wpseo_save_indexable', [ $this->instance, 'reset_children' ] ) );
+		self::assertSame( $set_object_terms_action, \has_action( 'set_object_terms', [ $this->instance, 'validate_primary_category' ] ) );
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Add filter to allow building hierarchy when using `wp_set_object_terms` with `wp_insert_post`.  

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds filter to allow building hierarchy when using `wp_set_object_terms` with `wp_insert_post`.  

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Go to `Yoast SEO`->`Settings`->`Advanced`->`Breadcrumbs`
* Check `Breadcrumbs for post types` has select `Category` in `Posts`.
* Add the following code to the php `header.php`
```php
add_filter( 'wpseo_hierarchy_ignore_already_saved', '__return_true');

$post_id = wp_insert_post([
   'post_type' => 'post',
   'post_title' => 'Test post',
   'post_content' => '',
   'post_status' => 'publish'
]);

if ($post_id != 0) {
    wp_set_object_terms($post_id, 'test_term', 'category');
}
```
* Visit home page and that would create a post.
* Go to posts
* View the recently created post.
* Check the breadcrumbs contain the right term `test_term`.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [#100](https://github.com/Yoast/reserved-tasks/issues/100)
