### PR TITLE
Docs: Correct some typos in `class-wpseo-option.php`.

### DIFF
--- a/inc/options/class-wpseo-option.php
+++ b/inc/options/class-wpseo-option.php
@@ -6,7 +6,7 @@
  */
 
 /**
- * This abstract class and it's concrete classes implement defaults and value validation for
+ * This abstract class and its concrete classes implement defaults and value validation for
  * all WPSEO options and subkeys within options.
  *
  * Some guidelines:
@@ -22,9 +22,9 @@
  *
  * [Updating/Adding options]
  * - For multisite site_options, please use the WPSEO_Options::update_site_option() method.
- * - For normal options, use the normal add/update_option() functions. As long a the classes here
+ * - For normal options, use the normal add/update_option() functions. As long as the classes here
  *   are instantiated, validation for all options and their subkeys will be automatic.
- * - On (succesfull) update of a couple of options, certain related actions will be run automatically.
+ * - On (successful) update of a couple of options, certain related actions will be run automatically.
  *   Some examples:
  *   - on change of wpseo[yoast_tracking], the cron schedule will be adjusted accordingly
  *   - on change of wpseo and wpseo_title, some caches will be cleared
@@ -41,7 +41,7 @@
  *   translate_defaults() method.
  * - When you remove an array key from an option: if it's important that the option is really removed,
  *   add the WPSEO_Option::clean_up( $option_name ) method to the upgrade run.
- *   This will re-save the option and automatically remove the array key no longer in existance.
+ *   This will re-save the option and automatically remove the array key no longer in existence.
  * - When you rename a sub-option: add it to the clean_option() routine and run that in the upgrade run.
  * - When you change the default for an option sub-key, make sure you verify that the validation routine will
  *   still work the way it should.
@@ -74,8 +74,8 @@ abstract class WPSEO_Option {
 	 * Option group name for use in settings forms.
 	 *
 	 * Will be set automagically if not set in concrete class (i.e.
-	 * if it confirm to the normal pattern 'yoast' . $option_name . 'options',
-	 * only set in conrete class if it doesn't).
+	 * if it conforms to the normal pattern 'yoast' . $option_name . 'options',
+	 * only set in concrete class if it doesn't).
 	 *
 	 * @var string
 	 */
@@ -107,7 +107,7 @@ abstract class WPSEO_Option {
 	protected $defaults;
 
 	/**
-	 * Array of variable option name patterns for the option - if any -.
+	 * Array of variable option name patterns for the option - if any.
 	 *
 	 * Set this when the option contains array keys which vary based on post_type
 	 * or taxonomy.
@@ -230,7 +230,7 @@ abstract class WPSEO_Option {
 	 * ```
 	 * ---------------
 	 *
-	 * Concrete classes *may* contain a enrich_defaults method to add additional defaults once
+	 * Concrete classes *may* contain an enrich_defaults method to add additional defaults once
 	 * all post_types and taxonomies have been registered.
 	 *
 	 * ```
@@ -497,7 +497,7 @@ abstract class WPSEO_Option {
 		return $filtered;
 	}
 
-	/* *********** METHODS influencing add_uption(), update_option() and saving from admin pages. *********** */
+	/* *********** METHODS influencing add_option(), update_option() and saving from admin pages. *********** */
 
 	/**
 	 * Register (whitelist) the option for the configuration pages.
@@ -523,7 +523,7 @@ abstract class WPSEO_Option {
 	}
 
 	/**
-	 * Validate the option
+	 * Validate the option.
 	 *
 	 * @param mixed $option_value The unvalidated new value for the option.
 	 *
@@ -645,7 +645,7 @@ abstract class WPSEO_Option {
 	 *
 	 * @param mixed $value The new value for the option.
 	 *
-	 * @return bool Whether the update was succesfull.
+	 * @return bool Whether the update was successful.
 	 */
 	public function update_site_option( $value ) {
 		if ( $this->multisite_only === true && is_multisite() ) {
@@ -667,7 +667,7 @@ abstract class WPSEO_Option {
 	 * @uses WPSEO_Option::import()
 	 *
 	 * @param string|null $current_version Optional. Version from which to upgrade, if not set,
-	 *                                     version specific upgrades will be disregarded.
+	 *                                     version-specific upgrades will be disregarded.
 	 *
 	 * @return void
 	 */
@@ -692,7 +692,7 @@ abstract class WPSEO_Option {
 	 *
 	 * @param array       $option_value          Option value to be imported.
 	 * @param string|null $current_version       Optional. Version from which to upgrade, if not set,
-	 *                                           version specific upgrades will be disregarded.
+	 *                                           version-specific upgrades will be disregarded.
 	 * @param array|null  $all_old_option_values Optional. Only used when importing old options to
 	 *                                           have access to the real old values, in contrast to
 	 *                                           the saved ones.


### PR DESCRIPTION
## Context
There are some typos in the documentation of the `WPSEO_Option` class.

## Summary
This PR can be summarized in the following changelog entry:

* Improves the inline documentation for the `WPSEO_Option` class. Props to @costdev.

## Relevant technical choices:
N/A

## Test instructions
N/A

## Impact check
N/A

## UI changes
N/A

## Other environments
N/A

## Documentation
* [x] I have written documentation for this change.

## Quality assurance

* [x] **N/A** I have tested this code to the best of my abilities.
* [x] **N/A** During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] **N/A** I have added unit tests to verify the code works as intended.
* [x] **N/A** If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.