### PR TITLE
Set the `wp_attachment_pages_enabled` option (WP 6.4) when switching "Enable media pages"

### DIFF
--- a/src/integrations/watchers/indexable-attachment-watcher.php
+++ b/src/integrations/watchers/indexable-attachment-watcher.php
@@ -106,6 +106,11 @@ class Indexable_Attachment_Watcher implements Integration_Interface {
 			\delete_transient( Indexable_Post_Indexation_Action::UNINDEXED_COUNT_TRANSIENT );
 			\delete_transient( Indexable_Post_Indexation_Action::UNINDEXED_LIMITED_COUNT_TRANSIENT );
 
+			// Set this core option (introduced in WP 6.4) to ensure consistency.
+			if ( \get_option( 'wp_attachment_pages_enabled' ) !== false ) {
+				\update_option( 'wp_attachment_pages_enabled', (int) ! $new_value['disable-attachment'] );
+			}
+
 			switch ( $new_value['disable-attachment'] ) {
 				case false:
 					$this->indexing_helper->set_reason( Indexing_Reasons::REASON_ATTACHMENTS_MADE_ENABLED );

--- a/tests/unit/integrations/watchers/indexable-attachment-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-attachment-watcher-test.php
@@ -21,7 +21,7 @@ use Yoast_Notification_Center;
  * @group integrations
  * @group watchers
  *
- * @coversDefaultClass Yoast\WP\SEO\Integrations\Watchers\Indexable_Attachment_Watcher
+ * @coversDefaultClass \Yoast\WP\SEO\Integrations\Watchers\Indexable_Attachment_Watcher
  */
 class Indexable_Attachment_Watcher_Test extends TestCase {
 
@@ -206,6 +206,10 @@ class Indexable_Attachment_Watcher_Test extends TestCase {
 
 		Monkey\Functions\expect( 'delete_transient' )
 			->with( Indexable_Post_Indexation_Action::UNINDEXED_LIMITED_COUNT_TRANSIENT )
+			->times( $delete_transient_times );
+
+		Monkey\Functions\expect( 'update_option' )
+			->with( 'wp_attachment_pages_enabled', (int) ! $new_value )
 			->times( $delete_transient_times );
 
 		$this->indexing_helper


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to reduce the chances of confusion/conflict with the new `wp_attachment_pages_enabled` introduced by WP 6.4.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds support for the new `wp_attachment_pages_enabled` option introduced by WordPress 6.4, reducing the chances of inconsistencies with Yoast SEO's own "Enable media pages" setting.

## Relevant technical choices:

* I decided to avoid version checks and just go for updating the option if it's there. This way we can also avoid to change the code when we drop support for 6.3

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance-tested by following these steps:

#### WP 6.2 or 6.3 installation (regression test)
* make sure you are on a WP 6.2 or 6.3 site
* upload at least one image in Media if you don't have it already
* install Yoast SEO with this patch
* check the settings, you should have "Enable media pages" set to off as a default
* turn them on and save the settings
* perform a reindexation of the site
* visit Media, open an image, and see that the "View attachment page" link  leads to the attachment page, not the media file
* check the indexables table and see that the attachments have indexables
* check the options table and see that there is no `wp_attachment_pages_enabled` option
* turn "Enable media pages" off and save the settings
* perform a reindexation of the site
* visit Media, open an image, and see that the "View attachment page" link leads to the media file
* check the indexables table and see that the attachments don't have indexables
* check the options table and see that there is no `wp_attachment_pages_enabled` option

#### New WP 6.4 installation
* install a new WP 6.4 website (do not upgrade from a previous version)
* check the options table and see that there is a `wp_attachment_pages_enabled` option set to 0
* upload at least one image in Media if you don't have it already
* install Yoast SEO with this patch
* check the settings, you should have "Enable media pages" set to off as a default
* index your site
* visit Media, open an image, and see that the "View media file" link leads to the media file
* check the indexable table and see that the attachments don't have indexables
* turn "Enable media pages" on and save the settings
* perform a reindexation of the site
* visit Media, open an image, and see that the "View attachment page" link leads to the attachment page, not the media file
* check the indexables table and see that the attachments have indexables
* check the options table and see that the `wp_attachment_pages_enabled` option is set to 1
* turn "Enable media pages off and save the settings
* check the options table and see that the `wp_attachment_pages_enabled` option is set again to 0

#### Upgraded WP 6.4 installation
* install a new WP 6.3 website and upgrade it to WP 6.4 via e.g. the WordPress beta tester plugin
* check the options table and see that there is a `wp_attachment_pages_enabled` option set to 1
* upload at least one image in Media if you don't have it already
* install Yoast SEO with this patch
* check the settings, you should have "Enable media pages" set to off as a default
* index your site
* visit Media, open an image, and see that the "View attachment page" link leads to the media file
  * this is wrong in the WP 6.4 perspective but it's right in the Yoast perspective: basically it still behaves as in WP 6.3. This will be improved in the future.
* check the indexable table and see that the attachments don't have indexables
* turn "Enable media pages on and save the settings
* perform a reindexation of the site
* visit Media, open an image, and see that the "View attachment page" leads to the attachment page, not the media file
* check the indexables table and see that the attachments have indexables
* check the options table and see that the `wp_attachment_pages_enabled` option is still 1
* turn "Enable media pages" off and save the settings
* check the options table and see that the `wp_attachment_pages_enabled` option is set again to 0
* visit Media, open an image, and see that the "View media file" link leads to the media file
  * changing the Yoast SEO option twice has "fixed" the WP option so the link is now OK, too. 


#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #20749
