### PR TITLE
GH Actions: enable linting and testing against PHP 8.3

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,7 +37,7 @@ jobs:
       matrix:
         # Lint against the highest/lowest supported versions of each PHP major.
         # And also do a run against "nightly" (the current dev version of PHP).
-        php_version: ["7.2", "7.4", "8.0", "8.1", "8.2"]
+        php_version: ["7.2", "7.4", "8.0", "8.2", "8.3"]
 
     name: "Lint: PHP ${{ matrix.php_version }}"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,14 +47,14 @@ jobs:
 
     strategy:
       matrix:
-        php_version: ["7.4", "8.0", "8.1"]
+        php_version: ["7.4", "8.0", "8.2"]
         coverage: [false]
 
         # Run code coverage only on high/low PHP.
         include:
         - php_version: 7.2
           coverage: true
-        - php_version: 8.2
+        - php_version: 8.3
           coverage: true
 
     name: "Unit Test: PHP ${{ matrix.php_version }}"
@@ -164,6 +164,12 @@ jobs:
 
           - php_version: "8.2"
             wp_version: "6.3"
+            multisite: true
+            coverage: false
+
+          # WP 6.4 is the earliest version which supports PHP 8.3.
+          - php_version: '8.3'
+            wp_version: 'trunk'
             multisite: true
             coverage: true
 


### PR DESCRIPTION
## Context

* Ensure compatibility with all supported PHP versions

## Summary

This PR can be summarized in the following changelog entry:

* The plugin has no known incompatibilities with PHP 8.3

## Relevant technical choices:

* As the PHP 8.3 builds pass and the PHP 8.3 release is expected later this week, the builds are not _allowed to fail_.
* Update PHP version on which code coverage is run (high should now be 8.3 what with the release this week).


## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_ If the builds pass, we're good.