### PR TITLE
Tests/WP: remove some redundant skip conditions

### DIFF
--- a/tests/integration/admin/import/test-class-import-settings.php
+++ b/tests/integration/admin/import/test-class-import-settings.php
@@ -34,10 +34,6 @@ class WPSEO_Import_Settings_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Import_Settings::parse_options
 	 */
 	public function test_parse_options_empty() {
-		if ( version_compare( PHP_VERSION, '5.3', '<' ) ) {
-			$this->markTestSkipped( 'Not possible in PHP 5.2' );
-		}
-
 		$this->class_instance->parse_options( '' );
 
 		$this->assertEquals( false, $this->class_instance->status->status );
@@ -49,10 +45,6 @@ class WPSEO_Import_Settings_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Import_Settings::parse_options
 	 */
 	public function test_parse_options() {
-		if ( version_compare( PHP_VERSION, '5.3', '<' ) ) {
-			$this->markTestSkipped( 'Not possible in PHP 5.2' );
-		}
-
 		$this->assertEquals( true, WPSEO_Options::get( 'enable_admin_bar_menu' ) );
 
 		$settings = <<<'EO_DATA'
@@ -75,10 +67,6 @@ EO_DATA;
 	 * @covers WPSEO_Import_Settings::parse_options
 	 */
 	public function test_parse_options_invalid() {
-		if ( version_compare( PHP_VERSION, '5.3', '<' ) ) {
-			$this->markTestSkipped( 'Not possible in PHP 5.2' );
-		}
-
 		$settings = <<<'EO_DATA'
 Not a valid INI file format...
 EO_DATA;


### PR DESCRIPTION


## Context

* Minor test cleanup

## Summary

This PR can be summarized in the following changelog entry:

* Minor test cleanup


## Relevant technical choices:

Support for PHP < 5.3 was dropped long ago.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_ If the tests pass, we're good.