### PR TITLE
Improves translatability of upsells shown after deleting content

### DIFF
--- a/admin/watchers/class-slug-change-watcher.php
+++ b/admin/watchers/class-slug-change-watcher.php
@@ -64,8 +64,9 @@ class WPSEO_Slug_Change_Watcher implements WPSEO_WordPress_Integration {
 		$post_label = $this->get_post_type_label( get_post_type( $post_id ) );
 
 		/* translators: %1$s expands to the translated name of the post type. */
-		$first_sentence = sprintf( __( 'You just trashed a %1$s.', 'wordpress-seo' ), $post_label );
-		$message        = $this->get_message( $first_sentence, 'trashed', $post_label );
+		$first_sentence  = sprintf( __( 'You just trashed a %1$s.', 'wordpress-seo' ), $post_label );
+		$second_sentence = __( 'Search engines and other websites can still send traffic to your trashed content.', 'wordpress-seo' );
+		$message         = $this->get_message( $first_sentence, $second_sentence );
 
 		$this->add_notification( $message );
 	}
@@ -85,8 +86,9 @@ class WPSEO_Slug_Change_Watcher implements WPSEO_WordPress_Integration {
 		$post_label = $this->get_post_type_label( get_post_type( $post_id ) );
 
 		/* translators: %1$s expands to the translated name of the post type. */
-		$first_sentence = sprintf( __( 'You just deleted a %1$s.', 'wordpress-seo' ), $post_label );
-		$message        = $this->get_message( $first_sentence, 'deleted', $post_label );
+		$first_sentence  = sprintf( __( 'You just deleted a %1$s.', 'wordpress-seo' ), $post_label );
+		$second_sentence = __( 'Search engines and other websites can still send traffic to your deleted content.', 'wordpress-seo' );
+		$message         = $this->get_message( $first_sentence, $second_sentence );
 
 		$this->add_notification( $message );
 	}
@@ -107,8 +109,9 @@ class WPSEO_Slug_Change_Watcher implements WPSEO_WordPress_Integration {
 		$term_label = $this->get_taxonomy_label_for_term( $term->term_id );
 
 		/* translators: %1$s expands to the translated name of the term. */
-		$first_sentence = sprintf( __( 'You just deleted a %1$s.', 'wordpress-seo' ), $term_label );
-		$message        = $this->get_message( $first_sentence, 'deleted', $term_label );
+		$first_sentence  = sprintf( __( 'You just deleted a %1$s.', 'wordpress-seo' ), $term_label );
+		$second_sentence = __( 'Search engines and other websites can still send traffic to your deleted content.', 'wordpress-seo' );
+		$message         = $this->get_message( $first_sentence, $second_sentence );
 
 		$this->add_notification( $message );
 	}
@@ -209,17 +212,15 @@ class WPSEO_Slug_Change_Watcher implements WPSEO_WordPress_Integration {
 	 * Returns the message around changed URLs.
 	 *
 	 * @param string $first_sentence The first sentence of the notification.
-	 * @param string $action The action performed, either "deleted" or "trashed".
-	 * @param string $object_label The label of the object that was deleted or trashed.
+	 * @param string $second_sentence The second sentence of the notification.
 	 *
 	 * @return string The full notification.
 	 */
-	protected function get_message( $first_sentence, $action, $object_label ) {
+	protected function get_message( $first_sentence, $second_sentence ) {
 		return '<h2>' . __( 'Make sure you don\'t miss out on traffic!', 'wordpress-seo' ) . '</h2>'
 			. '<p>'
 			. $first_sentence
-			/* translators: %1$s expands to either "deleted" or "trashed". %2$s expands to the name of the post or term. */
-			. ' ' . sprintf( __( 'Search engines and other websites can still send traffic to your %1$s %2$s.', 'wordpress-seo' ), $action, $object_label )
+			. ' ' . $second_sentence
 			. ' ' . __( 'You should create a redirect to ensure your visitors do not get a 404 error when they click on the no longer working URL.', 'wordpress-seo' )
 			/* translators: %s expands to Yoast SEO Premium */
 			. ' ' . sprintf( __( 'With %s, you can easily create such redirects.', 'wordpress-seo' ), 'Yoast SEO Premium' )


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to improve the translatability of the upsells that are shown after deleting content that we last touched in [this PR](https://github.com/Yoast/wordpress-seo/pull/20584). In this PR, we remove the reference "this X" (where X can any content type) and remove the variable that can be either "trashed" or "deleted". 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves translatability of upsells shown after deleting content.

## Relevant technical choices:

* Non-user facing as the copy change is super-small. 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

*

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Upsells after deleting and trashing a post. 

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #20722 
