### PR TITLE
Add mysql 8 custom query to make sure it is BC.

### DIFF
--- a/tests/integration/sitemaps/test-class-wpseo-post-type-sitemap-provider.php
+++ b/tests/integration/sitemaps/test-class-wpseo-post-type-sitemap-provider.php
@@ -9,6 +9,7 @@
  * Class WPSEO_Post_Type_Sitemap_Provider_Test.
  *
  * @group sitemaps
+ * @coversDefaultClass \Yoast\WP\SEO\Models\SEO_Links\WPSEO_Post_Type_Sitemap_Provider
  */
 class WPSEO_Post_Type_Sitemap_Provider_Test extends WPSEO_UnitTestCase {
 
@@ -38,7 +39,7 @@ class WPSEO_Post_Type_Sitemap_Provider_Test extends WPSEO_UnitTestCase {
 	/**
 	 * No entries in the post or page types should still generate an index entry.
 	 *
-	 * @covers WPSEO_Post_Type_Sitemap_Provider::get_index_links
+	 * @covers ::get_index_links
 	 */
 	public function test_get_index_links_no_entries() {
 		$index_links = self::$class_instance->get_index_links( 1 );
@@ -48,7 +49,7 @@ class WPSEO_Post_Type_Sitemap_Provider_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Multiple pages of a post-type should result in multiple index entries.
 	 *
-	 * @covers WPSEO_Post_Type_Sitemap_Provider::get_index_links
+	 * @covers ::get_index_links
 	 */
 	public function test_get_index_links_one_entry_paged() {
 
@@ -68,7 +69,7 @@ class WPSEO_Post_Type_Sitemap_Provider_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Multiple entries should be on the same sitemap if not over page limit.
 	 *
-	 * @covers WPSEO_Post_Type_Sitemap_Provider::get_index_links
+	 * @covers ::get_index_links
 	 */
 	public function test_get_index_links_multiple_entries_non_paged() {
 		$this->factory->post->create();
@@ -82,7 +83,7 @@ class WPSEO_Post_Type_Sitemap_Provider_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Makes sure the filtered out entries do not cause a sitemap index link to return a 404.
 	 *
-	 * @covers WPSEO_Post_Type_Sitemap_Provider::get_index_links
+	 * @covers ::get_index_links
 	 */
 	public function test_get_index_links_empty_bucket() {
 
@@ -115,7 +116,7 @@ class WPSEO_Post_Type_Sitemap_Provider_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Makes sure invalid sitemap pages return no contents (404).
 	 *
-	 * @covers WPSEO_Post_Type_Sitemap_Provider::get_index_links
+	 * @covers ::get_index_links
 	 */
 	public function test_get_index_links_empty_sitemap() {
 		// Fetch the global sitemap.
@@ -135,7 +136,7 @@ class WPSEO_Post_Type_Sitemap_Provider_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the sitemap links for the different homepage possibilities.
 	 *
-	 * @covers WPSEO_Post_Type_Sitemap_Provider::get_sitemap_links
+	 * @covers ::get_sitemap_links
 	 */
 	public function test_get_sitemap_links() {
 		$sitemap_provider = new WPSEO_Post_Type_Sitemap_Provider_Double();
@@ -190,7 +191,7 @@ class WPSEO_Post_Type_Sitemap_Provider_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the excluded posts with the usage of the filter.
 	 *
-	 * @covers WPSEO_Post_Type_Sitemap_Provider::get_excluded_posts
+	 * @covers ::get_excluded_posts
 	 */
 	public function test_get_excluded_posts_with_set_filter() {
 		$sitemap_provider = new WPSEO_Post_Type_Sitemap_Provider_Double();
@@ -213,7 +214,7 @@ class WPSEO_Post_Type_Sitemap_Provider_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the excluded posts with the usage of a filter that returns an invalid value.
 	 *
-	 * @covers WPSEO_Post_Type_Sitemap_Provider::get_excluded_posts
+	 * @covers ::get_excluded_posts
 	 */
 	public function test_get_excluded_posts_with_set_filter_that_has_invalid_return_value() {
 		$sitemap_provider = new WPSEO_Post_Type_Sitemap_Provider_Double();
@@ -257,7 +258,7 @@ class WPSEO_Post_Type_Sitemap_Provider_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests if external URLs are not being included in the sitemap.
 	 *
-	 * @covers WPSEO_Post_Type_Sitemap_Provider::get_url
+	 * @covers ::get_url
 	 */
 	public function test_get_url() {
 		$current_home     = get_option( 'home' );
@@ -282,7 +283,7 @@ class WPSEO_Post_Type_Sitemap_Provider_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests a regular post is added to the sitemap.
 	 *
-	 * @covers WPSEO_Post_Type_Sitemap_Provider::get_sitemap_links
+	 * @covers ::get_sitemap_links
 	 */
 	public function test_regular_post() {
 		$this->factory->post->create();
@@ -294,7 +295,7 @@ class WPSEO_Post_Type_Sitemap_Provider_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests to make sure password protected posts are not in the sitemap.
 	 *
-	 * @covers WPSEO_Post_Type_Sitemap_Provider::get_sitemap_links
+	 * @covers ::get_sitemap_links
 	 */
 	public function test_password_protected_post() {
 		// Create password protected post.
@@ -315,7 +316,7 @@ class WPSEO_Post_Type_Sitemap_Provider_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests to make sure a regular attachment is include in the sitemap.
 	 *
-	 * @covers WPSEO_Post_Type_Sitemap_Provider::get_sitemap_links
+	 * @covers ::get_sitemap_links
 	 */
 	public function test_regular_attachment() {
 		// Enable attachments in the sitemap.
@@ -343,7 +344,7 @@ class WPSEO_Post_Type_Sitemap_Provider_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests to make sure attachment is not added when parent is a protected post.
 	 *
-	 * @covers WPSEO_Post_Type_Sitemap_Provider::get_sitemap_links
+	 * @covers ::get_sitemap_links
 	 *
 	 * @link https://github.com/Yoast/wordpress-seo/issues/9194
 	 */


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to make sure that our sitemaps work on mysql 8+ without warnings.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where PHP notice would happen when the sitemap index is generated on MySQL 8+.

## Relevant technical choices:

* The problem here is that in MySQL 8 the use of user defined variables has changed. You now need to use a `select @something into @somethingelse` construction to fill variables. But you cannot do this in a subquery (which we need in this case to get only the Nth row).
* So the solution here was to use the new ROW_NUMBER function introduced in MySQL 8 to get the same result. But to get every Nth row you need to use a modulo of the current row to determine if you are at the Nth row. So, now the query is split in 2 parts. The first to filter the result set to a temporary result set with the row numbers there (where we filter the actual results) and then a new select on that temporary result set where we get the Nth row, with the MOD function.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* To make sure everything still works as expected after this change create 2 new environments with 2000+ posts in each. One of the environments needs to be MySQL version 5.7 and one needs to be 8+ (this is possible in Local).
* Make sure you do not have Query monitor active. This will stop notices from showing in the XML sitemap page. And enable WP_DEBUG. `define( 'WP_DEBUG', true );` in your wp-config.php for both new sites.
* Install the latest released version/ trunk. And go to /sitemap.xml Take a screenshot of how the index page looks.
* Check out this PR/RC and refresh the page. Make sure everything is still the same.
* Also make sure there are no warnings in your log.

Tesing in Database:
* Make sure you have an environment with SQL 5.7
* Go to database and run the following SQL command:
```sql
SELECT post_modified_gmt
FROM (SELECT @rownum := 0) init
         JOIN wp_posts USE INDEX ( type_status_date )
WHERE post_status IN ('publish')
  AND post_type = 'post'
  AND (@rownum := @rownum + 1) % 1000 = 0
ORDER BY post_modified_gmt ASC;
```
* Check you get no errors.
* Change your environment to SQL 8+
* Go to database and run the following SQL command:
```sql
WITH ordering AS (SELECT ROW_NUMBER() OVER (ORDER BY post_modified_gmt) AS n, post_modified_gmt
                  FROM wp_posts USE INDEX ( type_status_date )
                  WHERE post_status IN ('publish')
                    AND post_type = 'post'
                  ORDER BY post_modified_gmt)
SELECT post_modified_gmt
FROM ordering
WHERE MOD(n, 1000) = 0;
```
* Check you get no errors.

* Also smoke test the result pages of the post sitemap (nothing was touched in this PR but just to make sure).

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.
* [X] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
16803