### PR TITLE
No longer presume the event is defined

### DIFF
--- a/packages/js/src/components/modals/editorModals/EditorModal.js
+++ b/packages/js/src/components/modals/editorModals/EditorModal.js
@@ -16,7 +16,7 @@ import { LocationProvider } from "@yoast/externals/contexts";
  */
 export const isCloseEvent = ( event ) => {
 	let shouldClose = true;
-	if ( event.type === "blur" ) {
+	if ( event?.type === "blur" ) {
 		// Catch any blur events that are not supposed to blur to modal, by identifying the clicked item.
 		const { relatedTarget } = event;
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* I don't quite follow what happened in WP 6.4, but something with detecting which level requested the modal closing made the event not always be defined anymore. I'm thinking we hit [this fallback](https://github.com/WordPress/gutenberg/pull/51602/files#diff-7d9147900701280de3fb09897ba9b4e36f424b18412332fc2f72774ef1afe035R47) in our EditorModal. Now added a safety check in our code.
* This error was only in our EditorModal, which is used in the Wincher and Insights (sidebar only) modals. As well as in our search and social modals (in the sidebar). However, the latter two are set to not close on click outside (due to something in Elementor).
  * Also, this component is being exposed via `editorModules`. But not actually used it seems. Not that important here due to fix being inside the EditorModal component itself.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes the console error output due to a change in the WP modal included in WP 6.4.

## Relevant technical choices:

* The fix is very straight forward, no problems with WP 6.3 or anything like that.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Edit a post
* Ensure you have a keyphrase to be able to open the Wincher modal
* Ensure you have the browser console opened
* Click on `Track SEO performance` to open the Wincher modal
* Click outside of the modal to close it again
* Verify the errors no longer show in the browser console
* Do the same for the Insights modal, in the sidebar

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [x] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Our EditorModal component.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/plugins-automated-testing/issues/1175
