### PR TITLE
Filters shortcode before getting the sentences for Japanese

### DIFF
--- a/packages/yoastseo/spec/languageProcessing/researches/keywordCountSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/keywordCountSpec.js
@@ -1856,6 +1856,35 @@ describe( "Test for counting the keyphrase in a text for Japanese", () => {
 				original: "私の猫はかわいいです。" } ) ] );
 	} );
 
+	it( "counts the keyphrase occurrence inside an image caption.", function() {
+		const mockPaper = new Paper( "<p>[caption id=\"attachment_157\" align=\"alignnone\" width=\"225\"]<img " +
+			"src=\"http://one.wordpress.test/wp-content/uploads/2023/07/IMG_0967_2-1-225x300.jpg\" alt=\"\" " +
+			"width=\"225\" height=\"300\" /> 一日一冊の本を読むのはできるかどうかやってみます。[/caption]</p>", {
+			locale: "ja",
+			keyphrase: "一冊の本を読む",
+			shortcodes: [
+				"wp_caption",
+				"caption",
+				"gallery",
+				"playlist" ],
+		} );
+		const keyphraseForms = [
+			[ "一冊" ],
+			[ "本" ],
+			[ "読む", "読み", "読ま", "読め", "読も", "読ん", "読める", "読ませ", "読ませる", "読まれ", "読まれる", "読もう" ],
+		];
+		const researcher = buildJapaneseMockResearcher( keyphraseForms, wordsCountHelper, matchWordsHelper );
+		buildTree( mockPaper, researcher );
+
+
+		expect( getKeyphraseCount( mockPaper, researcher ).count ).toBe( 1 );
+		expect( getKeyphraseCount( mockPaper, researcher ).markings ).toEqual( [
+			new Mark( {
+				marked: "一日<yoastmark class='yoast-text-mark'>一冊</yoastmark>の<yoastmark " +
+					"class='yoast-text-mark'>本</yoastmark>を<yoastmark class='yoast-text-mark'>読む</yoastmark>のはできるかどうかやってみます。",
+				original: "一日一冊の本を読むのはできるかどうかやってみます。" } ) ] );
+	} );
+
 	it( "counts/marks a string of text with multiple occurrences of the same keyphrase in it.", function() {
 		const mockPaper = new Paper( "<p>私の猫はかわいい猫です。</p>", { locale: "ja", keyphrase: "猫" } );
 		const researcher = buildJapaneseMockResearcher( [ [ "猫" ] ], wordsCountHelper, matchWordsHelper );

--- a/packages/yoastseo/src/languageProcessing/researches/keywordCount.js
+++ b/packages/yoastseo/src/languageProcessing/researches/keywordCount.js
@@ -6,6 +6,7 @@ import matchWordFormsWithSentence from "../helpers/match/matchWordFormsWithSente
 import isDoubleQuoted from "../helpers/match/isDoubleQuoted";
 import { markWordsInASentence } from "../helpers/word/markWordsInSentences";
 import getSentences from "../helpers/sentence/getSentences";
+import { filterShortcodesFromHTML } from "../helpers";
 
 /**
  * Counts the occurrences of the keyphrase in the text and creates the Mark objects for the matches.
@@ -90,8 +91,12 @@ export default function getKeyphraseCount( paper, researcher ) {
 	const matchWordCustomHelper = researcher.getHelper( "matchWordCustomHelper" );
 	const customSentenceTokenizer = researcher.getHelper( "memoizedTokenizer" );
 	const locale = paper.getLocale();
+	const text = matchWordCustomHelper
+		? filterShortcodesFromHTML( paper.getText(), paper._attributes && paper._attributes.shortcodes )
+		: paper.getText();
+
 	// When the custom helper is available, we're using the sentences retrieved from the text for the analysis.
-	const sentences = matchWordCustomHelper ? getSentences( paper.getText(), customSentenceTokenizer ) : getSentencesFromTree( paper );
+	const sentences = matchWordCustomHelper ? getSentences( text, customSentenceTokenizer ) : getSentencesFromTree( paper );
 	// Exact matching is requested when the keyphrase is enclosed in double quotes.
 	const isExactMatchRequested = isDoubleQuoted( paper.getKeyword() );
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We changed the way we handled shortcodes in this PR: https://github.com/Yoast/wordpress-seo/pull/20528
* With the above PR, it means that shortcodes enter the Paper as is and not excluded from Paper._text upstream in the worker before running the entire analysis. This is because we're relying on the Paper._text to build a tree with an accurate position information. For assessments that are still not yet adapted to use HTML parser, we filters out the shortcodes on assessment's level before running the assessment's analysis.
* For _keyphrase density_ assessment, we've adapted it to use the HTML Parser, which means that we didn't filter the shortcodes from Paper._text in the assessment level. However, it's important to note that the assessment is still not adapted yet for Japanese. This means that for Japanese, we still need to filter out the shortcodes before running the analysis.
* The fact that we didn't filter out the shortcodes before running  _keyphrase density_ assessment for Japanese is the reason of why the assessment cannot recognize the keyphrase occurrences inside media captions. In Classic editor, media captions are added as shortcodes.
* This PR makes sure that we filter out the shortcodes before running the  _keyphrase density_ assessment for Japanese.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where _keyphrase density_ assessment didn't recognize keyphrase occurrences inside media captions in Classic editor.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install and activate Yoast SEO
* Install and activate Yoast SEO Premium
* Activate Classic editor ⚠️ 
* Set site language to Japanese.
* Create a post or page or a CPT.
* Add text of at least 2 paragraphs, e.g.:
> ドイツ民主共和国（東ドイツ）の国境警備隊がベルリンの舗装道路を壊して石でバリケードを作り、町を横切る有刺鉄線を張りました。そして西ベルリンの周りを取り囲むように、人が乗り越えることのできない、３メートルの高さの壁を作りました。こうしてベルリンの西側部分は、東ドイツと東ベルリンから分離されました。
> 漆の歴史は古く、1万年以上前の縄文時代の遺跡からも漆塗りの装飾品が見つかっている。飛鳥・奈良時代には寺院などの建造物や仏具などにも使われるようになった。鎌倉・室町時代には漆器産業が盛んになり、貴族の食器や武士が身につける鎧（よろい）にも漆塗りが施された。江戸時代には輪島塗や会津塗など漆器の産地が全国に誕生。海外への輸出品としても珍重され、ベルサイユ宮殿のマリー・アントワネットの部屋には、漆器の展示スペースがあったという。西欧の王侯貴族に愛された日本の漆器は「Japan」と呼ばれ、中国の「陶器＝China」と並び、東洋を代表する工芸品として名声を博した。

* Between the 2 paragraphs, add an image with the caption: 一日一冊の本を読むのはできるかどうかやってみます。
* Set the keyphrase to: 一冊の本を読む
* Confirm that Keyphrase density reports 1 match:
> キーフレーズ密度: フォーカスキーフレーズが1回見つかりました。文字数に対するおすすめの最低数2回に足りません。キーフレーズにフォーカスしましょう !
* Click on the eye icon and confirm that the keyphrase is highlighted
* Style the focus keyphrase in the image caption. Try making it bold, italic, etc.
* Confirm that the focus keyphrase in the image caption is still highlighted when the eye icon of the Keyword density assessment is enabled
* Embed a link to the focus keyphrase in the caption
* Confirm that the focus keyphrase in the image caption IS highlighted when the eye icon of the Keyword density assessment is enabled
* Test a different word form of the keyphrase 
  * Change the keyphrase to this one: 一冊の本を読んだ
* Confirm that the focus keyphrase is detected by the Keyword density assessment and it's highlighted
* Add another sentence at the beginning of the caption, e.g.: フォーカスキーフレーズが2回見つかりました。
* Confirm that the focus keyphrase is matched in the second sentence
* Confirm that the focus keyphrase in the image caption is still highlighted when the eye icon of the Keyword density assessment is enabled
* Add the same text used as a caption (一日一冊の本を読むのはできるかどうかやってみます。) to the beginning of the first paragraph.
* Confirm that now Keyphrase density reports 2 matches:
> キーフレーズ密度: フォーカスキーフレーズが2回見つかりました。すばらしい !
* Click on the eye icon and confirm that the keyphrase is actually highlighted both in the caption and in the first paragraph
* Edit the caption of the image so that it now says 龍が好き
* Change the keyphrase to 龍
* Confirm that Keyphrase density reports 1 match:
キーフレーズ密度: フォーカスキーフレーズが1回見つかりました。文字数に対するおすすめの最低数3回に足りません。キーフレーズにフォーカスしましょう !
* Click on the eye icon and confirm that the keyphrase in the caption is highlighted

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* No further impact than what is covered in the testing instruction above.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/plugins-automated-testing/issues/1097
