### PR TITLE
Inclusive language: Change the feedback strings for overgeneralizing cases

### DIFF
--- a/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/cultureAssessmentsSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/cultureAssessmentsSpec.js
@@ -55,14 +55,16 @@ describe( "A test for Culture Assessments", () => {
 	} );
 } );
 
+// eslint-disable-next-line max-statements
 describe( "a test for targeting non-inclusive phrases in culture assessments", () => {
 	it( "should return the appropriate score and feedback string for: 'Third World'", () => {
 		const testData = [
 			{
 				identifier: "thirdWorld",
 				text: "There are bigger problems in the Third World.",
-				expectedFeedback: "Avoid using <i>Third World</i> as it is overgeneralizing. Consider using the specific name for the region " +
-					"or country instead.  <a href='https://yoa.st/inclusive-language-culture' target='_blank'>Learn more.</a>",
+				expectedFeedback: "Avoid using <i>Third World</i> as it is potentially harmful. Consider using an alternative," +
+					" such as the specific name for the region or country." +
+					" <a href='https://yoa.st/inclusive-language-culture' target='_blank'>Learn more.</a>",
 				expectedScore: 3,
 			},
 		];
@@ -533,7 +535,8 @@ describe( "a test for targeting non-inclusive phrases in culture assessments", (
 		const assessmentResult = assessor.getResult();
 		expect( assessmentResult.getScore() ).toEqual( 3 );
 		expect( assessmentResult.getText() ).toEqual(
-			"Avoid using <i>first-world</i> as it is overgeneralizing. Consider using the specific name for the country or region instead.  " +
+			"Avoid using <i>first-world</i> as it is potentially harmful. Consider using an alternative," +
+			" such as the specific name for the country or region. " +
 			"<a href='https://yoa.st/inclusive-language-culture' target='_blank'>Learn more.</a>"
 		);
 		expect( assessmentResult.hasMarks() ).toBeTruthy();
@@ -554,8 +557,8 @@ describe( "a test for targeting non-inclusive phrases in culture assessments", (
 		const assessmentResult = assessor.getResult();
 		expect( assessmentResult.getScore() ).toEqual( 3 );
 		expect( assessmentResult.getText() ).toEqual(
-			"Avoid using <i>first world countries</i> as it is overgeneralizing. " +
-			"Consider using the specific name for the countries or regions instead.  " +
+			"Avoid using <i>first world countries</i> as it is potentially harmful. Consider using an alternative, " +
+			"such as the specific name for the countries or regions. " +
 			"<a href='https://yoa.st/inclusive-language-culture' target='_blank'>Learn more.</a>"
 		);
 		expect( assessmentResult.hasMarks() ).toBeTruthy();
@@ -823,8 +826,8 @@ describe( "a test for targeting non-inclusive phrases in culture assessments", (
 			{
 				identifier: "firstWorldCountries",
 				text: "It's natural that one would choose one of the first world countries to raise a child.",
-				expectedFeedback: "Avoid using <i>first world countries</i> as it is overgeneralizing. " +
-					"Consider using the specific name for the countries or regions instead.  " +
+				expectedFeedback: "Avoid using <i>first world countries</i> as it is potentially harmful. " +
+					"Consider using an alternative, such as the specific name for the countries or regions. " +
 					"<a href='https://yoa.st/inclusive-language-culture' target='_blank'>Learn more.</a>",
 				expectedScore: 3,
 			},

--- a/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/cultureAssessmentsSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/cultureAssessmentsSpec.js
@@ -558,7 +558,7 @@ describe( "a test for targeting non-inclusive phrases in culture assessments", (
 		expect( assessmentResult.getScore() ).toEqual( 3 );
 		expect( assessmentResult.getText() ).toEqual(
 			"Avoid using <i>first world countries</i> as it is potentially harmful. Consider using an alternative, " +
-			"such as the specific name for the countries or regions. " +
+			"such as the specific name for the regions or countries. " +
 			"<a href='https://yoa.st/inclusive-language-culture' target='_blank'>Learn more.</a>"
 		);
 		expect( assessmentResult.hasMarks() ).toBeTruthy();
@@ -827,7 +827,7 @@ describe( "a test for targeting non-inclusive phrases in culture assessments", (
 				identifier: "firstWorldCountries",
 				text: "It's natural that one would choose one of the first world countries to raise a child.",
 				expectedFeedback: "Avoid using <i>first world countries</i> as it is potentially harmful. " +
-					"Consider using an alternative, such as the specific name for the countries or regions. " +
+					"Consider using an alternative, such as the specific name for the regions or countries. " +
 					"<a href='https://yoa.st/inclusive-language-culture' target='_blank'>Learn more.</a>",
 				expectedScore: 3,
 			},

--- a/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/cultureAssessmentsSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/cultureAssessmentsSpec.js
@@ -536,7 +536,7 @@ describe( "a test for targeting non-inclusive phrases in culture assessments", (
 		expect( assessmentResult.getScore() ).toEqual( 3 );
 		expect( assessmentResult.getText() ).toEqual(
 			"Avoid using <i>first-world</i> as it is potentially harmful. Consider using an alternative," +
-			" such as the specific name for the country or region. " +
+			" such as the specific name for the region or country. " +
 			"<a href='https://yoa.st/inclusive-language-culture' target='_blank'>Learn more.</a>"
 		);
 		expect( assessmentResult.hasMarks() ).toBeTruthy();

--- a/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessmentsSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessmentsSpec.js
@@ -898,7 +898,7 @@ describe( "a test for targeting non-inclusive phrases in disability assessments"
 		];
 		testInclusiveLanguageAssessments( testData );
 	} );
-	it( "should not show the feedback for the non-negated form of 'crazy about' when the negated form is used.", () => {
+	it( "should not show the feedback for the negated form of 'crazy about' when the non-negated form is used.", () => {
 		const mockPaper = new Paper( "I am so crazy about this album." );
 		const mockResearcher = Factory.buildMockResearcher( [ "I am so crazy about this album." ] );
 		const assessor = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "to be not crazy about" ) );
@@ -1211,8 +1211,8 @@ describe( "a test for targeting non-inclusive phrases in disability assessments"
 			{
 				identifier: "theMentallyIll",
 				text: "There is growing compassion for the mentally ill.",
-				expectedFeedback: "Avoid using <i>the mentally ill</i> as it is generalizing. Consider using an alternative, " +
-					"such as <i>people who are mentally ill</i>, <i>mentally ill people</i> instead. " +
+				expectedFeedback: "Avoid using <i>the mentally ill</i> as it is potentially harmful. Consider using an alternative," +
+					" such as <i>people who are mentally ill</i>, <i>mentally ill people</i>. " +
 					"<a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
 				expectedScore: 3,
 			},

--- a/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/sesAssessmentsSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/sesAssessmentsSpec.js
@@ -15,10 +15,9 @@ describe( "A test for SES assessments", function() {
 
 		expect( isApplicable ).toBeTruthy();
 		expect( assessmentResult.getScore() ).toEqual( 3 );
-		expect( assessmentResult.getText() ).toEqual(
-			"Avoid using <i>the poor</i> as it is potentially overgeneralizing. " +
-			"Consider using <i>people whose income is below the poverty threshold</i> or <i>people with low-income</i> instead. " +
-			"<a href='https://yoa.st/inclusive-language-ses' target='_blank'>Learn more.</a>" );
+		expect( assessmentResult.getText() ).toEqual( "Avoid using <i>the poor</i> as it is potentially harmful. " +
+			"Consider using an alternative, such as <i>people whose income is below the poverty threshold, people with low-income</i>." +
+			" <a href='https://yoa.st/inclusive-language-ses' target='_blank'>Learn more.</a>" );
 		expect( assessmentResult.hasMarks() ).toBeTruthy();
 		expect( assessor.getMarks() ).toEqual( [ new Mark( {
 			original: "The poor worked, the better they are.",
@@ -35,10 +34,9 @@ describe( "A test for SES assessments", function() {
 
 		expect( isApplicable ).toBeTruthy();
 		expect( assessmentResult.getScore() ).toEqual( 3 );
-		expect( assessmentResult.getText() ).toEqual(
-			"Avoid using <i>the poor</i> as it is potentially overgeneralizing. " +
-			"Consider using <i>people whose income is below the poverty threshold</i> or <i>people with low-income</i> instead. " +
-			"<a href='https://yoa.st/inclusive-language-ses' target='_blank'>Learn more.</a>" );
+		expect( assessmentResult.getText() ).toEqual( "Avoid using <i>the poor</i> as it is potentially harmful. " +
+			"Consider using an alternative, such as <i>people whose income is below the poverty threshold, people with low-income</i>." +
+			" <a href='https://yoa.st/inclusive-language-ses' target='_blank'>Learn more.</a>" );
 		expect( assessmentResult.hasMarks() ).toBeTruthy();
 		expect( assessor.getMarks() ).toEqual( [ new Mark( {
 			original: "The poor however, did not go to the zoo.",
@@ -55,10 +53,9 @@ describe( "A test for SES assessments", function() {
 
 		expect( isApplicable ).toBeTruthy();
 		expect( assessmentResult.getScore() ).toEqual( 3 );
-		expect( assessmentResult.getText() ).toEqual(
-			"Avoid using <i>the poor</i> as it is potentially overgeneralizing. " +
-			"Consider using <i>people whose income is below the poverty threshold</i> or <i>people with low-income</i> instead. " +
-			"<a href='https://yoa.st/inclusive-language-ses' target='_blank'>Learn more.</a>" );
+		expect( assessmentResult.getText() ).toEqual( "Avoid using <i>the poor</i> as it is potentially harmful. " +
+			"Consider using an alternative, such as <i>people whose income is below the poverty threshold, people with low-income</i>." +
+			" <a href='https://yoa.st/inclusive-language-ses' target='_blank'>Learn more.</a>" );
 		expect( assessmentResult.hasMarks() ).toBeTruthy();
 		expect( assessor.getMarks() ).toEqual( [ new Mark( {
 			original: "I have always loved the poor!",
@@ -247,49 +244,49 @@ describe( "a test for targeting non-inclusive phrases in other assessments", () 
 			{
 				identifier: "theHomeless",
 				text: "This ad is aimed at the homeless in LA. The target word is followed by a preposition.",
-				expectedFeedback: "Avoid using <i>the homeless</i> as it is generalizing. " +
-					"Consider using <i>people experiencing homelessness </i> instead. " +
-					"<a href='https://yoa.st/inclusive-language-ses' target='_blank'>Learn more.</a>",
+				expectedFeedback: "Avoid using <i>the homeless</i> as it is potentially harmful. Consider using an alternative, " +
+					"such as <i>people experiencing homelessness</i>. <a href='https://yoa.st/inclusive-language-ses'" +
+					" target='_blank'>Learn more.</a>",
 				expectedScore: 3,
 			},
 			{
 				identifier: "theUndocumented",
 				text: "This targets the undocumented across the US. The target word is followed by a preposition.",
-				expectedFeedback: "Avoid using <i>the undocumented</i> as it is potentially overgeneralizing. " +
-					"Consider using <i>people who are undocumented, undocumented people, people without papers </i> instead." +
-					" <a href='https://yoa.st/inclusive-language-ses' target='_blank'>Learn more.</a>",
+				expectedFeedback: "Avoid using <i>the undocumented</i> as it is potentially harmful. Consider using an alternative, such as " +
+					"<i>people who are undocumented, undocumented people, people without papers</i>. " +
+					"<a href='https://yoa.st/inclusive-language-ses' target='_blank'>Learn more.</a>",
 				expectedScore: 3,
 			},
 			{
 				identifier: "theHomeless",
 				text: "This ad is aimed at the homeless. The target word is followed by a punctuation mark.",
-				expectedFeedback: "Avoid using <i>the homeless</i> as it is generalizing. " +
-					"Consider using <i>people experiencing homelessness </i> instead. " +
-					"<a href='https://yoa.st/inclusive-language-ses' target='_blank'>Learn more.</a>",
+				expectedFeedback: "Avoid using <i>the homeless</i> as it is potentially harmful. Consider using an alternative, " +
+					"such as <i>people experiencing homelessness</i>. <a href='https://yoa.st/inclusive-language-ses'" +
+					" target='_blank'>Learn more.</a>",
 				expectedScore: 3,
 			},
 			{
 				identifier: "theUndocumented",
 				text: "This will be a major blow to the undocumented. The target word is followed by a punctuation mark.",
-				expectedFeedback: "Avoid using <i>the undocumented</i> as it is potentially overgeneralizing. " +
-					"Consider using <i>people who are undocumented, undocumented people, people without papers </i> instead." +
-					" <a href='https://yoa.st/inclusive-language-ses' target='_blank'>Learn more.</a>",
+				expectedFeedback: "Avoid using <i>the undocumented</i> as it is potentially harmful. Consider using an alternative, such as " +
+					"<i>people who are undocumented, undocumented people, people without papers</i>. " +
+					"<a href='https://yoa.st/inclusive-language-ses' target='_blank'>Learn more.</a>",
 				expectedScore: 3,
 			},
 			{
 				identifier: "theHomeless",
 				text: "The homeless faced staggering discrimination. The target word is followed by a past participle.",
-				expectedFeedback: "Avoid using <i>the homeless</i> as it is generalizing. " +
-					"Consider using <i>people experiencing homelessness </i> instead. " +
-					"<a href='https://yoa.st/inclusive-language-ses' target='_blank'>Learn more.</a>",
+				expectedFeedback: "Avoid using <i>the homeless</i> as it is potentially harmful. Consider using an alternative, " +
+					"such as <i>people experiencing homelessness</i>. <a href='https://yoa.st/inclusive-language-ses'" +
+					" target='_blank'>Learn more.</a>",
 				expectedScore: 3,
 			},
 			{
 				identifier: "theUndocumented",
 				text: "The undocumented didn't receive a fair trial. The target word is followed by a past participle.",
-				expectedFeedback: "Avoid using <i>the undocumented</i> as it is potentially overgeneralizing. " +
-					"Consider using <i>people who are undocumented, undocumented people, people without papers </i> instead." +
-					" <a href='https://yoa.st/inclusive-language-ses' target='_blank'>Learn more.</a>",
+				expectedFeedback: "Avoid using <i>the undocumented</i> as it is potentially harmful. Consider using an alternative, such as " +
+					"<i>people who are undocumented, undocumented people, people without papers</i>. " +
+					"<a href='https://yoa.st/inclusive-language-ses' target='_blank'>Learn more.</a>",
 				expectedScore: 3,
 			},
 		];
@@ -306,10 +303,9 @@ describe( "a test for targeting non-inclusive phrases in other assessments", () 
 		expect( isApplicable ).toBeTruthy();
 		const assessmentResult = assessor.getResult();
 		expect( assessmentResult.getScore() ).toEqual( 3 );
-		expect( assessmentResult.getText() ).toEqual(
-			"Avoid using <i>the undocumented</i> as it is potentially overgeneralizing. " +
-			"Consider using <i>people who are undocumented, undocumented people, people without papers </i> instead. " +
-			"<a href='https://yoa.st/inclusive-language-ses' target='_blank'>Learn more.</a>"
+		expect( assessmentResult.getText() ).toEqual( "Avoid using <i>the undocumented</i> as it is potentially harmful. " +
+			"Consider using an alternative, such as <i>people who are undocumented, undocumented people, people without papers</i>." +
+			" <a href='https://yoa.st/inclusive-language-ses' target='_blank'>Learn more.</a>"
 		);
 		expect( assessmentResult.hasMarks() ).toBeTruthy();
 		expect( assessor.getMarks() ).toEqual(   [ { _properties: {

--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/cultureAssessments.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/cultureAssessments.js
@@ -330,7 +330,7 @@ const cultureAssessments = [
 	{
 		identifier: "firstWorldCountries",
 		nonInclusivePhrases: [ "first world countries" ],
-		inclusiveAlternatives: "the specific name for the countries or regions",
+		inclusiveAlternatives: "the specific name for the regions or countries",
 		score: SCORES.NON_INCLUSIVE,
 		feedbackFormat: potentiallyHarmful,
 	},

--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/cultureAssessments.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/cultureAssessments.js
@@ -337,7 +337,7 @@ const cultureAssessments = [
 	{
 		identifier: "firstWorldHyphen",
 		nonInclusivePhrases: [ "first-world" ],
-		inclusiveAlternatives: "the specific name for the country or region",
+		inclusiveAlternatives: "the specific name for the region or country",
 		score: SCORES.NON_INCLUSIVE,
 		feedbackFormat: potentiallyHarmful,
 	},

--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/cultureAssessments.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/cultureAssessments.js
@@ -18,12 +18,6 @@ import {
 const potentiallyHarmfulUnlessCulture = "Be careful when using <i>%1$s</i> as it is potentially harmful. " +
 										"Consider using an alternative, such as %2$s instead, unless you are referring to the culture " +
 										"in which this term originated.";
-/*
- * Used for overgeneralizing terms, such as 'First World' or 'Third World'.
- *
- * "Avoid using <i>%1$s</i> as it is overgeneralizing. Consider using %2$s instead.
- */
-const overgeneralizing = "Avoid using <i>%1$s</i> as it is overgeneralizing. Consider using %2$s instead. ";
 
 const cultureAssessments = [
 	{
@@ -31,7 +25,7 @@ const cultureAssessments = [
 		nonInclusivePhrases: [ "First World" ],
 		inclusiveAlternatives: "the specific name for the region or country",
 		score: SCORES.NON_INCLUSIVE,
-		feedbackFormat: overgeneralizing,
+		feedbackFormat: potentiallyHarmful,
 		caseSensitive: true,
 		rule: ( words, nonInclusivePhrase ) => includesConsecutiveWords( words, nonInclusivePhrase )
 			.filter( isNotFollowedByException( words, nonInclusivePhrase, [ "War", "war", "Assembly", "assembly" ] ) ),
@@ -41,7 +35,7 @@ const cultureAssessments = [
 		nonInclusivePhrases: [ "Third World" ],
 		inclusiveAlternatives: "the specific name for the region or country",
 		score: SCORES.NON_INCLUSIVE,
-		feedbackFormat: overgeneralizing,
+		feedbackFormat: potentiallyHarmful,
 		caseSensitive: true,
 		rule: ( words, nonInclusivePhrase ) => includesConsecutiveWords( words, nonInclusivePhrase )
 			.filter( isNotFollowedByException( words, nonInclusivePhrase, [ "War", "war", "Quarterly", "quarterly", "country" ] ) ),
@@ -338,14 +332,14 @@ const cultureAssessments = [
 		nonInclusivePhrases: [ "first world countries" ],
 		inclusiveAlternatives: "the specific name for the countries or regions",
 		score: SCORES.NON_INCLUSIVE,
-		feedbackFormat: overgeneralizing,
+		feedbackFormat: potentiallyHarmful,
 	},
 	{
 		identifier: "firstWorldHyphen",
 		nonInclusivePhrases: [ "first-world" ],
 		inclusiveAlternatives: "the specific name for the country or region",
 		score: SCORES.NON_INCLUSIVE,
-		feedbackFormat: overgeneralizing,
+		feedbackFormat: potentiallyHarmful,
 	},
 	{
 		identifier: "third-worldCountry",

--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessments.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessments.js
@@ -30,12 +30,7 @@ import { sprintf } from "@wordpress/i18n";
  * "Avoid using <i>%1$s</i> as it is derogatory. Consider using an alternative, such as %2$s instead."
  */
 const derogatory = "Avoid using <i>%1$s</i> as it is derogatory. Consider using an alternative, such as %2$s instead.";
-/*
- * Used for generalizing terms, such as 'the mentally ill'.
- *
- * "Avoid using <i>%1$s</i> as it is generalizing. Consider using an alternative, such as %2$s instead."
- */
-const generalizing = "Avoid using <i>%1$s</i> as it is generalizing. Consider using an alternative, such as %2$s instead.";
+
 /*
  * Used for terms that are inclusive only if you are referring to a medical condition, for example 'manic' or 'OCD'.
  *
@@ -415,7 +410,7 @@ const disabilityAssessments =  [
 		inclusiveAlternatives: "<i>to be not impressed by, to be not enthusiastic about, to be not into, to not like</i>",
 		score: SCORES.NON_INCLUSIVE,
 		feedbackFormat: phrasesWithCrazyFeedback,
-		// Target only when preceded by a form of "to be", the negation "not", and an an optional intensifier (e.g. "is not so crazy about" ).
+		// Target only when preceded by a form of "to be", the negation "not", and an optional intensifier (e.g. "is not so crazy about" ).
 		rule: ( words, nonInclusivePhrase ) => {
 			return includesConsecutiveWords( words, nonInclusivePhrase )
 				.filter( isNotPrecededByException( words, formsOfToBeNotWithOptionalIntensifier ) );
@@ -427,7 +422,7 @@ const disabilityAssessments =  [
 		inclusiveAlternatives: "<i>to love, to be obsessed with, to be infatuated with</i>",
 		score: SCORES.NON_INCLUSIVE,
 		feedbackFormat: phrasesWithCrazyFeedback,
-		// Target only when preceded by a form of "to be" and an an optional intensifier (e.g. "am so crazy about")
+		// Target only when preceded by a form of "to be" and an optional intensifier (e.g. "am so crazy about")
 		rule: ( words, nonInclusivePhrase ) => {
 			return includesConsecutiveWords( words, nonInclusivePhrase )
 				.filter( isNotPrecededByException( words, formsOfToBeWithOptionalIntensifier ) );
@@ -598,7 +593,7 @@ const disabilityAssessments =  [
 		nonInclusivePhrases: [ "the mentally ill" ],
 		inclusiveAlternatives: "<i>people who are mentally ill</i>, <i>mentally ill people</i>",
 		score: SCORES.NON_INCLUSIVE,
-		feedbackFormat: [ generalizing ].join( " " ),
+		feedbackFormat: potentiallyHarmful,
 		rule: ( words, nonInclusivePhrase ) => {
 			return includesConsecutiveWords( words, nonInclusivePhrase )
 				.filter( notInclusiveWhenStandalone( words, nonInclusivePhrase ) );
@@ -609,7 +604,7 @@ const disabilityAssessments =  [
 		nonInclusivePhrases: [ "the disabled" ],
 		inclusiveAlternatives: "<i>people who have a disability</i>, <i>disabled people</i>",
 		score: SCORES.NON_INCLUSIVE,
-		feedbackFormat: [ potentiallyHarmful ].join( " " ),
+		feedbackFormat: potentiallyHarmful,
 		rule: ( words, nonInclusivePhrase ) => {
 			return includesConsecutiveWords( words, nonInclusivePhrase )
 				.filter( notInclusiveWhenStandalone( words, nonInclusivePhrase ) );

--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/sesAssessments.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/sesAssessments.js
@@ -91,9 +91,9 @@ const sesAssessments = [
 	{
 		identifier: "theHomeless",
 		nonInclusivePhrases: [ "the homeless" ],
-		inclusiveAlternatives: "<i>people experiencing homelessness </i>",
+		inclusiveAlternatives: "<i>people experiencing homelessness</i>",
 		score: SCORES.NON_INCLUSIVE,
-		feedbackFormat: "Avoid using <i>%1$s</i> as it is generalizing. Consider using %2$s instead.",
+		feedbackFormat: potentiallyHarmful,
 		rule: ( words, nonInclusivePhrase ) => {
 			return includesConsecutiveWords( words, nonInclusivePhrase )
 				.filter( notInclusiveWhenStandalone( words, nonInclusivePhrase ) );
@@ -102,9 +102,9 @@ const sesAssessments = [
 	{
 		identifier: "theUndocumented",
 		nonInclusivePhrases: [ "the undocumented" ],
-		inclusiveAlternatives: "<i>people who are undocumented, undocumented people, people without papers </i>",
+		inclusiveAlternatives: "<i>people who are undocumented, undocumented people, people without papers</i>",
 		score: SCORES.NON_INCLUSIVE,
-		feedbackFormat: "Avoid using <i>%1$s</i> as it is potentially overgeneralizing. Consider using %2$s instead.",
+		feedbackFormat: potentiallyHarmful,
 		rule: ( words, nonInclusivePhrase ) => {
 			return includesConsecutiveWords( words, nonInclusivePhrase )
 				.filter( notInclusiveWhenStandalone( words, nonInclusivePhrase ) );
@@ -113,9 +113,9 @@ const sesAssessments = [
 	{
 		identifier: "thePoor",
 		nonInclusivePhrases: [ "the poor" ],
-		inclusiveAlternatives: [ "people whose income is below the poverty threshold", "people with low-income" ],
+		inclusiveAlternatives: "<i>people whose income is below the poverty threshold, people with low-income</i>",
 		score: SCORES.NON_INCLUSIVE,
-		feedbackFormat: "Avoid using <i>%1$s</i> as it is potentially overgeneralizing. Consider using <i>%2$s</i> or <i>%3$s</i> instead.",
+		feedbackFormat: potentiallyHarmful,
 		rule: ( words, nonInclusivePhrase ) => {
 			return includesConsecutiveWords( words, nonInclusivePhrase )
 				.filter( notInclusiveWhenStandalone( words, nonInclusivePhrase ) );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* There are multiple variations of the feedback strings for "overgeneralizing" phrases. This PR improves the feedback strings so that they are more consistent. In [this research issue](https://github.com/Yoast/lingo-other-tasks/issues/19), it's decided to replace the overgeneralizing/generalizing strings with the `potentiallyHarmful` string. This PR implements that decision.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* _Inclusive language_ analysis: Improves the feedback strings for "overgeneralizing" phrases.
* [shopify-seo] _Inclusive language_ analysis: Improves the feedback strings for "overgeneralizing" phrases.
* [yoastseo] Replaces the feedback strings for generalization/overgeneralization phrases with `potentiallyHarmful` feedback string in _inclusive language_ analysis.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install and activate Yoast SEO
* Set the site language to English
* Enable the Inclusive language analysis in the setting (Yoast SEO > General> Site features > Inclusive language analysis)
* Create a post
* Add some text to the post
<details>
  <summary><strong>Test "First World"</strong></summary>
  <ul>
     <li>Add the following sentence to the text: 
        <ul>
           <li>These are my First World problems.</li>
        </ul>
     </li>
     <li>Go to Inclusive language analysis</li>
     <li>Confirm that you get the following feedback:
        <ul>
          <li>Traffic light: 🔴 </li>
          <li>Feedback: 
             <ul>
                 <li>Avoid using <i>First World</i> as it is potentially harmful. Consider using an alternative, such as the specific name for the region or country. Learn more.</li>
             </ul>
          </li>
        </ul>
      </li>
   </ul>
</details>

<details>
  <summary><strong>Test "Third World"</strong></summary>
  <ul>
     <li>Add the following sentence to the text: 
        <ul>
           <li>There are bigger problems in the Third World.</li>
        </ul>
     </li>
     <li>Go to Inclusive language analysis</li>
     <li>Confirm that you get the following feedback:
        <ul>
          <li>Traffic light: 🔴 </li>
          <li>Feedback: 
             <ul>
                 <li>Avoid using <i>Third World</i> as it is potentially harmful. Consider using an alternative, such as the specific name for the region or country. Learn more.</li>
             </ul>
          </li>
        </ul>
      </li>
   </ul>
</details>

<details>
  <summary><strong>Test "first world countries"</strong></summary>
  <ul>
     <li>Add the following sentence to the text: 
        <ul>
           <li>Many first world countries adopted the policy.</li>
        </ul>
     </li>
     <li>Go to Inclusive language analysis</li>
     <li>Confirm that you get the following feedback:
        <ul>
          <li>Traffic light: 🔴 </li>
          <li>Feedback: 
             <ul>
                 <li>Avoid using <i>first world countries</i> as it is potentially harmful. Consider using an alternative, such as the specific name for the regions or countries. Learn more.</li>
             </ul>
          </li>
        </ul>
      </li>
   </ul>
</details>

<details>
  <summary><strong>Test "first-world"</strong></summary>
  <ul>
     <li>Add the following sentence to the text: 
        <ul>
           <li>This sentence contains first-world.</li>
        </ul>
     </li>
     <li>Go to Inclusive language analysis</li>
     <li>Confirm that you get the following feedback:
        <ul>
          <li>Traffic light: 🔴 </li>
          <li>Feedback: 
             <ul>
                 <li>Avoid using <i>first-world</i> as it is potentially harmful. Consider using an alternative, such as the specific name for the region or country. Learn more.</li>
             </ul>
          </li>
        </ul>
      </li>
   </ul>
</details>

<details>
  <summary><strong>Test "the homeless"</strong></summary>
  <ul>
     <li>Add the following sentence to the text: 
        <ul>
           <li>This ad is aimed at the homeless in LA. </li>
        </ul>
     </li>
     <li>Go to Inclusive language analysis</li>
     <li>Confirm that you get the following feedback:
        <ul>
          <li>Traffic light: 🔴 </li>
          <li>Feedback: 
             <ul>
                 <li>Avoid using <i>the homeless</i> as it is potentially harmful. Consider using an alternative, such as <i>people experiencing homelessness</i>. Learn more.</li>
             </ul>
          </li>
        </ul>
      </li>
   </ul>
</details>

<details>
  <summary><strong>Test "the undocumented"</strong></summary>
  <ul>
     <li>Add the following sentence to the text: 
        <ul>
           <li>This targets the undocumented across the US. </li>
        </ul>
     </li>
     <li>Go to Inclusive language analysis</li>
     <li>Confirm that you get the following feedback:
        <ul>
          <li>Traffic light: 🔴 </li>
          <li>Feedback: 
             <ul>
                 <li>Avoid using <i>the undocumented</i> as it is potentially harmful. Consider using an alternative, such as <i>people who are undocumented, undocumented people, people without papers</i>. Learn more.</li>
             </ul>
          </li>
        </ul>
      </li>
   </ul>
</details>

<details>
  <summary><strong>Test "the poor"</strong></summary>
  <ul>
     <li>Add the following sentence to the text: 
        <ul>
           <li>The poor however, did not go to the zoo. </li>
        </ul>
     </li>
     <li>Go to Inclusive language analysis</li>
     <li>Confirm that you get the following feedback:
        <ul>
          <li>Traffic light: 🔴 </li>
          <li>Feedback: 
             <ul>
                 <li>Avoid using <i>the poor</i> as it is potentially harmful. Consider using an alternative, such as <i>people whose income is below the poverty threshold, people with low-income</i>. Learn more.</li>
             </ul>
          </li>
        </ul>
      </li>
   </ul>
</details>

<details>
  <summary><strong>Test "the mentally ill"</strong></summary>
  <ul>
     <li>Add the following sentence to the text: 
        <ul>
           <li>There is growing compassion for the mentally ill.</li>
        </ul>
     </li>
     <li>Go to Inclusive language analysis</li>
     <li>Confirm that you get the following feedback:
        <ul>
          <li>Traffic light: 🔴 </li>
          <li>Feedback: 
             <ul>
                 <li>Avoid using <i>the mentally ill</i> as it is potentially harmful. Consider using an alternative, such as <i>who are mentally ill, mentally ill people</i>. Learn more.</li>
             </ul>
          </li>
        </ul>
      </li>
   </ul>
</details>

⚠️ Note: I think testing in one content type and in one editor is enough

#### Test in Shopify
* Repeat the testing instruction above in Shopify
#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* There is no further impact other than what is already covered in the testing instruction above.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [x] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/lingo-other-tasks/issues/245
