### PR TITLE
Inclusive language: Adds Roma as a suggested alternative to 'gypsy'

### DIFF
--- a/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/cultureAssessmentsSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/cultureAssessmentsSpec.js
@@ -320,8 +320,9 @@ describe( "a test for targeting non-inclusive phrases in culture assessments", (
 			{
 				identifier: "gypsy",
 				text: "In North America, the word Gypsy is most commonly used as a reference to Romani ethnicity.",
-				expectedFeedback: "Be careful when using <i>gypsy</i> as it is potentially harmful. Consider using an alternative, such as " +
-					"<i>Romani, Romani person</i>, unless referring to someone who explicitly wants to be referred to with this term. " +
+				expectedFeedback: "Be careful when using <i>gypsy</i> as it is potentially harmful. " +
+					"Consider using an alternative, such as <i>Rom, Roma person, Romani, Romani person</i>, " +
+					"unless referring to someone who explicitly wants to be referred to with this term. " +
 					"If you are referring to a lifestyle rather than the ethnic group or their music, consider using " +
 					"an alternative such as <i>traveler, wanderer, free-spirited</i>." +
 					" <a href='https://yoa.st/inclusive-language-culture' target='_blank'>Learn more.</a>",
@@ -330,8 +331,9 @@ describe( "a test for targeting non-inclusive phrases in culture assessments", (
 			{
 				identifier: "gypsy",
 				text: "In North America, the word Gipsy is most commonly used as a reference to Romani ethnicity.",
-				expectedFeedback: "Be careful when using <i>gipsy</i> as it is potentially harmful. Consider using an alternative, such as " +
-					"<i>Romani, Romani person</i>, unless referring to someone who explicitly wants to be referred to with this term. " +
+				expectedFeedback: "Be careful when using <i>gipsy</i> as it is potentially harmful. " +
+					"Consider using an alternative, such as <i>Rom, Roma person, Romani, Romani person</i>, " +
+					"unless referring to someone who explicitly wants to be referred to with this term. " +
 					"If you are referring to a lifestyle rather than the ethnic group or their music, consider using " +
 					"an alternative such as <i>traveler, wanderer, free-spirited</i>." +
 					" <a href='https://yoa.st/inclusive-language-culture' target='_blank'>Learn more.</a>",
@@ -341,7 +343,7 @@ describe( "a test for targeting non-inclusive phrases in culture assessments", (
 				identifier: "gypsies",
 				text: "In the English language, the Romani people are widely known by the exonym Gypsies.",
 				expectedFeedback: "Be careful when using <i>gypsies</i> as it is potentially harmful. Consider using an alternative, " +
-					"such as <i>Romani, Romani people</i>, unless referring to someone who explicitly wants to be referred to " +
+					"such as <i>Roma, Romani, Romani people</i>, unless referring to someone who explicitly wants to be referred to " +
 					"with this term. If you are referring to a lifestyle rather than the ethnic group or their music, " +
 					"consider using an alternative such as <i>travelers, wanderers, free-spirited</i>. " +
 					"<a href='https://yoa.st/inclusive-language-culture' target='_blank'>Learn more.</a>",
@@ -351,7 +353,7 @@ describe( "a test for targeting non-inclusive phrases in culture assessments", (
 				identifier: "gypsies",
 				text: "In the English language, the Romani people are widely known by the exonym Gipsies.",
 				expectedFeedback: "Be careful when using <i>gipsies</i> as it is potentially harmful. Consider using an alternative, " +
-					"such as <i>Romani, Romani people</i>, unless referring to someone who explicitly wants to be referred to " +
+					"such as <i>Roma, Romani, Romani people</i>, unless referring to someone who explicitly wants to be referred to " +
 					"with this term. If you are referring to a lifestyle rather than the ethnic group or their music, " +
 					"consider using an alternative such as <i>travelers, wanderers, free-spirited</i>. " +
 					"<a href='https://yoa.st/inclusive-language-culture' target='_blank'>Learn more.</a>",

--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/cultureAssessments.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/cultureAssessments.js
@@ -242,15 +242,15 @@ const cultureAssessments = [
 	{
 		identifier: "gypsy",
 		nonInclusivePhrases: [ "gypsy", "gipsy" ],
-		inclusiveAlternatives: [ "<i>Romani, Romani person</i>", "<i>traveler, wanderer, free-spirited</i>" ],
+		inclusiveAlternatives: [ "<i>Rom, Roma person, Romani, Romani person</i>", "<i>traveler, wanderer, free-spirited</i>" ],
 		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
 		feedbackFormat: [ potentiallyHarmfulUnless, "If you are referring to a lifestyle rather than the ethnic group or " +
-						"their music, consider using an alternative such as %3$s." ].join( " " ),
+		"their music, consider using an alternative such as %3$s." ].join( " " ),
 	},
 	{
 		identifier: "gypsies",
 		nonInclusivePhrases: [ "gypsies", "gipsies" ],
-		inclusiveAlternatives: [ "<i>Romani, Romani people</i>", "<i>travelers, wanderers, free-spirited</i>" ],
+		inclusiveAlternatives: [ "<i>Roma, Romani, Romani people</i>", "<i>travelers, wanderers, free-spirited</i>" ],
 		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
 		feedbackFormat: [ potentiallyHarmfulUnless, "If you are referring to a lifestyle rather than the ethnic group or " +
 		"their music, consider using an alternative such as %3$s." ].join( " " ),


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* In this PR, we add "Roma" as a suggested alternative to the non-inclusive phrases "gypsy"/"gypsies". That is because they are often used interchangeably, see for example this [entry in a diversity style guide](https://www.diversitystyleguide.com/glossary/roma-romany-romani/).

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* _Inclusive language_ analysis: Adds 'Roma' as a suggested alternative to 'gypsy'.
* [shopify-seo] _Inclusive language_ analysis: Adds 'Roma' as a suggested alternative to 'gypsy'.

## Relevant technical choices:

* None.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Enable the Inclusive language analysis.
* Set your site language to English.
* Create a new post.
* Add the word "gypsy".
* Make sure the inclusive language analysis returns an orange traffic light 🟠 and the following feedback: "Be careful when using gypsy as it is potentially harmful. Consider using an alternative, such as _Rom, Roma person, Romani, Romani person_, unless referring to someone who explicitly wants to be referred to with this term. If you are referring to a lifestyle rather than the ethnic group or their music, consider using an alternative such as _traveler, wanderer, free-spirited_."
* Remove the word "gypsy", and add the word "gypsies".
* Make sure the inclusive language analysis returns an orange traffic light 🟠 and the following feedback: "Be careful when using gypsies as it is potentially harmful. Consider using an alternative, such as _Roma, Romani, Romani people_, unless referring to someone who explicitly wants to be referred to with this term. If you are referring to a lifestyle rather than the ethnic group or their music, consider using an alternative such as _travelers, wanderers, free-spirited_."

Note: The change is so minimal that testing in one editor/post type should suffice.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Feedback for the strings "gypsy" and "gypsies".

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [x] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/lingo-other-tasks/issues/7
