### PR TITLE
Add indexation disabled check before showing user an alert

### DIFF
--- a/packages/js/src/first-time-configuration/first-time-configuration-steps.js
+++ b/packages/js/src/first-time-configuration/first-time-configuration-steps.js
@@ -366,7 +366,9 @@ export default function FirstTimeConfigurationSteps() {
 	 * @returns {boolean} Whether the stepper can continue to the next step.
 	 */
 	function beforeContinueIndexationStep() {
-		if ( ! showRunIndexationAlert && indexingState === "idle" ) {
+		// When: not already showing the alert AND indexation state is "idle" (not yet interacted with) AND indexation is not disabled.
+		if ( ! showRunIndexationAlert && indexingState === "idle" && window.yoastIndexingData.disabled !== "1" ) {
+			// Then: show an alert to notify users that indexation is helpful.
 			setShowRunIndexationAlert( true );
 			return false;
 		}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Removes a superfluous warning in the first time configuration when the site environment is non-production.

## Relevant technical choices:

* I continued with the `window.` side-effects pattern instead of abstracting that out of the components because they are already used throughout. The `amount` of the `yoastIndexingData` as well as a lot from `wpseoFirstTimeConfigurationData`. For the sake of keeping this small.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

Be sure to test this on a non-production environment.

#### Issue goal
* Using the Yoast test helper:
  * Under Yoast SEO:
    * Click `Reset Indexables tables & migrations` to clear the data optimization progress
    * Click `Reset First time configuration progress` to start on step one
  * Under Development settings:
    * Deactivate `Enable development mode.`
* Go to Yoast SEO > General > First-time configuration
* Verify the `Start SEO data optimization` button is disabled and you see the warning:
  * > SEO data optimization is disabled for non-production environments. 
* Click on `Continue`
* Verify you no longer get the extra warning, but go to site representation right away (the next step)

#### Regression test for "production" environment
* Using the Yoast test helper, under development settings:
  * Activate `Enable development mode.`
  * Click on `Save`
* Go to Yoast SEO > General > First-time configuration
* Verify the `Start SEO data optimization` button is enabled and you don't see the previous warning, only:
  * > This feature includes and replaces the Text Link Counter and Internal Linking Analysis
* Click on `Continue`
* Verify you get the warning:
  * > Be aware that you should run the SEO data optimization for this configuration to take maximum effect.
* Click on `Start SEO data optimization`
* Verify the warnings disappear 
* Click on `Continue`
* Verify you went to the next step (site representation)

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The first-time-configuration

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/growth/issues/58
