### PR TITLE
Fix initial state for site name based on fallback

### DIFF
--- a/packages/js/src/first-time-configuration/first-time-configuration-steps.js
+++ b/packages/js/src/first-time-configuration/first-time-configuration-steps.js
@@ -120,7 +120,15 @@ async function saveFinishedSteps( finishedSteps ) {
  * @returns {Object} The initial state.
  */
 function calculateInitialState( windowObject, isStepFinished ) {
-	const { companyName, companyLogo, companyOrPersonOptions, shouldForceCompany, fallbackCompanyName } = windowObject;
+	const {
+		companyName,
+		companyLogo,
+		companyOrPersonOptions,
+		shouldForceCompany,
+		fallbackCompanyName,
+		websiteName,
+		fallbackWebsiteName,
+	} = windowObject;
 	let { companyOrPerson } = windowObject;
 	if ( ( companyOrPerson === "company" && ( ! companyName && ! companyLogo ) && ! isStepFinished( STEPS.siteRepresentation ) ) || shouldForceCompany ) {
 		// Set the stage for a prefilled step 2 in case the customer does seem to have consciously finished step 2 without setting data.
@@ -139,6 +147,7 @@ function calculateInitialState( windowObject, isStepFinished ) {
 		stepErrors: {},
 		editedSteps: [],
 		companyName: companyName || fallbackCompanyName,
+		websiteName: websiteName || fallbackWebsiteName,
 	};
 }
 

--- a/packages/js/src/first-time-configuration/first-time-configuration-steps.js
+++ b/packages/js/src/first-time-configuration/first-time-configuration-steps.js
@@ -120,8 +120,8 @@ async function saveFinishedSteps( finishedSteps ) {
  * @returns {Object} The initial state.
  */
 function calculateInitialState( windowObject, isStepFinished ) {
-	let { companyOrPerson, companyName, companyLogo, companyOrPersonOptions, shouldForceCompany } = windowObject; // eslint-disable-line prefer-const
-
+	const { companyName, companyLogo, companyOrPersonOptions, shouldForceCompany, fallbackCompanyName } = windowObject;
+	let { companyOrPerson } = windowObject;
 	if ( ( companyOrPerson === "company" && ( ! companyName && ! companyLogo ) && ! isStepFinished( STEPS.siteRepresentation ) ) || shouldForceCompany ) {
 		// Set the stage for a prefilled step 2 in case the customer does seem to have consciously finished step 2 without setting data.
 		companyOrPerson = "company";
@@ -138,6 +138,7 @@ function calculateInitialState( windowObject, isStepFinished ) {
 		errorFields: [],
 		stepErrors: {},
 		editedSteps: [],
+		companyName: companyName || fallbackCompanyName,
 	};
 }
 

--- a/packages/js/src/first-time-configuration/first-time-configuration-steps.js
+++ b/packages/js/src/first-time-configuration/first-time-configuration-steps.js
@@ -233,7 +233,7 @@ export default function FirstTimeConfigurationSteps() {
 	} );
 
 	const isCompanyAndEmpty = state.companyOrPerson === "company" && ( ! state.companyName || ( ! state.companyLogo && ! state.companyLogoFallback ) || ! state.websiteName );
-	const isPersonAndEmpty = state.companyOrPerson === "person" && ( ! state.personId || ( ! state.personLogo && ! state.personLogoFallback ) );
+	const isPersonAndEmpty = state.companyOrPerson === "person" && ( ! state.personId || ( ! state.personLogo && ! state.personLogoFallback ) || ! state.websiteName );
 
 	/**
 	 * Runs checks of finishing the site representation step.

--- a/packages/js/src/first-time-configuration/first-time-configuration-steps.js
+++ b/packages/js/src/first-time-configuration/first-time-configuration-steps.js
@@ -223,7 +223,7 @@ export default function FirstTimeConfigurationSteps() {
 		dispatch( { type: "SET_ERROR_FIELDS", payload: value } );
 	} );
 
-	const isCompanyAndEmpty = state.companyOrPerson === "company" && ( ! state.companyName || ( ! state.companyLogo && ! state.companyLogoFallback ) );
+	const isCompanyAndEmpty = state.companyOrPerson === "company" && ( ! state.companyName || ( ! state.companyLogo && ! state.companyLogoFallback ) || ! state.websiteName );
 	const isPersonAndEmpty = state.companyOrPerson === "person" && ( ! state.personId || ( ! state.personLogo && ! state.personLogoFallback ) );
 
 	/**

--- a/packages/js/src/first-time-configuration/tailwind-components/steps/site-representation/site-representation-step.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/steps/site-representation/site-representation-step.js
@@ -104,7 +104,7 @@ export default function SiteRepresentationStep( { onOrganizationOrPersonChange, 
 			id="website-name-input"
 			name="website-name"
 			label={ __( "Website name", "wordpress-seo" ) }
-			value={ ( state.websiteName === "" ) ? state.fallbackWebsiteName : state.websiteName }
+			value={ state.websiteName || state.fallbackWebsiteName }
 			onChange={ handleWebsiteNameChange }
 			feedback={ {
 				isVisible: state.errorFields.includes( "website_name" ),


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Fix initial state for site name based on fallback on site representation step in first time configuration. 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where initial state for site name would be empty when saving site representation step in first time configuration. 

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Reset First time configuration process and reset the options using the Yoast helper.
* Go to `Yoast SEO`->`General`->`First time configuration`
* Proceed to Site representation step.

### Organization
* Do not change the Site name, keep the defaults add an image.
* Save
* Check you do not get the warning: `Please be aware that you need to fill out all settings in this step to get the most value out of structured data...`
* Try to save when any of the fields is empty and check you are getting the warning message again.
* In order to check when Site Name field is empty, go to Settings->General and empty the Site Title field first.

### Person
* Rest FTC and Options
* Go to FTC->Site representation
* Change to Person
* Select a user
* Make sure there is no image
* Save 
* Check the warning appear.
* Save and continue
* Refresh the page
* Go back to site representation
* Empty the website name
* Add an image
* Save and continue
* Check you see the warning again.
 
#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
