### PR TITLE
fix introduction modal for admin pages

### DIFF
--- a/packages/js/src/ai-generator/components/modal-content.js
+++ b/packages/js/src/ai-generator/components/modal-content.js
@@ -18,7 +18,7 @@ export const ModalContent = () => {
 	const isWooSeoUpsell = useSelect( select => select( STORE ).getIsWooSeoUpsell(), [] );
 	const isProduct = useSelect( select => select( STORE ).getIsProduct(), [] );
 	const wooSeoNoPremium = isProduct && ! isWooSeoUpsell && ! isPremium;
-	const isProductCopy = isWooSeoUpsell || wooSeoNoPremium;
+	const isProductCopy = !! ( isWooSeoUpsell || wooSeoNoPremium );
 	const postModalprops = {
 		isProductCopy,
 		upsellLink: upsellLinkPremium,

--- a/packages/js/src/ai-generator/components/modal-content.js
+++ b/packages/js/src/ai-generator/components/modal-content.js
@@ -1,6 +1,8 @@
+/* eslint-disable complexity */
 import { useDispatch, useSelect } from "@wordpress/data";
 import { useMemo } from "@wordpress/element";
 import { AiGenerateTitlesAndDescriptionsUpsell } from "../../shared-admin/components";
+import { __, sprintf } from "@wordpress/i18n";
 
 const STORE = "yoast-seo/editor";
 
@@ -9,6 +11,52 @@ const STORE = "yoast-seo/editor";
  */
 export const ModalContent = () => {
 	const learnMoreLink = useSelect( select => select( STORE ).selectLink( "https://www.yoa.st/ai-generator-learn-more" ), [] );
+	const upsellLinkPremium = useSelect( select => select( STORE ).selectLink( "https://yoa.st/ai-generator-upsell" ), [] );
+	const upsellLinkWooPremiumBundle = useSelect( select => select( STORE ).selectLink( "https://yoa.st/ai-generator-upsell-woo-seo-premium-bundle" ), [] );
+	const upsellLinkWoo = useSelect( select => select( STORE ).selectLink( "https://yoa.st/ai-generator-upsell-woo-seo" ), [] );
+	const isPremium = useSelect( select => select( STORE ).getIsPremium(), [] );
+	const isWooSeoUpsell = useSelect( select => select( STORE ).getIsWooSeoUpsell(), [] );
+	const isProduct = useSelect( select => select( STORE ).getIsProduct(), [] );
+	const wooSeoNoPremium = isProduct && ! isWooSeoUpsell && ! isPremium;
+	const isProductCopy = isWooSeoUpsell || wooSeoNoPremium;
+	const postModalprops = {
+		isProductCopy,
+		upsellLink: upsellLinkPremium,
+	};
+
+	if ( isProductCopy ) {
+		const upsellPremiumWooLabel = sprintf(
+			/* translators: %1$s expands to Yoast SEO Premium, %2$s expands to Yoast WooCommerce SEO. */
+			__( "%1$s + %2$s", "wordpress-seo" ),
+			"Yoast SEO Premium",
+			"Yoast WooCommerce SEO"
+		);
+		postModalprops.newToText = sprintf(
+			/* translators: %1$s expands to Yoast SEO Premium and Yoast WooCommerce SEO. */
+			__( "New to %1$s", "wordpress-seo" ),
+			upsellPremiumWooLabel
+		);
+		postModalprops.title = __( "Generate product titles & descriptions with AI!", "wordpress-seo" );
+		if ( ! isPremium && isWooSeoUpsell ) {
+			postModalprops.upsellLabel = `${ sprintf(
+				/* translators: %1$s expands to Woo Premium bundle. */
+				__( "Unlock with the %1$s", "wordpress-seo" ),
+				"Woo Premium bundle"
+			)}*`;
+			postModalprops.bundleNote = <div className="yst-text-xs yst-text-slate-500 yst-mt-2">
+				{ `*${upsellPremiumWooLabel}` }
+			</div>;
+			postModalprops.upsellLink = upsellLinkWooPremiumBundle;
+		}
+		if ( isPremium ) {
+			postModalprops.upsellLabel = sprintf(
+				/* translators: %1$s expands to Yoast WooCommerce SEO. */
+				__( "Unlock with %1$s", "wordpress-seo" ),
+				"Yoast WooCommerce SEO"
+			);
+			postModalprops.upsellLink = upsellLinkWoo;
+		}
+	}
 
 
 	const imageLink = useSelect( select => select( STORE ).selectImageLink( "ai-generator-preview.png" ), [] );
@@ -29,6 +77,7 @@ export const ModalContent = () => {
 			learnMoreLink={ learnMoreLink }
 			thumbnail={ thumbnail }
 			wistiaEmbedPermission={ wistiaEmbedPermission }
+			{ ...postModalprops }
 		/>
 	);
 };

--- a/packages/js/src/shared-admin/components/ai-generate-titles-and-descriptions-upsell.js
+++ b/packages/js/src/shared-admin/components/ai-generate-titles-and-descriptions-upsell.js
@@ -15,7 +15,7 @@ import { OutboundLink, VideoFlow } from ".";
  * @param {string} title The title.
  * @param {string} upsellLabel The upsell label.
  * @param {string} newToText The new to text.
- * @param {string} bundleNote The bundle note.
+ * @param {string|JSX.Element } bundleNote The bundle note.
  * @returns {JSX.Element} The element.
  */
 export const AiGenerateTitlesAndDescriptionsUpsell = ( {
@@ -140,7 +140,10 @@ AiGenerateTitlesAndDescriptionsUpsell.propTypes = {
 	upsellLabel: PropTypes.string,
 	newToText: PropTypes.string,
 	isProductCopy: PropTypes.bool,
-	bundleNote: PropTypes.string,
+	bundleNote: PropTypes.oneOfType( [
+		PropTypes.string,
+		PropTypes.element,
+	  ] ),
 };
 
 AiGenerateTitlesAndDescriptionsUpsell.defaultProps = {

--- a/packages/js/src/shared-admin/components/ai-generate-titles-and-descriptions-upsell.js
+++ b/packages/js/src/shared-admin/components/ai-generate-titles-and-descriptions-upsell.js
@@ -1,38 +1,36 @@
-/* eslint-disable complexity */
 import { LockOpenIcon } from "@heroicons/react/outline";
 import { ArrowNarrowRightIcon } from "@heroicons/react/solid";
 import { createInterpolateElement } from "@wordpress/element";
-import { useSelect } from "@wordpress/data";
 import { __, sprintf } from "@wordpress/i18n";
 import { Badge, Button, useModalContext } from "@yoast/ui-library";
 import PropTypes from "prop-types";
 import { OutboundLink, VideoFlow } from ".";
 
-const STORE = "yoast-seo/editor";
-
 /**
  * @param {string} learnMoreLink The learn more link.
  * @param {Object} thumbnail The thumbnail: img props.
  * @param {Object} wistiaEmbedPermission The value, status and set for the Wistia embed permission.
+ * @param {string} upsellLink The upsell link.
+ * @param {boolean} isProductCopy Whether the upsell is for a product.
+ * @param {string} title The title.
+ * @param {string} upsellLabel The upsell label.
+ * @param {string} newToText The new to text.
+ * @param {string} bundleNote The bundle note.
  * @returns {JSX.Element} The element.
  */
-export const AiGenerateTitlesAndDescriptionsUpsell = ( { learnMoreLink, thumbnail, wistiaEmbedPermission } ) => {
+export const AiGenerateTitlesAndDescriptionsUpsell = ( {
+	learnMoreLink,
+	thumbnail,
+	wistiaEmbedPermission,
+	upsellLink,
+	isProductCopy,
+	title,
+	upsellLabel,
+	newToText,
+	bundleNote,
+} ) => {
 	const { onClose, initialFocus } = useModalContext();
-	const upsellLinkPremium = useSelect( select => select( STORE ).selectLink( "https://yoa.st/ai-generator-upsell" ), [] );
-	const upsellLinkWooPremiumBundle = useSelect( select => select( STORE ).selectLink( "https://yoa.st/ai-generator-upsell-woo-seo-premium-bundle" ), [] );
-	const upsellLinkWoo = useSelect( select => select( STORE ).selectLink( "https://yoa.st/ai-generator-upsell-woo-seo" ), [] );
-	const isPremium = useSelect( select => select( STORE ).getIsPremium(), [] );
-	const isWooSeoUpsell = useSelect( select => select( STORE ).getIsWooSeoUpsell(), [] );
-	const isProduct = useSelect( select => select( STORE ).getIsProduct(), [] );
 
-	const wooSeoNoPremium = isProduct && ! isWooSeoUpsell && ! isPremium;
-	const isProductCopy = isWooSeoUpsell || wooSeoNoPremium;
-	let upsellLink = upsellLinkPremium;
-	let newToText = sprintf(
-		/* translators: %1$s expands to Yoast SEO Premium. */
-		__( "New to %1$s", "wordpress-seo" ),
-		"Yoast SEO Premium"
-	);
 	const learnMoreLinkStructure = {
 		// eslint-disable-next-line jsx-a11y/anchor-has-content
 		a: <OutboundLink
@@ -42,49 +40,6 @@ export const AiGenerateTitlesAndDescriptionsUpsell = ( { learnMoreLink, thumbnai
 		/>,
 		ArrowNarrowRightIcon: <ArrowNarrowRightIcon className="yst-w-4 yst-h-4 rtl:yst-rotate-180" />,
 	};
-
-	let upsellLabel = sprintf(
-		/* translators: %1$s expands to Yoast SEO Premium. */
-		__( "Unlock with %1$s", "wordpress-seo" ),
-		"Yoast SEO Premium"
-	);
-	let bundleNote = "";
-	let title = __( "Generate titles & descriptions with Yoast AI!", "wordpress-seo" );
-
-
-	if ( isProductCopy ) {
-		const upsellPremiumWooLabel = sprintf(
-			/* translators: %1$s expands to Yoast SEO Premium, %2$s expands to Yoast WooCommerce SEO. */
-			__( "%1$s + %2$s", "wordpress-seo" ),
-			"Yoast SEO Premium",
-			"Yoast WooCommerce SEO"
-		);
-		newToText = sprintf(
-			/* translators: %1$s expands to Yoast SEO Premium and Yoast WooCommerce SEO. */
-			__( "New to %1$s", "wordpress-seo" ),
-			upsellPremiumWooLabel
-		);
-		title = __( "Generate product titles & descriptions with AI!", "wordpress-seo" );
-		if ( ! isPremium && isWooSeoUpsell ) {
-			upsellLabel = `${sprintf(
-				/* translators: %1$s expands to Woo Premium bundle. */
-				__( "Unlock with the %1$s", "wordpress-seo" ),
-				"Woo Premium bundle"
-			)}*`;
-			bundleNote = <div className="yst-text-xs yst-text-slate-500 yst-mt-2">
-				{ `*${upsellPremiumWooLabel}` }
-			</div>;
-			upsellLink = upsellLinkWooPremiumBundle;
-		}
-		if ( isPremium ) {
-			upsellLabel = sprintf(
-				/* translators: %1$s expands to Yoast WooCommerce SEO. */
-				__( "Unlock with %1$s", "wordpress-seo" ),
-				"Yoast WooCommerce SEO"
-			);
-			upsellLink = upsellLinkWoo;
-		}
-	}
 
 	return (
 		<div className="yst-flex yst-flex-col yst-items-center yst-p-10">
@@ -170,6 +125,7 @@ export const AiGenerateTitlesAndDescriptionsUpsell = ( { learnMoreLink, thumbnai
 };
 AiGenerateTitlesAndDescriptionsUpsell.propTypes = {
 	learnMoreLink: PropTypes.string.isRequired,
+	upsellLink: PropTypes.string.isRequired,
 	thumbnail: PropTypes.shape( {
 		src: PropTypes.string.isRequired,
 		width: PropTypes.string,
@@ -180,4 +136,25 @@ AiGenerateTitlesAndDescriptionsUpsell.propTypes = {
 		status: PropTypes.string.isRequired,
 		set: PropTypes.func.isRequired,
 	} ).isRequired,
+	title: PropTypes.string,
+	upsellLabel: PropTypes.string,
+	newToText: PropTypes.string,
+	isProductCopy: PropTypes.bool,
+	bundleNote: PropTypes.string,
+};
+
+AiGenerateTitlesAndDescriptionsUpsell.defaultProps = {
+	title: __( "Generate titles & descriptions with Yoast AI!", "wordpress-seo" ),
+	upsellLabel: sprintf(
+		/* translators: %1$s expands to Yoast SEO Premium. */
+		__( "Unlock with %1$s", "wordpress-seo" ),
+		"Yoast SEO Premium"
+	),
+	newToText: sprintf(
+		/* translators: %1$s expands to Yoast SEO Premium. */
+		__( "New to %1$s", "wordpress-seo" ),
+		"Yoast SEO Premium"
+	),
+	isProductCopy: false,
+	bundleNote: "",
 };


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Refactor the ai upsell modal to be more reusable for both admin pages and post editor

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fix ai upsell modal for yoast admin pages.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:


### Yoast Admin Pages
* Go to the database wp_usermeta table and remove all lines with value `_yoast_wpseo_introductions`
* Check Yoast premium is not active and also Yoast Woo SEO.
* Go to any Yoast admin page and check you see the Ai introduction modal with the following features:
   * New to Text: NEW TO YOAST SEO PREMIUM 21.0
   * Title: Generate titles & descriptions with Yoast AI!
   * Paragraph: Speed up your workflow with generative AI. Get high-quality title and description suggestions for your search and social appearance.
   * Button label: Unlock with Yoast SEO Premium
   * Button link: https://yoa.st/ai-generator-upsell (with tracking params)

### Post editors
* Check Yoast premium is not active and also Yoast Woo SEO.
* Edit a post or a page and check you see the `Use AI` Button, click and check you see introduction modal with the following features:
   * New to Text: NEW TO YOAST SEO PREMIUM 21.0
   * Title: Generate titles & descriptions with Yoast AI!
   * Paragraph: Speed up your workflow with generative AI. Get high-quality title and description suggestions for your search and social appearance.
   * Button label: Unlock with Yoast SEO Premium
   * Button link: https://yoa.st/ai-generator-upsell (with tracking params)

### Product Editor with no Yoast Premium and no Woo SEO
* Check Yoast premium is not active and also Yoast Woo SEO.
* Instal WooCommerce
* Edit a product and check you see the `Use AI` Button, click and check you see introduction modal with the following features:
   * New to Text: NEW TO YOAST SEO PREMIUM + Yoast WooCommerce SEO
   * Title: Generate _product_ titles & descriptions with AI!
   * Paragraph: Speed up your workflow with generative AI. Get high-quality _product_ title and description suggestions for your search and social appearance.
   * Button label: Unlock with Woo Premium bundle*
   * Button link: https://yoa.st/ai-generator-upsell-woo-seo-premium-bundle (with tracking params)
   * A note under the button: *NEW TO YOAST SEO PREMIUM + Yoast WooCommerce SEO

### Product Editor with Yoast Premium and no Woo SEO
* Check Yoast premium is active but not Yoast Woo SEO.
* Instal WooCommerce
* Edit a product and check you see the `Use AI` Button, click and check you see introduction modal with the following features:
   * New to Text: NEW TO YOAST SEO PREMIUM + Yoast WooCommerce SEO
   * Title: Generate _product_ titles & descriptions with AI!
   * Paragraph: Speed up your workflow with generative AI. Get high-quality _product_ title and description suggestions for your search and social appearance.
   * Button label: Unlock with Yoast WooCommerce SEO
   * Button link: https://yoa.st/ai-generator-upsell-woo-seo (with tracking params)

### Product Editor with no Yoast Premium and with Woo SEO
* Check Yoast premium is not active but Yoast Woo SEO is.
* Instal WooCommerce
* Edit a product and check you see the `Use AI` Button, click and check you see introduction modal with the following features:
   * New to Text: NEW TO YOAST SEO PREMIUM + Yoast WooCommerce SEO
   * Title: Generate _product_ titles & descriptions with AI!
   * Paragraph: Speed up your workflow with generative AI. Get high-quality _product_ title and description suggestions for your search and social appearance.
   * Button label: Unlock with Yoast SEO Premium
   * Button link: https://yoa.st/ai-generator-upsell (with tracking params)

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [[Minor] 21.6 AI: Introduction modal is not shown](https://github.com/Yoast/plugins-automated-testing/issues/1164)
