### PR TITLE
Make em and en dashes word boundaries

### DIFF
--- a/packages/yoastseo/spec/languageProcessing/AbstractResearcherSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/AbstractResearcherSpec.js
@@ -140,7 +140,7 @@ describe( "Adding a custom config to a Researcher", function() {
 			researcher.addConfig( "", {} );
 		} ).toThrowError( MissingArgument );
 
-		expect( Object.keys( researcher.config ).length ).toEqual( 0 );
+		expect( Object.keys( researcher.config ).length ).toEqual( 1 );
 	} );
 
 	it( "throws an error if an empty object is given as the config", function() {
@@ -148,7 +148,7 @@ describe( "Adding a custom config to a Researcher", function() {
 			researcher.addConfig( "pets", {} );
 		} ).toThrowError( MissingArgument );
 
-		expect( Object.keys( researcher.config ).length ).toEqual( 0 );
+		expect( Object.keys( researcher.config ).length ).toEqual( 1 );
 	} );
 
 	it( "throws an error if no config is given", function() {
@@ -156,26 +156,27 @@ describe( "Adding a custom config to a Researcher", function() {
 			researcher.addConfig( "pets" );
 		} ).toThrowError( MissingArgument );
 
-		expect( Object.keys( researcher.config ).length ).toEqual( 0 );
+		expect( Object.keys( researcher.config ).length ).toEqual( 1 );
 	} );
 
 	it( "adds a config to the config object", function() {
-		expect( Object.keys( researcher.config ).length ).toEqual( 0 );
+		expect( Object.keys( researcher.config ).length ).toEqual( 1 );
 		const petsList1 = [ "cats", "dogs", "rabbits" ];
 		researcher.addConfig( "pets", petsList1 );
-		expect( Object.keys( researcher.config ).length ).toEqual( 1 );
+		expect( Object.keys( researcher.config ).length ).toEqual( 2 );
 		expect( researcher.getConfig( "pets" ) ).toEqual( petsList1 );
 	} );
 
