### PR TITLE
1080 minor errors with stretched out sidebar ad on ipad screen resolution

### DIFF
--- a/css/src/yst_plugin_tools.css
+++ b/css/src/yst_plugin_tools.css
@@ -1024,6 +1024,9 @@ body.toplevel_page_wpseo_dashboard .wp-badge {
 }
 
 @media screen and (max-width: 500px) {
+  .yoast-sidebar__product .sidebar__sale_banner_container .sidebar__sale_banner {
+    transform: rotate(-4deg);
+  }
   #sidebar-container {
     display: block;
   }

--- a/css/src/yst_plugin_tools.css
+++ b/css/src/yst_plugin_tools.css
@@ -947,7 +947,7 @@ body.toplevel_page_wpseo_dashboard .wp-badge {
     width: auto;
     padding: 0;
   }
-  #sidebar-container .yoast-sidebar__section{
+  #sidebar-container .yoast-sidebar__section {
     margin-top: 80px;
   }
   /* Make the banners with product lists appear next to each other. */
@@ -1024,7 +1024,7 @@ body.toplevel_page_wpseo_dashboard .wp-badge {
   #sidebar-container {
     display: block;
   }
-  #sidebar-container .yoast-sidebar__section{
+  #sidebar-container .yoast-sidebar__section {
     margin-top: 20px;
   }
   body.toplevel_page_wpseo_dashboard .wp-badge {

--- a/css/src/yst_plugin_tools.css
+++ b/css/src/yst_plugin_tools.css
@@ -943,9 +943,12 @@ body.toplevel_page_wpseo_dashboard .wp-badge {
   }
   #sidebar-container {
     display: flex;
-    gap: 20px;
+    gap: 0.7rem;
     width: auto;
     padding: 0;
+  }
+  .yoast-sidebar__product .sidebar__sale_banner_container {
+    overflow-y:hidden;
   }
   #sidebar-container .yoast-sidebar__section {
     margin-top: 80px;

--- a/css/src/yst_plugin_tools.css
+++ b/css/src/yst_plugin_tools.css
@@ -951,7 +951,7 @@ body.toplevel_page_wpseo_dashboard .wp-badge {
     overflow-y:hidden;
   }
   #sidebar-container .yoast-sidebar__section {
-    margin-top: 80px;
+    margin-top: 5rem;
   }
   /* Make the banners with product lists appear next to each other. */
   .yoast-sidebar__product-list {

--- a/css/src/yst_plugin_tools.css
+++ b/css/src/yst_plugin_tools.css
@@ -942,8 +942,14 @@ body.toplevel_page_wpseo_dashboard .wp-badge {
     width: auto;
   }
   #sidebar-container {
+    display: flex;
+    gap: 20px;
     width: auto;
     padding: 0;
+  }
+
+  #sidebar-container .yoast-sidebar__section{
+    margin-top: 80px;
   }
   /* Make the banners with product lists appear next to each other. */
   .yoast-sidebar__product-list {
@@ -1016,6 +1022,14 @@ body.toplevel_page_wpseo_dashboard .wp-badge {
 }
 
 @media screen and (max-width: 500px) {
+  #sidebar-container {
+    display: block;
+  }
+
+  #sidebar-container .yoast-sidebar__section{
+    margin-top: 20px;
+  }
+  
   body.toplevel_page_wpseo_dashboard .wp-badge {
     padding-top: 80px;
     background-size: 100px 100px;

--- a/css/src/yst_plugin_tools.css
+++ b/css/src/yst_plugin_tools.css
@@ -947,7 +947,6 @@ body.toplevel_page_wpseo_dashboard .wp-badge {
     width: auto;
     padding: 0;
   }
-
   #sidebar-container .yoast-sidebar__section{
     margin-top: 80px;
   }
@@ -1025,11 +1024,9 @@ body.toplevel_page_wpseo_dashboard .wp-badge {
   #sidebar-container {
     display: block;
   }
-
   #sidebar-container .yoast-sidebar__section{
     margin-top: 20px;
   }
-  
   body.toplevel_page_wpseo_dashboard .wp-badge {
     padding-top: 80px;
     background-size: 100px 100px;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fix sidebar responsiveness in General page.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:


* Edit `src/promotions/domain/black-friday-promotion.php` change line 18:
```php
new Time_Interval( \gmmktime( 11, 00, 00, 11, 23, 2022 ), \gmmktime( 11, 00, 00, 11, 28, 2023 ) )
```
* Make sure Yoast Premium is disabled or not installed.
* Go to `Yoast SEO`->`General`.
* Inspect the page and reduce size of the screen under 1000.
* Check side bar cards are one next to the other.
* Change width to be under 500px.
* Check cards are one unde
![Screenshot 2023-10-05 at 12 48 35](https://github.com/Yoast/wordpress-seo/assets/65466507/c9750f07-5b6f-4907-ab4c-d42c3a8e4132)
r the other.



#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [X] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [#1080](https://github.com/Yoast/plugins-automated-testing/issues/1080)
