### PR TITLE
Migrate insights feature tests

### DIFF
--- a/packages/js/src/components/modals/editorModals/EditorModal.js
+++ b/packages/js/src/components/modals/editorModals/EditorModal.js
@@ -94,7 +94,7 @@ const EditorModal = ( { id, postTypeName, children, title, isOpen, close, open,
 				title={ title }
 				SuffixHeroIcon={ SuffixHeroIcon }
 				// Fall back to the pencil square SVG icon if no hero icon has been passed.
-				suffixIcon={ ! SuffixHeroIcon && { size: "20px", icon: "pencil-square" } }
+				suffixIcon={ SuffixHeroIcon ? null : { size: "20px", icon: "pencil-square" } }
 				onClick={ open }
 			/>
 		</Fragment>

--- a/packages/js/tests/__mocks__/@yoast/externals/contexts.js
+++ b/packages/js/tests/__mocks__/@yoast/externals/contexts.js
@@ -1,7 +1,12 @@
 import { LocationConsumer, LocationContext, LocationProvider } from "../../../../src/components/contexts/location";
+import Root, { RootContext } from "../../../../src/components/contexts/root";
+import useRootContext from "../../../../src/components/contexts/use-root-context";
 
 export {
 	LocationContext,
 	LocationProvider,
 	LocationConsumer,
+	RootContext,
+	Root,
+	useRootContext,
 };

--- a/packages/js/tests/insights/components/flesch-reading-ease.test.js
+++ b/packages/js/tests/insights/components/flesch-reading-ease.test.js
@@ -1,22 +1,9 @@
-// import React from "react";
 import { useSelect } from "@wordpress/data";
-import { set } from "lodash";
-
-// import FleschReadingEase from "../../../src/insights/components/flesch-reading-ease";
 import { DIFFICULTY } from "yoastseo";
+import FleschReadingEase from "../../../src/insights/components/flesch-reading-ease";
+import { render, screen } from "../../test-utils";
 
-jest.mock( "@wordpress/data", () => (
-	{
-		useSelect: jest.fn(),
-	}
-) );
-
-jest.mock( "@wordpress/element", () => (
-	{
-		...jest.requireActual( "@wordpress/element" ),
-		useMemo: jest.fn( fn => fn() ),
-	}
-) );
+jest.mock( "@wordpress/data", () => ( { useSelect: jest.fn() } ) );
 
 /**
  * Mocks the WordPress `useSelect` hook.
@@ -24,46 +11,86 @@ jest.mock( "@wordpress/element", () => (
  * @param {number} score The Flesch reading ease score to use.
  * @param {DIFFICULTY} difficulty The Flesch reading ease difficulty to use.
  *
- * @returns {void}
+ * @returns {function} The mock.
  */
-function mockSelect( score, difficulty ) {
-	const select = jest.fn(
-		() => (
-			{
-				getFleschReadingEaseScore: jest.fn( () => score ),
-				getFleschReadingEaseDifficulty: jest.fn( () => difficulty ),
-			}
-		)
-	);
+const mockSelect = ( score, difficulty ) => useSelect.mockImplementation( select => select( () => ( {
+	getFleschReadingEaseScore: () => score,
+	getFleschReadingEaseDifficulty: () => difficulty,
+} ) ) );
 
-	useSelect.mockImplementation(
-		selectFunction => selectFunction( select )
-	);
-}
+beforeAll( () => {
+	global.wpseoAdminL10n = {
+		"shortlinks-insights-flesch_reading_ease": "https://example.org/link",
+		"shortlinks-insights-flesch_reading_ease_article": "https://example.org/article",
+	};
+} );
+afterAll( () => {
+	delete global.wpseoAdminL10n;
+} );
 
-describe( "The FleschReadingEase component", () => {
-	set( window, "wpseoAdminL10n.shortlinks-insights-flesch_reading_ease", "https://example.org/link" );
-	set( window, "wpseoAdminL10n.shortlinks-insights-flesch_reading_ease_article", "https://example.org/article" );
+describe( "FleschReadingEase", () => {
+	afterEach( () => {
+		useSelect.mockRestore();
+	} );
 
-	it( "renders the component when the text is considered very difficult.", () => {
-		mockSelect( 10, DIFFICULTY.VERY_DIFFICULT );
+	it( "renders the title, help link and unit", () => {
+		mockSelect( 0, DIFFICULTY.NO_DATA );
+
+		render( <FleschReadingEase /> );
+
+		expect( screen.getByText( "Flesch reading ease" ) ).toBeInTheDocument();
+
+		const link = screen.getByText( "Learn more about Flesch reading ease" );
+		expect( link ).toBeInTheDocument();
+		expect( link.parentElement ).toBeInstanceOf( HTMLAnchorElement );
+		expect( link.parentElement.href ).toBe( "https://example.org/link" );
+
+		expect( screen.getByText( "out of 100" ) ).toBeInTheDocument();
 	} );
-	it( "renders the component when the text is considered very easy.", () => {
-		mockSelect( 90, DIFFICULTY.VERY_EASY );
-	} );
-	it( "renders the component when the text is considered easy.", () => {
-		mockSelect( 80, DIFFICULTY.EASY );
-	} );
-	it( "renders the component when the text is considered fairly easy.", () => {
-		mockSelect( 70, DIFFICULTY.FAIRLY_EASY );
-	} );
-	it( "renders the component when the text is considered okay.", () => {
-		mockSelect( 60, DIFFICULTY.OKAY );
-	} );
-	it( "renders the component when the text is considered fairly difficult.", () => {
-		mockSelect( 50, DIFFICULTY.FAIRLY_DIFFICULT );
-	} );
-	it( "renders the component when the text is considered difficult.", () => {
-		mockSelect( 30, DIFFICULTY.DIFFICULT );
+
+	test.each( [
+		[ "very easy", 90, DIFFICULTY.VERY_EASY, "The copy scores 90 in the test, which is considered very easy to read. Good job!", "" ],
+		[ "easy", 80, DIFFICULTY.EASY, "The copy scores 80 in the test, which is considered easy to read. Good job!", "" ],
+		[ "fairly easy", 70, DIFFICULTY.FAIRLY_EASY, "The copy scores 70 in the test, which is considered fairly easy to read. Good job!", "" ],
+		[ "okay", 60, DIFFICULTY.OKAY, "The copy scores 60 in the test, which is considered okay to read. Good job!", "" ],
+		[
+			"fairly difficult",
+			50,
+			DIFFICULTY.FAIRLY_DIFFICULT,
+			"The copy scores 50 in the test, which is considered fairly difficult to read.",
+			"Try to make shorter sentences, using less difficult words to improve readability.",
+		],
+		[
+			"difficult",
+			30,
+			DIFFICULTY.DIFFICULT,
+			"The copy scores 30 in the test, which is considered difficult to read.",
+			"Try to make shorter sentences, using less difficult words to improve readability.",
+		],
+		[
+			"very difficult",
+			10,
+			DIFFICULTY.VERY_DIFFICULT,
+			"The copy scores 10 in the test, which is considered very difficult to read.",
+			"Try to make shorter sentences, using less difficult words to improve readability.",
+		],
+	] )( "renders the component when the text is considered %s.", ( title, score, difficulty, description, ctaText ) => {
+		mockSelect( score, difficulty );
+
+		render( <FleschReadingEase /> );
+
+		// Test the description feedback string.
+		expect( screen.getByText( description ) ).toBeInTheDocument();
+
+		// Test the call to action string of the feedback.
+		if ( ctaText ) {
+			const cta = screen.getByText( ctaText );
+			expect( cta ).toBeInTheDocument();
+			expect( cta ).toBeInstanceOf( HTMLAnchorElement );
+			expect( cta.href ).toBe( "https://example.org/article" );
+		}
+
+		// Test the score.
+		expect( screen.getByText( score.toString() ) ).toBeInTheDocument();
 	} );
 } );

--- a/packages/js/tests/insights/components/insights-collapsible.test.js
+++ b/packages/js/tests/insights/components/insights-collapsible.test.js
@@ -1,53 +1,69 @@
-// import React from "react";
 import { useSelect } from "@wordpress/data";
 import { enableFeatures } from "@yoast/feature-flag";
-// import InsightsCollapsible from "../../../src/insights/components/insights-collapsible";
-// import FleschReadingEase from "../../../src/insights/components/flesch-reading-ease";
-// import TextFormality from "../../../src/insights/components/text-formality";
-// import TextLength from "../../../src/insights/components/text-length";
+import { DIFFICULTY } from "yoastseo";
+import InsightsCollapsible from "../../../src/insights/components/insights-collapsible";
+import { fireEvent, render, screen, waitFor } from "../../test-utils";
 
-jest.mock( "@wordpress/data", () => (
-	{
-		useSelect: jest.fn(),
-	}
-) );
+jest.mock( "@wordpress/data", () => ( {
+	// `registerStore` is used in WP components' Slot component, used in the TextFormality component.
+	registerStore: jest.requireActual( "@wordpress/data" ).registerStore,
+	useSelect: jest.fn(),
+} ) );
 
 /**
  * Mocks the WordPress `useSelect` hook.
  *
+ * @param {boolean} shouldUpsell Whether to upsell.
+ * @param {boolean} isProminentWordsAvailable Whether prominent words is available.
  * @param {boolean} isFleschReadingEaseAvailable Whether FRE is available.
+ * @param {boolean} isFormalitySupported Whether text formality is supported.
  *
- * @returns {void}
+ * @returns {function} The mock.
  */
-function mockSelect( isFleschReadingEaseAvailable ) {
-	const select = jest.fn(
-		() => (
-			{
-				isFleschReadingEaseAvailable: jest.fn( () => isFleschReadingEaseAvailable ),
+const mockSelect = ( shouldUpsell, isProminentWordsAvailable, isFleschReadingEaseAvailable, isFormalitySupported ) => {
+	return useSelect.mockImplementation( select => select( () => ( {
+		getPreference: ( preference, defaultValue ) => {
+			switch ( preference ) {
+				case "isProminentWordsAvailable":
+					return isProminentWordsAvailable;
+				case "shouldUpsell":
+					return shouldUpsell;
+				default:
+					return defaultValue;
 			}
-		)
-	);
+		},
+		getProminentWords: () => [],
+		getFleschReadingEaseScore: () => 0,
+		getFleschReadingEaseDifficulty: () => DIFFICULTY.NO_DATA,
+		getEstimatedReadingTime: () => 0,
+		getTextLength: () => ( { count: 0, unit: "word" } ),
+		isFleschReadingEaseAvailable: () => isFleschReadingEaseAvailable,
+		isFormalitySupported: () => isFormalitySupported,
+	} ) ) );
+};
 
-	useSelect.mockImplementation(
-		selectFunction => selectFunction( select )
-	);
-}
+describe( "InsightsCollapsible", () => {
+	afterEach( () => {
+		useSelect.mockRestore();
+	} );
 
-describe( "The insights collapsible component", () => {
-	it( "renders the Flesch reading ease (FRE) component if the FRE score and difficulty are available", () => {
-		mockSelect( true );
-	} );
-	it( "does not render the FRE component if the FRE score and difficulty are not available", () => {
-		mockSelect( false );
-	} );
-	it( "renders the TextLength component", () => {
-
-	} );
-	it( "does not render the Text formality component when the feature is disabled", () => {
-		mockSelect( true );
-	} );
-	it( "renders the Text formality component when the feature is enabled", () => {
+	it( "renders and opens the collapsible", async() => {
 		enableFeatures( [ "TEXT_FORMALITY" ] );
-		mockSelect( true );
+		mockSelect( true, true, true, true );
+
+		render( <InsightsCollapsible location={ "metabox" } /> );
+
+		const button = screen.getByRole( "button" );
+		expect( button ).toBeInTheDocument();
+		expect( button.textContent ).toBe( "Insights" );
+		fireEvent.click( button );
+
+		await waitFor( () => {
+			expect( screen.getByText( "Prominent words" ) ).toBeInTheDocument();
+			expect( screen.getByText( "Flesch reading ease" ) ).toBeInTheDocument();
+			expect( screen.getByText( "Reading time" ) ).toBeInTheDocument();
+			expect( screen.getByText( "Word count" ) ).toBeInTheDocument();
+			expect( screen.getByText( "Text formality" ) ).toBeInTheDocument();
+		} );
 	} );
 } );

--- a/packages/js/tests/insights/components/insights-modal.test.js
+++ b/packages/js/tests/insights/components/insights-modal.test.js
@@ -1,59 +1,91 @@
-// import React from "react";
 import { useSelect } from "@wordpress/data";
-// import FleschReadingEase from "../../../src/insights/components/flesch-reading-ease";
-// import InsightsModal from "../../../src/insights/components/insights-modal";
-// import TextFormality from "../../../src/insights/components/text-formality";
-// import TextLength from "../../../src/insights/components/text-length";
 import { enableFeatures } from "@yoast/feature-flag";
+import { useToggleState } from "@yoast/ui-library";
+import { DIFFICULTY } from "yoastseo";
+import EditorModal from "../../../src/components/modals/editorModals/EditorModal";
+import InsightsModal from "../../../src/insights/components/insights-modal";
+import { fireEvent, render, screen, waitFor } from "../../test-utils";
 
-jest.mock( "@wordpress/data", () => (
-	{
-		withSelect: jest.fn(),
-		withDispatch: jest.fn(),
-		useSelect: jest.fn(),
-	}
-) );
+/**
+ * Mocked EditorModal container.
+ *
+ * Circumvent the WP data withSelect and withDispatch mocking problems.
+ * As `jest.requireActual` does not seem to work on WP data.
+ *
+ * @param {Object} props The props.
+ *
+ * @returns {JSX.Element} The element.
+ */
+const EditorModalMock = props => {
+	const [ isOpen, , , open, close ] = useToggleState( false );
 
-jest.mock( "../../../src/containers/EditorModal", () => jest.fn() );
+	return <EditorModal { ...props } postTypeName="mock" isOpen={ isOpen } open={ open } close={ close } />;
+};
+
+jest.mock( "../../../src/containers/EditorModal", () => EditorModalMock );
+
+jest.mock( "@wordpress/data", () => ( {
+	// `registerStore` is used in WP components' Slot component, used in the TextFormality component.
+	registerStore: jest.requireActual( "@wordpress/data" ).registerStore,
+	useSelect: jest.fn(),
+} ) );
 
 /**
  * Mocks the WordPress `useSelect` hook.
  *
- * @param {boolean} isFleschReadingEaseAvailable    Whether FRE is available.
- * @param {boolean} isElementorEditor               Whether the editor is the Elementor editor.
+ * @param {boolean} shouldUpsell Whether to upsell.
+ * @param {boolean} isProminentWordsAvailable Whether prominent words is available.
+ * @param {boolean} isFleschReadingEaseAvailable Whether FRE is available.
+ * @param {boolean} isFormalitySupported Whether text formality is supported.
+ * @param {boolean} isElementorEditor Whether the editor is the Elementor editor.
  *
- * @returns {void}
+ * @returns {function} The mock.
  */
-function mockSelect( isFleschReadingEaseAvailable, isElementorEditor ) {
-	const select = jest.fn(
-		() => (
-			{
-				isFleschReadingEaseAvailable: jest.fn( () => isFleschReadingEaseAvailable ),
-				getIsElementorEditor: jest.fn( () => isElementorEditor ),
+const mockSelect = ( shouldUpsell, isProminentWordsAvailable, isFleschReadingEaseAvailable, isFormalitySupported, isElementorEditor ) => {
+	return useSelect.mockImplementation( select => select( () => ( {
+		getPreference: ( preference, defaultValue ) => {
+			switch ( preference ) {
+				case "isProminentWordsAvailable":
+					return isProminentWordsAvailable;
+				case "shouldUpsell":
+					return shouldUpsell;
+				default:
+					return defaultValue;
 			}
-		)
-	);
+		},
+		getProminentWords: () => [],
+		getFleschReadingEaseScore: () => 0,
+		getFleschReadingEaseDifficulty: () => DIFFICULTY.NO_DATA,
+		getEstimatedReadingTime: () => 0,
+		getTextLength: () => ( { count: 0, unit: "word" } ),
+		isFleschReadingEaseAvailable: () => isFleschReadingEaseAvailable,
+		isFormalitySupported: () => isFormalitySupported,
+		getIsElementorEditor: () => isElementorEditor,
+	} ) ) );
+};
 
-	useSelect.mockImplementation(
-		selectFunction => selectFunction( select )
-	);
-}
+describe( "InsightsModal", () => {
+	afterEach( () => {
+		useSelect.mockRestore();
+	} );
 
-describe( "The insights collapsible component", () => {
-	it( "renders the Flesch reading ease (FRE) component if the FRE score and difficulty are available", () => {
-		mockSelect( true, false );
-	} );
-	it( "does not render the FRE component if the FRE score and difficulty are not available", () => {
-		mockSelect( false, false );
-	} );
-	it( "renders the TextLength component", () => {
-
-	} );
-	it( "does not render the Text formality component when the feature is disabled", () => {
-		mockSelect( true, true );
-	} );
-	it( "renders the Text formality component when the feature is enabled", () => {
+	it( "renders and opens the modal", async() => {
 		enableFeatures( [ "TEXT_FORMALITY" ] );
-		mockSelect( true, true );
+		mockSelect( true, true, true, true, false );
+
+		render( <InsightsModal location={ "sidebar" } /> );
+
+		const button = screen.getByRole( "button" );
+		expect( button ).toBeInTheDocument();
+		expect( button.textContent ).toBe( "Insights" );
+		fireEvent.click( button );
+
+		await waitFor( () => {
+			expect( screen.getByText( "Prominent words" ) ).toBeInTheDocument();
+			expect( screen.getByText( "Flesch reading ease" ) ).toBeInTheDocument();
+			expect( screen.getByText( "Reading time" ) ).toBeInTheDocument();
+			expect( screen.getByText( "Word count" ) ).toBeInTheDocument();
+			expect( screen.getByText( "Text formality" ) ).toBeInTheDocument();
+		} );
 	} );
 } );

--- a/packages/js/tests/insights/components/text-formality.test.js
+++ b/packages/js/tests/insights/components/text-formality.test.js
@@ -1,56 +1,54 @@
-// import TextFormality from "../../../src/insights/components/text-formality";
-// import React from "react";
-// import TextFormalityUpsell from "../../../src/insights/components/text-formality-upsell";
 import { useSelect } from "@wordpress/data";
+import TextFormality from "../../../src/insights/components/text-formality";
+import { render, screen } from "../../test-utils";
 
-window.wpseoAdminL10n = {
-	"shortlinks-insights-text_formality_info_free": "https://yoa.st/formality-free",
-	"shortlinks-insights-text_formality_info_premium": "https://yoa.st/formality",
-};
+jest.mock( "@wordpress/data", () => ( {
+	// `registerStore` is used in WP components' Slot component, used in the TextFormality component.
+	registerStore: jest.requireActual( "@wordpress/data" ).registerStore,
+	useSelect: jest.fn(),
+} ) );
 
-jest.mock( "@wordpress/data", () => (
-	{
-		useSelect: jest.fn(),
-	}
-) );
+beforeAll( () => {
+	global.wpseoAdminL10n = {
+		"shortlinks-insights-text_formality_info_free": "https://yoa.st/formality-free",
+		"shortlinks-insights-text_formality_info_premium": "https://yoa.st/formality",
+	};
+	global.wpseoScriptData = {
+		metabox: {
+			isPremium: false,
+		},
+	};
+} );
+afterAll( () => {
+	delete global.wpseoAdminL10n;
+	delete global.wpseoScriptData;
+} );
 
 /**
  * Mocks the WordPress `useSelect` hook.
  *
- * @param {boolean} isFormalitySupported    Whether Formality feature is available.
+ * @param {boolean} isFormalitySupported Whether Formality feature is available.
  *
- * @returns {void}
+ * @returns {function} The mock.
  */
-function mockSelect( isFormalitySupported ) {
-	const select = jest.fn(
-		() => (
-			{
-				isFormalitySupported: jest.fn( () => isFormalitySupported ),
-			}
-		)
-	);
+const mockSelect = isFormalitySupported => useSelect.mockImplementation( select => select( () => ( {
+	isFormalitySupported: () => isFormalitySupported,
+} ) ) );
 
-	useSelect.mockImplementation(
-		selectFunction => selectFunction( select )
-	);
-}
-
-describe( "a test for TextFormality component", () => {
+describe( "TextFormality", () => {
 	it( "should not render the component if the locale is non-English", () => {
 		mockSelect( false );
-		window.wpseoScriptData = {
-			metabox: {
-				isPremium: false,
-			},
-		};
+
+		render( <TextFormality location="sidebar" name="YoastTextFormalitySidebar" /> );
+
+		expect( screen.queryByText( "will help you assess the formality level of your text." ) ).not.toBeInTheDocument();
 	} );
+
 	it( "renders the component in sidebar in Free when the locale is English", () => {
 		mockSelect( true );
 
-		window.wpseoScriptData = {
-			metabox: {
-				isPremium: false,
-			},
-		};
+		render( <TextFormality location="sidebar" name="YoastTextFormalitySidebar" /> );
+
+		expect( screen.getByText( "will help you assess the formality level of your text." ) ).toBeInTheDocument();
 	} );
 } );

--- a/packages/js/tests/insights/components/text-length.test.js
+++ b/packages/js/tests/insights/components/text-length.test.js
@@ -1,47 +1,57 @@
-// import React from "react";
 import { useSelect } from "@wordpress/data";
-// import TextLength from "../../../src/insights/components/text-length";
+import TextLength from "../../../src/insights/components/text-length";
+import { render, screen } from "../../test-utils";
 
-jest.mock( "@wordpress/data", () => (
-	{
-		useSelect: jest.fn(),
-	}
-) );
-
+jest.mock( "@wordpress/data", () => ( { useSelect: jest.fn() } ) );
 
 /**
  * Mocks the WordPress `useSelect` hook.
  *
- * @param {object} textLengthObject The result of text length research.
+ * @param {Object} textLength The result of text length research.
  *
- * @returns {void}
+ * @returns {function} The mock.
  */
-function mockSelect( textLengthObject ) {
-	const select = jest.fn(
-		() => (
-			{
-				getTextLength: jest.fn( () => textLengthObject ),
-			}
-		)
-	);
+const mockSelect = textLength => useSelect.mockImplementation( select => select( () => ( {
+	getTextLength: () => textLength,
+} ) ) );
 
-	useSelect.mockImplementation(
-		selectFunction => selectFunction( select )
-	);
-}
+beforeAll( () => {
+	global.wpseoAdminL10n = {
+		"shortlinks-insights-word_count": "https://example.com/link",
+	};
+} );
+afterAll( () => {
+	delete global.wpseoAdminL10n;
+} );
 
-describe( "a test for TextLength component", () => {
-	it( "returns the props for languages that use word as the unit for text length measurement", () => {
-		mockSelect( {
-			count: 300,
-			unit: "words",
-		} );
+describe( "TextLength", () => {
+	it( "renders the text length measurements for words", () => {
+		mockSelect( { count: 300, unit: "words" } );
+		render( <TextLength /> );
+
+		expect( screen.getByText( "Word count" ) ).toBeInTheDocument();
+
+		const link = screen.getByText( "Learn more about word count" );
+		expect( link ).toBeInTheDocument();
+		expect( link.parentElement ).toBeInstanceOf( HTMLAnchorElement );
+		expect( link.parentElement.href ).toBe( "https://example.com/link" );
+
+		expect( screen.getByText( "300" ) ).toBeInTheDocument();
+		expect( screen.getByText( "words" ) ).toBeInTheDocument();
 	} );
 
-	it( "returns the props for languages that use character as the unit for text length measurement", () => {
-		mockSelect( {
-			count: 300,
-			unit: "character",
-		} );
+	it( "renders the text length measurements for characters", () => {
+		mockSelect( { count: 300, unit: "character" } );
+		render( <TextLength /> );
+
+		expect( screen.getByText( "Character count" ) ).toBeInTheDocument();
+
+		const link = screen.getByText( "Learn more about character count" );
+		expect( link ).toBeInTheDocument();
+		expect( link.parentElement ).toBeInstanceOf( HTMLAnchorElement );
+		expect( link.parentElement.href ).toBe( "https://example.com/link" );
+
+		expect( screen.getByText( "300" ) ).toBeInTheDocument();
+		expect( screen.getByText( "characters" ) ).toBeInTheDocument();
 	} );
 } );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Following the issue for upgrading to React 18 and migrating all Enzyme tests to the React testing library.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Migrates the Insights tests to use the React testing library.
* Fixes a bug where the EditorModal would pass `false` to the SidebarButton's `suffixIcon` instead of `null`, resulting in a React prop type warning.

## Relevant technical choices:

* Complete the mocks for `@yoast/externals/contexts`, ran into missing `useRootContext` now that we actually render
* There is some funky stuff going on in WP data
  * had to "mock" `registerStore` by just passing `default` of the actual import, not sure how else to fix that
  * unable to get the container using `withSelect` and `withDispatch` to work, running into the similar `default` error as with `registerStore` only that fix does not work then

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### EditorModal prop fix
* Enable debug logging in WP (by defining `WP_DEBUG` and `SCRIPT_DEBUG`)
* Open the editor
* Open the sidebar
* Previously, that was the moment the React prop warning would appear:
```
Warning: Failed prop type: Invalid prop `suffixIcon` of type `boolean` supplied to `SidebarButton`, expected `object`.
```
* Verify you still see the icon at the end
![image](https://github.com/Yoast/wordpress-seo/assets/35524806/01dc9945-4bd3-41fe-816e-3f2d0b41bf57)
* Verify you can open the Insights modal

#### Tests
* Does the CI pass?
* Do the tests still verify the things they did before? (compared to `trunk`)

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [x] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Please test the first section (`EditorModal prop fix`) of the test instructions
* The tests are already passing, so nothing to test manually

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/wordpress-seo/issues/20674
