### PR TITLE
Remove version constraint for showing the ai introduction modal

### DIFF
--- a/src/introductions/application/ai-generate-titles-and-descriptions-introduction-upsell.php
+++ b/src/introductions/application/ai-generate-titles-and-descriptions-introduction-upsell.php
@@ -80,10 +80,6 @@ class Ai_Generate_Titles_And_Descriptions_Introduction_Upsell implements Introdu
 			return false;
 		}
 
-		if ( ! $this->is_version_between( $this->product_helper->get_version(), '20.11-RC4', '21.1-RC0' ) ) {
-			return false;
-		}
-
 		if ( ! $this->is_user_allowed( [ 'edit_posts' ] ) ) {
 			return false;
 		}

--- a/tests/unit/introductions/application/ai-generate-titles-and-descriptions-introduction-upsell-test.php
+++ b/tests/unit/introductions/application/ai-generate-titles-and-descriptions-introduction-upsell-test.php
@@ -104,7 +104,6 @@ class Ai_Generate_Titles_And_Descriptions_Introduction_Upsell_Test extends TestC
 	public function test_should_show(
 		$is_premium,
 		$previous_version,
-		$plugin_version,
 		$user_can_edit_posts,
 		$times,
 		$expected
@@ -117,12 +116,6 @@ class Ai_Generate_Titles_And_Descriptions_Introduction_Upsell_Test extends TestC
 			->times( $times['previous_version'] )
 			->with( 'previous_version', '' )
 			->andReturn( $previous_version );
-
-		// Don't show when not between version 21.0-RC1 and 21.1-RC1.
-		$this->product_helper->expects( 'get_version' )
-			->times( $times['plugin_version'] )
-			->withNoArgs()
-			->andReturn( $plugin_version );
 
 		// Don't show when user is not allowed to edit posts.
 		Functions\expect( 'current_user_can' )
@@ -143,11 +136,9 @@ class Ai_Generate_Titles_And_Descriptions_Introduction_Upsell_Test extends TestC
 			'showing'                                 => [
 				'is_premium'          => false,
 				'previous_version'    => '20.10',
-				'plugin_version'      => '21.0',
 				'user_can_edit_posts' => true,
 				'times'               => [
 					'previous_version'    => 1,
-					'plugin_version'      => 1,
 					'user_can_edit_posts' => 1,
 				],
 				'expected'            => true,
@@ -155,11 +146,9 @@ class Ai_Generate_Titles_And_Descriptions_Introduction_Upsell_Test extends TestC
 			'do not show when premium is active'      => [
 				'is_premium'          => true,
 				'previous_version'    => '20.10',
-				'plugin_version'      => '21.0',
 				'user_can_edit_posts' => true,
 				'times'               => [
 					'previous_version'    => 0,
-					'plugin_version'      => 0,
 					'user_can_edit_posts' => 0,
 				],
 				'expected'            => false,
@@ -167,23 +156,9 @@ class Ai_Generate_Titles_And_Descriptions_Introduction_Upsell_Test extends TestC
 			'do not show when on the first install'   => [
 				'is_premium'          => false,
 				'previous_version'    => '',
-				'plugin_version'      => '21.0',
 				'user_can_edit_posts' => true,
 				'times'               => [
 					'previous_version'    => 1,
-					'plugin_version'      => 0,
-					'user_can_edit_posts' => 0,
-				],
-				'expected'            => false,
-			],
-			'do not show when on over 21.0'           => [
-				'is_premium'          => false,
-				'previous_version'    => '20.10',
-				'plugin_version'      => '21.1',
-				'user_can_edit_posts' => true,
-				'times'               => [
-					'previous_version'    => 1,
-					'plugin_version'      => 1,
 					'user_can_edit_posts' => 0,
 				],
 				'expected'            => false,
@@ -191,11 +166,9 @@ class Ai_Generate_Titles_And_Descriptions_Introduction_Upsell_Test extends TestC
 			'do not show when user cannot edit posts' => [
 				'is_premium'          => false,
 				'previous_version'    => '20.10',
-				'plugin_version'      => '21.0',
 				'user_can_edit_posts' => false,
 				'times'               => [
 					'previous_version'    => 1,
-					'plugin_version'      => 1,
 					'user_can_edit_posts' => 1,
 				],
 				'expected'            => false,

--- a/tests/unit/introductions/application/ai-generate-titles-and-descriptions-introduction-upsell-test.php
+++ b/tests/unit/introductions/application/ai-generate-titles-and-descriptions-introduction-upsell-test.php
@@ -96,7 +96,6 @@ class Ai_Generate_Titles_And_Descriptions_Introduction_Upsell_Test extends TestC
 	 *
 	 * @param bool   $is_premium          Whether Premium is active.
 	 * @param string $previous_version    The previous plugin version.
-	 * @param string $plugin_version      The current plugin version.
 	 * @param bool   $user_can_edit_posts Whether the user can edit posts.
 	 * @param array  $times               The amount of times for expectations. Instead of adding logic to the tests.
 	 * @param bool   $expected            The expected result (whether the introduction should show).


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Starting from Yoast SEO 21.6 we want to re-instate the `AI title & description generator` introduction modal.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Re-introduces the `AI title & description generator` introduction modal.

## Relevant technical choices:

* N/A

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Make sure you have Premium disabled
* Go to the database table `wp_usermeta`, search for `meta_key` `_yoast_wpseo_introductions` and your `user_id` 
  * make sure the `meta_value` is as follows: `a:1:{s:42:"ai-generate-titles-and-descriptions-upsell";b:0;}`
* Go to `Tools`-> `Yoast test` and click on `Reset Free installation success page`
* Deactivate Yoast SEO and activate it back
  * Verify you see the installation success page and no modal is shown
* Navigate to any of the Yoast SEO admin pages
  * Verify you see the introduction modal and close it
* Navigate to another Yoast SEO admin page
  * Verify the Introduction modal is not shown
* Login as a different user that has SEO role
*  Go to `Yoast SEO` -> `Settings`
  * Verify the modal is shown

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* N/A

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.
* [X] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/reserved-tasks/issues/142
