### PR TITLE
Remove BF badge when user has valid subscription in premium page

### DIFF
--- a/admin/views/licenses.php
+++ b/admin/views/licenses.php
@@ -129,7 +129,7 @@ $new_tab_message         = sprintf(
 	esc_html__( '(Opens in a new browser tab)', 'wordpress-seo' )
 );
 
-$sale_badge = '';
+$sale_badge         = '';
 $premium_sale_badge = '';
 
 if ( YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-2023-promotion' ) ) {
@@ -138,8 +138,8 @@ if ( YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-202
 
 	$sale_badge = '<div class="yoast-seo-premium-extension-sale-badge">' . $sale_badge_span . '</div>';
 
-	$premium_sale_badge = $has_valid_premium_subscription ? '' : $sale_badge;
-	
+	$premium_sale_badge = ( $has_valid_premium_subscription ) ? '' : $sale_badge;
+
 }
 
 ?>

--- a/admin/views/licenses.php
+++ b/admin/views/licenses.php
@@ -130,13 +130,18 @@ $new_tab_message         = sprintf(
 );
 
 $sale_badge = '';
+$premium_sale_badge = '';
 
 if ( YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-2023-promotion' ) ) {
 	/* translators: %1$s expands to opening span, %2$s expands to closing span */
 	$sale_badge_span = sprintf( esc_html__( '%1$sSALE 30%% OFF!%2$s', 'wordpress-seo' ), '<span>', '</span>' );
 
 	$sale_badge = '<div class="yoast-seo-premium-extension-sale-badge">' . $sale_badge_span . '</div>';
+
+	$premium_sale_badge = $has_valid_premium_subscription ? '' : $sale_badge;
+	
 }
+
 ?>
 
 <div class="wrap yoast wpseo_table_page">
@@ -145,7 +150,7 @@ if ( YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-202
 
 	<div id="extensions">
 		<section class="yoast-seo-premium-extension">
-			<?php echo $sale_badge; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Reason: Output is already escaped ?>
+			<?php echo $premium_sale_badge; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Reason: Output is already escaped ?>
 			<h2>
 				<?php
 				printf(


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Remove Black Friday badge from Premium card in Premium page when user has valid subscription.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

### Without Black Friday promotion
* Without Premium active and Yoast free install, go to `Yoast SEO`->`Premium`
* Check that you see no Black Friday badges

* Replace the following line in `src/promotions/domain/black-friday-promotion.php` line 18:
```php
new Time_Interval( \gmmktime( 11, 00, 00, 11, 23, 2022 ), \gmmktime( 11, 00, 00, 11, 28, 2023 ) )
```
* Activate premium, deactivate the subscription and go to `Yoast SEO`->`Premium`
* Check you see the Black Friday Badge:
![Screenshot 2023-10-06 at 10 27 11](https://github.com/Yoast/wordpress-seo/assets/65466507/70585348-18f1-4623-a40c-72ee44b0fb74)
* Activate subscription.
* Go to `Yoast SEO`->`Premium`
* Check premium card has no badge:
![Screenshot 2023-10-06 at 10 20 21](https://github.com/Yoast/wordpress-seo/assets/65466507/7b2eac54-22fa-4225-be59-10a1617abe4a)
* Check other cads for add-ons still have a badge
* Deactivate premium
* Check you see the Black Friday badge again on the premium card.
![Screenshot 2023-10-06 at 10 22 13](https://github.com/Yoast/wordpress-seo/assets/65466507/2d96208f-ed87-4aca-a061-a2fa14051fa0)


#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/plugins-automated-testing/issues/1079
