### PR TITLE
Reimplement proof-of-concept for highlighting in Elementor#4125

### DIFF
--- a/packages/js/src/analysis/getApplyMarks.js
+++ b/packages/js/src/analysis/getApplyMarks.js
@@ -4,6 +4,7 @@ import { select } from "@wordpress/data";
 import * as tinyMCEHelper from "../lib/tinymce";
 import { tinyMCEDecorator } from "../decorator/tinyMCE";
 import { isAnnotationAvailable, applyAsAnnotations } from "../decorator/gutenberg";
+import { doAction } from "@wordpress/hooks";
 
 /**
  * Create decorators for each editor and applies marks to each editor
@@ -49,6 +50,8 @@ function applyMarks( paper, marks ) {
 		// Apply marks to other blocks
 		applyAsAnnotations( marks );
 	}
+
+	doAction( "yoast.seo.applyMarks", marks );
 }
 
 /**

--- a/packages/js/src/analysis/getApplyMarks.js
+++ b/packages/js/src/analysis/getApplyMarks.js
@@ -51,7 +51,7 @@ function applyMarks( paper, marks ) {
 		applyAsAnnotations( marks );
 	}
 
-	doAction( "yoast.seo.applyMarks", marks );
+	doAction( "yoast.analysis.applyMarks", marks );
 }
 
 /**

--- a/packages/js/src/elementor/initializers/editor-store.js
+++ b/packages/js/src/elementor/initializers/editor-store.js
@@ -18,7 +18,7 @@ const populateStore = store => {
 	// Initialize the focus keyphrase.
 	store.dispatch( actions.loadFocusKeyword() );
 	// Hide marker buttons.
-	store.dispatch( actions.setMarkerStatus( "hidden" ) );
+	store.dispatch( actions.setMarkerStatus( "enabled" ) );
 
 	store.dispatch(
 		actions.setSettings( {

--- a/packages/js/src/elementor/initializers/editor-store.js
+++ b/packages/js/src/elementor/initializers/editor-store.js
@@ -17,7 +17,7 @@ const populateStore = store => {
 	store.dispatch( actions.loadCornerstoneContent() );
 	// Initialize the focus keyphrase.
 	store.dispatch( actions.loadFocusKeyword() );
-	// Hide marker buttons.
+	// Enable marker buttons.
 	store.dispatch( actions.setMarkerStatus( "enabled" ) );
 
 	store.dispatch(

--- a/packages/js/src/elementor/initializers/editor-store.js
+++ b/packages/js/src/elementor/initializers/editor-store.js
@@ -17,7 +17,7 @@ const populateStore = store => {
 	store.dispatch( actions.loadCornerstoneContent() );
 	// Initialize the focus keyphrase.
 	store.dispatch( actions.loadFocusKeyword() );
-	// Enable marker buttons.
+	// Show marker buttons.
 	store.dispatch( actions.setMarkerStatus( "enabled" ) );
 
 	store.dispatch(

--- a/packages/js/src/initializers/analysis.js
+++ b/packages/js/src/initializers/analysis.js
@@ -7,6 +7,7 @@ import handleWorkerError from "../analysis/handleWorkerError";
 import { sortResultsByIdentifier } from "../analysis/refreshAnalysis";
 import { createAnalysisWorker, getAnalysisConfiguration } from "../analysis/worker";
 import { applyModifications } from "./pluggable";
+import getApplyMarks from "../analysis/getApplyMarks";
 
 /**
  * Runs the analysis.
@@ -28,6 +29,11 @@ async function runAnalysis( worker, data ) {
 			// Only update the main results, which are located under the empty string key.
 			const seoResults = seo[ "" ];
 
+			// Recreate the getMarker function after the worker is done.
+			seoResults.results.forEach( result => {
+				result.getMarker = () => () => window.YoastSEO.analysis.applyMarks( paper, result.marks );
+			} );
+
 			seoResults.results = sortResultsByIdentifier( seoResults.results );
 
 			dispatch( "yoast-seo/editor" ).setSeoResultsForKeyword( paper.getKeyword(), seoResults.results );
@@ -35,6 +41,11 @@ async function runAnalysis( worker, data ) {
 		}
 
 		if ( readability ) {
+			// Recreate the getMarker function after the worker is done.
+			readability.results.forEach( result => {
+				result.getMarker = () => () => window.YoastSEO.analysis.applyMarks( paper, result.marks );
+			} );
+
 			readability.results = sortResultsByIdentifier( readability.results );
 
 			dispatch( "yoast-seo/editor" ).setReadabilityResults( readability.results );
@@ -42,6 +53,13 @@ async function runAnalysis( worker, data ) {
 		}
 
 		if ( inclusiveLanguage ) {
+			// Recreate the getMarker function after the worker is done.
+			inclusiveLanguage.results.forEach( result => {
+				result.getMarker = () => () => {
+					window.YoastSEO.analysis.applyMarks( paper, result.marks );
+				}
+			} );
+
 			inclusiveLanguage.results = sortResultsByIdentifier( inclusiveLanguage.results );
 
 			dispatch( "yoast-seo/editor" ).setInclusiveLanguageResults( inclusiveLanguage.results );
@@ -106,10 +124,14 @@ export default function initAnalysis() {
 	// Create and initialize the worker.
 	const worker = createAnalysisWorker();
 	worker.initialize(
-		// Get the analysis configuration and extend it with the is cornerstone content value.
-		getAnalysisConfiguration( { useCornerstone: isCornerstoneContent() } )
+		// Get the analysis configuration and extend it with the is cornerstone content value and the marker function.
+		getAnalysisConfiguration( {
+			useCornerstone: isCornerstoneContent(),
+			marker: getApplyMarks(),
+		} )
 	).catch( handleWorkerError );
 
+	window.YoastSEO.analysis.applyMarks = ( paper, marks ) => getApplyMarks()( paper, marks );
 	// Initialize the data for the "is dirty" checks.
 	let previousAnalysisData = collectData();
 	let previousIsCornerstone = isCornerstoneContent();

--- a/packages/js/src/initializers/analysis.js
+++ b/packages/js/src/initializers/analysis.js
@@ -55,9 +55,7 @@ async function runAnalysis( worker, data ) {
 		if ( inclusiveLanguage ) {
 			// Recreate the getMarker function after the worker is done.
 			inclusiveLanguage.results.forEach( result => {
-				result.getMarker = () => () => {
-					window.YoastSEO.analysis.applyMarks( paper, result.marks );
-				}
+				result.getMarker = () => () => window.YoastSEO.analysis.applyMarks( paper, result.marks );
 			} );
 
 			inclusiveLanguage.results = sortResultsByIdentifier( inclusiveLanguage.results );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to make the highlighting feature available in Elementor. For this, we already create a proof-of-concept (https://github.com/Yoast/lingo-other-tasks/issues/140, https://github.com/Yoast/wordpress-seo/pull/20632). In this PR, we add an action in Free, so we can add the highlighting funcionality in an add-on. This change will also allow developers to implement highlighting for other editors. 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds a JavaScript action (`yoast.analysis.applyMarks`) that allow users to implement the highlighting functionality in other editors. 

## Relevant technical choices:

* It's search based highlighting what was implemented as a proof-of-concept redesigned and code moved to premium.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Please check the Premium PR: https://github.com/Yoast/wordpress-seo-premium/pull/4141

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* 

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* It effects only Elementor highlighting functionality.

## UI changes

* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #4125
