### PR TITLE
Re-order menu items to be consistent throughout various editors.

### DIFF
--- a/packages/js/src/components/fills/MetaboxFill.js
+++ b/packages/js/src/components/fills/MetaboxFill.js
@@ -98,14 +98,14 @@ export default function MetaboxFill( { settings } ) {
 				{ settings.isKeywordAnalysisActive && <SidebarItem key="additional-keywords-upsell" renderPriority={ 22 }>
 					{ settings.shouldUpsell && <KeywordUpsell /> }
 				</SidebarItem> }
-				{ settings.shouldUpsell && ! isTerm && <SidebarItem key="internal-linking-suggestions-upsell" renderPriority={ 23 }>
-					<InternalLinkingSuggestionsUpsell />
-				</SidebarItem> }
 				{ settings.isKeywordAnalysisActive && settings.isWincherIntegrationActive &&
-					<SidebarItem key="wincher-seo-performance" renderPriority={ 25 }>
+					<SidebarItem key="wincher-seo-performance" renderPriority={ 23 }>
 						<WincherSEOPerformanceModal location="metabox" />
 					</SidebarItem>
 				}
+				{ settings.shouldUpsell && ! isTerm && <SidebarItem key="internal-linking-suggestions-upsell" renderPriority={ 25 }>
+					<InternalLinkingSuggestionsUpsell />
+				</SidebarItem> }
 				{ settings.isCornerstoneActive && <SidebarItem key="cornerstone" renderPriority={ 30 }>
 					<CollapsibleCornerstone />
 				</SidebarItem> }

--- a/packages/js/src/components/fills/SidebarFill.js
+++ b/packages/js/src/components/fills/SidebarFill.js
@@ -60,29 +60,6 @@ export default function SidebarFill( { settings } ) {
 						isSEMrushIntegrationActive={ settings.isSEMrushIntegrationActive }
 					/>
 				</SidebarItem> }
-				<SidebarItem key="search-appearance" renderPriority={ 25 }>
-					<SearchAppearanceModal />
-				</SidebarItem>
-				{ ( settings.useOpenGraphData || settings.useTwitterData ) && <SidebarItem key="social-appearance" renderPriority={ 26 }>
-					<SocialAppearanceModal
-						useOpenGraphData={ settings.useOpenGraphData }
-						useTwitterData={ settings.useTwitterData }
-					/>
-				</SidebarItem> }
-				{ settings.displaySchemaSettings && <SidebarItem key="schema" renderPriority={ 28 }>
-					<SidebarCollapsible
-						title={ __( "Schema", "wordpress-seo" ) }
-					>
-						<SchemaTabContainer />
-					</SidebarCollapsible>
-				</SidebarItem> }
-				{ settings.displayAdvancedTab && <SidebarItem key="advanced" renderPriority={ 29 }>
-					<SidebarCollapsible
-						title={ __( "Advanced", "wordpress-seo" ) }
-					>
-						<AdvancedSettings />
-					</SidebarCollapsible>
-				</SidebarItem> }
 				{ settings.isKeywordAnalysisActive && <SidebarItem key="seo" renderPriority={ 10 }>
 					<Fragment>
 						<SeoAnalysis
@@ -103,16 +80,39 @@ export default function SidebarFill( { settings } ) {
 				{ settings.isKeywordAnalysisActive && <SidebarItem key="additional-keywords-upsell" renderPriority={ 22 }>
 					{ settings.shouldUpsell && <KeywordUpsell /> }
 				</SidebarItem> }
-				{ settings.shouldUpsell && <SidebarItem key="internal-linking-suggestions-upsell" renderPriority={ 23 }>
-					<InternalLinkingSuggestionsUpsell />
-				</SidebarItem> }
-				{ settings.isCornerstoneActive && <SidebarItem key="cornerstone" renderPriority={ 30 }>
-					<CollapsibleCornerstone />
-				</SidebarItem> }
 				{ settings.isKeywordAnalysisActive && settings.isWincherIntegrationActive && <SidebarItem renderPriority={ 23 }>
 					<WincherSEOPerformanceModal
 						location="sidebar"
 					/>
+				</SidebarItem> }
+				{ settings.shouldUpsell && <SidebarItem key="internal-linking-suggestions-upsell" renderPriority={ 25 }>
+					<InternalLinkingSuggestionsUpsell />
+				</SidebarItem> }
+				<SidebarItem key="search-appearance" renderPriority={ 26 }>
+					<SearchAppearanceModal />
+				</SidebarItem>
+				{ ( settings.useOpenGraphData || settings.useTwitterData ) && <SidebarItem key="social-appearance" renderPriority={ 27 }>
+					<SocialAppearanceModal
+						useOpenGraphData={ settings.useOpenGraphData }
+						useTwitterData={ settings.useTwitterData }
+					/>
+				</SidebarItem> }
+				{ settings.displaySchemaSettings && <SidebarItem key="schema" renderPriority={ 28 }>
+					<SidebarCollapsible
+						title={ __( "Schema", "wordpress-seo" ) }
+					>
+						<SchemaTabContainer />
+					</SidebarCollapsible>
+				</SidebarItem> }
+				{ settings.displayAdvancedTab && <SidebarItem key="advanced" renderPriority={ 29 }>
+					<SidebarCollapsible
+						title={ __( "Advanced", "wordpress-seo" ) }
+					>
+						<AdvancedSettings />
+					</SidebarCollapsible>
+				</SidebarItem> }
+				{ settings.isCornerstoneActive && <SidebarItem key="cornerstone" renderPriority={ 30 }>
+					<CollapsibleCornerstone />
 				</SidebarItem> }
 				{ settings.isInsightsEnabled && <SidebarItem renderPriority={ 32 }>
 					<InsightsModal location="sidebar" />

--- a/packages/js/src/elementor/components/fills/ElementorFill.js
+++ b/packages/js/src/elementor/components/fills/ElementorFill.js
@@ -76,6 +76,33 @@ export default function ElementorFill( { isLoading, onLoad, settings } ) {
 						<SEMrushRelatedKeyphrases />
 					</Fill> }
 				</SidebarItem> }
+				{ settings.isKeywordAnalysisActive && <SidebarItem renderPriority={ 10 }>
+					<Fragment>
+						<SeoAnalysis
+							shouldUpsell={ settings.shouldUpsell }
+							shouldUpsellWordFormRecognition={ settings.isWordFormRecognitionActive }
+						/>
+						{ settings.shouldUpsell && <PremiumSEOAnalysisModal /> }
+					</Fragment>
+				</SidebarItem> }
+				{ settings.isContentAnalysisActive && <SidebarItem renderPriority={ 15 }>
+					<ReadabilityAnalysis
+						shouldUpsell={ settings.shouldUpsell }
+					/>
+				</SidebarItem> }
+				{ settings.isInclusiveLanguageAnalysisActive && <SidebarItem renderPriority={ 19 }>
+					<InclusiveLanguageAnalysis />
+				</SidebarItem> }
+				{ settings.isKeywordAnalysisActive && <SidebarItem key="additional-keywords-upsell" renderPriority={ 22 }>
+					{ settings.shouldUpsell && <KeywordUpsell /> }
+				</SidebarItem> }
+				{ settings.isKeywordAnalysisActive && settings.isWincherIntegrationActive &&
+					<SidebarItem key="wincher-seo-performance" renderPriority={ 23 }>
+						<WincherSEOPerformanceModal location="sidebar" shouldCloseOnClickOutside={ false } />
+					</SidebarItem> }
+				{ settings.shouldUpsell && <SidebarItem key="internal-linking-suggestions-upsell" renderPriority={ 24 }>
+					<InternalLinkingSuggestionsUpsell />
+				</SidebarItem> }
 				<SidebarItem renderPriority={ 25 }>
 					<SearchAppearanceModal />
 				</SidebarItem>
@@ -99,33 +126,6 @@ export default function ElementorFill( { isLoading, onLoad, settings } ) {
 						<AdvancedSettings location="sidebar" />
 					</SidebarCollapsible>
 				</SidebarItem> }
-				{ settings.isKeywordAnalysisActive && <SidebarItem renderPriority={ 10 }>
-					<Fragment>
-						<SeoAnalysis
-							shouldUpsell={ settings.shouldUpsell }
-							shouldUpsellWordFormRecognition={ settings.isWordFormRecognitionActive }
-						/>
-						{ settings.shouldUpsell && <PremiumSEOAnalysisModal /> }
-					</Fragment>
-				</SidebarItem> }
-				{ settings.isContentAnalysisActive && <SidebarItem renderPriority={ 15 }>
-					<ReadabilityAnalysis
-						shouldUpsell={ settings.shouldUpsell }
-					/>
-				</SidebarItem> }
-				{ settings.isInclusiveLanguageAnalysisActive && <SidebarItem renderPriority={ 19 }>
-					<InclusiveLanguageAnalysis />
-				</SidebarItem> }
-				{ settings.isKeywordAnalysisActive && <SidebarItem key="additional-keywords-upsell" renderPriority={ 22 }>
-					{ settings.shouldUpsell && <KeywordUpsell /> }
-				</SidebarItem> }
-				{ settings.shouldUpsell && <SidebarItem key="internal-linking-suggestions-upsell" renderPriority={ 23 }>
-					<InternalLinkingSuggestionsUpsell />
-				</SidebarItem> }
-				{ settings.isKeywordAnalysisActive && settings.isWincherIntegrationActive &&
-					<SidebarItem key="wincher-seo-performance" renderPriority={ 23 }>
-						<WincherSEOPerformanceModal location="sidebar" shouldCloseOnClickOutside={ false } />
-					</SidebarItem> }
 				{ settings.isCornerstoneActive && <SidebarItem renderPriority={ 30 }>
 					<CollapsibleCornerstone />
 				</SidebarItem> }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to re-order menu items in sidebar and metabox to be consistent with Yoast SEO Premium.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Re-orders menu items in block editor metabox and sidebar, classic editor metabox and Elementor editor sidebar to be consistent with Yoast SEO Premium.

## Relevant technical choices:

* The moving around of the `SidebarItem` components has no effect on their rendering order, what matters is the `renderPriority` prop value, I moved them just to reflect their prop value.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Open a post for editing in the Block editor
  * Verify the elements in the metabox are as follows:
  <img width="646" alt="Block metabox" src="https://github.com/Yoast/wordpress-seo/assets/68744851/f9ea5be6-943a-44ea-925c-3cf3d53c2fd3">
  * Verify the elements in the sidebar are as follows:
  <img width="297" alt="Block sidebar" src="https://github.com/Yoast/wordpress-seo/assets/68744851/5a57aaf5-2d57-4c92-975a-a1e7c9b3c1bc">
* Activate the Classic editor
  * Verify the elements in the metabox are as follows:
   <img width="654" alt="classic metabox" src="https://github.com/Yoast/wordpress-seo/assets/68744851/1fe1b84a-3dda-4c2f-9a9d-e62f8f70d964">
* Edit a post in Elementor
  * Verify the elements in the sidebar are as follows: 
  <img width="320" alt="Elementor sidebar" src="https://github.com/Yoast/wordpress-seo/assets/68744851/ac21bfe2-a13f-4a87-9f24-97a2373772d3">

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* N/A

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.
* [X] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/wordpress-seo/issues/20841
