### PR TITLE
Prompt users to review Yoast on Trustpilot

### DIFF
--- a/packages/js/src/components/TimeConstrainedNotification.js
+++ b/packages/js/src/components/TimeConstrainedNotification.js
@@ -1,6 +1,6 @@
 import PropTypes from "prop-types";
 import { select } from "@wordpress/data";
-import PersistentDismissableNotification from "../containers/PersistentDismissableNotification";
+import ConnectedPersistentDismissableNotification from "../containers/PersistentDismissableNotification";
 
 /**
  * @param {string}      store The Redux store identifier from which to determine dismissed state.
@@ -24,7 +24,7 @@ export const TimeConstrainedNotification = ( {
 	const promotionActive = select( store ).isPromotionActive( promoId );
 
 	return (
-		promotionActive && <PersistentDismissableNotification
+		promotionActive && <ConnectedPersistentDismissableNotification
 			alertKey={ alertKey }
 			store={ store }
 			id={ alertKey }
@@ -33,7 +33,7 @@ export const TimeConstrainedNotification = ( {
 			{ ...props }
 		>
 			{ children }
-		</PersistentDismissableNotification>
+		</ConnectedPersistentDismissableNotification>
 	);
 };
 

--- a/packages/js/src/components/WebinarPromoNotification.js
+++ b/packages/js/src/components/WebinarPromoNotification.js
@@ -2,7 +2,7 @@ import { __ } from "@wordpress/i18n";
 import { useSelect } from "@wordpress/data";
 import PropTypes from "prop-types";
 
-import PersistentDismissableNotification from "../containers/PersistentDismissableNotification";
+import ConnectedPersistentDismissableNotification from "../containers/PersistentDismissableNotification";
 import { ReactComponent as DefaultImage } from "../../../../images/succes_marieke_bubble_optm.svg";
 
 /**
@@ -21,7 +21,7 @@ const WebinarPromoNotification = ( {
 	const isPremium = useSelect( select => select( store ).getIsPremium() );
 
 	return isPremium ? null : (
-		<PersistentDismissableNotification
+		<ConnectedPersistentDismissableNotification
 			alertKey="webinar-promo-notification"
 			store={ store }
 			id="webinar-promo-notification"
@@ -34,7 +34,7 @@ const WebinarPromoNotification = ( {
 			&nbsp;<a href={ url } target="_blank" rel="noreferrer">
 				{ __( "Sign up today!", "wordpress-seo" ) }
 			</a>
-		</PersistentDismissableNotification>
+		</ConnectedPersistentDismissableNotification>
 	);
 };
 

--- a/packages/js/src/components/fills/SidebarFill.js
+++ b/packages/js/src/components/fills/SidebarFill.js
@@ -9,6 +9,7 @@ import { get } from "lodash";
 import CollapsibleCornerstone from "../../containers/CollapsibleCornerstone";
 import Warning from "../../containers/Warning";
 import { KeywordInput, ReadabilityAnalysis, SeoAnalysis, InclusiveLanguageAnalysis } from "@yoast/externals/components";
+import { useFirstEligibleNotification } from "../../hooks/use-first-eligible-notification";
 import InsightsModal from "../../insights/components/insights-modal";
 import { InternalLinkingSuggestionsUpsell } from "../modals/InternalLinkingSuggestionsUpsell";
 import SidebarItem from "../SidebarItem";
@@ -19,10 +20,6 @@ import SchemaTabContainer from "../../containers/SchemaTab";
 import SidebarCollapsible from "../SidebarCollapsible";
 import AdvancedSettings from "../../containers/AdvancedSettings";
 import WincherSEOPerformanceModal from "../../containers/WincherSEOPerformanceModal";
-import WebinarPromoNotification from "../WebinarPromoNotification";
-import { BlackFridayPromotion } from "../BlackFridayPromotion";
-import { BlackFridaySidebarChecklistPromotion } from "../BlackFridaySidebarChecklistPromotion";
-import { shouldShowWebinarPromotionNotificationInSidebar } from "../../helpers/shouldShowWebinarPromotionNotification";
 import KeywordUpsell from "../modals/KeywordUpsell";
 
 /* eslint-disable complexity */
