### PR TITLE
Wincher/fix modal issues

### DIFF
--- a/packages/js/src/components/WincherRankingHistoryChart.js
+++ b/packages/js/src/components/WincherRankingHistoryChart.js
@@ -43,19 +43,23 @@ export default function WincherRankingHistoryChart( { datasets, isChartShown } )
 		return null;
 	}
 
-	const data = datasets.map( ( dataset, index ) => ( {
-		...dataset,
-		data: dataset.data.map( ( { datetime, value } ) => ( {
-			x: datetime,
-			y: value,
-		} ) ),
-		lineTension: 0,
-		pointRadius: 1,
-		pointHoverRadius: 4,
-		borderWidth: 2,
-		pointHitRadius: 6,
-		backgroundColor: CHART_COLORS[ index % CHART_COLORS.length ],
-	} ) ).filter( dataset => dataset.selected !== false );
+	const data = datasets.map( ( dataset, index ) => {
+		const color = CHART_COLORS[ index % CHART_COLORS.length ];
+		return {
+			...dataset,
+			data: dataset.data.map( ( { datetime, value } ) => ( {
+				x: datetime,
+				y: value,
+			} ) ),
+			lineTension: 0,
+			pointRadius: 1,
+			pointHoverRadius: 4,
+			borderWidth: 2,
+			pointHitRadius: 6,
+			backgroundColor: color,
+			borderColor: color,
+		};
+	} ).filter( dataset => dataset.selected !== false );
 
 	return (
 		<Line

--- a/packages/js/src/components/WincherRankingHistoryChart.js
+++ b/packages/js/src/components/WincherRankingHistoryChart.js
@@ -1,4 +1,5 @@
 /* External dependencies */
+import { useMemo } from "@wordpress/element";
 import { Line } from "react-chartjs-2";
 import { CategoryScale, Chart, LineController,	LineElement, LinearScale, PointElement, TimeScale, Legend, Tooltip, Interaction } from "chart.js";
 import "chartjs-adapter-moment";
@@ -77,13 +78,18 @@ Interaction.modes.xPoint = ( chart, e, _, useFinalPosition ) => {
  *
  * @returns {null|wp.Element} The Wincher ranking history chart.
  */
-export default function WincherRankingHistoryChart( { datasets, isChartShown } ) {
+export default function WincherRankingHistoryChart( { datasets, isChartShown, keyphrases } ) {
 	if ( ! isChartShown ) {
 		return null;
 	}
 
-	const data = datasets.map( ( dataset, index ) => {
-		const color = CHART_COLORS[ index % CHART_COLORS.length ];
+	const colors = useMemo( () => Object.fromEntries(
+		[ ...keyphrases ].sort()
+			.map( ( keyphrase, index ) => [ keyphrase, CHART_COLORS[ index % CHART_COLORS.length ] ] )
+	), [ keyphrases ] );
+
+	const data = datasets.map( ( dataset ) => {
+		const color = colors[ dataset.label ];
 		return {
 			...dataset,
 			data: dataset.data.map( ( { datetime, value } ) => ( {
@@ -180,4 +186,5 @@ WincherRankingHistoryChart.propTypes = {
 		} )
 	).isRequired,
 	isChartShown: PropTypes.bool.isRequired,
+	keyphrases: PropTypes.array.isRequired,
 };

--- a/packages/js/src/components/WincherRankingHistoryChart.js
+++ b/packages/js/src/components/WincherRankingHistoryChart.js
@@ -120,6 +120,7 @@ export default function WincherRankingHistoryChart( { datasets, isChartShown } )
 							precision: 0,
 							color: "black",
 						},
+						max: 101,
 					},
 				},
 			} }

--- a/packages/js/src/components/WincherSEOPerformance.js
+++ b/packages/js/src/components/WincherSEOPerformance.js
@@ -5,7 +5,7 @@ import { useCallback, useEffect, useMemo, useState } from "@wordpress/element";
 import { usePrevious } from "@wordpress/compose";
 import { __, sprintf } from "@wordpress/i18n";
 import PropTypes from "prop-types";
-import { isEmpty, orderBy } from "lodash";
+import { difference, isEmpty, orderBy } from "lodash";
 import styled from "styled-components";
 import moment from "moment";
 
@@ -357,7 +357,7 @@ const TableContent = ( props ) => {
 	const trackedKeyphrasesPrev = usePrevious( trackedKeyphrases );
 
 	useEffect( () => {
-		if ( ! isEmpty( trackedKeyphrases ) && Object.values( trackedKeyphrases ).length !== ( trackedKeyphrasesPrev || [] ).length ) {
+		if ( ! isEmpty( trackedKeyphrases ) && difference( Object.keys( trackedKeyphrases ), Object.keys( trackedKeyphrasesPrev || [] ) ).length ) {
 			const keywords = Object.values( trackedKeyphrases ).map( keyphrase => keyphrase.keyword );
 			setSelectedKeyphrases( keywords );
 		}

--- a/packages/js/src/components/WincherSEOPerformance.js
+++ b/packages/js/src/components/WincherSEOPerformance.js
@@ -408,6 +408,7 @@ const TableContent = ( props ) => {
 			<WincherRankingHistoryChart
 				isChartShown={ isChartShown }
 				datasets={ chartData }
+				keyphrases={ keyphrases }
 			/>
 		</ChartWrapper>
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

Fixes issues:
- https://github.com/Yoast/wordpress-seo/issues/20819
- https://github.com/Yoast/wordpress-seo/issues/20820
- https://github.com/Yoast/wordpress-seo/issues/20821

Also sets a max of 101 to the y-axis in the rankings chart

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

- Sets y-axis max value to 101 in ranking chart
- Fixes keyphrases being selected on period change in Wincher modal
- Fixes border color in Wincher modal
- Fixes many points of the same keyphrase being displayed in the Wincher chart tooltip

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

- Enable Wincher integration
- Create a new  post
- Add many keyphrases
- Click on Track SEO Performance
- Select all keyphrases if they are not already selected
- Check color border of each series is matching the series color in the legend.
- Check no many points of the same keyphrase are displayed when there are lots of keywords (e.g. select Last year period)
- Deselect keyphrases and keep one keyphrase selected. Change period. Check keyphrases are not selected back.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #

https://www.loom.com/share/83bcc018055d4fb38b6a090fe99775e3