### PR TITLE
Insights: Watches all data/modifications instead of just the editor content

### DIFF
--- a/packages/js/src/elementor.js
+++ b/packages/js/src/elementor.js
@@ -5,7 +5,7 @@ import initializeAiGenerator from "./ai-generator/initialize";
 import initEditorStore from "./elementor/initializers/editor-store";
 import initHighlightFocusKeyphraseForms from "./elementor/initializers/highlightFocusKeyphraseForms";
 import initializeIntroduction from "./elementor/initializers/introduction";
-import { applyModifications, pluginReady, pluginReloaded, registerModification, registerPlugin } from "./elementor/initializers/pluggable";
+import { applyModifications, pluginReady, pluginReloaded, registerModification, registerPlugin } from "./initializers/pluggable";
 import initializeUsedKeywords from "./elementor/initializers/used-keywords-assessment";
 import initReplaceVarPlugin, { addReplacement, ReplaceVar } from "./elementor/replaceVars/elementor-replacevar-plugin";
 import { isWordProofIntegrationActive } from "./helpers/wordproof";

--- a/packages/js/src/elementor/containers/SnippetEditor.js
+++ b/packages/js/src/elementor/containers/SnippetEditor.js
@@ -7,7 +7,7 @@ import PropTypes from "prop-types";
 import SnippetPreviewSection from "../../components/SnippetPreviewSection";
 import withLocation from "../../helpers/withLocation";
 import { strings } from "@yoast/helpers";
-import { applyModifications } from "../initializers/pluggable";
+import { applyModifications } from "../../initializers/pluggable";
 import { getCurrentReplacementVariablesForEditor } from "../replaceVars/elementor-replacevar-plugin";
 
 const { stripHTMLTags } = strings;

--- a/packages/js/src/elementor/redux/selectors/analysis.js
+++ b/packages/js/src/elementor/redux/selectors/analysis.js
@@ -2,7 +2,7 @@ import { strings } from "@yoast/helpers";
 import measureTextWidth from "../../../helpers/measureTextWidth";
 import { selectors } from "@yoast/externals/redux";
 
