### PR TITLE
Adds defensive coding to make sure warnings don't happen.

### DIFF
--- a/src/helpers/current-page-helper.php
+++ b/src/helpers/current-page-helper.php
@@ -482,10 +482,12 @@ class Current_Page_Helper {
 	 * @return int The amoumt of queried terms.
 	 */
 	protected function count_queried_terms() {
-		$wp_query      = $this->wp_query_wrapper->get_main_query();
-		$term          = $wp_query->get_queried_object();
+		$wp_query = $this->wp_query_wrapper->get_main_query();
+		$term     = $wp_query->get_queried_object();
+
+
 		$queried_terms = $wp_query->tax_query->queried_terms;
-		if ( empty( $queried_terms[ $term->taxonomy ]['terms'] ) ) {
+		if ( is_null( $term ) || empty( $queried_terms[ $term->taxonomy ]['terms'] ) ) {
 			return 0;
 		}
 

--- a/src/presentations/indexable-term-archive-presentation.php
+++ b/src/presentations/indexable-term-archive-presentation.php
@@ -172,7 +172,11 @@ class Indexable_Term_Archive_Presentation extends Indexable_Presentation {
 	 * @return string The title.
 	 */
 	public function generate_title() {
-		if ( is_wp_error( $this->source ) || $this->model->title ) {
+		if ( $this->model->title ) {
+			return $this->model->title;
+		}
+
+		if ( is_wp_error( $this->source ) ) {
 			return $this->model->title;
 		}
 

--- a/src/presentations/indexable-term-archive-presentation.php
+++ b/src/presentations/indexable-term-archive-presentation.php
@@ -92,7 +92,7 @@ class Indexable_Term_Archive_Presentation extends Indexable_Presentation {
 	 * @return array The source.
 	 */
 	public function generate_source() {
-		if ( ! empty( $this->model->object_id ) ) {
+		if ( ! empty( $this->model->object_id ) || is_null( \get_queried_object() ) ) {
 			return \get_term( $this->model->object_id, $this->model->object_sub_type );
 		}
 
@@ -152,7 +152,7 @@ class Indexable_Term_Archive_Presentation extends Indexable_Presentation {
 		 * First we get the no index option for this taxonomy, because it can be overwritten the indexable value for
 		 * this specific term.
 		 */
-		if ( ! $this->taxonomy->is_indexable( $this->source->taxonomy ) ) {
+		if ( is_wp_error( $this->source ) || ! $this->taxonomy->is_indexable( $this->source->taxonomy ) ) {
 			$robots['index'] = 'noindex';
 		}
 
@@ -172,7 +172,7 @@ class Indexable_Term_Archive_Presentation extends Indexable_Presentation {
 	 * @return string The title.
 	 */
 	public function generate_title() {
-		if ( $this->model->title ) {
+		if ( is_wp_error( $this->source ) || $this->model->title ) {
 			return $this->model->title;
 		}
 
@@ -206,6 +206,10 @@ class Indexable_Term_Archive_Presentation extends Indexable_Presentation {
 		$query = $this->wp_query_wrapper->get_query();
 
 		if ( ! isset( $query->tax_query ) ) {
+			return false;
+		}
+
+		if ( is_wp_error( $this->source ) ) {
 			return false;
 		}
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to add some defensive coding so that we don't throw warnings when our code runs.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds defensive coding to the supress warnings on archive pages with the `/%category%/%postname%/` permalink structure. Props to @Mte90.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install and enable Elementor.
* Make sure Landing pages are enabled here: /wp-admin/admin.php?page=elementor#tab-experiments
* Set your permalink structure to a custom structure with `/%category%/%postname%/`
* Create a new landing page in elementor (it is an option in the templates CPT from elementor)
* Without this PR make sure you get 5 warnings when visiting the front-end of the landing page.
* With the PR make sure they are gone. 

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
