### PR TITLE
Refactor mapCustomTaxonomies to update replacement variables in batch

### DIFF
--- a/packages/js/src/redux/actions/snippetEditor.js
+++ b/packages/js/src/redux/actions/snippetEditor.js
@@ -5,6 +5,7 @@ export const UPDATE_DATA = "SNIPPET_EDITOR_UPDATE_DATA";
 export const FIND_CUSTOM_FIELDS = "SNIPPET_EDITOR_FIND_CUSTOM_FIELDS";
 export const CUSTOM_FIELD_RESULTS = "SNIPPET_EDITOR_CUSTOM_FIELD_RESULTS";
 export const UPDATE_REPLACEMENT_VARIABLE = "SNIPPET_EDITOR_UPDATE_REPLACEMENT_VARIABLE";
+export const UPDATE_REPLACEMENT_VARIABLES_BATCH = "SNIPPET_EDITOR_UPDATE_REPLACEMENT_VARIABLES_BATCH";
 export const HIDE_REPLACEMENT_VARIABLES = "SNIPPET_EDITOR_HIDE_REPLACEMENT_VARIABLES";
 export const REMOVE_REPLACEMENT_VARIABLE = "SNIPPET_EDITOR_REMOVE_REPLACEMENT_VARIABLE";
 export const REFRESH = "SNIPPET_EDITOR_REFRESH";
@@ -83,6 +84,20 @@ export function updateReplacementVariable( name, value, label = "", hidden = fal
 		value: unescapedValue,
 		label,
 		hidden,
+	};
+}
+
+/**
+ * Updates replacement variables in redux.
+ *
+ * @param {object} updatedVariables   The object containing all the replacement variables.
+ *
+ * @returns {Object} An action for redux.
+ */
+export function updateReplacementVariablesBatch( updatedVariables ) {
+	return {
+		type: UPDATE_REPLACEMENT_VARIABLES_BATCH,
+		updatedVariables,
 	};
 }
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Improve performance when using high number of taxonomies. For examples in woocommerce as attributes. 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improve performance when editing a product.

## Relevant technical choices:

* Added a function to update replacement variables in batch.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install WooCommerce
* Use WP CLI to add 600 attributes with the following code:
```
for i in {1..600}; do wp wc product_attribute create --name="Att${i}" --user=1 --allow-root; done
```
* Add a product and edit it.
* Inspect page and go to Performance tab
* Clear the report 🚫 and re run the diagnosis using 🔄 on the top left side of the devtool toolbar. 
* Check the Summary
* The `scripting` should be under 10 seconds.

![Screenshot 2023-12-08 at 16 51 44](https://github.com/Yoast/wordpress-seo/assets/65466507/a4f137f2-5388-49b0-971b-f6c121c24e8c)


#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #19165 
