### PR TITLE
Disallow `wp-polyfill` from running inside the worker

### DIFF
--- a/packages/js/src/analysis-worker.js
+++ b/packages/js/src/analysis-worker.js
@@ -19,6 +19,7 @@ const disallowedDependencies = [
 	 */
 	"wp-inert-polyfill",
 	"wp-polyfill-inert",
+	"wp-polyfill",
 ];
 
 /**

--- a/packages/js/src/analysis-worker.js
+++ b/packages/js/src/analysis-worker.js
@@ -15,10 +15,11 @@ const disallowedDependencies = [
 	/**
 	 * References `Element`, a DOM interface not available in web workers.
 	 *
-	 * Was renamed, hence the two variants.
+	 * `wp-inert-polyfill` was renamed to `wp-polyfill-inert`, hence the two variants.
 	 */
 	"wp-inert-polyfill",
 	"wp-polyfill-inert",
+	// Elementor 3.18.0 added `wp-polyfill`.
 	"wp-polyfill",
 ];
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Elementor 3.18.0 added(?) `wp-polyfill`. See this PR: https://github.com/elementor/elementor/pull/24424/files
* As a result, it breaks the analysis and causes an error in the console when it enters the worker. This is because `wp-polyfill` is not available inside the worker.

![Screenshot 2023-12-05 at 13 54 02](https://github.com/Yoast/wordpress-seo/assets/32479012/7c5ba529-d0f2-4c30-be4b-be1851f587d7)

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the analysis didn't work inside the Elementor editor when using Elementor version 3.18.0. 

## Relevant technical choices:

* We add `wp-polyfill` to the `disallowedDependencies`. See also [this PR where this solution was applied to as similar issue.](https://github.com/Yoast/wordpress-seo/pull/19668).

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Activate Yoast SEO 21.6 and Elementor 3.18.0
* Open a post in Elementor 
* Confirm there are no "Refused to execute script..." and "Failed to execute importScripts..." console errors (see screenshot in the context section)
     * The "Uncaught TypeError..." error is caused by Elementor, not us  
* Confirm that the SEO, readability, and inclusive language analysis works
* Confirm that the social appearance preview is loaded
* Confirm that the Insights modal is fully loaded and the results make sense
* Click the `Get related keyphrase` button next to the keyphrase input field, and confirm that the Semrush feature is working
* Confirm that the related keyphrase input field is present and works correctly
* Confirm that the internal linking suggestions show up

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
