### PR TITLE
Fixes incorrect highlighting for H1s with mark-up in the block editor

### DIFF
--- a/packages/js/src/decorator/gutenberg.js
+++ b/packages/js/src/decorator/gutenberg.js
@@ -285,7 +285,7 @@ function removeAllAnnotationsFromBlock( blockClientId ) {
  * @returns {void}
  */
 export function reapplyAnnotationsForSelectedBlock() {
-	const block = select( "core/editor" ).getSelectedBlock();
+	const block = select( "core/block-editor" ).getSelectedBlock();
 	const activeMarkerId  = select( "yoast-seo/editor" ).getActiveMarker();
 
 	if ( ! block || ! activeMarkerId ) {

--- a/packages/yoastseo/spec/scoring/assessments/seo/SingleH1AssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/SingleH1AssessmentSpec.js
@@ -57,21 +57,21 @@ describe( "An assessment to check whether there is more than one H1 in the text"
 
 describe( "A test for marking incorrect H1s in the body", function() {
 	it( "returns markers for incorrect H1s in the body", function() {
-		const mockPaper = new Paper( "<p>a paragraph</p><h1>heading</h1>" );
+		const mockPaper = new Paper( "<p>a paragraph</p><h1>this is a <strong>heading</strong></h1>" );
 		const mockResearcher = new EnglishResearcher( mockPaper );
 		buildTree( mockPaper, mockResearcher );
 		h1Assessment.getResult( mockPaper, mockResearcher );
 
 		const expected = [
 			new Mark( {
-				original: "<h1>heading</h1>",
-				marked: "<h1><yoastmark class='yoast-text-mark'>heading</yoastmark></h1>",
+				original: "<h1>this is a heading</h1>",
+				marked: "<h1><yoastmark class='yoast-text-mark'>this is a heading</yoastmark></h1>",
 				position: {
-					startOffset: 22,
-					endOffset: 29,
 					clientId: "",
-					endOffsetBlock: 7,
+					startOffset: 22,
+					endOffset: 56,
 					startOffsetBlock: 0,
+					endOffsetBlock: 34,
 				} } ),
 		];
 

--- a/packages/yoastseo/src/scoring/assessments/seo/SingleH1Assessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/SingleH1Assessment.js
@@ -99,7 +99,7 @@ class SingleH1Assessment extends Assessment {
 					startOffset: h1.position.startOffset,
 					endOffset: h1.position.endOffset,
 					startOffsetBlock: 0,
-					endOffsetBlock: h1.content.length,
+					endOffsetBlock: h1.position.endOffset - h1.position.startOffset,
 					clientId: h1.position.clientId,
 				},
 			} );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to resolve an unreleased bug where H1s with mark-up are not properly highlighted in the block editor.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where the highlighting for the _single H1_ assessment would not function correctly when the content had markup. 

## Relevant technical choices:

* In this same PR we also remove a deprecation warning in the console. 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* See the steps to reproduce in [this issue](https://github.com/Yoast/plugins-automated-testing/issues/1089).
* Note that while editing with the eye marker activated, the console error from [this issue](https://github.com/Yoast/plugins-automated-testing/issues/1088) does not appear.
* Finally, note that this was only a problem in the block editor. 

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The highlighting for the Single H1 assessment.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/plugins-automated-testing/issues/1088
Fixes https://github.com/Yoast/plugins-automated-testing/issues/1089
