### PR TITLE
Make sure that slug is available before trying to return it

### DIFF
--- a/packages/js/src/analysis/PostDataCollector.js
+++ b/packages/js/src/analysis/PostDataCollector.js
@@ -134,7 +134,7 @@ PostDataCollector.prototype.getTitle = function() {
  */
 PostDataCollector.prototype.getUrl = function() {
 	const editorSelectors = select( "core/editor" );
-	if ( editorSelectors ) {
+	if ( editorSelectors && editorSelectors.getCurrentPostAttribute( "slug" ) ) {
 		return editorSelectors.getCurrentPostAttribute( "slug" );
 	}
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* When editing a product with WooCommerce v8.2.0-beta.1, the slug would not set in the slug field of the snippet editor after the product is published. This is also the case when WooCommerce v8.1.1 is active accompanied by WordProof plugin. 
* The problem is WooCommerce makes available the "core/editor" store in 8.2.0, in earlier versions it did not do that. When fetching the slug for a saved/published post we first resort to the data from that store — but that’s empty for posts in classic editor (it’s filled only for saved/published posts in block editor).
We could reproduce this same issue also with WordProof — which similarly makes that store available on posts in the classic editor.
* This is [the PR](https://github.com/Yoast/wordpress-seo/pull/15857) that introduced this code, which was intended to only fetch the slug from that store when Block editor is used — but because the store is made available in the classic editor by WooCommerce / WordProof, we arrive at this issue.
* In this PR, we fix the above problem by adding an extra check before retrieving the slug from the "core/editor" store. We now make sure that slug is available in the store before trying to return it.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the slug in the search appearance editor would not be set when published posts were edited in the classic editor and the "core/editor" store was available.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Scenario 1: Test with WooCommerce v8.2.0-beta.1 
* Install and activate WooCommerce v8.2.0-beta.1
* Install and activate Yoast SEO, Yoast SEO Premium and Yoast SEO for WooCommerce
* Create a product
* Add a title: Wayang kulit
* Add a text to the product

> Wayang kulit ([Javanese](https://en.wikipedia.org/wiki/Javanese_language): ꦮꦪꦁ​ꦏꦸꦭꦶꦠ꧀) is a traditional form of [puppet-shadow play](https://en.wikipedia.org/wiki/Shadow_puppetry) originally found in the cultures of [Java](https://en.wikipedia.org/wiki/Java) and [Bali](https://en.wikipedia.org/wiki/Bali) in [Indonesia](https://en.wikipedia.org/wiki/Indonesia).[[1]](https://en.wikipedia.org/wiki/Wayang_kulit#cite_note-1) In a wayang kulit performance, the puppet figures are rear-projected on a taut linen screen with a coconut-oil (or electric) light. The [dalang](https://en.wikipedia.org/wiki/Dalang_(puppeteer)) (shadow artist) manipulates carved leather figures between the lamp and the screen to bring the shadows to life. The narratives of wayang kulit often have to do with the major theme of good vs. evil.

* Scroll down to the snippet editor metabox
* Confirm that the slug field is populated with the title value: wayang-kulit
* Add a keyphrase: wayang kulit
* Confirm that the Keyphrase in slug assessment returns a green bullet 🍏 
* Save the product
* Scroll down to the snippet editor metabox
* Confirm that the slug field is STILL populated with the title value: wayang-kulit
* Confirm that the Keyphrase in slug assessment STILL returns a green bullet 🍏

#### Scenario 2: Test with WooCommerce v8.2.0-beta.1  + WordProof
* Install and activate WordProof plugin
* Install and activate WooCommerce v8.2.0-beta.1
* Install and activate Yoast SEO, Yoast SEO Premium and Yoast SEO for WooCommerce
* Create a product
* Add a title: Wayang kulit
* Add a text to the product

> Wayang kulit ([Javanese](https://en.wikipedia.org/wiki/Javanese_language): ꦮꦪꦁ​ꦏꦸꦭꦶꦠ꧀) is a traditional form of [puppet-shadow play](https://en.wikipedia.org/wiki/Shadow_puppetry) originally found in the cultures of [Java](https://en.wikipedia.org/wiki/Java) and [Bali](https://en.wikipedia.org/wiki/Bali) in [Indonesia](https://en.wikipedia.org/wiki/Indonesia).[[1]](https://en.wikipedia.org/wiki/Wayang_kulit#cite_note-1) In a wayang kulit performance, the puppet figures are rear-projected on a taut linen screen with a coconut-oil (or electric) light. The [dalang](https://en.wikipedia.org/wiki/Dalang_(puppeteer)) (shadow artist) manipulates carved leather figures between the lamp and the screen to bring the shadows to life. The narratives of wayang kulit often have to do with the major theme of good vs. evil.

* Scroll down to the snippet editor metabox
* Confirm that the slug field is populated with the title value: wayang-kulit
* Add a keyphrase: wayang kulit
* Confirm that the Keyphrase in slug assessment returns a green bullet 🍏 
* Save the product
* Scroll down to the snippet editor metabox
* Confirm that the slug field is STILL populated with the title value: wayang-kulit
* Confirm that the Keyphrase in slug assessment STILL returns a green bullet 🍏

#### Scenario 3: Test with WooCommerce v8.1.1  + WordProof
* Install and activate WordProof plugin
* Install and activate WooCommerce v8.1.1
* Install and activate Yoast SEO, Yoast SEO Premium and Yoast SEO for WooCommerce
* Create a product
* Add a title: Wayang kulit
* Add a text to the product

> Wayang kulit ([Javanese](https://en.wikipedia.org/wiki/Javanese_language): ꦮꦪꦁ​ꦏꦸꦭꦶꦠ꧀) is a traditional form of [puppet-shadow play](https://en.wikipedia.org/wiki/Shadow_puppetry) originally found in the cultures of [Java](https://en.wikipedia.org/wiki/Java) and [Bali](https://en.wikipedia.org/wiki/Bali) in [Indonesia](https://en.wikipedia.org/wiki/Indonesia).[[1]](https://en.wikipedia.org/wiki/Wayang_kulit#cite_note-1) In a wayang kulit performance, the puppet figures are rear-projected on a taut linen screen with a coconut-oil (or electric) light. The [dalang](https://en.wikipedia.org/wiki/Dalang_(puppeteer)) (shadow artist) manipulates carved leather figures between the lamp and the screen to bring the shadows to life. The narratives of wayang kulit often have to do with the major theme of good vs. evil.

* Scroll down to the snippet editor metabox
* Confirm that the slug field is populated with the title value: wayang-kulit
* Add a keyphrase: wayang kulit
* Confirm that the Keyphrase in slug assessment returns a green bullet 🍏 
* Save the product
* Scroll down to the snippet editor metabox
* Confirm that the slug field is STILL populated with the title value: wayang-kulit
* Confirm that the Keyphrase in slug assessment STILL returns a green bullet 🍏

#### Scenario 4: Test in a post/page/CPT in Classic editor + WordProof
* Install and activate WordProof plugin
* Install and activate Classic editor
* Install and activate Yoast SEO and Yoast SEO Premium
* Create a post/page/CPT (it does not really matter what you pick here, the same code is applied)
* Add a title: Wayang kulit
* Add a text to the post/page/CPT:

> Wayang kulit ([Javanese](https://en.wikipedia.org/wiki/Javanese_language): ꦮꦪꦁ​ꦏꦸꦭꦶꦠ꧀) is a traditional form of [puppet-shadow play](https://en.wikipedia.org/wiki/Shadow_puppetry) originally found in the cultures of [Java](https://en.wikipedia.org/wiki/Java) and [Bali](https://en.wikipedia.org/wiki/Bali) in [Indonesia](https://en.wikipedia.org/wiki/Indonesia).[[1]](https://en.wikipedia.org/wiki/Wayang_kulit#cite_note-1) In a wayang kulit performance, the puppet figures are rear-projected on a taut linen screen with a coconut-oil (or electric) light. The [dalang](https://en.wikipedia.org/wiki/Dalang_(puppeteer)) (shadow artist) manipulates carved leather figures between the lamp and the screen to bring the shadows to life. The narratives of wayang kulit often have to do with the major theme of good vs. evil.

* Scroll down to the snippet editor metabox
* Confirm that the slug field is populated with the title value: wayang-kulit
* Add a keyphrase: wayang kulit
* Confirm that the Keyphrase in slug assessment returns a green bullet 🍏 
* Save the product
* Scroll down to the snippet editor metabox
* Confirm that the slug field is STILL populated with the title value: wayang-kulit
* Confirm that the Keyphrase in slug assessment STILL returns a green bullet 🍏

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* No additional impact

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/plugins-automated-testing/issues/1046
