### PR TITLE
Fix prev query loop

### DIFF
--- a/src/integrations/front-end-integration.php
+++ b/src/integrations/front-end-integration.php
@@ -177,6 +177,20 @@ class Front_End_Integration implements Integration_Interface {
 	];
 
 	/**
+	 * The next output.
+	 *
+	 * @var string
+	 */
+	protected $next;
+
+	/**
+	 * The prev output.
+	 *
+	 * @var string
+	 */
+	protected $prev;
+
+	/**
 	 * Returns the conditionals based on which this loadable should be active.
 	 *
 	 * @return array The conditionals.
@@ -184,20 +198,6 @@ class Front_End_Integration implements Integration_Interface {
 	public static function get_conditionals() {
 		return [ Front_End_Conditional::class ];
 	}
-
-	/**
-	 * The next output.
-	 *
-	 * @var bool
-	 */
-	public $next;
-
-	/**
-	 * The prev output.
-	 *
-	 * @var bool
-	 */
-	public $prev;
 
 	/**
 	 * Front_End_Integration constructor.
@@ -315,6 +315,10 @@ class Front_End_Integration implements Integration_Interface {
 	 * @return string The correct link.
 	 */
 	public function adjacent_rel_url( $link, $rel, $presentation = null ) {
+		if ( $link === \home_url( '/' ) ) {
+			return $link;
+		}
+
 		if ( $rel === 'next' || $rel === 'prev' ) {
 
 			// WP_HTML_Tag_Processor was introduced in WordPress 6.2.
@@ -337,6 +341,8 @@ class Front_End_Integration implements Integration_Interface {
 				}
 			}
 		}
+
+		return $link;
 	}
 
 	/**

--- a/tests/integration/doubles/front-end-integration-double.php
+++ b/tests/integration/doubles/front-end-integration-double.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * WPSEO plugin test file.
+ *
+ * @package WPSEO\Tests\Doubles
+ */
+
+use Yoast\WP\SEO\Integrations\Front_End_Integration;
+
+/**
+ * Test Helper Class.
+ */
+class Front_End_Integration_Double extends Front_End_Integration {
+
+	/**
+	 * Sets the `prev` property.
+	 *
+	 * @param string $prev The value for the property.
+	 *
+	 * @return void
+	 */
+	public function set_prev( $prev ) {
+		$this->prev = $prev;
+	}
+
+	/**
+	 * Sets the `next` property.
+	 *
+	 * @param string $next The value for the property.
+	 *
+	 * @return void
+	 */
+	public function set_next( $next ) {
+		$this->next = $next;
+	}
+}

--- a/tests/integration/frontend/test-front-end-integration.php
+++ b/tests/integration/frontend/test-front-end-integration.php
@@ -1,0 +1,157 @@
+<?php
+/**
+ * WPSEO plugin test file.
+ *
+ * @package WPSEO\Frontend
+ */
+
+use Yoast\WP\SEO\Helpers\Options_Helper;
+use Yoast\WP\SEO\Helpers\Request_Helper;
+use Yoast\WP\SEO\Integrations\Front_End_Integration;
+use Yoast\WP\SEO\Memoizers\Meta_Tags_Context_Memoizer;
+use Yoast\WP\SEO\Presentations\Indexable_Presentation;
+use Yoast\WP\SEO\Surfaces\Helpers_Surface;
+use YoastSEO_Vendor\Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Class Front_End_Integration_Test.
+ * Integration Test Class for the Front_End_Integration class.
+ *
+ * @coversDefaultClass Yoast\WP\SEO\Integrations\Front_End_Integration
+ */
+class Front_End_Integration_Test extends WPSEO_UnitTestCase {
+
+	/**
+	 * The memoizer for the meta tags context.
+	 *
+	 * @var Meta_Tags_Context_Memoizer
+	 */
+	private $context_memoizer;
+
+	/**
+	 * The container.
+	 *
+	 * @var ContainerInterface
+	 */
+	protected $container;
+
+	/**
+	 * Represents the options helper.
+	 *
+	 * @var Options_Helper
+	 */
+	protected $options;
+
+	/**
+	 * Represents the request helper.
+	 *
+	 * @var Request_Helper
+	 */
+	protected $request;
+
+	/**
+	 * The helpers surface.
+	 *
+	 * @var Helpers_Surface
+	 */
+	protected $helpers;
+
+	/**
+	 * The replace vars helper.
+	 *
+	 * @var WPSEO_Replace_Vars
+	 */
+	protected $replace_vars;
+
+	/**
+	 * The instance.
+	 *
+	 * @var \Front_End_Integration_Double
+	 */
+	private $instance;
+
+	/**
+	 * Sets up the test class.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->context_memoizer = Mockery::mock( Meta_Tags_Context_Memoizer::class );
+		$this->container        = Mockery::mock( ContainerInterface::class );
+		$this->options          = Mockery::mock( Options_Helper::class );
+		$this->request          = Mockery::mock( Request_Helper::class );
+		$this->helpers          = Mockery::mock( Helpers_Surface::class );
+		$this->replace_vars     = Mockery::mock( WPSEO_Replace_Vars::class );
+
+		$this->instance = new Front_End_Integration_Double(
+			$this->context_memoizer,
+			$this->container,
+			$this->options,
+			$this->request,
+			$this->helpers,
+			$this->replace_vars
+		);
+	}
+
+	/**
+	 * Tests that the correct next/prev links are set in head tag.
+	 *
+	 * @covers ::adjacent_rel_url
+	 *
+	 * @dataProvider data_provider_adjacent_rel_url
+	 *
+	 * @param string $link     The value to be filtered.
+	 * @param string $rel      Rel attribute.
+	 * @param string $prev     The value to be set as the `prev` property of the instance.
+	 * @param string $next     The value to be set as the `next` property of the instance.
+	 * @param string $expected Expected result.
+	 */
+	public function test_adjacent_rel_url( $link, $rel, $prev, $next, $expected ) {
+		$this->instance->set_prev( $prev );
+		$this->instance->set_next( $next );
+
+		$presentation            = Mockery::mock( Indexable_Presentation::class );
+		$presentation->permalink = 'https://example.org/';
+
+		$result = $this->instance->adjacent_rel_url( $link, $rel, $presentation );
+
+		$this->assertSame( $expected, $result );
+	}
+
+	/**
+	 * Data provider for the test_adjacent_rel_url test.
+	 *
+	 * @return array
+	 */
+	public static function data_provider_adjacent_rel_url() {
+		return [
+			'no links' => [
+				'link'     => '',
+				'rel'      => 'nothing',
+				'prev'     => '<a href="/?query-1-page=2">Prev</a>',
+				'next'     => '<a href="/?query-1-page=4">Next</a>',
+				'expected' => '',
+			],
+			'next link' => [
+				'link'     => 'https://example.org?query-1-page=4',
+				'rel'      => 'next',
+				'prev'     => '<a href="/?query-1-page=2">Prev</a>',
+				'next'     => '<a href="/?query-1-page=4">Next</a>',
+				'expected' => 'https://example.org/?query-1-page=4',
+			],
+			'prev link' => [
+				'link'     => 'https://example.org?query-1-page=2',
+				'rel'      => 'prev',
+				'prev'     => '<a href="/?query-1-page=2">Prev</a>',
+				'next'     => '<a href="/?query-1-page=4">Next</a>',
+				'expected' => 'https://example.org/?query-1-page=2',
+			],
+			'prev link is home' => [
+				'link'     => 'https://example.org/',
+				'rel'      => 'prev',
+				'prev'     => '<a href="/?query-1-page=2">Prev</a>',
+				'next'     => '<a href="/?query-1-page=4">Next</a>',
+				'expected' => 'https://example.org/?query-1-page=2',
+			],
+		];
+	}
+}

