### PR TITLE
Adds extra security to new API Endpoint.

### DIFF
--- a/src/introductions/application/introductions-collector.php
+++ b/src/introductions/application/introductions-collector.php
@@ -109,4 +109,21 @@ class Introductions_Collector {
 
 		return false;
 	}
+
+	/**
+	 * Returns if the given introduction id is a know ID to the system.
+	 *
+	 * @param string $introduction_id The introduction id to check.
+	 *
+	 * @return bool
+	 */
+	public function is_available_introduction( string $introduction_id ): bool {
+		foreach ( $this->introductions as $introduction ) {
+			if ( $introduction->get_id() === $introduction_id ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
 }

--- a/src/introductions/application/introductions-collector.php
+++ b/src/introductions/application/introductions-collector.php
@@ -111,9 +111,9 @@ class Introductions_Collector {
 	}
 
 	/**
-	 * Returns if the given introduction id is a know ID to the system.
+	 * Checks if the given introduction ID is a known ID to the system.
 	 *
-	 * @param string $introduction_id The introduction id to check.
+	 * @param string $introduction_id The introduction ID to check.
 	 *
 	 * @return bool
 	 */

--- a/tests/unit/introductions/application/introductions-collector-test.php
+++ b/tests/unit/introductions/application/introductions-collector-test.php
@@ -266,13 +266,13 @@ class Introductions_Collector_Test extends TestCase {
 		];
 
 		return [
-			'no introductions'        => [
+			'no introductions' => [
 				'initial_introductions'  => [],
 				'filtered_introductions' => [],
 				'to_test_introduction'   => '',
 				'expected_result'        => false,
 			],
-			'introduction is known'   => [
+			'introduction is known in initial introductions' => [
 				'initial_introductions'  => [
 					$introductions['test1'],
 				],
@@ -280,6 +280,17 @@ class Introductions_Collector_Test extends TestCase {
 					$introductions['test1'],
 				],
 				'to_test_introduction'   => $introductions['test1']->get_id(),
+				'expected_result'        => true,
+			],
+			'introduction is known in filtered introductions' => [
+				'initial_introductions'  => [
+					$introductions['test1'],
+				],
+				'filtered_introductions' => [
+					$introductions['test1'],
+					$introductions['test2'],
+				],
+				'to_test_introduction'   => $introductions['test2']->get_id(),
 				'expected_result'        => true,
 			],
 			'introduction is unknown' => [
@@ -290,7 +301,7 @@ class Introductions_Collector_Test extends TestCase {
 					$introductions['test1'],
 					$introductions['test2'],
 				],
-				'to_test_introduction'   => 'unknowintroduction',
+				'to_test_introduction'   => 'unknown-introduction',
 				'expected_result'        => false,
 			],
 		];

--- a/tests/unit/introductions/application/introductions-collector-test.php
+++ b/tests/unit/introductions/application/introductions-collector-test.php
@@ -222,4 +222,77 @@ class Introductions_Collector_Test extends TestCase {
 			],
 		];
 	}
+
+	/**
+	 * Tests the constructor and filter.
+	 *
+	 * @covers ::__construct
+	 * @covers ::add_introductions
+	 * @covers ::is_available_introduction
+	 *
+	 * @dataProvider collector_is_available_introduction_data
+	 *
+	 * @param array $initial_introductions  The introductions via dependency injection.
+	 * @param array $filtered_introductions The introductions after the filter.
+	 * @param mixed $to_test_introduction   The given introduction to check against.
+	 * @param array $expected_result        The array with the applicable introduction data.
+	 *
+	 * @return void
+	 */
+	public function test_is_available_introduction(
+		$initial_introductions,
+		$filtered_introductions,
+		$to_test_introduction,
+		$expected_result
+	) {
+		Monkey\Filters\expectApplied( 'wpseo_introductions' )
+			->once()
+			->with( $initial_introductions )
+			->andReturn( $filtered_introductions );
+
+		$sut = new Introductions_Collector( ...$initial_introductions );
+		$this->assertEquals( $expected_result, $sut->is_available_introduction( $to_test_introduction ) );
+	}
+
+	/**
+	 * Data provider for the `test_is_available_introduction()` test.
+	 *
+	 * @return array
+	 */
+	public function collector_is_available_introduction_data() {
+		$introductions = [
+			'test1' => new Introduction_Mock( 'test1', 1, true ),
+			'test2' => new Introduction_Mock( 'test2', 2, true ),
+		];
+
+		return [
+			'no introductions'        => [
+				'initial_introductions'  => [],
+				'filtered_introductions' => [],
+				'to_test_introduction'   => '',
+				'expected_result'        => false,
+			],
+			'introduction is known'   => [
+				'initial_introductions'  => [
+					$introductions['test1'],
+				],
+				'filtered_introductions' => [
+					$introductions['test1'],
+				],
+				'to_test_introduction'   => $introductions['test1']->get_id(),
+				'expected_result'        => true,
+			],
+			'introduction is unknown' => [
+				'initial_introductions'  => [
+					$introductions['test1'],
+				],
+				'filtered_introductions' => [
+					$introductions['test1'],
+					$introductions['test2'],
+				],
+				'to_test_introduction'   => 'unknowintroduction',
+				'expected_result'        => false,
+			],
+		];
+	}
 }

--- a/tests/unit/introductions/user-interface/introductions-seen-route-test.php
+++ b/tests/unit/introductions/user-interface/introductions-seen-route-test.php
@@ -269,7 +269,6 @@ class Introductions_Seen_Route_Test extends TestCase {
 	 * @covers ::set_introduction_seen
 	 */
 	public function test_set_introduction_seen_invalid_id() {
-		$user_id         = 1;
 		$introduction_id = 'intro';
 		$this->introductions_collector->expects( 'is_available_introduction' )->with( $introduction_id )->andReturnFalse();
 		$this->introductions_seen_repository

--- a/tests/unit/introductions/user-interface/introductions-seen-route-test.php
+++ b/tests/unit/introductions/user-interface/introductions-seen-route-test.php
@@ -9,6 +9,7 @@ use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;
 use Yoast\WP\SEO\Helpers\User_Helper;
+use Yoast\WP\SEO\Introductions\Application\Introductions_Collector;
 use Yoast\WP\SEO\Introductions\Infrastructure\Introductions_Seen_Repository;
 use Yoast\WP\SEO\Introductions\User_Interface\Introductions_Seen_Route;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
@@ -44,6 +45,13 @@ class Introductions_Seen_Route_Test extends TestCase {
 	private $introductions_seen_repository;
 
 	/**
+	 * Holds the introductions seen repository.
+	 *
+	 * @var \Mockery\MockInterface|\Yoast\WP\SEO\Introductions\Application\Introductions_Collector
+	 */
+	private $introductions_collector;
+
+	/**
 	 * Sets up the test fixtures.
 	 */
 	protected function set_up() {
@@ -53,8 +61,9 @@ class Introductions_Seen_Route_Test extends TestCase {
 
 		$this->introductions_seen_repository = Mockery::mock( Introductions_Seen_Repository::class );
 		$this->user_helper                   = Mockery::mock( User_Helper::class );
+		$this->introductions_collector       = Mockery::mock( Introductions_Collector::class );
 
-		$this->instance = new Introductions_Seen_Route( $this->introductions_seen_repository, $this->user_helper );
+		$this->instance = new Introductions_Seen_Route( $this->introductions_seen_repository, $this->user_helper, $this->introductions_collector );
 	}
 
 	/**
@@ -138,6 +147,7 @@ class Introductions_Seen_Route_Test extends TestCase {
 		$user_id         = 1;
 		$introduction_id = 'intro';
 		$this->user_helper->expects( 'get_current_user_id' )->andReturn( $user_id );
+		$this->introductions_collector->expects( 'is_available_introduction' )->with( $introduction_id )->andReturnTrue();
 		$this->introductions_seen_repository
 			->expects( 'set_introduction' )
 			->once()
@@ -183,6 +193,7 @@ class Introductions_Seen_Route_Test extends TestCase {
 		$user_id         = 1;
 		$introduction_id = 'intro';
 		$this->user_helper->expects( 'get_current_user_id' )->andReturn( $user_id );
+		$this->introductions_collector->expects( 'is_available_introduction' )->with( $introduction_id )->andReturnTrue();
 		$this->introductions_seen_repository
 			->expects( 'set_introduction' )
 			->once()
@@ -228,6 +239,7 @@ class Introductions_Seen_Route_Test extends TestCase {
 		$user_id         = -1;
 		$introduction_id = 'intro';
 		$this->user_helper->expects( 'get_current_user_id' )->andReturn( $user_id );
+		$this->introductions_collector->expects( 'is_available_introduction' )->with( $introduction_id )->andReturnTrue();
 		$this->introductions_seen_repository
 			->expects( 'set_introduction' )
 			->once()
@@ -247,6 +259,44 @@ class Introductions_Seen_Route_Test extends TestCase {
 
 		$this->assertInstanceOf(
 			'WP_Error',
+			$this->instance->set_introduction_seen( $wp_rest_request )
+		);
+	}
+
+	/**
+	 * Tests the set_introduction_seen route's happy path.
+	 *
+	 * @covers ::set_introduction_seen
+	 */
+	public function test_set_introduction_seen_invalid_id() {
+		$user_id         = 1;
+		$introduction_id = 'intro';
+		$this->introductions_collector->expects( 'is_available_introduction' )->with( $introduction_id )->andReturnFalse();
+		$this->introductions_seen_repository
+			->expects( 'set_introduction' )
+			->never();
+		$wp_rest_response_mock = Mockery::mock( 'overload:' . WP_REST_Response::class );
+		$wp_rest_response_mock
+			->expects( '__construct' )
+			->with(
+				[],
+				400
+			)
+			->once();
+
+		$wp_rest_request = Mockery::mock( WP_REST_Request::class );
+		$wp_rest_request
+			->expects( 'get_params' )
+			->once()
+			->andReturn(
+				[
+					'introduction_id' => $introduction_id,
+					'is_seen'         => true,
+				]
+			);
+
+		$this->assertInstanceOf(
+			'WP_REST_Response',
 			$this->instance->set_introduction_seen( $wp_rest_request )
 		);
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to make sure that the given introduction ID is an ID we expect, so that malicious users can not spam the database with unknown IDs.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds additional security to an unreleased API endpoint.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

🗒️ To send an authorized POST request create an "application password" for your user in `/wp-admin/profile.php` and use that with Basic Auth to authenticate yourself. You can use e.g. [Postman](https://www.postman.com/downloads/) to easily send these POST requests.

* Send an authorized POST request to `/wp-json/yoast/v1/introductions/<RANDOM_STRING>/seen`.
* Check the `usermeta` table in your database for the `_yoast_wpseo_introductions` key for the user that was used to send the request.
* See that the `RANDOM_STRING` you passed is **not** stored.
* Reset your notifications by deleting the `_yoast_wpseo_introductions` row from the database.
* With only Free installed, go to the Yoast dashboard (any page) and dismiss the AI upsell. Make sure that the upsell does not show up again after a refresh.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [x] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [X] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/plugins-automated-testing/issues/1178
