### PR TITLE
Introduce the promotions helper

### DIFF
--- a/config/dependency-injection/services.php
+++ b/config/dependency-injection/services.php
@@ -12,8 +12,6 @@ use WPSEO_Shortlinker;
 use WPSEO_Utils;
 use Yoast\WP\Lib\Migrations\Adapter;
 use Yoast\WP\SEO\Presenters\Robots_Txt_Presenter;
-use Yoast\WP\SEO\Promotions\Application\Promotion_Manager;
-use Yoast\WP\SEO\Promotions\Domain\Black_Friday_Promotion;
 use Yoast\WP\SEO\WordPress\Wrapper;
 use Yoast_Notification_Center;
 use YoastSEO_Vendor\Symfony\Component\DependencyInjection\ContainerInterface;
@@ -48,8 +46,6 @@ $container->setAlias( ContainerInterface::class, 'service_container' );
 
 // Required for the migrations framework.
 $container->register( Adapter::class, Adapter::class )->setAutowired( true )->setPublic( true );
-
-$container->register( Promotion_Manager::class, Promotion_Manager::class )->setAutowired( true )->setPublic( true )->setArguments( [ new Black_Friday_Promotion() ] );
 
 // Elegantly deprecate renamed classes.
 include __DIR__ . '/renamed-classes.php';

--- a/config/dependency-injection/services.php
+++ b/config/dependency-injection/services.php
@@ -49,7 +49,7 @@ $container->setAlias( ContainerInterface::class, 'service_container' );
 // Required for the migrations framework.
 $container->register( Adapter::class, Adapter::class )->setAutowired( true )->setPublic( true );
 
-$container->register(Promotion_Manager::class, Promotion_Manager::class)->setAutowired(true)->setPublic(true)->setArguments( [ new Black_Friday_Promotion(), ] );
+$container->register( Promotion_Manager::class, Promotion_Manager::class )->setAutowired( true )->setPublic( true )->setArguments( [ new Black_Friday_Promotion() ] );
 
 // Elegantly deprecate renamed classes.
 include __DIR__ . '/renamed-classes.php';

--- a/config/dependency-injection/services.php
+++ b/config/dependency-injection/services.php
@@ -12,6 +12,8 @@ use WPSEO_Shortlinker;
 use WPSEO_Utils;
 use Yoast\WP\Lib\Migrations\Adapter;
 use Yoast\WP\SEO\Presenters\Robots_Txt_Presenter;
+use Yoast\WP\SEO\Promotions\Application\Promotion_Manager;
+use Yoast\WP\SEO\Promotions\Domain\Black_Friday_Promotion;
 use Yoast\WP\SEO\WordPress\Wrapper;
 use Yoast_Notification_Center;
 use YoastSEO_Vendor\Symfony\Component\DependencyInjection\ContainerInterface;
@@ -46,6 +48,8 @@ $container->setAlias( ContainerInterface::class, 'service_container' );
 
 // Required for the migrations framework.
 $container->register( Adapter::class, Adapter::class )->setAutowired( true )->setPublic( true );
+
+$container->register(Promotion_Manager::class, Promotion_Manager::class)->setAutowired(true)->setPublic(true)->setArguments( [ new Black_Friday_Promotion(), ] );
 
 // Elegantly deprecate renamed classes.
 include __DIR__ . '/renamed-classes.php';

--- a/src/promotions/application/promotion-manager-interface.php
+++ b/src/promotions/application/promotion-manager-interface.php
@@ -16,12 +16,12 @@ interface Promotion_Manager_Interface {
 	 *
 	 * @return bool Whether the promotion is effective.
 	 */
-	public function is( string $promotion_name );
+	public function is( string $promotion_name ) : bool;
 
 	/**
 	 * Get the list of promotions.
 	 *
 	 * @return array The list of promotions.
 	 */
-	public function get_promotions_list();
+	public function get_promotions_list() : array;
 }

--- a/src/promotions/application/promotion-manager-interface.php
+++ b/src/promotions/application/promotion-manager-interface.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Yoast\WP\SEO\Promotions\Application;
+
+/**
+ * Interface for the promotion manager.
+ *
+ * @makePublic
+ */
+interface Promotion_Manager_Interface {
+
+	/**
+	 * Whether the promotion is effective.
+	 *
+	 * @param string $promotion_name The name of the promotion.
+	 *
+	 * @return bool Whether the promotion is effective.
+	 */
+	public function is( string $promotion_name );
+
+	/**
+	 * Get the list of promotions.
+	 *
+	 * @return array The list of promotions.
+	 */
+	public function get_promotions_list();
+}

