### PR TITLE
Remove Ebonics from non-inclusive phrases

### DIFF
--- a/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/cultureAssessmentsSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/cultureAssessmentsSpec.js
@@ -760,20 +760,6 @@ describe( "a test for targeting non-inclusive phrases in culture assessments", (
 
 		testInclusiveLanguageAssessments( testData );
 	} );
-	it( "should return the appropriate score and feedback string for: 'ebonics'", () => {
-		const testData = [
-			{
-				identifier: "ebonics",
-				text: "White North Americans do not always understand Ebonics.",
-				expectedFeedback: "Avoid using <i>Ebonics</i> as it is potentially harmful. " +
-					"Consider using an alternative, such as <i>African American English, African American Language</i>. " +
-					"<a href='https://yoa.st/inclusive-language-culture' target='_blank'>Learn more.</a>",
-				expectedScore: 3,
-			},
-		];
-
-		testInclusiveLanguageAssessments( testData );
-	} );
 	it( "should return the appropriate score and feedback string for: 'low man on the totem pole'", () => {
 		const testData = [
 			{

--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/cultureAssessments.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/cultureAssessments.js
@@ -313,14 +313,6 @@ const cultureAssessments = [
 		feedbackFormat: potentiallyHarmful,
 	},
 	{
-		identifier: "ebonics",
-		nonInclusivePhrases: [ "Ebonics" ],
-		inclusiveAlternatives: "<i>African American English, African American Language</i>",
-		score: SCORES.NON_INCLUSIVE,
-		feedbackFormat: potentiallyHarmful,
-		caseSensitive: true,
-	},
-	{
 		identifier: "powWow",
 		nonInclusivePhrases: [ "pow-wow" ],
 		inclusiveAlternatives: "<i>chat, brief conversation, brainstorm, huddle</i>",


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We ran into a case of a too rushed process of adding "Ebonics" (case-sensitive) to our inclusive language database. After extensive research following [our documentation](https://yoast.atlassian.net/wiki/spaces/LIN/pages/2728427529/What+words+get+added+to+the+Inclusive+language+database), it was decided that it can be removed. More details on the reasoning can be found in [the issue](https://github.com/Yoast/lingo-other-tasks/issues/13) or [documentation on removed or non-implemented terms](https://docs.google.com/spreadsheets/d/1YsSWmWq9hw5I24fTwy4v7wXxKF4XZdEE/edit?usp=sharing&ouid=113526085224830309121&rtpof=true&sd=true).

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Removes the word "Ebonics" from the non-inclusive phrases in the _inclusive language_ assessment.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Enable the Inclusive language assessment.
* Create a post of at least 300 words.
* Makes sure the Inclusive language assessment gives a green bullet.
* Add the word "Ebonics"
* Make sure the Inclusive language assessment still gives a green bullet.
* Add the word "oriental"
* Make sure the Inclusive language assessment give an orange bullet and the following feedback: 
`Be careful when using oriental as it is potentially harmful. Unless you are referring to objects or animals, consider using an alternative, such as Asian. When possible, be more specific (e.g. East Asian). Learn more.`

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [x] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [x] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #https://github.com/orgs/Yoast/projects/51/views/1?pane=issue&itemId=39920185
