### PR TITLE
Add Yoast icon to Premium plugin card

### DIFF
--- a/admin/views/licenses.php
+++ b/admin/views/licenses.php
@@ -22,6 +22,7 @@ $premium_extension = [
 	'title'    => 'Yoast SEO Premium',
 	/* translators: %1$s expands to Yoast SEO */
 	'desc'     => sprintf( __( 'The premium version of %1$s with more features & support.', 'wordpress-seo' ), 'Yoast SEO' ),
+	'image'    => plugin_dir_url( WPSEO_FILE ) . 'packages/js/images/Yoast_SEO_Icon.svg',
 	'benefits' => [],
 ];
 
@@ -154,8 +155,8 @@ if ( YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-202
 					$premium_extension['title']
 				);
 				?>
+				<img alt="" width="100" height="100" src="<?php echo esc_url( $premium_extension['image'] ); ?>"/>
 			</h2>
-
 			<?php
 			if ( ! $has_valid_premium_subscription ) :
 				?>

--- a/css/src/yoast-extensions.css
+++ b/css/src/yoast-extensions.css
@@ -671,6 +671,20 @@ a.promoblock:hover {
   margin-top: 16px;
   font-size: 1.5rem;
   color: rgb(166 30 105);
+  display: flex;
+}
+
+.yoast-seo-premium-extension img {
+  margin-left: 1rem;
+}
+@media screen and (max-width: 900px) {
+  .yoast-seo-premium-extension {
+    max-width: none;
+    width: calc( 100% - 8px );
+  }
+  .yoast-seo-premium-extension img {
+    display: none;
+  }
 }
 
 .yoast-seo-premium-extension:before, .yoast-seo-premium-extension:after {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds the Yoast icon to the Premium page's Premium card.

## Relevant technical choices:

* Breakpoint of 900px (like other plugins) to: hide the icon and 100% width the card
* Strange "- 8px" width to ensure the width is the same as the other plugins
* Using flex because why float

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Go to Yoast SEO > Premium (`/wp-admin/admin.php?page=wpseo_licenses`)
* Verify the Premium card now has the Yoast icon
* Change the browser screen to be < 900px and verify the Yoast icon is hidden (just like the icons of the other plugins)
* Optional:
  * Edit `src/promotions/domain/black-friday-promotion.php` change `\gmmktime( 11, 00, 00, 11, 23, 2023 )` to` \gmmktime( 11, 00, 00, 11, 23, 2022 )`
  * Verify the Sale indicator works nicely with the above changes

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/plugins-automated-testing/issues/1082
