### PR TITLE
Inclusive language: Align traffic light color and feedback for all phrases

### DIFF
--- a/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessmentsSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessmentsSpec.js
@@ -1196,11 +1196,12 @@ describe( "a test for targeting non-inclusive phrases in disability assessments"
 			{
 				identifier: "narcissistic",
 				text: "We all know, the lovebombing narcissistic type.",
-				expectedFeedback: "Be careful when using <i>narcissistic</i> as it is potentially harmful. If you are referencing the " +
-					"medical condition, use <i>person with narcissistic personality disorder</i> instead. If you are not referencing the " +
-					"medical condition, consider other alternatives to describe the trait or behavior, such as <i>selfish, egotistical, " +
-					"self-centered, self-absorbed, vain, toxic, manipulative</i>. " +
-					"<a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
+				expectedFeedback: "Be careful when using <i>narcissistic</i> as it is potentially harmful." +
+					" If you are referencing the medical condition, use <i>person with narcissistic personality disorder</i>" +
+					" instead, unless referring to someone who explicitly wants to be referred to with this term." +
+					" If you are not referencing the medical condition, consider other alternatives to describe the trait or behavior," +
+					" such as <i>selfish, egotistical, self-centered, self-absorbed, vain, toxic, manipulative</i>." +
+					" <a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
 				expectedScore: 6,
 			},
 		];
@@ -1225,9 +1226,9 @@ describe( "a test for targeting non-inclusive phrases in disability assessments"
 		const mockResearcher = Factory.buildMockResearcher( [ "That's a daft idea!" ] );
 
 		expect( assessment.isApplicable( mockPaper, mockResearcher ) ).toBe( true );
-		expect( assessment.getResult().score ).toBe( 6 );
-		expect( assessment.getResult().text ).toBe( "Be careful when using <i>daft</i> as it is potentially harmful. " +
-			"Consider using an alternative, such as <i>uninformed, ignorant, foolish, inconsiderate, irrational, reckless</i>." +
+		expect( assessment.getResult().score ).toBe( 3 );
+		expect( assessment.getResult().text ).toBe( "Avoid using <i>daft</i> as it is potentially harmful." +
+			" Consider using an alternative, such as <i>uninformed, ignorant, foolish, inconsiderate, irrational, reckless</i>." +
 			" <a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>" );
 	} );
 	it( "should return the appropriate score and feedback string for: 'imbecile'", () => {

--- a/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessmentsSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessmentsSpec.js
@@ -61,6 +61,17 @@ describe( "A test for Disability assessments", function() {
 		expect( assessor.getMarks() ).toEqual( [] );
 	} );
 
+	it( "should not target 'narcissistic' when followed by 'personality disorder'", () => {
+		const mockPaper = new Paper( "He was diagnosed with narcissistic personality disorder." );
+		const mockResearcher = Factory.buildMockResearcher( [ "He was diagnosed with narcissistic personality disorder." ] );
+		const assessor = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "narcissistic" ) );
+
+		const isApplicable = assessor.isApplicable( mockPaper, mockResearcher );
+
+		expect( isApplicable ).toBeFalsy();
+		expect( assessor.getMarks() ).toEqual( [] );
+	} );
+
 	it( "should only target retarded if preceded by mentally.", () => {
 		const assessment = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "retarded" ) );
 

--- a/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/sesAssessmentsSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/sesAssessmentsSpec.js
@@ -182,18 +182,18 @@ describe( "a test for targeting non-inclusive phrases in other assessments", () 
 			{
 				identifier: "felon",
 				text: "That person is a felon",
-				expectedFeedback: "Be careful when using <i>felon</i> as it is potentially harmful. Consider using an alternative, such as " +
-					"<i>person with felony convictions, person who has been incarcerated</i>. " +
+				expectedFeedback: "Avoid using <i>felon</i> as it is potentially harmful. Consider using an alternative," +
+					" such as <i>person with felony convictions, person who has been incarcerated</i>. " +
 					"<a href='https://yoa.st/inclusive-language-ses' target='_blank'>Learn more.</a>",
-				expectedScore: 6,
+				expectedScore: 3,
 			},
 			{
 				identifier: "felons",
 				text: "Those group of people are all felons",
-				expectedFeedback: "Be careful when using <i>felons</i> as it is potentially harmful. Consider using an alternative, such as " +
+				expectedFeedback: "Avoid using <i>felons</i> as it is potentially harmful. Consider using an alternative, such as " +
 					"<i>people with felony convictions, people who have been incarcerated</i>. " +
 					"<a href='https://yoa.st/inclusive-language-ses' target='_blank'>Learn more.</a>",
-				expectedScore: 6,
+				expectedScore: 3,
 			},
 		];
 

