### PR TITLE
Avoid storing the full user object in notifications meta

### DIFF
--- a/admin/class-yoast-notification-center.php
+++ b/admin/class-yoast-notification-center.php
@@ -915,10 +915,10 @@ class Yoast_Notification_Center {
 				unset( $serialized_notification['options']['user'] );
 				$serialized_notification['options']['user_id'] = $user_id;
 
-				$processed_notifications[] = $this->array_to_notification( $serialized_notification );
-
+				
 				$this->notifications_need_storage = true;
 			}
+			$processed_notifications[] = $this->array_to_notification( $serialized_notification );
 		}
 
 		return $processed_notifications;

--- a/admin/class-yoast-notification-center.php
+++ b/admin/class-yoast-notification-center.php
@@ -734,9 +734,15 @@ class Yoast_Notification_Center {
 			// Apply array_values to ensure we get a 0-indexed array.
 			$notifications = array_values( array_filter( $notifications, [ $this, 'filter_notification_current_user' ] ) );
 
-			$processed_notifications = $this->maybe_unset_notification_user_field( $user_id, $notifications );
+			foreach ( $notifications as $notification ) {
+				$notification_has_been_updated = $notification->user_to_user_id();
+				// Just one notification changed is enough to update the storage.
+				if ( $notification_has_been_updated ) {
+					$this->notifications_need_storage = true;
+				}
+			}
 
-			$this->notifications[ $user_id ] = $processed_notifications;
+			$this->notifications[ $user_id ] = $notifications;
 		}
 	}
 
@@ -896,31 +902,6 @@ class Yoast_Notification_Center {
 	 */
 	private function add_transaction_to_queue( $callback, $args ) {
 		$this->queued_transactions[] = [ $callback, $args ];
-	}
-
-	/**
-	 * Removes the 'user' field from notifications if it is set, and adds the 'user_id' one.
-	 *
-	 * @param int                  $user_id       The ID of the user to set the notifications for.
-	 * @param Yoast_Notification[] $notifications The notifications to process.
-	 *
-	 * @return Yoast_Notification[] The processed notifications.
-	 */
-	private function maybe_unset_notification_user_field( $user_id, $notifications ) {
-		$processed_notifications = [];
-
-		foreach ( $notifications as $notification ) {
-			$serialized_notification = $this->notification_to_array( $notification );
-			if ( array_key_exists( 'user', $serialized_notification['options'] ) ) {
-				unset( $serialized_notification['options']['user'] );
-				$serialized_notification['options']['user_id'] = $user_id;
-
-				$this->notifications_need_storage = true;
-			}
-			$processed_notifications[] = $this->array_to_notification( $serialized_notification );
-		}
-
-		return $processed_notifications;
 	}
 
 	/**

--- a/admin/class-yoast-notification-center.php
+++ b/admin/class-yoast-notification-center.php
@@ -731,16 +731,9 @@ class Yoast_Notification_Center {
 
 		if ( is_array( $stored_notifications ) ) {
 			$notifications = array_map( [ $this, 'array_to_notification' ], $stored_notifications );
+
 			// Apply array_values to ensure we get a 0-indexed array.
 			$notifications = array_values( array_filter( $notifications, [ $this, 'filter_notification_current_user' ] ) );
-
-			foreach ( $notifications as $notification ) {
-				$notification_has_been_updated = $notification->user_to_user_id();
-				// Just one notification changed is enough to update the storage.
-				if ( $notification_has_been_updated ) {
-					$this->notifications_need_storage = true;
-				}
-			}
 
 			$this->notifications[ $user_id ] = $notifications;
 		}
@@ -848,6 +841,13 @@ class Yoast_Notification_Center {
 			$notification_data['message'] = $notification_data['message']->present();
 		}
 
+		if ( isset( $notification_data['options']['user'] ) ) {
+			$notification_data['options']['user_id'] = $notification_data['options']['user']->ID;
+			unset( $notification_data['options']['user'] );
+
+			$this->notifications_need_storage = true;
+		}
+		
 		return new Yoast_Notification(
 			$notification_data['message'],
 			$notification_data['options']

--- a/admin/class-yoast-notification-center.php
+++ b/admin/class-yoast-notification-center.php
@@ -734,14 +734,6 @@ class Yoast_Notification_Center {
 			// Apply array_values to ensure we get a 0-indexed array.
 			$notifications = array_values( array_filter( $notifications, [ $this, 'filter_notification_current_user' ] ) );
 
-			foreach ( $notifications as $notification ) {
-				$notification_has_been_updated = $notification->user_to_user_id();
-				// Just one notification changed is enough to update the storage.
-				if ( $notification_has_been_updated ) {
-					$this->notifications_need_storage = true;
-				}
-			}
-
 			$this->notifications[ $user_id ] = $notifications;
 		}
 	}

--- a/admin/class-yoast-notification-center.php
+++ b/admin/class-yoast-notification-center.php
@@ -733,29 +733,11 @@ class Yoast_Notification_Center {
 			$notifications = array_map( [ $this, 'array_to_notification' ], $stored_notifications );
 			// Apply array_values to ensure we get a 0-indexed array.
 			$notifications = array_values( array_filter( $notifications, [ $this, 'filter_notification_current_user' ] ) );
-			
+
 			$processed_notifications = $this->maybe_unset_notification_user_field( $user_id, $notifications );
 
 			$this->notifications[ $user_id ] = $processed_notifications;
 		}
-	}
-
-	private function maybe_unset_notification_user_field( $user_id, $notifications) {
-		$processed_notifications = [];
-
-		foreach ( $notifications as $notification ) {
-			$serialized_notification = $this->notification_to_array( $notification );
-			if ( array_key_exists( 'user', $serialized_notification['options'] ) ) {
-				unset( $serialized_notification['options']['user'] );
-				$serialized_notification['options']['user_id'] = $user_id;
-
-				$processed_notifications[] = $this->array_to_notification( $serialized_notification );
-
-				$this->notifications_need_storage = true;
-			}
-		}
-
-		return $processed_notifications;
 	}
 
 	/**
@@ -914,6 +896,32 @@ class Yoast_Notification_Center {
 	 */
 	private function add_transaction_to_queue( $callback, $args ) {
 		$this->queued_transactions[] = [ $callback, $args ];
+	}
+
+	/**
+	 * Removes the 'user' field from notifications if it is set, and adds the 'user_id' one.
+	 *
+	 * @param int                  $user_id       The ID of the user to set the notifications for.
+	 * @param Yoast_Notification[] $notifications The notifications to process.
+	 *
+	 * @return Yoast_Notification[] The processed notifications.
+	 */
+	private function maybe_unset_notification_user_field( $user_id, $notifications ) {
+		$processed_notifications = [];
+
+		foreach ( $notifications as $notification ) {
+			$serialized_notification = $this->notification_to_array( $notification );
+			if ( array_key_exists( 'user', $serialized_notification['options'] ) ) {
+				unset( $serialized_notification['options']['user'] );
+				$serialized_notification['options']['user_id'] = $user_id;
+
+				$processed_notifications[] = $this->array_to_notification( $serialized_notification );
+
+				$this->notifications_need_storage = true;
+			}
+		}
+
+		return $processed_notifications;
 	}
 
 	/**

--- a/admin/class-yoast-notification-center.php
+++ b/admin/class-yoast-notification-center.php
@@ -915,7 +915,6 @@ class Yoast_Notification_Center {
 				unset( $serialized_notification['options']['user'] );
 				$serialized_notification['options']['user_id'] = $user_id;
 
-				
 				$this->notifications_need_storage = true;
 			}
 			$processed_notifications[] = $this->array_to_notification( $serialized_notification );

--- a/admin/class-yoast-notification-center.php
+++ b/admin/class-yoast-notification-center.php
@@ -847,7 +847,7 @@ class Yoast_Notification_Center {
 
 			$this->notifications_need_storage = true;
 		}
-		
+
 		return new Yoast_Notification(
 			$notification_data['message'],
 			$notification_data['options']

--- a/admin/class-yoast-notification-center.php
+++ b/admin/class-yoast-notification-center.php
@@ -734,6 +734,14 @@ class Yoast_Notification_Center {
 			// Apply array_values to ensure we get a 0-indexed array.
 			$notifications = array_values( array_filter( $notifications, [ $this, 'filter_notification_current_user' ] ) );
 
+			foreach ( $notifications as $notification ) {
+				$notification_has_been_updated = $notification->user_to_user_id();
+				// Just one notification changed is enough to update the storage.
+				if ( $notification_has_been_updated ) {
+					$this->notifications_need_storage = true;
+				}
+			}
+
 			$this->notifications[ $user_id ] = $notifications;
 		}
 	}

--- a/admin/class-yoast-notification.php
+++ b/admin/class-yoast-notification.php
@@ -402,7 +402,7 @@ class Yoast_Notification {
 
 		// Set to the id of the current user if not supplied.
 		if ( $options['user_id'] === null ) {
-			$user = wp_get_current_user();
+			$user               = wp_get_current_user();
 			$options['user_id'] = $user->ID;
 		}
 

--- a/admin/class-yoast-notification.php
+++ b/admin/class-yoast-notification.php
@@ -285,6 +285,10 @@ class Yoast_Notification {
 			return false;
 		}
 		$user = get_user_by( 'id', $user_id );
+		if ( ! $user ) {
+			return false;
+		}
+
 		return $user->has_cap( $capability );
 	}
 
@@ -403,7 +407,7 @@ class Yoast_Notification {
 		// Set to the id of the current user if not supplied.
 		if ( $options['user_id'] === null ) {
 			$user               = wp_get_current_user();
-			$options['user_id'] = $user->ID;
+			$options['user_id'] = (int) $user->ID;
 		}
 
 		return $options;

--- a/admin/class-yoast-notification.php
+++ b/admin/class-yoast-notification.php
@@ -405,11 +405,6 @@ class Yoast_Notification {
 			$options['capabilities'] = [ 'wpseo_manage_options' ];
 		}
 
-		if ( array_key_exists( 'user', $options ) ) {
-			$options['user_id'] = $options['user']->ID;
-			unset( $options['user'] );
-		}
-
 		// Set to the id of the current user if not supplied.
 		if ( $options['user_id'] === null ) {
 			$options['user_id'] = get_current_user_id();
@@ -426,5 +421,22 @@ class Yoast_Notification {
 	 */
 	private function parse_attributes( &$value, $key ) {
 		$value = sprintf( '%s="%s"', sanitize_key( $key ), esc_attr( $value ) );
+	}
+
+	/**
+	 * Unsets user field if present and set user_id.
+	 *
+	 * @internal This is meant to be used by the Yoast SEO plugin only.
+	 *
+	 * @return bool If the user field was present.
+	 */
+	public function user_to_user_id() {
+		if ( array_key_exists( 'user', $this->options ) ) {
+			// No check needed as we call this once the notification has already been stored.
+			$this->options['user_id'] = $this->options['user']->ID;
+			unset( $this->options['user'] );
+			return true;
+		}
+		return false;
 	}
 }

