### PR TITLE
update copy in ai introduction modal for products

### DIFF
--- a/packages/js/src/shared-admin/components/ai-generate-titles-and-descriptions-upsell.js
+++ b/packages/js/src/shared-admin/components/ai-generate-titles-and-descriptions-upsell.js
@@ -94,8 +94,8 @@ export const AiGenerateTitlesAndDescriptionsUpsell = ( { learnMoreLink, thumbnai
 				<span className="yst-introduction-modal-uppercase">
 					{ newToText }
 				</span>
-				&nbsp;
-				<span className="yst-uppercase yst-text-slate-700">21.0</span>
+
+				{ ! isWooSeoUpsell && <span className="yst-uppercase yst-text-slate-700"> 21.0</span> }
 			</div>
 			<div className="yst-mt-4 yst-mx-1.5 yst-text-center">
 				<h3 className="yst-text-slate-900 yst-text-lg yst-font-medium">

--- a/packages/js/src/shared-admin/components/ai-generate-titles-and-descriptions-upsell.js
+++ b/packages/js/src/shared-admin/components/ai-generate-titles-and-descriptions-upsell.js
@@ -21,9 +21,9 @@ export const AiGenerateTitlesAndDescriptionsUpsell = ( { learnMoreLink, thumbnai
 	const upsellLinkPremium = useSelect( select => select( STORE ).selectLink( "https://yoa.st/ai-generator-upsell" ), [] );
 	const upsellLinkWooPremiumBundle = useSelect( select => select( STORE ).selectLink( "https://yoa.st/ai-generator-upsell-woo-seo-premium-bundle" ), [] );
 	const upsellLinkWoo = useSelect( select => select( STORE ).selectLink( "https://yoa.st/ai-generator-upsell-woo-seo" ), [] );
-	const isPremium = useSelect( select => select( STORE ).getIsPremium(), false );
-	const isWooSeoUpsell = useSelect( select => select( STORE ).getIsWooSeoUpsell(), false );
-	const isProduct = useSelect( select => select( STORE ).getIsProduct(), false );
+	const isPremium = useSelect( select => select( STORE ).getIsPremium(), [] );
+	const isWooSeoUpsell = useSelect( select => select( STORE ).getIsWooSeoUpsell(), [] );
+	const isProduct = useSelect( select => select( STORE ).getIsProduct(), [] );
 
 	const wooSeoNoPremium = isProduct && ! isWooSeoUpsell && ! isPremium;
 	const isProductCopy = isWooSeoUpsell || wooSeoNoPremium;

--- a/packages/js/src/shared-admin/components/ai-generate-titles-and-descriptions-upsell.js
+++ b/packages/js/src/shared-admin/components/ai-generate-titles-and-descriptions-upsell.js
@@ -21,6 +21,20 @@ export const AiGenerateTitlesAndDescriptionsUpsell = ( { learnMoreLink, thumbnai
 	const upsellLinkWooPremiumBundle = useSelect( select => select( STORE ).selectLink( "https://yoa.st/ai-generator-upsell-woo-seo-premium-bundle" ), [] );
 	const upsellLinkWoo = useSelect( select => select( STORE ).selectLink( "https://yoa.st/ai-generator-upsell-woo-seo" ), [] );
 	let upsellLink = upsellLinkPremium;
+	let newToText = sprintf(
+		/* translators: %1$s expands to Yoast SEO Premium. */
+		__( "New to %1$s", "wordpress-seo" ),
+		"Yoast SEO Premium"
+	);
+	const learnMoreLinkStructure = {
+		// eslint-disable-next-line jsx-a11y/anchor-has-content
+		a: <OutboundLink
+			href={ learnMoreLink }
+			className="yst-inline-flex yst-items-center yst-gap-1 yst-no-underline yst-font-medium"
+			variant="primary"
+		/>,
+		ArrowNarrowRightIcon: <ArrowNarrowRightIcon className="yst-w-4 yst-h-4 rtl:yst-rotate-180" />,
+	};
 
 	const isPremium = useSelect( select => select( STORE ).getIsPremium(), [] );
 	const isWooSeoUpsell = useSelect( select => select( STORE ).getIsWooSeoUpsell(), [] );
@@ -30,8 +44,21 @@ export const AiGenerateTitlesAndDescriptionsUpsell = ( { learnMoreLink, thumbnai
 		"Yoast SEO Premium"
 	);
 	let bundleNote = "";
+	let title = __( "Generate titles & descriptions with Yoast AI!", "wordpress-seo" );
 
 	if ( isWooSeoUpsell ) {
+		const upsellPremiumWooLabel = sprintf(
+			/* translators: %1$s expands to Yoast SEO Premium, %2$s expands to Yoast WooCommerce SEO. */
+			__( "%1$s + %2$s", "wordpress-seo" ),
+			"Yoast SEO Premium",
+			"Yoast WooCommerce SEO"
+		);
+		newToText = sprintf(
+			/* translators: %1$s expands to Yoast SEO Premium and Yoast WooCommerce SEO. */
+			__( "New to %1$s", "wordpress-seo" ),
+			upsellPremiumWooLabel
+		);
+		title = __( "Generate product titles & descriptions with AI!", "wordpress-seo" );
 		if ( ! isPremium ) {
 			upsellLabel = `${sprintf(
 				/* translators: %1$s expands to Woo Premium bundle. */
@@ -39,12 +66,7 @@ export const AiGenerateTitlesAndDescriptionsUpsell = ( { learnMoreLink, thumbnai
 				"Woo Premium bundle"
 			)}*`;
 			bundleNote = <div className="yst-text-xs yst-text-slate-500 yst-mt-2">
-				{ `*${sprintf(
-				/* translators: %1$s expands to Yoast SEO Premium, %2$s expands to Yoast WooCommerce SEO. */
-					__( "%1$s + %2$s", "wordpress-seo" ),
-					"Yoast SEO Premium",
-					"Yoast WooCommerce SEO"
-				)}` }
+				{ `*${upsellPremiumWooLabel}` }
 			</div>;
 			upsellLink = upsellLinkWooPremiumBundle;
 		}
@@ -70,41 +92,42 @@ export const AiGenerateTitlesAndDescriptionsUpsell = ( { learnMoreLink, thumbnai
 			</div>
 			<div className="yst-mt-6 yst-text-xs yst-font-medium">
 				<span className="yst-introduction-modal-uppercase">
-					{ sprintf(
-						/* translators: %1$s expands to Yoast SEO Premium. */
-						__( "New to %1$s", "wordpress-seo" ),
-						"Yoast SEO Premium"
-					) }
+					{ newToText }
 				</span>
 				&nbsp;
 				<span className="yst-uppercase yst-text-slate-700">21.0</span>
 			</div>
 			<div className="yst-mt-4 yst-mx-1.5 yst-text-center">
 				<h3 className="yst-text-slate-900 yst-text-lg yst-font-medium">
-					{ __( "Generate titles & descriptions with Yoast AI!", "wordpress-seo" ) }
+					{ title }
 				</h3>
 				<div className="yst-mt-2 yst-text-slate-600 yst-text-sm">
-					{ createInterpolateElement(
+					{ isWooSeoUpsell ? createInterpolateElement(
 						sprintf(
 							/* translators: %1$s and %2$s are anchor tag; %3$s is the arrow icon. */
 							__(
-								"Speed up your workflow with generative AI. Get high-quality title and description suggestions for your search and social appearance. %1$sLearn more%2$s%3$s",
+								"Speed up your workflow with generative AI. Get high-quality product title and description suggestions for your search and social appearance. %1$sLearn more%2$s%3$s",
 								"wordpress-seo"
 							),
 							"<a>",
 							"<ArrowNarrowRightIcon />",
 							"</a>"
 						),
-						{
-							// eslint-disable-next-line jsx-a11y/anchor-has-content
-							a: <OutboundLink
-								href={ learnMoreLink }
-								className="yst-inline-flex yst-items-center yst-gap-1 yst-no-underline yst-font-medium"
-								variant="primary"
-							/>,
-							ArrowNarrowRightIcon: <ArrowNarrowRightIcon className="yst-w-4 yst-h-4 rtl:yst-rotate-180" />,
-						}
-					) }
+						learnMoreLinkStructure
+					)
+						: createInterpolateElement(
+							sprintf(
+							/* translators: %1$s and %2$s are anchor tag; %3$s is the arrow icon. */
+								__(
+									"Speed up your workflow with generative AI. Get high-quality title and description suggestions for your search and social appearance. %1$sLearn more%2$s%3$s",
+									"wordpress-seo"
+								),
+								"<a>",
+								"<ArrowNarrowRightIcon />",
+								"</a>"
+							),
+							learnMoreLinkStructure
+						) }
 				</div>
 			</div>
 			<div className="yst-w-full yst-flex yst-mt-10">

--- a/packages/js/src/shared-admin/components/ai-generate-titles-and-descriptions-upsell.js
+++ b/packages/js/src/shared-admin/components/ai-generate-titles-and-descriptions-upsell.js
@@ -1,3 +1,4 @@
+/* eslint-disable complexity */
 import { LockOpenIcon } from "@heroicons/react/outline";
 import { ArrowNarrowRightIcon } from "@heroicons/react/solid";
 import { createInterpolateElement } from "@wordpress/element";
@@ -20,6 +21,12 @@ export const AiGenerateTitlesAndDescriptionsUpsell = ( { learnMoreLink, thumbnai
 	const upsellLinkPremium = useSelect( select => select( STORE ).selectLink( "https://yoa.st/ai-generator-upsell" ), [] );
 	const upsellLinkWooPremiumBundle = useSelect( select => select( STORE ).selectLink( "https://yoa.st/ai-generator-upsell-woo-seo-premium-bundle" ), [] );
 	const upsellLinkWoo = useSelect( select => select( STORE ).selectLink( "https://yoa.st/ai-generator-upsell-woo-seo" ), [] );
+	const isPremium = useSelect( select => select( STORE ).getIsPremium(), false );
+	const isWooSeoUpsell = useSelect( select => select( STORE ).getIsWooSeoUpsell(), false );
+	const isProduct = useSelect( select => select( STORE ).getIsProduct(), false );
+
+	const wooSeoNoPremium = isProduct && ! isWooSeoUpsell && ! isPremium;
+	const isProductCopy = isWooSeoUpsell || wooSeoNoPremium;
 	let upsellLink = upsellLinkPremium;
 	let newToText = sprintf(
 		/* translators: %1$s expands to Yoast SEO Premium. */
@@ -36,8 +43,6 @@ export const AiGenerateTitlesAndDescriptionsUpsell = ( { learnMoreLink, thumbnai
 		ArrowNarrowRightIcon: <ArrowNarrowRightIcon className="yst-w-4 yst-h-4 rtl:yst-rotate-180" />,
 	};
 
-	const isPremium = useSelect( select => select( STORE ).getIsPremium(), [] );
-	const isWooSeoUpsell = useSelect( select => select( STORE ).getIsWooSeoUpsell(), [] );
 	let upsellLabel = sprintf(
 		/* translators: %1$s expands to Yoast SEO Premium. */
 		__( "Unlock with %1$s", "wordpress-seo" ),
@@ -46,7 +51,8 @@ export const AiGenerateTitlesAndDescriptionsUpsell = ( { learnMoreLink, thumbnai
 	let bundleNote = "";
 	let title = __( "Generate titles & descriptions with Yoast AI!", "wordpress-seo" );
 
-	if ( isWooSeoUpsell ) {
+
+	if ( isProductCopy ) {
 		const upsellPremiumWooLabel = sprintf(
 			/* translators: %1$s expands to Yoast SEO Premium, %2$s expands to Yoast WooCommerce SEO. */
 			__( "%1$s + %2$s", "wordpress-seo" ),
@@ -59,7 +65,7 @@ export const AiGenerateTitlesAndDescriptionsUpsell = ( { learnMoreLink, thumbnai
 			upsellPremiumWooLabel
 		);
 		title = __( "Generate product titles & descriptions with AI!", "wordpress-seo" );
-		if ( ! isPremium ) {
+		if ( ! isPremium && isWooSeoUpsell ) {
 			upsellLabel = `${sprintf(
 				/* translators: %1$s expands to Woo Premium bundle. */
 				__( "Unlock with the %1$s", "wordpress-seo" ),
@@ -95,14 +101,14 @@ export const AiGenerateTitlesAndDescriptionsUpsell = ( { learnMoreLink, thumbnai
 					{ newToText }
 				</span>
 
-				{ ! isWooSeoUpsell && <span className="yst-uppercase yst-text-slate-700"> 21.0</span> }
+				{ ! isProductCopy && <span className="yst-uppercase yst-text-slate-700"> 21.0</span> }
 			</div>
 			<div className="yst-mt-4 yst-mx-1.5 yst-text-center">
 				<h3 className="yst-text-slate-900 yst-text-lg yst-font-medium">
 					{ title }
 				</h3>
 				<div className="yst-mt-2 yst-text-slate-600 yst-text-sm">
-					{ isWooSeoUpsell ? createInterpolateElement(
+					{ isProductCopy ? createInterpolateElement(
 						sprintf(
 							/* translators: %1$s and %2$s are anchor tag; %3$s is the arrow icon. */
 							__(


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Update copy for ai introduction modal on product pages.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Update copy for ai introduction modal on product pages.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install WooCommerce
* Make sure Yoast Premium is not active
* Create or Edit a product
* Go to Google preview
* Click on `Use AI`
* Check the `New to` text and the title and description are as follow:
   * New to Text: "New to Yoast SEO Premium + Yoast WooCommerce SEO"
   * Title: "Generate product titles & descriptions with AI!"
   * Description: "Speed up your workflow with generative AI. Get high-quality product title and description suggestions for your search and social appearance. Learn more"
* Repeat those steps when:
  * Premium is active and WooCommerce SEO not active
  * Premium is not active and WooCommerce SEO is active

* Edit a post that is not a product
* Check the `New to` text and the title and description are as follow:
   * New to Text: "New to Yoast SEO Premium 21.0"
   * Title: "Generate titles & descriptions with Yoast AI!"
   * Description: "Speed up your workflow with generative AI. Get high-quality title and description suggestions for your search and social appearance. Learn more"

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/plugins-automated-testing/issues/1132
