### PR TITLE
84 improvements to the introduction modal

### DIFF
--- a/css/src/introductions.css
+++ b/css/src/introductions.css
@@ -7,8 +7,7 @@
 		focus:yst-ring-offset-0;
 	}
 	.yst-introduction-modal-panel {
-		background: rgb(237,210,225);
-		background: linear-gradient(180deg, rgba(237,210,225,1) 10%, rgb(255, 255, 255) 60%);
+        background-image: linear-gradient(180deg, rgba(166, 30, 105, 0.25) 10%, rgba(255, 255, 255, 0.25) 50%);
 	}
 	.yst-introduction-modal-uppercase{
 		letter-spacing: 0.8px;

--- a/css/src/introductions.css
+++ b/css/src/introductions.css
@@ -10,4 +10,8 @@
 		background: rgb(237,210,225);
 		background: linear-gradient(180deg, rgba(237,210,225,1) 10%, rgb(255, 255, 255) 60%);
 	}
+	.yst-introduction-modal-uppercase{
+		letter-spacing: 0.8px;
+		@apply yst-uppercase yst-text-slate-500;
+	}
 }

--- a/css/src/introductions.css
+++ b/css/src/introductions.css
@@ -6,4 +6,8 @@
 		focus:yst-outline-none
 		focus:yst-ring-offset-0;
 	}
+	.yst-introduction-modal-panel {
+		background: rgb(237,210,225);
+		background: linear-gradient(180deg, rgba(237,210,225,1) 10%, rgb(255, 255, 255) 60%);
+	}
 }

