### PR TITLE
81 create upsell for ai on woocommerce product pages

### DIFF
--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -935,7 +935,6 @@ class WPSEO_Metabox extends WPSEO_Meta {
 			'isJetpackBoostNotPremium'   => ( $is_block_editor ) ? YoastSEO()->classes->get( Jetpack_Boost_Not_Premium_Conditional::class )->is_met() : false,
 			'isWooCommerceActive'        => $woocommerce_active,
 			'woocommerceUpsell'          => get_post_type( $post_id ) === 'product' && ! $woocommerce_seo_active && $woocommerce_active,
-			'isWooCommerceActive'        => $woocommerce_active,
 			'linkParams'                 => WPSEO_Shortlinker::get_query_params(),
 			'pluginUrl'                  => \plugins_url( '', \WPSEO_FILE ),
 			'wistiaEmbedPermission'      => YoastSEO()->classes->get( Wistia_Embed_Permission_Repository::class )->get_value_for_user( \get_current_user_id() ),

--- a/packages/js/src/ai-generator/components/modal-content.js
+++ b/packages/js/src/ai-generator/components/modal-content.js
@@ -9,7 +9,7 @@ const STORE = "yoast-seo/editor";
  */
 export const ModalContent = () => {
 	const learnMoreLink = useSelect( select => select( STORE ).selectLink( "https://www.yoa.st/ai-generator-learn-more" ), [] );
-	const upsellLink = useSelect( select => select( STORE ).selectLink( "https://yoa.st/ai-generator-upsell" ), [] );
+
 
 	const imageLink = useSelect( select => select( STORE ).selectImageLink( "ai-generator-preview.png" ), [] );
 	const thumbnail = useMemo( () => ( {
@@ -23,10 +23,10 @@ export const ModalContent = () => {
 	const { setWistiaEmbedPermission: set } = useDispatch( STORE );
 	const wistiaEmbedPermission = useMemo( () => ( { value, status, set } ), [ value, status, set ] );
 
+
 	return (
 		<AiGenerateTitlesAndDescriptionsUpsell
 			learnMoreLink={ learnMoreLink }
-			upsellLink={ upsellLink }
 			thumbnail={ thumbnail }
 			wistiaEmbedPermission={ wistiaEmbedPermission }
 		/>

--- a/packages/js/src/ai-generator/initialize.js
+++ b/packages/js/src/ai-generator/initialize.js
@@ -44,19 +44,25 @@ AiGeneratorUpsell.propTypes = {
 	fieldId: PropTypes.string.isRequired,
 };
 
+const STORE = "yoast-seo/editor";
+
 /**
  * Initializes the AI Generator upsell.
  *
  * @returns {void}
  */
 const initializeAiGenerator = () => {
-	const isPremium = select( "yoast-seo/editor" ).getIsPremium();
+	const isPremium = select( STORE ).getIsPremium();
+	const isWooSeoUpsell = select( STORE ).getIsWooSeoUpsell();
+	const isProduct = select( STORE ).getIsProduct();
+
+	const shouldShowAiGeneratorUpsell =  ( isProduct ) ? ! isPremium || isWooSeoUpsell : ! isPremium;
 
 	addFilter(
 		"yoast.replacementVariableEditor.additionalButtons",
 		"yoast/yoast-seo-premium/AiGenerator",
 		( buttons, { fieldId } ) => {
-			if ( ! isPremium ) {
+			if ( shouldShowAiGeneratorUpsell ) {
 				buttons.push(
 					<Fill name={ `yoast.replacementVariableEditor.additionalButtons.${ fieldId }` }>
 						<AiGeneratorUpsell fieldId={ fieldId } />

--- a/packages/js/src/post-edit.js
+++ b/packages/js/src/post-edit.js
@@ -56,7 +56,7 @@ domReady( () => {
 	initializeInsights();
 
 
-	const AI_IGNORED_POST_TYPES = [ "attachment", "product" ];
+	const AI_IGNORED_POST_TYPES = [ "attachment" ];
 
 	if ( window.wpseoScriptData.postType && ! AI_IGNORED_POST_TYPES.includes( window.wpseoScriptData.postType ) ) {
 		// Initialize the AI Generator upsell.

--- a/packages/js/src/redux/selectors/index.js
+++ b/packages/js/src/redux/selectors/index.js
@@ -37,4 +37,5 @@ export * from "./WincherModal";
 export * from "./WincherRequest";
 export * from "./WincherSEOPerformance";
 export * from "./isPremium";
+export * from "./isWooSEO";
 export * from "./postId";

--- a/packages/js/src/redux/selectors/isWooSEO.js
+++ b/packages/js/src/redux/selectors/isWooSEO.js
@@ -1,0 +1,8 @@
+import { get } from "lodash";
+
+/**
+ * Determines whether the WooCommerce SEO addon is not active in a product page.
+ *
+ * @returns {Boolean}       Whether the plugin is WooCommerce SEO or not.
+ */
+export const getIsWooSeoUpsell = () => get( window, "wpseoScriptData.woocommerceUpsell", false );

--- a/packages/js/src/shared-admin/components/ai-generate-titles-and-descriptions-upsell.js
+++ b/packages/js/src/shared-admin/components/ai-generate-titles-and-descriptions-upsell.js
@@ -1,20 +1,62 @@
 import { LockOpenIcon } from "@heroicons/react/outline";
 import { ArrowNarrowRightIcon } from "@heroicons/react/solid";
 import { createInterpolateElement } from "@wordpress/element";
+import { useSelect } from "@wordpress/data";
 import { __, sprintf } from "@wordpress/i18n";
 import { Badge, Button, useModalContext } from "@yoast/ui-library";
 import PropTypes from "prop-types";
 import { OutboundLink, VideoFlow } from ".";
 
+const STORE = "yoast-seo/editor";
+
 /**
  * @param {string} learnMoreLink The learn more link.
- * @param {string} upsellLink The upsell link.
  * @param {Object} thumbnail The thumbnail: img props.
  * @param {Object} wistiaEmbedPermission The value, status and set for the Wistia embed permission.
  * @returns {JSX.Element} The element.
  */
-export const AiGenerateTitlesAndDescriptionsUpsell = ( { learnMoreLink, upsellLink, thumbnail, wistiaEmbedPermission } ) => {
+export const AiGenerateTitlesAndDescriptionsUpsell = ( { learnMoreLink, thumbnail, wistiaEmbedPermission } ) => {
 	const { onClose, initialFocus } = useModalContext();
+	const upsellLinkPremium = useSelect( select => select( STORE ).selectLink( "https://yoa.st/ai-generator-upsell" ), [] );
+	const upsellLinkWooPremiumBundle = useSelect( select => select( STORE ).selectLink( "https://yoa.st/ai-generator-upsell-woo-seo-premium-bundle" ), [] );
+	const upsellLinkWoo = useSelect( select => select( STORE ).selectLink( "https://yoa.st/ai-generator-upsell-woo-seo" ), [] );
+	let upsellLink = upsellLinkPremium;
+
+	const isPremium = useSelect( select => select( STORE ).getIsPremium(), [] );
+	const isWooSeoUpsell = useSelect( select => select( STORE ).getIsWooSeoUpsell(), [] );
+	let upsellLabel = sprintf(
+		/* translators: %1$s expands to Yoast SEO Premium. */
+		__( "Unlock with %1$s", "wordpress-seo" ),
+		"Yoast SEO Premium"
+	);
+	let bundleNote = "";
+
+	if ( isWooSeoUpsell ) {
+		if ( ! isPremium ) {
+			upsellLabel = `${sprintf(
+				/* translators: %1$s expands to Woo Premium bundle. */
+				__( "Unlock with the %1$s", "wordpress-seo" ),
+				"Woo Premium bundle"
+			)}*`;
+			bundleNote = <div className="yst-text-xs yst-text-slate-500 yst-mt-2">
+				{ `*${sprintf(
+				/* translators: %1$s expands to Yoast SEO Premium, %2$s expands to Yoast WooCommerce SEO. */
+					__( "%1$s + %2$s", "wordpress-seo" ),
+					"Yoast SEO Premium",
+					"Yoast WooCommerce SEO"
+				)}` }
+			</div>;
+			upsellLink = upsellLinkWooPremiumBundle;
+		}
+		if ( isPremium ) {
+			upsellLabel = sprintf(
+				/* translators: %1$s expands to Yoast WooCommerce SEO. */
+				__( "Unlock with %1$s", "wordpress-seo" ),
+				"Yoast WooCommerce SEO"
+			);
+			upsellLink = upsellLinkWoo;
+		}
+	}
 
 	return (
 		<div className="yst-flex yst-flex-col yst-items-center yst-p-10">
@@ -76,7 +118,7 @@ export const AiGenerateTitlesAndDescriptionsUpsell = ( { learnMoreLink, upsellLi
 					ref={ initialFocus }
 				>
 					<LockOpenIcon className="yst--ml-1 yst-mr-2 yst-h-5 yst-w-5" />
-					{ __( "Unlock with Premium", "wordpress-seo" ) }
+					{ upsellLabel }
 					<span className="yst-sr-only">
 						{
 							/* translators: Hidden accessibility text. */
@@ -85,6 +127,7 @@ export const AiGenerateTitlesAndDescriptionsUpsell = ( { learnMoreLink, upsellLi
 					</span>
 				</Button>
 			</div>
+			{ bundleNote }
 			<Button
 				as="a"
 				className="yst-mt-4"
@@ -98,7 +141,6 @@ export const AiGenerateTitlesAndDescriptionsUpsell = ( { learnMoreLink, upsellLi
 };
 AiGenerateTitlesAndDescriptionsUpsell.propTypes = {
 	learnMoreLink: PropTypes.string.isRequired,
-	upsellLink: PropTypes.string.isRequired,
 	thumbnail: PropTypes.shape( {
 		src: PropTypes.string.isRequired,
 		width: PropTypes.string,


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Add AI feature introduction modal to product pages.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds AI introduction modal to product pages when WooCommerce SEO and Premium are not active.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install Woocommerce and activate
* Install Yoast SEO premium but do not activate
* use the following branch for premium when testing: `disable-ai-feature-without-wooSEO-onproduct-page` (https://github.com/Yoast/wordpress-seo-premium/pull/4110)


#### Woo Premium bundle upsell
* Go to `Products` create a product or edit one.
* Go to the Google preview section and check you see `Use AI` button.
* Click the `Use AI` and check you get the introduction modal and the CTA button has the following label, link, note:
  * Label: Unlock with Woo Premium bundle*
  * Link: https://yoa.st/ai-generator-upsell-woo-seo-premium-bundle
  * And a note under the button: *Yoast SEO Premium + Yoast WooCommerce SEO
* Edit a page or post
* Click `Use AI` and check you get the introduction modal and the CTA button has the following label and link:
   * Label: Unlock with Yoast SEO Premium
   * Link: https://yoa.st/ai-generator-upsell

#### Yoast WooCommerce SEO upsell
* Enable Yoast Premium 
* Enable AI feature in `Yoast SEO`->`Settings`->`Site features`
* Edit a product
* Go to the Google preview section
* Check there is only one `Use AI` button.
* Click `Use AI` and check you get the introduction modal and the CTA button has the following label and link:
   * Label: Unlock with Yoast WooCommerce SEO
  * Link: https://yoa.st/ai-generator-upsell-woo-seo
* Edit a page or post)
* Click the `Use AI`
* Check you get a consent modal

#### Yoast SEO Premium upsell
* Disable Yoast Premium plugin
* Install and enable WooCommerce SEO
* Edit a product
* Go to the Google preview section
* Click the `Use AI` and check you get the introduction modal and the CTA button has the following label and link:
   * Label: Unlock with Yoast SEO Premium
   * Link: https://yoa.st/ai-generator-upsell
* Edit a page or post
* Click `Use AI` and check you get the introduction modal and the CTA button has the following label and link:
   * Label: Unlock with Yoast SEO Premium
   * Link: https://yoa.st/ai-generator-upsell

#### Yoast SEO Premium and Yoast WooCommerce SEO active
* Enable Yoast Premium plugin
* Enable AI feature in `Yoast SEO`->`Settings`->`Site features`
* Enable WooCommerce SEO
* Edit a product
* Go to the Google preview section
* Click the `Use AI` and check you get the the consent modal
* Edit a page or post
* Click `Use AI` and check you get the the consent modal

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [X] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [Create Upsell for AI on WooCommerce product pages](https://github.com/Yoast/ux/issues/81)
