### PR TITLE
Adds support for single <br> tags.

### DIFF
--- a/packages/js/src/decorator/helpers/getAnnotationsHelpers.js
+++ b/packages/js/src/decorator/helpers/getAnnotationsHelpers.js
@@ -183,7 +183,7 @@ export const getAnnotationsForFAQ = ( attributeWithAnnotationSupport, block, mar
  */
 export const getAnnotationsForHowTo = ( attributeWithAnnotationSupport, block, marks ) => {
 	const annotatableTextsFromBlock = block.attributes[ attributeWithAnnotationSupport.key ];
-	if ( annotatableTextsFromBlock.length === 0 ) {
+	if ( annotatableTextsFromBlock && annotatableTextsFromBlock.length === 0 ) {
 		return [];
 	}
 	const annotations = [];

--- a/packages/js/src/decorator/helpers/positionBasedAnnotationHelper.js
+++ b/packages/js/src/decorator/helpers/positionBasedAnnotationHelper.js
@@ -83,13 +83,23 @@ const adjustOffsetsForHtmlTags = ( slicedBlockHtmlToStartOffset, slicedBlockHtml
 	let foundHtmlTags = [ ...slicedBlockHtmlToStartOffset.matchAll( htmlTagsRegex ) ];
 	forEachRight( foundHtmlTags, ( foundHtmlTag ) => {
 		const [ tag ] = foundHtmlTag;
-		blockStartOffset -= tag.length;
+		let tagLength = tag.length;
+		// Here, we need to account for treating <br> tags as sentence delimiters, and subtract 1 from the tagLength.
+		if ( /<\/?br/.test( tag ) ) {
+			tagLength -= 1;
+		}
+		blockStartOffset -= tagLength;
 	} );
 
 	foundHtmlTags = [ ...slicedBlockHtmlToEndOffset.matchAll( htmlTagsRegex ) ];
 	forEachRight( foundHtmlTags, ( foundHtmlTag ) => {
 		const [ tag ] = foundHtmlTag;
-		blockEndOffset -= tag.length;
+		let tagLength = tag.length;
+		// Here, we need to account for treating <br> tags as sentence delimiters, and subtract 1 from the tagLength.
+		if ( /<\/?br/.test( tag ) ) {
+			tagLength -= 1;
+		}
+		blockEndOffset -= tagLength;
 	} );
 
 	return { blockStartOffset, blockEndOffset };

--- a/packages/yoastseo/spec/languageProcessing/researches/keywordCountSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/keywordCountSpec.js
@@ -954,11 +954,46 @@ const testCasesWithSpecialCharacters = [
 		skip: false,
 	},
 	{
+		description: "can match keyphrases in texts that contain <br> tags",
+		paper: new Paper( "<p>This is a test.<br>This is<br />another<br>test.</p>", { keyword: "test" } ),
+		keyphraseForms: [ [ "test" ] ],
+		expectedCount: 2,
+		expectedMarkings: [
+			new Mark( {
+				original: "This is a test.",
+				marked: "This is a <yoastmark class='yoast-text-mark'>test</yoastmark>.",
+				position: {
+					startOffset: 13,
+					endOffset: 17,
+					startOffsetBlock: 10,
+					endOffsetBlock: 14,
+					attributeId: "",
+					clientId: "",
+					isFirstSection: false,
+				} }
+			),
+			new Mark( {
+				original: "\nThis is\nanother\ntest.",
+				marked: "\nThis is\nanother\n<yoastmark class='yoast-text-mark'>test</yoastmark>.",
+				position: {
+					startOffset: 46,
+					endOffset: 50,
+					startOffsetBlock: 43,
+					endOffsetBlock: 47,
+					attributeId: "",
+					clientId: "",
+					isFirstSection: false,
+				} }
+			),
+		],
+		skip: false,
+	},
+	{
 		description: "can match paragraph gutenberg block",
 		paper: new Paper(
-			`<!-- wp:paragraph -->
-				<p>a string of text with the keyword in it</p>
-			<!-- /wp:paragraph -->`,
+			"<!-- wp:paragraph -->" +
+			"<p>a string of text with the keyword in it</p>" +
+			"<!-- /wp:paragraph -->",
 			{
 				keyword: "keyword",
 				wpBlocks: [
@@ -980,8 +1015,8 @@ const testCasesWithSpecialCharacters = [
 				marked: "a string of text with the <yoastmark class='yoast-text-mark'>keyword</yoastmark> in it",
 				original: "a string of text with the keyword in it",
 				position: {
-					startOffset: 55,
-					endOffset: 62,
+					startOffset: 50,
+					endOffset: 57,
 					startOffsetBlock: 26,
 					endOffsetBlock: 33,
 					attributeId: "",
@@ -995,16 +1030,16 @@ const testCasesWithSpecialCharacters = [
 	{
 		description: "can match complex paragraph gutenberg block",
 		paper: new Paper(
-			`<!-- wp:paragraph -->
-				<p><strong>Over the years, we’ve written&nbsp;quite a few articles about&nbsp;</strong>
-				<a href="https://yoast.com/tag/branding/">branding</a><strong>.
-				Branding is about getting people to relate to your company and
-				products. It’s also about trying to make your brand synonymous with a certain product or service.
-				This can be a lengthy and hard project. It can potentially cost you all of your revenue.
-				It’s no wonder that branding is often associated with investing lots of money in marketing and promotion.
-				However, for a lot of small business owners, the investment in branding will have
-				to&nbsp;be made with a&nbsp;relatively small budget.&nbsp;</strong></p>
-			<!-- /wp:paragraph -->`,
+			"<!-- wp:paragraph -->" +
+			"<p><strong>Over the years, we’ve written&nbsp;quite a few articles about&nbsp;</strong>" +
+			'<a href="https://yoast.com/tag/branding/">branding</a><strong>. ' +
+			"Branding is about getting people to relate to your company and products. " +
+			"It’s also about trying to make your brand synonymous with a certain product or service. " +
+			"This can be a lengthy and hard project. It can potentially cost you all of your revenue. " +
+			"It’s no wonder that branding is often associated with investing lots of money in marketing and promotion. " +
+			"However, for a lot of small business owners, the investment in branding will have " +
+			"to&nbsp;be made with a&nbsp;relatively small budget.&nbsp;</strong></p>" +
+			"<!-- /wp:paragraph -->",
 			{
 				keyword: "keyword",
 				wpBlocks: [
@@ -1029,10 +1064,10 @@ const testCasesWithSpecialCharacters = [
 				marked: " It's also about trying to make your brand <yoastmark class='yoast-text-mark'>synonymous</yoastmark> with a certain product or service.",
 				original: " It’s also about trying to make your brand synonymous with a certain product or service.",
 				position: {
-					startOffset: 295,
-					endOffset: 305,
-					startOffsetBlock: 266,
-					endOffsetBlock: 276,
+					startOffset: 277,
+					endOffset: 287,
+					startOffsetBlock: 253,
+					endOffsetBlock: 263,
 					attributeId: "",
 					clientId: "",
 					isFirstSection: false,
@@ -1044,13 +1079,13 @@ const testCasesWithSpecialCharacters = [
 	{
 		description: "can match complex paragraph gutenberg block",
 		paper: new Paper(
-			`<!-- wp:paragraph -->
-				<p>You might be a local bakery with 10 employees, or a local industrial company employing up to 500 people.
-				These all can be qualified as
-				‘small business’. All have the same main goal when they start: the need to establish a name in their field of expertise. There
-				are multiple ways to do this, without a huge budget.
-				In this post, I’ll share my thoughts on how to go about your own low-budget branding.</p>
-			<!-- /wp:paragraph -->`,
+			"<!-- wp:paragraph -->" +
+			"<p>You might be a local bakery with 10 employees, or a local industrial company employing up to 500 people. " +
+			"These all can be qualified as ‘small business’. " +
+			"All have the same main goal when they start: the need to establish a name in their field of expertise. " +
+			"There are multiple ways to do this, without a huge budget. " +
+			"In this post, I’ll share my thoughts on how to go about your own low-budget branding.</p>" +
+			"<!-- /wp:paragraph -->",
 			{
 				keyword: "expertise",
 				wpBlocks: [
@@ -1075,10 +1110,10 @@ const testCasesWithSpecialCharacters = [
 				marked: " All have the same main goal when they start: the need to establish a name in their field of <yoastmark class='yoast-text-mark'>expertise</yoastmark>.",
 				original: " All have the same main goal when they start: the need to establish a name in their field of expertise.",
 				position: {
-					startOffset: 282,
-					endOffset: 291,
-					startOffsetBlock: 253,
-					endOffsetBlock: 262,
+					startOffset: 269,
+					endOffset: 278,
+					startOffsetBlock: 245,
+					endOffsetBlock: 254,
 					attributeId: "",
 					clientId: "",
 					isFirstSection: false,
@@ -1090,9 +1125,9 @@ const testCasesWithSpecialCharacters = [
 	{
 		description: "can match heading gutenberg block",
 		paper: new Paper(
-			`<!-- wp:heading -->
-				<h2 class="wp-block-heading" id="h-define-and-communicate-brand-values">Define and communicate brand values</h2>
-			<!-- /wp:heading -->`,
+			"<!-- wp:heading -->" +
+			'<h2 class="wp-block-heading" id="h-define-and-communicate-brand-values">Define and communicate brand values</h2>' +
+			"<!-- /wp:heading -->",
 			{
 				keyword: "communicate",
 				wpBlocks: [
@@ -1116,8 +1151,8 @@ const testCasesWithSpecialCharacters = [
 				marked: "Define and <yoastmark class='yoast-text-mark'>communicate</yoastmark> brand values",
 				original: "Define and communicate brand values",
 				position: {
-					startOffset: 107,
-					endOffset: 118,
+					startOffset: 102,
+					endOffset: 113,
 					startOffsetBlock: 11,
 					endOffsetBlock: 22,
 					attributeId: "",
@@ -1131,19 +1166,19 @@ const testCasesWithSpecialCharacters = [
 	{
 		description: "can match complex paragraph gutenberg block",
 		paper: new Paper(
-			`<!-- wp:columns -->
-				<div class="wp-block-columns"><!-- wp:column -->
-				<div class="wp-block-column"><!-- wp:paragraph -->
-				<p><strong>Lorem Ipsum</strong>&nbsp;is simply dummy text of the printing and typesetting industry.</p>
-				<!-- /wp:paragraph --></div>
-				<!-- /wp:column -->
+			"<!-- wp:columns -->" +
+			'<div class="wp-block-columns"><!-- wp:column -->' +
+			'<div class="wp-block-column"><!-- wp:paragraph -->' +
+			"<p><strong>Lorem Ipsum</strong>&nbsp;is simply dummy text of the printing and typesetting industry.</p>" +
+			"<!-- /wp:paragraph --></div>" +
+			"<!-- /wp:column -->" +
 
-				<!-- wp:column -->
-				<div class="wp-block-column"><!-- wp:paragraph -->
-				<p>There are many variations of passages of Lorem Ipsum available</p>
-				<!-- /wp:paragraph --></div>
-				<!-- /wp:column --></div>
-			 <!-- /wp:columns -->`,
+			"<!-- wp:column -->" +
+			'<div class="wp-block-column"><!-- wp:paragraph -->' +
+			"<p>There are many variations of passages of Lorem Ipsum available</p>" +
+			"<!-- /wp:paragraph --></div>" +
+			"<!-- /wp:column --></div>" +
+			"<!-- /wp:columns -->",
 			{
 				keyword: "Ipsum",
 				wpBlocks: [
@@ -1195,8 +1230,8 @@ const testCasesWithSpecialCharacters = [
 				marked: "Lorem <yoastmark class='yoast-text-mark'>Ipsum</yoastmark> is simply dummy text of the printing and typesetting industry.",
 				original: "Lorem Ipsum is simply dummy text of the printing and typesetting industry.",
 				position: {
-					startOffset: 149,
-					endOffset: 154,
+					startOffset: 134,
+					endOffset: 139,
 					startOffsetBlock: 14,
 					endOffsetBlock: 19,
 					attributeId: "",
@@ -1208,8 +1243,8 @@ const testCasesWithSpecialCharacters = [
 				marked: "There are many variations of passages of Lorem <yoastmark class='yoast-text-mark'>Ipsum</yoastmark> available",
 				original: "There are many variations of passages of Lorem Ipsum available",
 				position: {
-					startOffset: 426,
-					endOffset: 431,
+					startOffset: 385,
+					endOffset: 390,
 					startOffsetBlock: 47,
 					endOffsetBlock: 52,
 					attributeId: "",

--- a/packages/yoastseo/spec/parse/build/private/getTextElementPositionsSpec.js
+++ b/packages/yoastseo/spec/parse/build/private/getTextElementPositionsSpec.js
@@ -141,6 +141,21 @@ describe( "A test for getting positions of sentences", () => {
 		expect( getTextElementPositions( node, sentences ) ).toEqual( sentencesWithPositions );
 	} );
 
+	it( "should determine the correct token positions when the sentence contains a br tag", function() {
+		// HTML: <p>Hello<br />world!</p>.
+		const html = "<p>Hello<br />world!</p>";
+		const tree = adapt( parseFragment( html, { sourceCodeLocationInfo: true } ) );
+		const paragraph = tree.childNodes[ 0 ];
+		const tokens = [ "Hello", "\n", "world", "!" ].map( string => new Token( string ) );
+
+		const [ hello, br, world, bang ] = getTextElementPositions( paragraph, tokens, 3 );
+
+		expect( hello.sourceCodeRange ).toEqual( { startOffset: 3, endOffset: 8 } );
+		expect( br.sourceCodeRange ).toEqual( { startOffset: 13, endOffset: 14 } );
+		expect( world.sourceCodeRange ).toEqual( { startOffset: 14, endOffset: 19 } );
+		expect( bang.sourceCodeRange ).toEqual( { startOffset: 19, endOffset: 20 } );
+	} );
+
 	it( "gets the sentence positions from a node that has a code child node", function() {
 		// HTML: <p>Hello <code>array.push( something )</code> code!</p>
 		const node = new Paragraph( {}, [

--- a/packages/yoastseo/spec/parse/build/private/tokenizeSpec.js
+++ b/packages/yoastseo/spec/parse/build/private/tokenizeSpec.js
@@ -477,6 +477,30 @@ describe( "A test for the tokenize function",
 				name: "#document-fragment",
 			} );
 		} );
+
+		it( "should correctly tokenize a paragraph with single br tags", function() {
+			const mockPaper = new Paper( "<p>This is a sentence.<br />This is<br>another sentence.</p>" );
+			const mockResearcher = new EnglishResearcher( mockPaper );
+			const languageProcessor = new LanguageProcessor( mockResearcher );
+			buildTreeNoTokenize( mockPaper );
+			const result = tokenize( mockPaper.getTree(), languageProcessor );
+			const sentences = result.childNodes[ 0 ].sentences;
+			expect( sentences.length ).toEqual( 2 );
+			const firstSentence = sentences[ 0 ];
+			expect( firstSentence.text ).toEqual( "This is a sentence." );
+			expect( firstSentence.sourceCodeRange ).toEqual( { startOffset: 3, endOffset: 22 } );
+			expect( firstSentence.tokens.length ).toEqual( 8 );
+			const secondSentence = sentences[ 1 ];
+			expect( secondSentence.text ).toEqual( "\nThis is\nanother sentence." );
+			expect( secondSentence.sourceCodeRange ).toEqual( { startOffset: 27, endOffset: 56 } );
+			expect( secondSentence.tokens.length ).toEqual( 9 );
+			const [ br1, this1, , is1, br2, another1, , , ] = secondSentence.tokens;
+			expect( br1.sourceCodeRange ).toEqual( { startOffset: 27, endOffset: 28 } );
+			expect( this1.sourceCodeRange ).toEqual( { startOffset: 28, endOffset: 32 } );
+			expect( is1.sourceCodeRange ).toEqual( { startOffset: 33, endOffset: 35 } );
+			expect( br2.sourceCodeRange ).toEqual( { startOffset: 38, endOffset: 39 } );
+			expect( another1.sourceCodeRange ).toEqual( { startOffset: 39, endOffset: 46 } );
+		} );
 	} );
 
 describe( "A test for tokenizing a Japanese sentence", function() {

--- a/packages/yoastseo/spec/parse/traverse/innerTextSpec.js
+++ b/packages/yoastseo/spec/parse/traverse/innerTextSpec.js
@@ -46,6 +46,17 @@ describe( "A test for innerText", () => {
 		expect( searchResult ).toEqual( expected );
 	} );
 
+	it( "should consider break tags to be line breaks", function() {
+		// Matsuo Bashō's "old pond".
+		paper._text = "<p>old pond<br />frog leaps in<br>water's sound</p>";
+		const tree = build( paper, languageProcessor );
+
+		const searchResult = innerText( tree );
+		const expected = "old pond\nfrog leaps in\nwater's sound";
+
+		expect( searchResult ).toEqual( expected );
+	} );
+
 	it( "should return an empty string when presented an empty node", function() {
 		const tree = new Node( "" );
 

--- a/packages/yoastseo/spec/scoring/assessments/seo/KeywordDensityAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/KeywordDensityAssessmentSpec.js
@@ -320,7 +320,7 @@ describe( "A test for marking the keyphrase", function() {
 		const keyphraseDensityAssessment = new KeyphraseDensityAssessment();
 		const paper = new Paper( "<p><img class='size-medium wp-image-33' src='http://basic.wordpress.test/wp-content/uploads/2021/08/" +
 			"cat-3957861_1280-211x300.jpeg' alt='a different cat with toy' width='211' height='300'></img> " +
-			"A flamboyant cat with a toy<br/>\n" +
+			"A flamboyant cat with a toy<br/>" +
 			"</p>",
 		{ keyword: "cat toy" } );
 		const researcher = new EnglishResearcher( paper );

--- a/packages/yoastseo/src/parse/build/private/getTextElementPositions.js
+++ b/packages/yoastseo/src/parse/build/private/getTextElementPositions.js
@@ -26,7 +26,18 @@ function getDescendantPositions( descendantNodes ) {
 			descendantTagPositions.push( node.sourceCodeLocation );
 		} else {
 			if ( node.sourceCodeLocation.startTag ) {
-				descendantTagPositions.push( node.sourceCodeLocation.startTag );
+				const startRange = {
+					startOffset: node.sourceCodeLocation.startTag.startOffset,
+					endOffset: node.sourceCodeLocation.startTag.endOffset,
+				};
+				/*
+				 * Here, we need to account for the fact that earlier (in innerText.js), we treated a <br> as a newline character.
+				 * Therefore, we need to subtract 1 from the endOffset to not count it twice.
+				 */
+				if ( node.name === "br" ) {
+					startRange.endOffset = startRange.endOffset - 1;
+				}
+				descendantTagPositions.push( startRange );
 			}
 			/*
 			 * Check whether node has an end tag before adding it to the array.

--- a/packages/yoastseo/src/parse/traverse/innerText.js
+++ b/packages/yoastseo/src/parse/traverse/innerText.js
@@ -14,6 +14,8 @@ export default function innerText( node ) {
 		node.childNodes.forEach( child => {
 			if ( child.name === "#text" ) {
 				text += child.value;
+			} else if ( child.name === "br" ) {
+				text += "\n";
 			} else {
 				text += innerText( child );
 			}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* In a previous PR, we added support for double `<br>` tags, which we consider signalling a split in paragraphs. In this PR, we add support for single <br> tags: we consider them to be line breaks (`\n`) and update position information accordingly. 
* In this PR, we also fix a bug where empty text in how-tos would break the content analysis when editing a post.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where single line breaks would not be handled correctly when highlighting text.
* Fixes an unreleased bug where empty text in how-tos would break the content analysis when editing a post.

## Relevant technical choices:

* 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

*

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The highlighting in the keyphrase density assessment whenever `<br>` tags are present in the text.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/plugins-automated-testing/issues/1086
