### PR TITLE
Support script strategy

### DIFF
--- a/src/integrations/third-party/wordproof.php
+++ b/src/integrations/third-party/wordproof.php
@@ -89,12 +89,17 @@ class Wordproof implements Integration_Interface {
 		 */
 		\add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_assets' ], 10, 0 );
 
-		/**
-		 * Add async to the wordproof scripts.
-		 */
-		if ( version_compare( strtok( get_bloginfo( 'version' ), '-' ), '6.3', '>=' ) ) {
-			wp_script_add_data( WPSEO_Admin_Asset_Manager::PREFIX . 'wordproof-uikit', 'strategy', 'async' );
-		} else {
+		if ( version_compare( strtok( get_bloginfo( 'version' ), '-' ), '6.3', '<' ) ) {
+			\add_action(
+				'wp_enqueue_scripts',
+				function() {
+					\wp_script_add_data( WPSEO_Admin_Asset_Manager::PREFIX . 'wordproof-uikit', 'strategy', 'async' );
+				},
+				11,
+				0
+			);
+		}
+		else {
 			\add_filter( 'script_loader_tag', [ $this, 'add_async_to_script' ], 10, 3 );
 		}
 

--- a/src/integrations/third-party/wordproof.php
+++ b/src/integrations/third-party/wordproof.php
@@ -89,7 +89,7 @@ class Wordproof implements Integration_Interface {
 		 */
 		\add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_assets' ], 10, 0 );
 
-		if ( version_compare( strtok( get_bloginfo( 'version' ), '-' ), '6.3', '<' ) ) {
+		if ( version_compare( strtok( get_bloginfo( 'version' ), '-' ), '6.3', '>=' ) ) {
 			\add_action(
 				'wp_enqueue_scripts',
 				function() {


### PR DESCRIPTION
## Context
* WordPress introduced a new strategy feature in the Script API in version 6.3. See [this post](https://make.wordpress.org/core/2023/07/14/registering-scripts-with-async-and-defer-attributes-in-wordpress-6-3/) for more details. Since Yoast SEO already adds the `async` attribute to its `wordprof` script, we can leverage the new API to do that in a more reliable way.
*Using the strategy feature will make using `async` more reliable than the approach currently used in `add_async_to_script` and also more future-proof. 
* The original PR proposing the change can be found [here](https://github.com/Yoast/wordpress-seo/pull/20712).
## Summary
This PR can be summarized in the following changelog entry:

* Leverages Script Strategy feature to add the async attribute to the `wordproof` script in case WordPress version is 6.3 or higher. Props to [adamsilverstein](https://github.com/adamsilverstein).

## Relevant technical choices:

* Using `wp_script_add_data` is the cleanest approach to adding the attribute
* The existing filter is left in place for older WordPress versions but can be removed once 6.3 is the oldest supported version (detects WordPress version, using new approach when available and falling back to existing approach)

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* **Please note**: To test this PR you need to have a publicly-reachable WordPress installation (you can use [instaWP](https://instawp.com/) to setup your test site)
* Go to `Yoast SEO` -> `Integrations`
  * make sure you have the `WordProof` integration active in the `Other integrations` section
* Go to `Settings` -> `Privacy`
  * take note of the page selected in the `Change your Privacy Policy page` drop-down menu: this is your `Privacy Policy page`
* Edit the `Privacy Policy page`
  * expand the `Advanced` section in the Yoast SEO metabox or sidebar
  * toggle the `Timestamp this page` switch (note you'll be asked to create a free WordProof account if you don't have one already) and save the page 
* Visit the `Privacy Policy page`:
  * if you're running WordPress 6.3 or newer, you should find the following `script` tag:
  `<script src='https://lucky-leopard-el7pr.instawp.xyz/wp-content/plugins/wordpress-seo/js/dist/wordproof-uikit.js?ver=214-RC3' id='yoast-seo-wordproof-uikit-js' async data-wp-strategy='async'></script>`
(mind the `data-wp-strategy='async'` part)

  * if you're running Wordpress with a version number lesser than 6.3, you should find the following `script` tag instead:
  `<script src=https://lucky-leopard-el7pr.instawp.xyz/wp-content/plugins/wordpress-seo/js/dist/wordproof-uikit.js?ver=214-RC3 async></script></body>` 
  (Please note the `scr` url will be different according to your installation)

#### Relevant test scenarios
* N/A

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.
 

## Impact check
* N/A

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.
* [X] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/wordpress-seo/issues/20713 https://github.com/Yoast/wordpress-seo/issues/20745
