### PR TITLE
73 change the copy on the sticky sidebar and sticky footer bar to claim your 30 off now

### DIFF
--- a/admin/class-admin-asset-manager.php
+++ b/admin/class-admin-asset-manager.php
@@ -622,6 +622,11 @@ class WPSEO_Admin_Asset_Manager {
 				'deps' => [ self::PREFIX . 'tailwind' ],
 			],
 			[
+				'name' => 'black-friday-banner',
+				'src'  => 'black-friday-banner-' . $flat_version,
+				'deps' => [ self::PREFIX . 'tailwind' ],
+			],
+			[
 				'name' => 'academy',
 				'src'  => 'academy-' . $flat_version,
 				'deps' => [ self::PREFIX . 'tailwind' ],

--- a/admin/class-premium-upsell-admin-block.php
+++ b/admin/class-premium-upsell-admin-block.php
@@ -68,7 +68,7 @@ class WPSEO_Premium_Upsell_Admin_Block {
 		$class = $this->get_html_class();
 
 		/* translators: %s expands to Yoast SEO Premium */
-		$button_text  = sprintf( esc_html__( 'Get %s', 'wordpress-seo' ), 'Yoast SEO Premium' );
+		$button_text  = YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-2023-promotion' ) ? \esc_html__( 'Claim your 30% off now!', 'wordpress-seo' ) : sprintf( esc_html__( 'Get %s', 'wordpress-seo' ), 'Yoast SEO Premium' );
 		$button_text .= '<span class="screen-reader-text">' . esc_html__( '(Opens in a new browser tab)', 'wordpress-seo' ) . '</span>' .
 			'<span aria-hidden="true" class="yoast-button-upsell__caret"></span>';
 

--- a/css/src/black-friday-banner.css
+++ b/css/src/black-friday-banner.css
@@ -1,0 +1,22 @@
+.sidebar__sale_banner_container .sidebar__sale_banner {
+    color: #fcd34d;
+    width: calc(100% + 60px);
+    line-height: 30px;
+    margin-left: -30px;
+    transform: rotate(-5deg);
+    letter-spacing: 0.5px;
+    box-shadow: 0 -1px 4px 0 #fcd34d, 0 1px 4px 0 #fcd34d, 0 -1px 0 0 #fcd34d, 0 1px 0 0 #fcd34d;
+    @apply yst-text-lg yst-font-bold yst-bg-black yst-mt-5 yst-text-center yst-mb-[10px] yst-px-0 yst-py-1;
+}
+
+.sidebar__sale_banner_container .sidebar__sale_banner .banner_text {
+    @apply yst-inline-block yst-my-0 yst-mx-[35px];
+}
+
+.sidebar__sale_banner_container {
+    width: calc(100% + 48px);
+    margin-left: -24px;
+    margin-bottom: -25px;
+    margin-top: -5px;
+    @apply yst-overflow-hidden yst-pb-[10px];
+}

--- a/css/src/black-friday-banner.css
+++ b/css/src/black-friday-banner.css
@@ -17,6 +17,6 @@
     width: calc(100% + 48px);
     margin-left: -24px;
     margin-bottom: -25px;
-    margin-top: -5px;
+    margin-top: -25px;
     @apply yst-overflow-hidden yst-pb-[10px];
 }

--- a/css/src/new-settings.css
+++ b/css/src/new-settings.css
@@ -241,6 +241,37 @@ body.seo_page_wpseo_page_settings {
 			yst-bg-slate-200
 			yst-text-slate-900;
 		}
+
+		.sidebar__sale_banner_container .sidebar__sale_banner {
+			background: #000;
+			color: #fcd34d;
+			width: calc(100% + 60px);
+			line-height: 30px;
+			margin-left: -30px;
+			transform: rotate(-5deg);
+			font-size: 18px;
+			font-weight: 500;
+			letter-spacing: 0.5px;
+			text-align: center;
+			margin-top: 20px;
+			margin-bottom: 10px;
+			box-shadow: 0 -1px 4px 0 #fcd34d, 0 1px 4px 0 #fcd34d, 0 -1px 0 0 #fcd34d, 0 1px 0 0 #fcd34d;
+			padding: 7px 0;
+		}
+		
+		.sidebar__sale_banner_container .sidebar__sale_banner .banner_text {
+			display: inline-block;
+			margin: 0 35px;
+		}
+
+		.sidebar__sale_banner_container {
+			width: calc(100% + 48px);
+			margin-left: -24px;
+			overflow: hidden;
+			padding-bottom: 10px;
+			margin-bottom: -25px;
+			margin-top: -5px;
+		}
 	}
 
 	/* RTL */