-import { applyModifications } from "../../initializers/pluggable";
+import { applyModifications } from "../../../initializers/pluggable";
 
 const {
 	getBaseUrlFromSettings,

--- a/packages/js/src/elementor/replaceVars/elementor-replacevar-plugin.js
+++ b/packages/js/src/elementor/replaceVars/elementor-replacevar-plugin.js
@@ -1,5 +1,5 @@
 import { get } from "lodash";
-import { registerPlugin, registerModification } from "../initializers/pluggable";
+import { registerPlugin, registerModification } from "../../initializers/pluggable";
 import * as replacementVariables from "../replaceVars/general";
 
 const PLUGIN_NAME = "replaceVariablePlugin";

--- a/packages/js/src/initializers/analysis.js
+++ b/packages/js/src/initializers/analysis.js
@@ -6,7 +6,7 @@ import { refreshDelay } from "../analysis/constants";
 import handleWorkerError from "../analysis/handleWorkerError";
 import { sortResultsByIdentifier } from "../analysis/refreshAnalysis";
 import { createAnalysisWorker, getAnalysisConfiguration } from "../analysis/worker";
-import { applyModifications } from "../elementor/initializers/pluggable";
+import { applyModifications } from "./pluggable";
 
 /**
  * Runs the analysis.

--- a/packages/js/src/initializers/pluggable.js
+++ b/packages/js/src/initializers/pluggable.js
@@ -1,5 +1,5 @@
 import { dispatch } from "@wordpress/data";
-import Pluggable from "../../lib/Pluggable";
+import Pluggable from "../lib/Pluggable";
 
 // Holds the singleton used in getPluggable.
 let pluggable = null;
@@ -11,8 +11,11 @@ let pluggable = null;
  */
 const getPluggable = () => {
 	if ( pluggable === null ) {
+		// Uses the initialized Pluggable plugin in `post-scraper.js` or `term-scraper.js` if available. If not, initiates a new Pluggable plugin.
 		const refresh = dispatch( "yoast-seo/editor" ).runAnalysis;
-		pluggable = new Pluggable( refresh );
+		pluggable = window.YoastSEO.app && window.YoastSEO.app.pluggable
+			? window.YoastSEO.app.pluggable
+			: new Pluggable( refresh );
 	}
 
 	return pluggable;
@@ -60,7 +63,7 @@ export const registerModification = ( modification, callable, pluginName, priori
 };
 
 /**
- * Register a plugin with YoastSEO.
+ * Registers a plugin with YoastSEO.
  *
  * A plugin can be declared "ready" right at registration or later using `this.ready`.
  *

--- a/packages/js/src/insights/initializer.js
+++ b/packages/js/src/insights/initializer.js
@@ -44,8 +44,8 @@ const createUpdater = () => {
  * @returns {function} The subscriber.
  */
 const createSubscriber = () => {
-	const { getEditorDataContent, getContentLocale } = select( "yoast-seo/editor" );
-	const collector = createCollector( getEditorDataContent, getContentLocale );
+	const { getContentLocale } = select( "yoast-seo/editor" );
+	const collector = createCollector( getContentLocale, collectData );
 	const updater = createUpdater();
 
 	// Force an initial update after 1.5 seconds.


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Previously, we only watched the editor content for updating the results in the Insights tab. In this PR, we instead watch the changes in the content **including the modifications**: the `collectData` function takes care of retrieving the content including the modifications (e.g. modifications/content from the ACF fields). This way, when there is a change in the ACF field for example, we would recalculate the analysis for Insights immediately without the need to save the post first.
* Also, previously, we would create a new `Pluggable` -- here we instead check if there is already a `Pluggable` on the window.
* Note that in this PR, we did **not** change anything in the calculation of prominent words, but the reading and word count should now be calculated correctly without requiring saving the post. In other words, https://github.com/Yoast/wordpress-seo-premium/issues/3982 remains unsolved after this PR. 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where modifications to the analysis data would not be included in the Insights analysis.
* [yoast-acf-analysis] Fixes a bug where content from custom fields would not be included in the Insights analysis.

## Relevant technical choices:

* For context: `getEditorDataContent` only retrieves the content from the main text editor. This is why we previously didn't update the analysis result in Insights when there is a change coming from a non-main text editor, like an ACF field.
* We have moved `packages/js/src/initializers/elementor/pluggable.js` up one level, as it’s also used in `packages/js/src/initializers/analysis.js`.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Test Insights with ACF plugin in a Post
NOTE: repeat the testing instructions below in both Classic and Block editor and confirm that you get the same result.
* Install and activate Yoast SEO, Yoast SEO Premium, Advanced Custom Fields, ACF Content Analysis for Yoast SEO
* Create a custom field (if you don't have one).
   * Go to ACF in your dashboard.
   * Add a new field group.
   * Go to settings for this field group and make sure it is available for post, product, and taxonomy in order to be able to fully test it. See screenshot below.
   * Within the field group add a new field. It is easiest if the field type is set to "text area".
   * If you open a post/page/product with classic editor, the the field should appear at the bottom.
<img width="1241" alt="Screenshot 2023-11-10 at 14 29 14" src="https://github.com/Yoast/wordpress-seo/assets/48715883/98f39354-6f66-483e-851e-cf66fb1bd817">

* Toggle on the Insights feature card in Yoast SEO settings.
* Create a post in Classic editor/Block editor.
* Don't add any content in the Text editor.
* Add the following text to the custom field you previously created:

```
Passiflora, known also as the passion flowers or passion vines, is a genus of about 550 species of flowering plants, the type genus of the family Passifloraceae.

They are mostly tendril-bearing vines, with some being shrubs or trees. They can be woody or herbaceous. Passion flowers produce regular and usually showy flowers with a distinctive corona. There can be as many as eight coronal series, as in the case of P. xiikzodz. The flower is pentamerous and ripens into an indehiscent fruit with numerous seeds.

Passion flowers have floral structures adapted for biotic pollination. Pollinators of Passiflora include bumblebees, carpenter bees (e.g., Xylocopa sonorina), wasps, bats, and hummingbirds (especially hermits such as Phaethornis); some others are additionally capable of self-pollination. Passiflora often exhibit high levels of pollinator specificity, which has led to frequent coevolution across the genus. The sword-billed hummingbird (Ensifera ensifera) is a notable example: it, with its immensely elongated bill, is the sole pollinator of 37 species of high Andean Passiflora in the supersection Tacsonia.

Bud of the passion flower

Passion flower bloom in water
The leaves are used for feeding by the larvae of a number of species of Lepidoptera. Famously, they are exclusively targeted by many butterfly species of the tribe Heliconiini. The many defensive adaptations visible on Passiflora include diverse leaf shapes (which help disguise their identity), colored nubs (which mimic butterfly eggs and can deter Heliconians from ovipositing on a seemingly crowded leaf), extrafloral nectaries, trichomes, variegation, and chemical defenses. These, combined with adaptations on the part of the butterflies, were important in the foundation of coevolutionary theory.
The generally high pollinator and parasite specificity in Passiflora may have led to the tremendous morphological variation in the genus. It is thought to have among the highest foliar diversity among all plant genera, with leaf shapes ranging from unlobed to five-lobed frequently found on the same plant. Coevolution can be a major driver of speciation, and may be responsible for the radiation of certain clades of Passiflora such as Tacsonia.
```

* **Don't save the changes yet**.
   * This is to make sure that the changes in the ACF field will update the analysis result both in the assessment analysis result and Insights analysis without the need to save the changes first. 
* Confirm that the _text length assessment_ recognizes that there are 335 words in the text.
* Confirm that in the _Insights_ modal, the word count shows 335 words.
* Save your post.
* Confirm that the _text length assessment_ recognizes that there are 335 words in the text.
* Confirm that in the _Insights_ modal, the word count shows 335 words.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [x] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The calculation of results for the Insights tab.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/wordpress-seo-premium/issues/3829