### PR TITLE
131 remove automatic rel on rss links

### DIFF
--- a/src/integrations/front-end/rss-footer-embed.php
+++ b/src/integrations/front-end/rss-footer-embed.php
@@ -182,13 +182,13 @@ class RSS_Footer_Embed implements Integration_Interface {
 	protected function get_link_template() {
 		/**
 		 * Filter: 'nofollow_rss_links' - Allow the developer to determine whether or not to follow the links in
-		 * the bits Yoast SEO adds to the RSS feed, defaults to true.
+		 * the bits Yoast SEO adds to the RSS feed, defaults to false.
 		 *
 		 * @api bool $unsigned Whether or not to follow the links in RSS feed, defaults to true.
 		 *
 		 * @since 1.4.20
 		 */
-		if ( \apply_filters( 'nofollow_rss_links', true ) ) {
+		if ( \apply_filters( 'nofollow_rss_links', false ) ) {
 			return '<a rel="nofollow" href="%1$s">%2$s</a>';
 		}
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Until now, the default for links in the RSS feed was to have a `rel=nofollow` attribute attached to each of them by default.  
* This PR switches the default so that `nofollow` is not added to RSS links, because it is no longer necessary from an SEO perspective. 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Removes the automatic `rel=nofollow` attribute for links in the RSS feed.
* [yoastseo] Switches the default setting of the `nofollow_rss_links` filter from `true` to `false` in order to disable the `rel=nofollow` attribute for RSS feed links.

## Relevant technical choices:

* 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Testing in the released version
* Create and publish new post with any link in content.
* Open RSS feed by adding /feed to the site url. Like https://wordpress.test/feed/ .
  * Note: the URL should be the homepage of your site, rather than the URL of the post you created above. 
* Confirm links have the **rel=nofollow** attribute. You can search (`cmd F`) for the word `nofollow`. 
#### Testing this change
* Create and publish new post with  any link in content.
  * Open rss feed by adding /feed to the site url. Like https://wordpress.test/feed/ .
  * Make sure that links doesn't have **rel=nofollow** attribute.
* Open the post created while testing the released version
  * Open rss feed by adding /feed to the site url. Like https://wordpress.test/feed/ .
  * Make sure that links doesn't have **rel=nofollow** attribute. 

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* None.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [x] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [#131](https://github.com/Yoast/reserved-tasks/issues/131)
