### PR TITLE
Add introductions seen route

### DIFF
--- a/packages/js/src/introductions/components/introduction.js
+++ b/packages/js/src/introductions/components/introduction.js
@@ -10,7 +10,7 @@ export const Introduction = () => {
 	const introduction = useSelect( select => select( STORE_NAME_INTRODUCTIONS ).selectCurrentIntroduction(), [] );
 	const components = useIntroductionsContext();
 
-	const Component = useMemo( () => components?.[ introduction?.name ], [ introduction, components ] );
+	const Component = useMemo( () => components?.[ introduction?.id ], [ introduction, components ] );
 
 	if ( ! Component ) {
 		return null;

--- a/packages/js/src/introductions/components/provider.js
+++ b/packages/js/src/introductions/components/provider.js
@@ -23,14 +23,14 @@ export const IntroductionProvider = ( { children, initialComponents } ) => {
 	const [ components, setComponents ] = useState( initialComponents );
 	const introductions = useSelect( select => select( STORE_NAME_INTRODUCTIONS ).selectIntroductions(), [] );
 
-	const registerComponent = useCallback( ( name, Component ) => {
-		const introduction = find( introductions, { name } );
+	const registerComponent = useCallback( ( id, Component ) => {
+		const introduction = find( introductions, { id } );
 		if ( ! introduction ) {
 			// Bail when unknown.
-			console.error( "Warning: Introductions received a registration for an unknown key:", name );
+			console.error( "Warning: Introductions received a registration for an unknown key:", id );
 			return;
 		}
-		setComponents( currentComponents => ( { ...currentComponents, [ name ]: Component } ) );
+		setComponents( currentComponents => ( { ...currentComponents, [ id ]: Component } ) );
 	}, [ introductions, setComponents ] );
 
 	useEffect( () => {

--- a/packages/js/src/introductions/store/introductions.js
+++ b/packages/js/src/introductions/store/introductions.js
@@ -4,7 +4,7 @@ import { get, map } from "lodash";
 export const INTRODUCTIONS_NAME = "introductions";
 
 const adapter = createEntityAdapter( {
-	selectId: introduction => introduction.name,
+	selectId: introduction => introduction.id,
 	sortComparer: ( a, b ) => {
 		if ( a.priority === b.priority ) {
 			return 0;
@@ -15,10 +15,10 @@ const adapter = createEntityAdapter( {
 
 /**
  * @param {Object} introduction The introduction.
- * @returns {{name: string, priority: number}} The prepared introduction.
+ * @returns {{id: string, priority: number}} The prepared introduction.
  */
 const prepareIntroduction = introduction => ( {
-	name: introduction.name || nanoid(),
+	id: introduction.id || nanoid(),
 	priority: introduction.priority || 0,
 } );
 

--- a/src/introductions/application/ai-generate-titles-and-descriptions-introduction-upsell.php
+++ b/src/introductions/application/ai-generate-titles-and-descriptions-introduction-upsell.php
@@ -48,12 +48,26 @@ class Ai_Generate_Titles_And_Descriptions_Introduction_Upsell implements Introdu
 	}
 
 	/**
+	 * Returns the ID.
+	 *
+	 * @return string
+	 */
+	public function get_id() {
+		return 'ai-generate-titles-and-descriptions-upsell';
+	}
+
+	/**
 	 * Returns the unique name.
+	 *
+	 * @deprecated 21.6
+	 * @codeCoverageIgnore
 	 *
 	 * @return string
 	 */
 	public function get_name() {
-		return 'ai-generate-titles-and-descriptions-upsell';
+		_deprecated_function( __METHOD__, 'Yoast SEO 21.6', 'Please use get_id() instead' );
+
+		return $this->get_id();
 	}
 
 	/**

--- a/src/introductions/application/introductions-collector.php
+++ b/src/introductions/application/introductions-collector.php
@@ -45,11 +45,11 @@ class Introductions_Collector {
 			if ( ! $introduction->should_show() ) {
 				continue;
 			}
-			if ( $this->is_seen( $introduction->get_name(), $metadata ) ) {
+			if ( $this->is_seen( $introduction->get_id(), $metadata ) ) {
 				continue;
 			}
 			$bucket->add_introduction(
-				new Introduction_Item( $introduction->get_name(), $introduction->get_priority() )
+				new Introduction_Item( $introduction->get_id(), $introduction->get_priority() )
 			);
 		}
 

--- a/src/introductions/application/introductions-collector.php
+++ b/src/introductions/application/introductions-collector.php
@@ -5,6 +5,7 @@ namespace Yoast\WP\SEO\Introductions\Application;
 use Yoast\WP\SEO\Introductions\Domain\Introduction_Interface;
 use Yoast\WP\SEO\Introductions\Domain\Introduction_Item;
 use Yoast\WP\SEO\Introductions\Domain\Introductions_Bucket;
+use Yoast\WP\SEO\Introductions\Infrastructure\Introductions_Seen_Repository;
 
 /**
  * Manages the collection of introductions.
@@ -87,7 +88,7 @@ class Introductions_Collector {
 	 * @return array The introductions' metadata.
 	 */
 	private function get_metadata( $user_id ) {
-		$metadata = \get_user_meta( $user_id, '_yoast_wpseo_introductions', true );
+		$metadata = \get_user_meta( $user_id, Introductions_Seen_Repository::USER_META_KEY, true );
 		if ( \is_array( $metadata ) ) {
 			return $metadata;
 		}

--- a/src/introductions/domain/introduction-interface.php
+++ b/src/introductions/domain/introduction-interface.php
@@ -8,7 +8,17 @@ namespace Yoast\WP\SEO\Introductions\Domain;
 interface Introduction_Interface {
 
 	/**
+	 * Returns the ID.
+	 *
+	 * @return string
+	 */
+	public function get_id();
+
+	/**
 	 * Returns the unique name.
+	 *
+	 * @deprecated 21.6
+	 * @codeCoverageIgnore
 	 *
 	 * @return string
 	 */

--- a/src/introductions/domain/introduction-item.php
+++ b/src/introductions/domain/introduction-item.php
@@ -8,11 +8,11 @@ namespace Yoast\WP\SEO\Introductions\Domain;
 class Introduction_Item {
 
 	/**
-	 * The unique name.
+	 * The ID.
 	 *
 	 * @var string
 	 */
-	private $name;
+	private $id;
 
 	/**
 	 * The priority.
@@ -24,11 +24,11 @@ class Introduction_Item {
 	/**
 	 * Constructs the instance.
 	 *
-	 * @param string $name     The unique name.
+	 * @param string $id       The ID.
 	 * @param int    $priority The priority.
 	 */
-	public function __construct( $name, $priority ) {
-		$this->name     = $name;
+	public function __construct( $id, $priority ) {
+		$this->id       = $id;
 		$this->priority = $priority;
 	}
 
@@ -39,18 +39,18 @@ class Introduction_Item {
 	 */
 	public function to_array() {
 		return [
-			'name'     => $this->get_name(),
+			'id'       => $this->get_id(),
 			'priority' => $this->get_priority(),
 		];
 	}
 
 	/**
-	 * Returns the unique name.
+	 * Returns the ID.
 	 *
 	 * @return string
 	 */
-	public function get_name() {
-		return $this->name;
+	public function get_id() {
+		return $this->id;
 	}
 
 	/**

--- a/src/introductions/domain/invalid-user-id-exception.php
+++ b/src/introductions/domain/invalid-user-id-exception.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Yoast\WP\SEO\Introductions\Domain;
+
+use InvalidArgumentException;
+use Throwable;
+
+/**
+ * Invalid user ID.
+ */
+class Invalid_User_Id_Exception extends InvalidArgumentException {
+
+	/**
+	 * Constructs the exception.
+	 *
+	 * @link https://php.net/manual/en/exception.construct.php
+	 *
+	 * @param string         $message  [optional] The Exception message to throw.
+	 * @param int            $code     [optional] The Exception code.
+	 * @param null|Throwable $previous [optional] The previous throwable used for the exception chaining.
+	 */
+	public function __construct( // phpcs:ignore Generic.CodeAnalysis.UselessOverridingMethod.Found -- Reason: A default message is used.
+		$message = 'Invalid User ID',
+		$code = 0,
+		$previous = null
+	) {
+		parent::__construct( $message, $code, $previous );
+	}
+}

--- a/src/introductions/infrastructure/introductions-seen-repository.php
+++ b/src/introductions/infrastructure/introductions-seen-repository.php
@@ -67,7 +67,7 @@ class Introductions_Seen_Repository {
 	 *              the one that is already in the database.
 	 */
 	public function set_all_introductions( $user_id, array $introductions ): bool {
-		return $this->user_helper->update_meta( $user_id, self::USER_META_KEY, $introductions ) === true;
+		return $this->user_helper->update_meta( $user_id, self::USER_META_KEY, $introductions ) !== false;
 	}
 
 	/**

--- a/src/introductions/infrastructure/introductions-seen-repository.php
+++ b/src/introductions/infrastructure/introductions-seen-repository.php
@@ -39,7 +39,7 @@ class Introductions_Seen_Repository {
 	 *
 	 * @return array The introductions.
 	 */
-	public function get_introductions( $user_id ): array {
+	public function get_all_introductions( $user_id ): array {
 		$seen_introductions = $this->user_helper->get_meta( $user_id, self::USER_META_KEY, true );
 		if ( $seen_introductions === false ) {
 			throw new Invalid_User_Id_Exception();
@@ -66,7 +66,7 @@ class Introductions_Seen_Repository {
 	 * @return bool True on successful update, false on failure or if the value passed to the function is the same as
 	 *              the one that is already in the database.
 	 */
-	public function set_introductions( $user_id, array $introductions ): bool {
+	public function set_all_introductions( $user_id, array $introductions ): bool {
 		return $this->user_helper->update_meta( $user_id, self::USER_META_KEY, $introductions ) === true;
 	}
 
@@ -81,7 +81,7 @@ class Introductions_Seen_Repository {
 	 * @return bool Whether the introduction is seen.
 	 */
 	public function is_introduction_seen( $user_id, string $introduction_id ): bool {
-		$introductions = $this->get_introductions( $user_id );
+		$introductions = $this->get_all_introductions( $user_id );
 
 		if ( \array_key_exists( $introduction_id, $introductions ) ) {
 			return (bool) $introductions[ $introduction_id ];
@@ -102,7 +102,7 @@ class Introductions_Seen_Repository {
 	 * @return bool False on failure. Not having to update is a success.
 	 */
 	public function set_introduction( $user_id, string $introduction_id, bool $is_seen = true ): bool {
-		$introductions = $this->get_introductions( $user_id );
+		$introductions = $this->get_all_introductions( $user_id );
 
 		// Check if the wanted value is already set.
 		if ( \array_key_exists( $introduction_id, $introductions ) && $introductions[ $introduction_id ] === $is_seen ) {
@@ -110,6 +110,6 @@ class Introductions_Seen_Repository {
 		}
 		$introductions[ $introduction_id ] = $is_seen;
 
-		return $this->set_introductions( $user_id, $introductions );
+		return $this->set_all_introductions( $user_id, $introductions );
 	}
 }

--- a/src/introductions/infrastructure/introductions-seen-repository.php
+++ b/src/introductions/infrastructure/introductions-seen-repository.php
@@ -7,8 +7,6 @@ use Yoast\WP\SEO\Introductions\Domain\Invalid_User_Id_Exception;
 
 /**
  * Stores and retrieves whether the user has seen certain introductions.
- *
- * @makePublic
  */
 class Introductions_Seen_Repository {
 

--- a/src/introductions/infrastructure/introductions-seen-repository.php
+++ b/src/introductions/infrastructure/introductions-seen-repository.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Yoast\WP\SEO\Introductions\Infrastructure;
+
+use Yoast\WP\SEO\Helpers\User_Helper;
+use Yoast\WP\SEO\Introductions\Domain\Invalid_User_Id_Exception;
+
+/**
+ * Stores and retrieves whether the user has seen certain introductions.
+ *
+ * @makePublic
+ */
+class Introductions_Seen_Repository {
+
+	const USER_META_KEY = '_yoast_wpseo_introductions';
+
+	const DEFAULT_VALUE = [];
+
+	/**
+	 * Holds the User_Helper instance.
+	 *
+	 * @var User_Helper
+	 */
+	private $user_helper;
+
+	/**
+	 * Constructs the class.
+	 *
+	 * @param User_Helper $user_helper The User_Helper.
+	 */
+	public function __construct( User_Helper $user_helper ) {
+		$this->user_helper = $user_helper;
+	}
+
+	/**
+	 * Retrieves the introductions.
+	 *
+	 * @param int $user_id User ID.
+	 *
+	 * @throws Invalid_User_Id_Exception If an invalid user ID is supplied.
+	 *
+	 * @return array The introductions.
+	 */
+	public function get_introductions( $user_id ): array {
+		$seen_introductions = $this->user_helper->get_meta( $user_id, self::USER_META_KEY, true );
+		if ( $seen_introductions === false ) {
+			throw new Invalid_User_Id_Exception();
+		}
+
+		if ( \is_array( $seen_introductions ) ) {
+			return $seen_introductions;
+		}
+
+		/**
+		 * Why could $value be invalid?
+		 * - When the database row does not exist yet, $value can be an empty string.
+		 * - Faulty data was stored?
+		 */
+		return self::DEFAULT_VALUE;
+	}
+
+	/**
+	 * Sets the introductions.
+	 *
+	 * @param int   $user_id       The user ID.
+	 * @param array $introductions The introductions.
+	 *
+	 * @return bool True on successful update, false on failure or if the value passed to the function is the same as
+	 *              the one that is already in the database.
+	 */
+	public function set_introductions( $user_id, array $introductions ): bool {
+		return $this->user_helper->update_meta( $user_id, self::USER_META_KEY, $introductions ) === true;
+	}
+
+	/**
+	 * Retrieves whether an introduction is seen.
+	 *
+	 * @param int    $user_id         User ID.
+	 * @param string $introduction_id The introduction ID.
+	 *
+	 * @throws Invalid_User_Id_Exception If an invalid user ID is supplied.
+	 *
+	 * @return bool Whether the introduction is seen.
+	 */
+	public function is_introduction_seen( $user_id, string $introduction_id ): bool {
+		$introductions = $this->get_introductions( $user_id );
+
+		if ( \array_key_exists( $introduction_id, $introductions ) ) {
+			return (bool) $introductions[ $introduction_id ];
+		}
+
+		return false;
+	}
+
+	/**
+	 * Sets the introduction as seen.
+	 *
+	 * @param int    $user_id         The user ID.
+	 * @param string $introduction_id The introduction ID.
+	 * @param bool   $is_seen         Whether the introduction is seen. Defaults to true.
+	 *
+	 * @throws Invalid_User_Id_Exception If an invalid user ID is supplied.
+	 *
+	 * @return bool False on failure. Not having to update is a success.
+	 */
+	public function set_introduction( $user_id, string $introduction_id, bool $is_seen = true ): bool {
+		$introductions = $this->get_introductions( $user_id );
+
+		// Check if the wanted value is already set.
+		if ( \array_key_exists( $introduction_id, $introductions ) && $introductions[ $introduction_id ] === $is_seen ) {
+			return true;
+		}
+		$introductions[ $introduction_id ] = $is_seen;
+
+		return $this->set_introductions( $user_id, $introductions );
+	}
+}

--- a/src/introductions/readme.md
+++ b/src/introductions/readme.md
@@ -4,13 +4,15 @@ Is for showing introductions to a user, on Yoast admin pages.
 Based on plugin version, page, user capabilities and whether the user has seen it already.
 
 - `Introduction_Interface` defines what data is needed
-    - `name` as unique identifier
+    - `id` as unique identifier
     - `plugin` and `version` to determine if the introduction is new (version > plugin version)
     - `pages` to be able to only show on certain Yoast admin pages
     - `capabilities` to be able to only show for certain users
 - `Introductions_Collector` uses that data to determine whether an introduction should be "shown" to a user
     - uses the `wpseo_introductions` filter to be extendable from our other plugins
-    - uses `_yoast_introductions` user metadata to determine if the user saw an introduction already
+    - uses `Introductions_Seen_Repository` to get the data to determine if the user saw an introduction already
+- `Introductions_Seen_Repository` is the doorway whether a user has seen an introduction or not
+    - uses the `_yoast_introductions` user metadata
 - `Introduction_Bucket` and `Introduction_Item` are used by the collector to get an array
 - `Introductions_Integration` runs on the Yoast Admin pages and loads the assets
     - only loads on our Yoast admin pages, but never on our installation success pages as to not disturb onboarding
@@ -20,6 +22,6 @@ Based on plugin version, page, user capabilities and whether the user has seen i
         - `css/src/ai-generator.css` holds the CSS
 
 Inside JS, register the modal content via `window.YoastSEO._registerIntroductionComponent`, which takes a
-`name` and a `Component`. The name needs to be the same as the name in the `Introduction_Interface`.
+`id` and a `Component`. The id needs to be the same as the id in the `Introduction_Interface`.
 The action `yoast.introductions.ready` can be used to know whether the registration function is available and ready for
 use.

--- a/src/introductions/user-interface/introductions-integration.php
+++ b/src/introductions/user-interface/introductions-integration.php
@@ -153,7 +153,7 @@ class Introductions_Integration implements Integration_Interface {
 			$metadata = [];
 		}
 		foreach ( $introductions as $introduction ) {
-			$metadata[ $introduction['name'] ] = true;
+			$metadata[ $introduction['id'] ] = true;
 		}
 		$this->user_helper->update_meta( $user_id, '_yoast_wpseo_introductions', $metadata );
 	}

--- a/src/introductions/user-interface/introductions-seen-route.php
+++ b/src/introductions/user-interface/introductions-seen-route.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace Yoast\WP\SEO\Introductions\User_Interface;
+
+use Exception;
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
+use Yoast\WP\SEO\Conditionals\No_Conditionals;
+use Yoast\WP\SEO\Helpers\User_Helper;
+use Yoast\WP\SEO\Introductions\Infrastructure\Introductions_Seen_Repository;
+use Yoast\WP\SEO\Main;
+use Yoast\WP\SEO\Routes\Route_Interface;
+
+/**
+ * Registers a route to set whether the user has seen an introduction.
+ *
+ * @makePublic
+ */
+class Introductions_Seen_Route implements Route_Interface {
+
+	use No_Conditionals;
+
+	/**
+	 * Represents the prefix.
+	 *
+	 * @var string
+	 */
+	const ROUTE_PREFIX = '/introductions/(?P<introduction_id>[\w-]+)/seen';
+
+	/**
+	 * Holds the repository.
+	 *
+	 * @var Introductions_Seen_Repository
+	 */
+	private $introductions_seen_repository;
+
+	/**
+	 * Holds the user helper.
+	 *
+	 * @var User_Helper
+	 */
+	private $user_helper;
+
+	/**
+	 * Constructs the class.
+	 *
+	 * @param Introductions_Seen_Repository $introductions_seen_repository The repository.
+	 * @param User_Helper                   $user_helper                   The user helper.
+	 */
+	public function __construct(
+		Introductions_Seen_Repository $introductions_seen_repository,
+		User_Helper $user_helper
+	) {
+		$this->introductions_seen_repository = $introductions_seen_repository;
+		$this->user_helper                   = $user_helper;
+	}
+
+	/**
+	 * Registers routes with WordPress.
+	 *
+	 * @return void
+	 */
+	public function register_routes() {
+		\register_rest_route(
+			Main::API_V1_NAMESPACE,
+			self::ROUTE_PREFIX,
+			[
+				[
+					'methods'             => 'POST',
+					'callback'            => [ $this, 'set_introduction_seen' ],
+					'permission_callback' => [ $this, 'permission_edit_posts' ],
+					'args'                => [
+						'introduction_id' => [
+							'required'          => true,
+							'type'              => 'string',
+							'sanitize_callback' => 'sanitize_text_field',
+						],
+						'is_seen'         => [
+							'required'          => false,
+							'type'              => 'bool',
+							'default'           => true,
+							'sanitize_callback' => 'rest_sanitize_boolean',
+						],
+					],
+				],
+			]
+		);
+	}
+
+	/**
+	 * Sets whether the introduction is seen.
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 *
+	 * @return WP_REST_Response|WP_Error The success or failure response.
+	 */
+	public function set_introduction_seen( WP_REST_Request $request ) {
+		$params          = $request->get_params();
+		$introduction_id = $params['introduction_id'];
+		$is_seen         = $params['is_seen'];
+
+		try {
+			$user_id = $this->user_helper->get_current_user_id();
+			$result  = $this->introductions_seen_repository->set_introduction( $user_id, $introduction_id, $is_seen );
+		} catch ( Exception $exception ) {
+			return new WP_Error(
+				'wpseo_introductions_seen_error',
+				$exception->getMessage(),
+				(object) []
+			);
+		}
+
+		return new WP_REST_Response(
+			[
+				'json' => (object) [
+					'success' => $result,
+				],
+			],
+			( $result ) ? 200 : 400
+		);
+	}
+
+	/**
+	 * Permission callback.
+	 *
+	 * @return bool True when user has 'edit_posts' permission.
+	 */
+	public function permission_edit_posts() {
+		return \current_user_can( 'edit_posts' );
+	}
+}

--- a/tests/unit/doubles/introductions/introduction-mock.php
+++ b/tests/unit/doubles/introductions/introduction-mock.php
@@ -10,11 +10,11 @@ use Yoast\WP\SEO\Introductions\Domain\Introduction_Interface;
 class Introduction_Mock implements Introduction_Interface {
 
 	/**
-	 * Holds the name.
+	 * Holds the ID.
 	 *
 	 * @var string
 	 */
-	private $name;
+	private $id;
 
 	/**
 	 * Holds the priority.
@@ -33,19 +33,33 @@ class Introduction_Mock implements Introduction_Interface {
 	/**
 	 * Constructs the introduction mock.
 	 */
-	public function __construct( $name, $priority, $should_show ) {
-		$this->name        = $name;
+	public function __construct( $id, $priority, $should_show ) {
+		$this->id          = $id;
 		$this->priority    = $priority;
 		$this->should_show = $should_show;
 	}
 
 	/**
+	 * Returns the ID.
+	 *
+	 * @return string
+	 */
+	public function get_id() {
+		return $this->id;
+	}
+
+	/**
 	 * Returns the unique name.
+	 *
+	 * @deprecated 21.6
+	 * @codeCoverageIgnore
 	 *
 	 * @return string
 	 */
 	public function get_name() {
-		return $this->name;
+		_deprecated_function( __METHOD__, 'Yoast SEO 21.6', 'Please use get_id() instead' );
+
+		return $this->id;
 	}
 
 	/**

--- a/tests/unit/introductions/application/ai-generate-titles-and-descriptions-introduction-upsell-test.php
+++ b/tests/unit/introductions/application/ai-generate-titles-and-descriptions-introduction-upsell-test.php
@@ -70,12 +70,12 @@ class Ai_Generate_Titles_And_Descriptions_Introduction_Upsell_Test extends TestC
 	}
 
 	/**
-	 * Tests getting the name.
+	 * Tests getting the ID.
 	 *
-	 * @covers ::get_name
+	 * @covers ::get_id
 	 */
 	public function test_get_name() {
-		$this->assertSame( 'ai-generate-titles-and-descriptions-upsell', $this->instance->get_name() );
+		$this->assertSame( 'ai-generate-titles-and-descriptions-upsell', $this->instance->get_id() );
 	}
 
 	/**

--- a/tests/unit/introductions/application/introductions-collector-test.php
+++ b/tests/unit/introductions/application/introductions-collector-test.php
@@ -82,7 +82,7 @@ class Introductions_Collector_Test extends TestCase {
 				'user_introductions_metadata' => [],
 				'expected_result'             => [
 					[
-						'name'     => 'test1',
+						'id'       => 'test1',
 						'priority' => 1,
 					],
 				],
@@ -98,11 +98,11 @@ class Introductions_Collector_Test extends TestCase {
 				'user_introductions_metadata' => [],
 				'expected_result'             => [
 					[
-						'name'     => 'test1',
+						'id'       => 'test1',
 						'priority' => 1,
 					],
 					[
-						'name'     => 'test2',
+						'id'       => 'test2',
 						'priority' => 2,
 					],
 				],
@@ -117,7 +117,7 @@ class Introductions_Collector_Test extends TestCase {
 				'user_introductions_metadata' => [],
 				'expected_result'             => [
 					[
-						'name'     => 'test2',
+						'id'       => 'test2',
 						'priority' => 2,
 					],
 				],
@@ -133,7 +133,7 @@ class Introductions_Collector_Test extends TestCase {
 				'user_introductions_metadata' => [],
 				'expected_result'             => [
 					[
-						'name'     => 'test2',
+						'id'       => 'test2',
 						'priority' => 2,
 					],
 				],
@@ -150,7 +150,7 @@ class Introductions_Collector_Test extends TestCase {
 				'user_introductions_metadata' => [],
 				'expected_result'             => [
 					[
-						'name'     => 'test1',
+						'id'       => 'test1',
 						'priority' => 1,
 					],
 				],
@@ -171,7 +171,7 @@ class Introductions_Collector_Test extends TestCase {
 				],
 				'expected_result'             => [
 					[
-						'name'     => 'test2',
+						'id'       => 'test2',
 						'priority' => 2,
 					],
 				],
@@ -190,11 +190,11 @@ class Introductions_Collector_Test extends TestCase {
 				'user_introductions_metadata' => false,
 				'expected_result'             => [
 					[
-						'name'     => 'test1',
+						'id'       => 'test1',
 						'priority' => 1,
 					],
 					[
-						'name'     => 'test2',
+						'id'       => 'test2',
 						'priority' => 2,
 					],
 				],
@@ -215,7 +215,7 @@ class Introductions_Collector_Test extends TestCase {
 				'user_introductions_metadata' => [],
 				'expected_result'             => [
 					[
-						'name'     => 'test1',
+						'id'       => 'test1',
 						'priority' => 1,
 					],
 				],

--- a/tests/unit/introductions/domain/introduction-item-test.php
+++ b/tests/unit/introductions/domain/introduction-item-test.php
@@ -37,7 +37,7 @@ class Introduction_Item_Test extends TestCase {
 	 * @covers ::__construct
 	 */
 	public function test_construct() {
-		$this->assertEquals( 'test', $this->getPropertyValue( $this->instance, 'name' ) );
+		$this->assertEquals( 'test', $this->getPropertyValue( $this->instance, 'id' ) );
 		$this->assertEquals( 5, $this->getPropertyValue( $this->instance, 'priority' ) );
 	}
 
@@ -49,7 +49,7 @@ class Introduction_Item_Test extends TestCase {
 	public function test_to_array() {
 		$this->assertEquals(
 			[
-				'name'     => 'test',
+				'id'       => 'test',
 				'priority' => 5,
 			],
 			$this->instance->to_array()
@@ -57,12 +57,12 @@ class Introduction_Item_Test extends TestCase {
 	}
 
 	/**
-	 * Tests getting the name.
+	 * Tests getting the ID.
 	 *
-	 * @covers ::get_name
+	 * @covers ::get_id
 	 */
-	public function test_get_name() {
-		$this->assertEquals( 'test', $this->instance->get_name() );
+	public function test_get_id() {
+		$this->assertEquals( 'test', $this->instance->get_id() );
 	}
 
 	/**

--- a/tests/unit/introductions/domain/introductions-bucket-test.php
+++ b/tests/unit/introductions/domain/introductions-bucket-test.php
@@ -53,11 +53,11 @@ class Introductions_Bucket_Test extends TestCase {
 		$this->assertEquals(
 			[
 				[
-					'name'     => 'test1',
+					'id'       => 'test1',
 					'priority' => 1,
 				],
 				[
-					'name'     => 'test2',
+					'id'       => 'test2',
 					'priority' => 2,
 				],
 			],

--- a/tests/unit/introductions/infrastructure/introductions-seen-repository-test.php
+++ b/tests/unit/introductions/infrastructure/introductions-seen-repository-test.php
@@ -1,0 +1,259 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Introductions\Infrastructure;
+
+use Mockery;
+use Yoast\WP\SEO\Helpers\User_Helper;
+use Yoast\WP\SEO\Introductions\Domain\Invalid_User_Id_Exception;
+use Yoast\WP\SEO\Introductions\Infrastructure\Introductions_Seen_Repository;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Tests the introductions seen repository.
+ *
+ * @group introductions
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Introductions\Infrastructure\Introductions_Seen_Repository
+ */
+class Introductions_Seen_Repository_Test extends TestCase {
+
+	/**
+	 * Holds the instance.
+	 *
+	 * @var \Yoast\WP\SEO\Introductions\Infrastructure\Introductions_Seen_Repository
+	 */
+	private $instance;
+
+	/**
+	 * Holds the user helper.
+	 *
+	 * @var \Mockery\MockInterface|\Yoast\WP\SEO\Helpers\User_Helper
+	 */
+	private $user_helper;
+
+	/**
+	 * Sets up the test fixtures.
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->user_helper = Mockery::mock( User_Helper::class );
+
+		$this->instance = new Introductions_Seen_Repository( $this->user_helper );
+	}
+
+	/**
+	 * Tests if the needed attributes are set correctly.
+	 *
+	 * @covers ::__construct
+	 */
+	public function test_constructor() {
+		$this->assertInstanceOf(
+			User_Helper::class,
+			$this->getPropertyValue( $this->instance, 'user_helper' )
+		);
+	}
+
+	/**
+	 * Tests the introductions retrieval.
+	 *
+	 * @covers ::get_introductions
+	 *
+	 * @dataProvider provide_get_introductions_test_data
+	 *
+	 * @param mixed   $meta     Value `get_meta` returns.
+	 * @param boolean $expected The expected value.
+	 *
+	 * @throws Invalid_User_Id_Exception Invalid User ID.
+	 */
+	public function test_get_introductions( $meta, $expected ) {
+		$user_id = 1;
+		$this->user_helper->expects( 'get_meta' )
+			->once()
+			->with( $user_id, Introductions_Seen_Repository::USER_META_KEY, true )
+			->andReturn( $meta );
+
+		$this->assertEquals( $expected, $this->instance->get_introductions( $user_id ) );
+	}
+
+	/**
+	 * Provides data for `test_get_introductions()`.
+	 *
+	 * @return array
+	 */
+	public function provide_get_introductions_test_data() {
+		return [
+			'nothing stored'    => [
+				'meta'     => '',
+				'expected' => Introductions_Seen_Repository::DEFAULT_VALUE,
+			],
+			'introduction seen' => [
+				'meta'     => [ 'foo' => true ],
+				'expected' => [ 'foo' => true ],
+			],
+			'string'            => [
+				'meta'     => 'foo',
+				'expected' => Introductions_Seen_Repository::DEFAULT_VALUE,
+			],
+		];
+	}
+
+	/**
+	 * Tests the introductions retrieval with an invalid user ID.
+	 *
+	 * @covers ::get_introductions
+	 *
+	 * @throws Invalid_User_Id_Exception Invalid User ID.
+	 */
+	public function test_get_introductions_with_invalid_user_id() {
+		$user_id = 1;
+		$this->user_helper->expects( 'get_meta' )
+			->once()
+			->with( $user_id, Introductions_Seen_Repository::USER_META_KEY, true )
+			->andReturn( false );
+
+		$this->expectException( Invalid_User_Id_Exception::class );
+
+		$this->instance->get_introductions( $user_id );
+	}
+
+	/**
+	 * Tests setting the introductions calls update_meta().
+	 *
+	 * @covers ::set_introductions
+	 */
+	public function test_set_introductions() {
+		$user_id       = 1;
+		$introductions = [ 'foo' => true ];
+		$this->user_helper->expects( 'update_meta' )
+			->once()
+			->with( $user_id, Introductions_Seen_Repository::USER_META_KEY, $introductions )
+			->andReturnTrue();
+
+		$this->instance->set_introductions( $user_id, $introductions );
+	}
+
+	/**
+	 * Tests the introduction is seen logic.
+	 *
+	 * @covers ::is_introduction_seen
+	 *
+	 * @dataProvider provide_is_introduction_seen_test_data
+	 *
+	 * @param string $introduction_id The introduction ID.
+	 * @param mixed  $meta            The get_meta return value.
+	 * @param bool   $expected        The expected result.
+	 *
+	 * @throws Invalid_User_Id_Exception Invalid User ID.
+	 */
+	public function test_is_introduction_seen( $introduction_id, $meta, $expected ) {
+		$user_id = 1;
+		$this->user_helper->expects( 'get_meta' )
+			->once()
+			->with( $user_id, Introductions_Seen_Repository::USER_META_KEY, true )
+			->andReturn( $meta );
+
+		$this->assertSame( $expected, $this->instance->is_introduction_seen( $user_id, $introduction_id ) );
+	}
+
+	/**
+	 * Provides data for `test_is_introduction_seen()`.
+	 *
+	 * @return array
+	 */
+	public function provide_is_introduction_seen_test_data() {
+		return [
+			'seen'             => [
+				'introduction_id' => 'foo',
+				'meta'            => [ 'foo' => true ],
+				'expected'        => true,
+			],
+			'not seen'         => [
+				'introduction_id' => 'foo',
+				'meta'            => [ 'foo' => false ],
+				'expected'        => false,
+			],
+			'not present'      => [
+				'introduction_id' => 'foo',
+				'meta'            => [],
+				'expected'        => false,
+			],
+			'type juggle: 1'   => [
+				'introduction_id' => 'foo',
+				'meta'            => [ 'foo' => 1 ],
+				'expected'        => true,
+			],
+			'type juggle: 0'   => [
+				'introduction_id' => 'foo',
+				'meta'            => [ 'foo' => 0 ],
+				'expected'        => false,
+			],
+			'type juggle: "1"' => [
+				'introduction_id' => 'foo',
+				'meta'            => [ 'foo' => '1' ],
+				'expected'        => true,
+			],
+			'type juggle: "0"' => [
+				'introduction_id' => 'foo',
+				'meta'            => [ 'foo' => 0 ],
+				'expected'        => false,
+			],
+		];
+	}
+
+	/**
+	 * Tests setting the introduction.
+	 *
+	 * @covers ::set_introduction
+	 *
+	 * @dataProvider provide_set_introduction_test_data
+	 *
+	 * @param string $introduction_id The introduction ID.
+	 * @param bool   $is_seen         Whether the introduction is seen.
+	 * @param mixed  $meta            The get_meta return value.
+	 * @param array  $expected_meta   The expected meta.
+	 *
+	 * @throws Invalid_User_Id_Exception Invalid User ID.
+	 */
+	public function test_set_introduction( $introduction_id, $is_seen, $meta, $expected_meta ) {
+		$user_id = 1;
+		$this->user_helper->expects( 'get_meta' )
+			->once()
+			->with( $user_id, Introductions_Seen_Repository::USER_META_KEY, true )
+			->andReturn( $meta );
+		$this->user_helper->expects( 'update_meta' )
+			->times( ( $meta === $expected_meta ) ? 0 : 1 )
+			->with( $user_id, Introductions_Seen_Repository::USER_META_KEY, $expected_meta )
+			->andReturnTrue();
+
+		$this->instance->set_introduction( $user_id, $introduction_id, $is_seen, $meta );
+	}
+
+	/**
+	 * Provides data for `test_set_introduction()`.
+	 *
+	 * @return array
+	 */
+	public function provide_set_introduction_test_data() {
+		return [
+			'seen'      => [
+				'introduction_id' => 'foo',
+				'is_seen'         => true,
+				'meta'            => [],
+				'expected_meta'   => [ 'foo' => true ],
+			],
+			'not seen'  => [
+				'introduction_id' => 'foo',
+				'is_seen'         => false,
+				'meta'            => [],
+				'expected_meta'   => [ 'foo' => false ],
+			],
+			'no change' => [
+				'introduction_id' => 'foo',
+				'is_seen'         => true,
+				'meta'            => [ 'foo' => true ],
+				'expected_meta'   => [ 'foo' => true ],
+			],
+		];
+	}
+}

--- a/tests/unit/introductions/infrastructure/introductions-seen-repository-test.php
+++ b/tests/unit/introductions/infrastructure/introductions-seen-repository-test.php
@@ -57,31 +57,31 @@ class Introductions_Seen_Repository_Test extends TestCase {
 	/**
 	 * Tests the introductions retrieval.
 	 *
-	 * @covers ::get_introductions
+	 * @covers ::get_all_introductions
 	 *
-	 * @dataProvider provide_get_introductions_test_data
+	 * @dataProvider provide_get_all_introductions_test_data
 	 *
 	 * @param mixed   $meta     Value `get_meta` returns.
 	 * @param boolean $expected The expected value.
 	 *
 	 * @throws Invalid_User_Id_Exception Invalid User ID.
 	 */
-	public function test_get_introductions( $meta, $expected ) {
+	public function test_get_all_introductions( $meta, $expected ) {
 		$user_id = 1;
 		$this->user_helper->expects( 'get_meta' )
 			->once()
 			->with( $user_id, Introductions_Seen_Repository::USER_META_KEY, true )
 			->andReturn( $meta );
 
-		$this->assertEquals( $expected, $this->instance->get_introductions( $user_id ) );
+		$this->assertEquals( $expected, $this->instance->get_all_introductions( $user_id ) );
 	}
 
 	/**
-	 * Provides data for `test_get_introductions()`.
+	 * Provides data for `test_get_all_introductions()`.
 	 *
 	 * @return array
 	 */
-	public function provide_get_introductions_test_data() {
+	public function provide_get_all_introductions_test_data() {
 		return [
 			'nothing stored'    => [
 				'meta'     => '',
@@ -101,11 +101,11 @@ class Introductions_Seen_Repository_Test extends TestCase {
 	/**
 	 * Tests the introductions retrieval with an invalid user ID.
 	 *
-	 * @covers ::get_introductions
+	 * @covers ::get_all_introductions
 	 *
 	 * @throws Invalid_User_Id_Exception Invalid User ID.
 	 */
-	public function test_get_introductions_with_invalid_user_id() {
+	public function test_get_all_introductions_with_invalid_user_id() {
 		$user_id = 1;
 		$this->user_helper->expects( 'get_meta' )
 			->once()
@@ -114,15 +114,15 @@ class Introductions_Seen_Repository_Test extends TestCase {
 
 		$this->expectException( Invalid_User_Id_Exception::class );
 
-		$this->instance->get_introductions( $user_id );
+		$this->instance->get_all_introductions( $user_id );
 	}
 
 	/**
 	 * Tests setting the introductions calls update_meta().
 	 *
-	 * @covers ::set_introductions
+	 * @covers ::set_all_introductions
 	 */
-	public function test_set_introductions() {
+	public function test_set_all_introductions() {
 		$user_id       = 1;
 		$introductions = [ 'foo' => true ];
 		$this->user_helper->expects( 'update_meta' )
@@ -130,7 +130,7 @@ class Introductions_Seen_Repository_Test extends TestCase {
 			->with( $user_id, Introductions_Seen_Repository::USER_META_KEY, $introductions )
 			->andReturnTrue();
 
-		$this->instance->set_introductions( $user_id, $introductions );
+		$this->instance->set_all_introductions( $user_id, $introductions );
 	}
 
 	/**

--- a/tests/unit/introductions/user-interface/introductions-seen-route-test.php
+++ b/tests/unit/introductions/user-interface/introductions-seen-route-test.php
@@ -1,0 +1,253 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Introductions\User_Interface;
+
+use Brain\Monkey\Functions;
+use Exception;
+use Mockery;
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
+use Yoast\WP\SEO\Helpers\User_Helper;
+use Yoast\WP\SEO\Introductions\Infrastructure\Introductions_Seen_Repository;
+use Yoast\WP\SEO\Introductions\User_Interface\Introductions_Seen_Route;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Tests the Introductions seen route.
+ *
+ * @group introductions
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Introductions\User_Interface\Introductions_Seen_Route
+ */
+class Introductions_Seen_Route_Test extends TestCase {
+
+	/**
+	 * Holds the instance.
+	 *
+	 * @var Introductions_Seen_Route
+	 */
+	private $instance;
+
+	/**
+	 * Holds the user helper.
+	 *
+	 * @var \Mockery\MockInterface|\Yoast\WP\SEO\Helpers\User_Helper
+	 */
+	private $user_helper;
+
+	/**
+	 * Holds the introductions seen repository.
+	 *
+	 * @var \Mockery\MockInterface|\Yoast\WP\SEO\Introductions\Infrastructure\Introductions_Seen_Repository
+	 */
+	private $introductions_seen_repository;
+
+	/**
+	 * Sets up the test fixtures.
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		Mockery::mock( WP_Error::class );
+
+		$this->introductions_seen_repository = Mockery::mock( Introductions_Seen_Repository::class );
+		$this->user_helper                   = Mockery::mock( User_Helper::class );
+
+		$this->instance = new Introductions_Seen_Route( $this->introductions_seen_repository, $this->user_helper );
+	}
+
+	/**
+	 * Tests if the needed attributes are set correctly.
+	 *
+	 * @covers ::__construct
+	 */
+	public function test_construct() {
+		$this->assertInstanceOf(
+			Introductions_Seen_Repository::class,
+			$this->getPropertyValue( $this->instance, 'introductions_seen_repository' )
+		);
+		$this->assertInstanceOf(
+			User_Helper::class,
+			$this->getPropertyValue( $this->instance, 'user_helper' )
+		);
+	}
+
+	/**
+	 * Tests the get_conditionals function.
+	 *
+	 * @covers ::get_conditionals
+	 */
+	public function test_get_conditionals() {
+		$this->assertEquals( [], Introductions_Seen_Route::get_conditionals() );
+	}
+
+	/**
+	 * Tests the registration of the routes.
+	 *
+	 * @covers ::register_routes
+	 */
+	public function test_register_routes() {
+		Functions\expect( 'register_rest_route' )
+			->once()
+			->with(
+				'yoast/v1',
+				'/introductions/(?P<introduction_id>[\w-]+)/seen',
+				[
+					[
+						'methods'             => 'POST',
+						'callback'            => [ $this->instance, 'set_introduction_seen' ],
+						'permission_callback' => [ $this->instance, 'permission_edit_posts' ],
+						'args'                => [
+							'introduction_id' => [
+								'required'          => true,
+								'type'              => 'string',
+								'sanitize_callback' => 'sanitize_text_field',
+							],
+							'is_seen'         => [
+								'required'          => false,
+								'type'              => 'bool',
+								'default'           => true,
+								'sanitize_callback' => 'rest_sanitize_boolean',
+							],
+						],
+					],
+				]
+			);
+
+		$this->instance->register_routes();
+	}
+
+	/**
+	 * Tests that the capability that is tested for is `edit_posts`.
+	 *
+	 * @covers ::permission_edit_posts
+	 */
+	public function test_permission_manage_options() {
+		Functions\expect( 'current_user_can' )->once()->with( 'edit_posts' )->andReturn( true );
+
+		$this->assertTrue( $this->instance->permission_edit_posts() );
+	}
+
+	/**
+	 * Tests the set_introduction_seen route's happy path.
+	 *
+	 * @covers ::set_introduction_seen
+	 */
+	public function test_set_introduction_seen() {
+		$user_id         = 1;
+		$introduction_id = 'intro';
+		$this->user_helper->expects( 'get_current_user_id' )->andReturn( $user_id );
+		$this->introductions_seen_repository
+			->expects( 'set_introduction' )
+			->once()
+			->with( $user_id, $introduction_id, true )
+			->andReturnTrue();
+
+		$wp_rest_response_mock = Mockery::mock( 'overload:' . WP_REST_Response::class );
+		$wp_rest_response_mock
+			->expects( '__construct' )
+			->with(
+				[
+					'json' => (object) [
+						'success' => true,
+					],
+				],
+				200
+			)
+			->once();
+
+		$wp_rest_request = Mockery::mock( WP_REST_Request::class );
+		$wp_rest_request
+			->expects( 'get_params' )
+			->once()
+			->andReturn(
+				[
+					'introduction_id' => $introduction_id,
+					'is_seen'         => true,
+				]
+			);
+
+		$this->assertInstanceOf(
+			'WP_REST_Response',
+			$this->instance->set_introduction_seen( $wp_rest_request )
+		);
+	}
+
+	/**
+	 * Tests the set_introduction_seen route that failed.
+	 *
+	 * @covers ::set_introduction_seen
+	 */
+	public function test_set_introduction_seen_failed() {
+		$user_id         = 1;
+		$introduction_id = 'intro';
+		$this->user_helper->expects( 'get_current_user_id' )->andReturn( $user_id );
+		$this->introductions_seen_repository
+			->expects( 'set_introduction' )
+			->once()
+			->with( $user_id, $introduction_id, true )
+			->andReturnFalse();
+
+		$wp_rest_response_mock = Mockery::mock( 'overload:' . WP_REST_Response::class );
+		$wp_rest_response_mock
+			->expects( '__construct' )
+			->with(
+				[
+					'json' => (object) [
+						'success' => false,
+					],
+				],
+				400
+			)
+			->once();
+
+		$wp_rest_request = Mockery::mock( WP_REST_Request::class );
+		$wp_rest_request
+			->expects( 'get_params' )
+			->once()
+			->andReturn(
+				[
+					'introduction_id' => $introduction_id,
+					'is_seen'         => true,
+				]
+			);
+
+		$this->assertInstanceOf(
+			'WP_REST_Response',
+			$this->instance->set_introduction_seen( $wp_rest_request )
+		);
+	}
+
+	/**
+	 * Tests the set_introduction_seen route with error.
+	 *
+	 * @covers ::set_introduction_seen
+	 */
+	public function test_set_wistia_embed_permission_with_error() {
+		$user_id         = -1;
+		$introduction_id = 'intro';
+		$this->user_helper->expects( 'get_current_user_id' )->andReturn( $user_id );
+		$this->introductions_seen_repository
+			->expects( 'set_introduction' )
+			->once()
+			->with( $user_id, $introduction_id, true )
+			->andThrow( new Exception( 'Invalid User ID' ) );
+
+		$wp_rest_request = Mockery::mock( WP_REST_Request::class );
+		$wp_rest_request
+			->expects( 'get_params' )
+			->once()
+			->andReturn(
+				[
+					'introduction_id' => $introduction_id,
+					'is_seen'         => true,
+				]
+			);
+
+		$this->assertInstanceOf(
+			'WP_Error',
+			$this->instance->set_introduction_seen( $wp_rest_request )
+		);
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Make it possible to mark an introduction as seen from JS (i.e. create a route).

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds an introductions seen route.

## Relevant technical choices:

* Rename `name` to `id` as that seems like a better name for a "unique name"
* Use `[\w-]+` matcher for the introduction ID in the route URL, as opposed to a query param without such regex limits. Mainly because this is more REST style

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Deactivate Premium, instructions for with Premium are in the Premium PR
* Either test with Premium or find a way to send a POST request with the right credentials (nonce + cookie) and:
  * Send a request to `/wp-json/yoast/v1/introductions/INTRO_ID/seen` where INTRO_ID is the ID of your introduction
  * You can add a param `is_seen` to indicate whether you have seen it or not, if you skip this it will default to seen
  * You can verify the route worked by checking the user metadata: `_yoast_wpseo_introductions`

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Introductions mechanism, though the only introductions still are the AI ones: upsell and Premium one. So all tests should be included in these features.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [x] This PR falls under an innovation project. I have attached the `innovation` label.
* [x] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/reserved-tasks/issues/141
