### PR TITLE
19098 custom filter image url for taxonomy sitemap images

### DIFF
--- a/inc/sitemaps/class-sitemap-image-parser.php
+++ b/inc/sitemaps/class-sitemap-image-parser.php
@@ -147,6 +147,14 @@ class WPSEO_Sitemap_Image_Parser {
 			];
 		}
 
+		/**
+		 * Filter images to be included for the term in XML sitemap.
+		 *
+		 * @param array $images  Array of image items.
+		 * @param int   $term_id ID of the post.
+		 */
+		$images = apply_filters( 'wpseo_sitemap_term_url_images', $images, $term->ID );
+
 		return $images;
 	}
 

--- a/inc/sitemaps/class-sitemap-image-parser.php
+++ b/inc/sitemaps/class-sitemap-image-parser.php
@@ -153,7 +153,7 @@ class WPSEO_Sitemap_Image_Parser {
 		 * @param array $images  Array of image items.
 		 * @param int   $term_id ID of the post.
 		 */
-		$images = apply_filters( 'wpseo_sitemap_term_url_images', $images, $term->ID );
+		$images = apply_filters( 'wpseo_sitemap_term_url_images', $images, $term->term_id );
 
 		return $images;
 	}

--- a/inc/sitemaps/class-sitemap-image-parser.php
+++ b/inc/sitemaps/class-sitemap-image-parser.php
@@ -153,7 +153,7 @@ class WPSEO_Sitemap_Image_Parser {
 		 * @param array $images  Array of image items.
 		 * @param int   $term_id ID of the post.
 		 */
-		$images = apply_filters( 'wpseo_sitemap_term_url_images', $images, $term->term_id );
+		$images = apply_filters( 'wpseo_sitemap_urlimages_term', $images, $term->term_id );
 
 		return $images;
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Add a filter to allow developers to add images to terms in the sitemaps.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds a filter to allow adding images to terms in sitemaps.

## Relevant technical choices:

* [This documentation](https://yoast.com/help/images-in-the-xml-sitemap/) would need an update after this PR is merged to include the filter for terms.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Create a post with a category.
* Install `Categories Images` plugin.
* Add an image to the category you added to the post.
* Go to `Yoast SEO`->`XML Sitemaps`
* View the sitemaps-> Category sitemap,  and check you see the category there with 0 images. 
* Install `Code Snippets` plugin
* Add the following PHP snippet:
```php
function add_sitemap_term_url_images( $images, $term_id ) {
    $image = get_option( 'z_taxonomy_image'.$term_id );
    if($image){
        array_push($images, ['src' => $image ]);
    }
    return $images;
};
add_filter( 'wpseo_sitemap_urlimages_term, 'add_sitemap_term_url_images', 10, 2 );
```
* View the sitemaps-> Category sitemap,  and check you see the category there with 1 images. 


#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [#19098](https://github.com/Yoast/wordpress-seo/issues/19098)