--- a/css/src/new-settings.css
+++ b/css/src/new-settings.css
@@ -243,25 +243,18 @@ body.seo_page_wpseo_page_settings {
 		}
 
 		.sidebar__sale_banner_container .sidebar__sale_banner {
-			background: #000;
 			color: #fcd34d;
 			width: calc(100% + 60px);
 			line-height: 30px;
 			margin-left: -30px;
 			transform: rotate(-5deg);
-			font-size: 18px;
-			font-weight: 500;
 			letter-spacing: 0.5px;
-			text-align: center;
-			margin-top: 20px;
-			margin-bottom: 10px;
 			box-shadow: 0 -1px 4px 0 #fcd34d, 0 1px 4px 0 #fcd34d, 0 -1px 0 0 #fcd34d, 0 1px 0 0 #fcd34d;
-			padding: 7px 0;
+			@apply yst-text-lg yst-font-bold yst-bg-black yst-mt-5 yst-text-center yst-mb-[10px] yst-px-0 yst-py-1;
 		}
 		
 		.sidebar__sale_banner_container .sidebar__sale_banner .banner_text {
-			display: inline-block;
-			margin: 0 35px;
+			@apply yst-inline-block yst-my-0 yst-mx-[35px];
 		}
 
 		.sidebar__sale_banner_container {

--- a/css/src/new-settings.css
+++ b/css/src/new-settings.css
@@ -241,30 +241,6 @@ body.seo_page_wpseo_page_settings {
 			yst-bg-slate-200
 			yst-text-slate-900;
 		}
-
-		.sidebar__sale_banner_container .sidebar__sale_banner {
-			color: #fcd34d;
-			width: calc(100% + 60px);
-			line-height: 30px;
-			margin-left: -30px;
-			transform: rotate(-5deg);
-			letter-spacing: 0.5px;
-			box-shadow: 0 -1px 4px 0 #fcd34d, 0 1px 4px 0 #fcd34d, 0 -1px 0 0 #fcd34d, 0 1px 0 0 #fcd34d;
-			@apply yst-text-lg yst-font-bold yst-bg-black yst-mt-5 yst-text-center yst-mb-[10px] yst-px-0 yst-py-1;
-		}
-		
-		.sidebar__sale_banner_container .sidebar__sale_banner .banner_text {
-			@apply yst-inline-block yst-my-0 yst-mx-[35px];
-		}
-
-		.sidebar__sale_banner_container {
-			width: calc(100% + 48px);
-			margin-left: -24px;
-			overflow: hidden;
-			padding-bottom: 10px;
-			margin-bottom: -25px;
-			margin-top: -5px;
-		}
 	}
 
 	/* RTL */