-	it( "overwrites a helper in the helpers object", function() {
+	it( "overwrites a config in the config object", function() {
 		expect( Object.keys( researcher.config ).length ).toEqual( 1 );
 		const petsList2 = [ "birds", "horses", "tortoise" ];
 
 		researcher.addConfig( "pets", petsList2 );
-		expect( Object.keys( researcher.config ).length ).toEqual( 1 );
+		expect( Object.keys( researcher.config ).length ).toEqual( 2 );
 		expect( researcher.hasConfig( "pets" ) ).toBeTruthy();
 		expect( researcher.getConfig( "pets" ) ).toEqual( petsList2 );
 		expect( researcher.getAvailableConfig() ).toEqual( {
+			areHyphensWordBoundaries: true,
 			pets: [ "birds", "horses", "tortoise" ],
 		} );
 	} );

--- a/packages/yoastseo/spec/languageProcessing/helpers/morphology/buildTopicStemsSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/helpers/morphology/buildTopicStemsSpec.js
@@ -4,13 +4,13 @@ import baseStemmer from "../../../../src/languageProcessing/helpers/morphology/b
 describe( "A test for building stems for an array of words", function() {
 	it( "returns an empty array if the input keyphrase is undefined", function() {
 		let keyphrase;
-		const forms = buildStems( keyphrase, baseStemmer, [] );
+		const forms = buildStems( keyphrase, baseStemmer, [], true );
 		expect( forms ).toEqual( new TopicPhrase( [], false )  );
 	} );
 
 	it( "returns the exact match if the input string is embedded in quotation marks (the language and morphAnalyzer do not matter)", function() {
 		const keyphrase = "\"I am going for a walk\"";
-		const forms = buildStems( keyphrase, baseStemmer, [] );
+		const forms = buildStems( keyphrase, baseStemmer, [], true );
 		expect( forms ).toEqual(
 			new TopicPhrase(
 				[ new StemOriginalPair( "I am going for a walk", keyphrase.substring( 1, keyphrase.length - 1 ) ) ],
@@ -21,7 +21,7 @@ describe( "A test for building stems for an array of words", function() {
 
 	it( "returns all (content) words if there is function words and no language specific stemmer for this language yet ", function() {
 		const functionWords = [ "kowe", "iki" ];
-		const forms = buildStems( "kowe budal makaryo", baseStemmer, functionWords );
+		const forms = buildStems( "kowe budal makaryo", baseStemmer, functionWords, true );
 		expect( forms ).toEqual(
 			new TopicPhrase(
 				[ new StemOriginalPair( "budal", "budal" ), new StemOriginalPair( "makaryo", "makaryo" ) ],
@@ -30,16 +30,32 @@ describe( "A test for building stems for an array of words", function() {
 	} );
 
 	it( "returns all (content) words if there is no language specific stemmer and no function words for this language yet", function() {
-		const forms = buildStems( "kowe lungo", baseStemmer, [] );
+		const forms = buildStems( "kowe lungo", baseStemmer, [], true );
 		expect( forms ).toEqual(
 			new TopicPhrase(
 				[ new StemOriginalPair( "kowe", "kowe" ), new StemOriginalPair( "lungo", "lungo" ) ],
 				false )
 		);
 	} );
+	it( "splits keyphrase on hyphen when hyphens should be considered word boundaries", function() {
+		const forms = buildStems( "kowe-lungo", baseStemmer, [], true );
+		expect( forms ).toEqual(
+			new TopicPhrase(
+				[ new StemOriginalPair( "kowe", "kowe" ), new StemOriginalPair( "lungo", "lungo" ) ],
+				false )
+		);
+	} );
+	it( "does not split keyphrase on hyphen when hyphens shouldn't be considered word boundaries", function() {
+		const forms = buildStems( "kowe-lungo", baseStemmer, [], false );
+		expect( forms ).toEqual(
+			new TopicPhrase(
+				[ new StemOriginalPair( "kowe-lungo", "kowe-lungo" ) ],
+				false )
+		);
+	} );
 	it( "returns all words if all words in keyphrase are function words", function() {
 		const functionWords = [ "I", "am", "small" ];
-		const forms = buildStems( "I am small", baseStemmer, functionWords );
+		const forms = buildStems( "I am small", baseStemmer, functionWords, true );
 		expect( forms ).toEqual(
 			new TopicPhrase(
 				[ new StemOriginalPair( "I", "I" ),
@@ -172,7 +188,7 @@ describe( "A test for topic phrase objects", function() {
 			new StemOriginalPair( "movie", "movies" ),
 			new StemOriginalPair( "work", "work" ),
 		],
-		false,
+		false
 	);
 
 	it( "constructs a topic phrase", () => {
@@ -206,7 +222,7 @@ describe( "A test for topic phrase objects", function() {
 				new StemOriginalPair( "movie", "movie" ),
 				new StemOriginalPair( "work", "work" ),
 			],
-			true,
+			true
 		);
 		expect( exactMatchTopicPhrase.getStems() ).toEqual( [] );
 	} );

--- a/packages/yoastseo/spec/languageProcessing/helpers/morphology/getAllWordsFromPaperSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/helpers/morphology/getAllWordsFromPaperSpec.js
@@ -19,11 +19,31 @@ const testPaper = new Paper( text, {
 	slug: "science-environment-55239628",
 } );
 
-describe( "Test for getting all words found in the text, title, slug and meta description of a given paper", () => {
+describe( "Test for getting all words found in the text, title, slug and meta description of a given paper when hyphens" +
+	"should be treated as word boundaries", () => {
 	it( "gets all words found in the text, title, slug and meta description of a given paper", () => {
 		const researcher = new EnglishResearcher( testPaper );
 		buildTree( testPaper, researcher );
-		expect( getAllWordsFromPaper( testPaper ) ).toEqual(  [ "Codenamed", "SN8", "the", "uncrewed", "rocket",
+		expect( getAllWordsFromPaper( testPaper, true ) ).toEqual(  [ "Codenamed", "SN8", "the", "uncrewed", "rocket",
+			"lifted", "away", "from", "the", "Boca", "Chica", "R&D", "facility", "on", "what", "had", "been", "billed",
+			"as", "a", "brief", "flight", "to", "12\\.5km", "41,000ft", "The", "50m", "tall", "vehicle", "crashed", "on",
+			"touchdown", "but", "Mr", "Musk", "was", "delighted", "with", "how", "much", "the", "test", "outing", "achieved",
+			"Before", "the", "flight", "the", "tech", "billionaire", "had", "dampened", "expectations", "warning", "his", "fans",
+			"that", "some", "mishap", "was", "likely", "Nonetheless", "Musk", "has", "big", "hopes", "for", "the", "Starship", "when",
+			"it", "is", "fully", "developed", "He", "says", "it", "is", "the", "future", "for", "his", "SpaceX", "company",
+			"Starship", "will", "launch", "people", "and", "cargo", "into", "orbit", "and", "the", "entrepreneur", "also",
+			"envisages", "the", "vehicle", "travelling", "to", "the", "Moon", "and", "Mars", "The", "SpaceX", "CEO", "praised",
+			"his", "team", "adding", "that", "the", "demonstration", "had", "acquired", "all", "the", "data", "we", "needed",
+			"Mars", "here", "we", "come", "he", "tweeted", "Elon", "Musk's", "Starship", "prototype", "makes", "a",
+			"big", "impact", "science", "environment", "55239628", "science", "environment", "55239628", "US", "entrepreneur",
+			"Elon", "Musk", "has", "launched", "the", "latest", "prototype", "of", "his", "Starship", "vehicle", "from",
+			"Texas", "a", "test" ] );
+	} );
+	it( "gets all words found in the text, title, slug and meta description of a given paper when hyphens shouldn't be treated" +
+		"as word boundaries", () => {
+		const researcher = new EnglishResearcher( testPaper );
+		buildTree( testPaper, researcher );
+		expect( getAllWordsFromPaper( testPaper, false ) ).toEqual(  [ "Codenamed", "SN8", "the", "uncrewed", "rocket",
 			"lifted", "away", "from", "the", "Boca", "Chica", "R&D", "facility", "on", "what", "had", "been", "billed",
 			"as", "a", "brief", "flight", "to", "12\\.5km", "41,000ft", "The", "50m-tall", "vehicle", "crashed", "on",
 			"touchdown", "but", "Mr", "Musk", "was", "delighted", "with", "how", "much", "the", "test", "outing", "achieved",

--- a/packages/yoastseo/spec/languageProcessing/helpers/word/getWordsForHTMLParserSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/helpers/word/getWordsForHTMLParserSpec.js
@@ -1,6 +1,5 @@
 import getWordsForHTMLParser from "../../../../src/languageProcessing/helpers/word/getWordsForHTMLParser";
 
-
 const testCases = [
 	{
 		description: "returns an empty array for an empty string",
@@ -25,7 +24,7 @@ const testCases = [
 	{
 		description: "correctly tokenizes a phrase with a hyphen",
 		text: "a-hyphenated-phrase",
-		expectedResult: [ "a-hyphenated-phrase" ],
+		expectedResult: [ "a", "-", "hyphenated", "-", "phrase" ],
 	},
 	{
 		description: "correctly tokenizes a phrase with an apostrophe",
@@ -56,7 +55,7 @@ const testCases = [
 		description: "correctly tokenizes a phrase that is separated by non-breaking spaces",
 		text: "a\u00a0phrase\u00a0that\u00a0is\u00a0separated\u00a0by\u00a0non-breaking\u00a0spaces",
 		expectedResult: [ "a", "\u00a0", "phrase", "\u00a0", "that", "\u00a0", "is", "\u00a0", "separated", "\u00a0", "by", "\u00a0",
-			"non-breaking", "\u00a0", "spaces" ],
+			"non", "-", "breaking", "\u00a0", "spaces" ],
 	},
 	{
 		description: "correctly tokenizes a phrase that is separated by tabs",
@@ -78,5 +77,12 @@ const testCases = [
 describe.each( testCases )( "getWordsForHTMLParser", ( { description, text, expectedResult } ) => {
 	it( description, () => {
 		expect( getWordsForHTMLParser( text ) ).toEqual( expectedResult );
+	} );
+} );
+
+describe( "A test for getting words with a custom word separator regex", () => {
+	it( "Doesn't split the string on hyphens if they are not part of the regex", () => {
+		expect( getWordsForHTMLParser( "Lorem ipsum, keyword-keyword, keyword elit.", /([\s\t\u00A0\u2014])/ ) ).toEqual(
+			[ "Lorem", " ", "ipsum", ",", " ", "keyword-keyword", ",", " ", "keyword", " ", "elit", "." ] );
 	} );
 } );

--- a/packages/yoastseo/spec/languageProcessing/helpers/word/getWordsSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/helpers/word/getWordsSpec.js
@@ -50,7 +50,7 @@ describe( "a test for getting words from a sentence", function() {
 
 	it( "doesn't remove punctuation when doRemovePunctuation is false.", () => {
 		const text = "A sentence with words. And some; punctuation.";
-		const words = getWords( text, false );
+		const words = getWords( text, "\\s", false );
 
 		expect( words ).toEqual( [
 			"A",
@@ -79,6 +79,13 @@ describe( "a test for getting words from a sentence", function() {
 		expect( getWords( text ).length ).toBe( 23 );
 		expect( getWords( text ) ).toEqual( [ "A", "very", "intelligent", "cat", "loves", "their", "human", "A", "dog",
 			"is", "very", "cute", "A", "subheading", "3", "text", "text", "text", "A", "subheading", "4", "more", "text" ] );
+	} );
+
+	it( "gets words when a non-default word boundary regex is used", function() {
+		const text = "Exercise is good for your cat's well-being but giving too many treats post–exercise is not";
+		expect( getWords( text, "[\\s\\u2013\\u002d]" ).length ).toBe( 17 );
+		expect( getWords( text, "[\\s\\u2013\\u002d]" ) ).toEqual( [ "Exercise", "is", "good",
+			"for", "your", "cat's", "well", "being", "but", "giving", "too", "many", "treats", "post", "exercise", "is", "not" ] );
 	} );
 } );
 

--- a/packages/yoastseo/spec/languageProcessing/researches/getKeywordDensitySpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/getKeywordDensitySpec.js
@@ -60,7 +60,7 @@ describe( "Test for counting the keyword density in a text with an English resea
 		expect( getKeywordDensity( mockPaper, new EnglishResearcher( mockPaper ) ) ).toBe( 0 );
 	} );
 
-	it( "should recognize a multiword keyphrase when it is occurs hyphenated", function() {
+	it( "should recognize a multiword keyphrase when it occurs hyphenated", function() {
 		const mockPaper = new Paper( "<p>a string of text with the key-word in it, density should be 7.7%</p>", { keyword: "key word" } );
 		const mockResearcher = new EnglishResearcher( mockPaper );
 

--- a/packages/yoastseo/spec/languageProcessing/researches/keywordCountInUrlSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/keywordCountInUrlSpec.js
@@ -200,18 +200,19 @@ describe( "test to check slug for keyword", function() {
 		expect( slugKeyword( paper, researcher ) ).toEqual( { keyphraseLength: 2, percentWordMatches: 100 } );
 	} );
 
-	it( "works with dash within the keyword in the slug", function() {
+	it( "works with multiple dashes within the keyword in the slug", function() {
 		const paper = new Paper( "", { slug: "on-the-go", keyword: "on-the-go" } );
 		const researcher = new EnglishResearcher( paper );
 		researcher.addResearchData( "morphology", morphologyData );
 		expect( slugKeyword( paper, researcher ) ).toEqual( { keyphraseLength: 3, percentWordMatches: 100 } );
 	} );
 
-	it( "works with dash within the keyword in the slug", function() {
+	it( "works with a dash in one of the words within the keyword", function() {
 		const paper = new Paper( "", { slug: "two-room-apartment", keyword: "two-room apartment" } );
 		const researcher = new EnglishResearcher( paper );
 		researcher.addResearchData( "morphology", morphologyData );
-		expect( slugKeyword( paper, researcher ) ).toEqual( { keyphraseLength: 3, percentWordMatches: 100 } );
+		// 'Two' is a function word so it's not counted in the keyphrase length - that's why the keyphrase length is 2.
+		expect( slugKeyword( paper, researcher ) ).toEqual( { keyphraseLength: 2, percentWordMatches: 100 } );
 	} );
 
 	it( "morphology works for hyphenated keyphrases", function() {
@@ -222,18 +223,40 @@ describe( "test to check slug for keyword", function() {
 	} );
 
 	it( "morphology works for hyphenated keyphrases with function words", function() {
-		const paper = new Paper( "", { slug: "two-year-old", keyword: "two-year-olds" } );
+		const paper = new Paper( "", { slug: "husband-to-be", keyword: "husbands-to-be" } );
+		const researcher = new EnglishResearcher( paper );
+		researcher.addResearchData( "morphology", morphologyData );
+		// 'To' and 'be' are function words so they're not counted in the keyphrase length - that's why the keyphrase length is 1.
+		expect( slugKeyword( paper, researcher ) ).toEqual( { keyphraseLength: 1, percentWordMatches: 100 } );
+	} );
+
+	it( "morphology works for partially hyphenated keyphrases with function words", function() {
+		const paper = new Paper( "", { slug: "gift-for-mother-in-law", keyword: "gifts for mothers-in-law" } );
 		const researcher = new EnglishResearcher( paper );
 		researcher.addResearchData( "morphology", morphologyData );
 		expect( slugKeyword( paper, researcher ) ).toEqual( { keyphraseLength: 3, percentWordMatches: 100 } );
 	} );
 
-	// Does not work yet.
+	/*
+	 * This is an edge case that does not work because 'olds' is not recognized as a form of 'old' (which makes sense),
+	 * even though 'two-year-olds' is a valid form of 'two-year-old'.
+	 */
 	xit( "morphology works for partially hyphenated keyphrases", function() {
 		const paper = new Paper( "", { slug: "how-to-entertain-two-year-old", keyword: "how to entertain two-year-olds" } );
 		const researcher = new EnglishResearcher( paper );
 		researcher.addResearchData( "morphology", morphologyData );
 		expect( slugKeyword( paper, researcher ) ).toEqual( { keyphraseLength: 6, percentWordMatches: 100 } );
+	} );
+
+	/*
+	 * This is an edge case that does not work because 'olds' is not recognized as a form of 'old' (which makes sense),
+	 * even though 'two-year-olds' is a valid form of 'two-year-old'.
+	 */
+	xit( "morphology works for partially hyphenated keyphrases", function() {
+		const paper = new Paper( "", { slug: "gift-for-mother-in-law", keyword: "gifts for mothers-in-law" } );
+		const researcher = new EnglishResearcher( paper );
+		researcher.addResearchData( "morphology", morphologyData );
+		expect( slugKeyword( paper, researcher ) ).toEqual( { keyphraseLength: 3, percentWordMatches: 100 } );
 	} );
 } );
 

--- a/packages/yoastseo/spec/parse/language/LanguageProcessorSpec.js
+++ b/packages/yoastseo/spec/parse/language/LanguageProcessorSpec.js
@@ -4,7 +4,7 @@ import memoizedSentenceTokenizer from "../../../src/languageProcessing/helpers/s
 import Sentence from "../../../src/parse/structure/Sentence";
 import splitIntoTokensCustom from "../../../src/languageProcessing/languages/ja/helpers/splitIntoTokensCustom";
 
-const researcher = Factory.buildMockResearcher( {}, true, false, false,
+const researcher = Factory.buildMockResearcher( {}, true, false, { areHyphensWordBoundaries: true },
 	{ memoizedTokenizer: memoizedSentenceTokenizer } );
 
 describe( "A test for the LanguageProcessor object", () => {
@@ -112,13 +112,16 @@ const splitIntoTokensTestCases = [
 		],
 	},
 	{
-		description: "should correctly tokenize a sentence with a word containing a dash",
+		description: "should split words on a hyphen if hyphens should be treated as word boundaries (according to the " +
+			"researcher config)",
 		sentence: "Hello, world-wide!",
 		expectedTokens: [
 			{ text: "Hello", sourceCodeRange: {} },
 			{ text: ",", sourceCodeRange: {} },
 			{ text: " ", sourceCodeRange: {} },
-			{ text: "world-wide", sourceCodeRange: {} },
+			{ text: "world", sourceCodeRange: {} },
+			{ text: "-", sourceCodeRange: {} },
+			{ text: "wide", sourceCodeRange: {} },
 			{ text: "!", sourceCodeRange: {} },
 		],
 	},
@@ -453,3 +456,25 @@ describe( "A test for the splitIntoTokens method in Japanese", () => {
 		] );
 	} );
 } );
+
+describe( "A test for the splitIntoTokens method in Indonesian", () => {
+	it( "should not split the sentence on hyphens", function() {
+		const indonesianResearcher = Factory.buildMockResearcher( {}, true, false, { areHyphensWordBoundaries: false },
+			{ memoizedTokenizer: memoizedSentenceTokenizer } );
+		const languageProcessor = new LanguageProcessor( indonesianResearcher );
+		const tokens = languageProcessor.splitIntoTokens( new Sentence( "Halo, Dunia! Buku-buku kucing." ) );
+		expect( tokens ).toEqual( [
+			{ text: "Halo", sourceCodeRange: {} },
+			{ text: ",", sourceCodeRange: {} },
+			{ text: " ", sourceCodeRange: {} },
+			{ text: "Dunia", sourceCodeRange: {} },
+			{ text: "!", sourceCodeRange: {} },
+			{ text: " ", sourceCodeRange: {} },
+			{ text: "Buku-buku", sourceCodeRange: {} },
+			{ text: " ", sourceCodeRange: {} },
+			{ text: "kucing", sourceCodeRange: {} },
+			{ text: ".", sourceCodeRange: {} },
+		] );
+	} );
+} );
+

--- a/packages/yoastseo/src/languageProcessing/AbstractResearcher.js
+++ b/packages/yoastseo/src/languageProcessing/AbstractResearcher.js
@@ -100,7 +100,9 @@ export default class AbstractResearcher {
 			memoizedTokenizer,
 		};
 
-		this.config = {};
+		this.config = {
+			areHyphensWordBoundaries: true,
+		};
 	}
 
 	/**

--- a/packages/yoastseo/src/languageProcessing/helpers/match/matchTextWithWord.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/match/matchTextWithWord.js
@@ -12,7 +12,7 @@ import { map } from "lodash-es";
  * Returns the number of matches in a given string
  *
  * @param {string}      text                    The text to use for matching the wordToMatch.
- * @param {string}      wordToMatch             The word to match in the text
+ * @param {string}      wordToMatch             The word to match in the text.
  * @param {string}      locale   				The locale used for transliteration.
  * @param {function}    matchWordCustomHelper  	The helper function to match word in text.
  *

--- a/packages/yoastseo/src/languageProcessing/helpers/morphology/getAllWordsFromPaper.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/morphology/getAllWordsFromPaper.js
@@ -8,11 +8,12 @@ import getImagesInTree from "../image/getImagesInTree";
 /**
  * Gets all words found in the text, title, slug and meta description of a given paper.
  *
- * @param {Paper} paper     The paper for which to get the words.
+ * @param {Paper} 	paper     					The paper for which to get the words.
+ * @param {boolean}	areHyphensWordBoundaries	Whether hyphens should be treated as word boundaries.
  *
  * @returns {string[]} All words found.
  */
-export default function( paper ) {
+export default function( paper, areHyphensWordBoundaries ) {
 	const paperText = paper.getText();
 	const altTagsInText = getImagesInTree( paper ).map( image => getAltAttribute( image ) );
 
@@ -25,6 +26,13 @@ export default function( paper ) {
 		altTagsInText.join( " " ),
 	].join( " " );
 
-	return getWords( paperContent ).map(
+	/*
+     * If hyphens should be treated as word boundaries, pass a custom word boundary regex string that includes hyphens
+ 	 * (u002d) and en-dashes (u2013).
+ 	 */
+	const words = areHyphensWordBoundaries ? getWords( paperContent, "[\\s\\u2013\\u002d]" )
+		: getWords( paperContent );
+
+	return words.map(
 		word => normalizeSingle( escapeRegExp( word ) ) );
 }

--- a/packages/yoastseo/src/languageProcessing/helpers/word/getWords.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/word/getWords.js
@@ -10,11 +10,12 @@ const interJectionRegex = new RegExp( interJectionRegexString, "g" );
  * Returns an array with words used in the text.
  *
  * @param {string} text The text to be counted.
+ * @param {string} wordBoundaryRegexString The regex string for the word boundary that should be used to split the text into words.
  * @param {boolean} [shouldRemovePunctuation=true] If punctuation should be removed. Defaults to `true`.
  *
  * @returns {Array} The array with all words.
  */
-export default function( text, shouldRemovePunctuation = true ) {
+export default function( text, wordBoundaryRegexString = "\\s", shouldRemovePunctuation = true ) {
 	// Unify whitespaces and non-breaking spaces, remove table of content and strip the tags and multiple spaces.
 	text = sanitizeString( text );
 
@@ -22,7 +23,9 @@ export default function( text, shouldRemovePunctuation = true ) {
 		return [];
 	}
 
-	let words = text.split( /\s/g );
+	const wordBoundaryRegex = new RegExp( wordBoundaryRegexString, "g" );
+
+	let words = text.split( wordBoundaryRegex );
 
 	if ( shouldRemovePunctuation ) {
 		words = words.map( removePunctuation );

--- a/packages/yoastseo/src/languageProcessing/helpers/word/getWordsForHTMLParser.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/word/getWordsForHTMLParser.js
@@ -12,8 +12,10 @@ import { hashedHtmlEntitiesRegexEnd, hashedHtmlEntitiesRegexStart } from "../../
  * A backslash is a word separator because it separates two words if it occurs between two words. For example: "foo\bar"
  * A tab is a word separator because it separates two words if it occurs between two words. For example: "foo	bar"
  * A non-breaking space is a word separator because it separates two words if it occurs between two words. For example: "foo\u00A0bar"
+ * An en-dash and an em-dash are word separators because they seperate two words if they occur between two words.
+ * For example: "foo–bar".
  */
-const wordSeparatorsRegex = /([\s\t\u00A0])/;
+const wordSeparatorsRegexDefault = /([\s\t\u00A0\u2013\u2014\u002d])/;
 
 /**
  * Tokenizes a text similar to getWords, but in a suitable way for the HTML parser.
@@ -25,10 +27,11 @@ const wordSeparatorsRegex = /([\s\t\u00A0])/;
  * This algorithm separates punctuation marks from words and keeps them as separate tokens.
  * It only splits them off if they appear at the start or end of a word.
  *
- * @param {string} text The text to tokenize.
+ * @param {string} text 				The text to tokenize.
+ * @param {RegExp} wordSeparatorsRegex  The word separator regex to use.
  * @returns {string[]} An array of tokens.
  */
-const getWordsForHTMLParser = ( text ) => {
+const getWordsForHTMLParser = ( text, wordSeparatorsRegex =  wordSeparatorsRegexDefault ) => {
 	if ( ! text ) {
 		return [];
 	}

--- a/packages/yoastseo/src/languageProcessing/languages/id/Researcher.js
+++ b/packages/yoastseo/src/languageProcessing/languages/id/Researcher.js
@@ -33,6 +33,7 @@ export default class Researcher extends AbstractResearcher {
 			functionWords,
 			transitionWords,
 			twoPartTransitionWords,
+			areHyphensWordBoundaries: false,
 		} );
 
 		Object.assign( this.helpers, {

--- a/packages/yoastseo/src/languageProcessing/researches/functionWordsInKeyphrase.js
+++ b/packages/yoastseo/src/languageProcessing/researches/functionWordsInKeyphrase.js
@@ -22,7 +22,22 @@ export default function( paper, researcher ) {
 		return false;
 	}
 
-	let keyphraseWords = getWordsCustomHelper ? getWordsCustomHelper( keyphrase ) : getWords( keyphrase );
+	/*
+	 * Whether we want to split words on hyphens depends on the language. In most languages, we do want to consider
+	 * hyphens (and en-dashes) word boundaries. But for example in Indonesian, hyphens are used to form plural forms
+	 * of nouns, e.g. 'buku' is the singular form for 'book' and 'buku-buku' is the plural form. So it makes sense to
+	 * not split words on hyphens in Indonesian and consider 'buku-buku' as one word rather than two.
+	 */
+	const areHyphensWordBoundaries = researcher.getConfig( "areHyphensWordBoundaries" );
+
+	let keyphraseWords;
+	if ( getWordsCustomHelper ) {
+		keyphraseWords = getWordsCustomHelper( keyphrase );
+	} else if ( areHyphensWordBoundaries ) {
+		keyphraseWords = getWords( keyphrase, "[\\s\\u2013\\u002d]" );
+	} else {
+		keyphraseWords = getWords( keyphrase );
+	}
 
 	keyphraseWords = filter( keyphraseWords, function( word ) {
 		return ( ! includes( functionWords, word.trim().toLocaleLowerCase() ) );

--- a/packages/yoastseo/src/languageProcessing/researches/keywordCountInUrl.js
+++ b/packages/yoastseo/src/languageProcessing/researches/keywordCountInUrl.js
@@ -1,98 +1,6 @@
 /** @module researches/keywordCountInSlug */
 import parseSlug from "../helpers/url/parseSlug";
 import { findTopicFormsInString } from "../helpers/match/findKeywordFormsInString.js";
-import { uniq } from "lodash-es";
-
-/**
- * Splits the word form on the hyphen and adds each part into a separate array inside the array of word forms.
- *
- * @param {string[]}	wordForms			The array with the word form.
- * @param {Array[]}		dehyphenatedForms	The array with the dehyphenated word forms.
- *
- * @returns {Array[]}	The array of dehyphenated word forms.
- */
-function dehyphenateWordsWithOneForm( wordForms, dehyphenatedForms ) {
-	wordForms.forEach( function( wordForm ) {
-		const splitWordForm = wordForm.split( "-" );
-		splitWordForm.forEach( compound => dehyphenatedForms.push( [ compound ] ) );
-	} );
-	return dehyphenatedForms;
-}
-
-/**
- * Checks how many parts the hyphenated word has. Creates an array for each part inside the array of dehyphenated
- * word forms. Splits each word form on the hyphen and puts each part into its corresponding array (i.e. the first
- * part into the first array, the second part into the second array, etc.). The result is that parts that are
- * forms of the same word are grouped together (e.g. if the hyphenated keyphrase forms are 'ex-husband' and 'ex-husbands',
- * 'husband' and 'husbands' are grouped together as forms of the same word).
- *
- * @param {string[]}	wordForms		The array with the word forms.
- * @param {Array[]}		dehyphenatedForms	The array with the dehyphenated word forms.
- *
- * @returns {Array[]}	The array of dehyphenated word forms.
- */
-function dehyphenateWordsWithMultipleForms( wordForms, dehyphenatedForms ) {
-	/*
-	 * Create one array for each part of the dehyphenated word in the array of dehyphenated word forms.
-	 * Put a number corresponding to the index of the part inside the array so that later we can put the part in the correct
-	 * array by looking for the array that contains the part index.
-	 */
-	const firstWordFormSplit = wordForms[ 0 ].split( "-" );
-	const numberOfParts = firstWordFormSplit.length;
-	for ( let i = 0; i < numberOfParts; i++ ) {
-		dehyphenatedForms.push( [ i ] );
-	}
-
-	// Split each word form on the hyphen and put each part into the corresponding array based on the index.
-	wordForms.forEach( function( wordForm ) {
-		const splitWordForm = wordForm.split( "-" );
-
-		for ( let i = 0; i < numberOfParts; i++ ) {
-			dehyphenatedForms[ i ].push( splitWordForm[ i ] );
-		}
-	} );
-
-	// Remove numbers and duplicates from the array of word forms.
-	for ( let i = 0; i < dehyphenatedForms.length; i++ ) {
-		dehyphenatedForms[ i ] = uniq( dehyphenatedForms[ i ] );
-		// Remove the numbers indicating the part index.
-		dehyphenatedForms[ i ].shift();
-	}
-
-	return dehyphenatedForms;
-}
-
-/**
- * Splits hyphenated keyphrases so that each part is an individual word, e.g. 'pop-art' becomes 'pop' and 'art'.
- * Splitting the keyphrase forms allows for hyphenated keyphrases to be detected in the slug. The slug is parsed on hyphens, and the words from
- * the keyphrase are compared with the words from the slug to find a match. Without dehyphenating the keyphrase, the word from the keyphrase would be
- * 'pop-art' while the words from the slug would be 'pop' and 'art', and a match would not be detected.
- *
- * @param {Array} topicForms The keyphraseForms and synonymsForms of the paper.
- *
- * @returns {Array} topicForms with split compounds.
- */
-function dehyphenateKeyphraseForms( topicForms ) {
-	let dehyphenatedKeyphraseForms = [];
-
-	topicForms.keyphraseForms.forEach( function( wordForms ) {
-		// If a word doesn't contain hyphens, don't split it.
-		if ( wordForms[ 0 ].indexOf( "-" ) === -1 ) {
-			dehyphenatedKeyphraseForms.push( wordForms );
-			return;
-		}
-
-		if ( wordForms.length === 1 ) {
-			dehyphenatedKeyphraseForms = dehyphenateWordsWithOneForm( wordForms, dehyphenatedKeyphraseForms );
-		} else {
-			dehyphenatedKeyphraseForms = dehyphenateWordsWithMultipleForms( wordForms, dehyphenatedKeyphraseForms );
-		}
-	} );
-
-	topicForms.keyphraseForms = dehyphenatedKeyphraseForms;
-
-	return topicForms;
-}
 
 /**
  * Matches the keyword in the slug. Replaces all dashes and underscores with whitespaces and uses whitespace as word boundary.
@@ -103,7 +11,7 @@ function dehyphenateKeyphraseForms( topicForms ) {
  * @returns {{keyphraseLength: int, percentWordMatches: int}} The length of the keyphrase and the percentage of keyphrase forms that has been found.
  */
 function keywordCountInSlug( paper, researcher ) {
-	const topicForms = dehyphenateKeyphraseForms( researcher.getResearch( "morphology" ) );
+	const topicForms = researcher.getResearch( "morphology" );
 	const parsedSlug = parseSlug( paper.getSlug() );
 	const locale = paper.getLocale();
 

--- a/packages/yoastseo/src/parse/language/LanguageProcessor.js
+++ b/packages/yoastseo/src/parse/language/LanguageProcessor.js
@@ -66,7 +66,17 @@ class LanguageProcessor {
 			return tokensCustom.map( tokenText => new Token( tokenText ) );
 		}
 
-		const tokenTexts = getWordsForHTMLParser( sentenceText );
+		/*
+		 * Whether we want to split words on hyphens depends on the language. In most languages, we do want to consider
+		 * hyphens (and en-dashes) word boundaries. But for example in Indonesian, hyphens are used to form plural forms
+		 * of nouns, e.g. 'buku' is the singular form for 'book' and 'buku-buku' is the plural form. So it makes sense to
+		 * not split words on hyphens in Indonesian and consider 'buku-buku' as one word rather than two.
+		 */
+		const areHyphensWordBoundaries = this.researcher.getConfig( "areHyphensWordBoundaries" );
+		console.log( areHyphensWordBoundaries, "areHyphensWordBoundaries in LanguageProcessor" );
+
+		const tokenTexts = areHyphensWordBoundaries ? getWordsForHTMLParser( sentenceText )
+			: getWordsForHTMLParser( sentenceText, /([\s\t\u00A0\u2014])/ );
 
 		return tokenTexts.map( tokenText => new Token( tokenText ) );
 	}

--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/InclusiveLanguageAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/InclusiveLanguageAssessment.js
@@ -70,12 +70,12 @@ export default class InclusiveLanguageAssessment {
 		this.foundPhrases = [];
 
 		sentences.forEach( sentence => {
-			let words = getWords( sentence, false );
+			let words = getWords( sentence, "\\s", false );
 			if ( ! this.caseSensitive ) {
 				words = words.map( word => word.toLocaleLowerCase() );
 			}
 
-			const foundPhrase = this.nonInclusivePhrases.find( phrase => this.rule( words, getWords( phrase, false ) ).length >= 1 );
+			const foundPhrase = this.nonInclusivePhrases.find( phrase => this.rule( words, getWords( phrase, "\\s", false ) ).length >= 1 );
 
 			if ( foundPhrase ) {
 				this.foundPhrases.push( {

--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/helpers/isFollowedByException.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/helpers/isFollowedByException.js
@@ -12,7 +12,7 @@ import { includesWordsAtPosition } from "./includesWordsAtPosition";
  * @returns {function} A function that checks whether the given list of words is contained in another list of words in the given order.
  */
 export function isFollowedByException( words, consecutiveWords, exceptions ) {
-	const splitExceptions = exceptions.map( exception => getWords( exception, false ) );
+	const splitExceptions = exceptions.map( exception => getWords( exception, "\\s", false ) );
 	return index => splitExceptions.some( exception => {
 		const startIndex = index + consecutiveWords.length;
 		if ( startIndex >= 0 ) {

--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/helpers/isPrecededByException.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/helpers/isPrecededByException.js
@@ -11,7 +11,7 @@ import { includesWordsAtPosition } from "./includesWordsAtPosition";
  * @returns {function} A function that checks whether the given list of words is contained in another list of words in the given order.
  */
 export function isPrecededByException( words, exceptions ) {
-	const splitExceptions = exceptions.map( exception => getWords( exception, false ) );
+	const splitExceptions = exceptions.map( exception => getWords( exception, "\\s", false ) );
 	return index => ! splitExceptions.some( exception => {
 		const startIndex = index - exception.length;
 		if ( startIndex >= 0 ) {

--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/helpers/notInclusiveWhenStandalone.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/helpers/notInclusiveWhenStandalone.js
@@ -8,7 +8,8 @@ import { getWords } from "../../../../languageProcessing";
 
 // Some punctuation marks are still removed in getWords, as they are not in our punctuation list.
 // Those are filtered here out to prevent getWords returning an empty list.
-const filteredPunctuationList = punctuationList.filter( punctuationMark => getWords( punctuationMark, false ).length > 0  );
+const filteredPunctuationList = punctuationList.filter( punctuationMark => getWords( punctuationMark,
+	"\\s", false ).length > 0  );
 
 /**
  * Returns a callback that checks whether a non-inclusive word is standalone:


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* 

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

*

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
