### PR TITLE
Fix error when adding image caption and highlighting not working in Yoast blocks

### DIFF
--- a/packages/yoastseo/spec/languageProcessing/helpers/sentence/getSentencesFromTreeSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/helpers/sentence/getSentencesFromTreeSpec.js
@@ -11,7 +11,7 @@ describe( "test to get sentences from the tree", () => {
 	} );
 	it( "returns the sentences from paragraph and heading nodes", () => {
 		const paper = new Paper( "<div><p>A very intelligent cat loves their human. A dog is very cute.</p><h3>A subheading 3" +
-			"</h3>text text text<h4>A subheading 4</h4>more text.</div>" );
+			"</h3><h4>A subheading 4</h4></div>" );
 		researcher.setPaper( paper );
 		buildTree( paper, researcher );
 		expect( getSentencesFromTree( paper ) ).toEqual( [
@@ -76,48 +76,76 @@ describe( "test to get sentences from the tree", () => {
 				parentClientId: "",
 			},
 			{
-				sourceCodeRange: { startOffset: 96, endOffset: 110 },
-				parentStartOffset: 96,
-				text: "text text text",
-				tokens: [
-					{ sourceCodeRange: { startOffset: 96, endOffset: 100 }, text: "text" },
-					{ sourceCodeRange: { startOffset: 100, endOffset: 101 }, text: " " },
-					{ sourceCodeRange: { startOffset: 101, endOffset: 105 }, text: "text" },
-					{ sourceCodeRange: { startOffset: 105, endOffset: 106 }, text: " " },
-					{ sourceCodeRange: { startOffset: 106, endOffset: 110 }, text: "text" },
-				],
-				isParentFirstSectionOfBlock: false,
-				parentAttributeId: "",
-				parentClientId: "",
-			},
-			{
-				sourceCodeRange: { startOffset: 114, endOffset: 128 },
-				parentStartOffset: 114,
+				sourceCodeRange: { startOffset: 100, endOffset: 114 },
+				parentStartOffset: 100,
 				text: "A subheading 4",
 				tokens: [
-					{ sourceCodeRange: { startOffset: 114, endOffset: 115 }, text: "A" },
-					{ sourceCodeRange: { startOffset: 115, endOffset: 116 }, text: " " },
-					{ sourceCodeRange: { startOffset: 116, endOffset: 126 }, text: "subheading" },
-					{ sourceCodeRange: { startOffset: 126, endOffset: 127 }, text: " " },
-					{ sourceCodeRange: { startOffset: 127, endOffset: 128 }, text: "4" },
+					{ sourceCodeRange: { startOffset: 100, endOffset: 101 }, text: "A" },
+					{ sourceCodeRange: { startOffset: 101, endOffset: 102 }, text: " " },
+					{ sourceCodeRange: { startOffset: 102, endOffset: 112 }, text: "subheading" },
+					{ sourceCodeRange: { startOffset: 112, endOffset: 113 }, text: " " },
+					{ sourceCodeRange: { startOffset: 113, endOffset: 114 }, text: "4" },
 				],
 				isParentFirstSectionOfBlock: false,
 				parentAttributeId: "",
 				parentClientId: "",
 			},
+		] );
+	} );
+	it( "returns the sentences from an implicit paragraph (an image caption)", () => {
+		const paper = new Paper( "[caption id=\"attachment_75\" align=\"alignnone\" width=\"200\"]<img class=\"wp-image-75 size-medium\"" +
+			" src=\"https://basic.wordpress.test/wp-content/uploads/2023/05/African_Bush_Elephant-200x300.jpg\" alt=\"elephant\"" +
+			" width=\"200\" height=\"300\" /> elephant[/caption]", { shortcodes: [ "caption" ] } );
+		researcher.setPaper( paper );
+		buildTree( paper, researcher );
+		expect( getSentencesFromTree( paper ) ).toEqual( [
 			{
-				sourceCodeRange: { startOffset: 133, endOffset: 143 },
-				parentStartOffset: 133,
-				text: "more text.",
-				tokens: [
-					{ sourceCodeRange: { startOffset: 133, endOffset: 137 }, text: "more" },
-					{ sourceCodeRange: { startOffset: 137, endOffset: 138 }, text: " " },
-					{ sourceCodeRange: { startOffset: 138, endOffset: 142 }, text: "text" },
-					{ sourceCodeRange: { startOffset: 142, endOffset: 143 }, text: "." },
-				],
 				isParentFirstSectionOfBlock: false,
 				parentAttributeId: "",
 				parentClientId: "",
+				parentStartOffset: 0,
+				sourceCodeRange: {
+					endOffset: 252,
+					startOffset: 0,
+				},
+				text: " elephant",
+				tokens: [
+					{
+						sourceCodeRange: {
+							endOffset: 234,
+							startOffset: 233,
+						},
+						text: " ",
+					},
+					{
+						sourceCodeRange: {
+							endOffset: 242,
+							startOffset: 234,
+						},
+						text: "elephant",
+					},
+					{
+						sourceCodeRange: {
+							endOffset: 243,
+							startOffset: 242,
+						},
+						text: "[",
+					},
+					{
+						sourceCodeRange: {
+							endOffset: 251,
+							startOffset: 243,
+						},
+						text: "/caption",
+					},
+					{
+						sourceCodeRange: {
+							endOffset: 252,
+							startOffset: 251,
+						},
+						text: "]",
+					},
+				],
 			},
 		] );
 	} );

