### PR TITLE
Add options/upsells to block unwanted bots

### DIFF
--- a/admin/tracking/class-tracking-settings-data.php
+++ b/admin/tracking/class-tracking-settings-data.php
@@ -232,6 +232,7 @@ class WPSEO_Tracking_Settings_Data implements WPSEO_Collection {
 		'deny_wp_json_crawling',
 		'deny_adsbot_crawling',
 		'deny_ccbot_crawling',
+		'deny_google_extended_crawling',
 		'deny_gptbot_crawling',
 		'last_known_no_unindexed',
 	];

--- a/admin/tracking/class-tracking-settings-data.php
+++ b/admin/tracking/class-tracking-settings-data.php
@@ -231,6 +231,7 @@ class WPSEO_Tracking_Settings_Data implements WPSEO_Collection {
 		'deny_search_crawling',
 		'deny_wp_json_crawling',
 		'deny_adsbot_crawling',
+		'deny_ccbot_crawling',
 		'deny_gptbot_crawling',
 		'last_known_no_unindexed',
 	];

--- a/admin/tracking/class-tracking-settings-data.php
+++ b/admin/tracking/class-tracking-settings-data.php
@@ -231,6 +231,7 @@ class WPSEO_Tracking_Settings_Data implements WPSEO_Collection {
 		'deny_search_crawling',
 		'deny_wp_json_crawling',
 		'deny_adsbot_crawling',
+		'deny_gptbot_crawling',
 		'last_known_no_unindexed',
 	];
 

--- a/inc/options/class-wpseo-option-wpseo.php
+++ b/inc/options/class-wpseo-option-wpseo.php
@@ -128,6 +128,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 		'deny_wp_json_crawling'                    => false,
 		'deny_adsbot_crawling'                     => false,
 		'deny_ccbot_crawling'                      => false,
+		'deny_google_extended_crawling'            => false,
 		'deny_gptbot_crawling'                     => false,
 		'redirect_search_pretty_urls'              => false,
 		'least_readability_ignore_list'            => [],
@@ -514,6 +515,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 				 *  'deny_wp_json_crawling'
 				 *  'deny_adsbot_crawling'
 				 *  'deny_ccbot_crawling'
+				 *  'deny_google_extended_crawling'
 				 *  'deny_gptbot_crawling'
 				 *  'redirect_search_pretty_urls'
 				 *  'should_redirect_after_install_free'

--- a/inc/options/class-wpseo-option-wpseo.php
+++ b/inc/options/class-wpseo-option-wpseo.php
@@ -127,6 +127,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 		'deny_search_crawling'                     => false,
 		'deny_wp_json_crawling'                    => false,
 		'deny_adsbot_crawling'                     => false,
+		'deny_gptbot_crawling'                     => false,
 		'redirect_search_pretty_urls'              => false,
 		'least_readability_ignore_list'            => [],
 		'least_seo_score_ignore_list'              => [],
@@ -511,6 +512,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 				 *  'search_cleanup_patterns'
 				 *  'deny_wp_json_crawling'
 				 *  'deny_adsbot_crawling'
+				 *  'deny_gptbot_crawling'
 				 *  'redirect_search_pretty_urls'
 				 *  'should_redirect_after_install_free'
 				 *  'show_new_content_type_notification'

--- a/inc/options/class-wpseo-option-wpseo.php
+++ b/inc/options/class-wpseo-option-wpseo.php
@@ -127,6 +127,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 		'deny_search_crawling'                     => false,
 		'deny_wp_json_crawling'                    => false,
 		'deny_adsbot_crawling'                     => false,
+		'deny_ccbot_crawling'                      => false,
 		'deny_gptbot_crawling'                     => false,
 		'redirect_search_pretty_urls'              => false,
 		'least_readability_ignore_list'            => [],
@@ -512,6 +513,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 				 *  'search_cleanup_patterns'
 				 *  'deny_wp_json_crawling'
 				 *  'deny_adsbot_crawling'
+				 *  'deny_ccbot_crawling'
 				 *  'deny_gptbot_crawling'
 				 *  'redirect_search_pretty_urls'
 				 *  'should_redirect_after_install_free'