--- a/packages/js/src/ai-generator/initialize.js
+++ b/packages/js/src/ai-generator/initialize.js
@@ -32,7 +32,7 @@ const AiGeneratorUpsell = ( { fieldId } ) => {
 				{ __( "Use AI", "wordpress-seo" ) }
 			</button>
 			<Modal className="yst-introduction-modal" isOpen={ isModalOpen } onClose={ setIsModalOpenFalse } initialFocus={ focusElementRef }>
-				<Modal.Panel className="yst-max-w-lg yst-p-0 yst-bg-gradient-to-b yst-from-[#EDD2E1] yst-rounded-3xl">
+				<Modal.Panel className="yst-max-w-lg yst-p-0 yst-rounded-3xl yst-introduction-modal-panel">
 					<ModalContent onClose={ setIsModalOpenFalse } focusElementRef={ focusElementRef } />
 				</Modal.Panel>
 			</Modal>

--- a/packages/js/src/shared-admin/components/ai-generate-titles-and-descriptions-upsell.js
+++ b/packages/js/src/shared-admin/components/ai-generate-titles-and-descriptions-upsell.js
@@ -27,7 +27,7 @@ export const AiGenerateTitlesAndDescriptionsUpsell = ( { learnMoreLink, upsellLi
 				<Badge className="yst-absolute yst-top-0 yst-right-2 yst-mt-2 yst-ml-2" variant="info">Beta</Badge>
 			</div>
 			<div className="yst-mt-6 yst-text-xs yst-font-medium">
-				<span className="yst-uppercase yst-text-slate-500">
+				<span className="yst-uppercase yst-text-slate-500 yst-tracking-[0.8]">
 					{ sprintf(
 						/* translators: %1$s expands to Yoast SEO Premium. */
 						__( "New to %1$s", "wordpress-seo" ),

--- a/packages/js/src/shared-admin/components/ai-generate-titles-and-descriptions-upsell.js
+++ b/packages/js/src/shared-admin/components/ai-generate-titles-and-descriptions-upsell.js
@@ -76,7 +76,11 @@ export const AiGenerateTitlesAndDescriptionsUpsell = ( { learnMoreLink, upsellLi
 					ref={ initialFocus }
 				>
 					<LockOpenIcon className="yst--ml-1 yst-mr-2 yst-h-5 yst-w-5" />
-					{ __( "Unlock with Premium", "wordpress-seo" ) }
+					{ sprintf(
+						/* translators: %1$s expands to Yoast SEO Premium. */
+						__( "Unlock with %1$s", "wordpress-seo" ),
+						"Yoast SEO Premium"
+					) }
 					<span className="yst-sr-only">
 						{
 							/* translators: Hidden accessibility text. */

--- a/packages/js/src/shared-admin/components/ai-generate-titles-and-descriptions-upsell.js
+++ b/packages/js/src/shared-admin/components/ai-generate-titles-and-descriptions-upsell.js
@@ -27,7 +27,7 @@ export const AiGenerateTitlesAndDescriptionsUpsell = ( { learnMoreLink, upsellLi
 				<Badge className="yst-absolute yst-top-0 yst-right-2 yst-mt-2 yst-ml-2" variant="info">Beta</Badge>
 			</div>
 			<div className="yst-mt-6 yst-text-xs yst-font-medium">
-				<span className="yst-uppercase yst-text-slate-500 yst-tracking-[0.8]">
+				<span className="yst-introduction-modal-uppercase">
 					{ sprintf(
 						/* translators: %1$s expands to Yoast SEO Premium. */
 						__( "New to %1$s", "wordpress-seo" ),

--- a/src/user-profiles-additions/user-interface/user-profiles-additions-ui.php
+++ b/src/user-profiles-additions/user-interface/user-profiles-additions-ui.php
@@ -2,6 +2,8 @@
 
 namespace Yoast\WP\SEO\User_Profiles_Additions\User_Interface;
 
+use WPSEO_Admin_Asset_Manager;
+use Yoast\WP\SEO\Helpers\Product_Helper;
 use Yoast\WP\SEO\Conditionals\User_Profile_Conditional;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
 
@@ -9,6 +11,34 @@ use Yoast\WP\SEO\Integrations\Integration_Interface;
  * Adds a new hook in the user profiles edit screen to add content.
  */
 class User_Profiles_Additions_Ui implements Integration_Interface {
+
+	/**
+	 * Holds the Product_Helper.
+	 *
+	 * @var Product_Helper
+	 */
+	private $product_helper;
+
+	/**
+	 * Holds the WPSEO_Admin_Asset_Manager.
+	 *
+	 * @var WPSEO_Admin_Asset_Manager
+	 */
+	private $asset_manager;
+
+	/**
+	 * Constructs Academy_Integration.
+	 *
+	 * @param WPSEO_Admin_Asset_Manager $asset_manager  The WPSEO_Admin_Asset_Manager.
+	 * @param Product_Helper            $product_helper The Product_Helper.
+	 */
+	public function __construct(
+		WPSEO_Admin_Asset_Manager $asset_manager,
+		Product_Helper $product_helper
+	) {
+		$this->asset_manager  = $asset_manager;
+		$this->product_helper = $product_helper;
+	}
 
 	/**
 	 * Returns the conditionals based in which this loadable should be active.
@@ -32,12 +62,23 @@ class User_Profiles_Additions_Ui implements Integration_Interface {
 	}
 
 	/**
+	 * Enqueues the assets needed for this integration.
+	 *
+	 * @return void
+	 */
+	public function enqueue_assets() {
+		if ( $this->product_helper->is_premium() ) {
+			$this->asset_manager->enqueue_style( 'introductions' );
+		}
+	}
+
+	/**
 	 * Add the inputs needed for SEO values to the User Profile page.
 	 *
 	 * @param WP_User $user User instance to output for.
 	 */
 	public function add_hook_to_user_profile( $user ) {
-
+		$this->enqueue_assets();
 		echo '<div class="yoast yoast-settings">';
 
 		/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Fix introduction modal styling and copy.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adjust styling and copy of the AI introduction copy.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Make sure Yoast SEO Premium is not active.
* Edit a post or page.
* Go to google preview
* Click on `Use AI` button
* Check AI introduction modal:
  * The upsell button should have the label: `Unlock with Yoast SEO Premium`
  * Check the line "NEW TO YOAST SEO PREMIUM 21.0` should have letter spacing of 0.8.
  * Check modal gradient should have the dark color not as the text background.  

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [Improvements to the introduction modal](https://github.com/Yoast/ux/issues/84)