--- a/packages/yoastseo/src/languageProcessing/helpers/sentence/getSentencesFromTree.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/sentence/getSentencesFromTree.js
@@ -15,7 +15,7 @@ function getStartOffset( node ) {
  * @returns {Node} The parent node.
  */
 function getParentNode( paper, node ) {
-	return paper.getTree().findAll( treeNode => treeNode.childNodes && treeNode.childNodes.includes( node ) )[ 0 ];
+	return paper.getTree().findAll( treeNode => treeNode.childNodes && treeNode.childNodes.includes( node ) )[ 0 ] || node;
 }
 
 /**

--- a/packages/yoastseo/src/languageProcessing/helpers/sentence/getSentencesFromTree.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/sentence/getSentencesFromTree.js
@@ -45,9 +45,9 @@ export default function( paper ) {
 			// The block client id of the parent node.
 			parentClientId: parentNode.clientId || "",
 			// The attribute id of the parent node, if available, otherwise an empty string.
-			parentAttributeId: parentNode.attributeId || "",
+			parentAttributeId: node.attributeId || "",
 			// Whether the parent node is the first section of Yoast sub-blocks.
-			isParentFirstSectionOfBlock: parentNode.isFirstSection || false,
+			isParentFirstSectionOfBlock: node.isFirstSection || false,
 		};
 	} ) );
 }

--- a/packages/yoastseo/src/languageProcessing/helpers/sentence/getSentencesFromTree.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/sentence/getSentencesFromTree.js
@@ -10,11 +10,12 @@ function getStartOffset( node ) {
 
 /**
  * Retrieves the parent node for a given node.
- * @param {Paper} paper The current paper.
- * @param {Node} node The current node.
+ * @param {Paper} 	paper 	The current paper.
+ * @param {Node} 	node 	The current node.
  * @returns {Node} The parent node.
  */
 function getParentNode( paper, node ) {
+	// Includes a fallback so that if a parent node cannot be found for an implicit paragraph, we use the current node as the parent node.
 	return paper.getTree().findAll( treeNode => treeNode.childNodes && treeNode.childNodes.includes( node ) )[ 0 ] || node;
 }
 
@@ -45,8 +46,9 @@ export default function( paper ) {
 			// The block client id of the parent node.
 			parentClientId: parentNode.clientId || "",
 			// The attribute id of the parent node, if available, otherwise an empty string.
+			// Only used for position-based highlighting in sub-blocks of Yoast blocks.
 			parentAttributeId: node.attributeId || "",
-			// Whether the parent node is the first section of Yoast sub-blocks.
+			// Whether the parent node is the first section of Yoast sub-blocks. Only used for position-based highlighting.
 			isParentFirstSectionOfBlock: node.isFirstSection || false,
 		};
 	} ) );