--- a/packages/js/src/settings/helpers/search.js
+++ b/packages/js/src/settings/helpers/search.js
@@ -601,6 +601,13 @@ export const createSearchIndex = ( postTypes, taxonomies, { userLocale } = {} ) 
 			fieldLabel: __( "Prevent Google AdsBot from crawling", "wordpress-seo" ),
 			keywords: [ "robots" ],
 		},
+		deny_ccbot_crawling: {
+			route: "/crawl-optimization",
+			routeLabel: __( "Crawl optimization", "wordpress-seo" ),
+			fieldId: "input-wpseo-deny_ccbot_crawling",
+			fieldLabel: __( "Prevent Common Crawl CCBot from crawling", "wordpress-seo" ),
+			keywords: [ "robots" ],
+		},
 		deny_gptbot_crawling: {
 			route: "/crawl-optimization",
 			routeLabel: __( "Crawl optimization", "wordpress-seo" ),

--- a/packages/js/src/settings/helpers/search.js
+++ b/packages/js/src/settings/helpers/search.js
@@ -608,6 +608,13 @@ export const createSearchIndex = ( postTypes, taxonomies, { userLocale } = {} ) 
 			fieldLabel: __( "Prevent Common Crawl CCBot from crawling", "wordpress-seo" ),
 			keywords: [ "robots" ],
 		},
+		deny_google_extended_crawling: {
+			route: "/crawl-optimization",
+			routeLabel: __( "Crawl optimization", "wordpress-seo" ),
+			fieldId: "input-wpseo-deny_google_extended_crawling",
+			fieldLabel: __( "Prevent Google' Bard and Vertex AI bots from crawling", "wordpress-seo" ),
+			keywords: [ "robots" ],
+		},
 		deny_gptbot_crawling: {
 			route: "/crawl-optimization",
 			routeLabel: __( "Crawl optimization", "wordpress-seo" ),

--- a/packages/js/src/settings/helpers/search.js
+++ b/packages/js/src/settings/helpers/search.js
@@ -612,14 +612,14 @@ export const createSearchIndex = ( postTypes, taxonomies, { userLocale } = {} ) 
 			route: "/crawl-optimization",
 			routeLabel: __( "Crawl optimization", "wordpress-seo" ),
 			fieldId: "input-wpseo-deny_google_extended_crawling",
-			fieldLabel: __( "Prevent Google' Bard and Vertex AI bots from crawling", "wordpress-seo" ),
+			fieldLabel: __( "Prevent Google Bard and Vertex AI bots from crawling", "wordpress-seo" ),
 			keywords: [ "robots" ],
 		},
 		deny_gptbot_crawling: {
 			route: "/crawl-optimization",
 			routeLabel: __( "Crawl optimization", "wordpress-seo" ),
 			fieldId: "input-wpseo-deny_gptbot_crawling",
-			fieldLabel: __( "Prevent OpenAI' GPTBot from crawling", "wordpress-seo" ),
+			fieldLabel: __( "Prevent OpenAI GPTBot from crawling", "wordpress-seo" ),
 			keywords: [ "robots", "chatgpt" ],
 		},
 		search_cleanup: {

--- a/packages/js/src/settings/helpers/search.js
+++ b/packages/js/src/settings/helpers/search.js
@@ -601,6 +601,13 @@ export const createSearchIndex = ( postTypes, taxonomies, { userLocale } = {} ) 
 			fieldLabel: __( "Prevent Google AdsBot from crawling", "wordpress-seo" ),
 			keywords: [ "robots" ],
 		},