--- a/packages/js/src/settings/components/sidebar-recommendations.js
+++ b/packages/js/src/settings/components/sidebar-recommendations.js
@@ -6,6 +6,7 @@ import { useSelectSettings } from "../hooks";
  */
 const SidebarRecommendations = () => {
 	const isPremium = useSelectSettings( "selectPreference", [], "isPremium" );
+	const isBlackFriday = useSelectSettings( "selectPreference", [], "isBlackFriday" );
 	const premiumLink = useSelectSettings( "selectLink", [], "https://yoa.st/jj" );
 	const premiumUpsellConfig = useSelectSettings( "selectUpsellSettingsAsProps" );
 	const academyLink = useSelectSettings( "selectLink", [], "https://yoa.st/3t6" );
@@ -16,7 +17,7 @@ const SidebarRecommendations = () => {
 
 	return (
 		<RecommendationsSidebar>
-			<PremiumUpsellCard link={ premiumLink } linkProps={ premiumUpsellConfig } />
+			<PremiumUpsellCard link={ premiumLink } linkProps={ premiumUpsellConfig } isBlackFriday={ isBlackFriday } />
 			<AcademyUpsellCard link={ academyLink } />
 		</RecommendationsSidebar>
 	);

--- a/packages/js/src/settings/components/sidebar-recommendations.js
+++ b/packages/js/src/settings/components/sidebar-recommendations.js
@@ -6,7 +6,7 @@ import { useSelectSettings } from "../hooks";
  */
 const SidebarRecommendations = () => {
 	const isPremium = useSelectSettings( "selectPreference", [], "isPremium" );
-	const promotions = useSelectSettings( "selectPreference", [], "promotions" );
+	const promotions = useSelectSettings( "selectPreference", [], "promotions", [] );
 	const premiumLink = useSelectSettings( "selectLink", [], "https://yoa.st/jj" );
 	const premiumUpsellConfig = useSelectSettings( "selectUpsellSettingsAsProps" );
 	const academyLink = useSelectSettings( "selectLink", [], "https://yoa.st/3t6" );

--- a/packages/js/src/settings/components/sidebar-recommendations.js
+++ b/packages/js/src/settings/components/sidebar-recommendations.js
@@ -6,7 +6,7 @@ import { useSelectSettings } from "../hooks";
  */
 const SidebarRecommendations = () => {
 	const isPremium = useSelectSettings( "selectPreference", [], "isPremium" );
-	const isBlackFriday = useSelectSettings( "selectPreference", [], "isBlackFriday" );
+	const promotions = useSelectSettings( "selectPreference", [], "promotions" );
 	const premiumLink = useSelectSettings( "selectLink", [], "https://yoa.st/jj" );
 	const premiumUpsellConfig = useSelectSettings( "selectUpsellSettingsAsProps" );
 	const academyLink = useSelectSettings( "selectLink", [], "https://yoa.st/3t6" );
@@ -17,7 +17,7 @@ const SidebarRecommendations = () => {
 
 	return (
 		<RecommendationsSidebar>
-			<PremiumUpsellCard link={ premiumLink } linkProps={ premiumUpsellConfig } isBlackFriday={ isBlackFriday } />
+			<PremiumUpsellCard link={ premiumLink } linkProps={ premiumUpsellConfig } promotions={ promotions } />
 			<AcademyUpsellCard link={ academyLink } />
 		</RecommendationsSidebar>
 	);

--- a/packages/js/src/shared-admin/components/premium-upsell-card.js
+++ b/packages/js/src/shared-admin/components/premium-upsell-card.js
@@ -2,6 +2,7 @@ import { ArrowNarrowRightIcon } from "@heroicons/react/outline";
 import { createInterpolateElement, useMemo } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
 import { Button, Title } from "@yoast/ui-library";
+import { get } from "lodash";
 import PropTypes from "prop-types";
 import { ReactComponent as StarHalf } from "../../../images/star-rating-half.svg";
 import { ReactComponent as Star } from "../../../images/star-rating-star.svg";
@@ -15,17 +16,8 @@ import { ReactComponent as G2Logo } from "./g2-logo-white.svg";
  * @returns {JSX.Element} The premium upsell card.
  */
 export const PremiumUpsellCard = ( { link, linkProps } ) => {
-	const info = useMemo( () => createInterpolateElement(
-		sprintf(
-			/* translators: %1$s and %2$s expand to opening and closing <strong> tags. */
-			__( "Be more efficient in creating titles and meta descriptions with the help of AI. %1$sGet 24/7 support%2$s and boost your website’s visibility.", "wordpress-seo" ),
-			"<strong>",
-			"</strong>"
-		),
-		{
-			strong: <strong />,
-		}
-	), [] );
+	const info = useMemo( () => __( "Use AI to generate titles and meta descriptions, automatically redirect deleted pages, get 24/7 support and much, much more!", "wordpress-seo" ), [] );
+	const isBlackFriday = get( window, "wpseoScriptData.isBlackFriday", "" );
 	const getPremium = createInterpolateElement(
 		sprintf(
 			/* translators: %1$s and %2$s expand to a span wrap to avoid linebreaks. %3$s expands to "Yoast SEO Premium". */
@@ -46,6 +38,11 @@ export const PremiumUpsellCard = ( { link, linkProps } ) => {
 			>
 				<YoastSeoLogo />
 			</figure>
+			{ isBlackFriday && <div className="sidebar__sale_banner_container">
+				<div className="sidebar__sale_banner">
+					<span className="banner_text">{ __( "BLACK FRIDAY - 30% OFF", "wordpress-seo" ) }</span>
+				</div>
+			</div> }
 			<Title as="h2" className="yst-mt-6 yst-text-base yst-font-extrabold yst-text-white">
 				{ getPremium }
 			</Title>
@@ -59,7 +56,7 @@ export const PremiumUpsellCard = ( { link, linkProps } ) => {
 				className="yst-flex yst-justify-center yst-gap-2 yst-mt-4 focus:yst-ring-offset-primary-500"
 				{ ...linkProps }
 			>
-				<span>{ getPremium }</span>
+				<span>{ isBlackFriday ? __( "Claim your 30% off now!", "wordpress-seo" ) : getPremium }</span>
 				<ArrowNarrowRightIcon className="yst-w-4 yst-h-4 yst-icon-rtl" />
 			</Button>
 			<a

--- a/packages/js/src/shared-admin/components/premium-upsell-card.js
+++ b/packages/js/src/shared-admin/components/premium-upsell-card.js
@@ -45,7 +45,7 @@ export const PremiumUpsellCard = ( { link, linkProps, promotions } ) => {
 	return (
 		<div className="yst-p-6 yst-rounded-lg yst-text-white yst-bg-primary-500 yst-shadow">
 			<figure
-				className="yst-logo-square yst-w-16 yst-h-16 yst-mt-[-2.6rem] yst-mx-auto yst-overflow-hidden yst-border yst-border-white yst-rounded-xl yst-rounded-br-none"
+				className="yst-logo-square yst-w-16 yst-h-16 yst-mx-auto yst-overflow-hidden yst-border yst-border-white yst-rounded-xl yst-rounded-br-none yst-relative yst-z-10 yst-mt-[-2.6rem]"
 			>
 				<YoastSeoLogo />
 			</figure>

--- a/packages/js/src/shared-admin/components/premium-upsell-card.js
+++ b/packages/js/src/shared-admin/components/premium-upsell-card.js
@@ -30,6 +30,17 @@ export const PremiumUpsellCard = ( { link, linkProps, promotions } ) => {
 		}
 	);
 	const isBlackFriday = promotions.includes( "black-friday-2023-promotion" );
+	const saveMoneyText = createInterpolateElement(
+		sprintf(
+			/* translators: %1$s and %2$s expand to strong tags. */
+			__( "%1$sSAVE 30%%%2$s on your 12 month subscription", "wordpress-seo" ),
+			"<strong>",
+			"</strong>"
+		),
+		{
+			strong: <strong />,
+		}
+	);
 
 	return (
 		<div className="yst-p-6 yst-rounded-lg yst-text-white yst-bg-primary-500 yst-shadow">
@@ -47,6 +58,11 @@ export const PremiumUpsellCard = ( { link, linkProps, promotions } ) => {
 				{ getPremium }
 			</Title>
 			<p className="yst-mt-2">{ info }</p>
+			{ isBlackFriday && <div className="yst-text-center yst-border-t-[1px] yst-border-white yst-italic yst-mt-3">
+				<p className="yst-text-[10px] yst-my-3 yst-mx-0">
+					{ saveMoneyText }
+				</p>
+			</div> }
 			<Button
 				as="a"
 				variant="upsell"

--- a/packages/js/src/shared-admin/components/premium-upsell-card.js
+++ b/packages/js/src/shared-admin/components/premium-upsell-card.js
@@ -12,10 +12,10 @@ import { ReactComponent as G2Logo } from "./g2-logo-white.svg";
 /**
  * @param {string} link The link.
  * @param {Object} [linkProps] Extra link props.
- * @param {boolean} [isBlackFriday] Whether it is Black Friday.
+ * @param {array} [promotions] Promotions.
  * @returns {JSX.Element} The premium upsell card.
  */
-export const PremiumUpsellCard = ( { link, linkProps, isBlackFriday } ) => {
+export const PremiumUpsellCard = ( { link, linkProps, promotions } ) => {
 	const info = useMemo( () => __( "Use AI to generate titles and meta descriptions, automatically redirect deleted pages, get 24/7 support and much, much more!", "wordpress-seo" ), [] );
 	const getPremium = createInterpolateElement(
 		sprintf(
@@ -29,6 +29,7 @@ export const PremiumUpsellCard = ( { link, linkProps, isBlackFriday } ) => {
 			nowrap: <span className="yst-whitespace-nowrap" />,
 		}
 	);
+	const isBlackFriday = promotions.includes( "black-friday-2023-promotion" );
 
 	return (
 		<div className="yst-p-6 yst-rounded-lg yst-text-white yst-bg-primary-500 yst-shadow">
@@ -86,9 +87,10 @@ export const PremiumUpsellCard = ( { link, linkProps, isBlackFriday } ) => {
 PremiumUpsellCard.propTypes = {
 	link: PropTypes.string.isRequired,
 	linkProps: PropTypes.object,
-	isBlackFriday: PropTypes.bool,
+	promotions: PropTypes.array,
 };
 
 PremiumUpsellCard.defaultProps = {
 	linkProps: {},
+	promotions: [],
 };

--- a/packages/js/src/shared-admin/components/premium-upsell-card.js
+++ b/packages/js/src/shared-admin/components/premium-upsell-card.js
@@ -2,7 +2,6 @@ import { ArrowNarrowRightIcon } from "@heroicons/react/outline";
 import { createInterpolateElement, useMemo } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
 import { Button, Title } from "@yoast/ui-library";
-import { get } from "lodash";
 import PropTypes from "prop-types";
 import { ReactComponent as StarHalf } from "../../../images/star-rating-half.svg";
 import { ReactComponent as Star } from "../../../images/star-rating-star.svg";
@@ -13,11 +12,11 @@ import { ReactComponent as G2Logo } from "./g2-logo-white.svg";
 /**
  * @param {string} link The link.
  * @param {Object} [linkProps] Extra link props.
+ * @param {boolean} [isBlackFriday] Whether it is Black Friday.
  * @returns {JSX.Element} The premium upsell card.
  */
-export const PremiumUpsellCard = ( { link, linkProps } ) => {
+export const PremiumUpsellCard = ( { link, linkProps, isBlackFriday } ) => {
 	const info = useMemo( () => __( "Use AI to generate titles and meta descriptions, automatically redirect deleted pages, get 24/7 support and much, much more!", "wordpress-seo" ), [] );
-	const isBlackFriday = get( window, "wpseoScriptData.isBlackFriday", "" );
 	const getPremium = createInterpolateElement(
 		sprintf(
 			/* translators: %1$s and %2$s expand to a span wrap to avoid linebreaks. %3$s expands to "Yoast SEO Premium". */
@@ -87,6 +86,7 @@ export const PremiumUpsellCard = ( { link, linkProps } ) => {
 PremiumUpsellCard.propTypes = {
 	link: PropTypes.string.isRequired,
 	linkProps: PropTypes.object,
+	isBlackFriday: PropTypes.bool,
 };
 
 PremiumUpsellCard.defaultProps = {

--- a/packages/js/src/support/app.js
+++ b/packages/js/src/support/app.js
@@ -33,6 +33,7 @@ const openHelpScoutBeacon = () => {
  */
 export const App = () => {
 	const isPremium = useSelectSupport( "selectPreference", [], "isPremium", false );
+	const isBlackFriday = useSelectSupport( "selectPreference", [], "isBlackFriday", false );
 	const premiumUpsellConfig = useSelectSupport( "selectUpsellSettingsAsProps" );
 	const pluginUrl = useSelectSupport( "selectPreference", [], "pluginUrl", "" );
 	const linkParams = useSelectSupport( "selectLinkParams" );
@@ -231,7 +232,7 @@ export const App = () => {
 				</Paper>
 				{ ! isPremium && (
 					<RecommendationsSidebar>
-						<PremiumUpsellCard link={ premiumLink } linkProps={ premiumUpsellConfig } />
+						<PremiumUpsellCard link={ premiumLink } linkProps={ premiumUpsellConfig } isBlackFriday={ isBlackFriday } />
 						<AcademyUpsellCard link={ academyLink } />
 					</RecommendationsSidebar>
 				) }

--- a/packages/js/src/support/app.js
+++ b/packages/js/src/support/app.js
@@ -33,7 +33,7 @@ const openHelpScoutBeacon = () => {
  */
 export const App = () => {
 	const isPremium = useSelectSupport( "selectPreference", [], "isPremium", false );
-	const promotions = useSelectSupport( "selectPreference", [], "promotions", false );
+	const promotions = useSelectSupport( "selectPreference", [], "promotions", [] );
 	const premiumUpsellConfig = useSelectSupport( "selectUpsellSettingsAsProps" );
 	const pluginUrl = useSelectSupport( "selectPreference", [], "pluginUrl", "" );
 	const linkParams = useSelectSupport( "selectLinkParams" );

--- a/packages/js/src/support/app.js
+++ b/packages/js/src/support/app.js
@@ -33,7 +33,7 @@ const openHelpScoutBeacon = () => {
  */
 export const App = () => {
 	const isPremium = useSelectSupport( "selectPreference", [], "isPremium", false );
-	const isBlackFriday = useSelectSupport( "selectPreference", [], "isBlackFriday", false );
+	const promotions = useSelectSupport( "selectPreference", [], "promotions", false );
 	const premiumUpsellConfig = useSelectSupport( "selectUpsellSettingsAsProps" );
 	const pluginUrl = useSelectSupport( "selectPreference", [], "pluginUrl", "" );
 	const linkParams = useSelectSupport( "selectLinkParams" );
@@ -232,7 +232,7 @@ export const App = () => {
 				</Paper>
 				{ ! isPremium && (
 					<RecommendationsSidebar>
-						<PremiumUpsellCard link={ premiumLink } linkProps={ premiumUpsellConfig } isBlackFriday={ isBlackFriday } />
+						<PremiumUpsellCard link={ premiumLink } linkProps={ premiumUpsellConfig } promotions={ promotions } />
 						<AcademyUpsellCard link={ academyLink } />
 					</RecommendationsSidebar>
 				) }

--- a/src/integrations/settings-integration.php
+++ b/src/integrations/settings-integration.php
@@ -461,6 +461,7 @@ class Settings_Integration implements Integration_Interface {
 			'isWooCommerceActive'           => $this->woocommerce_helper->is_active(),
 			'isLocalSeoActive'              => \defined( 'WPSEO_LOCAL_FILE' ),
 			'isNewsSeoActive'               => \defined( 'WPSEO_NEWS_FILE' ),
+			'isBlackFriday'                 => YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-2023-promotion' ),
 			'siteUrl'                       => \get_bloginfo( 'url' ),
 			'siteTitle'                     => \get_bloginfo( 'name' ),
 			'sitemapUrl'                    => WPSEO_Sitemaps_Router::get_base_url( 'sitemap_index.xml' ),
@@ -487,7 +488,6 @@ class Settings_Integration implements Integration_Interface {
 			'upsellSettings'                => $this->get_upsell_settings(),
 			'siteRepresentsPerson'          => $this->get_site_represents_person( $settings ),
 			'siteBasicsPolicies'            => $this->get_site_basics_policies( $settings ),
-			'isBlackFriday'                 => YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-2023-promotion' ),
 		];
 	}
 

--- a/src/integrations/settings-integration.php
+++ b/src/integrations/settings-integration.php
@@ -25,6 +25,8 @@ use Yoast\WP\SEO\Helpers\User_Helper;
 use Yoast\WP\SEO\Helpers\Woocommerce_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Content_Type_Visibility\Application\Content_Type_Visibility_Dismiss_Notifications;
+use Yoast\WP\SEO\Promotions\Application\Promotion_Manager;
+
 
 /**
  * Class Settings_Integration.
@@ -428,6 +430,7 @@ class Settings_Integration implements Integration_Interface {
 			'taxonomies'                     => $transformed_taxonomies,
 			'fallbacks'                      => $this->get_fallbacks(),
 			'showNewContentTypeNotification' => $show_new_content_type_notification,
+			'isBlackFriday'                  => YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-2023-promotion' ),
 		];
 	}
 

--- a/src/integrations/settings-integration.php
+++ b/src/integrations/settings-integration.php
@@ -433,7 +433,6 @@ class Settings_Integration implements Integration_Interface {
 			'taxonomies'                     => $transformed_taxonomies,
 			'fallbacks'                      => $this->get_fallbacks(),
 			'showNewContentTypeNotification' => $show_new_content_type_notification,
-			'isBlackFriday'                  => YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-2023-promotion' ),
 		];
 	}
 
@@ -488,6 +487,7 @@ class Settings_Integration implements Integration_Interface {
 			'upsellSettings'                => $this->get_upsell_settings(),
 			'siteRepresentsPerson'          => $this->get_site_represents_person( $settings ),
 			'siteBasicsPolicies'            => $this->get_site_basics_policies( $settings ),
+			'isBlackFriday'                  => YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-2023-promotion' ),
 		];
 	}
 

--- a/src/integrations/settings-integration.php
+++ b/src/integrations/settings-integration.php
@@ -461,7 +461,7 @@ class Settings_Integration implements Integration_Interface {
 			'isWooCommerceActive'           => $this->woocommerce_helper->is_active(),
 			'isLocalSeoActive'              => \defined( 'WPSEO_LOCAL_FILE' ),
 			'isNewsSeoActive'               => \defined( 'WPSEO_NEWS_FILE' ),
-			'isBlackFriday'                 => YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-2023-promotion' ),
+			'promotions'                    => YoastSEO()->classes->get( Promotion_Manager::class )->get_current_promotions(),
 			'siteUrl'                       => \get_bloginfo( 'url' ),
 			'siteTitle'                     => \get_bloginfo( 'name' ),
 			'sitemapUrl'                    => WPSEO_Sitemaps_Router::get_base_url( 'sitemap_index.xml' ),

--- a/src/integrations/settings-integration.php
+++ b/src/integrations/settings-integration.php
@@ -366,6 +366,9 @@ class Settings_Integration implements Integration_Interface {
 		\wp_enqueue_media();
 		$this->asset_manager->enqueue_script( 'new-settings' );
 		$this->asset_manager->enqueue_style( 'new-settings' );
+		if ( YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-2023-promotion' ) ) {
+			$this->asset_manager->enqueue_style( 'black-friday-banner' );
+		}
 		$this->asset_manager->localize_script( 'new-settings', 'wpseoScriptData', $this->get_script_data() );
 	}
 

--- a/src/integrations/settings-integration.php
+++ b/src/integrations/settings-integration.php
@@ -487,7 +487,7 @@ class Settings_Integration implements Integration_Interface {
 			'upsellSettings'                => $this->get_upsell_settings(),
 			'siteRepresentsPerson'          => $this->get_site_represents_person( $settings ),
 			'siteBasicsPolicies'            => $this->get_site_basics_policies( $settings ),
-			'isBlackFriday'                  => YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-2023-promotion' ),
+			'isBlackFriday'                 => YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-2023-promotion' ),
 		];
 	}
 

--- a/src/integrations/support-integration.php
+++ b/src/integrations/support-integration.php
@@ -164,7 +164,7 @@ class Support_Integration implements Integration_Interface {
 					'actionId'     => 'load-nfd-ctb',
 					'premiumCtbId' => 'f6a84663-465f-4cb5-8ba5-f7a6d72224b2',
 				],
-				'isBlackFriday' => YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-2023-promotion' ),
+				'isBlackFriday'  => YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-2023-promotion' ),
 			],
 			'linkParams'    => $this->shortlink_helper->get_query_params(),
 		];

--- a/src/integrations/support-integration.php
+++ b/src/integrations/support-integration.php
@@ -159,7 +159,7 @@ class Support_Integration implements Integration_Interface {
 			'preferences'   => [
 				'isPremium'      => $this->product_helper->is_premium(),
 				'isRtl'          => \is_rtl(),
-				'isBlackFriday'  => YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-2023-promotion' ),
+				'promotions'     => YoastSEO()->classes->get( Promotion_Manager::class )->get_current_promotions(),
 				'pluginUrl'      => \plugins_url( '', \WPSEO_FILE ),
 				'upsellSettings' => [
 					'actionId'     => 'load-nfd-ctb',

--- a/src/integrations/support-integration.php
+++ b/src/integrations/support-integration.php
@@ -159,12 +159,12 @@ class Support_Integration implements Integration_Interface {
 			'preferences'   => [
 				'isPremium'      => $this->product_helper->is_premium(),
 				'isRtl'          => \is_rtl(),
+				'isBlackFriday'  => YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-2023-promotion' ),
 				'pluginUrl'      => \plugins_url( '', \WPSEO_FILE ),
 				'upsellSettings' => [
 					'actionId'     => 'load-nfd-ctb',
 					'premiumCtbId' => 'f6a84663-465f-4cb5-8ba5-f7a6d72224b2',
 				],
-				'isBlackFriday'  => YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-2023-promotion' ),
 			],
 			'linkParams'    => $this->shortlink_helper->get_query_params(),
 		];

--- a/src/integrations/support-integration.php
+++ b/src/integrations/support-integration.php
@@ -164,9 +164,9 @@ class Support_Integration implements Integration_Interface {
 					'actionId'     => 'load-nfd-ctb',
 					'premiumCtbId' => 'f6a84663-465f-4cb5-8ba5-f7a6d72224b2',
 				],
+				'isBlackFriday' => YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-2023-promotion' ),
 			],
 			'linkParams'    => $this->shortlink_helper->get_query_params(),
-			'isBlackFriday' => YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-2023-promotion' ),
 		];
 	}
 }

--- a/src/integrations/support-integration.php
+++ b/src/integrations/support-integration.php
@@ -8,6 +8,7 @@ use Yoast\WP\SEO\Conditionals\User_Can_Manage_Wpseo_Options_Conditional;
 use Yoast\WP\SEO\Helpers\Current_Page_Helper;
 use Yoast\WP\SEO\Helpers\Product_Helper;
 use Yoast\WP\SEO\Helpers\Short_Link_Helper;
+use Yoast\WP\SEO\Promotions\Application\Promotion_Manager;
 
 /**
  * Class Support_Integration.
@@ -130,6 +131,9 @@ class Support_Integration implements Integration_Interface {
 		\remove_action( 'admin_print_scripts', 'print_emoji_detection_script' );
 		$this->asset_manager->enqueue_script( 'support' );
 		$this->asset_manager->enqueue_style( 'support' );
+		if ( YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-2023-promotion' ) ) {
+			$this->asset_manager->enqueue_style( 'black-friday-banner' );
+		}
 		$this->asset_manager->localize_script( 'support', 'wpseoScriptData', $this->get_script_data() );
 	}
 
@@ -152,7 +156,7 @@ class Support_Integration implements Integration_Interface {
 	 */
 	public function get_script_data() {
 		return [
-			'preferences' => [
+			'preferences'   => [
 				'isPremium'      => $this->product_helper->is_premium(),
 				'isRtl'          => \is_rtl(),
 				'pluginUrl'      => \plugins_url( '', \WPSEO_FILE ),
@@ -161,7 +165,8 @@ class Support_Integration implements Integration_Interface {
 					'premiumCtbId' => 'f6a84663-465f-4cb5-8ba5-f7a6d72224b2',
 				],
 			],
-			'linkParams'  => $this->shortlink_helper->get_query_params(),
+			'linkParams'    => $this->shortlink_helper->get_query_params(),
+			'isBlackFriday' => YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-2023-promotion' ),
 		];
 	}
 }

--- a/src/presenters/admin/sidebar-presenter.php
+++ b/src/presenters/admin/sidebar-presenter.php
@@ -60,8 +60,7 @@ class Sidebar_Presenter extends Abstract_Presenter {
 						</h2>
 						<p>
 							<?php
-							/* translators: %1$s expands to an opening strong tag, %2$s expands to a closing strong tag */
-							\printf( \esc_html__( 'Be more efficient in creating titles and meta descriptions with the help of AI. %1$sGet 24/7 support%2$s and boost your website’s visibility.', 'wordpress-seo' ), '<strong>', '</strong>' );
+							echo \esc_html__( 'Use AI to generate titles and meta descriptions, automatically redirect deleted pages, get 24/7 support and much, much more!', 'wordpress-seo' );
 							?>
 						</p>
 						<?php if ( YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-2023-promotion' ) ) : ?>

--- a/src/presenters/admin/sidebar-presenter.php
+++ b/src/presenters/admin/sidebar-presenter.php
@@ -77,8 +77,13 @@ class Sidebar_Presenter extends Abstract_Presenter {
 						<p class="plugin-buy-button">
 							<a class="yoast-button-upsell" data-action="load-nfd-ctb" data-ctb-id="f6a84663-465f-4cb5-8ba5-f7a6d72224b2" target="_blank" href="<?php echo \esc_url( $buy_yoast_seo_shortlink ); ?>">
 								<?php
-								/* translators: %s expands to Yoast SEO Premium */
-								\printf( \esc_html__( 'Get %s', 'wordpress-seo' ), 'Yoast SEO Premium' );
+								if ( YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-2023-promotion' ) ) {
+									echo \esc_html__( 'Claim your 30% off now!', 'wordpress-seo' );
+								}
+								else {
+									/* translators: %s expands to Yoast SEO Premium */
+									\printf( \esc_html__( 'Get %s', 'wordpress-seo' ), 'Yoast SEO Premium' );
+								}
 								?>
 								<span aria-hidden="true" class="yoast-button-upsell__caret"></span>
 							</a>

--- a/tests/unit/integrations/support-integration-test.php
+++ b/tests/unit/integrations/support-integration-test.php
@@ -11,6 +11,7 @@ use Yoast\WP\SEO\Helpers\Current_Page_Helper;
 use Yoast\WP\SEO\Helpers\Product_Helper;
 use Yoast\WP\SEO\Helpers\Short_Link_Helper;
 use Yoast\WP\SEO\Integrations\Support_Integration;
+use Yoast\WP\SEO\Promotions\Application\Promotion_Manager;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
@@ -23,32 +24,39 @@ class Support_Integration_Test extends TestCase {
 	const PAGE = 'wpseo_page_support';
 
 	/**
-	 * Holds the WPSEO_Admin_Asset_Manager.
+	 * Holds the WPSEO_Admin_Asset_Manager mock.
 	 *
 	 * @var Mockery\MockInterface|WPSEO_Admin_Asset_Manager
 	 */
 	private $asset_manager;
 
 	/**
-	 * Holds the Current_Page_Helper.
+	 * Holds the Current_Page_Helper mock.
 	 *
-	 * @var Current_Page_Helper
+	 * @var Mockery\MockInterface|Current_Page_Helper
 	 */
 	private $current_page_helper;
 
 	/**
-	 * Holds the Product_Helper.
+	 * Holds the Product_Helper mock.
 	 *
-	 * @var Product_Helper
+	 * @var Mockery\MockInterface|Product_Helper
 	 */
 	private $product_helper;
 
 	/**
-	 * Holds the Short_Link_Helper.
+	 * Holds the Short_Link_Helper mock.
 	 *
-	 * @var Short_Link_Helper
+	 * @var Mockery\MockInterface|Short_Link_Helper
 	 */
 	private $shortlink_helper;
+
+	/**
+	 * Holds the Promotion_Manager mock.
+	 *
+	 * @var Mockery\MockInterface|Promotion_Manager
+	 */
+	private $promotion_manager;
 
 	/**
 	 * The class under test.
@@ -67,6 +75,7 @@ class Support_Integration_Test extends TestCase {
 		$this->current_page_helper = Mockery::mock( Current_Page_Helper::class );
 		$this->product_helper      = Mockery::mock( Product_Helper::class );
 		$this->shortlink_helper    = Mockery::mock( Short_Link_Helper::class );
+		$this->promotion_manager   = Mockery::mock( Promotion_Manager::class );
 
 		$this->instance = new Support_Integration(
 			$this->asset_manager,
@@ -217,15 +226,45 @@ class Support_Integration_Test extends TestCase {
 	}
 
 	/**
+	 * Data provider for test_enqueue_assets
+	 *
+	 * @return array
+	 */
+	public function data_provider_enqueu_black_friday_style() {
+		return [
+			'is black friday' => [
+				'is_black_friday' => true,
+				'expected'        => 1,
+			],
+			'is not black friday' => [
+				'is_black_friday' => false,
+				'expected'        => 0,
+			],
+		];
+	}
+
+	/**
 	 * Test enqueue_assets
 	 *
 	 * @covers ::enqueue_assets
 	 * @covers ::get_script_data
+	 *
+	 * @dataProvider data_provider_enqueu_black_friday_style
+	 *
+	 * @param bool $is_black_friday Whether it is black friday or not.
+	 * @param int  $expected The number of times the action should be called.
+	 * @return void
 	 */
-	public function test_enqueue_assets() {
+	public function test_enqueue_assets( $is_black_friday, $expected ) {
 		Monkey\Functions\expect( 'remove_action' )
 			->with( 'admin_print_scripts', 'print_emoji_detection_script' )
 			->once();
+
+		// In enqueue_assets.
+		$this->assert_black_friday_promotion( $is_black_friday );
+
+		// In get_script_data method.
+		$this->assert_black_friday_promotion( $is_black_friday );
 
 		$this->asset_manager
 			->expects( 'enqueue_script' )
@@ -236,6 +275,11 @@ class Support_Integration_Test extends TestCase {
 			->expects( 'enqueue_style' )
 			->with( 'support' )
 			->once();
+
+		$this->asset_manager
+			->expects( 'enqueue_style' )
+			->with( 'black-friday-banner' )
+			->times( $expected );
 
 		$this->asset_manager
 			->expects( 'localize_script' )
@@ -289,8 +333,10 @@ class Support_Integration_Test extends TestCase {
 	public function test_get_script_data() {
 		$link_params = $this->expect_get_script_data();
 
+		$this->assert_black_friday_promotion();
+
 		$expected = [
-			'preferences' => [
+			'preferences'   => [
 				'isPremium'      => false,
 				'isRtl'          => false,
 				'pluginUrl'      => 'http://basic.wordpress.test/wp-content/worspress-seo',
@@ -299,9 +345,28 @@ class Support_Integration_Test extends TestCase {
 					'premiumCtbId' => 'f6a84663-465f-4cb5-8ba5-f7a6d72224b2',
 				],
 			],
-			'linkParams'  => $link_params,
+			'linkParams'    => $link_params,
+			'isBlackFriday' => false,
 		];
 
 		$this->assertSame( $expected, $this->instance->get_script_data() );
+	}
+
+	/**
+	 * Asserts the check for the black friday promotion.
+	 *
+	 * @param bool $is_black_friday Whether it is black friday or not.
+	 * @return void
+	 */
+	protected function assert_black_friday_promotion( $is_black_friday = false ) {
+		$this->promotion_manager->expects( 'is' )
+			->with( 'black-friday-2023-promotion' )
+			->once()
+			->andReturn( $is_black_friday );
+
+		$container = $this->create_container_with( [ Promotion_Manager::class => $this->promotion_manager ] );
+
+		Monkey\Functions\expect( 'YoastSEO' )
+			->andReturn( (object) [ 'classes' => $this->create_classes_surface( $container ) ] );
 	}
 }

--- a/tests/unit/integrations/support-integration-test.php
+++ b/tests/unit/integrations/support-integration-test.php
@@ -344,9 +344,9 @@ class Support_Integration_Test extends TestCase {
 					'actionId'     => 'load-nfd-ctb',
 					'premiumCtbId' => 'f6a84663-465f-4cb5-8ba5-f7a6d72224b2',
 				],
+				'isBlackFriday'  => false,
 			],
 			'linkParams'    => $link_params,
-			'isBlackFriday' => false,
 		];
 
 		$this->assertSame( $expected, $this->instance->get_script_data() );

--- a/tests/unit/integrations/support-integration-test.php
+++ b/tests/unit/integrations/support-integration-test.php
@@ -339,12 +339,12 @@ class Support_Integration_Test extends TestCase {
 			'preferences'   => [
 				'isPremium'      => false,
 				'isRtl'          => false,
+				'isBlackFriday'  => false,
 				'pluginUrl'      => 'http://basic.wordpress.test/wp-content/worspress-seo',
 				'upsellSettings' => [
 					'actionId'     => 'load-nfd-ctb',
 					'premiumCtbId' => 'f6a84663-465f-4cb5-8ba5-f7a6d72224b2',
 				],
-				'isBlackFriday'  => false,
 			],
 			'linkParams'    => $link_params,
 		];


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Updating Black Friday promotion copy and appearence.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds Black Friday banner in settings page sidebar upsell card.
* Updates copy for sidebar upsell card.
* Updates label for Black Friday upsell sidebar card CTA button.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:


* Make sure you have Yoast premium disabled or not installed.
* Go to `Yoast SEO`->`General`
* Check the sidebar and the upsell block in the bottom of the page, both have the label `Get Yoast SEO Premium`
* Check the text to the upsell sidebar card is: "Use AI to generate titles and meta descriptions, automatically redirect deleted pages, get 24/7 support and much, much more!"
* Check the text is the same in `Yoast SEO`->`Settings` and `Yoast SEO`->`Support`.
* In `src/promotions/domain/black-friday-promotion.php` replace line 18 with:
```php
new Time_Interval( \gmmktime( 11, 00, 00, 11, 23, 2022 ), \gmmktime( 11, 00, 00, 11, 28, 2023 ) )
```
* Go to `Yoast SEO`->`General`
* Check you see the following Black Friday promotion: ![image](https://github.com/Yoast/wordpress-seo/assets/35524806/4908acf8-08e0-4a3b-9fff-0c968f03bd1e)
* Check the sidebar and the upsell block in the bottom of the page, both have the label `Claim your 30% off now!`.
* Check the text to the upsell sidebar card is the same.
* Go to `Yoast SEO`->`Settings`.
* Check you see the same sidebar text and button label.
* Go to `Yoast SEO`->`Support`
* Check you see the same sidebar text and button label.

<img src="https://github.com/Yoast/wordpress-seo/assets/65466507/d4496083-1811-46f0-8fa4-c5efc0fd8906">

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [X] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [X] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.
* [X] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [Black Friday banner is not visible on support page in plugin](https://github.com/Yoast/ux/issues/76)
Fixes [Improve copy sticky sidebar in the plugin](https://github.com/Yoast/ux/issues/75)
Fixes [Change the copy on the ‘sticky sidebar’ and ‘sticky footer bar’ to Claim your 30% off now!](https://github.com/Yoast/ux/issues/73)
