### PR TITLE
Fixes highlighting behaviour for posts converted from Classic to Gutenberg

### DIFF
--- a/packages/js/tests/blockEditorData.test.js
+++ b/packages/js/tests/blockEditorData.test.js
@@ -11,23 +11,30 @@ const store = {
 	dispatch: jest.fn(),
 };
 
-// Mocks the getEditedPostAttribute function.
+// Mocks the getEditedPostAttribute/getBlocks functions.
 const mockGetEditedPostAttribute = jest.fn().mockImplementation( value => value );
+const mockGetBlocks = jest.fn().mockImplementation( value => value );
 
-// Ensures mockSelect.getEditedPostAttribute is a function.
 jest.mock( "@wordpress/data", () => {
 	return {
 		select: () => {
 			return {
 				getEditedPostAttribute: mockGetEditedPostAttribute,
-				getEditedPostContent: jest.fn().mockReturnValue( "" ),
+				getEditedPostContent: jest.fn().mockReturnValue( "test block test" ),
 				getActiveMarker: () => null,
 				getPermalinkParts: jest.fn().mockReturnValue( { prefix: "https://www.yoast.com/", postName: "", suffix: "/" } ),
 				isEditedPostNew: jest.fn().mockReturnValue( false ),
+				getBlocks: mockGetBlocks,
 			};
 		},
 		subscribe: () => {},
 		combineReducers: jest.requireActual( "@wordpress/data" ).combineReducers,
+	};
+} );
+
+jest.mock( "@wordpress/blocks", () => {
+	return {
+		getBlockContent: jest.fn().mockReturnValue( "test classic test" ),
 	};
 } );
 
@@ -95,7 +102,7 @@ describe( "getPostAttribute", () => {
 describe( "collectGutenbergData", () => {
 	it( "collects the GutenbergData", () => {
 		const expected = {
-			content: "content",
+			content: "test block test",
 			contentImage: "",
 			title: "title",
 			slug: "slug",
@@ -110,12 +117,37 @@ describe( "collectGutenbergData", () => {
 		mockGetFeaturedImage.mockReturnValue( "featured-image" );
 		data.getFeaturedImage = mockGetFeaturedImage;
 
+		mockGetBlocks.mockReturnValueOnce( [ { name: "core/paragraph" } ] );
+
+		const actual = data.collectGutenbergData();
+		expect( actual ).toEqual( expected );
+	} );
+
+	it( "collects the GutenbergData when the post has been converted from the Classic editor", () => {
+		const expected = {
+			content: "test classic test",
+			contentImage: "",
+			title: "title",
+			slug: "slug",
+			excerpt: "excerpt",
+			// eslint-disable-next-line camelcase
+			excerpt_only: "excerpt",
+			snippetPreviewImageURL: "featured-image",
+			baseUrl: "https://www.yoast.com/",
+		};
+
+		mockGetBlocks.mockReturnValueOnce( [ { name: "core/freeform" } ] );
+
 		const actual = data.collectGutenbergData();
 		expect( actual ).toEqual( expected );
 	} );
 } );
 
 describe( "refreshYoastSEO", () => {
+	beforeEach( () =>
+		mockGetBlocks.mockReturnValueOnce( [ { name: "core/paragraph" } ] )
+	);
+
 	/*
 		After the first call of collectGutenbergData in refreshYoastSEO, the Gutenberg data is always dirty,
 		because data is initially an empty object.


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* When posts are converted from Classic editor to the default (block/Gutenberg) editor, the posts is displayed using a `core/freeform` block ([docs](https://developer.wordpress.org/block-editor/reference-guides/core-blocks/#classic)). Under the hood, the WordPress `autop` function ([docs](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-autop/)) is applied to these blocks (see e.g. [this PR](https://github.com/WordPress/gutenberg/pull/52716) for context). Our new position-based highlighting functionality did not work in that case, because these `<p>` tags were not parts of the HTML that is stored in the database (they are removed on save through `removep` ([docs](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-autop/#removep))). 
* In this PR, we do not account for the situation where multiple Classic blocks are added, or a Classic block is added to a post with other blocks. We consider that situation unlikely -- either your whole post is one Classic block, or you have multiple regular blocks. 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where the highlighting functionality would not work when posts were converted from Classic editor. 

## Relevant technical choices:

* We now use `getEditedPostContent` to fetch the content, which is functionally the same, but reads better than `this.getPostAttribute( "content" )`. 
* Did a little bit of boy scouting in the touched files. 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Use scenario 3 from https://github.com/Yoast/wordpress-seo/pull/20595.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The highlighting feature for Classic blocks in Gutenberg.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [x] This PR falls under an innovation project. I have attached the `innovation` label.
* [x] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/lingo-other-tasks/issues/217