--- a/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/sexualOrientationAssessmentsSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/sexualOrientationAssessmentsSpec.js
@@ -17,9 +17,10 @@ describe( "A test for Sexual orientation assessments", function() {
 		expect( isApplicable ).toBeTruthy();
 		expect( assessmentResult.getScore() ).toEqual( 6 );
 		expect( assessmentResult.getText() ).toEqual(
-			"Be careful when using <i>homosexuals</i> as it may overgeneralize or be harmful. " +
-			"Instead, be specific about the group you are referring to (e.g. <i>gay men, queer people, lesbians</i>). " +
-			"<a href='https://yoa.st/inclusive-language-orientation' target='_blank'>Learn more.</a>" );
+			"Be careful when using <i>homosexuals</i> as it is potentially harmful. Consider using an alternative," +
+			" such as <i>gay people, queer people, lesbians, gay men, people in same-gender relationships</i>, unless referring" +
+			" to someone who explicitly wants to be referred to with this term. Be as specific possible and use people's preferred" +
+			" labels if they are known. <a href='https://yoa.st/inclusive-language-orientation' target='_blank'>Learn more.</a>" );
 		expect( assessmentResult.hasMarks() ).toBeTruthy();
 		expect( assessor.getMarks() ).toEqual( [ new Mark( {
 			original: mockText,

--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessments.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessments.js
@@ -576,6 +576,8 @@ const disabilityAssessments =  [
 		feedbackFormat: "Be careful when using <i>%1$s</i> as it is potentially harmful. If you are referencing the " +
 			"medical condition, use %2$s instead, unless referring to someone who explicitly wants to be referred to with this term." +
 			" If you are not referencing the medical condition, consider other alternatives to describe the trait or behavior, such as %3$s.",
+		rule: ( words, nonInclusivePhrase ) => includesConsecutiveWords( words, nonInclusivePhrase )
+			.filter( isNotFollowedByException( words, nonInclusivePhrase, [ "personality disorder" ] ) ),
 	},
 	{
 		identifier: "OCD",

--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessments.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessments.js
@@ -1,6 +1,5 @@
 import {
 	potentiallyHarmful,
-	potentiallyHarmfulCareful,
 	potentiallyHarmfulUnless,
 	harmfulPotentiallyNonInclusive,
 	alternative,
@@ -155,8 +154,8 @@ const disabilityAssessments =  [
 		identifier: "daft",
 		nonInclusivePhrases: [ "daft" ],
 		inclusiveAlternatives: "<i>uninformed, ignorant, foolish, inconsiderate, irrational, reckless</i>",
-		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
-		feedbackFormat: potentiallyHarmfulCareful,
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmful,
 	},
 	{
 		identifier: "handicapped",
@@ -575,8 +574,8 @@ const disabilityAssessments =  [
 			"<i>selfish, egotistical, self-centered, self-absorbed, vain, toxic, manipulative</i>" ],
 		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
 		feedbackFormat: "Be careful when using <i>%1$s</i> as it is potentially harmful. If you are referencing the " +
-			"medical condition, use %2$s instead. If you are not referencing the medical condition, consider other" +
-			" alternatives to describe the trait or behavior, such as %3$s.",
+			"medical condition, use %2$s instead, unless referring to someone who explicitly wants to be referred to with this term." +
+			" If you are not referencing the medical condition, consider other alternatives to describe the trait or behavior, such as %3$s.",
 	},
 	{
 		identifier: "OCD",

--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/sesAssessments.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/sesAssessments.js
@@ -1,4 +1,4 @@
-import { potentiallyHarmful, potentiallyHarmfulCareful, potentiallyHarmfulUnless } from "./feedbackStrings";
+import { potentiallyHarmful, potentiallyHarmfulUnless } from "./feedbackStrings";
 import { SCORES } from "./scores";
 import { includesConsecutiveWords } from "../helpers/includesConsecutiveWords";
 import notInclusiveWhenStandalone from "../helpers/notInclusiveWhenStandalone";
@@ -64,15 +64,15 @@ const sesAssessments = [
 		identifier: "felon",
 		nonInclusivePhrases: [ "felon" ],
 		inclusiveAlternatives: "<i>person with felony convictions, person who has been incarcerated</i>",
-		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
-		feedbackFormat: potentiallyHarmfulCareful,
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmful,
 	},
 	{
 		identifier: "felons",
 		nonInclusivePhrases: [ "felons" ],
 		inclusiveAlternatives: "<i>people with felony convictions, people who have been incarcerated</i>",
-		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
-		feedbackFormat: potentiallyHarmfulCareful,
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: potentiallyHarmful,
 	},
 	{
 		identifier: "ex-offender",

--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/sexualOrientationAssessments.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/sexualOrientationAssessments.js
@@ -1,13 +1,13 @@
 import { SCORES } from "./scores";
+import { potentiallyHarmfulUnless } from "./feedbackStrings";
 
 const sexualOrientationAssessments = [
 	{
 		identifier: "homosexuals",
 		nonInclusivePhrases: [ "homosexuals" ],
-		inclusiveAlternatives: "<i>gay men, queer people, lesbians</i>",
+		inclusiveAlternatives: "<i>gay people, queer people, lesbians, gay men, people in same-gender relationships</i>",
 		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
-		feedbackFormat: "Be careful when using <i>%1$s</i> as it may overgeneralize or be harmful. " +
-			"Instead, be specific about the group you are referring to (e.g. %2$s).",
+		feedbackFormat: [ potentiallyHarmfulUnless, "Be as specific possible and use people's preferred labels if they are known." ].join( " " ),
 	},
 ];
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to have a consistent meaning of the orange traffic light as ‘potentially non-inclusive’. This PR changes either the written feedback or the traffic light color for phrases where the feedback and traffic light color didn't align.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves the feedback for phrases where the traffic light color and the written feedback didn't align.

## Relevant technical choices:

* The feedback for 'homosexuals' is further improved by adding a few more alternatives, and simplifying the feedback string to say 'harmful' rather than 'overgeneralize or be harmful' (since overgeneralization falls under being harmful).
* In this PR we also address [this issue](https://github.com/Yoast/lingo-other-tasks/issues/20) to add a rule to not target 'narcissistic' when followed by 'personality disorder'.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Activate Yoast SEO Free and the inclusive language feature
* Create a new post and add the sentence `They are homosexuals.`
* Confirm that the Inclusive language analysis shows an **orange** traffic light with the following feedback:
     * Be careful when using _homosexuals_ as it is potentially harmful. Consider using an alternative, such as _gay people, queer people, lesbians, gay men, people in same-gender relationships_, unless referring to someone who explicitly wants to be referred to with this term. Be as specific possible and use people's preferred labels if they are known. Learn more.
* Add another sentence: `She is very narcissistic.`
* Confirm that the Inclusive language analysis shows another **orange** traffic light with the following feedback:
     * Be careful when using _narcissistic_ as it is potentially harmful. If you are referencing the medical condition, use person with narcissistic personality disorder instead, unless referring to someone who explicitly wants to be referred to with this term. If you are not referencing the medical condition, consider other alternatives to describe the trait or behavior, such as _selfish, egotistical, self-centered, self-absorbed, vain, toxic, manipulative_. Learn more.
* Change the sentence to `She has narcissistic personality disorder.`
* Confirm that the feedback for `narcissistic` disappears.
* Add another sentence: `He is a felon.`
* Confirm that the Inclusive language analysis shows a **red** traffic light with the following feedback:
     * Avoid using _felon_ as it is potentially harmful. Consider using an alternative, such as _person with felony convictions, person who has been incarcerated_. Learn more.
* Add another sentence: `They are both felons.`
* Confirm that the Inclusive language analysis shows a **red** traffic light with the following feedback:
     * Avoid using _felons_ as it is potentially harmful. Consider using an alternative, such as _people with felony convictions, people who has been incarcerated_. Learn more.
* Add another sentence: `This is so daft.`
* Confirm that the Inclusive language analysis shows a **red** traffic light with the following feedback:
     * Avoid using _daft_ as it is potentially harmful. Consider using an alternative, such as _uninformed, ignorant, foolish, inconsiderate, irrational, reckless_. Learn more.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* No further impact.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [x] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [Align bullet color and feedback string for all phrases](https://github.com/Yoast/lingo-other-tasks/issues/29) & [Don't target 'narcissistic' when followed by 'personality disorder'](https://github.com/Yoast/lingo-other-tasks/issues/20)
