### PR TITLE
Tests/first time configuration notice helper

### DIFF
--- a/tests/integration/helpers/test-first-time-configuration-notice-helper.php
+++ b/tests/integration/helpers/test-first-time-configuration-notice-helper.php
@@ -58,6 +58,25 @@ class First_Time_Configuration_Notice_Helper_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
+	 * Tests contruct method.
+	 *
+	 * @covers ::__construct
+	 */
+	public function test_construct() {
+		$this->assertInstanceOf(
+			Options_Helper::class,
+			$this->getPropertyValue( $this->instance, 'options_helper' )
+		);
+		$this->assertInstanceOf(
+			Indexing_Helper::class,
+			$this->getPropertyValue( $this->instance, 'indexing_helper' )
+		);
+		$this->assertIsBool(
+			$this->getPropertyValue( $this->instance, 'show_alternate_message' )
+		);
+	}
+
+	/**
 	 * Tests the display notice.
 	 *
 	 * @covers ::should_display_first_time_configuration_notice

--- a/tests/integration/helpers/test-first-time-configuration-notice-helper.php
+++ b/tests/integration/helpers/test-first-time-configuration-notice-helper.php
@@ -92,6 +92,7 @@ class First_Time_Configuration_Notice_Helper_Test extends WPSEO_UnitTestCase {
 				'is_initial_indexing'             => true,
 				'is_finished_indexables_indexing' => false,
 				'expected'                        => false,
+				'title'                           => 'First-time SEO configuration',
 			],
 			'Check user has permission and first time configuration not finished' => [
 				'user'                            => 'administrator',
@@ -100,6 +101,7 @@ class First_Time_Configuration_Notice_Helper_Test extends WPSEO_UnitTestCase {
 				'is_initial_indexing'             => true,
 				'is_finished_indexables_indexing' => false,
 				'expected'                        => false,
+				'title'                           => 'First-time SEO configuration',
 			],
 			'Check user has permission and first time configuration not finished and is first time install' => [
 				'user'                            => 'administrator',
@@ -108,6 +110,7 @@ class First_Time_Configuration_Notice_Helper_Test extends WPSEO_UnitTestCase {
 				'is_initial_indexing'             => true,
 				'is_finished_indexables_indexing' => false,
 				'expected'                        => true,
+				'title'                           => 'First-time SEO configuration',
 			],
 			'Check user has permission and first time configuration not finished and not first time install and is initial indexing' => [
 				'user'                            => 'administrator',
@@ -116,6 +119,7 @@ class First_Time_Configuration_Notice_Helper_Test extends WPSEO_UnitTestCase {
 				'is_initial_indexing'             => false,
 				'is_finished_indexables_indexing' => false,
 				'expected'                        => false,
+				'title'                           => 'First-time SEO configuration',
 			],
 			'Check user has permission and first time configuration not finished and not first time install and is not initial indexing and finished indexables indexing' => [
 				'user'                            => 'administrator',
@@ -124,6 +128,7 @@ class First_Time_Configuration_Notice_Helper_Test extends WPSEO_UnitTestCase {
 				'is_initial_indexing'             => true,
 				'is_finished_indexables_indexing' => true,
 				'expected'                        => false,
+				'title'                           => 'First-time SEO configuration',
 			],
 			'Check are_site_representation_name_and_logo_set' => [
 				'user'                            => 'administrator',
@@ -132,6 +137,7 @@ class First_Time_Configuration_Notice_Helper_Test extends WPSEO_UnitTestCase {
 				'is_initial_indexing'             => true,
 				'is_finished_indexables_indexing' => false,
 				'expected'                        => true,
+				'title'                           => 'SEO configuration',
 			],
 		];
 	}
@@ -143,6 +149,7 @@ class First_Time_Configuration_Notice_Helper_Test extends WPSEO_UnitTestCase {
 	 * @covers ::user_can_do_first_time_configuration
 	 * @covers ::are_site_representation_name_and_logo_set
 	 * @covers ::is_first_time_configuration_finished
+	 * @covers ::get_first_time_configuration_title
 	 *
 	 * @dataProvider data_provider_first_time_configuration_not_finished
 	 *
@@ -152,10 +159,11 @@ class First_Time_Configuration_Notice_Helper_Test extends WPSEO_UnitTestCase {
 	 * @param bool   $is_initial_indexing Whether is initial indexing.
 	 * @param bool   $is_finished_indexables_indexing Whether finidhed indexing.
 	 * @param bool   $expected The expected result.
+	 * @param string $title First time configuration title.
 	 *
 	 * @return void
 	 */