@@ -38,8 +35,8 @@ import KeywordUpsell from "../modals/KeywordUpsell";
  * @constructor
  */
 export default function SidebarFill( { settings } ) {
-	const webinarIntroBlockEditorUrl = get( window, "wpseoScriptData.webinarIntroBlockEditorUrl", "https://yoa.st/webinar-intro-block-editor" );
-	const isWooCommerce = get( window, "wpseoScriptData.isWooCommerceActive", "" );
+	const webinarIntroUrl = get( window, "wpseoScriptData.webinarIntroBlockEditorUrl", "https://yoa.st/webinar-intro-block-editor" );
+	const FirstEligibleNotification = useFirstEligibleNotification( { webinarIntroUrl } );
 
 	return (
 		<Fragment>
@@ -47,12 +44,7 @@ export default function SidebarFill( { settings } ) {
 				<SidebarItem key="warning" renderPriority={ 1 }>
 					<Warning />
 					<div style={ { margin: "0 16px" } }>
-						{ /* eslint-disable max-len */ }
-						{ shouldShowWebinarPromotionNotificationInSidebar() &&
-							<WebinarPromoNotification hasIcon={ false } image={ null } url={ webinarIntroBlockEditorUrl } />
-						}
-						{ isWooCommerce && <BlackFridaySidebarChecklistPromotion hasIcon={ false } /> }
-						<BlackFridayPromotion image={ null } hasIcon={ false } />
+						{ FirstEligibleNotification && <FirstEligibleNotification /> }
 					</div>
 				</SidebarItem>
 				{ settings.isKeywordAnalysisActive && <SidebarItem key="keyword-input" renderPriority={ 8 }>

--- a/packages/js/src/components/trustpilot-review-notification/constants.js
+++ b/packages/js/src/components/trustpilot-review-notification/constants.js
@@ -1,0 +1,3 @@
+export const ALERT_KEY = "trustpilot-review-notification";
+
+export const STORE_NAME = "yoast-seo/editor";

--- a/packages/js/src/components/trustpilot-review-notification/hooks.js
+++ b/packages/js/src/components/trustpilot-review-notification/hooks.js
@@ -1,0 +1,28 @@
+import { useDispatch, useSelect } from "@wordpress/data";
+import { useCallback, useEffect, useState } from "@wordpress/element";
+import getIndicatorForScore from "../../analysis/getIndicatorForScore";
+import { ALERT_KEY, STORE_NAME } from "./constants";
+
+/**
+ * Returns the props for the Trustpilot review notification.
+ * @returns {{dismiss: (function(): *), shouldShow: boolean}} The props.
+ */
+export const useTrustpilotReviewNotification = () => {
+	const isPremium = useSelect( ( select ) => select( STORE_NAME ).getIsPremium(), [] );
+	const isDismissed = useSelect( ( select ) => select( STORE_NAME ).isAlertDismissed( ALERT_KEY ), [] );
+	const { overallScore } = useSelect( ( select ) => select( STORE_NAME ).getResultsForFocusKeyword(), [] );
+	const { dismissAlert } = useDispatch( STORE_NAME );
+	const dismiss = useCallback( () => dismissAlert( ALERT_KEY ), [ dismissAlert ] );
+	const [ hadGoodRating, setHadGoodRating ] = useState( false );
+
+	useEffect( () => {
+		if ( getIndicatorForScore( overallScore )?.className === "good" ) {
+			setHadGoodRating( true );
+		}
+	}, [ overallScore ] );
+
+	return {
+		shouldShow: ! isPremium && ! isDismissed && hadGoodRating,
+		dismiss,
+	};
+};

--- a/packages/js/src/components/trustpilot-review-notification/index.js
+++ b/packages/js/src/components/trustpilot-review-notification/index.js
@@ -1,0 +1,2 @@
+export { TrustpilotReviewNotification } from "./trustpilot-review-notification";
+export { useTrustpilotReviewNotification } from "./hooks";

--- a/packages/js/src/components/trustpilot-review-notification/trustpilot-review-notification.js
+++ b/packages/js/src/components/trustpilot-review-notification/trustpilot-review-notification.js
@@ -1,0 +1,38 @@
+import { useSelect } from "@wordpress/data";
+import { __ } from "@wordpress/i18n";
+import { useRootContext } from "@yoast/externals/contexts";
+import { makeOutboundLink } from "@yoast/helpers";
+import { PersistentDismissableNotification } from "../../containers/PersistentDismissableNotification";
+import { ALERT_KEY, STORE_NAME } from "./constants";
+import { useTrustpilotReviewNotification } from "./hooks";
+
+const OutboundLink = makeOutboundLink();
+
+/**
+ * The Trustpilot review notification.
+ * @returns {JSX.Element|null} The notification or null.
+ */
+export const TrustpilotReviewNotification = () => {
+	const { shouldShow, dismiss } = useTrustpilotReviewNotification();
+	const { locationContext } = useRootContext();
+	const trustpilotLink = useSelect( ( select ) => select( STORE_NAME ).selectLink( "https://yoa.st/trustpilot-review", { context: locationContext } ), [ locationContext ] );
+
+	return (
+		<PersistentDismissableNotification
+			alertKey={ ALERT_KEY }
+			store={ STORE_NAME }
+			id={ ALERT_KEY }
+			title={ __( "Show Yoast SEO some love!", "wordpress-seo" ) }
+			hasIcon={ false }
+			isAlertDismissed={ ! shouldShow }
+			onDismissed={ dismiss }
+		>
+			{ __( "Happy with the plugin?", "wordpress-seo" ) }
+			{ " " }
+			<OutboundLink href={ trustpilotLink } rel="noopener noreferrer">
+				{ __( "Leave a quick review", "wordpress-seo" ) }
+			</OutboundLink>
+			{ "." }
+		</PersistentDismissableNotification>
+	);
+};

--- a/packages/js/src/containers/PersistentDismissableNotification.js
+++ b/packages/js/src/containers/PersistentDismissableNotification.js
@@ -4,15 +4,15 @@ import withPersistentDismiss from "./withPersistentDismiss";
 
 /**
  * @param {string} id The id.
- * @param {boolean} hasIcon Wether or not to show icon before title.
+ * @param {boolean} hasIcon Whether or not to show icon before title.
  * @param {object | string} title The title.
  * @param {JSX.Element|null} image The image or null if no image.
- * @param {isAlertDismissed} boolean Wether or not the notification is dismissed.
+ * @param {boolean} isAlertDismissed Whether or not the notification is dismissed.
  * @param {Function} onDismissed The dismissal prop to be renamed for Notification component.
  *
  * @returns {Component} The composed Notification component.
  */
-const PersistentDismissableNotification = ( {
+export const PersistentDismissableNotification = ( {
 	children,
 	id,
 	hasIcon = true,

--- a/packages/js/src/elementor/components/fills/ElementorFill.js
+++ b/packages/js/src/elementor/components/fills/ElementorFill.js
@@ -8,6 +8,7 @@ import { InternalLinkingSuggestionsUpsell } from "../../../components/modals/Int
 
 // Internal dependencies.
 import CollapsibleCornerstone from "../../../containers/CollapsibleCornerstone";
+import { useFirstEligibleNotification } from "../../../hooks/use-first-eligible-notification";
 import InsightsModal from "../../../insights/components/insights-modal";
 import Alert from "../../containers/Alert";
 import { KeywordInput, ReadabilityAnalysis, SeoAnalysis, InclusiveLanguageAnalysis } from "@yoast/externals/components";
@@ -22,10 +23,6 @@ import SEMrushRelatedKeyphrases from "../../../containers/SEMrushRelatedKeyphras
 import WincherSEOPerformanceModal from "../../../containers/WincherSEOPerformanceModal";
 import { isWordProofIntegrationActive } from "../../../helpers/wordproof";
 import WordProofAuthenticationModals from "../../../components/modals/WordProofAuthenticationModals";
-import WebinarPromoNotification from "../../../components/WebinarPromoNotification";
-import { BlackFridaySidebarChecklistPromotion } from "../../../components/BlackFridaySidebarChecklistPromotion";
-import { BlackFridayPromotion } from "../../../components/BlackFridayPromotion";
-import { shouldShowWebinarPromotionNotificationInSidebar } from "../../../helpers/shouldShowWebinarPromotionNotification";
 import KeywordUpsell from "../../../components/modals/KeywordUpsell";
 
 /* eslint-disable complexity */
@@ -39,6 +36,9 @@ import KeywordUpsell from "../../../components/modals/KeywordUpsell";
  * @constructor
  */
 export default function ElementorFill( { isLoading, onLoad, settings } ) {
+	const webinarIntroUrl = get( window, "wpseoScriptData.webinarIntroElementorUrl", "https://yoa.st/webinar-intro-elementor" );
+	const FirstEligibleNotification = useFirstEligibleNotification( { webinarIntroUrl } );
+
 	useEffect( () => {
 		setTimeout( () => {
 			if ( isLoading ) {
@@ -51,22 +51,13 @@ export default function ElementorFill( { isLoading, onLoad, settings } ) {
 		return null;
 	}
 
-	const webinarIntroElementorUrl = get( window, "wpseoScriptData.webinarIntroElementorUrl", "https://yoa.st/webinar-intro-elementor" );
-	const isWooCommerce = get( window, "wpseoScriptData.isWooCommerceActive", "" );
-
 	return (
 		<>
 			{ isWordProofIntegrationActive() && <WordProofAuthenticationModals /> }
 			<Fill name="YoastElementor">
 				<SidebarItem renderPriority={ 1 }>
 					<Alert />
-
-					{ shouldShowWebinarPromotionNotificationInSidebar() &&
-						<WebinarPromoNotification hasIcon={ false } image={ null } url={ webinarIntroElementorUrl } />
-					}
-					{ isWooCommerce && <BlackFridaySidebarChecklistPromotion hasIcon={ false } /> }
-					<BlackFridayPromotion image={ null } hasIcon={ false } />
-
+					{ FirstEligibleNotification && <FirstEligibleNotification /> }
 				</SidebarItem>
 				{ settings.isKeywordAnalysisActive && <SidebarItem renderPriority={ 8 }>
 					<KeywordInput

--- a/packages/js/src/hooks/use-first-eligible-notification.js
+++ b/packages/js/src/hooks/use-first-eligible-notification.js
@@ -1,0 +1,57 @@
+import { BlackFridayPromotion } from "../components/BlackFridayPromotion";
+import { BlackFridaySidebarChecklistPromotion } from "../components/BlackFridaySidebarChecklistPromotion";
+import { TrustpilotReviewNotification, useTrustpilotReviewNotification } from "../components/trustpilot-review-notification";
+import WebinarPromoNotification from "../components/WebinarPromoNotification";
+import { isWooCommerceActive } from "../helpers/isWooCommerceActive";
+import { shouldShowWebinarPromotionNotificationInSidebar } from "../helpers/shouldShowWebinarPromotionNotification";
+
+/**
+ * Returns the first eligible entry from a list.
+ * An entry should have a callback functions that determines if an entry is eligible.
+ *
+ * @param {{getIsEligible: func}[]} list Array of objects with a callback function under `getIsEligible`.
+ *
+ * @returns {Object|null} The first entry that is eligible or null.
+ */
+const getFirstEligible = ( list ) => {
+	for ( const entry of list ) {
+		if ( entry?.getIsEligible() ) {
+			return entry;
+		}
+	}
+
+	return null;
+};
+
+/**
+ * Returns the first eligible notification.
+ * The idea is to only show one notification at a time.
+ *
+ * @param {string} webinarIntroUrl The webinar intro URL.
+ *
+ * @returns {JSX.ElementClass|null} The first eligible notification or null.
+ */
+export const useFirstEligibleNotification = ( { webinarIntroUrl } ) => {
+	const { shouldShow: shouldShowTrustpilotReviewNotification } = useTrustpilotReviewNotification();
+
+	const firstEligible = getFirstEligible( [
+		{
+			getIsEligible: () => shouldShowTrustpilotReviewNotification,
+			component: TrustpilotReviewNotification,
+		},
+		{
+			getIsEligible: shouldShowWebinarPromotionNotificationInSidebar,
+			component: () => <WebinarPromoNotification hasIcon={ false } image={ null } url={ webinarIntroUrl } />,
+		},
+		{
+			getIsEligible: isWooCommerceActive,
+			component: () => <BlackFridaySidebarChecklistPromotion hasIcon={ false } />,
+		},
+		{
+			getIsEligible: () => true,
+			component: () => <BlackFridayPromotion hasIcon={ false } />,
+		},
+	] );
+
+	return firstEligible?.component || null;
+};

--- a/packages/js/src/shared-admin/store/link-params.js
+++ b/packages/js/src/shared-admin/store/link-params.js
@@ -22,8 +22,9 @@ linkParamsSelectors.selectLink = createSelector(
 	[
 		linkParamsSelectors.selectLinkParams,
 		( state, url ) => url,
+		( state, url, extraParams = {} ) => extraParams,
 	],
-	( linkParams, link ) => addQueryArgs( link, linkParams )
+	( linkParams, link, extraParams ) => addQueryArgs( link, { ...linkParams, ...extraParams } )
 );
 
 export const linkParamsActions = slice.actions;

--- a/packages/js/tests/shared-admin/store/link-params.test.js
+++ b/packages/js/tests/shared-admin/store/link-params.test.js
@@ -95,6 +95,10 @@ describe( "linkParams", () => {
 			it( "adds the link params to the given url", () => {
 				expect( linkParamsSelectors.selectLink( state, "https://example.com" ) ).toBe( "https://example.com?foo=bar&one=two" );
 			} );
+
+			it( "adds extra params to the given url", () => {
+				expect( linkParamsSelectors.selectLink( state, "https://example.com", { extra: true } ) ).toBe( "https://example.com?foo=bar&one=two&extra=true" );
+			} );
 		} );
 	} );
 } );

--- a/src/integrations/alerts/trustpilot-review-notification.php
+++ b/src/integrations/alerts/trustpilot-review-notification.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Yoast\WP\SEO\Integrations\Alerts;
+
+/**
+ * Trustpilot_Review_Notification class.
+ */
+class Trustpilot_Review_Notification extends Abstract_Dismissable_Alert {
+
+	/**
+	 * Holds the alert identifier.
+	 *
+	 * @var string
+	 */
+	protected $alert_identifier = 'trustpilot-review-notification';
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds a notification in the sidebar to leave a quick review.

## Relevant technical choices:

* Use our dismissible alert mechanism
* Add new "first eligible notification" component to only show one at a time
* Using locationContext in the `context` parameter of the link

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

Before you start
  * Deactivate Premium
  * Remove all the dismissed alerts: in your DB, remove the user meta: `_yoast_alerts_dismissed`

Block editor
* Edit a post in the block editor
* Open the sidebar
* Which notification you see will depend on if your overall SEO score
  * If your post does not have a green bullet, it is expected that you see the Webinar notification
  * If you post does have a green bullet, it is expected that you see the new review notification
* Follow our SEO analysis advice until you have a green SEO score
* Verify you see the review notification
  * Verify the link is: `https://yoa.st/trustpilot-review`
  * Verify the link includes the parameter: `context` which is `block-sidebar`
* Remove the focus keyphrase
  * It is expected that this will immediately make the overall SEO score worse than green
  * However, if it is not enough, do more to make the overall SEO score worse than green
* Verify you still see the review notification
* Save the post
* Refresh the page
* Verify you see the Webinar notification
* Add the focus keyphrase back, and/or make the overall SEO score green
* Save the post
* Activate Premium
* Go back to edit the post
* Verify you do not see the review notification
* Deactivate Premium
* Go back to edit the post
* Dismiss the review notification
* Verify you see the Webinar notification
* Refresh the page
* Verify you see the Webinar notification (while the overall SEO score is green)
* Remove all the dismissed alerts: in your DB, remove the user meta: `_yoast_alerts_dismissed`

Elementor editor
* Remove the dismissed alerts again: in your DB, remove the user meta: `_yoast_alerts_dismissed`
* Edit a post in the Elementor editor
* Follow the same steps as above
  * However, when checking the `context` link parameter, it should be `elementor-sidebar`

Verify issue instructions are followed:
https://github.com/Yoast/reserved-tasks/issues/160

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/reserved-tasks/issues/160