--- a/src/promotions/application/promotion-manager.php
+++ b/src/promotions/application/promotion-manager.php
@@ -34,7 +34,7 @@ class Promotion_Manager implements Promotion_Manager_Interface {
 	 *
 	 * @return bool Whether the promotion is effective.
 	 */
-	public function is( string $promotion_name ) {
+	public function is( string $promotion_name ) : bool {
 		$time = \time();
 
 		foreach ( $this->promotions_list as $promotion ) {
@@ -51,7 +51,7 @@ class Promotion_Manager implements Promotion_Manager_Interface {
 	 *
 	 * @return array<Abstract_Promotion> The list of promotions.
 	 */
-	public function get_promotions_list() {
+	public function get_promotions_list() : array {
 		return $this->promotions_list;
 	}
 }

--- a/src/promotions/application/promotion-manager.php
+++ b/src/promotions/application/promotion-manager.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Yoast\WP\SEO\Promotions\Application;
+
+use Yoast\WP\SEO\Promotions\Domain\Promotion_Interface;
+
+/**
+ * Class to manage promotional promotions.
+ *
+ * @makePublic
+ */
+class Promotion_Manager implements Promotion_Manager_Interface {
+
+	/**
+	 * The centralized list of promotions: all promotions should be passed to the constructor.
+	 *
+	 * @var array
+	 */
+	private $promotions_list = [];
+
+	/**
+	 * Class constructor.
+	 */
+	public function __construct( Promotion_Interface ...$promotions ) {
+		$this->promotions_list = $promotions;
+	}
+
+	/**
+	 * Whether the promotion is effective.
+	 *
+	 * @param string $promotion_name The name of the promotion.
+	 *
+	 * @return bool Whether the promotion is effective.
+	 */
+	public function is( string $promotion_name ) {
+		$time = \time();
+
+		foreach ( $this->promotions_list as $promotion ) {
+			if ( $promotion->get_promotion_name() === $promotion_name ) {
+				return $promotion->get_time_interval()->contains( $time );
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Get the list of promotions.
+	 *
+	 * @return array The list of promotions.
+	 */
+	public function get_promotions_list() {
+		return $this->promotions_list;
+	}
+}

--- a/src/promotions/application/promotion-manager.php
+++ b/src/promotions/application/promotion-manager.php
@@ -20,6 +20,8 @@ class Promotion_Manager implements Promotion_Manager_Interface {
 
 	/**
 	 * Class constructor.
+	 *
+	 * @param Promotion_Interface ...$promotions list of promotions.
 	 */
 	public function __construct( Promotion_Interface ...$promotions ) {
 		$this->promotions_list = $promotions;

--- a/src/promotions/application/promotion-manager.php
+++ b/src/promotions/application/promotion-manager.php
@@ -14,7 +14,7 @@ class Promotion_Manager implements Promotion_Manager_Interface {
 	/**
 	 * The centralized list of promotions: all promotions should be passed to the constructor.
 	 *
-	 * @var array
+	 * @var array<Abstract_Promotion>
 	 */
 	private $promotions_list = [];
 
@@ -47,7 +47,7 @@ class Promotion_Manager implements Promotion_Manager_Interface {
 	/**
 	 * Get the list of promotions.
 	 *
-	 * @return array The list of promotions.
+	 * @return array<Abstract_Promotion> The list of promotions.
 	 */
 	public function get_promotions_list() {
 		return $this->promotions_list;

--- a/src/promotions/domain/abstract-promotion.php
+++ b/src/promotions/domain/abstract-promotion.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Yoast\WP\SEO\Promotions\Domain;
+
+/**
+ * Abstract class for a promotion.
+ */
+abstract class Abstract_Promotion implements Promotion_Interface{
+
+	private $promotion_name;
+
+	private $time_interval;
+
+	/**
+	 * Class constructor.
+	 */
+	public function __construct( string $promotion_name, Time_Interval $time_interval ) {
+		$this->promotion_name = $promotion_name;
+		$this->time_interval = $time_interval;
+	}
+
+	public function get_promotion_name() {
+		return $this->promotion_name;
+	}
+
+	public function get_time_interval() {
+		return $this->time_interval;
+	}
+
+}

--- a/src/promotions/domain/abstract-promotion.php
+++ b/src/promotions/domain/abstract-promotion.php
@@ -5,26 +5,48 @@ namespace Yoast\WP\SEO\Promotions\Domain;
 /**
  * Abstract class for a promotion.
  */
-abstract class Abstract_Promotion implements Promotion_Interface{
+abstract class Abstract_Promotion implements Promotion_Interface {
 
+	/**
+	 * The promotion name.
+	 *
+	 * @var string
+	 */
 	private $promotion_name;
 
+	/**
+	 * The time interval in which the promotion is active.
+	 *
+	 * @var Time_Interval
+	 */
 	private $time_interval;
 
 	/**
 	 * Class constructor.
+	 *
+	 * @param string        $promotion_name The promotion name.
+	 * @param Time_Interval $time_interval  The time interval in which the promotion is active.
 	 */
 	public function __construct( string $promotion_name, Time_Interval $time_interval ) {
 		$this->promotion_name = $promotion_name;
-		$this->time_interval = $time_interval;
+		$this->time_interval  = $time_interval;
 	}
 
+	/**
+	 * Returns the promotion name.
+	 *
+	 * @return string
+	 */
 	public function get_promotion_name() {
 		return $this->promotion_name;
 	}
 
+	/**
+	 * Returns the time interval in which the promotion is active.
+	 *
+	 * @return Time_Interval
+	 */
 	public function get_time_interval() {
 		return $this->time_interval;
 	}
-
 }

--- a/src/promotions/domain/black-friday-promotion.php
+++ b/src/promotions/domain/black-friday-promotion.php
@@ -2,19 +2,20 @@
 
 namespace Yoast\WP\SEO\Promotions\Domain;
 
-
 /**
  * Class to manage the Black Friday promotion.
  *
  * @makePublic
  */
-class Black_Friday_Promotion extends Abstract_Promotion implements Promotion_Interface{
+class Black_Friday_Promotion extends Abstract_Promotion implements Promotion_Interface {
 
+	/**
+	 * Class constructor.
+	 */
 	public function __construct() {
 		parent::__construct(
 			'black_friday_2023',
 			new Time_Interval( \gmmktime( 11, 00, 00, 12, 23, 2021 ), \gmmktime( 11, 00, 00, 12, 28, 2025 ) )
 		);
-	
 	}
 }

--- a/src/promotions/domain/black-friday-promotion.php
+++ b/src/promotions/domain/black-friday-promotion.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Yoast\WP\SEO\Promotions\Domain;
+
+
+/**
+ * Class to manage the Black Friday promotion.
+ *
+ * @makePublic
+ */
+class Black_Friday_Promotion extends Abstract_Promotion implements Promotion_Interface{
+
+	public function __construct() {
+		parent::__construct(
+			'black_friday_2023',
+			new Time_Interval( \gmmktime( 11, 00, 00, 12, 23, 2021 ), \gmmktime( 11, 00, 00, 12, 28, 2025 ) )
+		);
+	
+	}
+}

--- a/src/promotions/domain/black-friday-promotion.php
+++ b/src/promotions/domain/black-friday-promotion.php
@@ -15,7 +15,7 @@ class Black_Friday_Promotion extends Abstract_Promotion implements Promotion_Int
 	public function __construct() {
 		parent::__construct(
 			'black_friday_2023',
-			new Time_Interval( \gmmktime( 11, 00, 00, 12, 23, 2021 ), \gmmktime( 11, 00, 00, 12, 28, 2025 ) )
+			new Time_Interval( \gmmktime( 11, 00, 00, 11, 23, 2023 ), \gmmktime( 11, 00, 00, 11, 28, 2023 ) )
 		);
 	}
 }

--- a/src/promotions/domain/promotion-interface.php
+++ b/src/promotions/domain/promotion-interface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Yoast\WP\SEO\Promotions\Domain;
+
+/**
+ * Interface for a Promotion.
+ */
+interface Promotion_Interface {}

--- a/src/promotions/domain/time-interval.php
+++ b/src/promotions/domain/time-interval.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Yoast\WP\SEO\Promotions\Domain;
+
+/**
+ * Class Time_Interval
+ *
+ * Value object for a time interval.
+ */
+class Time_Interval {
+
+	/**
+	 * The starting time of the interval as a Unix timestamp.
+	 *
+	 * @var int
+	 */
+	public $time_start;
+
+	/**
+	 * The ending time of the interval as a Unix timestamp.
+	 *
+	 * @var int
+	 */
+	public $time_end;
+
+	/**
+	 * Time_Interval constructor.
+	 *
+	 * @codeCoverageIgnore
+	 *
+	 * @param int $time_start Interval start time.
+	 * @param int $time_end  Interval end time.
+	 */
+	public function __construct( int $time_start, int $time_end ) {
+		$this->time_start = $time_start;
+		$this->time_end   = $time_end;
+	}
+
+	/**
+	 * Checks if the given time is within the interval.
+	 *
+	 * @param int $time The time to check.
+	 *
+	 * @return bool Whether the given time is within the interval.
+	 */
+	public function contains( int $time ): bool {
+		return ( ( $time > $this->time_start ) && ( $time < $this->time_end ) );
+	}
+
+	/**
+	 * Sets the interval astarting date.
+	 *
+	 * @param int $time_start The interval start time.
+	 *
+	 * @return void
+	 */
+	public function set_start_date( int $time_start ) {
+		$this->time_start = $time_start;
+	}
+
+	/**
+	 * Sets the interval ending date.
+	 *
+	 * @param int $time_end The interval end time.
+	 *
+	 * @return void
+	 */
+	public function set_end_date( int $time_end ) {
+		$this->time_end = $time_end;
+	}
+}

--- a/tests/unit/promotions/application/fake-expired-promotion.php
+++ b/tests/unit/promotions/application/fake-expired-promotion.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Promotions\Application;
+
+use Yoast\WP\SEO\Promotions\Domain\Abstract_Promotion;
+use Yoast\WP\SEO\Promotions\Domain\Promotion_Interface;
+use Yoast\WP\SEO\Promotions\Domain\Time_Interval;
+
+/**
+ * Class representing a fake promotion which has been expired.
+ */
+class Fake_Expired_Promotion extends Abstract_Promotion implements Promotion_Interface {
+
+	/**
+	 * Class constructor.
+	 */
+	public function __construct() {
+		parent::__construct(
+			'fake_expired_promotion',
+			new Time_Interval( \gmmktime( 00, 00, 00, 01, 01, 1980 ), \gmmktime( 00, 00, 00, 12, 31, 1980 ) )
+		);
+	}
+}

--- a/tests/unit/promotions/application/fake-promotion.php
+++ b/tests/unit/promotions/application/fake-promotion.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Promotions\Application;
+
+use Yoast\WP\SEO\Promotions\Domain\Abstract_Promotion;
+use Yoast\WP\SEO\Promotions\Domain\Promotion_Interface;
+use Yoast\WP\SEO\Promotions\Domain\Time_Interval;
+
+/**
+ * Class representing a fake promotion.
+ */
+class Fake_Promotion extends Abstract_Promotion implements Promotion_Interface {
+
+	/**
+	 * Class constructor.
+	 */
+	public function __construct() {
+		parent::__construct(
+			'fake_promotion',
+			new Time_Interval( ( \time() - 10000 ), ( \time() + 10000 ) )
+		);
+	}
+}

--- a/tests/unit/promotions/application/promotion-manager-test.php
+++ b/tests/unit/promotions/application/promotion-manager-test.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Promotions\Application;
+
+use Yoast\WP\SEO\Promotions\Application\Promotion_Manager;
+use Yoast\WP\SEO\Promotions\Domain\Black_Friday_Promotion;
+use Yoast\WP\SEO\Tests\Unit\Promotions\Application\Fake_Promotion;
+use Yoast\WP\SEO\Tests\Unit\Promotions\Application\Fake_Expired_Promotion;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+/**
+ * Class Promotion_Manager_Test
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Promotions\Application\Promotion_Manager
+ */
+class Promotion_Manager_Test extends TestCase {
+
+	/**
+	 * Represents the class to test.
+	 *
+	 * @var Promotion_Manager
+	 */
+	protected $instance;
+
+	/**
+	 * Setup the tests.
+	 */
+	protected function set_up() {
+		parent::set_up();
+		$this->instance = new Promotion_Manager( new Fake_Promotion(), new Fake_Expired_Promotion() );
+	}
+
+	/**
+	 * Tests the is function which tests if a promotion is currently active.
+	 *
+	 * @covers ::is
+	 */
+	public function test_is() {
+		$this->assertTrue( $this->instance->is( 'fake_promotion' ) );
+		$this->assertFalse( $this->instance->is( 'non_existent_promotion' ) );
+		$this->assertFalse( $this->instance->is( 'fake_expired_promotion' ) );
+	}
+
+	/**
+	 * Tests the get_promotions_list function which returns the list of promotions.
+	 *
+	 * @covers ::get_promotions_list
+	 */
+	public function test_get_promotions_list() {
+		$this->assertCount( 2, $this->instance->get_promotions_list() );
+		$this->assertEquals( $this->instance->get_promotions_list()[0]->get_promotion_name(), 'fake_promotion' );
+	}
+}

--- a/tests/unit/promotions/domain/time-interval-test.php
+++ b/tests/unit/promotions/domain/time-interval-test.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Yoast\WP\SEO\Promotions\Domain;
+
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+use Yoast\WP\SEO\Promotions\Domain\Time_Interval;
+
+/**
+ * Class Time_Interval_Test
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Promotions\Domain\Time_Interval
+ */
+class Time_Interval_Test extends TestCase {
+
+	/**
+	 * Represents the class to test.
+	 *
+	 * @var Time_Interval
+	 */
+	protected $instance;
+
+	/**
+	 * Setup the tests.
+	 */
+	protected function set_up() {
+		parent::set_up();
+		$start_date = \gmmktime( 11, 00, 00, 12, 23, 2021 );
+		$end_date   = \gmmktime( 11, 00, 00, 12, 28, 2025 );
+		$this->instance = new Time_Interval( $start_date, $end_date );
+	}
+
+	/**
+	 * Tests setting the start date.
+	 *
+	 * @covers ::set_start_date
+	 */
+	public function test_set_start_date() {
+		$new_start_date = \gmmktime( 11, 00, 00, 12, 23, 2021 );
+
+		$this->instance->set_start_date( $new_start_date );
+
+		$this->assertEquals( $new_start_date, $this->instance->time_start );
+	}
+
+	/**
+	 * Tests checking if a time is within the interval.
+	 *
+	 * @covers ::contains
+	 */
+	public function test_contains() {
+		$time = \gmmktime( 11, 00, 00, 12, 23, 2022 );
+
+		$this->assertTrue( $this->instance->contains( $time ) );
+	}
+
+	/**
+	 * Tests setting the end date.
+	 *
+	 * @covers ::set_end_date
+	 */
+	public function test_set_end_date() {
+		$new_end_date = \gmmktime( 11, 00, 00, 12, 23, 2026 );
+
+		$this->instance->set_end_date( $new_end_date );
+
+		$this->assertEquals( $new_end_date, $this->instance->time_end );
+	}
+}

--- a/tests/unit/promotions/domain/time-interval-test.php
+++ b/tests/unit/promotions/domain/time-interval-test.php
@@ -24,8 +24,8 @@ class Time_Interval_Test extends TestCase {
 	 */
 	protected function set_up() {
 		parent::set_up();
-		$start_date = \gmmktime( 11, 00, 00, 12, 23, 2021 );
-		$end_date   = \gmmktime( 11, 00, 00, 12, 28, 2025 );
+		$start_date     = \gmmktime( 11, 00, 00, 12, 23, 2021 );
+		$end_date       = \gmmktime( 11, 00, 00, 12, 28, 2025 );
 		$this->instance = new Time_Interval( $start_date, $end_date );
 	}
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to systematize the way we introduce and manage temporary promotions (e.g., the Black Friday ads).

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Introduces the `Promotions_Manager` class and related classes to manage temporary promotions ads.

## Relevant technical choices:

* The `Promotions_Manager` is instantiated an registered as a service in the DI container. It accepts an array of  `Promotions`. Each Promotion has a unique name and a time frame in which it is considered active.
* A `Black_Friday_Promotion` is also introduced in this PR, which represents the time frame for the sales related to the Black Friday 2023 promotions.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Start a debugging session by putting a breakpoint, e.g. in `src/integrations/admin/first-time-configuration-integration.php`, in the `register_hooks` method
* in the debug console, get the `Promotions_Manager` instance by typing:
`$promotion_manager = YoastSEO()->classes->get( Yoast\WP\SEO\Promotions\Application\Promotion_Manager::class );`  
  * verify the promotion manager returns `false` when checking if the Black Friday promotion is active by typing:
    `$promotion_manager->is('black_friday_2023')`
* Stop the debugging session
* Go to `src/promotions/domain/black-friday-promotion.php` and edit the promotion starting date by changing `\gmmktime( 11, 00, 00, 11, 23, 2023 )` to `\gmmktime( 11, 00, 00, 11, 23, 2022 )`
  * this ensures we are in the promotion time frame
* Start the debugging session again and repeat the passages above to get the promotion manager and check  if the Black Friday promotion is active
  * verify you now get `true` when checking for the promotion  
#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* QA is not supposed to test this PR, as it represents the technical foundation for the user-facing Black Friday PRs. QA will test those PRs instead.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The promotion manager is a self-contained feature, so no additional checks should be performed.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [X] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.
* [X] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