-	public function test_first_time_configuration_not_finished( $user, $steps_complete, $first_time_install, $is_initial_indexing, $is_finished_indexables_indexing, $expected ) {
+	public function test_first_time_configuration_not_finished( $user, $steps_complete, $first_time_install, $is_initial_indexing, $is_finished_indexables_indexing, $expected, $title ) {
 
 		$this->indexing_helper
 			->expects( 'is_finished_indexables_indexing' )
@@ -176,5 +184,18 @@ class First_Time_Configuration_Notice_Helper_Test extends WPSEO_UnitTestCase {
 
 		$result = $this->instance->first_time_configuration_not_finished();
 		$this->assertSame( $expected, $result );
+
+		$first_time_configuration_title = $this->instance->get_first_time_configuration_title();
+		$this->assertEquals( $title, $first_time_configuration_title, 'First time configuration title check.' );
+	}
+
+	/**
+	 * Tests should_show_alternate_message.
+	 *
+	 * @covers ::should_show_alternate_message
+	 */
+	public function test_should_show_alternate_message() {
+		$result = $this->instance->should_show_alternate_message();
+		$this->assertFalse( $result );
 	}
 }

--- a/tests/integration/helpers/test-first-time-configuration-notice-helper.php
+++ b/tests/integration/helpers/test-first-time-configuration-notice-helper.php
@@ -2,7 +2,7 @@
 /**
  * WPSEO plugin test file.
  *
- * @package WPSEO\Tests\Content_Type_Visibility
+ * @package WPSEO\Tests\Helpers
  */
 
 use Yoast\WP\SEO\Helpers\First_Time_Configuration_Notice_Helper;
@@ -54,11 +54,11 @@ class First_Time_Configuration_Notice_Helper_Test extends WPSEO_UnitTestCase {
 		$this->indexing_helper        = Mockery::mock( Indexing_Helper::class );
 		$this->show_alternate_message = false;
 
-		$this->instance = new First_Time_Configuration_Notice_Helper( $this->options_helper, $this->indexing_helper, $this->show_alternate_message );
+		$this->instance = new First_Time_Configuration_Notice_Helper( $this->options_helper, $this->indexing_helper );
 	}
 
 	/**
-	 * Tests contruct method.
+	 * Tests the constructor.
 	 *
 	 * @covers ::__construct
 	 */
@@ -77,7 +77,7 @@ class First_Time_Configuration_Notice_Helper_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	 * Tests the display notice.
+	 * Tests whether the display notice should be displayed.
 	 *
 	 * @covers ::should_display_first_time_configuration_notice
 	 * @covers ::on_wpseo_admin_page_or_dashboard
@@ -94,7 +94,7 @@ class First_Time_Configuration_Notice_Helper_Test extends WPSEO_UnitTestCase {
 
 		$this->options_helper->set( 'dismiss_configuration_workout_notice', true );
 		$result = $this->instance->should_display_first_time_configuration_notice();
-		$this->assertFalse( $result, 'Checking with dismiss_configuration_workout_notice option set to false' );
+		$this->assertFalse( $result, 'Checking with dismiss_configuration_workout_notice option set to true' );
 	}
 
 	/**
@@ -172,17 +172,17 @@ class First_Time_Configuration_Notice_Helper_Test extends WPSEO_UnitTestCase {
 	 *
 	 * @dataProvider data_provider_first_time_configuration_not_finished
 	 *
-	 * @param string $user The user capabilities.
-	 * @param array  $steps_complete The array of steps.
-	 * @param bool   $first_time_install Whether it is first installation.
-	 * @param bool   $is_initial_indexing Whether is initial indexing.
-	 * @param bool   $is_finished_indexables_indexing Whether finidhed indexing.
+	 * @param string $user_role The user role.
+	 * @param array  $steps_complete The array of first time configuration steps.
+	 * @param bool   $first_time_install Whether this is a first installation.
+	 * @param bool   $is_initial_indexing Whether the indexing is initial.
+	 * @param bool   $is_finished_indexables_indexing Whether indexing has been finished.
 	 * @param bool   $expected The expected result.
 	 * @param string $title First time configuration title.
 	 *
 	 * @return void
 	 */
-	public function test_first_time_configuration_not_finished( $user, $steps_complete, $first_time_install, $is_initial_indexing, $is_finished_indexables_indexing, $expected, $title ) {
+	public function test_first_time_configuration_not_finished( $user_role, $steps_complete, $first_time_install, $is_initial_indexing, $is_finished_indexables_indexing, $expected, $title ) {
 
 		$this->indexing_helper
 			->expects( 'is_finished_indexables_indexing' )
@@ -194,7 +194,7 @@ class First_Time_Configuration_Notice_Helper_Test extends WPSEO_UnitTestCase {
 			->withNoArgs()
 			->andReturn( $is_initial_indexing );
 
-		$user = self::factory()->user->create_and_get( [ 'role' => $user ] );
+		$user = self::factory()->user->create_and_get( [ 'role' => $user_role ] );
 		wp_set_current_user( $user->ID );
 
 		$this->options_helper->set( 'first_time_install', $first_time_install );

--- a/tests/integration/helpers/test-first-time-configuration-notice-helper.php
+++ b/tests/integration/helpers/test-first-time-configuration-notice-helper.php
@@ -179,11 +179,11 @@ class First_Time_Configuration_Notice_Helper_Test extends WPSEO_UnitTestCase {
 		wp_set_current_user( $user->ID );
 
 		$this->options_helper->set( 'first_time_install', $first_time_install );
-		$this->options_helper->set( 'company_or_person', '' );
+
 		$this->options_helper->set( 'configuration_finished_steps', $steps_complete );
 
 		$result = $this->instance->first_time_configuration_not_finished();
-		$this->assertSame( $expected, $result );
+		$this->assertSame( $expected, $result, 'Check if first time configuration was not completed.' );
 
 		$first_time_configuration_title = $this->instance->get_first_time_configuration_title();
 		$this->assertEquals( $title, $first_time_configuration_title, 'First time configuration title check.' );

--- a/tests/integration/helpers/test-first-time-configuration-notice-helper.php
+++ b/tests/integration/helpers/test-first-time-configuration-notice-helper.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * WPSEO plugin test file.
+ *
+ * @package WPSEO\Tests\Content_Type_Visibility
+ */
+
+use Yoast\WP\SEO\Helpers\First_Time_Configuration_Notice_Helper;
+use Yoast\WP\SEO\Helpers\Indexing_Helper;
+use Yoast\WP\SEO\Helpers\Options_Helper;
+
+/**
+ * Class First_Time_Configuration_Notice_Helper_Test.
+ * Integration Test Class for the First_Time_Configuration_Notice_Helper class.
+ *
+ * @coversDefaultClass Yoast\WP\SEO\Helpers\First_Time_Configuration_Notice_Helper
+ */
+class First_Time_Configuration_Notice_Helper_Test extends WPSEO_UnitTestCase {
+
+	/**
+	 * The options' helper.
+	 *
+	 * @var Options_Helper
+	 */
+	private $options_helper;
+
+	/**
+	 * The indexing helper.
+	 *
+	 * @var Mockery\MockInterface|Indexing_Helper
+	 */
+	private $indexing_helper;
+
+	/**
+	 * Whether we show the alternate message.
+	 *
+	 * @var bool
+	 */
+	private $show_alternate_message;
+
+	/**
+	 * The instance.
+	 *
+	 * @var First_Time_Configuration_Notice_Helper
+	 */
+	private $instance;
+
+	/**
+	 * Sets up the test class.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->options_helper         = new Options_Helper();
+		$this->indexing_helper        = Mockery::mock( Indexing_Helper::class );
+		$this->show_alternate_message = false;
+
+		$this->instance = new First_Time_Configuration_Notice_Helper( $this->options_helper, $this->indexing_helper, $this->show_alternate_message );
+	}
+
+	/**
+	 * Tests the display notice.
+	 *
+	 * @covers ::should_display_first_time_configuration_notice
+	 * @covers ::on_wpseo_admin_page_or_dashboard
+	 * @return void
+	 */
+	public function test_should_display_first_time_configuration_notice() {
+		$result = $this->instance->should_display_first_time_configuration_notice();
+		$this->assertFalse( $result, 'Checking the default variable' );
+
+		global $pagenow;
+		$pagenow = 'edit.php';
+		$result  = $this->instance->should_display_first_time_configuration_notice();
+		$this->assertFalse( $result, 'Checking on edit.php' );
+
+		$this->options_helper->set( 'dismiss_configuration_workout_notice', true );
+		$result = $this->instance->should_display_first_time_configuration_notice();
+		$this->assertFalse( $result, 'Checking with dismiss_configuration_workout_notice option set to false' );
+	}
+
+	/**
+	 * Tests whether the configuration has been finished.
+	 *
+	 * @covers ::first_time_configuration_not_finished
+	 * @covers ::user_can_do_first_time_configuration
+	 * @return void
+	 */
+	public function test_first_time_configuration_not_finished() {
+		$this->indexing_helper
+			->expects( 'is_initial_indexing' )
+			->withNoArgs()
+			->andReturnTrue();
+		$this->indexing_helper
+			->expects( 'is_finished_indexables_indexing' )
+			->withNoArgs()
+			->andReturnTrue();
+
+		$user = self::factory()->user->create_and_get( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $user->ID );
+		$result = $this->instance->first_time_configuration_not_finished();
+		$this->assertFalse( $result, 'Checking on administrator' );
+
+		$this->options_helper->set( 'configuration_finished_steps', [ 1, 2, 3, 4 ] );
+		$result = $this->instance->first_time_configuration_not_finished();
+		$this->assertFalse( $result, 'Checking on finished steps' );
+
+		$this->options_helper->set( 'first_time_install', false );
+		$result = $this->instance->first_time_configuration_not_finished();
+		$this->assertFalse( $result, 'Checking on finished steps' );
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Add integration tests to first time configuration notice helper from hackathon.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds integration tests to first time configuration notice helper.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* When generating integration tests report, this class coverage should be %81.4.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
