### PR TITLE
Add black Friday banner to upsell block in settings

### DIFF
--- a/packages/js/src/settings/app.js
+++ b/packages/js/src/settings/app.js
@@ -171,7 +171,7 @@ const PremiumUpsellList = () => {
 				<div>{ __( "BLACK FRIDAY", "wordpress-seo" ) }</div>
 				<div>{ __( "30% OFF", "wordpress-seo" ) }</div>
 			</div> }
-			<div className="yst-p-6">
+			<div className="yst-p-6 yst-flex yst-flex-col">
 				<Title as="h2" size="4" className="yst-text-xl yst-text-primary-500">
 					{ sprintf(
 					/* translators: %s expands to "Yoast SEO" Premium */
@@ -214,7 +214,7 @@ const PremiumUpsellList = () => {
 					variant="upsell"
 					size="large"
 					href={ premiumLink }
-					className="yst-gap-2 yst-mt-4 yst-w-full"
+					className="yst-gap-2 yst-mt-4"
 					target="_blank"
 					rel="noopener"
 					{ ...premiumUpsellConfig }

--- a/packages/js/src/settings/app.js
+++ b/packages/js/src/settings/app.js
@@ -164,61 +164,67 @@ const PremiumUpsellList = () => {
 	const premiumUpsellConfig = useSelectSettings( "selectUpsellSettingsAsProps" );
 
 	return (
-		<Paper as="div" className="yst-p-6 xl:yst-max-w-3xl">
-			<Title as="h2" size="4" className="yst-text-xl yst-text-primary-500">
-				{ sprintf(
+		<Paper as="div" className="xl:yst-max-w-3xl">
+			<div className="yst-rounded-t-lg yst-h-9 yst-flex yst-justify-between yst-items-center yst-bg-black yst-text-amber-300 yst-px-4 yst-text-lg yst-border-y yst-border-amber-300 yst-border-solid">
+				<div>{ __( "BLACK FRIDAY", "wordpress-seo" ) }</div>
+				<div>{ __( "30% OFF", "wordpress-seo" ) }</div>
+			</div>
+			<div className="yst-p-6">
+				<Title as="h2" size="4" className="yst-text-xl yst-text-primary-500">
+					{ sprintf(
 					/* translators: %s expands to "Yoast SEO" Premium */
-					__( "Upgrade to %s", "wordpress-seo" ),
-					"Yoast SEO Premium"
-				) }
-			</Title>
-			<ul className="yst-grid yst-grid-cols-1 sm:yst-grid-cols-2 yst-gap-x-6 yst-list-disc yst-pl-[1em] yst-list-outside yst-text-slate-800 yst-mt-6">
-				<li>
-					<span className="yst-font-semibold">{ __( "Use AI", "wordpress-seo" ) }</span>
-					:&nbsp;
-					{ __( "Quickly create titles & meta descriptions", "wordpress-seo" ) }
-				</li>
-				<li>
-					<span className="yst-font-semibold">{ __( "No more dead links", "wordpress-seo" ) }</span>
-					:&nbsp;
-					{ __( "Easy redirect manager", "wordpress-seo" ) }
-				</li>
-				<li><span className="yst-font-semibold">{ __( "Superfast internal linking suggestions", "wordpress-seo" ) }</span></li>
-				<li>
-					<span className="yst-font-semibold">{ __( "Social media preview", "wordpress-seo" ) }</span>
-					:&nbsp;
-					{ __( "Facebook & Twitter", "wordpress-seo" ) }
-				</li>
-				<li>
-					<span className="yst-font-semibold">{ __( "Multiple keyphrases", "wordpress-seo" ) }</span>
-					:&nbsp;
-					{ __( "Increase your SEO reach", "wordpress-seo" ) }
-				</li>
-				<li>
-					<span className="yst-font-semibold">{ __( "SEO Workouts", "wordpress-seo" ) }</span>
-					:&nbsp;
-					{ __( "Get guided in routine SEO tasks", "wordpress-seo" ) }
-				</li>
-				<li><span className="yst-font-semibold">{ __( "24/7 email support", "wordpress-seo" ) }</span></li>
-				<li><span className="yst-font-semibold">{ __( "No ads!", "wordpress-seo" ) }</span></li>
-			</ul>
-			<Button
-				as="a"
-				variant="upsell"
-				size="large"
-				href={ premiumLink }
-				className="yst-gap-2 yst-mt-4"
-				target="_blank"
-				rel="noopener"
-				{ ...premiumUpsellConfig }
-			>
-				{ sprintf(
+						__( "Upgrade to %s", "wordpress-seo" ),
+						"Yoast SEO Premium"
+					) }
+				</Title>
+				<ul className="yst-grid yst-grid-cols-1 sm:yst-grid-cols-2 yst-gap-x-6 yst-list-disc yst-pl-[1em] yst-list-outside yst-text-slate-800 yst-mt-6">
+					<li>
+						<span className="yst-font-semibold">{ __( "Use AI", "wordpress-seo" ) }</span>
+						:&nbsp;
+						{ __( "Quickly create titles & meta descriptions", "wordpress-seo" ) }
+					</li>
+					<li>
+						<span className="yst-font-semibold">{ __( "No more dead links", "wordpress-seo" ) }</span>
+						:&nbsp;
+						{ __( "Easy redirect manager", "wordpress-seo" ) }
+					</li>
+					<li><span className="yst-font-semibold">{ __( "Superfast internal linking suggestions", "wordpress-seo" ) }</span></li>
+					<li>
+						<span className="yst-font-semibold">{ __( "Social media preview", "wordpress-seo" ) }</span>
+						:&nbsp;
+						{ __( "Facebook & Twitter", "wordpress-seo" ) }
+					</li>
+					<li>
+						<span className="yst-font-semibold">{ __( "Multiple keyphrases", "wordpress-seo" ) }</span>
+						:&nbsp;
+						{ __( "Increase your SEO reach", "wordpress-seo" ) }
+					</li>
+					<li>
+						<span className="yst-font-semibold">{ __( "SEO Workouts", "wordpress-seo" ) }</span>
+						:&nbsp;
+						{ __( "Get guided in routine SEO tasks", "wordpress-seo" ) }
+					</li>
+					<li><span className="yst-font-semibold">{ __( "24/7 email support", "wordpress-seo" ) }</span></li>
+					<li><span className="yst-font-semibold">{ __( "No ads!", "wordpress-seo" ) }</span></li>
+				</ul>
+				<Button
+					as="a"
+					variant="upsell"
+					size="large"
+					href={ premiumLink }
+					className="yst-gap-2 yst-mt-4"
+					target="_blank"
+					rel="noopener"
+					{ ...premiumUpsellConfig }
+				>
+					{ sprintf(
 					/* translators: %s expands to "Yoast SEO" Premium */
-					__( "Get %s", "wordpress-seo" ),
-					"Yoast SEO Premium"
-				) }
-				<ArrowNarrowRightIcon className="yst-w-4 yst-h-4 yst-icon-rtl" />
-			</Button>
+						__( "Get %s", "wordpress-seo" ),
+						"Yoast SEO Premium"
+					) }
+					<ArrowNarrowRightIcon className="yst-w-4 yst-h-4 yst-icon-rtl" />
+				</Button>
+			</div>
 		</Paper>
 	);
 };

--- a/packages/js/src/settings/app.js
+++ b/packages/js/src/settings/app.js
@@ -162,13 +162,15 @@ Menu.propTypes = {
 const PremiumUpsellList = () => {
 	const premiumLink = useSelectSettings( "selectLink", [], "https://yoa.st/17h" );
 	const premiumUpsellConfig = useSelectSettings( "selectUpsellSettingsAsProps" );
+	const promotions = useSelectSettings( "selectPreference", [], "promotions", [] );
+	const isBlackFriday = promotions.includes( "black-friday-2023-promotion" );
 
 	return (
 		<Paper as="div" className="xl:yst-max-w-3xl">
-			<div className="yst-rounded-t-lg yst-h-9 yst-flex yst-justify-between yst-items-center yst-bg-black yst-text-amber-300 yst-px-4 yst-text-lg yst-border-y yst-border-amber-300 yst-border-solid">
+			{ isBlackFriday && <div className="yst-rounded-t-lg yst-h-9 yst-flex yst-justify-between yst-items-center yst-bg-black yst-text-amber-300 yst-px-4 yst-text-lg yst-border-b yst-border-amber-300 yst-border-solid yst-font-semibold">
 				<div>{ __( "BLACK FRIDAY", "wordpress-seo" ) }</div>
 				<div>{ __( "30% OFF", "wordpress-seo" ) }</div>
-			</div>
+			</div> }
 			<div className="yst-p-6">
 				<Title as="h2" size="4" className="yst-text-xl yst-text-primary-500">
 					{ sprintf(

--- a/packages/js/src/settings/app.js
+++ b/packages/js/src/settings/app.js
@@ -219,7 +219,7 @@ const PremiumUpsellList = () => {
 					rel="noopener"
 					{ ...premiumUpsellConfig }
 				>
-					{ sprintf(
+					{ isBlackFriday ? __( "Claim your 30% off now!", "wordpress-seo" ) : sprintf(
 					/* translators: %s expands to "Yoast SEO" Premium */
 						__( "Get %s", "wordpress-seo" ),
 						"Yoast SEO Premium"

--- a/packages/js/src/settings/app.js
+++ b/packages/js/src/settings/app.js
@@ -214,7 +214,7 @@ const PremiumUpsellList = () => {
 					variant="upsell"
 					size="large"
 					href={ premiumLink }
-					className="yst-gap-2 yst-mt-4"
+					className="yst-gap-2 yst-mt-4 yst-w-full"
 					target="_blank"
 					rel="noopener"
 					{ ...premiumUpsellConfig }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds Black Friday banner to upsell block in Settings page.
* Adds different upsell label to the button for Black Friday in the Upsell block in Settings page.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Check Yoast Premium is not installed or activated
* Go to `Yoast SEO`->`Settings`
* Scroll to the bottom of the page, check you see the following upsell block:
![Screenshot 2023-10-05 at 11 27 54](https://github.com/Yoast/wordpress-seo/assets/65466507/f7d767a0-ac6e-4821-95f0-727354fc31a9)

* Edit `src/promotions/domain/black-friday-promotion.php` change line 18:
```php
new Time_Interval( \gmmktime( 11, 00, 00, 11, 23, 2022 ), \gmmktime( 11, 00, 00, 11, 28, 2023 ) )
```
* Refresh the page and check the block has Black Friday banner and the button label has changed:
![Screenshot 2023-10-05 at 11 18 51](https://github.com/Yoast/wordpress-seo/assets/65466507/ffa789f9-39fb-490b-8e3d-96abaabb6652)


#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/plugins-automated-testing/issues/1078
