### PR TITLE
Use the Person piece only for publishers.

### DIFF
--- a/src/generators/schema/person.php
+++ b/src/generators/schema/person.php
@@ -46,7 +46,7 @@ class Person extends Abstract_Schema_Piece {
 			return false;
 		}
 
-		return $this->context->site_represents === 'person' || $this->context->indexable->object_type === 'user';
+		return $this->context->site_represents === 'person';
 	}
 
 	/**

--- a/tests/unit/generators/schema/person-test.php
+++ b/tests/unit/generators/schema/person-test.php
@@ -394,20 +394,6 @@ class Person_Test extends TestCase {
 	}
 
 	/**
-	 * Tests whether the person Schema piece is shown on author archive pages.
-	 *
-	 * @covers ::is_needed
-	 * @covers ::site_represents_current_author
-	 */
-	public function test_is_shown_on_author_archive_pages() {
-		$this->instance->context->indexable = (object) [
-			'object_type' => 'user',
-		];
-
-		$this->assertTrue( $this->instance->is_needed( $this->instance->context ) );
-	}
-
-	/**
 	 * Tests is not needed when the site represents an organization.
 	 *
 	 * @covers ::is_needed


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The `Person` schema piece is wrongly generated on authors archive pages ( so when `indexable type = 'user'`) and the site was previously setup to represent a Person different than the author. We want to avoid this.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where an additional `Organization, Person` schema piece is wrongly generated for author pages in case a website representing an organization was previously set to represent a person different than the author.

## Relevant technical choices:

* The `is_needed` method  of the `Person` schema piece generator has been updated to not take into account the case in which `indexable_type = 'user'`. This is because this piece, being of type `Organization, Person` is meant to represent the website publisher in case the website represents a person. Giving the fact we create a `'user'` indexable only for authors, the case is covered by the `Author` schema piece generator.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

### Without this PR - reproduce the bug
* Make sure you have at least two authors  in your website
* Go to `Yoast SEO` -> `General` `First-time configuration` tab
* Perform the SEO optimization in step 1
* In step 2 `Site representation` choose the website to represent a person and choose an author
* Specify the website name and select a picture for the author
* Finish the first-time configuration
* Edit the `Site representation` step and change the website to represent an organization
* Set both the organization name and the organization logo, then save the changes
* Now visit an author archive page for an author different than the one you have previously selected to be represented by the webpage
  * Verify that you still have a schema piece of type `Organization, Person` representing the previously selected author

### With this PR
* Again, visit an author archive page for an author different than the one you have previously selected to be represented by the webpage
  * Verify that the schema piece of type `Organization, Person` representing the previously selected author is not generated anymore


#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Please perform a regression test on schema generation

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.
* [X] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/wordpress-seo/issues/20601
