### PR TITLE
Fix major errors in case post was created in elementor and switched to block editor

### DIFF
--- a/packages/js/src/analysis/collectAnalysisData.js
+++ b/packages/js/src/analysis/collectAnalysisData.js
@@ -37,6 +37,7 @@ export default function collectAnalysisData( editorData, store, customAnalysisDa
 	let blocks = null;
 	if ( blockEditorDataModule ) {
 		blocks = blockEditorDataModule.getBlocks();
+		blocks = blocks.filter( block => block.isValid === true );
 	}
 
 	// Make a data structure for the paper data.

--- a/packages/js/src/analysis/collectAnalysisData.js
+++ b/packages/js/src/analysis/collectAnalysisData.js
@@ -36,7 +36,7 @@ export default function collectAnalysisData( editorData, store, customAnalysisDa
 	// Retrieve the block editor blocks from WordPress and filter on useful information.
 	let blocks = null;
 	if ( blockEditorDataModule ) {
-		blocks = blockEditorDataModule.getBlocks();
+		blocks = blockEditorDataModule.getBlocks() || [];
 		blocks = blocks.filter( block => block.isValid );
 	}
 

--- a/packages/js/src/analysis/collectAnalysisData.js
+++ b/packages/js/src/analysis/collectAnalysisData.js
@@ -37,7 +37,7 @@ export default function collectAnalysisData( editorData, store, customAnalysisDa
 	let blocks = null;
 	if ( blockEditorDataModule ) {
 		blocks = blockEditorDataModule.getBlocks();
-		blocks = blocks.filter( block => block.isValid === true );
+		blocks = blocks.filter( block => block.isValid );
 	}
 
 	// Make a data structure for the paper data.

--- a/packages/yoastseo/src/pluggable.js
+++ b/packages/yoastseo/src/pluggable.js
@@ -119,7 +119,7 @@ Pluggable.prototype._reloaded = function( pluginName ) {
  * @param {string}      pluginName 	    The plugin that is registering the modification.
  * @param {number}      priority	    (optional) Used to specify the order in which the callables associated with a particular filter are called.
  * 									    Lower numbers correspond with earlier execution.
- * @returns {boolean}                   Whether or not applying the hook was successfull.
+ * @returns {boolean}                   Whether or not applying the hook was successful.
  */
 Pluggable.prototype._registerModification = function( modification, callable, pluginName, priority ) {
 	if ( typeof modification !== "string" ) {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where the analysis would not work when switching from Elementor to Block editor. 

## Relevant technical choices:
* The invalid blocks are filtered out from entering the Paper in `collectAnalysisData`. We think this is a safe solution:
   * We cannot analyze invalid blocks anyway
   * The data we add to wpBlocks in the Paper is only used for position-based highlighting in Block editor. So not providing the whole list of blocks in the "limbo" state (between editors) is not such a big deal since we cannot highlight anything anyway.
   * This way, the analysis still works as before

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install and activate Yoast SEO
* Create a post in Elementor with the following text:
```
<p><!-- wp:paragraph --></p>
<p>The red panda's coat is mainly red or orange-brown with a black belly and legs. The muzzle, cheeks, brows and inner ear margins are mostly white while the bushy tail has red and buff ring patterns and a dark brown tip. The colouration appears to serve as camouflage in habitat with red moss and white lichen-covered trees. The guard hairs are longer and rougher while the dense undercoat is fluffier with shorter hairs. The guard hairs on the back have a circular cross-section and are 47–56 mm (1.9–2.2 in) long. It has moderately long whiskers around the mouth, lower jaw and chin. The hair on the soles of the paws allows the animal to walk in snow.</p>
<p>&nbsp;</p>
<ul style="margin-top: 0; margin-bottom: 0; padding-inline-start: 48px;">
<li dir="ltr" style="list-style-type: circle; font-size: 11pt; font-family: Arial,sans-serif; color: #000000; background-color: transparent; font-weight: 400; font-style: normal; font-variant: normal; text-decoration: none; vertical-align: baseline; white-space: pre; margin-left: 36pt;" aria-level="2">
<p dir="ltr" style="line-height: 1.38; margin-top: 0pt; margin-bottom: 0pt;" role="presentation"><span style="font-size: 11pt; font-family: Arial,sans-serif; color: #000000; background-color: transparent; font-weight: 400; font-style: normal; font-variant: normal; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;">Panda and cat-friendly parks are the best!</span></p>
</li>
</ul>
<p><span id="docs-internal-guid-0e02c773-7fff-b362-78f7-d30c477adabe"><span style="font-size: 11pt; font-family: Arial, sans-serif; color: #000000; background-color: transparent; font-variant-numeric: normal; font-variant-east-asian: normal; font-variant-alternates: normal; font-variant-position: normal; vertical-align: baseline; white-space-collapse: preserve;">Panda-friendly parks are designed to provide suitable habitats for pandas, allowing them to thrive and reproduce.</span></span></p>
<p><span id="docs-internal-guid-d9a39701-7fff-cc45-e64b-7a16258f1980"><span style="font-size: 11pt; font-family: Arial, sans-serif; color: #000000; background-color: transparent; font-variant-numeric: normal; font-variant-east-asian: normal; font-variant-alternates: normal; font-variant-position: normal; vertical-align: baseline; white-space-collapse: preserve;">Parks that are friendly towards panda are instrumental in protecting the giant panda species</span></span></p>
<p><!-- /wp:paragraph --></p>
<p><!-- wp:list --></p>
<ul>
<li style="list-style-type: none;">
<ul><!-- wp:list-item --></ul>
</li>
</ul>
<ul>
<li style="list-style-type: none;">
<ul>
<li>The red panda (Ailurus fulgens), also known as the lesser panda, is a small mammal native to the eastern Himalayas and southwestern China.</li>
</ul>
</li>
</ul>
<p><!-- /wp:list-item --></p>
<p><!-- /wp:list --></p>
<p><!-- wp:paragraph --></p>
<p>The red panda has a relatively small head, though proportionally larger than in similarly sized raccoons, with a reduced snout and triangular ears, and nearly evenly lengthed limbs. It has a head-body length of 51–63.5 cm (20.1–25.0 in) with a 28–48.5 cm (11.0–19.1 in) tail. The Himalayan red panda is recorded to weigh 3.2–9.4 kg (7.1–20.7 lb), while the Chinese red panda weighs 4–15 kg (8.8–33.1 lb) for females and 4.2–13.4 kg (9.3–29.5 lb) for males. It has five curved digits on each foot, each with curved semi-retractile claws that aid in climbing. The pelvis and hindlimbs have flexible joints, adaptations for an arboreal quadrupedal lifestyle. While not prehensile, the tail helps the animal balance while climbing.</p>
<p><!-- /wp:paragraph --></p>
<p><!-- wp:paragraph --></p>
<p>The forepaws possess a "false thumb", which is an extension of a wrist bone, the radial sesamoid found in many carnivorans. This thumb allows the animal to grip onto bamboo stalks and both the digits and wrist bones are highly flexible. The red panda shares this feature with the giant panda, which has a larger sesamoid that is more compressed at the sides. In addition, the red panda's sesamoid has a more sunken tip while the giant panda's curves in the middle. </p>
<p><!-- /wp:paragraph --></p>
<p><!-- wp:paragraph --></p>
<p>These features give the giant panda more developed dexterity.</p>
<p><!-- /wp:paragraph --></p>
<p><!-- wp:list --></p>
<ul>
<li style="list-style-type: none;">
<ul><!-- wp:list-item --></ul>
</li>
</ul>
<ul>
<li style="list-style-type: none;">
<ul>
<li>The red panda red panda red panda appears to be both nocturnal and crepuscular, sleeping in between periods of activity at night. </li>
</ul>
</li>
</ul>
<p><!-- /wp:list-item --></p>
<p><!-- wp:list-item --></p>
<ul>
<li style="list-style-type: none;">
<ul>
<li>The sentence above contains 3 consecutive keyphrase matching</li>
</ul>
</li>
</ul>
<p><!-- /wp:list-item --></p>
<p><!-- /wp:list --></p>
<p><!-- wp:paragraph --></p>
<p>The red panda's skull is wide, and its lower jaw is robust. However, because it eats leaves and stems, which are not as tough, it has smaller chewing muscles than the giant panda. The digestive system of the red panda is only 4.2 times its body length, with a simple stomach, no noticeable divide between the ileum and colon, and no caecum.</p>
<p><!-- /wp:paragraph --></p>
```
* Set the focus keyphrase to: panda
* Save the post
* Open the console
* Switch editor
* In the "in-between" editors, confirm that the Yoast analysis metabox is loaded
* Confirm that the following error message doesn't appear in the console  `Uncaught DOMException: Failed to execute 'postMessage' on 'Worker': (t,...r)=>e("Block validation: "+t,...r) could not be cloned.`
* Still in the "in-between" editors, go to Keyphrase density assessment and click on the eye icon
* Confirm that no error appears in the console

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/plugins-automated-testing/issues/1091
