### PR TITLE
Fix condition to avoid showing promotion badge when Premium is installed

### DIFF
--- a/admin/menu/class-base-menu.php
+++ b/admin/menu/class-base-menu.php
@@ -257,7 +257,11 @@ abstract class WPSEO_Base_Menu implements WPSEO_WordPress_Integration {
 		static $title = null;
 
 		if ( $title === null ) {
-			$title = YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-2023-promotion' ) ? __( 'Premium', 'wordpress-seo' ) . '<span class="yoast-menu-bf-sale-badge">' . __( '30% OFF', 'wordpress-seo' ) . '</span>' : __( 'Premium', 'wordpress-seo' );
+			$title = __( 'Premium', 'wordpress-seo' );
+		}
+
+		if ( YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-2023-promotion' ) && ! YoastSEO()->helpers->product->is_premium() ) {
+			$title .= '<span class="yoast-menu-bf-sale-badge">' . __( '30% OFF', 'wordpress-seo' ) . '</span>';
 		}
 
 		return $title;

--- a/admin/menu/class-base-menu.php
+++ b/admin/menu/class-base-menu.php
@@ -261,7 +261,7 @@ abstract class WPSEO_Base_Menu implements WPSEO_WordPress_Integration {
 		}
 
 		if ( YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-2023-promotion' ) && ! YoastSEO()->helpers->product->is_premium() ) {
-			$title .= '<span class="yoast-menu-bf-sale-badge">' . __( '30% OFF', 'wordpress-seo' ) . '</span>';
+			$title = __( 'Premium', 'wordpress-seo' ) . '<span class="yoast-menu-bf-sale-badge">' . __( '30% OFF', 'wordpress-seo' ) . '</span>';
 		}
 
 		return $title;

--- a/css/src/adminbar.css
+++ b/css/src/adminbar.css
@@ -31,13 +31,25 @@
 	border-radius: 14px;
 }
 
+#wpadminbar .yoast-menu-bf-sale-badge{
+    margin-left: 5px;
+    border-radius: 8px;
+    border: 1px solid #FCD34D;
+    background-color: #1F2937;
+    color: #FCD34D;
+    padding: 2px 8px;
+    font-size: 10px;
+    font-weight: 600;
+    line-height: normal;
+}
+
 #wpadminbar .quicklinks #wp-admin-bar-wpseo-menu .wpseo-focus-keyword {
 	max-width: 100px !important;
 	display: inline-block !important;
 	text-overflow: ellipsis !important;
 	white-space: nowrap;
 	overflow: hidden;
-	vertical-align: bottom;                                                                       
+	vertical-align: bottom;
 }
 
 #wpadminbar .yoast-badge {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to avoid showing the `30% OFF` badge aside the `Premium` menu item when Yoast SEO Premium is activated.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Avoids showing the `30% OFF` badge aside the `Premium` menu item when Yoast SEO Premium is activated.

## Relevant technical choices:

* N/A

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install and activate Yoast SEO Premium
* Edit `src/promotions/domain/black-friday-promotion.php`
  * change `\gmmktime( 11, 00, 00, 11, 23, 2023 )` to `\gmmktime( 11, 00, 00, 11, 23, 2022 )`
* Without this PR a `30% OFF` badge is shown aside the `Premium` Yoast SEO menu item
  <img width="160" alt="Screenshot 2023-10-03 at 15 37 45" src="https://github.com/Yoast/wordpress-seo/assets/68744851/5fd52aea-ecf1-4b78-ae55-398577411f0a">
   * With this PR, no `30% OFF` badge is shown
* disable Premium
* look at the Yoast menu in the admin bar, both in the backend and in the frontend
* Without this PR, the style for the badge in the backend is wrong:
![Schermata a 2023-10-03 16-17-02](https://github.com/Yoast/wordpress-seo/assets/15989132/8b7b5cef-4848-4c80-924d-588d768c4334)
   * With this PR, the style is OK
* Without this PR, the style for the badge in the frontend is wrong:
![Schermata a 2023-10-03 16-18-54](https://github.com/Yoast/wordpress-seo/assets/15989132/66f6be39-7835-4fb4-a165-41e27aaaaa56)
   * With this PR, the style is OK



#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* N/A

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.
* [X] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/plugins-automated-testing/issues/1068