+		deny_gptbot_crawling: {
+			route: "/crawl-optimization",
+			routeLabel: __( "Crawl optimization", "wordpress-seo" ),
+			fieldId: "input-wpseo-deny_gptbot_crawling",
+			fieldLabel: __( "Prevent OpenAI' GPTBot from crawling", "wordpress-seo" ),
+			keywords: [ "robots", "chatgpt" ],
+		},
 		search_cleanup: {
 			route: "/crawl-optimization",
 			routeLabel: __( "Crawl optimization", "wordpress-seo" ),

--- a/packages/js/src/settings/routes/crawl-optimization.js
+++ b/packages/js/src/settings/routes/crawl-optimization.js
@@ -1,7 +1,7 @@
 /* eslint-disable complexity */
 import { createInterpolateElement, useMemo } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
-import { Alert, Code, FeatureUpsell, TextField, ToggleField } from "@yoast/ui-library";
+import { Alert, Badge, Code, FeatureUpsell, TextField, ToggleField } from "@yoast/ui-library";
 import { Field, useFormikContext } from "formik";
 import { FieldsetLayout, FormikTagField, FormikValueChangeField, FormLayout, RouteLayout } from "../components";
 import { withDisabledMessageSupport, withFormikDummySelectField, withFormikError } from "../hocs";
@@ -578,6 +578,7 @@ const CrawlOptimization = () => {
 								id="input-wpseo-deny_google_extended_crawling"
 								label={ __( "Prevent Google' Bard and Vertex AI bots from crawling", "wordpress-seo" ) }
 								description={ __( "Add a 'disallow' rule to your robots.txt file to prevent crawling by Google-Extended bot. You should only enable this setting if you're not supportive of Bard or Vertex AI using your site content.", "wordpress-seo" ) }
+								labelSuffix={ isPremium && <Badge className="yst-ml-1.5" size="small" variant="upsell">Premium</Badge> }
 								className="yst-max-w-2xl"
 								isDummy={ ! isPremium }
 							/>
@@ -588,6 +589,7 @@ const CrawlOptimization = () => {
 								id="input-wpseo-deny_gptbot_crawling"
 								label={ __( "Prevent OpenAI' GPTBot from crawling", "wordpress-seo" ) }
 								description={ __( "Add a 'disallow' rule to your robots.txt file to prevent crawling by OpenAI's GPTBot. You should only enable this setting if you're not supportive of OpenAI using your site content.", "wordpress-seo" ) }
+								labelSuffix={ isPremium && <Badge className="yst-ml-1.5" size="small" variant="upsell">Premium</Badge> }
 								className="yst-max-w-2xl"
 								isDummy={ ! isPremium }
 							/>
@@ -598,6 +600,7 @@ const CrawlOptimization = () => {
 								id="input-wpseo-deny_ccbot_crawling"
 								label={ __( "Prevent Common Crawl CCBot from crawling", "wordpress-seo" ) }
 								description={ __( "Add a 'disallow' rule to your robots.txt file to prevent crawling by Common Crawl' CCBot. You should only enable this setting if you're not supportive of Common Crawl using your site content.", "wordpress-seo" ) }
+								labelSuffix={ isPremium && <Badge className="yst-ml-1.5" size="small" variant="upsell">Premium</Badge> }
 								className="yst-max-w-2xl"
 								isDummy={ ! isPremium }
 							/>

--- a/packages/js/src/settings/routes/crawl-optimization.js
+++ b/packages/js/src/settings/routes/crawl-optimization.js
@@ -573,6 +573,16 @@ const CrawlOptimization = () => {
 							<FormikValueChangeFieldWithDisabledMessageAndDummy
 								as={ ToggleField }
 								type="checkbox"
+								name="wpseo.deny_google_extended_crawling"
+								id="input-wpseo-deny_google_extended_crawling"
+								label={ __( "Prevent Google' Bard and Vertex AI bots from crawling", "wordpress-seo" ) }
+								description={ __( "Add a 'disallow' rule to your robots.txt file to prevent crawling by Google-Extended bot. You should only enable this setting if you're not supportive of Bard or Vertex AI using your site content.", "wordpress-seo" ) }
+								className="yst-max-w-2xl"
+								isDummy={ ! isPremium }
+							/>
+							<FormikValueChangeFieldWithDisabledMessageAndDummy
+								as={ ToggleField }
+								type="checkbox"
 								name="wpseo.deny_gptbot_crawling"
 								id="input-wpseo-deny_gptbot_crawling"
 								label={ __( "Prevent OpenAI' GPTBot from crawling", "wordpress-seo" ) }

--- a/packages/js/src/settings/routes/crawl-optimization.js
+++ b/packages/js/src/settings/routes/crawl-optimization.js
@@ -580,6 +580,16 @@ const CrawlOptimization = () => {
 								className="yst-max-w-2xl"
 								isDummy={ ! isPremium }
 							/>
+							<FormikValueChangeFieldWithDisabledMessageAndDummy
+								as={ ToggleField }
+								type="checkbox"
+								name="wpseo.deny_ccbot_crawling"
+								id="input-wpseo-deny_ccbot_crawling"
+								label={ __( "Prevent Common Crawl CCBot from crawling", "wordpress-seo" ) }
+								description={ __( "Add a 'disallow' rule to your robots.txt file to prevent crawling by Common Crawl' CCBot. You should only enable this setting if you're not supportive of Common Crawl using your site content.", "wordpress-seo" ) }
+								className="yst-max-w-2xl"
+								isDummy={ ! isPremium }
+							/>
 						</FeatureUpsell>
 					</FieldsetLayout>
 					<hr className="yst-my-8" />

--- a/packages/js/src/settings/routes/crawl-optimization.js
+++ b/packages/js/src/settings/routes/crawl-optimization.js
@@ -3,6 +3,7 @@ import { createInterpolateElement, useMemo } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
 import { Alert, Badge, Code, FeatureUpsell, TextField, ToggleField } from "@yoast/ui-library";
 import { Field, useFormikContext } from "formik";
+import { OutboundLink } from "../../shared-admin/components";
 import { FieldsetLayout, FormikTagField, FormikValueChangeField, FormLayout, RouteLayout } from "../components";
 import { withDisabledMessageSupport, withFormikDummySelectField, withFormikError } from "../hocs";
 import { useSelectSettings } from "../hooks";
@@ -20,6 +21,7 @@ const CrawlOptimization = () => {
 	const premiumUpsellConfig = useSelectSettings( "selectUpsellSettingsAsProps" );
 	const crawlSettingsLink = useSelectSettings( "selectLink", [], "https://yoa.st/crawl-settings" );
 	const permalinkCleanupLink = useSelectSettings( "selectLink", [], "https://yoa.st/permalink-cleanup" );
+	const blockUnwantedBotsInfoLink = useSelectSettings( "selectLink", [], "https://yoa.st/block-unwanted-bots-info" );
 	const premiumBlockUnwantedBotsLink = useSelectSettings( "selectLink", [], "https://yoa.st/block-unwanted-bots-upsell" );
 
 	const codeExample = useMemo( () => sprintf(
@@ -158,6 +160,19 @@ const CrawlOptimization = () => {
 				{ "https://www.example.com/?rest_route=/" }
 			</Code>,
 		} ),
+
+		// Block unwanted bots.
+		blockUnwantedBots: createInterpolateElement(
+			sprintf(
+				/* translators: %1$s expands to an opening tag. %2$s expands to a closing tag. */
+				__( "Lots of web traffic comes from bots crawling the web. Some can benefit your site or business, while other bots don’t. Blocking unwanted bots can save energy, help with site performance, and protect copyrighted content. Read our %1$shelp article on when to block unwanted bots%2$s.", "wordpress-seo" ),
+				"<a>",
+				"</a>"
+			),
+			{
+				a: <OutboundLink id="link-block-unwanted-bots-info" href={ blockUnwantedBotsInfoLink } />,
+			}
+		),
 
 		// Internal site search cleanup.
 		redirectSearchPrettyUrls: createInterpolateElement(
@@ -549,7 +564,7 @@ const CrawlOptimization = () => {
 					<hr className="yst-my-8" />
 					<FieldsetLayout
 						title={ __( "Block unwanted bots", "wordpress-seo" ) }
-						description={ __( "Lots of web traffic comes from bots crawling the web. Some of these can be beneficial to your site or to your business, but some just waste resources. Blocking unwanted bots can save energy and help with site performance.", "wordpress-seo" ) }
+						description={ descriptions.blockUnwantedBots }
 					>
 						<FormikValueChangeFieldWithDisabledMessage
 							as={ ToggleField }
@@ -557,7 +572,7 @@ const CrawlOptimization = () => {
 							name="wpseo.deny_adsbot_crawling"
 							id="input-wpseo-deny_adsbot_crawling"
 							label={ __( "Prevent Google AdsBot from crawling", "wordpress-seo" ) }
-							description={ __( "Add a 'disallow' rule to your robots.txt file to prevent crawling by Google's AdsBot. You should only enable this setting if you're not using Google Ads on your site.", "wordpress-seo" ) }
+							description={ __( "Add a ‘disallow’ rule to your robots.txt file to prevent crawling by Google AdsBot. You should only enable this setting if you're not using Google Ads on your site.", "wordpress-seo" ) }
 							className="yst-max-w-2xl"
 						/>
 						<FeatureUpsell
@@ -576,8 +591,8 @@ const CrawlOptimization = () => {
 								type="checkbox"
 								name="wpseo.deny_google_extended_crawling"
 								id="input-wpseo-deny_google_extended_crawling"
-								label={ __( "Prevent Google' Bard and Vertex AI bots from crawling", "wordpress-seo" ) }
-								description={ __( "Add a 'disallow' rule to your robots.txt file to prevent crawling by Google-Extended bot. You should only enable this setting if you're not supportive of Bard or Vertex AI using your site content.", "wordpress-seo" ) }
+								label={ __( "Prevent Google Bard and Vertex AI bots from crawling", "wordpress-seo" ) }
+								description={ __( "Add a ‘disallow’ rule to your robots.txt file to prevent crawling by the Google-Extended bot. Enabling this setting won’t prevent Google from indexing your website.", "wordpress-seo" ) }
 								labelSuffix={ isPremium && <Badge className="yst-ml-1.5" size="small" variant="upsell">Premium</Badge> }
 								className="yst-max-w-2xl"
 								isDummy={ ! isPremium }
@@ -587,8 +602,8 @@ const CrawlOptimization = () => {
 								type="checkbox"
 								name="wpseo.deny_gptbot_crawling"
 								id="input-wpseo-deny_gptbot_crawling"
-								label={ __( "Prevent OpenAI' GPTBot from crawling", "wordpress-seo" ) }
-								description={ __( "Add a 'disallow' rule to your robots.txt file to prevent crawling by OpenAI's GPTBot. You should only enable this setting if you're not supportive of OpenAI using your site content.", "wordpress-seo" ) }
+								label={ __( "Prevent OpenAI GPTBot from crawling", "wordpress-seo" ) }
+								description={ __( "Add a ‘disallow’ rule to your robots.txt file to prevent crawling by OpenAI GPTBot.", "wordpress-seo" ) }
 								labelSuffix={ isPremium && <Badge className="yst-ml-1.5" size="small" variant="upsell">Premium</Badge> }
 								className="yst-max-w-2xl"
 								isDummy={ ! isPremium }
@@ -599,7 +614,7 @@ const CrawlOptimization = () => {
 								name="wpseo.deny_ccbot_crawling"
 								id="input-wpseo-deny_ccbot_crawling"
 								label={ __( "Prevent Common Crawl CCBot from crawling", "wordpress-seo" ) }
-								description={ __( "Add a 'disallow' rule to your robots.txt file to prevent crawling by Common Crawl' CCBot. You should only enable this setting if you're not supportive of Common Crawl using your site content.", "wordpress-seo" ) }
+								description={ __( "Add a ‘disallow’ rule to your robots.txt file to prevent crawling by Common Crawl CCBot.", "wordpress-seo" ) }
 								labelSuffix={ isPremium && <Badge className="yst-ml-1.5" size="small" variant="upsell">Premium</Badge> }
 								className="yst-max-w-2xl"
 								isDummy={ ! isPremium }

--- a/packages/js/src/settings/routes/crawl-optimization.js
+++ b/packages/js/src/settings/routes/crawl-optimization.js
@@ -165,7 +165,7 @@ const CrawlOptimization = () => {
 		blockUnwantedBots: createInterpolateElement(
 			sprintf(
 				/* translators: %1$s expands to an opening tag. %2$s expands to a closing tag. */
-				__( "Lots of web traffic comes from bots crawling the web. Some can benefit your site or business, while other bots don’t. Blocking unwanted bots can save energy, help with site performance, and protect copyrighted content. Read our %1$shelp article on when to block unwanted bots%2$s.", "wordpress-seo" ),
+				__( "Lots of web traffic comes from bots crawling the web. Some can benefit your site or business, while other bots don’t. Blocking unwanted bots can save energy, help with site performance, and protect copyrighted content. Learn more about %1$swhen to block unwanted bots%2$s.", "wordpress-seo" ),
 				"<a>",
 				"</a>"
 			),

--- a/packages/js/src/settings/routes/crawl-optimization.js
+++ b/packages/js/src/settings/routes/crawl-optimization.js
@@ -16,6 +16,7 @@ const FormikValueChangeFieldWithDisabledMessageAndDummy = withFormikDummySelectF
  */
 const CrawlOptimization = () => {
 	const isPremium = useSelectSettings( "selectPreference", [], "isPremium", false );
+	const isMultisite = useSelectSettings( "selectPreference", [], "isMultisite", false );
 	const premiumUpsellConfig = useSelectSettings( "selectUpsellSettingsAsProps" );
 	const crawlSettingsLink = useSelectSettings( "selectLink", [], "https://yoa.st/crawl-settings" );
 	const permalinkCleanupLink = useSelectSettings( "selectLink", [], "https://yoa.st/permalink-cleanup" );
@@ -560,7 +561,7 @@ const CrawlOptimization = () => {
 							className="yst-max-w-2xl"
 						/>
 						<FeatureUpsell
-							shouldUpsell={ ! isPremium }
+							shouldUpsell={ ! isMultisite && ! isPremium }
 							variant="card"
 							cardLink={ premiumBlockUnwantedBotsLink }
 							cardText={ sprintf(

--- a/packages/js/src/settings/routes/crawl-optimization.js
+++ b/packages/js/src/settings/routes/crawl-optimization.js
@@ -1,21 +1,25 @@
 /* eslint-disable complexity */
 import { createInterpolateElement, useMemo } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
-import { Alert, Code, TextField, ToggleField } from "@yoast/ui-library";
+import { Alert, Code, FeatureUpsell, TextField, ToggleField } from "@yoast/ui-library";
 import { Field, useFormikContext } from "formik";
 import { FieldsetLayout, FormikTagField, FormikValueChangeField, FormLayout, RouteLayout } from "../components";
-import { withDisabledMessageSupport, withFormikError } from "../hocs";
+import { withDisabledMessageSupport, withFormikDummySelectField, withFormikError } from "../hocs";
 import { useSelectSettings } from "../hooks";
 
 const FormikFieldWithError = withFormikError( Field );
 const FormikValueChangeFieldWithDisabledMessage = withDisabledMessageSupport( FormikValueChangeField );
+const FormikValueChangeFieldWithDisabledMessageAndDummy = withFormikDummySelectField( FormikValueChangeFieldWithDisabledMessage );
 
 /**
  * @returns {JSX.Element} The crawl optimization route.
  */
 const CrawlOptimization = () => {
+	const isPremium = useSelectSettings( "selectPreference", [], "isPremium", false );
+	const premiumUpsellConfig = useSelectSettings( "selectUpsellSettingsAsProps" );
 	const crawlSettingsLink = useSelectSettings( "selectLink", [], "https://yoa.st/crawl-settings" );
 	const permalinkCleanupLink = useSelectSettings( "selectLink", [], "https://yoa.st/permalink-cleanup" );
+	const premiumBlockUnwantedBotsLink = useSelectSettings( "selectLink", [], "https://yoa.st/block-unwanted-bots-upsell" );
 
 	const codeExample = useMemo( () => sprintf(
 		/* translators: %1$s expands to an example within a code tag. */
@@ -555,6 +559,28 @@ const CrawlOptimization = () => {
 							description={ __( "Add a 'disallow' rule to your robots.txt file to prevent crawling by Google's AdsBot. You should only enable this setting if you're not using Google Ads on your site.", "wordpress-seo" ) }
 							className="yst-max-w-2xl"
 						/>
+						<FeatureUpsell
+							shouldUpsell={ ! isPremium }
+							variant="card"
+							cardLink={ premiumBlockUnwantedBotsLink }
+							cardText={ sprintf(
+								/* translators: %1$s expands to Premium. */
+								__( "Unlock with %1$s", "wordpress-seo" ),
+								"Premium"
+							) }
+							{ ...premiumUpsellConfig }
+						>
+							<FormikValueChangeFieldWithDisabledMessageAndDummy
+								as={ ToggleField }
+								type="checkbox"
+								name="wpseo.deny_gptbot_crawling"
+								id="input-wpseo-deny_gptbot_crawling"
+								label={ __( "Prevent OpenAI' GPTBot from crawling", "wordpress-seo" ) }
+								description={ __( "Add a 'disallow' rule to your robots.txt file to prevent crawling by OpenAI's GPTBot. You should only enable this setting if you're not supportive of OpenAI using your site content.", "wordpress-seo" ) }
+								className="yst-max-w-2xl"
+								isDummy={ ! isPremium }
+							/>
+						</FeatureUpsell>
 					</FieldsetLayout>
 					<hr className="yst-my-8" />
 					<FieldsetLayout

--- a/src/integrations/settings-integration.php
+++ b/src/integrations/settings-integration.php
@@ -90,6 +90,7 @@ class Settings_Integration implements Integration_Interface {
 			'deny_search_crawling',
 			'deny_wp_json_crawling',
 			'deny_adsbot_crawling',
+			'deny_gptbot_crawling',
 		],
 	];
 

--- a/src/integrations/settings-integration.php
+++ b/src/integrations/settings-integration.php
@@ -90,6 +90,7 @@ class Settings_Integration implements Integration_Interface {
 			'deny_search_crawling',
 			'deny_wp_json_crawling',
 			'deny_adsbot_crawling',
+			'deny_ccbot_crawling',
 			'deny_gptbot_crawling',
 		],
 	];

--- a/src/integrations/settings-integration.php
+++ b/src/integrations/settings-integration.php
@@ -91,6 +91,7 @@ class Settings_Integration implements Integration_Interface {
 			'deny_wp_json_crawling',
 			'deny_adsbot_crawling',
 			'deny_ccbot_crawling',
+			'deny_google_extended_crawling',
 			'deny_gptbot_crawling',
 		],
 	];

--- a/src/integrations/settings-integration.php
+++ b/src/integrations/settings-integration.php
@@ -461,6 +461,7 @@ class Settings_Integration implements Integration_Interface {
 			'isRtl'                         => \is_rtl(),
 			'isNetworkAdmin'                => \is_network_admin(),
 			'isMainSite'                    => \is_main_site(),
+			'isMultisite'                   => \is_multisite(),
 			'isWooCommerceActive'           => $this->woocommerce_helper->is_active(),
 			'isLocalSeoActive'              => \defined( 'WPSEO_LOCAL_FILE' ),
 			'isNewsSeoActive'               => \defined( 'WPSEO_NEWS_FILE' ),


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Add options/upsells to block unwanted bots: `Google-Extended`, `GPTBot` and `CCBot`.

## Relevant technical choices:

* Make upsell exception when the environment is multisite (due to robots.txt and multisite). Preventing a possibly awkward upsell for functionality that is not available.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Single site
* Disable Premium
* Go to the settings
* Search for `bot` and verify you see the 3 new options in the list: 
![image](https://github.com/Yoast/wordpress-seo/assets/35524806/a522e48e-f9f8-45bd-9ec5-b7a7f64dc8d7)
* Verify that all 3 focus the field
* Verify the upsell looks similar to: 
![image](https://github.com/Yoast/wordpress-seo/assets/35524806/6dce145c-ed19-456b-a2be-6e944008b2de)
* Verify the copy is the same as in https://docs.google.com/document/d/1nFaJDKDYr1c0-VGxPkSm_k8nY_v8wnlzBvrTrkythsA
  * Including a change in the section and  Google AdsBot descriptions.
* Verify the section link links to `https://yoa.st/block-unwanted-bots-info` (currently no post behind it yet)
* Verify the unlock button links to `https://yoa.st/block-unwanted-bots-upsell` (currently no post behind it yet)

#### Multisite
* Go to a multisite
* Verify the options are `Unavailable for multisites`
* Verify there is no upsell around them

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [x] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/reserved-tasks/issues/136
Fixes https://github.com/Yoast/featurerequests/issues/949
Fixes https://github.com/Yoast/reserved-tasks/issues/137