### PR TITLE
Revert 20599 100 investigate wp set object terms doesnt add term into a breadcrumbs

### DIFF
--- a/src/builders/indexable-hierarchy-builder.php
+++ b/src/builders/indexable-hierarchy-builder.php
@@ -132,21 +132,6 @@ class Indexable_Hierarchy_Builder {
 	 * @return bool True when indexable has a built hierarchy.
 	 */
 	protected function hierarchy_is_built( Indexable $indexable ) {
-		/**
-		 * Filters ignoring checking if the hierarchy is already built.
-		 *
-		 * Used when adding term with `wp_set_object_terms` together with `wp_insert_post`.
-		 *
-		 * @since 21.2
-		 *
-		 * @param bool $ignore_already_saved If the hierarchy already saved check should be ignored.
-		 * @return bool The filtered value of the `$ignore_already_saved` parameter.
-		 */
-		$ignore_already_saved = apply_filters( 'wpseo_hierarchy_ignore_already_saved', false );
-		if ( $ignore_already_saved ) {
-			return false;
-		}
-
 		if ( \in_array( $indexable->id, $this->saved_ancestors, true ) ) {
 			return true;
 		}

--- a/src/integrations/watchers/indexable-ancestor-watcher.php
+++ b/src/integrations/watchers/indexable-ancestor-watcher.php
@@ -92,9 +92,6 @@ class Indexable_Ancestor_Watcher implements Integration_Interface {
 	 */
 	public function register_hooks() {
 		\add_action( 'wpseo_save_indexable', [ $this, 'reset_children' ], \PHP_INT_MAX, 2 );
-		if ( ! \check_ajax_referer( 'inlineeditnonce', '_inline_edit', false ) ) {
-			\add_action( 'set_object_terms', [ $this, 'build_post_hierarchy' ], 10, 6 );
-		}
 	}
 
 	/**
@@ -104,29 +101,6 @@ class Indexable_Ancestor_Watcher implements Integration_Interface {
 	 */
 	public static function get_conditionals() {
 		return [ Migrations_Conditional::class ];
-	}
-
-	/**
-	 * Validates if the current primary category is still present. If not just remove the post meta for it.
-	 *
-	 * @param int    $object_id Object ID.
-	 * @param array  $terms     Unused. An array of object terms.
-	 * @param array  $tt_ids    An array of term taxonomy IDs.
-	 * @param string $taxonomy  Taxonomy slug.
-	 * @param bool   $append     Whether to append new terms to the old terms.
-	 * @param array  $old_tt_ids Old array of term taxonomy IDs.
-	 */
-	public function build_post_hierarchy( $object_id, $terms, $tt_ids, $taxonomy, $append, $old_tt_ids ) {
-		$post = \get_post( $object_id );
-		if ( $this->post_type_helper->is_excluded( $post->post_type ) ) {
-			return;
-		}
-
-		$indexable = $this->indexable_repository->find_by_id_and_type( $post->ID, $post->post_type );
-
-		if ( $indexable instanceof Indexable ) {
-			$this->indexable_hierarchy_builder->build( $indexable );
-		}
 	}
 
 	/**

--- a/tests/unit/integrations/watchers/indexable-ancestor-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-ancestor-watcher-test.php
@@ -169,115 +169,14 @@ class Indexable_Ancestor_Watcher_Test extends TestCase {
 	}
 
 	/**
-	 * Data provider for the register_hooks test.
-	 *
-	 * @return array The data.
-	 */
-	public function data_provider_register_hooks() {
-		return [
-			'When ancestor is changes inline edit' => [
-				'is_inline_edit'          => true,
-				'set_object_terms_action' => false,
-			],
-			'When ancestor is changes not inline edit' => [
-				'is_inline_edit'          => false,
-				'set_object_terms_action' => 10,
-			],
-		];
-	}
-
-	/**
 	 * Tests if the expected hooks are registered.
 	 *
 	 * @covers ::register_hooks
-	 *
-	 * @dataProvider data_provider_register_hooks
-	 *
-	 * @param bool     $is_inline_edit      Whether or not the request is an inline edit.
-	 * @param bool|int $set_object_terms_action The set_object_terms action return value.
 	 */
-	public function test_register_hooks( $is_inline_edit, $set_object_terms_action ) {
-
-		Functions\expect( 'check_ajax_referer' )
-			->once()
-			->with( 'inlineeditnonce', '_inline_edit', false )
-			->andReturn( $is_inline_edit );
-
+	public function test_register_hooks() {
 		$this->instance->register_hooks();
 
 		self::assertNotFalse( \has_action( 'wpseo_save_indexable', [ $this->instance, 'reset_children' ] ) );
-		self::assertSame( $set_object_terms_action, \has_action( 'set_object_terms', [ $this->instance, 'build_post_hierarchy' ] ) );
-	}
-
-	/**
-	 * Data provider for the build_post_hierarchy test.
-	 *
-	 * @return array The data.
-	 */
-	public static function data_provider_build_post_hierarchy() {
-		$indexable = Mockery::mock( Indexable_Mock::class );
-		return [
-			'Building hierarchy' => [
-				'is_excluded'               => false,
-				'find_by_id_and_type_times' => 1,
-				'indexable'                 => $indexable,
-				'build_times'               => 1,
-			],
-			'Not building hierarchy because no indexable' => [
-				'is_excluded'               => false,
-				'find_by_id_and_type_times' => 1,
-				'indexable'                 => (object) [ 'ID' => 5 ],
-				'build_times'               => 0,
-			],
-			'Not building because excluded post type' => [
-				'is_excluded'               => true,
-				'find_by_id_and_type_times' => 0,
-				'indexable'                 => (object) [ 'ID' => 5 ],
-				'build_times'               => 0,
-			],
-		];
-	}
-
-	/**
-	 * Tests the build_post_hierarchy.
-	 *
-	 * @covers ::build_post_hierarchy
-	 *
-	 * @dataProvider data_provider_build_post_hierarchy
-	 *
-	 * @param bool           $is_excluded Whether or not the post type is excluded.
-	 * @param int            $find_by_id_and_type_times The number of times the find_by_id_and_type method is called.
-	 * @param Indexable_Mock $indexable The indexable.
-	 * @param int            $build_times The number of times the build method is called.
-	 */
-	public function test_build_post_hierarchy( $is_excluded, $find_by_id_and_type_times, $indexable, $build_times ) {
-		$post            = Mockery::mock( \WP_Post::class );
-		$post->post_type = 'post';
-		$post->ID        = 5;
-
-		Functions\expect( 'get_post' )
-			->once()
-			->with( 5 )
-			->andReturn( $post );
-
-		$this->post_type_helper
-			->expects( 'is_excluded' )
-			->once()
-			->with( $post->post_type )
-			->andReturn( $is_excluded );
-
-		$this->indexable_repository
-			->expects( 'find_by_id_and_type' )
-			->times( $find_by_id_and_type_times )
-			->with( $post->ID, $post->post_type )
-			->andReturn( $indexable );
-
-		$this->indexable_hierarchy_builder
-			->expects( 'build' )
-			->times( $build_times )
-			->with( $indexable );
-
-		$this->instance->build_post_hierarchy( 5, [ 'test_term' ], [ 7 ], 'category', false, [] );
 	}
 
 	/**


### PR DESCRIPTION
This PR can be summarized in the following changelog entry:

* Reverts Yoast/wordpress-seo#20599 