### PR TITLE
Don't return the shortcodes if it's not available in the window

### DIFF
--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -893,8 +893,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 				'has_taxonomies'           => $this->current_post_type_has_taxonomies(),
 			],
 			'shortcodes' => [
-				'wpseo_filter_shortcodes_nonce' => wp_create_nonce( 'wpseo-filter-shortcodes' ),
-				'wpseo_shortcode_tags'          => $this->get_valid_shortcode_tags(),
+				'wpseo_shortcode_tags' => $this->get_valid_shortcode_tags(),
 			],
 		];
 

--- a/admin/taxonomy/class-taxonomy.php
+++ b/admin/taxonomy/class-taxonomy.php
@@ -163,6 +163,9 @@ class WPSEO_Taxonomy {
 							'recommended_replace_vars' => $this->get_recommended_replace_vars(),
 							'scope'                    => $this->determine_scope(),
 						],
+						'shortcodes' => [
+							'wpseo_shortcode_tags' => $this->get_valid_shortcode_tags(),
+						],
 					],
 					'worker'  => [
 						'url'                     => YoastSEO()->helpers->asset->get_asset_url( 'yoast-seo-analysis-worker' ),
@@ -445,5 +448,20 @@ class WPSEO_Taxonomy {
 		$page_type = $recommended_replace_vars->determine_for_term( $taxonomy );
 
 		return $recommended_replace_vars->get_recommended_replacevars_for( $page_type );
+	}
+
+	/**
+	 * Returns an array with shortcode tags for all registered shortcodes.
+	 *
+	 * @return array
+	 */
+	private function get_valid_shortcode_tags() {
+		$shortcode_tags = [];
+
+		foreach ( $GLOBALS['shortcode_tags'] as $tag => $description ) {
+			$shortcode_tags[] = $tag;
+		}
+
+		return $shortcode_tags;
 	}
 }

--- a/packages/js/src/analysis/collectAnalysisData.js
+++ b/packages/js/src/analysis/collectAnalysisData.js
@@ -72,7 +72,9 @@ export default function collectAnalysisData( editorData, store, customAnalysisDa
 	data.titleWidth = measureTextWidth( filteredSEOTitle || storeData.snippetEditor.data.title );
 	data.locale = getContentLocale();
 	data.writingDirection = getWritingDirection();
-	data.shortcodes = window.wpseoScriptData.analysis.plugins.shortcodes ? window.wpseoScriptData.analysis.plugins.shortcodes.wpseo_shortcode_tags : [];
+	data.shortcodes = window.wpseoScriptData.analysis.plugins.shortcodes
+		? window.wpseoScriptData.analysis.plugins.shortcodes.wpseo_shortcode_tags
+		: [];
 
 	return Paper.parse( applyFilters( "yoast.analysis.data", data ) );
 }

--- a/packages/js/src/analysis/collectAnalysisData.js
+++ b/packages/js/src/analysis/collectAnalysisData.js
@@ -72,7 +72,7 @@ export default function collectAnalysisData( editorData, store, customAnalysisDa
 	data.titleWidth = measureTextWidth( filteredSEOTitle || storeData.snippetEditor.data.title );
 	data.locale = getContentLocale();
 	data.writingDirection = getWritingDirection();
-	data.shortcodes = window.wpseoScriptData.analysis.plugins.shortcodes.wpseo_shortcode_tags;
+	data.shortcodes = window.wpseoScriptData.analysis.plugins.shortcodes ? window.wpseoScriptData.analysis.plugins.shortcodes.wpseo_shortcode_tags : [];
 
 	return Paper.parse( applyFilters( "yoast.analysis.data", data ) );
 }

--- a/src/integrations/third-party/elementor.php
+++ b/src/integrations/third-party/elementor.php
@@ -434,8 +434,7 @@ class Elementor implements Integration_Interface {
 				'has_taxonomies'           => $this->current_post_type_has_taxonomies(),
 			],
 			'shortcodes'  => [
-				'wpseo_filter_shortcodes_nonce' => \wp_create_nonce( 'wpseo-filter-shortcodes' ),
-				'wpseo_shortcode_tags'          => $this->get_valid_shortcode_tags(),
+				'wpseo_shortcode_tags' => $this->get_valid_shortcode_tags(),
 			],
 		];
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* In [this PR](https://github.com/Yoast/wordpress-seo/pull/20528), we changed the way we remove shortcodes from the analysis. However, we relied on a window variable (`wpseo_shortcode_tags`) that was not available in terms. This PR fixes that, and also adds some defensive coding. 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where shortcode removal would not work when editing a term.

## Relevant technical choices:

* We also remove the unused window variable `wpseo_filter_shortcodes_nonce` as we no longer ship the shortcode plugin.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install and activate Yoast SEO
* Open any Category or Tag (or any other term) and check console
* Confirm that you don't see the following console error:
```
Uncaught TypeError: Cannot read properties of undefined (reading 'wpseo_shortcode_tags')
```
<img width="637" alt="Screenshot 2023-10-03 at 16 00 40" src="https://github.com/Yoast/wordpress-seo/assets/48715883/ff3d3add-9580-476f-b3f0-10963c505915">

* Confirm shortcodes are removed from the analysis (a quick check suffices, we do a more extensive test in the ATP testing tasks ([this scenario](https://docs.google.com/document/d/11w5ZY17qESN9zYOD9PIsuvU4ykBgVR8rpee-8qzU3Ag/edit#heading=h.iqwi8b53no6q)).

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/plugins-automated-testing/issues/1076
