### PR TITLE
Fix typos in inclusive language feedback

### DIFF
--- a/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/appearanceAssessmentsSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/appearanceAssessmentsSpec.js
@@ -121,7 +121,7 @@ describe( "A test for Appearance assessments", function() {
 	it( "should not target other grammatical forms of the phrases", function() {
 		const mockPaper = new Paper( "This ad is aimed at harelips." );
 		const mockResearcher = new EnglishResearcher( mockPaper );
-		const assessor = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "harelip" )  );
+		const assessor = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "harelip" ) );
 
 		const isApplicable = assessor.isApplicable( mockPaper, mockResearcher );
 

--- a/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/cultureAssessmentsSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/cultureAssessmentsSpec.js
@@ -518,7 +518,7 @@ describe( "a test for targeting non-inclusive phrases in culture assessments", (
 
 		);
 		expect( assessmentResult.hasMarks() ).toBeTruthy();
-		expect( assessor.getMarks() ).toEqual(   [ { _properties: {
+		expect( assessor.getMarks() ).toEqual( [ { _properties: {
 			fieldsToMark: [],
 			marked: "<yoastmark class='yoast-text-mark'>This sentence contains pow-wow.</yoastmark>",
 			original: "This sentence contains pow-wow." } } ]
@@ -540,7 +540,7 @@ describe( "a test for targeting non-inclusive phrases in culture assessments", (
 			"<a href='https://yoa.st/inclusive-language-culture' target='_blank'>Learn more.</a>"
 		);
 		expect( assessmentResult.hasMarks() ).toBeTruthy();
-		expect( assessor.getMarks() ).toEqual(   [ { _properties: {
+		expect( assessor.getMarks() ).toEqual( [ { _properties: {
 			fieldsToMark: [],
 			marked: "<yoastmark class='yoast-text-mark'>This sentence contains first-world.</yoastmark>",
 			original: "This sentence contains first-world." } } ]
@@ -562,7 +562,7 @@ describe( "a test for targeting non-inclusive phrases in culture assessments", (
 			"<a href='https://yoa.st/inclusive-language-culture' target='_blank'>Learn more.</a>"
 		);
 		expect( assessmentResult.hasMarks() ).toBeTruthy();
-		expect( assessor.getMarks() ).toEqual(   [ { _properties: {
+		expect( assessor.getMarks() ).toEqual( [ { _properties: {
 			fieldsToMark: [],
 			marked: "<yoastmark class='yoast-text-mark'>first world countries</yoastmark>",
 			original: "first world countries" } } ]
@@ -585,7 +585,7 @@ describe( "a test for targeting non-inclusive phrases in culture assessments", (
 
 		);
 		expect( assessmentResult.hasMarks() ).toBeTruthy();
-		expect( assessor.getMarks() ).toEqual(   [ { _properties: {
+		expect( assessor.getMarks() ).toEqual( [ { _properties: {
 			fieldsToMark: [],
 			marked: "<yoastmark class='yoast-text-mark'>This sentence contains third-world country.</yoastmark>",
 			original: "This sentence contains third-world country." } } ]

--- a/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessmentsSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessmentsSpec.js
@@ -244,7 +244,7 @@ describe( "A test for Disability assessments", function() {
 			"<a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>"
 		);
 		expect( assessmentResult.hasMarks() ).toBeTruthy();
-		expect( assessor.getMarks() ).toEqual(   [ { _properties: {
+		expect( assessor.getMarks() ).toEqual( [ { _properties: {
 			fieldsToMark: [],
 			marked: "<yoastmark class='yoast-text-mark'>This sentence contains wheelchair-bound.</yoastmark>",
 			original: "This sentence contains wheelchair-bound." } } ]
@@ -266,7 +266,7 @@ describe( "A test for Disability assessments", function() {
 			"<a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>"
 		);
 		expect( assessmentResult.hasMarks() ).toBeTruthy();
-		expect( assessor.getMarks() ).toEqual(   [ { _properties: {
+		expect( assessor.getMarks() ).toEqual( [ { _properties: {
 			fieldsToMark: [],
 			marked: "<yoastmark class='yoast-text-mark'>This sentence contains hard-of-hearing.</yoastmark>",
 			original: "This sentence contains hard-of-hearing." } } ]
@@ -289,7 +289,7 @@ describe( "A test for Disability assessments", function() {
 			"<a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>"
 		);
 		expect( assessmentResult.hasMarks() ).toBeTruthy();
-		expect( assessor.getMarks() ).toEqual(   [ { _properties: {
+		expect( assessor.getMarks() ).toEqual( [ { _properties: {
 			fieldsToMark: [],
 			marked: "<yoastmark class='yoast-text-mark'>This sentence contains high-functioning autism.</yoastmark>",
 			original: "This sentence contains high-functioning autism." } } ]
@@ -312,7 +312,7 @@ describe( "A test for Disability assessments", function() {
 			"<a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>"
 		);
 		expect( assessmentResult.hasMarks() ).toBeTruthy();
-		expect( assessor.getMarks() ).toEqual(   [ { _properties: {
+		expect( assessor.getMarks() ).toEqual( [ { _properties: {
 			fieldsToMark: [],
 			marked: "<yoastmark class='yoast-text-mark'>This sentence contains low-functioning autism.</yoastmark>",
 			original: "This sentence contains low-functioning autism." } } ]
@@ -335,7 +335,7 @@ describe( "A test for Disability assessments", function() {
 			"<a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>"
 		);
 		expect( assessmentResult.hasMarks() ).toBeTruthy();
-		expect( assessor.getMarks() ).toEqual(   [ { _properties: {
+		expect( assessor.getMarks() ).toEqual( [ { _properties: {
 			fieldsToMark: [],
 			marked: "<yoastmark class='yoast-text-mark'>This sentence contains brain-damaged.</yoastmark>",
 			original: "This sentence contains brain-damaged." } } ]
@@ -786,7 +786,7 @@ describe( "a test for targeting non-inclusive phrases in disability assessments"
 			"<a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>"
 		);
 		expect( assessmentResult.hasMarks() ).toBeTruthy();
-		expect( assessor.getMarks() ).toEqual(   [ { _properties: {
+		expect( assessor.getMarks() ).toEqual( [ { _properties: {
 			fieldsToMark: [],
 			marked: "<yoastmark class='yoast-text-mark'>This sentence contains differently-abled.</yoastmark>",
 			original: "This sentence contains differently-abled." } } ]

--- a/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessmentsSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessmentsSpec.js
@@ -410,7 +410,7 @@ describe( "a test for targeting non-inclusive phrases in disability assessments"
 				identifier: "cripple",
 				text: "He's afraid to look like a cripple.",
 				expectedFeedback: "Avoid using <i>a cripple</i> as it is derogatory. Consider using an alternative, such as " +
-					"<i>person with a physical disability, a physically disabled person</i> instead. " +
+					"<i>person with a physical disability, a physically disabled person</i>. " +
 					"<a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
 				expectedScore: 3,
 			},
@@ -1250,7 +1250,7 @@ describe( "a test for targeting non-inclusive phrases in disability assessments"
 		expect( assessment.isApplicable( mockPaper, mockResearcher ) ).toBe( true );
 		expect( assessment.getResult().score ).toBe( 3 );
 		expect( assessment.getResult().text ).toBe( "Avoid using <i>imbecile</i> as it is derogatory. Consider using an alternative, " +
-			"such as <i>uninformed, ignorant, foolish, inconsiderate, irrational, reckless</i> instead. " +
+			"such as <i>uninformed, ignorant, foolish, inconsiderate, irrational, reckless</i>. " +
 			"<a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>" );
 	} );
 } );

--- a/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessmentsSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessmentsSpec.js
@@ -881,28 +881,28 @@ describe( "a test for targeting non-inclusive phrases in disability assessments"
 		const testData = [
 			// The negated phrase for 'crazy about' without an intensifier.
 			{
-				identifier: "to be not crazy about",
+				identifier: "to not be crazy about",
 				text: "They are not crazy about this album.",
 				expectedFeedback: "Avoid using <i>crazy</i> as it is potentially harmful. " +
-					"Consider using an alternative, such as <i>to be not impressed by, to be not enthusiastic about, to be not into, " +
+					"Consider using an alternative, such as <i>to not be impressed by, to not be enthusiastic about, to not be into, " +
 					"to not like</i>. <a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
 				expectedScore: 3,
 			},
 			// The negated phrase for 'crazy about' with an intensifier.
 			{
-				identifier: "to be not crazy about",
+				identifier: "to not be crazy about",
 				text: "They are not too crazy about this album.",
 				expectedFeedback: "Avoid using <i>crazy</i> as it is potentially harmful. " +
-					"Consider using an alternative, such as <i>to be not impressed by, to be not enthusiastic about, to be not into, " +
+					"Consider using an alternative, such as <i>to not be impressed by, to not be enthusiastic about, to not be into, " +
 					"to not like</i>. <a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
 				expectedScore: 3,
 			},
 			// The contracted negated phrase for 'crazy about' with an intensifier.
 			{
-				identifier: "to be not crazy about",
+				identifier: "to not be crazy about",
 				text: "They aren't too crazy about this album.",
 				expectedFeedback: "Avoid using <i>crazy</i> as it is potentially harmful. " +
-					"Consider using an alternative, such as <i>to be not impressed by, to be not enthusiastic about, to be not into, " +
+					"Consider using an alternative, such as <i>to not be impressed by, to not be enthusiastic about, to not be into, " +
 					"to not like</i>. <a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
 				expectedScore: 3,
 			},
@@ -912,7 +912,7 @@ describe( "a test for targeting non-inclusive phrases in disability assessments"
 	it( "should not show the feedback for the negated form of 'crazy about' when the non-negated form is used.", () => {
 		const mockPaper = new Paper( "I am so crazy about this album." );
 		const mockResearcher = Factory.buildMockResearcher( [ "I am so crazy about this album." ] );
-		const assessor = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "to be not crazy about" ) );
+		const assessor = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "to not be crazy about" ) );
 		const isApplicable = assessor.isApplicable( mockPaper, mockResearcher );
 		expect( isApplicable ).toBeFalsy();
 	} );

--- a/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/genderAssessmentsSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/genderAssessmentsSpec.js
@@ -173,7 +173,7 @@ describe( "Tests for exclusionary and potentially exclusionary phrases", functio
 } );
 
 describe( "Tests for phrases that are exclusionary UNLESS there is a condition when they're acceptable", function() {
-	it( "targets  versions of the phrases 'men and women' and 'girls and boys'", () => {
+	it( "targets versions of the phrases 'men and women' and 'girls and boys'", () => {
 		const testData = [
 			{
 				identifier: "menAndWomen",
@@ -448,7 +448,7 @@ describe( "A test for Gender assessments", function() {
 	it( "should not target inclusive phrases", function() {
 		const mockPaper = new Paper( "Look at those firefighters! They're putting out the fire." );
 		const mockResearcher = Factory.buildMockResearcher( [ "Look at those firefighters!", "They're putting out the fire." ] );
-		const assessor = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "firemen" )  );
+		const assessor = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "firemen" ) );
 
 		const isApplicable = assessor.isApplicable( mockPaper, mockResearcher );
 

--- a/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/otherAssessmentsSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/otherAssessmentsSpec.js
@@ -136,7 +136,7 @@ describe( "Checks highlighting for 'minorities' and a non-triggering condition f
 		const mockText = "This ad is aimed at minorities.";
 		const mockPaper = new Paper( mockText );
 		const mockResearcher = new EnglishResearcher( mockPaper );
-		const assessor = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "minorities" )  );
+		const assessor = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "minorities" ) );
 
 		const isApplicable = assessor.isApplicable( mockPaper, mockResearcher );
 		const assessmentResult = assessor.getResult();

--- a/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/sesAssessmentsSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/sesAssessmentsSpec.js
@@ -308,7 +308,7 @@ describe( "a test for targeting non-inclusive phrases in other assessments", () 
 			" <a href='https://yoa.st/inclusive-language-ses' target='_blank'>Learn more.</a>"
 		);
 		expect( assessmentResult.hasMarks() ).toBeTruthy();
-		expect( assessor.getMarks() ).toEqual(   [ { _properties: {
+		expect( assessor.getMarks() ).toEqual( [ { _properties: {
 			fieldsToMark: [],
 			marked: "<yoastmark class='yoast-text-mark'>This sentence contains the undocumented.</yoastmark>",
 			original: "This sentence contains the undocumented." } } ]

--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessments.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessments.js
@@ -404,9 +404,9 @@ const disabilityAssessments =  [
 		feedbackFormat: potentiallyHarmful,
 	},
 	{
-		identifier: "to be not crazy about",
+		identifier: "to not be crazy about",
 		nonInclusivePhrases: [ "crazy about" ],
-		inclusiveAlternatives: "<i>to be not impressed by, to be not enthusiastic about, to be not into, to not like</i>",
+		inclusiveAlternatives: "<i>to not be impressed by, to not be enthusiastic about, to not be into, to not like</i>",
 		score: SCORES.NON_INCLUSIVE,
 		feedbackFormat: phrasesWithCrazyFeedback,
 		// Target only when preceded by a form of "to be", the negation "not", and an optional intensifier (e.g. "is not so crazy about" ).

--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessments.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessments.js
@@ -26,9 +26,9 @@ import { sprintf } from "@wordpress/i18n";
 /*
  * Used for derogatory terms, such as 'cripple'.
  *
- * "Avoid using <i>%1$s</i> as it is derogatory. Consider using an alternative, such as %2$s instead."
+ * "Avoid using <i>%1$s</i> as it is derogatory. Consider using an alternative, such as %2$s."
  */
-const derogatory = "Avoid using <i>%1$s</i> as it is derogatory. Consider using an alternative, such as %2$s instead.";
+const derogatory = "Avoid using <i>%1$s</i> as it is derogatory. Consider using an alternative, such as %2$s.";
 
 /*
  * Used for terms that are inclusive only if you are referring to a medical condition, for example 'manic' or 'OCD'.


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves the phrasing of some inclusive language feedback strings.

## Relevant technical choices:

* No feedback strings with double spaces were found, I only found some in the code for the unit tests.
* The word 'instead' was removed from the string `Avoid using <i>%1$s</i> as it is derogatory. Consider using an alternative, such as %2$s instead.` for consistency with other strings. 
     * Note that there are still some strings containing the word 'instead', such as: `Be careful when using <i>sociopath</i> as it is potentially harmful. If you are referencing the medical condition, use <i>person with antisocial personality disorder</i> instead, unless referring to someone who explicitly wants to be referred to with this term.`. I decided to keep them there because I think they are still useful for parsing the sentence. In sentences like `Consider using an alternative, such as %2$s instead.`, the 'instead' was originally removed because the word 'alternative' already implies using something instead of something else. But the strings where I kept 'instead' don't contain the word 'alternative'.


## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Create a post and add the following non-inclusive phrase to it: `a cripple`
* Confirm that the inclusive language analysis shows a red traffic light with the following feedback: `Avoid using a cripple as it is derogatory. Consider using an alternative, such as person with a physical disability, a physically disabled person. Learn more.`
* Add the sentence `I'm not crazy about this idea.` 
* Confirm that the inclusive language analysis shows a red traffic light with the following feedback: `Avoid using crazy as it is potentially harmful. Consider using an alternative, such as to not be impressed by, to not be enthusiastic about, to not be into, to not like. Learn more.`

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [x] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [Inclusive language: Fix typos in inclusive language feedback strings](https://github.com/Yoast/lingo-other-tasks/issues/144)
