### PR TITLE
Mark translations that are only for screen readers

### DIFF
--- a/admin/class-admin-utils.php
+++ b/admin/class-admin-utils.php
@@ -75,6 +75,7 @@ class WPSEO_Admin_Utils {
 	public static function get_new_tab_message() {
 		return sprintf(
 			'<span class="screen-reader-text">%s</span>',
+			/* translators: Hidden accessibility text. */
 			esc_html__( '(Opens in a new browser tab)', 'wordpress-seo' )
 		);
 	}

--- a/admin/class-bulk-editor-list-table.php
+++ b/admin/class-bulk-editor-list-table.php
@@ -408,6 +408,7 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 				printf(
 					'<label for="%1$s" class="screen-reader-text">%2$s</label>',
 					esc_attr( 'post-type-filter-' . $instance_type ),
+					/* translators: Hidden accessibility text. */
 					esc_html__( 'Filter by content type', 'wordpress-seo' )
 				);
 				printf(

--- a/admin/class-bulk-editor-list-table.php
+++ b/admin/class-bulk-editor-list-table.php
@@ -810,7 +810,7 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 			$actions['edit'] = sprintf(
 				'<a href="%s" aria-label="%s">%s</a>',
 				esc_url( get_edit_post_link( $rec->ID, true ) ),
-				/* translators: %s: post title */
+				/* translators: Hidden accessibility text; %s: post title. */
 				esc_attr( sprintf( __( 'Edit &#8220;%s&#8221;', 'wordpress-seo' ), $title ) ),
 				__( 'Edit', 'wordpress-seo' )
 			);
@@ -822,7 +822,7 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 					$actions['view'] = sprintf(
 						'<a href="%s" aria-label="%s">%s</a>',
 						esc_url( add_query_arg( 'preview', 'true', get_permalink( $rec->ID ) ) ),
-						/* translators: %s: post title */
+						/* translators: Hidden accessibility text; %s: post title. */
 						esc_attr( sprintf( __( 'Preview &#8220;%s&#8221;', 'wordpress-seo' ), $title ) ),
 						__( 'Preview', 'wordpress-seo' )
 					);
@@ -832,7 +832,7 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 				$actions['view'] = sprintf(
 					'<a href="%s" aria-label="%s" rel="bookmark">%s</a>',
 					esc_url( get_permalink( $rec->ID ) ),
-					/* translators: %s: post title */
+					/* translators: Hidden accessibility text; %s: post title. */
 					esc_attr( sprintf( __( 'View &#8220;%s&#8221;', 'wordpress-seo' ), $title ) ),
 					__( 'View', 'wordpress-seo' )
 				);

--- a/admin/class-meta-columns.php
+++ b/admin/class-meta-columns.php
@@ -97,11 +97,21 @@ class WPSEO_Meta_Columns {
 		$added_columns = [];
 
 		if ( $this->analysis_seo->is_enabled() ) {
-			$added_columns['wpseo-score'] = '<span class="yoast-column-seo-score yoast-column-header-has-tooltip" data-tooltip-text="' . esc_attr__( 'SEO score', 'wordpress-seo' ) . '"><span class="screen-reader-text">' . __( 'SEO score', 'wordpress-seo' ) . '</span></span></span>';
+			$added_columns['wpseo-score'] = '<span class="yoast-column-seo-score yoast-column-header-has-tooltip" data-tooltip-text="' .
+											esc_attr__( 'SEO score', 'wordpress-seo' ) .
+											'"><span class="screen-reader-text">' .
+											/* translators: Hidden accessibility text. */
+											__( 'SEO score', 'wordpress-seo' ) .
+											'</span></span></span>';
 		}
 
 		if ( $this->analysis_readability->is_enabled() ) {
-			$added_columns['wpseo-score-readability'] = '<span class="yoast-column-readability yoast-column-header-has-tooltip" data-tooltip-text="' . esc_attr__( 'Readability score', 'wordpress-seo' ) . '"><span class="screen-reader-text">' . __( 'Readability score', 'wordpress-seo' ) . '</span></span></span>';
+			$added_columns['wpseo-score-readability'] = '<span class="yoast-column-readability yoast-column-header-has-tooltip" data-tooltip-text="' .
+														esc_attr__( 'Readability score', 'wordpress-seo' ) .
+														'"><span class="screen-reader-text">' .
+														/* translators: Hidden accessibility text. */
+														__( 'Readability score', 'wordpress-seo' ) .
+														'</span></span></span>';
 		}
 
 		$added_columns['wpseo-title']    = __( 'SEO Title', 'wordpress-seo' );
@@ -154,6 +164,7 @@ class WPSEO_Meta_Columns {
 				}
 				if ( $metadesc_val === '' ) {
 					echo '<span aria-hidden="true">&#8212;</span><span class="screen-reader-text">',
+					/* translators: Hidden accessibility text. */
 					esc_html__( 'Meta description not set.', 'wordpress-seo' ),
 					'</span>';
 
@@ -169,6 +180,7 @@ class WPSEO_Meta_Columns {
 
 				if ( $focuskw_val === '' ) {
 					echo '<span aria-hidden="true">&#8212;</span><span class="screen-reader-text">',
+					/* translators: Hidden accessibility text. */
 					esc_html__( 'Focus keyphrase not set.', 'wordpress-seo' ),
 					'</span>';
 
@@ -238,6 +250,7 @@ class WPSEO_Meta_Columns {
 
 		$ranks = WPSEO_Rank::get_all_ranks();
 
+		/* translators: Hidden accessibility text. */
 		echo '<label class="screen-reader-text" for="wpseo-filter">' . esc_html__( 'Filter by SEO Score', 'wordpress-seo' ) . '</label>';
 		echo '<select name="seo_filter" id="wpseo-filter">';
 
@@ -266,6 +279,7 @@ class WPSEO_Meta_Columns {
 
 		$ranks = WPSEO_Rank::get_all_readability_ranks();
 
+		/* translators: Hidden accessibility text. */
 		echo '<label class="screen-reader-text" for="wpseo-readability-filter">' . esc_html__( 'Filter by Readability Score', 'wordpress-seo' ) . '</label>';
 		echo '<select name="readability_filter" id="wpseo-readability-filter">';
 

--- a/admin/class-meta-columns.php
+++ b/admin/class-meta-columns.php
@@ -100,7 +100,6 @@ class WPSEO_Meta_Columns {
 			$added_columns['wpseo-score'] = '<span class="yoast-column-seo-score yoast-column-header-has-tooltip" data-tooltip-text="' .
 											esc_attr__( 'SEO score', 'wordpress-seo' ) .
 											'"><span class="screen-reader-text">' .
-											/* translators: Hidden accessibility text. */
 											__( 'SEO score', 'wordpress-seo' ) .
 											'</span></span></span>';
 		}
@@ -109,7 +108,6 @@ class WPSEO_Meta_Columns {
 			$added_columns['wpseo-score-readability'] = '<span class="yoast-column-readability yoast-column-header-has-tooltip" data-tooltip-text="' .
 														esc_attr__( 'Readability score', 'wordpress-seo' ) .
 														'"><span class="screen-reader-text">' .
-														/* translators: Hidden accessibility text. */
 														__( 'Readability score', 'wordpress-seo' ) .
 														'</span></span></span>';
 		}

--- a/admin/class-premium-popup.php
+++ b/admin/class-premium-popup.php
@@ -78,7 +78,8 @@ class WPSEO_Premium_Popup {
 		$assets_uri = trailingslashit( plugin_dir_url( WPSEO_FILE ) );
 
 		/* translators: %s expands to Yoast SEO Premium */
-		$cta_text        = esc_html( sprintf( __( 'Get %s', 'wordpress-seo' ), 'Yoast SEO Premium' ) );
+		$cta_text = esc_html( sprintf( __( 'Get %s', 'wordpress-seo' ), 'Yoast SEO Premium' ) );
+		/* translators: Hidden accessibility text. */
 		$new_tab_message = '<span class="screen-reader-text">' . esc_html__( '(Opens in a new browser tab)', 'wordpress-seo' ) . '</span>';
 		$caret_icon      = '<span aria-hidden="true" class="yoast-button-upsell__caret"></span>';
 		$classes         = '';

--- a/admin/class-premium-upsell-admin-block.php
+++ b/admin/class-premium-upsell-admin-block.php
@@ -66,7 +66,8 @@ class WPSEO_Premium_Upsell_Admin_Block {
 		$class = $this->get_html_class();
 
 		/* translators: %s expands to Yoast SEO Premium */
-		$button_text  = sprintf( esc_html__( 'Get %s', 'wordpress-seo' ), 'Yoast SEO Premium' );
+		$button_text = sprintf( esc_html__( 'Get %s', 'wordpress-seo' ), 'Yoast SEO Premium' );
+		/* translators: Hidden accessibility text. */
 		$button_text .= '<span class="screen-reader-text">' . esc_html__( '(Opens in a new browser tab)', 'wordpress-seo' ) . '</span>' .
 			'<span aria-hidden="true" class="yoast-button-upsell__caret"></span>';
 

--- a/admin/class-suggested-plugins.php
+++ b/admin/class-suggested-plugins.php
@@ -132,7 +132,7 @@ class WPSEO_Suggested_Plugins implements WPSEO_WordPress_Integration {
 		return sprintf(
 			'<a href="%s" aria-label="%s" target="_blank" rel="noopener noreferrer">',
 			$url,
-			/* translators: %1$s expands to the dependency name. */
+			/* translators: Hidden accessibility text; %1$s expands to the dependency name */
 			sprintf( __( 'More information about %1$s', 'wordpress-seo' ), $name )
 		);
 	}

--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -917,6 +917,7 @@ class Yoast_Form {
 							'<span aria-hidden="true" class="yoast-button--buy__caret"></span></a>';
 		}
 
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- All variable output is escaped above.
 		echo '<a></a></div></fieldset><div class="clear"></div>' . $upsell_button . '</div>' . PHP_EOL . PHP_EOL;
 	}
 

--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -909,8 +909,12 @@ class Yoast_Form {
 
 		$upsell_button = '';
 		if ( $has_premium_upsell ) {
-			$upsell_button = '<a class="yoast-button yoast-button--buy yoast-button--small" data-action="load-nfd-ctb" data-ctb-id="f6a84663-465f-4cb5-8ba5-f7a6d72224b2" href=' . esc_url( $attr['premium_upsell_url'] ) . ' target="_blank">' . esc_html__( 'Unlock with Premium!', 'wordpress-seo' ) . '<span class="screen-reader-text">' . esc_html__( '(Opens in a new browser tab)', 'wordpress-seo' ) . '</span>' .
-			'<span aria-hidden="true" class="yoast-button--buy__caret"></span></a>';
+			$upsell_button = '<a class="yoast-button yoast-button--buy yoast-button--small" data-action="load-nfd-ctb" data-ctb-id="f6a84663-465f-4cb5-8ba5-f7a6d72224b2" href=' .
+							esc_url( $attr['premium_upsell_url'] ) . ' target="_blank">' .
+							esc_html__( 'Unlock with Premium!', 'wordpress-seo' ) .
+							/* translators: Hidden accessibility text. */
+							'<span class="screen-reader-text">' . esc_html__( '(Opens in a new browser tab)', 'wordpress-seo' ) . '</span>' .
+							'<span aria-hidden="true" class="yoast-button--buy__caret"></span></a>';
 		}
 
 		echo '<a></a></div></fieldset><div class="clear"></div>' . $upsell_button . '</div>' . PHP_EOL . PHP_EOL;

--- a/admin/formatter/class-metabox-formatter.php
+++ b/admin/formatter/class-metabox-formatter.php
@@ -240,6 +240,7 @@ class WPSEO_Metabox_Formatter {
 			'content-analysis.highlight'                     => __( 'Highlight this result in the text', 'wordpress-seo' ),
 			'content-analysis.nohighlight'                   => __( 'Remove highlight from the text', 'wordpress-seo' ),
 			'content-analysis.disabledButton'                => __( 'Marks are disabled in current view', 'wordpress-seo' ),
+			/* translators: Hidden accessibility text. */
 			'a11yNotice.opensInNewTab'                       => __( '(Opens in a new browser tab)', 'wordpress-seo' ),
 		];
 	}

--- a/admin/menu/class-admin-menu.php
+++ b/admin/menu/class-admin-menu.php
@@ -114,7 +114,7 @@ class WPSEO_Admin_Menu extends WPSEO_Base_Menu {
 		$notification_count  = $notification_center->get_notification_count();
 
 		// Add main page.
-		/* translators: %s: number of notifications; Hidden accessibility text. */
+		/* translators: Hidden accessibility text; %s: number of notifications. */
 		$notifications = sprintf( _n( '%s notification', '%s notifications', $notification_count, 'wordpress-seo' ), number_format_i18n( $notification_count ) );
 
 		return sprintf( '<span class="update-plugins count-%1$d"><span class="plugin-count" aria-hidden="true">%1$d</span><span class="screen-reader-text">%2$s</span></span>', $notification_count, $notifications );

--- a/admin/menu/class-admin-menu.php
+++ b/admin/menu/class-admin-menu.php
@@ -114,12 +114,10 @@ class WPSEO_Admin_Menu extends WPSEO_Base_Menu {
 		$notification_count  = $notification_center->get_notification_count();
 
 		// Add main page.
-		/* translators: %s: number of notifications */
+		/* translators: %s: number of notifications; Hidden accessibility text. */
 		$notifications = sprintf( _n( '%s notification', '%s notifications', $notification_count, 'wordpress-seo' ), number_format_i18n( $notification_count ) );
 
-		$counter = sprintf( '<span class="update-plugins count-%1$d"><span class="plugin-count" aria-hidden="true">%1$d</span><span class="screen-reader-text">%2$s</span></span>', $notification_count, $notifications );
-
-		return $counter;
+		return sprintf( '<span class="update-plugins count-%1$d"><span class="plugin-count" aria-hidden="true">%1$d</span><span class="screen-reader-text">%2$s</span></span>', $notification_count, $notifications );
 	}
 
 	/**

--- a/admin/taxonomy/class-taxonomy-columns.php
+++ b/admin/taxonomy/class-taxonomy-columns.php
@@ -85,13 +85,11 @@ class WPSEO_Taxonomy_Columns {
 
 			if ( $column_name === 'description' && $this->analysis_seo->is_enabled() ) {
 				$new_columns['wpseo-score'] = '<span class="yoast-tooltip yoast-tooltip-n yoast-tooltip-alt" data-label="' . esc_attr__( 'SEO score', 'wordpress-seo' ) . '"><span class="yoast-column-seo-score yoast-column-header-has-tooltip"><span class="screen-reader-text">' .
-											/* translators: Hidden accessibility text. */
 											__( 'SEO score', 'wordpress-seo' ) . '</span></span></span>';
 			}
 
 			if ( $column_name === 'description' && $this->analysis_readability->is_enabled() ) {
 				$new_columns['wpseo-score-readability'] = '<span class="yoast-tooltip yoast-tooltip-n yoast-tooltip-alt" data-label="' . esc_attr__( 'Readability score', 'wordpress-seo' ) . '"><span class="yoast-column-readability yoast-column-header-has-tooltip"><span class="screen-reader-text">' .
-														/* translators: Hidden accessibility text. */
 														__( 'Readability score', 'wordpress-seo' ) . '</span></span></span>';
 			}
 		}

--- a/admin/taxonomy/class-taxonomy-columns.php
+++ b/admin/taxonomy/class-taxonomy-columns.php
@@ -84,11 +84,15 @@ class WPSEO_Taxonomy_Columns {
 			$new_columns[ $column_name ] = $column_value;
 
 			if ( $column_name === 'description' && $this->analysis_seo->is_enabled() ) {
-				$new_columns['wpseo-score'] = '<span class="yoast-tooltip yoast-tooltip-n yoast-tooltip-alt" data-label="' . esc_attr__( 'SEO score', 'wordpress-seo' ) . '"><span class="yoast-column-seo-score yoast-column-header-has-tooltip"><span class="screen-reader-text">' . __( 'SEO score', 'wordpress-seo' ) . '</span></span></span>';
+				$new_columns['wpseo-score'] = '<span class="yoast-tooltip yoast-tooltip-n yoast-tooltip-alt" data-label="' . esc_attr__( 'SEO score', 'wordpress-seo' ) . '"><span class="yoast-column-seo-score yoast-column-header-has-tooltip"><span class="screen-reader-text">' .
+											/* translators: Hidden accessibility text. */
+											__( 'SEO score', 'wordpress-seo' ) . '</span></span></span>';
 			}
 
 			if ( $column_name === 'description' && $this->analysis_readability->is_enabled() ) {
-				$new_columns['wpseo-score-readability'] = '<span class="yoast-tooltip yoast-tooltip-n yoast-tooltip-alt" data-label="' . esc_attr__( 'Readability score', 'wordpress-seo' ) . '"><span class="yoast-column-readability yoast-column-header-has-tooltip"><span class="screen-reader-text">' . __( 'Readability score', 'wordpress-seo' ) . '</span></span></span>';
+				$new_columns['wpseo-score-readability'] = '<span class="yoast-tooltip yoast-tooltip-n yoast-tooltip-alt" data-label="' . esc_attr__( 'Readability score', 'wordpress-seo' ) . '"><span class="yoast-column-readability yoast-column-header-has-tooltip"><span class="screen-reader-text">' .
+														/* translators: Hidden accessibility text. */
+														__( 'Readability score', 'wordpress-seo' ) . '</span></span></span>';
 			}
 		}
 

--- a/admin/views/js-templates-primary-term.php
+++ b/admin/views/js-templates-primary-term.php
@@ -14,7 +14,7 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 
 <script type="text/html" id="tmpl-primary-term-ui">
 	<?php
-	/* translators: accessibility text. %1$s expands to the term title, %2$s to the taxonomy title. */
+	/* translators: Hidden accessibility text; %1$s expands to the term title, %2$s to the taxonomy title. */
 	$yoast_free_js_button_label = __( 'Make %1$s primary %2$s', 'wordpress-seo' );
 	$yoast_free_js_button_label = sprintf(
 		$yoast_free_js_button_label,

--- a/admin/views/licenses.php
+++ b/admin/views/licenses.php
@@ -122,6 +122,7 @@ $has_valid_premium_subscription = YoastSEO()->helpers->product->is_premium() && 
 $wpseo_extensions_header = sprintf( __( '%1$s Extensions', 'wordpress-seo' ), 'Yoast SEO' );
 $new_tab_message         = sprintf(
 	'<span class="screen-reader-text">%1$s</span>',
+	/* translators: Hidden accessibility text. */
 	esc_html__( '(Opens in a new browser tab)', 'wordpress-seo' )
 );
 

--- a/admin/views/partial-notifications-template.php
+++ b/admin/views/partial-notifications-template.php
@@ -35,6 +35,7 @@ if ( ! function_exists( '_yoast_display_notifications' ) ) {
 				case 'active':
 					$button = sprintf(
 						'<button type="button" class="button dismiss"><span class="screen-reader-text">%1$s</span><span class="dashicons dashicons-hidden"></span></button>',
+						/* translators: Hidden accessibility text. */
 						esc_html__( 'Hide this item.', 'wordpress-seo' )
 					);
 					break;
@@ -42,6 +43,7 @@ if ( ! function_exists( '_yoast_display_notifications' ) ) {
 				case 'dismissed':
 					$button = sprintf(
 						'<button type="button" class="button restore"><span class="screen-reader-text">%1$s</span><span class="dashicons yoast-svg-icon-eye"></span></button>',
+						/* translators: Hidden accessibility text. */
 						esc_html__( 'Show this item.', 'wordpress-seo' )
 					);
 					break;

--- a/admin/views/tabs/network/features.php
+++ b/admin/views/tabs/network/features.php
@@ -58,7 +58,7 @@ $feature_toggles = Yoast_Feature_Toggles::instance()->get_all();
 
 		$feature_help = new WPSEO_Admin_Help_Panel(
 			WPSEO_Option::ALLOW_KEY_PREFIX . $feature->setting,
-			/* translators: %s expands to a feature's name; Hidden accessibility text. */
+			/* translators: Hidden accessibility text; %s expands to a feature's name. */
 			sprintf( esc_html__( 'Help on: %s', 'wordpress-seo' ), esc_html( $feature->name ) ),
 			$help_text
 		);

--- a/admin/views/tabs/network/features.php
+++ b/admin/views/tabs/network/features.php
@@ -58,7 +58,7 @@ $feature_toggles = Yoast_Feature_Toggles::instance()->get_all();
 
 		$feature_help = new WPSEO_Admin_Help_Panel(
 			WPSEO_Option::ALLOW_KEY_PREFIX . $feature->setting,
-			/* translators: %s expands to a feature's name */
+			/* translators: %s expands to a feature's name; Hidden accessibility text. */
 			sprintf( esc_html__( 'Help on: %s', 'wordpress-seo' ), esc_html( $feature->name ) ),
 			$help_text
 		);

--- a/admin/views/tabs/network/integrations.php
+++ b/admin/views/tabs/network/integrations.php
@@ -46,7 +46,7 @@ $integration_toggles = Yoast_Integration_Toggles::instance()->get_all();
 
 			$feature_help = new WPSEO_Admin_Help_Panel(
 				WPSEO_Option::ALLOW_KEY_PREFIX . $integration->setting,
-				/* translators: %s expands to an integration's name; Hidden accessibility text. */
+				/* translators: Hidden accessibility text; %s expands to an integration's name. */
 				sprintf( esc_html__( 'Help on: %s', 'wordpress-seo' ), esc_html( $integration->name ) ),
 				$help_text
 			);

--- a/admin/views/tabs/network/integrations.php
+++ b/admin/views/tabs/network/integrations.php
@@ -46,7 +46,7 @@ $integration_toggles = Yoast_Integration_Toggles::instance()->get_all();
 
 			$feature_help = new WPSEO_Admin_Help_Panel(
 				WPSEO_Option::ALLOW_KEY_PREFIX . $integration->setting,
-				/* translators: %s expands to an integration's name */
+				/* translators: %s expands to an integration's name; Hidden accessibility text. */
 				sprintf( esc_html__( 'Help on: %s', 'wordpress-seo' ), esc_html( $integration->name ) ),
 				$help_text
 			);

--- a/admin/watchers/class-slug-change-watcher.php
+++ b/admin/watchers/class-slug-change-watcher.php
@@ -227,6 +227,7 @@ class WPSEO_Slug_Change_Watcher implements WPSEO_WordPress_Integration {
 			. '<p><a class="yoast-button-upsell" href="' . WPSEO_Shortlinker::get( 'https://yoa.st/1d0' ) . '" target="_blank">'
 			/* translators: %s expands to Yoast SEO Premium */
 			. sprintf( __( 'Get %s', 'wordpress-seo' ), 'Yoast SEO Premium' )
+			/* translators: Hidden accessibility text. */
 			. '<span class="screen-reader-text">' . __( '(Opens in a new browser tab)', 'wordpress-seo' ) . '</span>'
 			. '<span aria-hidden="true" class="yoast-button-upsell__caret"></span>'
 			. '</a></p>';

--- a/composer.json
+++ b/composer.json
@@ -81,7 +81,7 @@
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_coding_standards"
 		],
 		"check-cs-thresholds": [
-			"@putenv YOASTCS_THRESHOLD_ERRORS=130",
+			"@putenv YOASTCS_THRESHOLD_ERRORS=129",
 			"@putenv YOASTCS_THRESHOLD_WARNINGS=202",
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_cs_thresholds"
 		],

--- a/inc/class-wpseo-admin-bar-menu.php
+++ b/inc/class-wpseo-admin-bar-menu.php
@@ -699,7 +699,6 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 	 * @return string Admin bar title markup.
 	 */
 	protected function get_title() {
-		/* translators: Hidden accessibility text. */
 		return '<div id="yoast-ab-icon" class="ab-item yoast-logo svg"><span class="screen-reader-text">' . __( 'SEO', 'wordpress-seo' ) . '</span></div>';
 	}
 

--- a/inc/class-wpseo-admin-bar-menu.php
+++ b/inc/class-wpseo-admin-bar-menu.php
@@ -850,7 +850,7 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 			return '';
 		}
 
-		/* translators: %s: number of notifications; Hidden accessibility text. */
+		/* translators: Hidden accessibility text; %s: number of notifications. */
 		$counter_screen_reader_text = sprintf( _n( '%s notification', '%s notifications', $notification_count, 'wordpress-seo' ), number_format_i18n( $notification_count ) );
 
 		return sprintf( ' <div class="wp-core-ui wp-ui-notification yoast-issue-counter"><span class="yoast-issues-count" aria-hidden="true">%d</span><span class="screen-reader-text">%s</span></div>', $notification_count, $counter_screen_reader_text );

--- a/inc/class-wpseo-admin-bar-menu.php
+++ b/inc/class-wpseo-admin-bar-menu.php
@@ -699,6 +699,7 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 	 * @return string Admin bar title markup.
 	 */
 	protected function get_title() {
+		/* translators: Hidden accessibility text. */
 		return '<div id="yoast-ab-icon" class="ab-item yoast-logo svg"><span class="screen-reader-text">' . __( 'SEO', 'wordpress-seo' ) . '</span></div>';
 	}
 
@@ -850,7 +851,7 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 			return '';
 		}
 
-		/* translators: %s: number of notifications */
+		/* translators: %s: number of notifications; Hidden accessibility text. */
 		$counter_screen_reader_text = sprintf( _n( '%s notification', '%s notifications', $notification_count, 'wordpress-seo' ), number_format_i18n( $notification_count ) );
 
 		return sprintf( ' <div class="wp-core-ui wp-ui-notification yoast-issue-counter"><span class="yoast-issues-count" aria-hidden="true">%d</span><span class="screen-reader-text">%s</span></div>', $notification_count, $counter_screen_reader_text );

--- a/packages/components/src/Alert.js
+++ b/packages/components/src/Alert.js
@@ -132,6 +132,7 @@ class Alert extends React.Component {
 		}
 
 		const options          = this.getTypeDisplayOptions( this.props.type );
+		/* translators: Hidden accessibility text. */
 		const dismissAriaLabel = this.props.dismissAriaLabel || __( "Dismiss this alert", "wordpress-seo" );
 
 		return <AlertContainer alertColor={ options.color } alertBackground={ options.background } className={ this.props.className }>

--- a/packages/components/src/data-model/DataModel.js
+++ b/packages/components/src/data-model/DataModel.js
@@ -21,7 +21,7 @@ const dataItemProps = {
  * @returns {HTMLElement} A list item.
  */
 const DataItem = ( props ) => {
-	/* translators: %d expands to number of occurrences; Hidden accessibility text. */
+	/* translators: Hidden accessibility text; %d expands to number of occurrences. */
 	const screenReaderText = sprintf( __( "%d occurrences", "wordpress-seo" ), props.number );
 	return (
 		<li

--- a/packages/components/src/data-model/DataModel.js
+++ b/packages/components/src/data-model/DataModel.js
@@ -21,7 +21,7 @@ const dataItemProps = {
  * @returns {HTMLElement} A list item.
  */
 const DataItem = ( props ) => {
-	/* Translators: %d expands to number of occurrences. */
+	/* translators: %d expands to number of occurrences; Hidden accessibility text. */
 	const screenReaderText = sprintf( __( "%d occurrences", "wordpress-seo" ), props.number );
 	return (
 		<li

--- a/packages/components/src/help-icon/HelpIcon.js
+++ b/packages/components/src/help-icon/HelpIcon.js
@@ -46,8 +46,8 @@ const HelpIcon = ( { linkTo, linkText } ) => (
 				/>
 			</svg>
 		</span>
-		<span className="screen-reader-text">{ __( linkText, "wordpress-seo" ) }</span>
 		<span className="screen-reader-text">{ __( "(Opens in a new browser tab)", "wordpress-seo" ) }</span>
+		<span className="screen-reader-text">{ linkText }</span>
 	</a>
 );
 

--- a/packages/components/src/help-icon/HelpIcon.js
+++ b/packages/components/src/help-icon/HelpIcon.js
@@ -46,8 +46,13 @@ const HelpIcon = ( { linkTo, linkText } ) => (
 				/>
 			</svg>
 		</span>
-		<span className="screen-reader-text">{ __( "(Opens in a new browser tab)", "wordpress-seo" ) }</span>
 		<span className="screen-reader-text">{ linkText }</span>
+		<span className="screen-reader-text">
+			{
+				/* translators: Hidden accessibility text. */
+				__( "(Opens in a new browser tab)", "wordpress-seo" )
+			}
+		</span>
 	</a>
 );
 

--- a/packages/components/src/image-select/ImageSelect.js
+++ b/packages/components/src/image-select/ImageSelect.js
@@ -40,9 +40,7 @@ function ImageSelect( props ) {
 			<span className="screen-reader-text">
 				{
 					imageSelected
-						/* translators: Hidden accessibility text. */
 						? __( "Replace image", "wordpress-seo" )
-						/* translators: Hidden accessibility text. */
 						: __( "Select image", "wordpress-seo" )
 				}
 			</span>

--- a/packages/components/src/image-select/ImageSelect.js
+++ b/packages/components/src/image-select/ImageSelect.js
@@ -40,7 +40,9 @@ function ImageSelect( props ) {
 			<span className="screen-reader-text">
 				{
 					imageSelected
+						/* translators: Hidden accessibility text. */
 						? __( "Replace image", "wordpress-seo" )
+						/* translators: Hidden accessibility text. */
 						: __( "Select image", "wordpress-seo" )
 				}
 			</span>

--- a/packages/helpers/src/makeOutboundLink.js
+++ b/packages/helpers/src/makeOutboundLink.js
@@ -72,6 +72,7 @@ export const makeOutboundLink = ( Component = "a" ) => {
 				React.createElement(
 					A11yNotice,
 					null,
+					/* translators: Hidden accessibility text. */
 					__( "(Opens in a new browser tab)", "wordpress-seo" )
 				)
 			);

--- a/packages/js/src/academy/app.js
+++ b/packages/js/src/academy/app.js
@@ -277,6 +277,7 @@ const App = () => {
 											{ __( "Start free trial lesson", "wordpress-seo" ) }
 											<span className="yst-sr-only">
 												{
+													/* translators: Hidden accessibility text. */
 													__( "(Opens in a new browser tab)", "wordpress-seo" )
 												}
 											</span>

--- a/packages/js/src/analysis/getIndicatorForScore.js
+++ b/packages/js/src/analysis/getIndicatorForScore.js
@@ -14,7 +14,6 @@ function getIndicatorForRating( rating ) {
 		case "feedback":
 			return {
 				className: "na",
-				/* translators: Hidden accessibility text. */
 				screenReaderText: __( "Feedback", "wordpress-seo" ),
 				screenReaderReadabilityText: "",
 				screenReaderInclusiveLanguageText: "",
@@ -22,31 +21,22 @@ function getIndicatorForRating( rating ) {
 		case "bad":
 			return {
 				className: "bad",
-				/* translators: Hidden accessibility text. */
 				screenReaderText: __( "Needs improvement", "wordpress-seo" ),
-				/* translators: Hidden accessibility text. */
 				screenReaderReadabilityText: __( "Needs improvement", "wordpress-seo" ),
-				/* translators: Hidden accessibility text. */
 				screenReaderInclusiveLanguageText: __( "Needs improvement", "wordpress-seo" ),
 			};
 		case "ok":
 			return {
 				className: "ok",
-				/* translators: Hidden accessibility text. */
 				screenReaderText: __( "OK SEO score", "wordpress-seo" ),
-				/* translators: Hidden accessibility text. */
 				screenReaderReadabilityText: __( "OK", "wordpress-seo" ),
-				/* translators: Hidden accessibility text. */
 				screenReaderInclusiveLanguageText: __( "Potentially non-inclusive", "wordpress-seo" ),
 			};
 		case "good":
 			return {
 				className: "good",
-				/* translators: Hidden accessibility text. */
 				screenReaderText: __( "Good SEO score", "wordpress-seo" ),
-				/* translators: Hidden accessibility text. */
 				screenReaderReadabilityText: __( "Good", "wordpress-seo" ),
-				/* translators: Hidden accessibility text. */
 				screenReaderInclusiveLanguageText: __( "Good", "wordpress-seo" ),
 			};
 		default:

--- a/packages/js/src/analysis/getIndicatorForScore.js
+++ b/packages/js/src/analysis/getIndicatorForScore.js
@@ -14,6 +14,7 @@ function getIndicatorForRating( rating ) {
 		case "feedback":
 			return {
 				className: "na",
+				/* translators: Hidden accessibility text. */
 				screenReaderText: __( "Feedback", "wordpress-seo" ),
 				screenReaderReadabilityText: "",
 				screenReaderInclusiveLanguageText: "",
@@ -21,22 +22,31 @@ function getIndicatorForRating( rating ) {
 		case "bad":
 			return {
 				className: "bad",
+				/* translators: Hidden accessibility text. */
 				screenReaderText: __( "Needs improvement", "wordpress-seo" ),
+				/* translators: Hidden accessibility text. */
 				screenReaderReadabilityText: __( "Needs improvement", "wordpress-seo" ),
+				/* translators: Hidden accessibility text. */
 				screenReaderInclusiveLanguageText: __( "Needs improvement", "wordpress-seo" ),
 			};
 		case "ok":
 			return {
 				className: "ok",
+				/* translators: Hidden accessibility text. */
 				screenReaderText: __( "OK SEO score", "wordpress-seo" ),
+				/* translators: Hidden accessibility text. */
 				screenReaderReadabilityText: __( "OK", "wordpress-seo" ),
+				/* translators: Hidden accessibility text. */
 				screenReaderInclusiveLanguageText: __( "Potentially non-inclusive", "wordpress-seo" ),
 			};
 		case "good":
 			return {
 				className: "good",
+				/* translators: Hidden accessibility text. */
 				screenReaderText: __( "Good SEO score", "wordpress-seo" ),
+				/* translators: Hidden accessibility text. */
 				screenReaderReadabilityText: __( "Good", "wordpress-seo" ),
+				/* translators: Hidden accessibility text. */
 				screenReaderInclusiveLanguageText: __( "Good", "wordpress-seo" ),
 			};
 		default:

--- a/packages/js/src/components/AdvancedSettings.js
+++ b/packages/js/src/components/AdvancedSettings.js
@@ -92,6 +92,7 @@ const MetaRobotsNoIndex = ( { noIndex, onNoIndexChange, editorContext, isPrivate
 					options={ metaRobotsNoIndexOptions }
 					selected={ noIndex }
 					linkTo={ wpseoAdminL10n[ "shortlinks.advanced.allow_search_engines" ] }
+					/* translators: Hidden accessibility text. */
 					linkText={ __( "Learn more about the no-index setting on our help page.", "wordpress-seo" ) }
 				/>
 			</Fragment>;
@@ -132,6 +133,7 @@ const MetaRobotsNoFollow = ( { noFollow, onNoFollowChange, postTypeName } ) => {
 				onChange={ onNoFollowChange }
 				selected={ noFollow }
 				linkTo={ wpseoAdminL10n[ "shortlinks.advanced.follow_links" ] }
+				/* translators: Hidden accessibility text. */
 				linkText={ __( "Learn more about the no-follow setting on our help page.", "wordpress-seo" ) }
 			/>;
 		} }
@@ -169,6 +171,7 @@ const MetaRobotsAdvanced = ( { advanced, onAdvancedChange } ) => {
 				] }
 				selected={ advanced }
 				linkTo={ wpseoAdminL10n[ "shortlinks.advanced.meta_robots" ] }
+				/* translators: Hidden accessibility text. */
 				linkText={ __( "Learn more about advanced meta robots settings on our help page.", "wordpress-seo" ) }
 			/>;
 		} }
@@ -197,6 +200,7 @@ const BreadcrumbsTitle = ( { breadcrumbsTitle, onBreadcrumbsTitleChange } ) => {
 					onChange={ onBreadcrumbsTitleChange }
 					value={ breadcrumbsTitle }
 					linkTo={ wpseoAdminL10n[ "shortlinks.advanced.breadcrumbs_title" ] }
+					/* translators: Hidden accessibility text. */
 					linkText={ __( "Learn more about the breadcrumbs title setting on our help page.", "wordpress-seo" ) }
 				/>;
 			}
@@ -226,6 +230,7 @@ const CanonicalURL = ( { canonical, onCanonicalChange } ) => {
 					onChange={ onCanonicalChange }
 					value={ canonical }
 					linkTo={ "https://yoa.st/canonical-url" }
+					/* translators: Hidden accessibility text. */
 					linkText={ __( "Learn more about canonical URLs on our help page.", "wordpress-seo" ) }
 				/>;
 			}

--- a/packages/js/src/components/JetpackBoost.js
+++ b/packages/js/src/components/JetpackBoost.js
@@ -61,7 +61,12 @@ const JetpackBoost = ( { store, isAlertDismissed, onDismissed } ) => {
 					<JetpackBoostLogo className="yst-h-5 yst-w-5 yst--ml-0.5" />
 					<button className="yst-ml-auto" onClick={ onDismissed }>
 						<XIcon className="yst-h-4 yst-w-4 yst-text-gray-400" />
-						<span className="yst-sr-only">{ __( "Dismiss get Jetpack Boost", "wordpress-seo" ) }</span>
+						<span className="yst-sr-only">
+							{
+								/* translators: Hidden accessibility text. */
+								__( "Dismiss get Jetpack Boost", "wordpress-seo" )
+							}
+						</span>
 					</button>
 				</div>
 				<Title as="h2" size="3" className="yst-mt-3 yst-text-sm yst-leading-normal yst-font-semibold">
@@ -88,7 +93,12 @@ const JetpackBoost = ( { store, isAlertDismissed, onDismissed } ) => {
 						) }
 					</span>
 					<ExternalLinkIcon className="yst-inline yst-ml-1 yst-h-4 yst-w-4 yst-text-indigo-600" />
-					<span className="yst-sr-only">{ __( "(Opens in a new browser tab)", "wordpress-seo" ) }</span>
+					<span className="yst-sr-only">
+						{
+							/* translators: Hidden accessibility text. */
+							__( "(Opens in a new browser tab)", "wordpress-seo" )
+						}
+					</span>
 				</Link>
 			</Root>
 		</PluginPrePublishPanel>

--- a/packages/js/src/components/PostPublish.js
+++ b/packages/js/src/components/PostPublish.js
@@ -21,14 +21,24 @@ export default function PostPublish( { permalink } ) {
 				<a href={ "https://www.facebook.com/sharer/sharer.php?u=" + encodedUrl } target="_blank" rel="noopener noreferrer">
 					<FacebookIcon />
 					{ __( "Facebook", "wordpress-seo" ) }
-					<span className="screen-reader-text">{ __( "(Opens in a new browser tab)", "wordpress-seo" ) }</span>
+					<span className="screen-reader-text">
+						{
+							/* translators: Hidden accessibility text. */
+							__( "(Opens in a new browser tab)", "wordpress-seo" )
+						}
+					</span>
 				</a>
 			</li>
 			<li>
 				<a href={ "https://twitter.com/share?url=" + encodedUrl } target="_blank" rel="noopener noreferrer">
 					<TwitterIcon />
 					{ __( "Twitter", "wordpress-seo" ) }
-					<span className="screen-reader-text">{ __( "(Opens in a new browser tab)", "wordpress-seo" ) }</span>
+					<span className="screen-reader-text">
+						{
+							/* translators: Hidden accessibility text. */
+							__( "(Opens in a new browser tab)", "wordpress-seo" )
+						}
+					</span>
 				</a>
 			</li>
 		</ul>

--- a/packages/js/src/components/SEMrushRelatedKeyphrasesModal.js
+++ b/packages/js/src/components/SEMrushRelatedKeyphrasesModal.js
@@ -209,8 +209,11 @@ class SEMrushRelatedKeyphrasesModal extends Component {
 						onClick={ this.onLinkClick }
 					>
 						{ __( "Get related keyphrases", "wordpress-seo" ) }
-						<span className={ "screen-reader-text" }>
-							{ __( "(Opens in a new browser window)", "wordpress-seo" ) }
+						<span className="screen-reader-text">
+							{
+								/* translators: Hidden accessibility text. */
+								__( "(Opens in a new browser tab)", "wordpress-seo" )
+							}
 						</span>
 					</ButtonStyledLink>
 				</div> }

--- a/packages/js/src/components/SchemaTab.js
+++ b/packages/js/src/components/SchemaTab.js
@@ -122,6 +122,7 @@ const Header = ( props ) => {
 	return <FieldGroup
 		label={ props.helpTextTitle }
 		linkTo={ props.helpTextLink }
+		/* translators: Hidden accessibility text. */
 		linkText={ __( "Learn more about structured data with Schema.org", "wordpress-seo" ) }
 		description={ props.helpTextDescription }
 	/>;
@@ -181,6 +182,7 @@ const Content = ( props ) => {
 			<FieldGroup
 				label={ __( "What type of page or content is this?", "wordpress-seo" ) }
 				linkTo={ props.additionalHelpTextLink }
+				/* translators: Hidden accessibility text. */
 				linkText={ __( "Learn more about page or content types", "wordpress-seo" ) }
 			/>
 			{ woocommerceUpsell && <WooCommerceUpsell link={ woocommerceUpsellLink } text={ woocommerceUpsellText } /> }

--- a/packages/js/src/components/WincherPostPublish.js
+++ b/packages/js/src/components/WincherPostPublish.js
@@ -30,6 +30,7 @@ export default function WincherPostPublish( props ) {
 			<FieldGroup
 				label={ __( "SEO performance", "wordpress-seo" ) }
 				linkTo={ wpseoAdminL10n[ "shortlinks.wincher.seo_performance" ] }
+				/* translators: Hidden accessibility text. */
 				linkText={ __( "Learn more about the SEO performance feature.", "wordpress-seo" ) }
 				wrapperClassName={ "yoast-field-group yoast-wincher-post-publish" }
 			/>

--- a/packages/js/src/components/WincherSEOPerformance.js
+++ b/packages/js/src/components/WincherSEOPerformance.js
@@ -293,6 +293,7 @@ export default function WincherSEOPerformance( props ) {
 				{ __( "SEO performance", "wordpress-seo" ) }
 				<HelpIcon
 					linkTo={ wpseoAdminL10n[ "shortlinks.wincher.seo_performance" ] }
+					/* translators: Hidden accessibility text. */
 					linkText={ __( "Learn more about the SEO performance feature.", "wordpress-seo" ) }
 				/>
 			</Title>

--- a/packages/js/src/components/WordProofTimestampToggle.js
+++ b/packages/js/src/components/WordProofTimestampToggle.js
@@ -132,8 +132,8 @@ class WordProofTimestampToggle extends Component {
 		return (
 			<Fragment>
 				<FieldGroup
-					linkText={ __( "Learn more about timestamping",
-						"wordpress-seo" ) }
+					/* translators: Hidden accessibility text. */
+					linkText={ __( "Learn more about timestamping", "wordpress-seo" ) }
 					linkTo={ "https://yoa.st/wordproof-integration" }
 					htmlFor={ this.props.id }
 					label={ __( "Timestamp with WordProof", "wordpress-seo" ) }

--- a/packages/js/src/components/contentAnalysis/InclusiveLanguageAnalysis.js
+++ b/packages/js/src/components/contentAnalysis/InclusiveLanguageAnalysis.js
@@ -74,7 +74,10 @@ const InclusiveLanguageAnalysis = ( props ) => {
 						className="dashicons"
 					>
 						<span className="screen-reader-text">
-							{ __( "Learn more about the inclusive language analysis", "wordpress-seo" ) }
+							{
+								/* translators: Hidden accessibility text. */
+								__( "Learn more about the inclusive language analysis", "wordpress-seo" )
+							}
 						</span>
 					</StyledHelpLink>
 				</AnalysisHeader>
@@ -137,7 +140,10 @@ const InclusiveLanguageAnalysis = ( props ) => {
 						className="dashicons"
 					>
 						<span className="screen-reader-text">
-							{ __( "Learn more about the inclusive language analysis", "wordpress-seo" ) }
+							{
+								/* translators: Hidden accessibility text. */
+								__( "Learn more about the inclusive language analysis", "wordpress-seo" )
+							}
 						</span>
 					</StyledHelpLink>
 				</AnalysisHeader>

--- a/packages/js/src/components/contentAnalysis/KeywordInput.js
+++ b/packages/js/src/components/contentAnalysis/KeywordInput.js
@@ -44,7 +44,10 @@ class KeywordInput extends Component {
 				className="dashicons"
 			>
 				<span className="screen-reader-text">
-					{ __( "Help on choosing the perfect focus keyphrase", "wordpress-seo" ) }
+					{
+						/* translators: Hidden accessibility text. */
+						__( "Help on choosing the perfect focus keyphrase", "wordpress-seo" )
+					}
 				</span>
 			</HelpLink>
 		);

--- a/packages/js/src/components/contentAnalysis/ReadabilityAnalysis.js
+++ b/packages/js/src/components/contentAnalysis/ReadabilityAnalysis.js
@@ -55,7 +55,10 @@ class ReadabilityAnalysis extends Component {
 						className="dashicons"
 					>
 						<span className="screen-reader-text">
-							{ __( "Learn more about the readability analysis", "wordpress-seo" ) }
+							{
+								/* translators: Hidden accessibility text. */
+								__( "Learn more about the readability analysis", "wordpress-seo" )
+							}
 						</span>
 					</StyledHelpLink>
 				</AnalysisHeader>

--- a/packages/js/src/components/modals/SEMrushKeyphrasesTable.js
+++ b/packages/js/src/components/modals/SEMrushKeyphrasesTable.js
@@ -109,7 +109,10 @@ class SEMrushKeyphrasesTable extends Component {
 									className="dashicons"
 								>
 									<span className="screen-reader-text">
-										{ __( "Learn more about the related keyphrases volume", "wordpress-seo" ) }
+										{
+											/* translators: Hidden accessibility text. */
+											__( "Learn more about the related keyphrases volume", "wordpress-seo" )
+										}
 									</span>
 								</HelpLink>
 							</th>
@@ -123,7 +126,10 @@ class SEMrushKeyphrasesTable extends Component {
 									className="dashicons"
 								>
 									<span className="screen-reader-text">
-										{ __( "Learn more about the related keyphrases trend", "wordpress-seo" ) }
+										{
+											/* translators: Hidden accessibility text. */
+											__( "Learn more about the related keyphrases trend", "wordpress-seo" )
+										}
 									</span>
 								</HelpLink>
 							</th>

--- a/packages/js/src/containers/PersistentDismissableNotification.js
+++ b/packages/js/src/containers/PersistentDismissableNotification.js
@@ -34,7 +34,12 @@ const PersistentDismissableNotification = ( {
 				{ Image && <Image height="60" /> }
 			</div>
 			<button className="notice-dismiss" onClick={ onDismissed }>
-				<span className="screen-reader-text">{ __( "Dismiss this notice.", "wordpress-seo" ) }</span>
+				<span className="screen-reader-text">
+					{
+						/* translators: Hidden accessibility text. */
+						__( "Dismiss this notice.", "wordpress-seo" )
+					}
+				</span>
 			</button>
 		</div>
 	);

--- a/packages/js/src/first-time-configuration/tailwind-components/steps/social-profiles/social-field-array.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/steps/social-profiles/social-field-array.js
@@ -50,7 +50,12 @@ const SocialFieldArray = ( { items, onAddProfile, onRemoveProfile, onChangeProfi
 							data-index={ index }
 							onClick={ handleRemove }
 						>
-							<span className="yst-sr-only">{ __( "Delete item", "wordpress-seo" ) }</span>
+							<span className="yst-sr-only">
+								{
+									/* translators: Hidden accessibility text. */
+									__( "Delete item", "wordpress-seo" )
+								}
+							</span>
 							<TrashIcon className="yst-relative yst--top-0.5 yst-w-5 yst-h-5" />
 						</button>
 					</div>

--- a/packages/js/src/first-time-configuration/tailwind-components/tailwind-modal.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/tailwind-modal.js
@@ -55,7 +55,12 @@ export default function TailwindModal( { isOpen, handleClose, hasCloseButton, ch
 									onClick={ handleClose }
 									className="yst-bg-white yst-rounded-md yst-text-slate-400 hover:yst-text-slate-600 focus:yst-outline-none focus:yst-ring-2 focus:yst-ring-offset-2 focus:yst-ring-primary-500"
 								>
-									<span className="yst-sr-only">{ __( "Close", "wordpress-seo" ) }</span>
+									<span className="yst-sr-only">
+										{
+											/* translators: Hidden accessibility text. */
+											__( "Close", "wordpress-seo" )
+										}
+									</span>
 									<XIcon className="yst-h-6 yst-w-6" />
 								</button>
 							</div> }

--- a/packages/js/src/first-time-configuration/tailwind-components/tailwind-modal.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/tailwind-modal.js
@@ -55,12 +55,7 @@ export default function TailwindModal( { isOpen, handleClose, hasCloseButton, ch
 									onClick={ handleClose }
 									className="yst-bg-white yst-rounded-md yst-text-slate-400 hover:yst-text-slate-600 focus:yst-outline-none focus:yst-ring-2 focus:yst-ring-offset-2 focus:yst-ring-primary-500"
 								>
-									<span className="yst-sr-only">
-										{
-											/* translators: Hidden accessibility text. */
-											__( "Close", "wordpress-seo" )
-										}
-									</span>
+									<span className="yst-sr-only">{ __( "Close", "wordpress-seo" ) }</span>
 									<XIcon className="yst-h-6 yst-w-6" />
 								</button>
 							</div> }

--- a/packages/js/src/inline-links/inline.js
+++ b/packages/js/src/inline-links/inline.js
@@ -277,7 +277,10 @@ function InlineLinkUI( {
 		className="dashicons"
 	>
 		<span className="screen-reader-text">
-			{ __( "Learn more about marking a link as nofollow or sponsored.", "wordpress-seo" ) }
+			{
+				/* translators: Hidden accessibility text. */
+				__( "Learn more about marking a link as nofollow or sponsored.", "wordpress-seo" )
+			}
 		</span>
 	</HelpLink>;
 

--- a/packages/js/src/insights/components/estimated-reading-time.js
+++ b/packages/js/src/insights/components/estimated-reading-time.js
@@ -18,6 +18,7 @@ const EstimatedReadingTime = () => {
 			unit={ _n( "minute", "minutes", estimatedReadingTime, "wordpress-seo" ) }
 			title={ __( "Reading time", "wordpress-seo" ) }
 			linkTo={ estimatedReadingTimeLink }
+			/* translators: Hidden accessibility text. */
 			linkText={ __( "Learn more about reading time", "wordpress-seo" ) }
 		/>
 	);

--- a/packages/js/src/insights/components/flesch-reading-ease.js
+++ b/packages/js/src/insights/components/flesch-reading-ease.js
@@ -135,6 +135,7 @@ const FleschReadingEase = () => {
 			unit={ __( "out of 100", "wordpress-seo" ) }
 			title={ __( "Flesch reading ease", "wordpress-seo" ) }
 			linkTo={ link }
+			/* translators: Hidden accessibility text. */
 			linkText={ __( "Learn more about Flesch reading ease", "wordpress-seo" ) }
 			description={ description }
 		/>

--- a/packages/js/src/insights/components/prominent-words.js
+++ b/packages/js/src/insights/components/prominent-words.js
@@ -98,7 +98,7 @@ const ProminentWords = ( { location } ) => { // eslint-disable-line complexity
 			<DataModel
 				data={ data }
 				itemScreenReaderText={
-					/* translators: %d expands to the number of occurrences; Hidden accessibility text. */
+					/* translators: Hidden accessibility text; %d expands to the number of occurrences. */
 					__( "%d occurrences", "wordpress-seo" )
 				}
 				aria-label={ __( "Prominent words", "wordpress-seo" ) }

--- a/packages/js/src/insights/components/prominent-words.js
+++ b/packages/js/src/insights/components/prominent-words.js
@@ -98,7 +98,7 @@ const ProminentWords = ( { location } ) => { // eslint-disable-line complexity
 			<DataModel
 				data={ data }
 				itemScreenReaderText={
-					// translators: %d expands to the number of occurrences.
+					/* translators: %d expands to the number of occurrences; Hidden accessibility text. */
 					__( "%d occurrences", "wordpress-seo" )
 				}
 				aria-label={ __( "Prominent words", "wordpress-seo" ) }

--- a/packages/js/src/insights/components/text-formality.js
+++ b/packages/js/src/insights/components/text-formality.js
@@ -24,6 +24,7 @@ const TextFormality = ( { location, name } ) => {
 		? get( window, "wpseoAdminL10n.shortlinks-insights-text_formality_info_premium", "" )
 		: get( window, "wpseoAdminL10n.shortlinks-insights-text_formality_info_free", "" );
 
+	/* translators: Hidden accessibility text. */
 	const linkText = __( "Read more about text formality.", "wordpress-seo" );
 
 	if ( ! isFormalitySupported ) {

--- a/packages/js/src/insights/components/text-length.js
+++ b/packages/js/src/insights/components/text-length.js
@@ -14,10 +14,12 @@ const TextLength = () => {
 
 	let unitString = _n( "word", "words", textLength.count, "wordpress-seo" );
 	let titleString = __( "Word count", "wordpress-seo" );
+	/* translators: Hidden accessibility text. */
 	let linkText =  __( "Learn more about word count", "wordpress-seo" );
 	if ( textLength.unit === "character" ) {
 		unitString = _n( "character", "characters", textLength.count, "wordpress-seo" );
 		titleString = __( "Character count", "wordpress-seo" );
+		/* translators: Hidden accessibility text. */
 		linkText =  __( "Learn more about character count", "wordpress-seo" );
 	}
 

--- a/packages/js/src/integrations-page/algolia-integration.js
+++ b/packages/js/src/integrations-page/algolia-integration.js
@@ -77,6 +77,7 @@ export const AlgoliaIntegration = ( {
 					/> }
 					<span className="yst-sr-only">
 						{
+							/* translators: Hidden accessibility text. */
 							__( "(Opens in a new browser tab)", "wordpress-seo" )
 						}
 					</span>
@@ -98,6 +99,7 @@ export const AlgoliaIntegration = ( {
 							Learn more
 							<span className="yst-sr-only">
 								{
+									/* translators: Hidden accessibility text. */
 									__( "(Opens in a new browser tab)", "wordpress-seo" )
 								}
 							</span>
@@ -136,6 +138,7 @@ export const AlgoliaIntegration = ( {
 					{ __( "Unlock with Premium", "wordpress-seo" ) }
 					<span className="yst-sr-only">
 						{
+							/* translators: Hidden accessibility text. */
 							__( "(Opens in a new browser tab)", "wordpress-seo" )
 						}
 					</span>

--- a/packages/js/src/integrations-page/jetpack-boost-integration.js
+++ b/packages/js/src/integrations-page/jetpack-boost-integration.js
@@ -116,6 +116,7 @@ export const JetpackBoostIntegration = () => {
 					/> }
 					<span className="yst-sr-only">
 						{
+							/* translators: Hidden accessibility text. */
 							__( "(Opens in a new browser tab)", "wordpress-seo" )
 						}
 					</span>
@@ -135,7 +136,10 @@ export const JetpackBoostIntegration = () => {
 						>
 							{ learnMoreLinkText }
 							<span className="yst-sr-only">
-								{ __( "(Opens in a new browser tab)", "wordpress-seo" ) }
+								{
+									/* translators: Hidden accessibility text. */
+									__( "(Opens in a new browser tab)", "wordpress-seo" )
+								}
 							</span>
 							<ArrowSmRightIcon className="yst-h-4 yst-w-4 yst-ml-1 yst-icon-rtl" />
 						</Link> }

--- a/packages/js/src/integrations-page/simple-integration.js
+++ b/packages/js/src/integrations-page/simple-integration.js
@@ -29,6 +29,7 @@ export const SimpleIntegration = ( { integration, isActive, children } ) => {
 					{ integration.logo && <IntegrationLogo alt={ `${integration.name} logo` } className={ `${ isActive ? "" : "yst-opacity-50 yst-filter yst-grayscale" }` } /> }
 					<span className="yst-sr-only">
 						{
+							/* translators: Hidden accessibility text. */
 							__( "(Opens in a new browser tab)", "wordpress-seo" )
 						}
 					</span>
@@ -61,6 +62,7 @@ export const SimpleIntegration = ( { integration, isActive, children } ) => {
 						Learn more
 						<span className="yst-sr-only">
 							{
+								/* translators: Hidden accessibility text. */
 								__( "(Opens in a new browser tab)", "wordpress-seo" )
 							}
 						</span>
@@ -86,6 +88,7 @@ export const SimpleIntegration = ( { integration, isActive, children } ) => {
 					{ __( "Unlock with Premium", "wordpress-seo" ) }
 					<span className="yst-sr-only">
 						{
+							/* translators: Hidden accessibility text. */
 							__( "(Opens in a new browser tab)", "wordpress-seo" )
 						}
 					</span>

--- a/packages/js/src/integrations-page/toggleable-integration.js
+++ b/packages/js/src/integrations-page/toggleable-integration.js
@@ -74,6 +74,7 @@ export const ToggleableIntegration = ( {
 					/> }
 					<span className="yst-sr-only">
 						{
+							/* translators: Hidden accessibility text. */
 							__( "(Opens in a new browser tab)", "wordpress-seo" )
 						}
 					</span>
@@ -95,6 +96,7 @@ export const ToggleableIntegration = ( {
 							Learn more
 							<span className="yst-sr-only">
 								{
+									/* translators: Hidden accessibility text. */
 									__( "(Opens in a new browser tab)", "wordpress-seo" )
 								}
 							</span>
@@ -125,6 +127,7 @@ export const ToggleableIntegration = ( {
 					{ __( "Unlock with Premium", "wordpress-seo" ) }
 					<span className="yst-sr-only">
 						{
+							/* translators: Hidden accessibility text. */
 							__( "(Opens in a new browser tab)", "wordpress-seo" )
 						}
 					</span>

--- a/packages/js/src/integrations-page/woocommerce-integration.js
+++ b/packages/js/src/integrations-page/woocommerce-integration.js
@@ -86,6 +86,7 @@ export const WoocommerceIntegration = ( {
 					}
 					<span className="yst-sr-only">
 						{
+							/* translators: Hidden accessibility text. */
 							__( "(Opens in a new browser tab)", "wordpress-seo" )
 						}
 					</span>

--- a/packages/js/src/settings/app.js
+++ b/packages/js/src/settings/app.js
@@ -247,7 +247,9 @@ const App = () => {
 				<SidebarNavigation.Mobile
 					openButtonId="button-open-settings-navigation-mobile"
 					closeButtonId="button-close-settings-navigation-mobile"
+					/* translators: Hidden accessibility text. */
 					openButtonScreenReaderText={ __( "Open settings navigation", "wordpress-seo" ) }
+					/* translators: Hidden accessibility text. */
 					closeButtonScreenReaderText={ __( "Close settings navigation", "wordpress-seo" ) }
 					aria-label={ __( "Settings navigation", "wordpress-seo" ) }
 				>

--- a/packages/js/src/settings/components/form-layout.js
+++ b/packages/js/src/settings/components/form-layout.js
@@ -56,10 +56,7 @@ const FormLayout = ( { children } ) => {
 								{ __( "Discard changes", "wordpress-seo" ) }
 							</Button>
 							<Modal onClose={ unsetRequestUndo } isOpen={ isRequestUndo }>
-								<Modal.Panel
-									/* translators: Hidden accessibility text. */
-									closeButtonScreenReaderText={ __( "Close", "wordpress-seo" ) }
-								>
+								<Modal.Panel closeButtonScreenReaderText={ __( "Close", "wordpress-seo" ) }>
 									<div className="sm:yst-flex sm:yst-items-start">
 										<div
 											className="yst-mx-auto yst-flex-shrink-0 yst-flex yst-items-center yst-justify-center yst-h-12 yst-w-12 yst-rounded-full yst-bg-red-100 sm:yst-mx-0 sm:yst-h-10 sm:yst-w-10"

--- a/packages/js/src/settings/components/form-layout.js
+++ b/packages/js/src/settings/components/form-layout.js
@@ -56,7 +56,10 @@ const FormLayout = ( { children } ) => {
 								{ __( "Discard changes", "wordpress-seo" ) }
 							</Button>
 							<Modal onClose={ unsetRequestUndo } isOpen={ isRequestUndo }>
-								<Modal.Panel closeButtonScreenReaderText={ __( "Close", "wordpress-seo" ) }>
+								<Modal.Panel
+									/* translators: Hidden accessibility text. */
+									closeButtonScreenReaderText={ __( "Close", "wordpress-seo" ) }
+								>
 									<div className="sm:yst-flex sm:yst-items-start">
 										<div
 											className="yst-mx-auto yst-flex-shrink-0 yst-flex yst-items-center yst-justify-center yst-h-12 yst-w-12 yst-rounded-full yst-bg-red-100 sm:yst-mx-0 sm:yst-h-10 sm:yst-w-10"

--- a/packages/js/src/settings/components/formik-page-select-field.js
+++ b/packages/js/src/settings/components/formik-page-select-field.js
@@ -87,6 +87,7 @@ const FormikPageSelectField = ( { name, id, className = "", ...props } ) => {
 			onQueryChange={ handleQueryChange }
 			className={ classNames( className, props.disabled && "yst-autocomplete--disabled" ) }
 			nullable={ true }
+			/* translators: Hidden accessibility text. */
 			clearButtonScreenReaderText={ __( "Clear selection", "wordpress-seo" ) }
 			{ ...props }
 		>

--- a/packages/js/src/settings/components/notifications.js
+++ b/packages/js/src/settings/components/notifications.js
@@ -81,6 +81,7 @@ const Notifications = () => {
 		...notification,
 		onDismiss: removeNotification,
 		autoDismiss: notification.variant === "success" ? 5000 : null,
+		/* translators: Hidden accessibility text. */
 		dismissScreenReaderLabel: __( "Dismiss", "wordpress-seo" ),
 	} ) ), [ notifications ] );
 

--- a/packages/js/src/settings/components/search.js
+++ b/packages/js/src/settings/components/search.js
@@ -261,12 +261,7 @@ const Search = ( { buttonId = "button-search", modalId = "modal-search" } ) => {
 								onClick={ setClose }
 								className="yst-modal__close-button"
 							>
-								<span className="yst-sr-only">
-									{
-										/* translators: Hidden accessibility text. */
-										__( "Close", "wordpress-seo" )
-									}
-								</span>
+								<span className="yst-sr-only">{ __( "Close", "wordpress-seo" ) }</span>
 								<XIcon className="yst-h-6 yst-w-6" { ...ariaSvgProps } />
 							</button>
 						</div>

--- a/packages/js/src/settings/components/search.js
+++ b/packages/js/src/settings/components/search.js
@@ -261,7 +261,12 @@ const Search = ( { buttonId = "button-search", modalId = "modal-search" } ) => {
 								onClick={ setClose }
 								className="yst-modal__close-button"
 							>
-								<span className="yst-sr-only">{ __( "Close", "wordpress-seo" ) }</span>
+								<span className="yst-sr-only">
+									{
+										/* translators: Hidden accessibility text. */
+										__( "Close", "wordpress-seo" )
+									}
+								</span>
 								<XIcon className="yst-h-6 yst-w-6" { ...ariaSvgProps } />
 							</button>
 						</div>

--- a/packages/js/src/settings/routes/site-features.js
+++ b/packages/js/src/settings/routes/site-features.js
@@ -187,7 +187,12 @@ const SiteFeatures = () => {
 			<FormLayout>
 				<div className="yst-max-w-6xl">
 					<fieldset className="yst-min-w-0">
-						<legend className="yst-sr-only">{ __( "Writing", "wordpress-seo" ) }</legend>
+						<legend className="yst-sr-only">
+							{
+								/* translators: Hidden accessibility text. */
+								__( "Writing", "wordpress-seo" )
+							}
+						</legend>
 						<div className="yst-max-w-screen-sm yst-mb-8">
 							<Title as="h2" size="2">
 								{ __( "Writing", "wordpress-seo" ) }
@@ -252,7 +257,12 @@ const SiteFeatures = () => {
 					</fieldset>
 					<hr className="yst-my-8" />
 					<fieldset className="yst-min-w-0">
-						<legend className="yst-sr-only">{ __( "Site structure", "wordpress-seo" ) }</legend>
+						<legend className="yst-sr-only">
+							{
+								/* translators: Hidden accessibility text. */
+								__( "Site structure", "wordpress-seo" )
+							}
+						</legend>
 						<div className="yst-max-w-screen-sm yst-mb-8">
 							<Title as="h2" size="2">
 								{ __( "Site structure", "wordpress-seo" ) }
@@ -296,7 +306,12 @@ const SiteFeatures = () => {
 					</fieldset>
 					<hr className="yst-my-8" />
 					<fieldset id="section-social-sharing" className="yst-min-w-0">
-						<legend className="yst-sr-only">{ __( "Social sharing", "wordpress-seo" ) }</legend>
+						<legend className="yst-sr-only">
+							{
+								/* translators: Hidden accessibility text. */
+								__( "Social sharing", "wordpress-seo" )
+							}
+						</legend>
 						<div className="yst-max-w-screen-sm yst-mb-8">
 							<Title as="h2" size="2" className="yst-mb-2">
 								{ __( "Social sharing", "wordpress-seo" ) }
@@ -339,7 +354,12 @@ const SiteFeatures = () => {
 					</fieldset>
 					<hr className="yst-my-8" />
 					<fieldset className="yst-min-w-0">
-						<legend className="yst-sr-only">{ __( "Tools", "wordpress-seo" ) }</legend>
+						<legend className="yst-sr-only">
+							{
+								/* translators: Hidden accessibility text. */
+								__( "Tools", "wordpress-seo" )
+							}
+						</legend>
 						<div className="yst-max-w-screen-sm yst-mb-8">
 							<Title as="h2" size="2">
 								{ __( "Tools", "wordpress-seo" ) }
@@ -366,7 +386,12 @@ const SiteFeatures = () => {
 					</fieldset>
 					<hr className="yst-my-8" />
 					<fieldset className="yst-min-w-0">
-						<legend className="yst-sr-only">{ __( "APIs", "wordpress-seo" ) }</legend>
+						<legend className="yst-sr-only">
+							{
+								/* translators: Hidden accessibility text. */
+								__( "APIs", "wordpress-seo" )
+							}
+						</legend>
 						<div className="yst-max-w-screen-sm yst-mb-8">
 							<Title as="h2" size="2">
 								{ __( "APIs", "wordpress-seo" ) }

--- a/packages/js/src/settings/routes/site-features.js
+++ b/packages/js/src/settings/routes/site-features.js
@@ -187,12 +187,7 @@ const SiteFeatures = () => {
 			<FormLayout>
 				<div className="yst-max-w-6xl">
 					<fieldset className="yst-min-w-0">
-						<legend className="yst-sr-only">
-							{
-								/* translators: Hidden accessibility text. */
-								__( "Writing", "wordpress-seo" )
-							}
-						</legend>
+						<legend className="yst-sr-only">{ __( "Writing", "wordpress-seo" ) }</legend>
 						<div className="yst-max-w-screen-sm yst-mb-8">
 							<Title as="h2" size="2">
 								{ __( "Writing", "wordpress-seo" ) }
@@ -257,16 +252,9 @@ const SiteFeatures = () => {
 					</fieldset>
 					<hr className="yst-my-8" />
 					<fieldset className="yst-min-w-0">
-						<legend className="yst-sr-only">
-							{
-								/* translators: Hidden accessibility text. */
-								__( "Site structure", "wordpress-seo" )
-							}
-						</legend>
+						<legend className="yst-sr-only">{ __( "Site structure", "wordpress-seo" ) }</legend>
 						<div className="yst-max-w-screen-sm yst-mb-8">
-							<Title as="h2" size="2">
-								{ __( "Site structure", "wordpress-seo" ) }
-							</Title>
+							<Title as="h2" size="2">{ __( "Site structure", "wordpress-seo" ) }</Title>
 						</div>
 						<div className={ gridClassNames }>
 							<FeatureCard
@@ -306,16 +294,9 @@ const SiteFeatures = () => {
 					</fieldset>
 					<hr className="yst-my-8" />
 					<fieldset id="section-social-sharing" className="yst-min-w-0">
-						<legend className="yst-sr-only">
-							{
-								/* translators: Hidden accessibility text. */
-								__( "Social sharing", "wordpress-seo" )
-							}
-						</legend>
+						<legend className="yst-sr-only">{ __( "Social sharing", "wordpress-seo" ) }</legend>
 						<div className="yst-max-w-screen-sm yst-mb-8">
-							<Title as="h2" size="2" className="yst-mb-2">
-								{ __( "Social sharing", "wordpress-seo" ) }
-							</Title>
+							<Title as="h2" size="2" className="yst-mb-2">{ __( "Social sharing", "wordpress-seo" ) }</Title>
 						</div>
 						<div className={ gridClassNames }>
 							<FeatureCard
@@ -354,16 +335,9 @@ const SiteFeatures = () => {
 					</fieldset>
 					<hr className="yst-my-8" />
 					<fieldset className="yst-min-w-0">
-						<legend className="yst-sr-only">
-							{
-								/* translators: Hidden accessibility text. */
-								__( "Tools", "wordpress-seo" )
-							}
-						</legend>
+						<legend className="yst-sr-only">{ __( "Tools", "wordpress-seo" ) }</legend>
 						<div className="yst-max-w-screen-sm yst-mb-8">
-							<Title as="h2" size="2">
-								{ __( "Tools", "wordpress-seo" ) }
-							</Title>
+							<Title as="h2" size="2">{ __( "Tools", "wordpress-seo" ) }</Title>
 						</div>
 						<div className={ gridClassNames }>
 							<FeatureCard
@@ -386,16 +360,9 @@ const SiteFeatures = () => {
 					</fieldset>
 					<hr className="yst-my-8" />
 					<fieldset className="yst-min-w-0">
-						<legend className="yst-sr-only">
-							{
-								/* translators: Hidden accessibility text. */
-								__( "APIs", "wordpress-seo" )
-							}
-						</legend>
+						<legend className="yst-sr-only">{ __( "APIs", "wordpress-seo" ) }</legend>
 						<div className="yst-max-w-screen-sm yst-mb-8">
-							<Title as="h2" size="2">
-								{ __( "APIs", "wordpress-seo" ) }
-							</Title>
+							<Title as="h2" size="2">{ __( "APIs", "wordpress-seo" ) }</Title>
 						</div>
 						<div className={ gridClassNames }>
 							<FeatureCard

--- a/packages/js/src/settings/routes/site-features.js
+++ b/packages/js/src/settings/routes/site-features.js
@@ -145,7 +145,13 @@ const LearnMoreLink = ( { id, link, ariaLabel, ...props } ) => {
 			className="yst-flex yst-items-center yst-gap-1 yst-no-underline yst-font-medium"
 			target="_blank"
 			rel="noopener"
-			aria-label={ `Learn more about ${ ariaLabel } (Opens in a new browser tab)` }
+			aria-label={
+				sprintf(
+					/* translators: Hidden accessibility text; %s expands to a translated string of this feature, e.g. "SEO analysis". */
+					__( "Learn more about %s (Opens in a new browser tab)", "wordpress-seo" ),
+					ariaLabel
+				)
+			}
 			{ ...props }
 		>
 			{ __( "Learn more", "wordpress-seo" ) }

--- a/packages/js/src/shared-admin/components/ai-generate-titles-and-descriptions-upsell.js
+++ b/packages/js/src/shared-admin/components/ai-generate-titles-and-descriptions-upsell.js
@@ -78,7 +78,10 @@ export const AiGenerateTitlesAndDescriptionsUpsell = ( { learnMoreLink, upsellLi
 					<LockOpenIcon className="yst--ml-1 yst-mr-2 yst-h-5 yst-w-5" />
 					{ __( "Unlock with Premium", "wordpress-seo" ) }
 					<span className="yst-sr-only">
-						{ __( "(Opens in a new browser tab)", "wordpress-seo" ) }
+						{
+							/* translators: Hidden accessibility text. */
+							__( "(Opens in a new browser tab)", "wordpress-seo" )
+						}
 					</span>
 				</Button>
 			</div>

--- a/packages/js/src/shared-admin/components/outbound-link.js
+++ b/packages/js/src/shared-admin/components/outbound-link.js
@@ -11,7 +11,12 @@ import PropTypes from "prop-types";
 export const OutboundLink = ( { href, children, ...props } ) => (
 	<Link target="_blank" rel="noopener noreferrer" { ...props } href={ href }>
 		{ children }
-		<span className="yst-sr-only">{ __( "(Opens in a new browser tab)", "wordpress-seo" ) }</span>
+		<span className="yst-sr-only">
+			{
+				/* translators: Hidden accessibility text. */
+				__( "(Opens in a new browser tab)", "wordpress-seo" )
+			}
+		</span>
 	</Link>
 );
 OutboundLink.propTypes = {

--- a/packages/js/src/structured-data-blocks/how-to/components/HowTo.js
+++ b/packages/js/src/structured-data-blocks/how-to/components/HowTo.js
@@ -642,10 +642,7 @@ export default class HowTo extends Component {
 							htmlFor="schema-how-to-duration-hours"
 							className="screen-reader-text"
 						>
-							{
-								/* translators: Hidden accessibility text. */
-								__( "hours", "wordpress-seo" )
-							}
+							{ __( "hours", "wordpress-seo" ) }
 						</label>
 						<input
 							id="schema-how-to-duration-hours"
@@ -660,10 +657,7 @@ export default class HowTo extends Component {
 							htmlFor="schema-how-to-duration-minutes"
 							className="screen-reader-text"
 						>
-							{
-								/* translators: Hidden accessibility text. */
-								__( "minutes", "wordpress-seo" )
-							}
+							{ __( "minutes", "wordpress-seo" ) }
 						</label>
 						<input
 							id="schema-how-to-duration-minutes"

--- a/packages/js/src/structured-data-blocks/how-to/components/HowTo.js
+++ b/packages/js/src/structured-data-blocks/how-to/components/HowTo.js
@@ -624,7 +624,10 @@ export default class HowTo extends Component {
 							htmlFor="schema-how-to-duration-days"
 							className="screen-reader-text"
 						>
-							{ __( "days", "wordpress-seo" ) }
+							{
+								/* translators: Hidden accessibility text. */
+								__( "days", "wordpress-seo" )
+							}
 						</label>
 						<input
 							id="schema-how-to-duration-days"
@@ -639,7 +642,10 @@ export default class HowTo extends Component {
 							htmlFor="schema-how-to-duration-hours"
 							className="screen-reader-text"
 						>
-							{ __( "hours", "wordpress-seo" ) }
+							{
+								/* translators: Hidden accessibility text. */
+								__( "hours", "wordpress-seo" )
+							}
 						</label>
 						<input
 							id="schema-how-to-duration-hours"
@@ -654,7 +660,10 @@ export default class HowTo extends Component {
 							htmlFor="schema-how-to-duration-minutes"
 							className="screen-reader-text"
 						>
-							{ __( "minutes", "wordpress-seo" ) }
+							{
+								/* translators: Hidden accessibility text. */
+								__( "minutes", "wordpress-seo" )
+							}
 						</label>
 						<input
 							id="schema-how-to-duration-minutes"

--- a/packages/js/src/support/components/resource-card.js
+++ b/packages/js/src/support/components/resource-card.js
@@ -36,7 +36,10 @@ export const ResourceCard = ( { imageSrc, title, description, linkHref, linkText
 		>
 			{ linkText }
 			<span className="yst-sr-only">
-				{ __( "(Opens in a new browser tab)", "wordpress-seo" ) }
+				{
+					/* translators: Hidden accessibility text. */
+					__( "(Opens in a new browser tab)", "wordpress-seo" )
+				}
 			</span>
 			<ArrowSmRightIcon className="yst-h-4 yst-w-4 yst-ml-1 yst-icon-rtl" />
 		</Link>

--- a/packages/search-metadata-previews/src/snippet-preview/SnippetPreview.js
+++ b/packages/search-metadata-previews/src/snippet-preview/SnippetPreview.js
@@ -910,10 +910,7 @@ export default class SnippetPreview extends PureComponent {
 					<PartContainer>
 						{ this.renderUrl() }
 						<ScreenReaderText>
-							{
-								/* translators: Hidden accessibility text. */
-								__( "SEO title preview", "wordpress-seo" ) + ":"
-							}
+							{ __( "SEO title preview", "wordpress-seo" ) + ":" }
 						</ScreenReaderText>
 						<SnippetTitle
 							onMouseUp={ onMouseUp.bind( null, "title" ) }
@@ -930,10 +927,7 @@ export default class SnippetPreview extends PureComponent {
 					</PartContainer>
 					<PartContainer>
 						<ScreenReaderText>
-							{
-								/* translators: Hidden accessibility text. */
-								__( "Meta description preview:", "wordpress-seo" )
-							}
+							{ __( "Meta description preview:", "wordpress-seo" ) }
 						</ScreenReaderText>
 						{ this.renderDescription() }
 					</PartContainer>

--- a/packages/search-metadata-previews/src/snippet-preview/SnippetPreview.js
+++ b/packages/search-metadata-previews/src/snippet-preview/SnippetPreview.js
@@ -662,7 +662,10 @@ export default class SnippetPreview extends PureComponent {
 		/* eslint-disable jsx-a11y/mouse-events-have-key-events */
 		return <React.Fragment>
 			<ScreenReaderText>
-				{ __( "Url preview", "wordpress-seo" ) + ":" }
+				{
+					/* translators: Hidden accessibility text. */
+					__( "Url preview", "wordpress-seo" ) + ":"
+				}
 			</ScreenReaderText>
 			<Url>
 				<BaseUrlOverflowContainer
@@ -836,7 +839,10 @@ export default class SnippetPreview extends PureComponent {
 			return (
 				<PartContainer className="yoast-shopping-data-preview--desktop">
 					<ScreenReaderText>
-						{ __( "Shopping data preview:", "wordpress-seo" ) }
+						{
+							/* translators: Hidden accessibility text. */
+							__( "Shopping data preview:", "wordpress-seo" )
+						}
 					</ScreenReaderText>
 					<ProductDataDesktop shoppingData={ safeShoppingData } />
 				</PartContainer>
@@ -847,7 +853,10 @@ export default class SnippetPreview extends PureComponent {
 			return (
 				<PartContainer className="yoast-shopping-data-preview--mobile">
 					<ScreenReaderText>
-						{ __( "Shopping data preview:", "wordpress-seo" ) }
+						{
+							/* translators: Hidden accessibility text. */
+							__( "Shopping data preview:", "wordpress-seo" )
+						}
 					</ScreenReaderText>
 					<ProductDataMobile shoppingData={ safeShoppingData } />
 				</PartContainer>
@@ -901,7 +910,10 @@ export default class SnippetPreview extends PureComponent {
 					<PartContainer>
 						{ this.renderUrl() }
 						<ScreenReaderText>
-							{ __( "SEO title preview", "wordpress-seo" ) + ":" }
+							{
+								/* translators: Hidden accessibility text. */
+								__( "SEO title preview", "wordpress-seo" ) + ":"
+							}
 						</ScreenReaderText>
 						<SnippetTitle
 							onMouseUp={ onMouseUp.bind( null, "title" ) }
@@ -918,7 +930,10 @@ export default class SnippetPreview extends PureComponent {
 					</PartContainer>
 					<PartContainer>
 						<ScreenReaderText>
-							{ __( "Meta description preview:", "wordpress-seo" ) }
+							{
+								/* translators: Hidden accessibility text. */
+								__( "Meta description preview:", "wordpress-seo" )
+							}
 						</ScreenReaderText>
 						{ this.renderDescription() }
 					</PartContainer>

--- a/src/integrations/admin/link-count-columns-integration.php
+++ b/src/integrations/admin/link-count-columns-integration.php
@@ -135,6 +135,7 @@ class Link_Count_Columns_Integration implements Integration_Interface {
 		$columns[ 'wpseo-' . self::COLUMN_LINKS ] = \sprintf(
 			'<span class="yoast-linked-to yoast-column-header-has-tooltip" data-tooltip-text="%1$s"><span class="screen-reader-text">%2$s</span></span>',
 			\esc_attr__( 'Number of outgoing internal links in this post. See "Yoast Columns" text in the help tab for more info.', 'wordpress-seo' ),
+			/* translators: Hidden accessibility text. */
 			\esc_html__( 'Outgoing internal links', 'wordpress-seo' )
 		);
 
@@ -142,6 +143,7 @@ class Link_Count_Columns_Integration implements Integration_Interface {
 			$columns[ 'wpseo-' . self::COLUMN_LINKED ] = \sprintf(
 				'<span class="yoast-linked-from yoast-column-header-has-tooltip" data-tooltip-text="%1$s"><span class="screen-reader-text">%2$s</span></span>',
 				\esc_attr__( 'Number of internal links linking to this post. See "Yoast Columns" text in the help tab for more info.', 'wordpress-seo' ),
+				/* translators: Hidden accessibility text. */
 				\esc_html__( 'Received internal links', 'wordpress-seo' )
 			);
 		}

--- a/src/integrations/admin/workouts-integration.php
+++ b/src/integrations/admin/workouts-integration.php
@@ -207,6 +207,7 @@ class Workouts_Integration implements Integration_Interface {
 			);
 			$button = '<a class="yoast-button yoast-button-upsell yoast-button--small" href="' . \esc_url( $url ) . '" target="_blank">'
 					. \esc_html__( 'Renew your subscription', 'wordpress-seo' )
+					/* translators: Hidden accessibility text. */
 					. '<span class="screen-reader-text">' . \__( '(Opens in a new browser tab)', 'wordpress-seo' ) . '</span>'
 					. '<span aria-hidden="true" class="yoast-button-upsell__caret"></span>'
 					. '</a>';
@@ -236,6 +237,7 @@ class Workouts_Integration implements Integration_Interface {
 			);
 			$button = '<a class="yoast-button yoast-button--primary yoast-button--small" href="' . \esc_url( $url_button ) . '" target="_blank">'
 					. \esc_html__( 'Get help activating your subscription', 'wordpress-seo' )
+					/* translators: Hidden accessibility text. */
 					. '<span class="screen-reader-text">' . \__( '(Opens in a new browser tab)', 'wordpress-seo' ) . '</span>'
 					. '</a>';
 		}

--- a/src/presenters/admin/help-link-presenter.php
+++ b/src/presenters/admin/help-link-presenter.php
@@ -72,7 +72,8 @@ class Help_Link_Presenter extends Abstract_Presenter {
 
 		if ( $this->opens_in_new_browser_tab ) {
 			$target_blank_attribute = ' target="_blank"';
-			$new_tab_message        = ' ' . \__( '(Opens in a new browser tab)', 'wordpress-seo' );
+			/* translators: Hidden accessibility text. */
+			$new_tab_message = ' ' . \__( '(Opens in a new browser tab)', 'wordpress-seo' );
 		}
 
 		return \sprintf(


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Improve translator context by adding a `Hidden accessibility text.` comment whenever translations are _only_ used in either screen reader texts or aria labels. To be clear: this means searching for the same translation in the same text domain, if it is used in any other context than screen reader/aria label that means no comment should be there. This is due comments appearing above _all_ the references.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds mark above translations that are used only for screen readers.
* [@yoast/components 0.0.1] Adds mark above translations that are used only for screen readers.
* [@yoast/search-metadata-previews 0.0.1] Adds mark above translations that are used only for screen readers.
* [@yoast/components 0.0.1] Removes translation around variable in the HelpIcon component. The `linkText` prop is expected to already be translated. 
* Fixes a bug where the `aria-label` text of the `Learn more` links in the Site features settings where not translated.

## Relevant technical choices:

* I went with the WP version: `/* translators: Hidden accessibility text. */`.
* Out of scope changes:
  * Ignoring PHPCS output not escaped instance where I saw it was all properly escaped above.
  * Removing the `__()` around the `linkText` prop of the HelpIcon component.
    * AFAIK, the retrieving of translations won't follow variables. Coincidentally, the implementers of this variable seem to all already call `__()` on the string itself.
  * Fixing an untranslated aria-label in settings -> site features.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* It would be nice to have a search yourself, to see if I missed any instances?
  * Note that I intentionally ignored where the variable was used in more than just the screen reader, or in apps, or deprecated. Or when the same translation was used in a non screen reader capacity elsewhere.
* The comments should show up in the `.pot` file after running the i18n grunt task.
* Not really testable until translations are there, but when they are there:
  * Switch site away from English
  * Go to Yoast settings -> Site features
  * Verify the `aria-label` of the `Learn more` links are translated

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Not really testable until translations are there, but when they are there:
  * Switch site away from English
  * Go to Yoast settings -> Site features
  * Verify the `aria-label` of the `Learn more` links are translated
* The rest is not testable, since its only code comments.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Should only be comments in the code, without any consequences in production.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/wordpress-seo/issues/19854
