### PR TITLE
Composer: normalize the file, add script descriptions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -149,5 +149,30 @@
 			"Yoast\\WP\\SEO\\Composer\\Actions::prefix_dependencies",
 			"composer compile-di"
 		]
+	},
+	"scripts-descriptions": {
+		"lint": "Check the PHP files for parse errors.",
+		"lint-files": "Internal use.",
+		"lint-branch": "Check the PHP files changed in the current branch for parse errors.",
+		"lint-staged": "Check the staged PHP files for parse errors.",
+		"cs": "See a menu with the code style checking script options.",
+		"check-cs-thresholds": "Check the PHP files for code style violations and best practices and verify the number of issues does not exceed predefined thresholds.",
+		"check-cs": "Check the PHP files for code style violations and best practices, ignoring warnings.",
+		"check-cs-errors": "Alias for check-cs command",
+		"check-cs-warnings": "Check the PHP files for code style violations and best practices, including warnings.",
+		"check-staged-cs": "Check the staged PHP files for code style violations and best practices.",
+		"check-branch-cs": "Check the PHP files changed in the current branch for code style violations and best practices.",
+		"fix-cs": "Auto-fix code style violations in the PHP files.",
+		"test": "Run the unit tests without code coverage.",
+		"coverage": "Run the unit tests with code coverage.",
+		"integration-test": "Run the integration tests without code coverage.",
+		"integration-coverage": "Run the integration tests with code coverage.",
+		"prefix-dependencies": "Create the vendor_prefixed directory.",
+		"prefix-oauth2-client": "Prefix the OAuth2 Client dependencies and place them in the vendor_prefixed directory.",
+		"prefix-symfony": "Prefix the Symfony dependencies and place them in the vendor_prefixed directory.",
+		"prefix-wordproof": "Prefix the WordProof dependencies and place them in the vendor_prefixed directory.",
+		"compile-di": "Compile the dependency injection layer.",
+		"generate-migration": "Generate a migration.",
+		"generate-unit-test": "Generates a unit test template for the fully qualified class provided as a CLI arg."
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -1,12 +1,12 @@
 {
 	"name": "yoast/wordpress-seo",
 	"description": "Improve your WordPress SEO: Write better content and have a fully optimized WordPress site using the Yoast SEO plugin.",
+	"license": "GPL-2.0-or-later",
+	"type": "wordpress-plugin",
 	"keywords": [
 		"wordpress",
 		"seo"
 	],
-	"homepage": "https://yoa.st/1ui",
-	"license": "GPL-2.0-or-later",
 	"authors": [
 		{
 			"name": "Team Yoast",
@@ -14,7 +14,7 @@
 			"homepage": "https://yoa.st/1--"
 		}
 	],
-	"type": "wordpress-plugin",
+	"homepage": "https://yoa.st/1ui",
 	"support": {
 		"issues": "https://github.com/Yoast/wordpress-seo/issues",
 		"forum": "https://wordpress.org/support/plugin/wordpress-seo",
@@ -26,16 +26,16 @@
 		"composer/installers": "^1.12 || ^2.0"
 	},
 	"require-dev": {
+		"guzzlehttp/guzzle": "7.8.0",
 		"humbug/php-scoper": "^0.13.4",
 		"league/oauth2-client": "2.7.0",
 		"psr/container": "1.0.0",
 		"psr/log": "^1.0",
 		"symfony/config": "^3.4",
 		"symfony/dependency-injection": "^3.4",
+		"wordproof/wordpress-sdk": "1.3.5",
 		"yoast/wp-test-utils": "^1.1.1",
-		"yoast/yoastcs": "^2.3.1",
-		"guzzlehttp/guzzle": "7.8.0",
-		"wordproof/wordpress-sdk": "1.3.5"
+		"yoast/yoastcs": "^2.3.1"
 	},
 	"minimum-stability": "dev",
 	"prefer-stable": true,
@@ -53,6 +53,16 @@
 			"tests/",
 			"config/"
 		]
+	},
+	"config": {
+		"allow-plugins": {
+			"dealerdirect/phpcodesniffer-composer-installer": true,
+			"composer/package-versions-deprecated": true,
+			"composer/installers": true
+		},
+		"platform": {
+			"php": "7.2.5"
+		}
 	},
 	"scripts": {
 		"test": [
@@ -139,15 +149,5 @@
 		"generate-unit-test": [
 			"Yoast\\WP\\SEO\\Composer\\Actions::generate_unit_test"
 		]
-	},
-	"config": {
-    	"platform": {
-			"php": "7.2.5"
-		},
-		"allow-plugins": {
-			"dealerdirect/phpcodesniffer-composer-installer": true,
-			"composer/package-versions-deprecated": true,
-			"composer/installers": true
-		}
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -65,18 +65,6 @@
 		}
 	},
 	"scripts": {
-		"test": [
-			"@php ./vendor/phpunit/phpunit/phpunit --no-coverage"
-		],
-		"coverage": [
-			"@php ./vendor/phpunit/phpunit/phpunit"
-		],
-		"integration-test": [
-			"@php ./vendor/phpunit/phpunit/phpunit -c phpunit-integration.xml.dist --no-coverage"
-		],
-		"integration-coverage": [
-			"@php ./vendor/phpunit/phpunit/phpunit -c phpunit-integration.xml.dist"
-		],
 		"lint": [
 			"@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --show-deprecated --exclude vendor --exclude node_modules --exclude .git"
 		],
@@ -116,6 +104,18 @@
 		"fix-cs": [
 			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf"
 		],
+		"test": [
+			"@php ./vendor/phpunit/phpunit/phpunit --no-coverage"
+		],
+		"coverage": [
+			"@php ./vendor/phpunit/phpunit/phpunit"
+		],
+		"integration-test": [
+			"@php ./vendor/phpunit/phpunit/phpunit -c phpunit-integration.xml.dist --no-coverage"
+		],
+		"integration-coverage": [
+			"@php ./vendor/phpunit/phpunit/phpunit -c phpunit-integration.xml.dist"
+		],
 		"prefix-dependencies": [
 			"composer prefix-oauth2-client",
 			"composer prefix-symfony",
@@ -139,15 +139,15 @@
 			"composer du --no-scripts",
 			"Yoast\\WP\\SEO\\Composer\\Actions::compile_dependency_injection_container"
 		],
-		"post-autoload-dump": [
-			"Yoast\\WP\\SEO\\Composer\\Actions::prefix_dependencies",
-			"composer compile-di"
-		],
 		"generate-migration": [
 			"Yoast\\WP\\SEO\\Composer\\Actions::generate_migration"
 		],
 		"generate-unit-test": [
 			"Yoast\\WP\\SEO\\Composer\\Actions::generate_unit_test"
+		],
+		"post-autoload-dump": [
+			"Yoast\\WP\\SEO\\Composer\\Actions::prefix_dependencies",
+			"composer compile-di"
 		]
 	}
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cfc42583bbfee6d1fd714d8de5c29edc",
+    "content-hash": "8d22b68e86ccc7840900566af2880cc4",
     "packages": [
         {
             "name": "composer/installers",


### PR DESCRIPTION
## Context

* Tidy up `composer.json` file and improve usability of scripts

## Summary

This PR can be summarized in the following changelog entry:

* Tidy up `composer.json` file and improve usability of scripts

## Relevant technical choices:

### Composer: normalize the file

Well, mostly (scripts are not alphabetized, but still grouped by task).

Note: this is done as a one-time only action. The normalize script will **_not_** be run in CI to enforce normalization.

Style has been standardized to `--indent-style=tab --indent-size=1`.

Ref: https://github.com/ergebnis/composer-normalize

### Composer: order the scripts by category

### Composer: add script descriptions

These descriptions will be used when a list of the available scripts is requested on the command-line using the `composer list` or `composer run -l` commands.

These descriptions also help document the different scripts for the maintainers of the `composer.json` file.

Ref: https://getcomposer.org/doc/articles/scripts.md#custom-descriptions-

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_