### PR TITLE
Improve upsells

### DIFF
--- a/admin/class-admin-asset-manager.php
+++ b/admin/class-admin-asset-manager.php
@@ -549,6 +549,7 @@ class WPSEO_Admin_Asset_Manager {
 				'src'  => 'metabox-' . $flat_version,
 				'deps' => [
 					self::PREFIX . 'admin-css',
+					self::PREFIX . 'tailwind',
 					'wp-components',
 				],
 			],

--- a/admin/class-expose-shortlinks.php
+++ b/admin/class-expose-shortlinks.php
@@ -31,10 +31,8 @@ class WPSEO_Expose_Shortlinks implements WPSEO_WordPress_Integration {
 		'shortlinks.upsell.social_preview.social'                   => 'https://yoa.st/social-preview-facebook',
 		'shortlinks.upsell.social_preview.twitter'                  => 'https://yoa.st/social-preview-twitter',
 		'shortlinks.upsell.sidebar.news'                            => 'https://yoa.st/get-news-sidebar',
-		'shortlinks.upsell.sidebar.focus_keyword_synonyms_link'     => 'https://yoa.st/textlink-synonyms-popup-sidebar',
 		'shortlinks.upsell.sidebar.focus_keyword_synonyms_button'   => 'https://yoa.st/keyword-synonyms-popup-sidebar',
 		'shortlinks.upsell.sidebar.premium_seo_analysis_button'     => 'https://yoa.st/premium-seo-analysis-sidebar',
-		'shortlinks.upsell.sidebar.focus_keyword_additional_link'   => 'https://yoa.st/textlink-keywords-popup-sidebar',
 		'shortlinks.upsell.sidebar.focus_keyword_additional_button' => 'https://yoa.st/add-keywords-popup-sidebar',
 		'shortlinks.upsell.sidebar.additional_link'                 => 'https://yoa.st/textlink-keywords-sidebar',
 		'shortlinks.upsell.sidebar.additional_button'               => 'https://yoa.st/add-keywords-sidebar',
@@ -42,10 +40,8 @@ class WPSEO_Expose_Shortlinks implements WPSEO_WordPress_Integration {
 		'shortlinks.upsell.sidebar.word_complexity'                 => 'https://yoa.st/word-complexity-sidebar',
 		'shortlinks.upsell.metabox.news'                            => 'https://yoa.st/get-news-metabox',
 		'shortlinks.upsell.metabox.go_premium'                      => 'https://yoa.st/pe-premium-page',
-		'shortlinks.upsell.metabox.focus_keyword_synonyms_link'     => 'https://yoa.st/textlink-synonyms-popup-metabox',
 		'shortlinks.upsell.metabox.focus_keyword_synonyms_button'   => 'https://yoa.st/keyword-synonyms-popup',
 		'shortlinks.upsell.metabox.premium_seo_analysis_button'     => 'https://yoa.st/premium-seo-analysis-metabox',
-		'shortlinks.upsell.metabox.focus_keyword_additional_link'   => 'https://yoa.st/textlink-keywords-popup-metabox',
 		'shortlinks.upsell.metabox.focus_keyword_additional_button' => 'https://yoa.st/add-keywords-popup',
 		'shortlinks.upsell.metabox.additional_link'                 => 'https://yoa.st/textlink-keywords-metabox',
 		'shortlinks.upsell.metabox.additional_button'               => 'https://yoa.st/add-keywords-metabox',
@@ -117,9 +113,7 @@ class WPSEO_Expose_Shortlinks implements WPSEO_WordPress_Integration {
 
 		$shortlinks = $this->shortlinks;
 
-		$shortlinks['shortlinks.upsell.metabox.focus_keyword_synonyms_link']     = 'https://yoa.st/textlink-synonyms-popup-metabox-term';
 		$shortlinks['shortlinks.upsell.metabox.focus_keyword_synonyms_button']   = 'https://yoa.st/keyword-synonyms-popup-term';
-		$shortlinks['shortlinks.upsell.metabox.focus_keyword_additional_link']   = 'https://yoa.st/textlink-keywords-popup-metabox-term';
 		$shortlinks['shortlinks.upsell.metabox.focus_keyword_additional_button'] = 'https://yoa.st/add-keywords-popup-term';
 		$shortlinks['shortlinks.upsell.metabox.additional_link']                 = 'https://yoa.st/textlink-keywords-metabox-term';
 		$shortlinks['shortlinks.upsell.metabox.additional_button']               = 'https://yoa.st/add-keywords-metabox-term';

--- a/admin/class-expose-shortlinks.php
+++ b/admin/class-expose-shortlinks.php
@@ -38,6 +38,7 @@ class WPSEO_Expose_Shortlinks implements WPSEO_WordPress_Integration {
 		'shortlinks.upsell.sidebar.additional_button'               => 'https://yoa.st/add-keywords-sidebar',
 		'shortlinks.upsell.sidebar.keyphrase_distribution'          => 'https://yoa.st/keyphrase-distribution-sidebar',
 		'shortlinks.upsell.sidebar.word_complexity'                 => 'https://yoa.st/word-complexity-sidebar',
+		'shortlinks.upsell.sidebar.internal_linking_suggestions'    => 'https://yoa.st/internal-linking-suggestions-sidebar',
 		'shortlinks.upsell.metabox.news'                            => 'https://yoa.st/get-news-metabox',
 		'shortlinks.upsell.metabox.go_premium'                      => 'https://yoa.st/pe-premium-page',
 		'shortlinks.upsell.metabox.focus_keyword_synonyms_button'   => 'https://yoa.st/keyword-synonyms-popup',
@@ -47,6 +48,7 @@ class WPSEO_Expose_Shortlinks implements WPSEO_WordPress_Integration {
 		'shortlinks.upsell.metabox.additional_button'               => 'https://yoa.st/add-keywords-metabox',
 		'shortlinks.upsell.metabox.keyphrase_distribution'          => 'https://yoa.st/keyphrase-distribution-metabox',
 		'shortlinks.upsell.metabox.word_complexity'                 => 'https://yoa.st/word-complexity-metabox',
+		'shortlinks.upsell.metabox.internal_linking_suggestions'    => 'https://yoa.st/internal-linking-suggestions-metabox',
 		'shortlinks.upsell.gsc.create_redirect_button'              => 'https://yoa.st/redirects',
 		'shortlinks.readability_analysis_info'                      => 'https://yoa.st/readability-analysis',
 		'shortlinks.inclusive_language_analysis_info'               => 'https://yoa.st/inclusive-language-analysis',
@@ -120,6 +122,7 @@ class WPSEO_Expose_Shortlinks implements WPSEO_WordPress_Integration {
 		$shortlinks['shortlinks.upsell.sidebar.morphology_upsell_metabox']       = 'https://yoa.st/morphology-upsell-metabox-term';
 		$shortlinks['shortlinks.upsell.metabox.keyphrase_distribution']          = 'https://yoa.st/keyphrase-distribution-metabox-term';
 		$shortlinks['shortlinks.upsell.metabox.word_complexity']                 = 'https://yoa.st/word-complexity-metabox-term';
+		$shortlinks['shortlinks.upsell.metabox.internal_linking_suggestions']    = 'https://yoa.st/internal-linking-suggestions-metabox-term';
 
 		return $shortlinks;
 	}

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -865,7 +865,6 @@ class WPSEO_Metabox extends WPSEO_Meta {
 		$asset_manager->enqueue_style( 'metabox-css' );
 		$asset_manager->enqueue_style( 'scoring' );
 		$asset_manager->enqueue_style( 'monorepo' );
-		$asset_manager->enqueue_style( 'tailwind' );
 		$asset_manager->enqueue_style( 'ai-generator' );
 
 		$is_block_editor  = WP_Screen::get()->is_block_editor();

--- a/admin/taxonomy/class-taxonomy.php
+++ b/admin/taxonomy/class-taxonomy.php
@@ -144,7 +144,6 @@ class WPSEO_Taxonomy {
 
 			$asset_manager->enqueue_style( 'metabox-css' );
 			$asset_manager->enqueue_style( 'scoring' );
-			$asset_manager->enqueue_style( 'tailwind' );
 			$asset_manager->enqueue_script( 'term-edit' );
 
 			/**

--- a/packages/js/src/components/KeywordUpsell.js
+++ b/packages/js/src/components/KeywordUpsell.js
@@ -1,46 +1,123 @@
 /* global wpseoAdminL10n */
-import { LocationConsumer } from "@yoast/externals/contexts";
+import { LockClosedIcon } from "@heroicons/react/solid";
+import { useContext } from "@wordpress/element";
+import { __, sprintf } from "@wordpress/i18n";
+import { addQueryArgs } from "@wordpress/url";
+import { SvgIcon } from "@yoast/components";
+import { LocationContext, useRootContext } from "@yoast/externals/contexts";
 import { colors } from "@yoast/style-guide";
-import { __ } from "@wordpress/i18n";
-import MetaboxCollapsible from "./MetaboxCollapsible";
-import MultipleKeywords from "./modals/MultipleKeywords";
-import SidebarCollapsible from "./SidebarCollapsible";
+import { Badge, useSvgAria, useToggleState } from "@yoast/ui-library";
+import { ModalContainer } from "./modals/Container";
+import Modal, { defaultModalClassName } from "./modals/Modal";
+import SidebarButton from "./SidebarButton";
+import UpsellBox from "./UpsellBox";
+
+/**
+ * @returns {Object} The location context.
+ */
+const useLocation = () => useContext( LocationContext );
 
 /**
  * Renders the UpsellBox component.
  *
- * @returns {wp.Element} The UpsellBox component.
+ * @returns {JSX.Element} The UpsellBox component.
  */
 const KeywordUpsell = () => {
+	const [ isOpen, , , openModal, closeModal ] = useToggleState( false );
+	const location = useLocation();
+	const { locationContext } = useRootContext();
+	const svgAriaProps = useSvgAria();
+
+	const buyLink = wpseoAdminL10n[
+		location.toLowerCase() === "sidebar"
+			? "shortlinks.upsell.sidebar.additional_button"
+			: "shortlinks.upsell.metabox.additional_button"
+	];
+	const infoParagraphs = [
+		__( "Get help optimizing for up to 5 related keyphrases. This helps you reach a wider audience and get more traffic.", "wordpress-seo" ),
+		<span key="KeywordUpsell-infoParagraph-benefitsTitle" className="yst-text-[#303030] yst-text-[13px] yst-font-semibold">
+			{ __( "What’s more in Yoast SEO Premium?", "wordpress-seo" ) }
+		</span>,
+	];
+	const benefits = [
+		__( "Get extra SEO checks with the Premium SEO analysis", "wordpress-seo" ),
+		__( "Avoid dead links on your site", "wordpress-seo" ),
+		__( "Easily improve the structure of your site", "wordpress-seo" ),
+		__( "Preview how your content looks when shared on social", "wordpress-seo" ),
+		__( "Get guidance & save time on routine SEO tasks", "wordpress-seo" ),
+	];
+
 	return (
-		<LocationConsumer>
-			{ location => {
-				// Default to metabox.
-				let link = wpseoAdminL10n[ "shortlinks.upsell.metabox.additional_link" ];
-				let buyLink = wpseoAdminL10n[ "shortlinks.upsell.metabox.additional_button" ];
-				let Collapsible = MetaboxCollapsible;
-
-				if ( location.toLowerCase() === "sidebar" ) {
-					link = wpseoAdminL10n[ "shortlinks.upsell.sidebar.additional_link" ];
-					buyLink = wpseoAdminL10n[ "shortlinks.upsell.sidebar.additional_button" ];
-					Collapsible = SidebarCollapsible;
-				}
-
-				return (
-					<Collapsible
-						prefixIcon={ { icon: "plus", color: colors.$color_grey_medium_dark } }
-						prefixIconCollapsed={ { icon: "plus", color: colors.$color_grey_medium_dark } }
-						title={ __( "Add related keyphrase", "wordpress-seo" ) }
-						id={ `yoast-additional-keyphrase-collapsible-${ location }` }
-					>
-						<MultipleKeywords
-							link={ link }
-							buyLink={ buyLink }
+		<>
+			{ isOpen && (
+				<Modal
+					title={ __( "Add related keyphrases", "wordpress-seo" ) }
+					onRequestClose={ closeModal }
+					additionalClassName=""
+					className={ defaultModalClassName }
+					id="yoast-premium-seo-analysis-modal"
+					shouldCloseOnClickOutside={ true }
+				>
+					<ModalContainer>
+						<h2>{ __( "Reach a wider audience", "wordpress-seo" ) }</h2>
+						<UpsellBox
+							infoParagraphs={ infoParagraphs }
+							benefits={ benefits }
+							upsellButtonText={
+								sprintf(
+									/* translators: %s expands to 'Yoast SEO Premium'. */
+									__( "Unlock with %s", "wordpress-seo" ),
+									"Yoast SEO Premium"
+								)
+							}
+							upsellButton={ {
+								href: addQueryArgs( buyLink, { context: locationContext } ),
+								className: "yoast-button-upsell",
+								rel: null,
+								"data-ctb-id": "f6a84663-465f-4cb5-8ba5-f7a6d72224b2",
+								"data-action": "load-nfd-ctb",
+							} }
+							upsellButtonLabel={ __( "1 year of premium support and updates included!", "wordpress-seo" ) }
 						/>
-					</Collapsible>
-				);
-			} }
-		</LocationConsumer>
+					</ModalContainer>
+				</Modal>
+			) }
+			{ location === "sidebar" && (
+				<SidebarButton
+					id="yoast-additional-keyphrase-modal-open-button"
+					title={ __( "Add related keyphrase", "wordpress-seo" ) }
+					prefixIcon={ { icon: "plus", color: colors.$color_grey_medium_dark } }
+					onClick={ openModal }
+				>
+					<div className="yst-root">
+						<Badge size="small" variant="upsell">
+							<LockClosedIcon className="yst-w-2.5 yst-h-2.5 yst-shrink-0" { ...svgAriaProps } />
+						</Badge>
+					</div>
+				</SidebarButton>
+			) }
+			{ location === "metabox" && (
+				<div className="yst-root">
+					<button
+						id="yoast-additional-keyphrase-metabox-modal-open-button"
+						type="button"
+						className="yst-flex yst-items-center yst-w-full yst-pl-6 yst-p-4 yst-space-x-2 yst-border-t yst-border-t-[rgb(0,0,0,0.2)] yst-rounded-none yst-transition-all hover:yst-bg-[#f0f0f0] focus:yst-outline focus:yst-outline-[1px] focus:yst-outline-[color:#0066cd] focus:-yst-outline-offset-1 focus:yst-shadow-[0_0_3px_rgba(8,74,103,0.8)]"
+						onClick={ openModal }
+					>
+						<SvgIcon icon="plus" color={ colors.$color_grey_medium_dark } />
+						<span
+							className="yst-grow yst-overflow-hidden yst-overflow-ellipsis yst-whitespace-nowrap yst-font-wp yst-text-[#555] yst-text-base yst-leading-[normal] yst-subpixel-antialiased yst-text-left"
+						>
+							{ __( "Add related keyphrase", "wordpress-seo" ) }
+						</span>
+						<Badge size="small" variant="upsell">
+							<LockClosedIcon className="yst-w-2.5 yst-h-2.5 yst-mr-1 yst-shrink-0" { ...svgAriaProps } />
+							<span>Premium</span>
+						</Badge>
+					</button>
+				</div>
+			) }
+		</>
 	);
 };
 

--- a/packages/js/src/components/KeywordUpsell.js
+++ b/packages/js/src/components/KeywordUpsell.js
@@ -7,6 +7,7 @@ import { SvgIcon } from "@yoast/components";
 import { LocationContext, useRootContext } from "@yoast/externals/contexts";
 import { colors } from "@yoast/style-guide";
 import { Badge, useSvgAria, useToggleState } from "@yoast/ui-library";
+import { MetaboxButton } from "./MetaboxButton";
 import { ModalContainer } from "./modals/Container";
 import Modal, { defaultModalClassName } from "./modals/Modal";
 import SidebarButton from "./SidebarButton";
@@ -54,8 +55,8 @@ const KeywordUpsell = () => {
 					title={ __( "Add related keyphrases", "wordpress-seo" ) }
 					onRequestClose={ closeModal }
 					additionalClassName=""
+					id="yoast-additional-keyphrases-modal"
 					className={ defaultModalClassName }
-					id="yoast-premium-seo-analysis-modal"
 					shouldCloseOnClickOutside={ true }
 				>
 					<ModalContainer>
@@ -98,23 +99,19 @@ const KeywordUpsell = () => {
 			) }
 			{ location === "metabox" && (
 				<div className="yst-root">
-					<button
+					<MetaboxButton
 						id="yoast-additional-keyphrase-metabox-modal-open-button"
-						type="button"
-						className="yst-flex yst-items-center yst-w-full yst-pl-6 yst-p-4 yst-space-x-2 yst-border-t yst-border-t-[rgb(0,0,0,0.2)] yst-rounded-none yst-transition-all hover:yst-bg-[#f0f0f0] focus:yst-outline focus:yst-outline-[1px] focus:yst-outline-[color:#0066cd] focus:-yst-outline-offset-1 focus:yst-shadow-[0_0_3px_rgba(8,74,103,0.8)]"
 						onClick={ openModal }
 					>
 						<SvgIcon icon="plus" color={ colors.$color_grey_medium_dark } />
-						<span
-							className="yst-grow yst-overflow-hidden yst-overflow-ellipsis yst-whitespace-nowrap yst-font-wp yst-text-[#555] yst-text-base yst-leading-[normal] yst-subpixel-antialiased yst-text-left"
-						>
+						<MetaboxButton.Text>
 							{ __( "Add related keyphrase", "wordpress-seo" ) }
-						</span>
+						</MetaboxButton.Text>
 						<Badge size="small" variant="upsell">
 							<LockClosedIcon className="yst-w-2.5 yst-h-2.5 yst-mr-1 yst-shrink-0" { ...svgAriaProps } />
 							<span>Premium</span>
 						</Badge>
-					</button>
+					</MetaboxButton>
 				</div>
 			) }
 		</>

--- a/packages/js/src/components/MetaboxButton.js
+++ b/packages/js/src/components/MetaboxButton.js
@@ -1,0 +1,56 @@
+import classNames from "classnames";
+import PropTypes from "prop-types";
+
+/**
+ * Text for in the MetaboxButton.
+ *
+ * @param {string} [className] Extra classes.
+ * @param {Object} [props] Extra props.
+ *
+ * @returns {JSX.Element} The element.
+ */
+const MetaboxButtonText = ( { className, ...props } ) => (
+	<span
+		className={ classNames(
+			"yst-grow yst-overflow-hidden yst-overflow-ellipsis yst-whitespace-nowrap yst-font-wp yst-text-[#555] yst-text-base yst-leading-[normal] yst-subpixel-antialiased yst-text-left",
+			className
+		) }
+		{ ...props }
+	/>
+);
+MetaboxButtonText.displayName = "MetaboxButton.Text";
+MetaboxButtonText.propTypes = {
+	className: PropTypes.string,
+};
+MetaboxButtonText.defaultProps = {
+	className: "",
+};
+
+/**
+ * Lookalike for a simple (un-collapsible) version of the @yoast/components Collapsible in Tailwind style.
+ *
+ * Expects a `yst-root` parent and the Tailwind stylesheet loaded in.
+ *
+ * @param {string} [className] Extra classes.
+ * @param {Object} [props] Extra props.
+ *
+ * @returns {JSX.Element} The element.
+ */
+export const MetaboxButton = ( { className, ...props } ) => (
+	<button
+		type="button"
+		className={ classNames(
+			"yst-flex yst-items-center yst-w-full yst-pl-6 yst-p-4 yst-space-x-2 yst-border-t yst-border-t-[rgb(0,0,0,0.2)] yst-rounded-none yst-transition-all hover:yst-bg-[#f0f0f0] focus:yst-outline focus:yst-outline-[1px] focus:yst-outline-[color:#0066cd] focus:-yst-outline-offset-1 focus:yst-shadow-[0_0_3px_rgba(8,74,103,0.8)]",
+			className
+		) }
+		{ ...props }
+	/>
+);
+MetaboxButton.propTypes = {
+	className: PropTypes.string,
+};
+MetaboxButton.defaultProps = {
+	className: "",
+};
+
+MetaboxButton.Text = MetaboxButtonText;

--- a/packages/js/src/components/contentAnalysis/SeoAnalysis.js
+++ b/packages/js/src/components/contentAnalysis/SeoAnalysis.js
@@ -2,14 +2,15 @@
 import { withSelect } from "@wordpress/data";
 import { Component, Fragment } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
+import { addQueryArgs } from "@wordpress/url";
 import { YoastSeoIcon } from "@yoast/components";
+import { LocationConsumer, RootContext } from "@yoast/externals/contexts";
 import PropTypes from "prop-types";
 import styled from "styled-components";
 import getIndicatorForScore from "../../analysis/getIndicatorForScore";
 import getL10nObject from "../../analysis/getL10nObject";
 import Results from "../../containers/Results";
 import AnalysisUpsell from "../AnalysisUpsell";
-import { LocationConsumer, RootContext } from "@yoast/externals/contexts";
 import MetaboxCollapsible from "../MetaboxCollapsible";
 import { ModalContainer, ModalIcon } from "../modals/Container";
 import KeywordSynonyms from "../modals/KeywordSynonyms";
@@ -19,7 +20,6 @@ import ScoreIconPortal from "../portals/ScoreIconPortal";
 import SidebarCollapsible from "../SidebarCollapsible";
 import SynonymSlot from "../slots/SynonymSlot";
 import { getIconForScore } from "./mapResults";
-import { addQueryArgs } from "@wordpress/url";
 
 const AnalysisHeader = styled.span`
 	font-size: 1em;
@@ -87,47 +87,33 @@ class SeoAnalysis extends Component {
 	 * Renders the multiple keywords upsell modal.
 	 *
 	 * @param {string} location The location of the upsell component. Used to determine the shortlinks in the component.
+	 * @param {string} locationContext In which editor this component is rendered.
 	 *
 	 * @returns {wp.Element} A modalButtonContainer component with the modal for a multiple keywords upsell.
 	 */
-	renderMultipleKeywordsUpsell( location ) {
+	renderMultipleKeywordsUpsell( location, locationContext ) {
 		const modalProps = {
 			classes: {
 				openButton: "wpseo-multiple-keywords button-link",
 			},
 			labels: {
 				open: "+ " + __( "Add related keyphrase", "wordpress-seo" ),
-				modalAriaLabel: sprintf(
-					/* translators: %s expands to 'Yoast SEO Premium'. */
-					__( "Get %s", "wordpress-seo" ),
-					"Yoast SEO Premium"
-				),
-				heading: sprintf(
-					/* translators: %s expands to 'Yoast SEO Premium'. */
-					__( "Get %s", "wordpress-seo" ),
-					"Yoast SEO Premium"
-				),
+				modalAriaLabel: __( "Add related keyphrases", "wordpress-seo" ),
+				heading: __( "Add related keyphrases", "wordpress-seo" ),
 			},
 		};
 
-		// Defaults to metabox
-		let link = wpseoAdminL10n[ "shortlinks.upsell.metabox.focus_keyword_additional_link" ];
-		let buyLink = wpseoAdminL10n[ "shortlinks.upsell.metabox.focus_keyword_additional_button" ];
-
-		if ( location.toLowerCase() === "sidebar" ) {
-			link = wpseoAdminL10n[ "shortlinks.upsell.sidebar.focus_keyword_additional_link" ];
-			buyLink = wpseoAdminL10n[ "shortlinks.upsell.sidebar.focus_keyword_additional_button" ];
-		}
+		const buyLink = wpseoAdminL10n[
+			location.toLowerCase() === "sidebar"
+				? "shortlinks.upsell.sidebar.focus_keyword_additional_button"
+				: "shortlinks.upsell.metabox.focus_keyword_additional_button"
+		];
 
 		return (
 			<Modal { ...modalProps }>
 				<ModalContainer>
-					<ModalIcon icon={ YoastSeoIcon } />
-					<h2>{ __( "Would you like to add a related keyphrase?", "wordpress-seo" ) }</h2>
-					<MultipleKeywords
-						link={ link }
-						buyLink={ buyLink }
-					/>
+					<h2>{ __( "Reach a wider audience", "wordpress-seo" ) }</h2>
+					<MultipleKeywords buyLink={ addQueryArgs( buyLink, { context: locationContext } ) } />
 				</ModalContainer>
 			</Modal>
 		);
@@ -260,7 +246,7 @@ class SeoAnalysis extends Component {
 											<SynonymSlot location={ location } />
 											{ this.props.shouldUpsell && <Fragment>
 												{ this.renderSynonymsUpsell( location, locationContext ) }
-												{ this.renderMultipleKeywordsUpsell( location ) }
+												{ this.renderMultipleKeywordsUpsell( location, locationContext ) }
 											</Fragment> }
 											{ this.props.shouldUpsellWordFormRecognition && this.renderWordFormsUpsell( location, locationContext ) }
 											<AnalysisHeader>

--- a/packages/js/src/components/contentAnalysis/SeoAnalysis.js
+++ b/packages/js/src/components/contentAnalysis/SeoAnalysis.js
@@ -60,7 +60,7 @@ class SeoAnalysis extends Component {
 		return (
 			<Modal { ...modalProps }>
 				<ModalContainer>
-					<h2>{ __( "Write more natural and engaging content", "wordpress-seo" ) }</h2>
+					<h2 className="yst-mt-0 yst-mb-4">{ __( "Write more natural and engaging content", "wordpress-seo" ) }</h2>
 					<KeywordSynonyms buyLink={ addQueryArgs( buyLink, { context: locationContext } ) } />
 				</ModalContainer>
 			</Modal>
@@ -96,7 +96,7 @@ class SeoAnalysis extends Component {
 		return (
 			<Modal { ...modalProps }>
 				<ModalContainer>
-					<h2>{ __( "Reach a wider audience", "wordpress-seo" ) }</h2>
+					<h2 className="yst-mt-0 yst-mb-4">{ __( "Reach a wider audience", "wordpress-seo" ) }</h2>
 					<MultipleKeywords buyLink={ addQueryArgs( buyLink, { context: locationContext } ) } />
 				</ModalContainer>
 			</Modal>

--- a/packages/js/src/components/contentAnalysis/SeoAnalysis.js
+++ b/packages/js/src/components/contentAnalysis/SeoAnalysis.js
@@ -3,7 +3,6 @@ import { withSelect } from "@wordpress/data";
 import { Component, Fragment } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
 import { addQueryArgs } from "@wordpress/url";
-import { YoastSeoIcon } from "@yoast/components";
 import { LocationConsumer, RootContext } from "@yoast/externals/contexts";
 import PropTypes from "prop-types";
 import styled from "styled-components";
@@ -12,7 +11,7 @@ import getL10nObject from "../../analysis/getL10nObject";
 import Results from "../../containers/Results";
 import AnalysisUpsell from "../AnalysisUpsell";
 import MetaboxCollapsible from "../MetaboxCollapsible";
-import { ModalContainer, ModalIcon } from "../modals/Container";
+import { ModalContainer } from "../modals/Container";
 import KeywordSynonyms from "../modals/KeywordSynonyms";
 import MultipleKeywords from "../modals/MultipleKeywords";
 import Modal from "../modals/SeoAnalysisModal";
@@ -47,37 +46,22 @@ class SeoAnalysis extends Component {
 			},
 			labels: {
 				open: "+ " + __( "Add synonyms", "wordpress-seo" ),
-				modalAriaLabel: sprintf(
-					/* translators: %s expands to 'Yoast SEO Premium'. */
-					__( "Get %s", "wordpress-seo" ),
-					"Yoast SEO Premium"
-				),
-				heading: sprintf(
-					/* translators: %s expands to 'Yoast SEO Premium'. */
-					__( "Get %s", "wordpress-seo" ),
-					"Yoast SEO Premium"
-				),
+				modalAriaLabel: __( "Add synonyms", "wordpress-seo" ),
+				heading: __( "Add synonyms", "wordpress-seo" ),
 			},
 		};
 
-		// Defaults to metabox.
-		let link = wpseoAdminL10n[ "shortlinks.upsell.metabox.focus_keyword_synonyms_link" ];
-		let buyLink = wpseoAdminL10n[ "shortlinks.upsell.metabox.focus_keyword_synonyms_button" ];
-
-		if ( location.toLowerCase() === "sidebar" ) {
-			link = wpseoAdminL10n[ "shortlinks.upsell.sidebar.focus_keyword_synonyms_link" ];
-			buyLink = wpseoAdminL10n[ "shortlinks.upsell.sidebar.focus_keyword_synonyms_button" ];
-		}
-		link = addQueryArgs( link, { context: locationContext } );
-		buyLink = addQueryArgs( buyLink, { context: locationContext } );
+		const buyLink = wpseoAdminL10n[
+			location.toLowerCase() === "sidebar"
+				? "shortlinks.upsell.sidebar.focus_keyword_synonyms_button"
+				: "shortlinks.upsell.metabox.focus_keyword_synonyms_button"
+		];
 
 		return (
 			<Modal { ...modalProps }>
 				<ModalContainer>
-					<ModalIcon icon={ YoastSeoIcon } />
-					<h2>{ __( "Would you like to add keyphrase synonyms?", "wordpress-seo" ) }</h2>
-
-					<KeywordSynonyms link={ link } buyLink={ buyLink } />
+					<h2>{ __( "Write more natural and engaging content", "wordpress-seo" ) }</h2>
+					<KeywordSynonyms buyLink={ addQueryArgs( buyLink, { context: locationContext } ) } />
 				</ModalContainer>
 			</Modal>
 		);

--- a/packages/js/src/components/fills/MetaboxFill.js
+++ b/packages/js/src/components/fills/MetaboxFill.js
@@ -13,6 +13,7 @@ import Warning from "../../containers/Warning";
 import { KeywordInput, ReadabilityAnalysis, SeoAnalysis, InclusiveLanguageAnalysis } from "@yoast/externals/components";
 import InsightsCollapsible from "../../insights/components/insights-collapsible";
 import MetaboxCollapsible from "../MetaboxCollapsible";
+import { InternalLinkingSuggestionsUpsell } from "../modals/InternalLinkingSuggestionsUpsell";
 import SidebarItem from "../SidebarItem";
 import AdvancedSettings from "../../containers/AdvancedSettings";
 import SocialMetadataPortal from "../portals/SocialMetadataPortal";
@@ -109,6 +110,9 @@ export default function MetaboxFill( { settings, wincherKeyphrases, setWincherNo
 				</SidebarItem> }
 				{ settings.isKeywordAnalysisActive && <SidebarItem key="additional-keywords-upsell" renderPriority={ 22 }>
 					{ settings.shouldUpsell && <KeywordUpsell /> }
+				</SidebarItem> }
+				{ settings.shouldUpsell && <SidebarItem key="internal-linking-suggestions-upsell" renderPriority={ 23 }>
+					<InternalLinkingSuggestionsUpsell />
 				</SidebarItem> }
 				{ settings.isKeywordAnalysisActive && settings.isWincherIntegrationActive &&
 					<SidebarItem key="wincher-seo-performance" renderPriority={ 25 }>

--- a/packages/js/src/components/fills/MetaboxFill.js
+++ b/packages/js/src/components/fills/MetaboxFill.js
@@ -22,15 +22,15 @@ import WincherSEOPerformance from "../../containers/WincherSEOPerformance";
 import { isWordProofIntegrationActive } from "../../helpers/wordproof";
 import WordProofAuthenticationModals from "../../components/modals/WordProofAuthenticationModals";
 import PremiumSEOAnalysisModal from "../modals/PremiumSEOAnalysisModal";
-import KeywordUpsell from "../KeywordUpsell";
+import KeywordUpsell from "../modals/KeywordUpsell";
 import { BlackFridayProductEditorChecklistPromo } from "../BlackFridayProductEditorChecklistPromo";
 import { isWooCommerceActive } from "../../helpers/isWooCommerceActive";
 
 /* eslint-disable complexity */
 /**
  * Creates the Metabox component.
-*
-* @param {Object} settings 				The feature toggles.
+ *
+ * @param {Object} settings 				The feature toggles.
  * @param {Object} store    				The Redux store.
  * @param {Object} theme    				The theme to use.
  * @param {Array} wincherKeyphrases 		The Wincher trackable keyphrases.
@@ -111,18 +111,18 @@ export default function MetaboxFill( { settings, wincherKeyphrases, setWincherNo
 					{ settings.shouldUpsell && <KeywordUpsell /> }
 				</SidebarItem> }
 				{ settings.isKeywordAnalysisActive && settings.isWincherIntegrationActive &&
-				<SidebarItem key="wincher-seo-performance" renderPriority={ 25 }>
-					<MetaboxCollapsible
-						id={ "yoast-wincher-seo-performance-metabox" }
-						title={ __( "Track SEO performance", "wordpress-seo" ) }
-						initialIsOpen={ false }
-						prefixIcon={ { icon: "chart-square-bar", color: colors.$color_grey_medium_dark } }
-						prefixIconCollapsed={ { icon: "chart-square-bar", color: colors.$color_grey_medium_dark } }
-						onToggle={ onToggleWincher }
-					>
-						<WincherSEOPerformance />
-					</MetaboxCollapsible>
-				</SidebarItem> }
+					<SidebarItem key="wincher-seo-performance" renderPriority={ 25 }>
+						<MetaboxCollapsible
+							id={ "yoast-wincher-seo-performance-metabox" }
+							title={ __( "Track SEO performance", "wordpress-seo" ) }
+							initialIsOpen={ false }
+							prefixIcon={ { icon: "chart-square-bar", color: colors.$color_grey_medium_dark } }
+							prefixIconCollapsed={ { icon: "chart-square-bar", color: colors.$color_grey_medium_dark } }
+							onToggle={ onToggleWincher }
+						>
+							<WincherSEOPerformance />
+						</MetaboxCollapsible>
+					</SidebarItem> }
 				{ settings.isCornerstoneActive && <SidebarItem key="cornerstone" renderPriority={ 30 }>
 					<CollapsibleCornerstone />
 				</SidebarItem> }

--- a/packages/js/src/components/fills/SidebarFill.js
+++ b/packages/js/src/components/fills/SidebarFill.js
@@ -20,7 +20,7 @@ import AdvancedSettings from "../../containers/AdvancedSettings";
 import WincherSEOPerformanceModal from "../../containers/WincherSEOPerformanceModal";
 import WebinarPromoNotification from "../WebinarPromoNotification";
 import BlackFridayPromoNotification from "../BlackFridayPromoNotification";
-import KeywordUpsell from "../KeywordUpsell";
+import KeywordUpsell from "../modals/KeywordUpsell";
 
 /* eslint-disable complexity */
 /**

--- a/packages/js/src/components/fills/SidebarFill.js
+++ b/packages/js/src/components/fills/SidebarFill.js
@@ -10,6 +10,7 @@ import CollapsibleCornerstone from "../../containers/CollapsibleCornerstone";
 import Warning from "../../containers/Warning";
 import { KeywordInput, ReadabilityAnalysis, SeoAnalysis, InclusiveLanguageAnalysis } from "@yoast/externals/components";
 import InsightsModal from "../../insights/components/insights-modal";
+import { InternalLinkingSuggestionsUpsell } from "../modals/InternalLinkingSuggestionsUpsell";
 import SidebarItem from "../SidebarItem";
 import SearchAppearanceModal from "../modals/editorModals/SearchAppearanceModal";
 import PremiumSEOAnalysisModal from "../modals/PremiumSEOAnalysisModal";
@@ -98,6 +99,9 @@ export default function SidebarFill( { settings } ) {
 				</SidebarItem> }
 				{ settings.isKeywordAnalysisActive && <SidebarItem key="additional-keywords-upsell" renderPriority={ 22 }>
 					{ settings.shouldUpsell && <KeywordUpsell /> }
+				</SidebarItem> }
+				{ settings.shouldUpsell && <SidebarItem key="internal-linking-suggestions-upsell" renderPriority={ 23 }>
+					<InternalLinkingSuggestionsUpsell />
 				</SidebarItem> }
 				{ settings.isCornerstoneActive && <SidebarItem key="cornerstone" renderPriority={ 30 }>
 					<CollapsibleCornerstone />

--- a/packages/js/src/components/modals/InternalLinkingSuggestionsUpsell.js
+++ b/packages/js/src/components/modals/InternalLinkingSuggestionsUpsell.js
@@ -1,0 +1,116 @@
+/* global wpseoAdminL10n */
+import { LockClosedIcon } from "@heroicons/react/solid";
+import { __, sprintf } from "@wordpress/i18n";
+import { addQueryArgs } from "@wordpress/url";
+import { useRootContext } from "@yoast/externals/contexts";
+import { Badge, useSvgAria, useToggleState } from "@yoast/ui-library";
+import { MetaboxButton } from "../MetaboxButton";
+import SidebarButton from "../SidebarButton";
+import UpsellBox from "../UpsellBox";
+import { ModalContainer } from "./Container";
+import Modal, { defaultModalClassName } from "./Modal";
+
+/**
+ * @returns {JSX.Element} The element.
+ */
+export const InternalLinkingSuggestionsUpsell = () => {
+	const [ isOpen, , , openModal, closeModal ] = useToggleState( false );
+	const { locationContext } = useRootContext();
+	const svgAriaProps = useSvgAria();
+
+	const isSidebar = locationContext.includes( "sidebar" );
+	const isMetabox = locationContext.includes( "metabox" );
+	const buyLink = wpseoAdminL10n[
+		isSidebar
+			? "shortlinks.upsell.sidebar.internal_linking_suggestions"
+			: "shortlinks.upsell.metabox.internal_linking_suggestions"
+	];
+
+	return (
+		<>
+			{ isOpen && (
+				<Modal
+					title={ __( "Get internal linking suggestions", "wordpress-seo" ) }
+					onRequestClose={ closeModal }
+					additionalClassName=""
+					id="yoast-internal-linking-suggestions-upsell"
+					className={ defaultModalClassName }
+					shouldCloseOnClickOutside={ true }
+				>
+					<ModalContainer>
+						<h2 className="yst-mt-0 yst-mb-4">{ __( "Rank higher by connecting your content", "wordpress-seo" ) }</h2>
+						<UpsellBox
+							infoParagraphs={ [
+								<span key="InternalLinkingSuggestionsUpsell-infoParagraph-description" className="yst-block yst-max-w-[426px]">
+									{ sprintf(
+										/* translators: %s expands to Yoast SEO Premium. */
+										__( "%s automatically suggests to what content you can link with easy drag-and-drop functionality, which is good for your SEO!", "wordpress-seo" ),
+										"Yoast SEO Premium"
+									) }
+								</span>,
+								<span
+									key="InternalLinkingSuggestionsUpsell-infoParagraph-benefitsTitle"
+									className="yst-block yst-my-3 yst-text-[#303030] yst-text-[13px] yst-font-semibold"
+								>
+									{ __( "What’s more in Yoast SEO Premium?", "wordpress-seo" ) }
+								</span>,
+							] }
+							benefits={ [
+								__( "Create content faster: Use AI to create titles & meta descriptions", "wordpress-seo" ),
+								__( "Get extra SEO checks with the Premium SEO analysis", "wordpress-seo" ),
+								__( "Get help ranking for multiple keyphrases", "wordpress-seo" ),
+								__( "Avoid dead links on your site", "wordpress-seo" ),
+								__( "Preview how your content looks when shared on social", "wordpress-seo" ),
+								__( "Get guidance & save time on routine SEO tasks", "wordpress-seo" ),
+							] }
+							upsellButtonText={
+								sprintf(
+									/* translators: %s expands to 'Yoast SEO Premium'. */
+									__( "Unlock with %s", "wordpress-seo" ),
+									"Yoast SEO Premium"
+								)
+							}
+							upsellButton={ {
+								href: addQueryArgs( buyLink, { context: locationContext } ),
+								className: "yoast-button-upsell",
+								rel: null,
+								"data-ctb-id": "f6a84663-465f-4cb5-8ba5-f7a6d72224b2",
+								"data-action": "load-nfd-ctb",
+							} }
+							upsellButtonLabel={ __( "1 year free support and updates included!", "wordpress-seo" ) }
+						/>
+					</ModalContainer>
+				</Modal>
+			) }
+			{ isSidebar && (
+				<SidebarButton
+					id="yoast-internal-linking-suggestions-sidebar-modal-open-button"
+					title={ __( "Internal linking suggestions", "wordpress-seo" ) }
+					onClick={ openModal }
+				>
+					<div className="yst-root">
+						<Badge size="small" variant="upsell">
+							<LockClosedIcon className="yst-w-2.5 yst-h-2.5 yst-shrink-0" { ...svgAriaProps } />
+						</Badge>
+					</div>
+				</SidebarButton>
+			) }
+			{ isMetabox && (
+				<div className="yst-root">
+					<MetaboxButton
+						id="yoast-internal-linking-suggestions-metabox-modal-open-button"
+						onClick={ openModal }
+					>
+						<MetaboxButton.Text>
+							{ __( "Internal linking suggestions", "wordpress-seo" ) }
+						</MetaboxButton.Text>
+						<Badge size="small" variant="upsell">
+							<LockClosedIcon className="yst-w-2.5 yst-h-2.5 yst-mr-1 yst-shrink-0" { ...svgAriaProps } />
+							<span>Premium</span>
+						</Badge>
+					</MetaboxButton>
+				</div>
+			) }
+		</>
+	);
+};

--- a/packages/js/src/components/modals/KeywordSynonyms.js
+++ b/packages/js/src/components/modals/KeywordSynonyms.js
@@ -11,14 +11,14 @@ import UpsellBox from "../UpsellBox";
  */
 const KeywordSynonyms = ( props ) => {
 	const infoParagraphs = [
-		<div key="KeywordSynonyms-infoParagraph-description" className="yst-max-w-[426px]">
+		<span key="KeywordSynonyms-infoParagraph-description" className="yst-block yst-max-w-[426px]">
 			{ sprintf(
 				/* translators: %s expands to "Yoast SEO Premium" */
 				__( "Synonyms help users understand your copy better. It’s easier to read for both users and Google. In %s, you can add synonyms for your focus keyphrase, and we’ll help you optimize for them.", "wordpress-seo" ),
 				"Yoast SEO Premium"
 			) }
-		</div>,
-		<span key="KeywordSynonyms-infoParagraph-benefitsTitle" className="yst-text-[#303030] yst-text-[13px] yst-font-semibold">
+		</span>,
+		<span key="KeywordSynonyms-infoParagraph-benefitsTitle" className="yst-block yst-my-3 yst-text-[#303030] yst-text-[13px] yst-font-semibold">
 			{ __( "What’s more in Yoast SEO Premium?", "wordpress-seo" ) }
 		</span>,
 	];

--- a/packages/js/src/components/modals/KeywordSynonyms.js
+++ b/packages/js/src/components/modals/KeywordSynonyms.js
@@ -1,11 +1,6 @@
-import interpolateComponents from "interpolate-components";
 import { __, sprintf } from "@wordpress/i18n";
-
-import { makeOutboundLink } from "@yoast/helpers";
 import PropTypes from "prop-types";
 import UpsellBox from "../UpsellBox";
-
-const PremiumLandingPageLink = makeOutboundLink();
 
 /**
  * Creates the content for a keyword synonyms upsell modal.
@@ -15,56 +10,35 @@ const PremiumLandingPageLink = makeOutboundLink();
  * @returns {wp.Element} The Keyword Synonyms upsell component.
  */
 const KeywordSynonyms = ( props ) => {
-	const intro = sprintf(
-		/* translators: %1$s expands to a 'Yoast SEO Premium' text linked to the yoast.com website. */
-		__( "Great news: you can, with %1$s!", "wordpress-seo" ),
-		"{{link}}Yoast SEO Premium{{/link}}"
-	);
-
-	const interpolated = interpolateComponents( {
-		mixedString: intro,
-		components: { link: <PremiumLandingPageLink href={ props.link } /> },
-	} );
-
-	const benefits = [
-		sprintf(
-			/* translators: %1$s expands to a 'strong' start tag, %2$s to a 'strong' end tag. */
-			__( "%1$sCreate content faster%2$s: Use AI to create titles & meta descriptions", "wordpress-seo" ),
-			"<strong>",
-			"</strong>"
-		),
-		`<strong>${ __( "Rank better with synonyms & related keyphrases", "wordpress-seo" ) }</strong>`,
-		sprintf(
-			/* translators: %1$s expands to a 'strong' start tag, %2$s to a 'strong' end tag. */
-			__( "%1$sNo more dead links%2$s: easy redirect manager", "wordpress-seo" ),
-			"<strong>",
-			"</strong>"
-		),
-		`<strong>${ __( "Superfast internal linking suggestions", "wordpress-seo" ) }</strong>`,
-		sprintf(
-			/* translators: %1$s expands to a 'strong' start tag, %2$s to a 'strong' end tag. */
-			__( "%1$sSocial media preview%2$s: Facebook & Twitter", "wordpress-seo" ),
-			"<strong>",
-			"</strong>"
-		),
-		`<strong>${ __( "24/7 email support", "wordpress-seo" ) }</strong>`,
-		`<strong>${ __( "No ads!", "wordpress-seo" ) }</strong>`,
+	const infoParagraphs = [
+		<div key="KeywordSynonyms-infoParagraph-description" className="yst-max-w-[426px]">
+			{ sprintf(
+				/* translators: %s expands to "Yoast SEO Premium" */
+				__( "Synonyms help users understand your copy better. It’s easier to read for both users and Google. In %s, you can add synonyms for your focus keyphrase, and we’ll help you optimize for them.", "wordpress-seo" ),
+				"Yoast SEO Premium"
+			) }
+		</div>,
+		<span key="KeywordSynonyms-infoParagraph-benefitsTitle" className="yst-text-[#303030] yst-text-[13px] yst-font-semibold">
+			{ __( "What’s more in Yoast SEO Premium?", "wordpress-seo" ) }
+		</span>,
 	];
-
-	const otherBenefits = sprintf(
-		/* translators: %s expands to 'Yoast SEO Premium'. */
-		__( "Other benefits of %s for you:", "wordpress-seo" ),
-		"Yoast SEO Premium"
-	);
+	const benefits = [
+		__( "Create content faster: Use AI to create titles & meta descriptions", "wordpress-seo" ),
+		__( "Get extra SEO checks with the Premium SEO analysis", "wordpress-seo" ),
+		__( "Avoid dead links on your site", "wordpress-seo" ),
+		__( "Easily improve the structure of your site", "wordpress-seo" ),
+		__( "Preview how your content looks when shared on social", "wordpress-seo" ),
+		__( "Get guidance & save time on routine SEO tasks", "wordpress-seo" ),
+	];
 
 	return (
 		<UpsellBox
-			infoParagraphs={ [ interpolated, otherBenefits ] }
+			infoParagraphs={ infoParagraphs }
 			benefits={ benefits }
 			upsellButtonText={
 				sprintf(
 					/* translators: %s expands to 'Yoast SEO Premium'. */
-					__( "Get %s", "wordpress-seo" ),
+					__( "Unlock with %s", "wordpress-seo" ),
 					"Yoast SEO Premium"
 				)
 			}
@@ -79,9 +53,7 @@ const KeywordSynonyms = ( props ) => {
 		/>
 	);
 };
-
 KeywordSynonyms.propTypes = {
-	link: PropTypes.string.isRequired,
 	buyLink: PropTypes.string.isRequired,
 };
 

--- a/packages/js/src/components/modals/KeywordUpsell.js
+++ b/packages/js/src/components/modals/KeywordUpsell.js
@@ -47,7 +47,7 @@ const KeywordUpsell = () => {
 					shouldCloseOnClickOutside={ true }
 				>
 					<ModalContainer>
-						<h2>{ __( "Reach a wider audience", "wordpress-seo" ) }</h2>
+						<h2 className="yst-mt-0 yst-mb-4">{ __( "Reach a wider audience", "wordpress-seo" ) }</h2>
 						<MultipleKeywords buyLink={ addQueryArgs( buyLink, { context: locationContext } ) } />
 					</ModalContainer>
 				</Modal>

--- a/packages/js/src/components/modals/KeywordUpsell.js
+++ b/packages/js/src/components/modals/KeywordUpsell.js
@@ -1,7 +1,7 @@
 /* global wpseoAdminL10n */
 import { LockClosedIcon } from "@heroicons/react/solid";
 import { useContext } from "@wordpress/element";
-import { __, sprintf } from "@wordpress/i18n";
+import { __ } from "@wordpress/i18n";
 import { addQueryArgs } from "@wordpress/url";
 import { SvgIcon } from "@yoast/components";
 import { LocationContext, useRootContext } from "@yoast/externals/contexts";
@@ -9,9 +9,9 @@ import { colors } from "@yoast/style-guide";
 import { Badge, useSvgAria, useToggleState } from "@yoast/ui-library";
 import { MetaboxButton } from "../MetaboxButton";
 import SidebarButton from "../SidebarButton";
-import UpsellBox from "../UpsellBox";
 import { ModalContainer } from "./Container";
 import Modal, { defaultModalClassName } from "./Modal";
+import MultipleKeywords from "./MultipleKeywords";
 
 /**
  * @returns {Object} The location context.
@@ -34,19 +34,6 @@ const KeywordUpsell = () => {
 			? "shortlinks.upsell.sidebar.additional_button"
 			: "shortlinks.upsell.metabox.additional_button"
 	];
-	const infoParagraphs = [
-		__( "Get help optimizing for up to 5 related keyphrases. This helps you reach a wider audience and get more traffic.", "wordpress-seo" ),
-		<span key="KeywordUpsell-infoParagraph-benefitsTitle" className="yst-text-[#303030] yst-text-[13px] yst-font-semibold">
-			{ __( "What’s more in Yoast SEO Premium?", "wordpress-seo" ) }
-		</span>,
-	];
-	const benefits = [
-		__( "Get extra SEO checks with the Premium SEO analysis", "wordpress-seo" ),
-		__( "Avoid dead links on your site", "wordpress-seo" ),
-		__( "Easily improve the structure of your site", "wordpress-seo" ),
-		__( "Preview how your content looks when shared on social", "wordpress-seo" ),
-		__( "Get guidance & save time on routine SEO tasks", "wordpress-seo" ),
-	];
 
 	return (
 		<>
@@ -61,25 +48,7 @@ const KeywordUpsell = () => {
 				>
 					<ModalContainer>
 						<h2>{ __( "Reach a wider audience", "wordpress-seo" ) }</h2>
-						<UpsellBox
-							infoParagraphs={ infoParagraphs }
-							benefits={ benefits }
-							upsellButtonText={
-								sprintf(
-									/* translators: %s expands to 'Yoast SEO Premium'. */
-									__( "Unlock with %s", "wordpress-seo" ),
-									"Yoast SEO Premium"
-								)
-							}
-							upsellButton={ {
-								href: addQueryArgs( buyLink, { context: locationContext } ),
-								className: "yoast-button-upsell",
-								rel: null,
-								"data-ctb-id": "f6a84663-465f-4cb5-8ba5-f7a6d72224b2",
-								"data-action": "load-nfd-ctb",
-							} }
-							upsellButtonLabel={ __( "1 year of premium support and updates included!", "wordpress-seo" ) }
-						/>
+						<MultipleKeywords buyLink={ addQueryArgs( buyLink, { context: locationContext } ) } />
 					</ModalContainer>
 				</Modal>
 			) }

--- a/packages/js/src/components/modals/KeywordUpsell.js
+++ b/packages/js/src/components/modals/KeywordUpsell.js
@@ -7,11 +7,11 @@ import { SvgIcon } from "@yoast/components";
 import { LocationContext, useRootContext } from "@yoast/externals/contexts";
 import { colors } from "@yoast/style-guide";
 import { Badge, useSvgAria, useToggleState } from "@yoast/ui-library";
-import { MetaboxButton } from "./MetaboxButton";
-import { ModalContainer } from "./modals/Container";
-import Modal, { defaultModalClassName } from "./modals/Modal";
-import SidebarButton from "./SidebarButton";
-import UpsellBox from "./UpsellBox";
+import { MetaboxButton } from "../MetaboxButton";
+import SidebarButton from "../SidebarButton";
+import UpsellBox from "../UpsellBox";
+import { ModalContainer } from "./Container";
+import Modal, { defaultModalClassName } from "./Modal";
 
 /**
  * @returns {Object} The location context.

--- a/packages/js/src/components/modals/MultipleKeywords.js
+++ b/packages/js/src/components/modals/MultipleKeywords.js
@@ -1,78 +1,42 @@
-import interpolateComponents from "interpolate-components";
-import { makeOutboundLink } from "@yoast/helpers";
 import { __, sprintf } from "@wordpress/i18n";
-import UpsellBox from "../UpsellBox";
 import PropTypes from "prop-types";
-import { useRootContext }  from "@yoast/externals/contexts";
-import { addQueryArgs } from "@wordpress/url";
-
-const PremiumLandingPageLink = makeOutboundLink();
+import UpsellBox from "../UpsellBox";
 
 /**
  * Creates the content for a Multiple Keywords upsell modal.
  *
  * @param {Object} props The props for the component.
  *
- * @returns {wp.Element} The Multiple Keywords upsell component.
+ * @returns {JSX.Element} The Multiple Keywords upsell component.
  */
 const MultipleKeywords = ( props ) => {
-	const intro = sprintf(
-		/* translators: %s expands to a 'Yoast SEO Premium' text linked to the yoast.com website. */
-		__( "Great news: you can, with %s!", "wordpress-seo" ),
-		"{{link}}Yoast SEO Premium{{/link}}"
-	);
-
-	const benefits = [
-		sprintf(
-			/* translators: %1$s expands to a 'strong' start tag, %2$s to a 'strong' end tag. */
-			__( "%1$sCreate content faster%2$s: Use AI to create titles & meta descriptions", "wordpress-seo" ),
-			"<strong>",
-			"</strong>"
-		),
-		sprintf(
-			/* translators: %1$s expands to a 'strong' start tag, %2$s to a 'strong' end tag. */
-			__( "%1$sNo more dead links%2$s: easy redirect manager", "wordpress-seo" ),
-			"<strong>",
-			"</strong>"
-		),
-		`<strong>${ __( "Superfast internal linking suggestions", "wordpress-seo" ) }</strong>`,
-		sprintf(
-			/* translators: %1$s expands to a 'strong' start tag, %2$s to a 'strong' end tag. */
-			__( "%1$sSocial media preview%2$s: Facebook & Twitter", "wordpress-seo" ),
-			"<strong>",
-			"</strong>"
-		),
-		`<strong>${__( "24/7 email support", "wordpress-seo" )}</strong>`,
-		`<strong>${__( "No ads!", "wordpress-seo" )}</strong>`,
+	const infoParagraphs = [
+		__( "Get help optimizing for up to 5 related keyphrases. This helps you reach a wider audience and get more traffic.", "wordpress-seo" ),
+		<span key="KeywordUpsell-infoParagraph-benefitsTitle" className="yst-text-[#303030] yst-text-[13px] yst-font-semibold">
+			{ __( "What’s more in Yoast SEO Premium?", "wordpress-seo" ) }
+		</span>,
 	];
-
-	const { locationContext } = useRootContext();
-	// Interpolate links
-	const interpolated = interpolateComponents( {
-		mixedString: intro,
-		components: { link: <PremiumLandingPageLink href={ addQueryArgs( props.link, { context: locationContext } ) } /> },
-	} );
-
-	const otherBenefits = sprintf(
-		/* translators: %s expands to 'Yoast SEO Premium'. */
-		__( "Other benefits of %s for you:", "wordpress-seo" ),
-		"Yoast SEO Premium"
-	);
-
+	const benefits = [
+		__( "Get extra SEO checks with the Premium SEO analysis", "wordpress-seo" ),
+		__( "Avoid dead links on your site", "wordpress-seo" ),
+		__( "Easily improve the structure of your site", "wordpress-seo" ),
+		__( "Preview how your content looks when shared on social", "wordpress-seo" ),
+		__( "Get guidance & save time on routine SEO tasks", "wordpress-seo" ),
+	];
 
 	return (
 		<UpsellBox
-			infoParagraphs={ [ interpolated, otherBenefits ] }
+			infoParagraphs={ infoParagraphs }
 			benefits={ benefits }
 			upsellButtonText={
 				sprintf(
 					/* translators: %s expands to 'Yoast SEO Premium'. */
-					__( "Get %s", "wordpress-seo" ),
+					__( "Unlock with %s", "wordpress-seo" ),
 					"Yoast SEO Premium"
 				)
 			}
 			upsellButton={ {
-				href: addQueryArgs( props.buyLink, { context: locationContext } ),
+				href: props.buyLink,
 				className: "yoast-button-upsell",
 				rel: null,
 				"data-ctb-id": "f6a84663-465f-4cb5-8ba5-f7a6d72224b2",
@@ -82,11 +46,8 @@ const MultipleKeywords = ( props ) => {
 		/>
 	);
 };
-
 MultipleKeywords.propTypes = {
-	link: PropTypes.string.isRequired,
 	buyLink: PropTypes.string.isRequired,
 };
-
 
 export default MultipleKeywords;

--- a/packages/js/src/components/modals/MultipleKeywords.js
+++ b/packages/js/src/components/modals/MultipleKeywords.js
@@ -11,10 +11,10 @@ import UpsellBox from "../UpsellBox";
  */
 const MultipleKeywords = ( props ) => {
 	const infoParagraphs = [
-		<div key="KeywordUpsell-infoParagraph-description" className="yst-max-w-[426px]">
+		<span key="KeywordUpsell-infoParagraph-description" className="yst-block yst-max-w-[426px]">
 			{ __( "Get help optimizing for up to 5 related keyphrases. This helps you reach a wider audience and get more traffic.", "wordpress-seo" ) }
-		</div>,
-		<span key="KeywordUpsell-infoParagraph-benefitsTitle" className="yst-text-[#303030] yst-text-[13px] yst-font-semibold">
+		</span>,
+		<span key="KeywordUpsell-infoParagraph-benefitsTitle" className="yst-block yst-my-3 yst-text-[#303030] yst-text-[13px] yst-font-semibold">
 			{ __( "What’s more in Yoast SEO Premium?", "wordpress-seo" ) }
 		</span>,
 	];

--- a/packages/js/src/components/modals/MultipleKeywords.js
+++ b/packages/js/src/components/modals/MultipleKeywords.js
@@ -11,7 +11,9 @@ import UpsellBox from "../UpsellBox";
  */
 const MultipleKeywords = ( props ) => {
 	const infoParagraphs = [
-		__( "Get help optimizing for up to 5 related keyphrases. This helps you reach a wider audience and get more traffic.", "wordpress-seo" ),
+		<div key="KeywordUpsell-infoParagraph-description" className="yst-max-w-[426px]">
+			{ __( "Get help optimizing for up to 5 related keyphrases. This helps you reach a wider audience and get more traffic.", "wordpress-seo" ) }
+		</div>,
 		<span key="KeywordUpsell-infoParagraph-benefitsTitle" className="yst-text-[#303030] yst-text-[13px] yst-font-semibold">
 			{ __( "What’s more in Yoast SEO Premium?", "wordpress-seo" ) }
 		</span>,

--- a/packages/js/src/components/modals/MultipleKeywords.js
+++ b/packages/js/src/components/modals/MultipleKeywords.js
@@ -17,6 +17,7 @@ const MultipleKeywords = ( props ) => {
 		</span>,
 	];
 	const benefits = [
+		__( "Create content faster: Use AI to create titles & meta descriptions", "wordpress-seo" ),
 		__( "Get extra SEO checks with the Premium SEO analysis", "wordpress-seo" ),
 		__( "Avoid dead links on your site", "wordpress-seo" ),
 		__( "Easily improve the structure of your site", "wordpress-seo" ),

--- a/packages/js/src/components/modals/PremiumSEOAnalysisModal.js
+++ b/packages/js/src/components/modals/PremiumSEOAnalysisModal.js
@@ -1,12 +1,12 @@
 import { LockClosedIcon } from "@heroicons/react/solid";
 import { Fragment, useCallback, useState } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
-import { SvgIcon, YoastSeoIcon } from "@yoast/components";
+import { SvgIcon } from "@yoast/components";
 import { colors } from "@yoast/style-guide";
 import { Badge, useSvgAria } from "@yoast/ui-library";
 import PropTypes from "prop-types";
 import SidebarButton from "../SidebarButton";
-import { ModalContainer, ModalIcon } from "./Container";
+import { ModalContainer } from "./Container";
 import Modal, { defaultModalClassName } from "./Modal";
 import PremiumSEOAnalysisUpsell from "./PremiumSEOAnalysisUpsell";
 
@@ -32,8 +32,7 @@ const PremiumSEOAnalysisModal = ( { location } ) => {
 				shouldCloseOnClickOutside={ true }
 			>
 				<ModalContainer>
-					<ModalIcon icon={ YoastSeoIcon } />
-					<h2>{ __( "Optimize even further with our premium SEO analysis", "wordpress-seo" ) }</h2>
+					<h2>{ __( "Improve your SEO by using the Premium SEO analysis", "wordpress-seo" ) }</h2>
 					<PremiumSEOAnalysisUpsell buyLink={ `shortlinks.upsell.${ location }.premium_seo_analysis_button` } />
 				</ModalContainer>
 			</Modal> }

--- a/packages/js/src/components/modals/PremiumSEOAnalysisModal.js
+++ b/packages/js/src/components/modals/PremiumSEOAnalysisModal.js
@@ -33,7 +33,7 @@ const PremiumSEOAnalysisModal = ( { location } ) => {
 				shouldCloseOnClickOutside={ true }
 			>
 				<ModalContainer>
-					<h2>{ __( "Improve your SEO by using the Premium SEO analysis", "wordpress-seo" ) }</h2>
+					<h2 className="yst-mt-0 yst-mb-4">{ __( "Improve your SEO by using the Premium SEO analysis", "wordpress-seo" ) }</h2>
 					<PremiumSEOAnalysisUpsell buyLink={ `shortlinks.upsell.${ location }.premium_seo_analysis_button` } />
 				</ModalContainer>
 			</Modal> }

--- a/packages/js/src/components/modals/PremiumSEOAnalysisModal.js
+++ b/packages/js/src/components/modals/PremiumSEOAnalysisModal.js
@@ -1,43 +1,30 @@
-/* External dependencies */
+import { LockClosedIcon } from "@heroicons/react/solid";
+import { Fragment, useCallback, useState } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
-import { Fragment, useState, useCallback } from "@wordpress/element";
-import PropTypes from "prop-types";
-import styled from "styled-components";
-
-/* Internal dependencies */
-import { YoastSeoIcon, CollapsibleStateless } from "@yoast/components";
+import { SvgIcon, YoastSeoIcon } from "@yoast/components";
 import { colors } from "@yoast/style-guide";
+import { Badge, useSvgAria } from "@yoast/ui-library";
+import PropTypes from "prop-types";
+import SidebarButton from "../SidebarButton";
 import { ModalContainer, ModalIcon } from "./Container";
 import Modal, { defaultModalClassName } from "./Modal";
-import SidebarButton from "../SidebarButton";
 import PremiumSEOAnalysisUpsell from "./PremiumSEOAnalysisUpsell";
-
-const MetaboxModalButton = styled( CollapsibleStateless )`
-	h2 > button {
-		padding-left: 24px;
-		padding-top: 16px;
-
-		&:hover {
-			background-color: #f0f0f0;
-		}
-	}
-`;
 
 /**
  * The Premium SEO Analysis Modal.
  *
- * @returns {React.Component} The Premium SEO Analysis Modal.
+ * @returns {JSX.Element} The Premium SEO Analysis Modal.
  */
 const PremiumSEOAnalysisModal = ( { location } ) => {
 	const [ isOpen, setIsOpen ] = useState( false );
-
 	const closeModal = useCallback( () => setIsOpen( false ), [] );
 	const openModal = useCallback( () => setIsOpen( true ), [] );
+	const svgAriaProps = useSvgAria();
 
 	return (
 		<Fragment>
 			{ isOpen && <Modal
-				title={ __( "Get Yoast SEO Premium", "wordpress-seo" ) }
+				title={ __( "Get the Premium SEO analysis", "wordpress-seo" ) }
 				onRequestClose={ closeModal }
 				additionalClassName=""
 				className={ defaultModalClassName }
@@ -46,34 +33,38 @@ const PremiumSEOAnalysisModal = ( { location } ) => {
 			>
 				<ModalContainer>
 					<ModalIcon icon={ YoastSeoIcon } />
-					{
-						<h2>{ __( "Optimize even further with our premium SEO analysis", "wordpress-seo" ) }</h2>
-					}
-
+					<h2>{ __( "Optimize even further with our premium SEO analysis", "wordpress-seo" ) }</h2>
 					<PremiumSEOAnalysisUpsell buyLink={ `shortlinks.upsell.${ location }.premium_seo_analysis_button` } />
 				</ModalContainer>
 			</Modal> }
 			{ location === "sidebar" && <SidebarButton
-				id={  "yoast-premium-seo-analysis-modal-open-button" }
+				id={ "yoast-premium-seo-analysis-modal-open-button" }
 				title={ __( "Premium SEO analysis", "wordpress-seo" ) }
 				prefixIcon={ { icon: "seo-score-none", color: colors.$color_grey } }
 				suffixIcon={ { icon: "pencil-square", size: "20px" } }
 				onClick={ openModal }
 			/> }
-			{ location === "metabox" && <MetaboxModalButton
-				hasPadding={ false }
-				hasSeparator={ true }
-				isOpen={ false }
-				id={  "yoast-premium-seo-analysis-metabox-modal-open-button" }
-				title={ __( "Premium SEO analysis", "wordpress-seo" ) }
-				prefixIconCollapsed={ { icon: "seo-score-none", color: colors.$color_grey, size: "16px" } }
-				suffixIconCollapsed={ {
-					icon: "pencil-square",
-					color: colors.$black,
-					size: "20px",
-				} }
-				onToggle={ openModal }
-			/> }
+			{ location === "metabox" && (
+				<div className="yst-root">
+					<button
+						id="yoast-premium-seo-analysis-metabox-modal-open-button"
+						type="button"
+						className="yst-flex yst-items-center yst-w-full yst-pl-6 yst-p-4 yst-space-x-2 yst-border-t yst-border-t-[rgb(0,0,0,0.2)] yst-rounded-none yst-transition-all hover:yst-bg-[#f0f0f0] focus:yst-outline focus:yst-outline-[1px] focus:yst-outline-[color:#0066cd] focus:-yst-outline-offset-1 focus:yst-shadow-[0_0_3px_rgba(8,74,103,0.8)]"
+						onClick={ openModal }
+					>
+						<SvgIcon icon="seo-score-none" color={ colors.$color_grey } />
+						<span
+							className="yst-grow yst-overflow-hidden yst-overflow-ellipsis yst-whitespace-nowrap yst-font-wp yst-text-[#555] yst-text-base yst-leading-[normal] yst-subpixel-antialiased yst-text-left"
+						>
+							{ __( "Premium SEO analysis", "wordpress-seo" ) }
+						</span>
+						<Badge size="small" variant="upsell">
+							<LockClosedIcon className="yst-w-2.5 yst-h-2.5 yst-mr-1 yst-shrink-0" { ...svgAriaProps } />
+							<span>Premium</span>
+						</Badge>
+					</button>
+				</div>
+			) }
 		</Fragment>
 	);
 };
@@ -81,7 +72,6 @@ const PremiumSEOAnalysisModal = ( { location } ) => {
 PremiumSEOAnalysisModal.propTypes = {
 	location: PropTypes.string,
 };
-
 PremiumSEOAnalysisModal.defaultProps = {
 	location: "sidebar",
 };

--- a/packages/js/src/components/modals/PremiumSEOAnalysisModal.js
+++ b/packages/js/src/components/modals/PremiumSEOAnalysisModal.js
@@ -5,6 +5,7 @@ import { SvgIcon } from "@yoast/components";
 import { colors } from "@yoast/style-guide";
 import { Badge, useSvgAria } from "@yoast/ui-library";
 import PropTypes from "prop-types";
+import { MetaboxButton } from "../MetaboxButton";
 import SidebarButton from "../SidebarButton";
 import { ModalContainer } from "./Container";
 import Modal, { defaultModalClassName } from "./Modal";
@@ -52,23 +53,19 @@ const PremiumSEOAnalysisModal = ( { location } ) => {
 			) }
 			{ location === "metabox" && (
 				<div className="yst-root">
-					<button
+					<MetaboxButton
 						id="yoast-premium-seo-analysis-metabox-modal-open-button"
-						type="button"
-						className="yst-flex yst-items-center yst-w-full yst-pl-6 yst-p-4 yst-space-x-2 yst-border-t yst-border-t-[rgb(0,0,0,0.2)] yst-rounded-none yst-transition-all hover:yst-bg-[#f0f0f0] focus:yst-outline focus:yst-outline-[1px] focus:yst-outline-[color:#0066cd] focus:-yst-outline-offset-1 focus:yst-shadow-[0_0_3px_rgba(8,74,103,0.8)]"
 						onClick={ openModal }
 					>
 						<SvgIcon icon="seo-score-none" color={ colors.$color_grey } />
-						<span
-							className="yst-grow yst-overflow-hidden yst-overflow-ellipsis yst-whitespace-nowrap yst-font-wp yst-text-[#555] yst-text-base yst-leading-[normal] yst-subpixel-antialiased yst-text-left"
-						>
+						<MetaboxButton.Text>
 							{ __( "Premium SEO analysis", "wordpress-seo" ) }
-						</span>
+						</MetaboxButton.Text>
 						<Badge size="small" variant="upsell">
 							<LockClosedIcon className="yst-w-2.5 yst-h-2.5 yst-mr-1 yst-shrink-0" { ...svgAriaProps } />
 							<span>Premium</span>
 						</Badge>
-					</button>
+					</MetaboxButton>
 				</div>
 			) }
 		</Fragment>

--- a/packages/js/src/components/modals/PremiumSEOAnalysisModal.js
+++ b/packages/js/src/components/modals/PremiumSEOAnalysisModal.js
@@ -36,13 +36,20 @@ const PremiumSEOAnalysisModal = ( { location } ) => {
 					<PremiumSEOAnalysisUpsell buyLink={ `shortlinks.upsell.${ location }.premium_seo_analysis_button` } />
 				</ModalContainer>
 			</Modal> }
-			{ location === "sidebar" && <SidebarButton
-				id={ "yoast-premium-seo-analysis-modal-open-button" }
-				title={ __( "Premium SEO analysis", "wordpress-seo" ) }
-				prefixIcon={ { icon: "seo-score-none", color: colors.$color_grey } }
-				suffixIcon={ { icon: "pencil-square", size: "20px" } }
-				onClick={ openModal }
-			/> }
+			{ location === "sidebar" && (
+				<SidebarButton
+					id="yoast-premium-seo-analysis-modal-open-button"
+					title={ __( "Premium SEO analysis", "wordpress-seo" ) }
+					prefixIcon={ { icon: "seo-score-none", color: colors.$color_grey } }
+					onClick={ openModal }
+				>
+					<div className="yst-root">
+						<Badge size="small" variant="upsell">
+							<LockClosedIcon className="yst-w-2.5 yst-h-2.5 yst-shrink-0" { ...svgAriaProps } />
+						</Badge>
+					</div>
+				</SidebarButton>
+			) }
 			{ location === "metabox" && (
 				<div className="yst-root">
 					<button

--- a/packages/js/src/components/modals/PremiumSEOAnalysisUpsell.js
+++ b/packages/js/src/components/modals/PremiumSEOAnalysisUpsell.js
@@ -1,10 +1,9 @@
 /* global wpseoAdminL10n */
-
 import { __, sprintf } from "@wordpress/i18n";
-import UpsellBox from "../UpsellBox";
-import PropTypes from "prop-types";
-import { useRootContext }  from "@yoast/externals/contexts";
 import { addQueryArgs } from "@wordpress/url";
+import { useRootContext } from "@yoast/externals/contexts";
+import PropTypes from "prop-types";
+import UpsellBox from "../UpsellBox";
 
 /**
  * Creates the content for a PremiumSEOAnalysisUpsell modal.
@@ -14,13 +13,18 @@ import { addQueryArgs } from "@wordpress/url";
  * @returns {wp.Element} The PremiumSEOAnalysisUpsell component.
  */
 const PremiumSEOAnalysisUpsell = ( props ) => {
-	const intro = __( "Get extra, smarter recommendations about your site’s structure, content, and SEO opportunities.", "wordpress-seo" );
-
+	const infoParagraphs = [
+		__( "Check your text on more SEO criteria and get an enhanced keyphrase analysis, making it easier to write optimized content.", "wordpress-seo" ),
+		<span key="PremiumSEOAnalysisUpsell-infoParagraph-benefitsTitle" className="yst-text-[#303030] yst-text-[13px] yst-font-semibold">
+			{ __( "What’s more in Yoast SEO Premium?", "wordpress-seo" ) }
+		</span>,
+	];
 	const benefits = [
-		__( "Use AI to create titles & meta descriptions", "wordpress-seo" ),
-		__( "Target multiple focus keyphrases", "wordpress-seo" ),
-		__( "Use synonyms, plurals, and variations", "wordpress-seo" ),
-		__( "Unlock expert workouts and workflows", "wordpress-seo" ),
+		__( "Get help ranking for multiple keyphrases", "wordpress-seo" ),
+		__( "Avoid dead links on your site", "wordpress-seo" ),
+		__( "Easily improve the structure of your site", "wordpress-seo" ),
+		__( "Preview how your content looks when shared on social", "wordpress-seo" ),
+		__( "Get guidance & save time on routine SEO tasks", "wordpress-seo" ),
 	];
 
 	const { locationContext } = useRootContext();
@@ -28,7 +32,7 @@ const PremiumSEOAnalysisUpsell = ( props ) => {
 
 	return (
 		<UpsellBox
-			infoParagraphs={ [ intro ] }
+			infoParagraphs={ infoParagraphs }
 			benefits={ benefits }
 			upsellButtonText={
 				sprintf(

--- a/packages/js/src/components/modals/PremiumSEOAnalysisUpsell.js
+++ b/packages/js/src/components/modals/PremiumSEOAnalysisUpsell.js
@@ -20,6 +20,7 @@ const PremiumSEOAnalysisUpsell = ( props ) => {
 		</span>,
 	];
 	const benefits = [
+		__( "Create content faster: Use AI to create titles & meta descriptions", "wordpress-seo" ),
 		__( "Get help ranking for multiple keyphrases", "wordpress-seo" ),
 		__( "Avoid dead links on your site", "wordpress-seo" ),
 		__( "Easily improve the structure of your site", "wordpress-seo" ),

--- a/packages/js/src/components/modals/PremiumSEOAnalysisUpsell.js
+++ b/packages/js/src/components/modals/PremiumSEOAnalysisUpsell.js
@@ -14,10 +14,10 @@ import UpsellBox from "../UpsellBox";
  */
 const PremiumSEOAnalysisUpsell = ( props ) => {
 	const infoParagraphs = [
-		<div key="PremiumSEOAnalysisUpsell-infoParagraph-description" className="yst-max-w-[426px]">
+		<span key="PremiumSEOAnalysisUpsell-infoParagraph-description" className="yst-block yst-max-w-[426px]">
 			{ __( "Check your text on more SEO criteria and get an enhanced keyphrase analysis, making it easier to write optimized content.", "wordpress-seo" ) }
-		</div>,
-		<span key="PremiumSEOAnalysisUpsell-infoParagraph-benefitsTitle" className="yst-text-[#303030] yst-text-[13px] yst-font-semibold">
+		</span>,
+		<span key="PremiumSEOAnalysisUpsell-infoParagraph-benefitsTitle" className="yst-block yst-my-3 yst-text-[#303030] yst-text-[13px] yst-font-semibold">
 			{ __( "What’s more in Yoast SEO Premium?", "wordpress-seo" ) }
 		</span>,
 	];

--- a/packages/js/src/components/modals/PremiumSEOAnalysisUpsell.js
+++ b/packages/js/src/components/modals/PremiumSEOAnalysisUpsell.js
@@ -14,7 +14,9 @@ import UpsellBox from "../UpsellBox";
  */
 const PremiumSEOAnalysisUpsell = ( props ) => {
 	const infoParagraphs = [
-		__( "Check your text on more SEO criteria and get an enhanced keyphrase analysis, making it easier to write optimized content.", "wordpress-seo" ),
+		<div key="PremiumSEOAnalysisUpsell-infoParagraph-description" className="yst-max-w-[426px]">
+			{ __( "Check your text on more SEO criteria and get an enhanced keyphrase analysis, making it easier to write optimized content.", "wordpress-seo" ) }
+		</div>,
 		<span key="PremiumSEOAnalysisUpsell-infoParagraph-benefitsTitle" className="yst-text-[#303030] yst-text-[13px] yst-font-semibold">
 			{ __( "What’s more in Yoast SEO Premium?", "wordpress-seo" ) }
 		</span>,

--- a/packages/js/src/elementor/components/fills/ElementorFill.js
+++ b/packages/js/src/elementor/components/fills/ElementorFill.js
@@ -4,6 +4,7 @@ import { Fragment, useEffect } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
 import { get } from "lodash";
 import PropTypes from "prop-types";
+import { InternalLinkingSuggestionsUpsell } from "../../../components/modals/InternalLinkingSuggestionsUpsell";
 
 // Internal dependencies.
 import CollapsibleCornerstone from "../../../containers/CollapsibleCornerstone";
@@ -114,6 +115,9 @@ export default function ElementorFill( { isLoading, onLoad, settings } ) {
 				</SidebarItem> }
 				{ settings.isKeywordAnalysisActive && <SidebarItem key="additional-keywords-upsell" renderPriority={ 22 }>
 					{ settings.shouldUpsell && <KeywordUpsell /> }
+				</SidebarItem> }
+				{ settings.shouldUpsell && <SidebarItem key="internal-linking-suggestions-upsell" renderPriority={ 23 }>
+					<InternalLinkingSuggestionsUpsell />
 				</SidebarItem> }
 				{ settings.isKeywordAnalysisActive && settings.isWincherIntegrationActive &&
 					<SidebarItem key="wincher-seo-performance" renderPriority={ 23 }>

--- a/packages/js/src/elementor/components/fills/ElementorFill.js
+++ b/packages/js/src/elementor/components/fills/ElementorFill.js
@@ -23,7 +23,7 @@ import { isWordProofIntegrationActive } from "../../../helpers/wordproof";
 import WordProofAuthenticationModals from "../../../components/modals/WordProofAuthenticationModals";
 import WebinarPromoNotification from "../../../components/WebinarPromoNotification";
 import BlackFridayPromoNotification from "../../../components/BlackFridayPromoNotification";
-import KeywordUpsell from "../../../components/KeywordUpsell";
+import KeywordUpsell from "../../../components/modals/KeywordUpsell";
 
 /* eslint-disable complexity */
 /**

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -24,6 +24,19 @@ module.exports = {
 			animation: {
 				slideRight: "slideRight .5s ease-in-out forwards",
 			},
+			fontFamily: {
+				wp: [
+					"-apple-system",
+					"BlinkMacSystemFont",
+					"Segoe UI",
+					"Roboto",
+					"Oxygen-Sans",
+					"Ubuntu",
+					"Cantarell",
+					"Helvetica Neue",
+					"sans-serif",
+				],
+			},
 		},
 	},
 	safelist: [


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves the "Premium SEO analysis" upsell.
* Improves the "Add related keyphrase" upsell.
* Improves the "Add synonyms" upsell.
* Adds an "Internal linking suggestions" upsell.

## Relevant technical choices:

* Added the Tailwind stylesheet as dependency to the metabox stylesheet. This should allow us to use Tailwind classes (as long as we ensure they are nested within a `yst-root`) in the editors.
* I tried to keep it simple here as I _think_ this is a style we eventually want to revamp. For now it is mostly looking like old. So if I had to make new things I did my best to make it look like it does now (without using styled components !!)
  * The collapsible there is no way to easily add the badge there instead of the suffix icon. Due to the weird and specific classes I moved that into a separate file to be used in the other implementations. 
  * I didn't bother creating an overarching abstraction for the modal + upsell thing, nor bother changing the upsell itself (with the 2 spans in the `infoParagraph`) that all have now.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Deactivate Premium, as this is all Free only
* Edit a post type
* Verify the upsells in the metabox look like [the design](https://www.sketch.com/s/2ff95a8b-b3fb-452c-982c-906d6d7ed96d/prototype/69069CA7-60FB-4321-9749-9F3CED022504/a/69069CA7-60FB-4321-9749-9F3CED022504) [_if applicable_]
<details closed>
<summary>Metabox screenshot in my local environment</summary>

![image](https://github.com/Yoast/wordpress-seo/assets/35524806/a02487b7-53f3-4076-9225-53edaeb66e08)

</details>

* Verify the upsells in the sidebar look like [the design](https://www.sketch.com/s/2ff95a8b-b3fb-452c-982c-906d6d7ed96d/prototype/69069CA7-60FB-4321-9749-9F3CED022504/a/69069CA7-60FB-4321-9749-9F3CED022504) [_if applicable_]
<details closed>
<summary>Sidebar screenshot in my local environment</summary>

![image](https://github.com/Yoast/wordpress-seo/assets/35524806/e593c237-0fb6-41bf-bcfc-1e5060ef9b1b)
</details>

* Click on the Premium SEO analysis upsell and verify the modal looks like [the design](https://www.sketch.com/s/2ff95a8b-b3fb-452c-982c-906d6d7ed96d/prototype/69069CA7-60FB-4321-9749-9F3CED022504/a/9450FB97-4D18-49BD-8134-C9A69ED344C5)
  * Note the first upsell point about AI is not in the design, but added as [per later request](https://yoast.slack.com/archives/C03KU0EHCNQ/p1695205351071929?thread_ts=1695198890.831619&cid=C03KU0EHCNQ)
  * Verify the Unlock button (still) links to either `https://yoa.st/premium-seo-analysis-metabox` or `https://yoa.st/premium-seo-analysis-sidebar`. Depending on where you opened it. Note the missing `-term` variant, I kept this the same.
    * Verify the query parameter `context` is a variant of either `block-metabox`, `block-sidebar`, `elementor-sidebar` or `classic-metabox`. Depending on where you opened it.
    * In Elementor, please verify the spacing of the title and list tile are looking the same as in other editors.
<details closed>
<summary>Premium SEO analysis screenshot in my local environment</summary>

![image](https://github.com/Yoast/wordpress-seo/assets/35524806/ea05fb73-4e24-48c7-9ab6-5727ec24e0f0)
</details>

* Click on the Add related keyphrase upsell and verify the modal looks like [the design](https://www.sketch.com/s/2ff95a8b-b3fb-452c-982c-906d6d7ed96d/prototype/69069CA7-60FB-4321-9749-9F3CED022504/a/9BC454FC-29BF-4608-BF82-0409CE0D6FC7)
  * Note the first upsell point about AI is not in the design, but added as [per later request](https://yoast.slack.com/archives/C03KU0EHCNQ/p1695205351071929?thread_ts=1695198890.831619&cid=C03KU0EHCNQ)
  * Verify the Unlock button (still) links to either `https://yoa.st/add-keywords-metabox`, `https://yoa.st/add-keywords-sidebar` or `https://yoa.st/add-keywords-metabox-term`. Depending on where you opened it.
    * Verify the query parameter `context` is a variant of either `block-metabox`, `block-sidebar`, `elementor-sidebar` or `classic-metabox`. Depending on where you opened it.
    * In Elementor, please verify the spacing of the title and list tile are looking the same as in other editors.
  * Verify the `+ Add related keyphrase` under the `SEO analysis` also opens the modal that looks and behaves the same
    * Verify that for these the Unlock button (still) links to either `https://yoa.st/add-keywords-popup`, `https://yoa.st/add-keywords-popup-sidebar` or `https://yoa.st/add-keywords-popup-term`. 
<details closed>
<summary>Add related keyphrase screenshot in my local environment</summary>

![image](https://github.com/Yoast/wordpress-seo/assets/35524806/adb75085-459d-4147-bea3-1581b3dec2ec)
</details>

* Click on the Internal linking suggestions upsell and verify the modal looks like [the design](https://www.sketch.com/s/2ff95a8b-b3fb-452c-982c-906d6d7ed96d/prototype/69069CA7-60FB-4321-9749-9F3CED022504/a/A1356966-7D0E-488E-834F-7E0025BFF4BD)
  * Note the first upsell point about AI is not in the design, but added as [per later request](https://yoast.slack.com/archives/C03KU0EHCNQ/p1695205351071929?thread_ts=1695198890.831619&cid=C03KU0EHCNQ)
  * Verify the Unlock button links to either `https://yoa.st/internal-linking-suggestions-metabox`, `https://yoa.st/internal-linking-suggestions-sidebar` or `https://yoa.st/internal-linking-suggestions-metabox-term`. Depending on where you opened it.
    * Note that the shortlink might not work yet, as this is a new one.
    * Verify the query parameter `context` is a variant of either `block-metabox`, `block-sidebar`, `elementor-sidebar` or `classic-metabox`. Depending on where you opened it.
    * In Elementor, please verify the spacing of the title and list tile are looking the same as in other editors.
<details closed>
<summary>Internal linking suggestions screenshot in my local environment</summary>

![image](https://github.com/Yoast/wordpress-seo/assets/35524806/a2efb65a-5487-47f5-9c90-421db6c7c0d5)
</details>

* Under the SEO analysis, click on the `+ Add synonyms` upsell and verify the modal looks like the others.
  * Verify the copy is as [per request](https://yoast.slack.com/archives/C03KU0EHCNQ/p1695205351071929?thread_ts=1695198890.831619&cid=C03KU0EHCNQ)
  * Verify the Unlock button (still) links to either `https://yoa.st/keyword-synonyms-popup`, `https://yoa.st/keyword-synonyms-popup-sidebar` or `https://yoa.st/keyword-synonyms-popup-term`. Depending on where you opened it.
    * Verify the query parameter `context` is a variant of either `block-metabox`, `block-sidebar`, `elementor-sidebar` or `classic-metabox`. Depending on where you opened it.
    * In Elementor, please verify the spacing of the title and list tile are looking the same as in other editors.
<details closed>
<summary>Add synonyms screenshot in my local environment</summary>

![image](https://github.com/Yoast/wordpress-seo/assets/35524806/b1ebbba6-009c-4d7d-a3e9-bacbb9df5642)
</details>

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [x] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The current/previous version of those upsells, obviously. Other than that the Tailwind stylesheet was added as dependency to our metabox stylesheet, in most editors this was already the case. But in Elementor, this is new. Should not have influence on anything as we nest it in `yst-root`. But mentioning here anyway.

## UI changes

* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/wordpress-seo-premium/issues/4020
Fixes https://github.com/Yoast/wordpress-seo-premium/issues/4021