### PR TITLE
Change textdomain

### DIFF
--- a/packages/js/src/first-time-configuration/tailwind-components/base/image-select.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/base/image-select.js
@@ -50,7 +50,7 @@ export default function ImageSelect( {
 			return (
 				<div className="yst-text-center">
 					<Spinner size="10" color="gray-400" className="yst-inline-block" />
-					<p className="yst-mt-3">{ __( "Uploading image...", "admin-ui" ) }</p>
+					<p className="yst-mt-3">{ __( "Uploading image...", "wordpress-seo" ) }</p>
 				</div>
 			);
 		} else if ( url ) {
@@ -80,7 +80,7 @@ export default function ImageSelect( {
 					className="yst-button yst-button yst-button--secondary yst-mr-2"
 					onClick={ onSelectImageClick }
 				>
-					{ url ? __( "Replace image", "admin-ui" ) : __( "Select image", "admin-ui" ) }
+					{ url ? __( "Replace image", "wordpress-seo" ) : __( "Select image", "wordpress-seo" ) }
 				</button>
 				{ url && (
 					<button
@@ -89,7 +89,7 @@ export default function ImageSelect( {
 						className="yst-button--remove"
 						onClick={ onRemoveImageClick }
 					>
-						{ __( "Remove image", "admin-ui" ) }
+						{ __( "Remove image", "wordpress-seo" ) }
 					</button>
 				) }
 			</div>

--- a/packages/js/src/first-time-configuration/tailwind-components/tailwind-modal.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/tailwind-modal.js
@@ -55,7 +55,7 @@ export default function TailwindModal( { isOpen, handleClose, hasCloseButton, ch
 									onClick={ handleClose }
 									className="yst-bg-white yst-rounded-md yst-text-slate-400 hover:yst-text-slate-600 focus:yst-outline-none focus:yst-ring-2 focus:yst-ring-offset-2 focus:yst-ring-primary-500"
 								>
-									<span className="yst-sr-only">{ __( "Close", "admin-ui" ) }</span>
+									<span className="yst-sr-only">{ __( "Close", "wordpress-seo" ) }</span>
 									<XIcon className="yst-h-6 yst-w-6" />
 								</button>
 							</div> }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the first-time configuration' site representation logo button would not be translated. Props to @fxbenard.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Switch your site language (or user language) to something that has translations (I tested Dutch). And be sure to pull in the translations (via the WP updates screen)
* Go to Yoast SEO > General and switch to the First-time configuration tab
* Go to the site representation step
* Verify the image upload button's text is now translated (note: this works right away because the translations are the same as used in other places)
* Upload an image
* Verify the image replace button's text is now translated
* Verify the remove image button's text is now translated

There is also an `Upload image...` translation if it is loading, but not sure where to see that I'm afraid. Since we do the WP upload thing and when loading we are not on that step. So I'm presuming it is also fixed now.
Then there is a change in a component we no longer use. So can't test that.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* First-time configuration textdomain

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