--- a/tests/unit/integrations/front-end-integration-test.php
+++ b/tests/unit/integrations/front-end-integration-test.php
@@ -740,7 +740,7 @@ class Front_End_Integration_Test extends TestCase {
 
 		$this->instance->query_loop_next_prev( $html, $block );
 
-		$this->assertEquals( $this->instance->$variable, $html );
+		$this->assertEquals( self::getPropertyValue( $this->instance, $variable ), $html );
 	}
 
 	/**
@@ -762,49 +762,5 @@ class Front_End_Integration_Test extends TestCase {
 
 		$result = $this->instance->query_loop_next_prev( $html, $block );
 		$this->assertNotFalse( \has_filter( 'wpseo_adjacent_rel_url', [ $this->instance, 'adjacent_rel_url' ] ), 'Set the correct next/prev links in head tag' );
-	}
-
-	/**
-	 * Data provider for the test_adjacent_rel_url test.
-	 *
-	 * @return array
-	 */
-	public static function data_provider_adjacent_rel_url() {
-		return [
-			'no links' => [
-				'rel'      => 'nothing',
-				'expected' => null,
-			],
-			'next link' => [
-				'rel'      => 'next',
-				'expected' => 'https://example.com/?query-1-page=2',
-			],
-			'prev link' => [
-				'rel'      => 'prev',
-				'expected' => 'https://example.com/?query-1-page=3',
-			],
-		];
-	}
-
-	/**
-	 * Tests that the correct next/prev links are set in head tag.
-	 *
-	 * @covers ::adjacent_rel_url
-	 *
-	 * @dataProvider data_provider_adjacent_rel_url
-	 *
-	 * @param string $rel Rel attribute.
-	 * @param string $expected Expected result.
-	 */
-	public function test_adjacent_rel_url( $rel, $expected ) {
-
-		$this->instance->next = '<a href="/?query-1-page=2">Next</a>';
-		$this->instance->prev = '<a href="/?query-1-page=3">Prev</a>';
-
-		$presentation            = Mockery::mock( Presentation::class );
-		$presentation->permalink = 'https://example.com/';
-		$result                  = $this->instance->adjacent_rel_url( '', $rel, $presentation );
-
-		$this->assertEquals( $expected, $result );
 	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where the `prev` tag would be not be filled with the home url as expected when using a custom query loop block.

## Relevant technical choices:

* I moved the test from unit-type to integration-type because we were testing only the legacy code to support WP 6.1 and older, which won't be the case soon anymore
* I changed the visibility of the properties since they were public only for testing purposes.
* I also added a return statment to the method since it's used in a filter so it should ALWAYS return something.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Perform the acceptance test of https://github.com/Yoast/wordpress-seo/pull/20542 and check that the `prev` meta tag in the second page points to the home url without params.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/plugins-automated-testing/issues/1017