--- a/admin/class-yoast-notification.php
+++ b/admin/class-yoast-notification.php
@@ -72,7 +72,7 @@ class Yoast_Notification {
 	private $defaults = [
 		'type'             => self::UPDATED,
 		'id'               => '',
-		'user'             => null,
+		'user_id'          => null,
 		'nonce'            => null,
 		'priority'         => 0.5,
 		'data_json'        => [],
@@ -110,12 +110,12 @@ class Yoast_Notification {
 	}
 
 	/**
-	 * Retrieve the user to show the notification for.
+	 * Retrieve the id of the user to show the notification for.
 	 *
-	 * @return WP_User The user to show this notification for.
+	 * @return int The user id.
 	 */
 	public function get_user() {
-		return $this->options['user'];
+		return $this->options['user_id'];
 	}
 
 	/**
@@ -127,7 +127,7 @@ class Yoast_Notification {
 	 */
 	public function get_user_id() {
 		if ( $this->get_user() !== null ) {
-			return $this->get_user()->ID;
+			return $this->get_user();
 		}
 		return get_current_user_id();
 	}
@@ -220,7 +220,7 @@ class Yoast_Notification {
 	 */
 	public function match_capabilities() {
 		// Super Admin can do anything.
-		if ( is_multisite() && is_super_admin( $this->options['user']->ID ) ) {
+		if ( is_multisite() && is_super_admin( $this->options['user_id'] ) ) {
 			return true;
 		}
 
@@ -280,7 +280,11 @@ class Yoast_Notification {
 	 * @return bool
 	 */
 	private function has_capability( $capability ) {
-		$user = $this->options['user'];
+		$user_id = $this->options['user_id'];
+		if ( ! is_numeric( $user_id ) ) {
+			return false;
+		}
+		$user = get_user_by( 'id', $user_id );
 		return $user->has_cap( $capability );
 	}
 
@@ -396,9 +400,10 @@ class Yoast_Notification {
 			$options['capabilities'] = [ 'wpseo_manage_options' ];
 		}
 
-		// Set to the current user if not supplied.
-		if ( $options['user'] === null ) {
-			$options['user'] = wp_get_current_user();
+		// Set to the id of the current user if not supplied.
+		if ( $options['user_id'] === null ) {
+			$user = wp_get_current_user();
+			$options['user_id'] = $user->ID;
 		}
 
 		return $options;

--- a/admin/class-yoast-notification.php
+++ b/admin/class-yoast-notification.php
@@ -422,4 +422,22 @@ class Yoast_Notification {
 	private function parse_attributes( &$value, $key ) {
 		$value = sprintf( '%s="%s"', sanitize_key( $key ), esc_attr( $value ) );
 	}
+
+	/**
+	 * Unsets user field if present and set user_id.
+	 *
+	 * @internal This is meant to be used by the Yoast SEO plugin only.
+	 *
+	 * @return bool If the user field was present.
+	 */
+	public function user_to_user_id() {
+		if ( array_key_exists( 'user', $this->options ) ) {
+			// No check needed as we call this once the notification has already been stored.
+			$user_id = $this->options['user']->ID;
+			unset( $this->options['user'] );
+			$this->options['user_id'] = $user_id;
+			return true;
+		}
+		return false;
+	}
 }

--- a/admin/class-yoast-notification.php
+++ b/admin/class-yoast-notification.php
@@ -406,8 +406,7 @@ class Yoast_Notification {
 
 		// Set to the id of the current user if not supplied.
 		if ( $options['user_id'] === null ) {
-			$user               = wp_get_current_user();
-			$options['user_id'] = (int) $user->ID;
+			$options['user_id'] = get_current_user_id();
 		}
 
 		return $options;

--- a/admin/class-yoast-notification.php
+++ b/admin/class-yoast-notification.php
@@ -110,12 +110,16 @@ class Yoast_Notification {
 	}
 
 	/**
-	 * Retrieve the id of the user to show the notification for.
+	 * Retrieve the user to show the notification for.
 	 *
-	 * @return int The user id.
+	 * @deprecated 21.6
+	 * @codeCoverageIgnore
+	 *
+	 * @return WP_User The user to show this notification for.
 	 */
 	public function get_user() {
-		return $this->options['user_id'];
+		\_deprecated_function( __METHOD__, 'Yoast SEO 21.6' );
+		return null;
 	}
 
 	/**
@@ -126,10 +130,7 @@ class Yoast_Notification {
 	 * @return int The user id
 	 */
 	public function get_user_id() {
-		if ( $this->get_user() !== null ) {
-			return $this->get_user();
-		}
-		return get_current_user_id();
+		return ( $this->options['user_id'] ?? get_current_user_id() );
 	}
 
 	/**

--- a/admin/class-yoast-notification.php
+++ b/admin/class-yoast-notification.php
@@ -422,21 +422,4 @@ class Yoast_Notification {
 	private function parse_attributes( &$value, $key ) {
 		$value = sprintf( '%s="%s"', sanitize_key( $key ), esc_attr( $value ) );
 	}
-
-	/**
-	 * Unsets user field if present and set user_id.
-	 *
-	 * @internal This is meant to be used by the Yoast SEO plugin only.
-	 *
-	 * @return bool If the user field was present.
-	 */
-	public function user_to_user_id() {
-		if ( array_key_exists( 'user', $this->options ) ) {
-			// No check needed as we call this once the notification has already been stored.
-			$this->options['user_id'] = $this->options['user']->ID;
-			unset( $this->options['user'] );
-			return true;
-		}
-		return false;
-	}
 }

--- a/admin/class-yoast-notification.php
+++ b/admin/class-yoast-notification.php
@@ -405,6 +405,11 @@ class Yoast_Notification {
 			$options['capabilities'] = [ 'wpseo_manage_options' ];
 		}
 
+		if ( array_key_exists( 'user', $options ) ) {
+			$options['user_id'] = $options['user']->ID;
+			unset( $options['user'] );
+		}
+
 		// Set to the id of the current user if not supplied.
 		if ( $options['user_id'] === null ) {
 			$options['user_id'] = get_current_user_id();
@@ -421,22 +426,5 @@ class Yoast_Notification {
 	 */
 	private function parse_attributes( &$value, $key ) {
 		$value = sprintf( '%s="%s"', sanitize_key( $key ), esc_attr( $value ) );
-	}
-
-	/**
-	 * Unsets user field if present and set user_id.
-	 *
-	 * @internal This is meant to be used by the Yoast SEO plugin only.
-	 *
-	 * @return bool If the user field was present.
-	 */
-	public function user_to_user_id() {
-		if ( array_key_exists( 'user', $this->options ) ) {
-			// No check needed as we call this once the notification has already been stored.
-			$this->options['user_id'] = $this->options['user']->ID;
-			unset( $this->options['user'] );
-			return true;
-		}
-		return false;
 	}
 }

--- a/admin/class-yoast-notification.php
+++ b/admin/class-yoast-notification.php
@@ -432,9 +432,8 @@ class Yoast_Notification {
 	public function user_to_user_id() {
 		if ( array_key_exists( 'user', $this->options ) ) {
 			// No check needed as we call this once the notification has already been stored.
-			$user_id = $this->options['user']->ID;
+			$this->options['user_id'] = $this->options['user']->ID;
 			unset( $this->options['user'] );
-			$this->options['user_id'] = $user_id;
 			return true;
 		}
 		return false;

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -89,7 +89,7 @@ class WPSEO_Upgrade {
 			'20.5-RC0'   => 'upgrade_205',
 			'20.7-RC0'   => 'upgrade_207',
 			'20.8-RC0'   => 'upgrade_208',
-			'21.6-rc0'   => 'upgrade_216'
+			'21.6-rc0'   => 'upgrade_216',
 		];
 
 		array_walk( $routines, [ $this, 'run_upgrade_routine' ], $version );

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -89,7 +89,6 @@ class WPSEO_Upgrade {
 			'20.5-RC0'   => 'upgrade_205',
 			'20.7-RC0'   => 'upgrade_207',
 			'20.8-RC0'   => 'upgrade_208',
-			'21.6-rc0'   => 'upgrade_216',
 		];
 
 		array_walk( $routines, [ $this, 'run_upgrade_routine' ], $version );
@@ -1015,14 +1014,6 @@ class WPSEO_Upgrade {
 	}
 
 	/**
-	 * Performs the 21.6 upgrade routine.
-	 * Avoid storing the full WP_User object in each notification and saves just the user id instead.
-	 */
-	private function upgrade_216() {
-		add_action( 'init', [ $this, 'update_notifications_user_id_for_216' ] );
-	}
-
-	/**
 	 * Sets the home_url option for the 15.1 upgrade routine.
 	 *
 	 * @return void
@@ -1661,42 +1652,6 @@ class WPSEO_Upgrade {
 			array_merge( array_values( $object_ids ), array_values( $newest_indexable_ids ), [ $object_type ] )
 		);
 		// phpcs:enable
-	}
-
-	/**
-	 * Function to update all users' notifications to store the user id instead of the full WP_User object.
-	 */
-	private function update_notifications_user_id_for_216() {
-		global $wpdb;
-		$meta_key = $wpdb->get_blog_prefix() . Yoast_Notification_Center::STORAGE_KEY;
-
-		$usermetas = $wpdb->get_results(
-			$wpdb->prepare(
-				'
-				SELECT user_id, meta_value
-				FROM ' . $wpdb->usermeta . '
-				WHERE meta_key = %s
-				',
-				$meta_key
-			),
-			ARRAY_A
-		);
-
-		if ( empty( $usermetas ) ) {
-			return;
-		}
-
-		foreach ( $usermetas as $usermeta ) {
-			$notifications = maybe_unserialize( $usermeta['meta_value'] );
-
-			foreach ( $notifications as $notification ) {
-				if ( ! empty( $notification['options']['user'] ) ) {
-					unset( $notification['options']['user'] );
-					$notification['options']['user_id'] = $usermeta['user_id'];
-				}
-			}
-			update_user_meta( $usermeta['user_id'], Yoast_Notification_Center::STORAGE_KEY, $notifications );
-		}
 	}
 
 	/**

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -89,6 +89,7 @@ class WPSEO_Upgrade {
 			'20.5-RC0'   => 'upgrade_205',
 			'20.7-RC0'   => 'upgrade_207',
 			'20.8-RC0'   => 'upgrade_208',
+			'21.6-rc0'   => 'upgrade_216'
 		];
 
 		array_walk( $routines, [ $this, 'run_upgrade_routine' ], $version );
@@ -1014,6 +1015,14 @@ class WPSEO_Upgrade {
 	}
 
 	/**
+	 * Performs the 21.6 upgrade routine.
+	 * Avoid storing the full WP_User object in each notification and saves just the user id instead.
+	 */
+	private function upgrade_216() {
+		add_action( 'init', [ $this, 'update_notifications_user_id_for_216' ] );
+	}
+
+	/**
 	 * Sets the home_url option for the 15.1 upgrade routine.
 	 *
 	 * @return void
@@ -1652,6 +1661,42 @@ class WPSEO_Upgrade {
 			array_merge( array_values( $object_ids ), array_values( $newest_indexable_ids ), [ $object_type ] )
 		);
 		// phpcs:enable
+	}
+
+	/**
+	 * Function to update all users' notifications to store the user id instead of the full WP_User object.
+	 */
+	private function update_notifications_user_id_for_216() {
+		global $wpdb;
+		$meta_key = $wpdb->get_blog_prefix() . Yoast_Notification_Center::STORAGE_KEY;
+
+		$usermetas = $wpdb->get_results(
+			$wpdb->prepare(
+				'
+				SELECT user_id, meta_value
+				FROM ' . $wpdb->usermeta . '
+				WHERE meta_key = %s
+				',
+				$meta_key
+			),
+			ARRAY_A
+		);
+
+		if ( empty( $usermetas ) ) {
+			return;
+		}
+
+		foreach ( $usermetas as $usermeta ) {
+			$notifications = maybe_unserialize( $usermeta['meta_value'] );
+
+			foreach ( $notifications as $notification ) {
+				if ( ! empty( $notification['options']['user'] ) ) {
+					unset( $notification['options']['user'] );
+					$notification['options']['user_id'] = $usermeta['user_id'];
+				}
+			}
+			update_user_meta( $usermeta['user_id'], Yoast_Notification_Center::STORAGE_KEY, $notifications );
+		}
 	}
 
 	/**

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -1666,7 +1666,7 @@ class WPSEO_Upgrade {
 	/**
 	 * Function to update all users' notifications to store the user id instead of the full WP_User object.
 	 */
-	private function update_notifications_user_id_for_216() {
+	public function update_notifications_user_id_for_216() {
 		global $wpdb;
 		$meta_key = $wpdb->get_blog_prefix() . Yoast_Notification_Center::STORAGE_KEY;
 

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -1666,7 +1666,7 @@ class WPSEO_Upgrade {
 	/**
 	 * Function to update all users' notifications to store the user id instead of the full WP_User object.
 	 */
-	public function update_notifications_user_id_for_216() {
+	private function update_notifications_user_id_for_216() {
 		global $wpdb;
 		$meta_key = $wpdb->get_blog_prefix() . Yoast_Notification_Center::STORAGE_KEY;
 

--- a/tests/integration/notifications/test-class-yoast-notification-center.php
+++ b/tests/integration/notifications/test-class-yoast-notification-center.php
@@ -840,14 +840,16 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 	public function test_add_notifications_only_once_for_user() {
 
 		$instance = $this->get_notification_center();
-
-		$user_mock = $this->mock_wp_user( 3, [ 'wpseo_manage_options' => true ] );
+		
+		$user_id = $this->factory->user->create();
+		$user = new WP_User( $user_id );
+		$user->add_cap( 'wpseo_manage_options' );
 
 		$notification = new Yoast_Notification(
 			'Hello, user 3!',
 			[
 				'id'           => 'Yoast_Notification_Test',
-				'user_id'         => $user_mock->ID,
+				'user_id'         => $user_id,
 				'capabilities' => [ 'wpseo_manage_options' ],
 			]
 		);
@@ -856,7 +858,7 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 		$instance->add_notification( $notification );
 
 		$expected = [ $notification ];
-		$actual   = $instance->get_notifications_for_user( 3 );
+		$actual   = $instance->get_notifications_for_user( $user_id );
 
 		$this->assertEquals( $expected, $actual );
 	}

--- a/tests/integration/notifications/test-class-yoast-notification-center.php
+++ b/tests/integration/notifications/test-class-yoast-notification-center.php
@@ -806,7 +806,7 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 		$notification_for_user_1 = new Yoast_Notification(
 			'Hello, user 1!',
 			[
-				'user_id'         => $user_mock_1->ID,
+				'user_id'      => $user_mock_1->ID,
 				'capabilities' => [ 'wpseo_manage_options' ],
 			]
 		);
@@ -814,7 +814,7 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 		$notification_for_user_2 = new Yoast_Notification(
 			'Hello, user 2!',
 			[
-				'user_id'         => $user_mock_2->ID,
+				'user_id'      => $user_mock_2->ID,
 				'capabilities' => [ 'wpseo_manage_options' ],
 			]
 		);
@@ -840,16 +840,16 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 	public function test_add_notifications_only_once_for_user() {
 
 		$instance = $this->get_notification_center();
-		
+
 		$user_id = $this->factory->user->create();
-		$user = new WP_User( $user_id );
+		$user    = new WP_User( $user_id );
 		$user->add_cap( 'wpseo_manage_options' );
 
 		$notification = new Yoast_Notification(
 			'Hello, user 3!',
 			[
 				'id'           => 'Yoast_Notification_Test',
-				'user_id'         => $user_id,
+				'user_id'      => $user_id,
 				'capabilities' => [ 'wpseo_manage_options' ],
 			]
 		);

--- a/tests/integration/notifications/test-class-yoast-notification-center.php
+++ b/tests/integration/notifications/test-class-yoast-notification-center.php
@@ -806,7 +806,7 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 		$notification_for_user_1 = new Yoast_Notification(
 			'Hello, user 1!',
 			[
-				'user'         => $user_mock_1,
+				'user_id'         => $user_mock_1->ID,
 				'capabilities' => [ 'wpseo_manage_options' ],
 			]
 		);
@@ -814,7 +814,7 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 		$notification_for_user_2 = new Yoast_Notification(
 			'Hello, user 2!',
 			[
-				'user'         => $user_mock_2,
+				'user_id'         => $user_mock_2->ID,
 				'capabilities' => [ 'wpseo_manage_options' ],
 			]
 		);
@@ -847,7 +847,7 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 			'Hello, user 3!',
 			[
 				'id'           => 'Yoast_Notification_Test',
-				'user'         => $user_mock,
+				'user_id'         => $user_mock->ID,
 				'capabilities' => [ 'wpseo_manage_options' ],
 			]
 		);

--- a/tests/integration/notifications/test-class-yoast-notification-center.php
+++ b/tests/integration/notifications/test-class-yoast-notification-center.php
@@ -800,13 +800,18 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 
 		$instance = $this->get_notification_center();
 
-		$user_mock_1 = $this->mock_wp_user( 1, [ 'wpseo_manage_options' => true ] );
-		$user_mock_2 = $this->mock_wp_user( 2, [ 'wpseo_manage_options' => true ] );
+		$user_1_id = $this->factory->user->create();
+		$user_1    = new WP_User( $user_1_id );
+		$user_1->add_cap( 'wpseo_manage_options' );
+
+		$user_2_id = $this->factory->user->create();
+		$user_2    = new WP_User( $user_2_id );
+		$user_2->add_cap( 'wpseo_manage_options' );
 
 		$notification_for_user_1 = new Yoast_Notification(
 			'Hello, user 1!',
 			[
-				'user_id'      => $user_mock_1->ID,
+				'user_id'      => $user_1_id,
 				'capabilities' => [ 'wpseo_manage_options' ],
 			]
 		);
@@ -814,7 +819,7 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 		$notification_for_user_2 = new Yoast_Notification(
 			'Hello, user 2!',
 			[
-				'user_id'      => $user_mock_2->ID,
+				'user_id'      => $user_2_id,
 				'capabilities' => [ 'wpseo_manage_options' ],
 			]
 		);
@@ -918,36 +923,5 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 		$notification_center->setup_current_notifications();
 
 		return $notification_center;
-	}
-
-	/**
-	 * Creates a mock WordPress user.
-	 *
-	 * @param int   $user_id The ID of the user.
-	 * @param array $caps    A map, mapping capabilities to `true` (user has capability) or `false` ( user has not).
-	 *
-	 * @return PHPUnit_Framework_MockObject_Invocation_Object | WP_User
-	 */
-	private function mock_wp_user( $user_id, $caps ) {
-		$user_mock = $this
-			->getMockBuilder( 'WP_User' )
-			->setMethods( [ 'has_cap' ] )
-			->getMock();
-
-		$user_mock
-			->expects( $this->any() )
-			->method( 'has_cap' )
-			->with( $this->isType( 'string' ) )
-			->willReturn(
-				$this->returnCallback(
-					static function( $argument ) use ( $caps ) {
-						return isset( $caps[ $argument ] ) ? $caps[ $argument ] : false;
-					}
-				)
-			);
-
-		$user_mock->ID = $user_id;
-
-		return $user_mock;
 	}
 }

--- a/tests/integration/notifications/test-class-yoast-notification-center.php
+++ b/tests/integration/notifications/test-class-yoast-notification-center.php
@@ -828,10 +828,10 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 		$instance->add_notification( $notification_for_user_2 );
 
 		$expected_for_user_1 = [ $notification_for_user_1 ];
-		$actual_for_user_1   = $instance->get_notifications_for_user( 1 );
+		$actual_for_user_1   = $instance->get_notifications_for_user( $user_1_id );
 
 		$expected_for_user_2 = [ $notification_for_user_2 ];
-		$actual_for_user_2   = $instance->get_notifications_for_user( 2 );
+		$actual_for_user_2   = $instance->get_notifications_for_user( $user_2_id );
 
 		$this->assertEquals( $expected_for_user_1, $actual_for_user_1 );
 		$this->assertEquals( $expected_for_user_2, $actual_for_user_2 );

--- a/tests/integration/notifications/test-class-yoast-notification-center.php
+++ b/tests/integration/notifications/test-class-yoast-notification-center.php
@@ -800,10 +800,10 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 
 		$instance = $this->get_notification_center();
 
-		$user_1    = $this->factory->user->create_and_get();
+		$user_1 = $this->factory->user->create_and_get();
 		$user_1->add_cap( 'wpseo_manage_options' );
 
-		$user_2    = $this->factory->user->create_and_get();
+		$user_2 = $this->factory->user->create_and_get();
 		$user_2->add_cap( 'wpseo_manage_options' );
 
 		$notification_for_user_1 = new Yoast_Notification(

--- a/tests/integration/notifications/test-class-yoast-notification-center.php
+++ b/tests/integration/notifications/test-class-yoast-notification-center.php
@@ -800,18 +800,16 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 
 		$instance = $this->get_notification_center();
 
-		$user_1_id = $this->factory->user->create();
-		$user_1    = new WP_User( $user_1_id );
+		$user_1    = $this->factory->user->create_and_get();
 		$user_1->add_cap( 'wpseo_manage_options' );
 
-		$user_2_id = $this->factory->user->create();
-		$user_2    = new WP_User( $user_2_id );
+		$user_2    = $this->factory->user->create_and_get();
 		$user_2->add_cap( 'wpseo_manage_options' );
 
 		$notification_for_user_1 = new Yoast_Notification(
 			'Hello, user 1!',
 			[
-				'user_id'      => $user_1_id,
+				'user_id'      => $user_1->ID,
 				'capabilities' => [ 'wpseo_manage_options' ],
 			]
 		);
@@ -819,7 +817,7 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 		$notification_for_user_2 = new Yoast_Notification(
 			'Hello, user 2!',
 			[
-				'user_id'      => $user_2_id,
+				'user_id'      => $user_2->ID,
 				'capabilities' => [ 'wpseo_manage_options' ],
 			]
 		);
@@ -828,10 +826,10 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 		$instance->add_notification( $notification_for_user_2 );
 
 		$expected_for_user_1 = [ $notification_for_user_1 ];
-		$actual_for_user_1   = $instance->get_notifications_for_user( $user_1_id );
+		$actual_for_user_1   = $instance->get_notifications_for_user( $user_1->ID );
 
 		$expected_for_user_2 = [ $notification_for_user_2 ];
-		$actual_for_user_2   = $instance->get_notifications_for_user( $user_2_id );
+		$actual_for_user_2   = $instance->get_notifications_for_user( $user_2->ID );
 
 		$this->assertEquals( $expected_for_user_1, $actual_for_user_1 );
 		$this->assertEquals( $expected_for_user_2, $actual_for_user_2 );
@@ -846,15 +844,14 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 
 		$instance = $this->get_notification_center();
 
-		$user_id = $this->factory->user->create();
-		$user    = new WP_User( $user_id );
+		$user = $this->factory->user->create_and_get();
 		$user->add_cap( 'wpseo_manage_options' );
 
 		$notification = new Yoast_Notification(
 			'Hello, user 3!',
 			[
 				'id'           => 'Yoast_Notification_Test',
-				'user_id'      => $user_id,
+				'user_id'      => $user->ID,
 				'capabilities' => [ 'wpseo_manage_options' ],
 			]
 		);
@@ -863,7 +860,7 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 		$instance->add_notification( $notification );
 
 		$expected = [ $notification ];
-		$actual   = $instance->get_notifications_for_user( $user_id );
+		$actual   = $instance->get_notifications_for_user( $user->ID );
 
 		$this->assertEquals( $expected, $actual );
 	}

--- a/tests/integration/notifications/test-class-yoast-notification.php
+++ b/tests/integration/notifications/test-class-yoast-notification.php
@@ -40,12 +40,13 @@ class Yoast_Notification_Test extends WPSEO_UnitTestCase {
 	public function test_set_defaults() {
 		$subject = new Yoast_Notification( 'message', [] );
 		$test    = $subject->to_array();
+		$user = wp_get_current_user();
 
 		$this->assertEquals(
 			[
 				'type'             => 'updated',
 				'id'               => '',
-				'user'             => wp_get_current_user(),
+				'user_id'          => $user->ID,
 				'nonce'            => null,
 				'priority'         => 0.5,
 				'data_json'        => [],
@@ -167,6 +168,7 @@ class Yoast_Notification_Test extends WPSEO_UnitTestCase {
 				'capability_check' => 'any',
 			]
 		);
+
 
 		$this->assertTrue( $subject->display_for_current_user() );
 

--- a/tests/integration/notifications/test-class-yoast-notification.php
+++ b/tests/integration/notifications/test-class-yoast-notification.php
@@ -13,6 +13,13 @@
 class Yoast_Notification_Test extends WPSEO_UnitTestCase {
 
 	/**
+	 * User ID.
+	 *
+	 * @var int
+	 */
+	private $user_id;
+
+	/**
 	 * Test capability filters get set.
 	 *
 	 * @var array
@@ -25,6 +32,20 @@ class Yoast_Notification_Test extends WPSEO_UnitTestCase {
 	 * @var array
 	 */
 	private $verify_capability_match_filter_args = [];
+
+	/**
+	 * Create user with proper caps.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->user_id = $this->factory->user->create();
+
+		$user = new WP_User( $this->user_id );
+		$user->add_cap( 'wpseo_manage_options' );
+
+		wp_set_current_user( $this->user_id );
+	}
 
 	/**
 	 * No ID is not persistent.

--- a/tests/integration/notifications/test-class-yoast-notification.php
+++ b/tests/integration/notifications/test-class-yoast-notification.php
@@ -61,7 +61,7 @@ class Yoast_Notification_Test extends WPSEO_UnitTestCase {
 	public function test_set_defaults() {
 		$subject = new Yoast_Notification( 'message', [] );
 		$test    = $subject->to_array();
-		$user = wp_get_current_user();
+		$user    = wp_get_current_user();
 
 		$this->assertEquals(
 			[

--- a/tests/integration/notifications/test-class-yoast-notification.php
+++ b/tests/integration/notifications/test-class-yoast-notification.php
@@ -13,13 +13,6 @@
 class Yoast_Notification_Test extends WPSEO_UnitTestCase {
 
 	/**
-	 * User ID.
-	 *
-	 * @var int
-	 */
-	private $user_id;
-
-	/**
 	 * Test capability filters get set.
 	 *
 	 * @var array
@@ -39,12 +32,10 @@ class Yoast_Notification_Test extends WPSEO_UnitTestCase {
 	public function set_up() {
 		parent::set_up();
 
-		$this->user_id = $this->factory->user->create();
-
-		$user = new WP_User( $this->user_id );
+		$user = $this->factory->user->create_and_get();
 		$user->add_cap( 'wpseo_manage_options' );
 
-		wp_set_current_user( $this->user_id );
+		wp_set_current_user( $user->ID );
 	}
 
 	/**

--- a/tests/unit/admin/admin-features-test.php
+++ b/tests/unit/admin/admin-features-test.php
@@ -38,7 +38,7 @@ class Admin_Features_Test extends TestCase {
 			->with( 'https://example.org', 'dismiss-5star-upsell' )
 			->andReturn( 'https://example.org?_wpnonce=test-nonce' );
 
-		$admin_user = Mockery::mock( WP_User::class );
+		$admin_user     = Mockery::mock( WP_User::class );
 		$admin_user->ID = 1;
 
 		Monkey\Functions\expect( 'wp_get_current_user' )

--- a/tests/unit/admin/admin-features-test.php
+++ b/tests/unit/admin/admin-features-test.php
@@ -41,9 +41,9 @@ class Admin_Features_Test extends TestCase {
 		$admin_user     = Mockery::mock( WP_User::class );
 		$admin_user->ID = 1;
 
-		Monkey\Functions\expect( 'wp_get_current_user' )
+		Monkey\Functions\expect( 'get_current_user_id' )
 			->once()
-			->andReturn( $admin_user );
+			->andReturn( $admin_user->ID );
 
 		return new WPSEO_Admin();
 	}

--- a/tests/unit/admin/admin-features-test.php
+++ b/tests/unit/admin/admin-features-test.php
@@ -38,9 +38,12 @@ class Admin_Features_Test extends TestCase {
 			->with( 'https://example.org', 'dismiss-5star-upsell' )
 			->andReturn( 'https://example.org?_wpnonce=test-nonce' );
 
-			Monkey\Functions\expect( 'wp_get_current_user' )
-				->once()
-				->andReturn( Mockery::mock( WP_User::class ) );
+		$admin_user = Mockery::mock( WP_User::class );
+		$admin_user->ID = 1;
+
+		Monkey\Functions\expect( 'wp_get_current_user' )
+			->once()
+			->andReturn( $admin_user );
 
 		return new WPSEO_Admin();
 	}

--- a/tests/unit/admin/admin-gutenberg-compatibility-notification-test.php
+++ b/tests/unit/admin/admin-gutenberg-compatibility-notification-test.php
@@ -139,9 +139,9 @@ class WPSEO_Admin_Gutenberg_Compatibility_Notification_Test extends TestCase {
 			]
 		);
 
-		Monkey\Functions\expect( 'wp_get_current_user' )
+		Monkey\Functions\expect( 'get_current_user_id' )
 			->once()
-			->andReturn( $this->admin_user );
+			->andReturn( $this->admin_user->ID );
 
 		$this->notification_center_mock->expects( 'add_notification' )->once()->withArgs(
 			static function ( $arg ) {

--- a/tests/unit/admin/admin-gutenberg-compatibility-notification-test.php
+++ b/tests/unit/admin/admin-gutenberg-compatibility-notification-test.php
@@ -23,6 +23,13 @@ use Yoast_Notification_Center;
 class WPSEO_Admin_Gutenberg_Compatibility_Notification_Test extends TestCase {
 
 	/**
+	 * Holds the admin user mock instance.
+	 *
+	 * @var WP_User
+	 */
+	private $admin_user;
+
+	/**
 	 * Holds the WPSEO_Gutenberg_Compatibility mock instance.
 	 *
 	 * @var WPSEO_Gutenberg_Compatibility
@@ -48,6 +55,11 @@ class WPSEO_Admin_Gutenberg_Compatibility_Notification_Test extends TestCase {
 	 */
 	public function set_up() {
 		parent::set_up();
+
+		$this->stubTranslationFunctions();
+
+		$this->admin_user     = Mockery::mock( WP_User::class );
+		$this->admin_user->ID = 1;
 
 		$this->gutenberg_compatibility_mock = Mockery::mock( WPSEO_Gutenberg_Compatibility::class )->makePartial();
 		$this->notification_center_mock     = Mockery::mock( Yoast_Notification_Center::class );
@@ -120,21 +132,16 @@ class WPSEO_Admin_Gutenberg_Compatibility_Notification_Test extends TestCase {
 	 * @covers WPSEO_Gutenberg_Compatibility::get_installed_version
 	 */
 	public function test_manage_notification_gutenberg_show_notification() {
-		Monkey\Functions\stubs(
-			[
-				'__'                  => null,
-				'wp_get_current_user' => static function() {
-					return null;
-				},
-			]
-		);
-
 		$this->gutenberg_compatibility_mock->allows(
 			[
 				'is_installed'        => true,
 				'is_fully_compatible' => false,
 			]
 		);
+
+		Monkey\Functions\expect( 'wp_get_current_user' )
+			->once()
+			->andReturn( $this->admin_user );
 
 		$this->notification_center_mock->expects( 'add_notification' )->once()->withArgs(
 			static function ( $arg ) {

--- a/tests/unit/content-type-visibility/application/content-type-visibility-watcher-actions-test.php
+++ b/tests/unit/content-type-visibility/application/content-type-visibility-watcher-actions-test.php
@@ -22,6 +22,13 @@ use Yoast\WP\SEO\Content_Type_Visibility\Application\Content_Type_Visibility_Dis
 class Content_Type_Visibility_Watcher_Actions_Test extends TestCase {
 
 	/**
+	 * Holds the admin user mock instance.
+	 *
+	 * @var WP_User
+	 */
+	private $admin_user;
+
+	/**
 	 * Holds the Options_Helper instance.
 	 *
 	 * @var Mockery\MockInterface|Options_Helper
@@ -56,6 +63,9 @@ class Content_Type_Visibility_Watcher_Actions_Test extends TestCase {
 		parent::set_up();
 
 		$this->stubTranslationFunctions();
+
+		$this->admin_user     = Mockery::mock( WP_User::class );
+		$this->admin_user->ID = 1;
 
 		$this->options                            = Mockery::mock( Options_Helper::class );
 		$this->notification_center                = Mockery::mock( Yoast_Notification_Center::class );
@@ -310,9 +320,12 @@ class Content_Type_Visibility_Watcher_Actions_Test extends TestCase {
 			[
 				'esc_url'             => 'https://yoa.st/3.0-content-types',
 				'admin_url'           => 'admin.php?page=wpseo_page_settings',
-				'wp_get_current_user' => Mockery::mock( WP_User::class ),
 			]
 		);
+
+		Monkey\Functions\expect( 'wp_get_current_user' )
+			->once()
+			->andReturn( $this->admin_user );
 
 		$this->notification_center
 			->expects( 'add_notification' )

--- a/tests/unit/content-type-visibility/application/content-type-visibility-watcher-actions-test.php
+++ b/tests/unit/content-type-visibility/application/content-type-visibility-watcher-actions-test.php
@@ -323,9 +323,9 @@ class Content_Type_Visibility_Watcher_Actions_Test extends TestCase {
 			]
 		);
 
-		Monkey\Functions\expect( 'wp_get_current_user' )
+		Monkey\Functions\expect( 'get_current_user_id' )
 			->once()
-			->andReturn( $this->admin_user );
+			->andReturn( $this->admin_user->ID );
 
 		$this->notification_center
 			->expects( 'add_notification' )

--- a/tests/unit/inc/addon-manager-test.php
+++ b/tests/unit/inc/addon-manager-test.php
@@ -1160,9 +1160,9 @@ class Addon_Manager_Test extends TestCase {
 		$admin_user     = Mockery::mock( WP_User::class );
 		$admin_user->ID = 1;
 
-		Monkey\Functions\expect( 'wp_get_current_user' )
+		Monkey\Functions\expect( 'get_current_user_id' )
 			->twice()
-			->andReturn( $admin_user );
+			->andReturn( $admin_user->ID );
 
 		Monkey\Functions\expect( 'YoastSEO' )
 			->once()

--- a/tests/unit/inc/addon-manager-test.php
+++ b/tests/unit/inc/addon-manager-test.php
@@ -1157,8 +1157,12 @@ class Addon_Manager_Test extends TestCase {
 			]
 		);
 
+		$admin_user     = Mockery::mock( WP_User::class );
+		$admin_user->ID = 1;
+
 		Monkey\Functions\expect( 'wp_get_current_user' )
-			->twice();
+			->twice()
+			->andReturn( $admin_user );
 
 		Monkey\Functions\expect( 'YoastSEO' )
 			->once()

--- a/tests/unit/integrations/admin/indexing-notification-integration-test.php
+++ b/tests/unit/integrations/admin/indexing-notification-integration-test.php
@@ -346,8 +346,8 @@ class Indexing_Notification_Integration_Test extends TestCase {
 
 		$admin_user     = Mockery::mock( WP_User::class );
 		$admin_user->ID = 1;
-		Monkey\Functions\expect( 'wp_get_current_user' )
-			->andReturn( $admin_user );
+		Monkey\Functions\expect( 'get_current_user_id' )
+			->andReturn( $admin_user->ID );
 
 		$this->notification_helper
 			->expects( 'restore_notification' )
@@ -404,8 +404,8 @@ class Indexing_Notification_Integration_Test extends TestCase {
 
 		$admin_user     = Mockery::mock( WP_User::class );
 		$admin_user->ID = 1;
-		Monkey\Functions\expect( 'wp_get_current_user' )
-			->andReturn( $admin_user );
+		Monkey\Functions\expect( 'get_current_user_id' )
+			->andReturn( $admin_user->ID );
 
 		$this->notification_helper
 			->expects( 'restore_notification' )

--- a/tests/unit/integrations/admin/indexing-notification-integration-test.php
+++ b/tests/unit/integrations/admin/indexing-notification-integration-test.php
@@ -344,8 +344,10 @@ class Indexing_Notification_Integration_Test extends TestCase {
 			->once()
 			->andReturn( Indexing_Reasons::REASON_INDEXING_FAILED );
 
+		$admin_user     = Mockery::mock( WP_User::class );
+		$admin_user->ID = 1;
 		Monkey\Functions\expect( 'wp_get_current_user' )
-			->andReturn( 'user' );
+			->andReturn( $admin_user );
 
 		$this->notification_helper
 			->expects( 'restore_notification' )
@@ -400,8 +402,10 @@ class Indexing_Notification_Integration_Test extends TestCase {
 			->once()
 			->andReturn( $reason );
 
+		$admin_user     = Mockery::mock( WP_User::class );
+		$admin_user->ID = 1;
 		Monkey\Functions\expect( 'wp_get_current_user' )
-			->andReturn( 'user' );
+			->andReturn( $admin_user );
 
 		$this->notification_helper
 			->expects( 'restore_notification' )

--- a/tests/unit/integrations/third-party/wpml-wpseo-notification-test.php
+++ b/tests/unit/integrations/third-party/wpml-wpseo-notification-test.php
@@ -122,8 +122,8 @@ class WPML_WPSEO_Notification_Test extends TestCase {
 
 		$admin_user     = Mockery::mock( WP_User::class );
 		$admin_user->ID = 1;
-		Monkey\Functions\expect( 'wp_get_current_user' )
-			->andReturn( $admin_user );
+		Monkey\Functions\expect( 'get_current_user_id' )
+			->andReturn( $admin_user->ID );
 
 		$this->notification_center
 			->expects( 'add_notification' )

--- a/tests/unit/integrations/third-party/wpml-wpseo-notification-test.php
+++ b/tests/unit/integrations/third-party/wpml-wpseo-notification-test.php
@@ -120,8 +120,10 @@ class WPML_WPSEO_Notification_Test extends TestCase {
 		// Mock that the Yoast SEO Multilingual plugin is not installed and activated.
 		$this->wpml_wpseo_conditional->expects( 'is_met' )->andReturnFalse();
 
+		$admin_user     = Mockery::mock( WP_User::class );
+		$admin_user->ID = 1;
 		Monkey\Functions\expect( 'wp_get_current_user' )
-			->andReturn( 'user' );
+			->andReturn( $admin_user );
 
 		$this->notification_center
 			->expects( 'add_notification' )

--- a/tests/unit/integrations/watchers/search-engines-discouraged-watcher-test.php
+++ b/tests/unit/integrations/watchers/search-engines-discouraged-watcher-test.php
@@ -348,9 +348,9 @@ class Search_Engines_Discouraged_Watcher_Test extends TestCase {
 				->expects( 'restore_notification' );
 			$this->notification_center
 				->expects( 'add_notification' );
-			Monkey\Functions\expect( 'wp_get_current_user' )
+			Monkey\Functions\expect( 'get_current_user_id' )
 				->once()
-				->andReturn( $this->admin_user );
+				->andReturn( $this->admin_user->ID );
 		}
 		else {
 			$this->notification_helper

--- a/tests/unit/integrations/watchers/search-engines-discouraged-watcher-test.php
+++ b/tests/unit/integrations/watchers/search-engines-discouraged-watcher-test.php
@@ -23,6 +23,13 @@ use Yoast_Notification_Center;
 class Search_Engines_Discouraged_Watcher_Test extends TestCase {
 
 	/**
+	 * Holds the admin user mock instance.
+	 *
+	 * @var WP_User
+	 */
+	private $admin_user;
+
+	/**
 	 * Yoast_Notification_Center mock.
 	 *
 	 * @var Mockery\MockInterface|Yoast_Notification_Center
@@ -69,6 +76,9 @@ class Search_Engines_Discouraged_Watcher_Test extends TestCase {
 	 */
 	public function set_up() {
 		parent::set_up();
+
+		$this->admin_user     = Mockery::mock( WP_User::class );
+		$this->admin_user->ID = 1;
 
 		$this->notification_center = Mockery::mock( Yoast_Notification_Center::class );
 		$this->notification_helper = Mockery::mock( Notification_Helper::class );
@@ -340,7 +350,7 @@ class Search_Engines_Discouraged_Watcher_Test extends TestCase {
 				->expects( 'add_notification' );
 			Monkey\Functions\expect( 'wp_get_current_user' )
 				->once()
-				->andReturn( null );
+				->andReturn( $this->admin_user );
 		}
 		else {
 			$this->notification_helper


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to avoid storing the full `WP_User` object in each user's notification.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Do not store in the `wp_yoast_notifications` usermeta the full `WP_User` object.

## Relevant technical choices:

* Notifications already saved in the database are managed on a user-by-user basis by the `Notification_Center::maybe_unset_notification_user_field` method. This is going to be less impactful for sites with a large number of users with respect to using an upgrade routine.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Without this PR checked out
* Go to `Yoast SEO` -> `General` -> `Dashboard` tab
  *  take note of the notifications (`Problems` and `Notifications` section) you have there and their state (visible or hidden)
  * if you have no notifications, use the `Yoast Test` helper to `Reset indexable tables&migrations`: this would trigger a notification about the need to run the SEO data optimization
* Go in your database, `wp_usermeta` table, and look for the row where `User Id` =  your user id, `meta_key` = `wp_yoast_notifications`
  * search the `Meta value` for `WP_User` and verify you have one instance per notification
* Create another user with `SEO Manager` role and repeat the points above for this user
#### With this PR checked out
* Login with one of the two users
* Go to `Yoast SEO` -> `General` -> `Dashboard` tab
  * verify you still see your previous notifications with the correct status 
* Go in your database, `wp_usermeta` table, and look for the row where `User Id` =  your user id, `meta_key` = `wp_yoast_notifications`
  * search the `Meta value` for `WP_User` and verify you have no instances in any of the notifications
  * now look for the row where `User Id` =  your other user id, `meta_key` = `wp_yoast_notifications`
  * search the `Meta value` for `WP_User` and verify you still have one instance per notification

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [X] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* This PR changes one of the base mechanisms used by the Notification center to associate each notification to its user: please perform a regression test for the Notification center. 

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.
* [X] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/wordpress-seo/issues/20796
