### PR TITLE
Fix crash for Single title assessment when one of the H1s doesn't have text

### DIFF
--- a/packages/yoastseo/spec/languageProcessing/researches/h1sSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/h1sSpec.js
@@ -7,6 +7,11 @@ describe( "Gets all H1s in the text", function() {
 		expect( h1s( mockPaper ) ).toEqual( [] );
 	} );
 
+	it( "should return empty when there is only empty H1s", function() {
+		const mockPaper = new Paper( "some content<h1></h1> other content <h1></h1>" );
+		expect( h1s( mockPaper ) ).toEqual( [] );
+	} );
+
 	it( "should return one object when there is one H1", function() {
 		const mockPaper = new Paper( "<h1>first h1</h1>some content<h2>content h2</h2>" );
 		expect( h1s( mockPaper ) ).toEqual( [ { tag: "h1", content: "first h1", position: 0 } ] );

--- a/packages/yoastseo/src/languageProcessing/researches/h1s.js
+++ b/packages/yoastseo/src/languageProcessing/researches/h1s.js
@@ -1,7 +1,7 @@
 import { getBlocks } from "../helpers/html/html";
 import { reject } from "lodash-es";
 
-const h1Regex = /<h1.*?>(.*?)<\/h1>/;
+const h1Regex = /<h1.*?>(.+?)<\/h1>/;
 
 /**
  * Gets a block from a text and checks if it is totally empty or if it is an empty paragraph.


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Fix crash for Single title assessment in Block editor when one of the H1s doesn't have text.
* Now empty H1s also don't trigger the assessment at all.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [yoastseo] Don't count empty h1s when looking for h1s in the text in the `h1s.js` research.
* [shopify-seo]  Fixes a bug where an H1 with no text could trigger the Single title assessment.
* Fixes the editor crashing when clicking the highlight button for the Single title assessment in Block editor when one of the H1s doesn't have text.

## Relevant technical choices:

* h1 filter regex was modified to exclude items with empty content, so that empty h1s also don't trigger the assessment.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Follow the testing instruction for Single H1 assessment in [this ATP](https://docs.google.com/document/d/11w5ZY17qESN9zYOD9PIsuvU4ykBgVR8rpee-8qzU3Ag/edit#heading=h.10yyqbkwqyyx)
* Make sure that no crash when empty h1 is added in block editor.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [x] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Can input other cases for  check single title assessment 

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [x] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [#196](https://github.com/Yoast/lingo-other-tasks/issues/196)
