### PR TITLE
Use useselect hook instead of select for invoking selectors

### DIFF
--- a/packages/js/src/components/BlackFridayProductEditorChecklistPromotion.js
+++ b/packages/js/src/components/BlackFridayProductEditorChecklistPromotion.js
@@ -1,5 +1,5 @@
 import { __, sprintf } from "@wordpress/i18n";
-import { select } from "@wordpress/data";
+import { useSelect } from "@wordpress/data";
 import { createInterpolateElement } from "@wordpress/element";
 import { addQueryArgs } from "@wordpress/url";
 
@@ -12,7 +12,7 @@ import { TimeConstrainedNotification } from "./TimeConstrainedNotification";
  * @returns {JSX.Element} The BlackFridayProductEditorChecklistPromotion component.
  */
 export const BlackFridayProductEditorChecklistPromotion = () => {
-	const linkParams = select( "yoast-seo/editor" ).selectLinkParams();
+	const linkParams = useSelect( select => select( "yoast-seo/editor" ).selectLinkParams(), [] );
 	const title = sprintf(
 		/* translators: %1$s expands to 'WooCommerce'. */
 		__( "Is your %1$s store ready for Black Friday?", "wordpress-seo" ),

--- a/packages/js/src/components/BlackFridayPromotion.js
+++ b/packages/js/src/components/BlackFridayPromotion.js
@@ -1,5 +1,5 @@
 import { __, sprintf } from "@wordpress/i18n";
-import { select } from "@wordpress/data";
+import { useSelect } from "@wordpress/data";
 import { addQueryArgs } from "@wordpress/url";
 import { createInterpolateElement } from "@wordpress/element";
 import PropTypes from "prop-types";
@@ -19,8 +19,8 @@ export const BlackFridayPromotion = ( {
 	location = "sidebar",
 	...props
 } ) => {
-	const isPremium = select( store ).getIsPremium();
-	const linkParams = select( store ).selectLinkParams();
+	const isPremium = useSelect( select => select( store ).getIsPremium(), [ store ] );
+	const linkParams = useSelect( select => select( store ).selectLinkParams(), [ store ] );
 	const title = location === "sidebar"
 		? sprintf(
 			__( "BLACK FRIDAY SALE: %1$s", "wordpress-seo" ),
@@ -29,7 +29,7 @@ export const BlackFridayPromotion = ( {
 		: createInterpolateElement(
 			sprintf(
 				/* Translators: %1$s expands to YOAST SEO PREMIUM, %2$s expands to a link on yoast.com, %3$s expands to the anchor end tag. */
-				__( "BLACK FRIDAY SALE: %1$s, %2$sBuy now!%3$s", "wordpress-seo" ),
+				__( "BLACK FRIDAY SALE LEL: %1$s, %2$sBuy now!%3$s", "wordpress-seo" ),
 				"YOAST SEO PREMIUM",
 				"<a>",
 				"</a>"

--- a/packages/js/src/components/BlackFridayPromotion.js
+++ b/packages/js/src/components/BlackFridayPromotion.js
@@ -29,7 +29,7 @@ export const BlackFridayPromotion = ( {
 		: createInterpolateElement(
 			sprintf(
 				/* Translators: %1$s expands to YOAST SEO PREMIUM, %2$s expands to a link on yoast.com, %3$s expands to the anchor end tag. */
-				__( "BLACK FRIDAY SALE LEL: %1$s, %2$sBuy now!%3$s", "wordpress-seo" ),
+				__( "BLACK FRIDAY SALE: %1$s, %2$sBuy now!%3$s", "wordpress-seo" ),
 				"YOAST SEO PREMIUM",
 				"<a>",
 				"</a>"

--- a/packages/js/src/components/BlackFridaySidebarChecklistPromotion.js
+++ b/packages/js/src/components/BlackFridaySidebarChecklistPromotion.js
@@ -1,4 +1,4 @@
-import { select } from "@wordpress/data";
+import { useSelect } from "@wordpress/data";
 import { createInterpolateElement } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
 import { addQueryArgs } from "@wordpress/url";
@@ -18,7 +18,7 @@ export const BlackFridaySidebarChecklistPromotion = ( {
 	store = "yoast-seo/editor",
 	...props
 } ) => {
-	const linkParams = select( store ).selectLinkParams();
+	const linkParams = useSelect( select => select( store ).selectLinkParams(), [ store ] );
 	const body = createInterpolateElement(
 		sprintf(
 		/* translators:  %1$s expands to Yoast, %2$s expands to a 'strong' start tag, %2$s to a 'strong' end tag. */


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to follow the best practice of using `useselect` hook inside React components instead of `select`

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Uses `useselect` hook instead of `select` inside React components.

## Relevant technical choices:

* N/A

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Preliminary steps
* Deactivate Premium
* Activate WooCommerce
* Make sure you have no notifications alredy dismissed
  * With a MySQL client edit the `wp_usermeta` table
  * search  for the tuple with `user_id` = your user id and `meta_key` = `_yoast_alerts_dismissed`
    * set `meta_value` to `a:0:{}`  
* Edit `src/promotions/domain/black-friday-checklist-promotion.php`
  * change `\gmmktime( 11, 00, 00, 9, 19, 2023 )` to `\gmmktime( 11, 00, 00, 9, 19, 2022 )`
  
#### Check the correctness of the link in the product editor BF checklist notification
* Go to `Products` -> `Add new`
* In the Yoast metabox, verify that the `Get the checklist and start optimizing now!` link inside the `Is your WooCommerce store ready for Black Friday?` notification has the usual parameters attached, i.e. it should be of the form:
```https://yoa.st/black-friday-checklist?php_version=7.4&platform=wordpress&platform_version=6.3.1&software=free&software_version=21.2-RC1&days_active=23&user_language=en_GB``` (please note parameters values might be different)

#### Check the correctness of the link in the Yoast sidebar BF checklist notification
* Go to `Posts` -> `Add new`
* In the Yoast sidebar, verify that the `Get the checklist and start optimizing now!` link inside the `Is your WooCommerce store ready for Black Friday?` notification has the usual parameters attached, i.e. it should be of the form:
```https://yoa.st/black-friday-checklist?php_version=7.4&platform=wordpress&platform_version=6.3.1&software=free&software_version=21.2-RC1&days_active=23&user_language=en_GB``` (please note parameters values might be different)

#### Check the correctness of the link in the Yoast sidebar / metabox BF notification
* Revert the changes you made to `src/promotions/domain/black-friday-checklist-promotion.php`
* Edit `src/promotions/domain/black-friday-promotion.php`
  * change `\gmmktime( 11, 00, 00, 11, 23, 2023 )` to `\gmmktime( 11, 00, 00, 11, 23, 2022 )`
* Go to `Posts` -> `Add new`
* In the Yoast metabox and sidebar:
  * verify that the `BLACK FRIDAY SALE: YOAST SEO PREMIUM` notification is visible
  * verify the  `Buy now!` link inside the notification has the usual parameters attached, i.e. it should be of the form:
```ttps://yoa.st/black-friday-sale?php_version=7.4&platform=wordpress&platform_version=6.3.1&software=free&software_version=21.2-RC1&days_active=23&user_language=en_GB``` (please note parameters values might be different)

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [X] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* N/A

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.
* [X] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/wordpress-seo/issues/20652