--- a/packages/yoastseo/src/parse/structure/Node.js
+++ b/packages/yoastseo/src/parse/structure/Node.js
@@ -46,9 +46,9 @@ class Node {
 	/**
 	 * Finds all nodes in the tree that satisfies the given condition.
 	 *
-	 * @param {function} condition The condition that a node should satisfy to end up in the list.
-	 * @param {boolean} recurseFoundNodes=false Whether to recurse into found nodes
-	 * to see if the condition also applies to sub-nodes of the found node.
+	 * @param {function} 	condition 					The condition that a node should satisfy to end up in the list.
+	 * @param {boolean} 	recurseFoundNodes=false 	Whether to recurse into found nodes to see if the condition
+	 *  also applies to sub-nodes of the found node.
 	 *
 	 * @returns {(Node|Text|Paragraph|Heading)[]} The list of nodes that satisfy the condition.
 	 */

--- a/packages/yoastseo/src/parse/traverse/findAllInTree.js
+++ b/packages/yoastseo/src/parse/traverse/findAllInTree.js
@@ -1,9 +1,10 @@
 /**
  * Finds all nodes in the tree that satisfies the given condition.
  *
- * @param {Object} tree The tree.
- * @param {function} condition The condition that a node should satisfy to end up in the list.
- * @param {boolean} recurseFoundNodes=false Whether to recurse into found nodes to see if the condition also applies to sub-nodes of the found node.
+ * @param {Object} 		tree 						The tree.
+ * @param {function} 	condition 					The condition that a node should satisfy to end up in the list.
+ * @param {boolean} 	recurseFoundNodes=false 	Whether to recurse into found nodes to see if the condition also applies to
+ * sub-nodes of the found node.
  * If false, as soon as a node is found that satisfies the condition, it is added to the list and no further recursion is done through its children.
  * If true, the node is added to the list and its children are also checked for the condition.
  * If they satisfy the condition, they are also added to the list.


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The code that was introduced in [this PR](https://github.com/Yoast/wordpress-seo/pull/20741) caused the issues fixed in this PR.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where the analysis would crash when adding an image caption for some languages.
* Fixes an unreleased bug where highlighting for the keyphrase density assessment wouldn't work in the first part of a Yoast block.

## Relevant technical choices:

* We added a fallback so that if a parent node cannot be found for an implicit paragraph, we use the current node as the parent node.
* The `parentAttributeId` and `isParentFirstSectionOfBlock` values of the Sentence object are only used for position-based highlighting in Yoast blocks. Yoast blocks consists of sub-blocks (e.g. question and answer). In the `getSentencesFromTree` helper, in case of a Yoast block the `parentNode` refers to the Yoast block as a whole, while we need to retrieve the `parentAttributeId` and `isParentFirstSectionOfBlock` of the individual sub-blocks. The individual block is represented by the `node` variable.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Activate Yoast SEO and Yoast SEO Premium

#### Test whether there is no error when adding image caption
* Set your site language to English
* Create a post in Classic editor
* Add an image with a caption
* Confirm that the Premium SEO analysis is working and there are no console errors
* Set the keyphrase to one of the words from the caption
* Confirm that the keyphrase density assessment recognizes the keyphrase occurrence
* Click the highlight button next to the keyphrase density assessment and confirm that the keyphrase is highlighted

#### Test highlighting in Yoast blocks
* Use the test instructions for the Yoast FAQ and How-to blocks from [this ATP](https://docs.google.com/document/d/11w5ZY17qESN9zYOD9PIsuvU4ykBgVR8rpee-8qzU3Ag/edit#heading=h.bbfe8rdn2ka9) (scenarios 1.1.1.1 A and B, excluding the steps about List block)

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* No further impact than what is already covered in the test instructions

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [x] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/plugins-automated-testing/issues/1099
