### PR TITLE
Add rules to avoid false positives in medical contexts

### DIFF
--- a/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessmentsSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessmentsSpec.js
@@ -255,17 +255,8 @@ describe( "A test for Disability assessments", function() {
 			expect( assessment.isApplicable( mockPaper, mockResearcher ) ).toBe( false );
 		} );
 	} );
-	it( "should not target 'bipolar' when followed by exception words.", () => {
-		const assessment = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "bipolar" ) );
-		[ "disorder"  ].map( ( exceptionWord ) => {
-			const testSentence = `We ${exceptionWord}.`;
-			const mockPaper = new Paper( testSentence );
-			const mockResearcher = Factory.buildMockResearcher( [ testSentence ] );
-			expect( assessment.isApplicable( mockPaper, mockResearcher ) ).toBe( false );
-		} );
-	} );
 	it( "should not target 'paranoid' when followed by exception words.", () => {
-		const assessment = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "bipolar" ) );
+		const assessment = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "paranoid" ) );
 		[ "delusion", "delusions", "personality disorder", "ideation"  ].map( ( exceptionWord ) => {
 			const testSentence = `We ${exceptionWord}.`;
 			const mockPaper = new Paper( testSentence );
@@ -1233,7 +1224,7 @@ describe( "a test for targeting non-inclusive phrases in disability assessments"
 	it( "should return the appropriate score and feedback string for: 'bipolar'", () => {
 		const testData = [
 			{
-				identifier: "bipolar",
+				identifier: "schizophrenic",
 				text: "She dances in a bipolar way.",
 				expectedFeedback: "Be careful when using <i>bipolar</i> as it is potentially harmful. Unless you are referencing the " +
 					"specific medical condition, consider using another alternative to describe the trait or behavior, such as " +

--- a/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessmentsSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessmentsSpec.js
@@ -221,7 +221,61 @@ describe( "A test for Disability assessments", function() {
 	} );
 	it( "should not target 'binge'' when followed by exception words.", () => {
 		const assessment = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "binge" ) );
-		[ "drink", "drinks", "drinking" ].map( ( exceptionWord ) => {
+		[ "drink", "drinks", "drinking", "eating disorder", "and purge", "behavior", "behaviors", "behaviour", "behaviours" ].map( ( exceptionWord ) => {
+			const testSentence = `We ${exceptionWord}.`;
+			const mockPaper = new Paper( testSentence );
+			const mockResearcher = Factory.buildMockResearcher( [ testSentence ] );
+			expect( assessment.isApplicable( mockPaper, mockResearcher ) ).toBe( false );
+		} );
+	} );
+	it( "should not target 'bingeing' when followed by exception words.", () => {
+		const assessment = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "bingeing" ) );
+		[ "and purging", "behavior", "behaviors", "behaviour", "behaviours"  ].map( ( exceptionWord ) => {
+			const testSentence = `We ${exceptionWord}.`;
+			const mockPaper = new Paper( testSentence );
+			const mockResearcher = Factory.buildMockResearcher( [ testSentence ] );
+			expect( assessment.isApplicable( mockPaper, mockResearcher ) ).toBe( false );
+		} );
+	} );
+	it( "should not target 'binged' when followed by exception words.", () => {
+		const assessment = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "binged" ) );
+		[ "and purged"  ].map( ( exceptionWord ) => {
+			const testSentence = `We ${exceptionWord}.`;
+			const mockPaper = new Paper( testSentence );
+			const mockResearcher = Factory.buildMockResearcher( [ testSentence ] );
+			expect( assessment.isApplicable( mockPaper, mockResearcher ) ).toBe( false );
+		} );
+	} );
+	it( "should not target 'binges' when followed by exception words.", () => {
+		const assessment = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "binged" ) );
+		[ "and purges"  ].map( ( exceptionWord ) => {
+			const testSentence = `We ${exceptionWord}.`;
+			const mockPaper = new Paper( testSentence );
+			const mockResearcher = Factory.buildMockResearcher( [ testSentence ] );
+			expect( assessment.isApplicable( mockPaper, mockResearcher ) ).toBe( false );
+		} );
+	} );
+	it( "should not target 'bipolar' when followed by exception words.", () => {
+		const assessment = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "bipolar" ) );
+		[ "disorder"  ].map( ( exceptionWord ) => {
+			const testSentence = `We ${exceptionWord}.`;
+			const mockPaper = new Paper( testSentence );
+			const mockResearcher = Factory.buildMockResearcher( [ testSentence ] );
+			expect( assessment.isApplicable( mockPaper, mockResearcher ) ).toBe( false );
+		} );
+	} );
+	it( "should not target 'paranoid' when followed by exception words.", () => {
+		const assessment = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "bipolar" ) );
+		[ "delusion", "delusions", "personality disorder", "ideation"  ].map( ( exceptionWord ) => {
+			const testSentence = `We ${exceptionWord}.`;
+			const mockPaper = new Paper( testSentence );
+			const mockResearcher = Factory.buildMockResearcher( [ testSentence ] );
+			expect( assessment.isApplicable( mockPaper, mockResearcher ) ).toBe( false );
+		} );
+	} );
+	it( "should not target 'manic' when followed by exception words.", () => {
+		const assessment = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "manic" ) );
+		[ "episode", "episodes", "state", "states", "symptoms", "and depressive episodes", "and hypomanic", "oror hypomanic"  ].map( ( exceptionWord ) => {
 			const testSentence = `We ${exceptionWord}.`;
 			const mockPaper = new Paper( testSentence );
 			const mockResearcher = Factory.buildMockResearcher( [ testSentence ] );
@@ -1170,6 +1224,20 @@ describe( "a test for targeting non-inclusive phrases in disability assessments"
 				expectedFeedback: "Be careful when using <i>manic</i> as it is potentially harmful. Unless you are referencing the " +
 					"specific medical condition, consider using another alternative to describe the trait or behavior, such as " +
 					"<i>excited, raving, unbalanced, wild</i>. " +
+					"<a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
+				expectedScore: 6,
+			},
+		];
+		testInclusiveLanguageAssessments( testData );
+	} );
+	it( "should return the appropriate score and feedback string for: 'bipolar'", () => {
+		const testData = [
+			{
+				identifier: "bipolar",
+				text: "She dances in a bipolar way.",
+				expectedFeedback: "Be careful when using <i>bipolar</i> as it is potentially harmful. Unless you are referencing the " +
+					"specific medical condition, consider using another alternative to describe the trait or behavior, such as " +
+					"<i>of two minds, chaotic, confusing</i>. " +
 					"<a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
 				expectedScore: 6,
 			},

--- a/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessmentsSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessmentsSpec.js
@@ -219,10 +219,11 @@ describe( "A test for Disability assessments", function() {
 
 		expect( isApplicable ).toBeFalsy();
 	} );
-	it( "should not target 'binge'' when followed by exception words.", () => {
+	it( "should not target 'binge' when followed by exception words.", () => {
 		const assessment = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "binge" ) );
-		[ "drink", "drinks", "drinking", "eating disorder", "and purge", "behavior", "behaviors", "behaviour", "behaviours" ].map( ( exceptionWord ) => {
-			const testSentence = `We ${exceptionWord}.`;
+		const exceptionWords = [ "drink", "drinks", "drinking", "eating disorder", "and purge", "behavior", "behaviors", "behaviour", "behaviours" ];
+		exceptionWords.map( ( exceptionWord ) => {
+			const testSentence = `We binge ${exceptionWord}.`;
 			const mockPaper = new Paper( testSentence );
 			const mockResearcher = Factory.buildMockResearcher( [ testSentence ] );
 			expect( assessment.isApplicable( mockPaper, mockResearcher ) ).toBe( false );
@@ -230,8 +231,8 @@ describe( "A test for Disability assessments", function() {
 	} );
 	it( "should not target 'bingeing' when followed by exception words.", () => {
 		const assessment = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "bingeing" ) );
-		[ "and purging", "behavior", "behaviors", "behaviour", "behaviours"  ].map( ( exceptionWord ) => {
-			const testSentence = `We ${exceptionWord}.`;
+		[ "and purging", "behavior", "behaviors", "behaviour", "behaviours" ].map( ( exceptionWord ) => {
+			const testSentence = `We were bingeing ${exceptionWord}.`;
 			const mockPaper = new Paper( testSentence );
 			const mockResearcher = Factory.buildMockResearcher( [ testSentence ] );
 			expect( assessment.isApplicable( mockPaper, mockResearcher ) ).toBe( false );
@@ -239,17 +240,17 @@ describe( "A test for Disability assessments", function() {
 	} );
 	it( "should not target 'binged' when followed by exception words.", () => {
 		const assessment = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "binged" ) );
-		[ "and purged"  ].map( ( exceptionWord ) => {
-			const testSentence = `We ${exceptionWord}.`;
+		[ "and purged" ].map( ( exceptionWord ) => {
+			const testSentence = `We binged ${exceptionWord}.`;
 			const mockPaper = new Paper( testSentence );
 			const mockResearcher = Factory.buildMockResearcher( [ testSentence ] );
 			expect( assessment.isApplicable( mockPaper, mockResearcher ) ).toBe( false );
 		} );
 	} );
 	it( "should not target 'binges' when followed by exception words.", () => {
-		const assessment = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "binged" ) );
-		[ "and purges"  ].map( ( exceptionWord ) => {
-			const testSentence = `We ${exceptionWord}.`;
+		const assessment = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "binges" ) );
+		[ "and purges" ].map( ( exceptionWord ) => {
+			const testSentence = `He binges ${exceptionWord}.`;
 			const mockPaper = new Paper( testSentence );
 			const mockResearcher = Factory.buildMockResearcher( [ testSentence ] );
 			expect( assessment.isApplicable( mockPaper, mockResearcher ) ).toBe( false );
@@ -257,8 +258,9 @@ describe( "A test for Disability assessments", function() {
 	} );
 	it( "should not target 'paranoid' when followed by exception words.", () => {
 		const assessment = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "paranoid" ) );
-		[ "delusion", "delusions", "personality disorder", "ideation"  ].map( ( exceptionWord ) => {
-			const testSentence = `We ${exceptionWord}.`;
+		const exceptionWords = [ "delusion", "delusions", "personality disorder", "ideation" ];
+		exceptionWords.map( ( exceptionWord ) => {
+			const testSentence = `They displayed a paranoid ${exceptionWord}.`;
 			const mockPaper = new Paper( testSentence );
 			const mockResearcher = Factory.buildMockResearcher( [ testSentence ] );
 			expect( assessment.isApplicable( mockPaper, mockResearcher ) ).toBe( false );
@@ -266,8 +268,9 @@ describe( "A test for Disability assessments", function() {
 	} );
 	it( "should not target 'manic' when followed by exception words.", () => {
 		const assessment = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "manic" ) );
-		[ "episode", "episodes", "state", "states", "symptoms", "and depressive episodes", "and hypomanic", "oror hypomanic"  ].map( ( exceptionWord ) => {
-			const testSentence = `We ${exceptionWord}.`;
+		const exceptionWords = [ "episode", "episodes", "state", "states", "symptoms", "and depressive episodes", "and hypomanic", "or hypomanic" ];
+		exceptionWords.map( ( exceptionWord ) => {
+			const testSentence = `We were going through a manic ${exceptionWord}.`;
 			const mockPaper = new Paper( testSentence );
 			const mockResearcher = Factory.buildMockResearcher( [ testSentence ] );
 			expect( assessment.isApplicable( mockPaper, mockResearcher ) ).toBe( false );

--- a/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/exportInclusiveLanguageConfigs.test.js
+++ b/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/exportInclusiveLanguageConfigs.test.js
@@ -100,7 +100,7 @@ describe( "Export of the inclusive language configuration", () => {
 		expect( retrieveRule( assessment.rule.toString() ) ).toEqual( "" );
 
 		assessment = new InclusiveLanguageAssessment( inclusiveLanguageAssessmentsConfigs.find( obj => obj.identifier === "binge" ) );
-		expect( retrieveRule( assessment.rule.toString() ) ).toEqual( "NotFollowedBy: \"drink\", \"drinks\" \"drinking\", \"eating disorder\", \"and purge\", \"behavior\", \"behaviors\", \"behaviour\", \"behaviours\"" );
+		expect( retrieveRule( assessment.rule.toString() ) ).toEqual( "NotFollowedBy: \"drink\", \"drinks\", \"drinking\", +\"eating disorder\", \"and purge\", \"behavior\", \"behaviors\", \"behaviour\", \"behaviours\"" );
 
 		assessment = new InclusiveLanguageAssessment( inclusiveLanguageAssessmentsConfigs.find( obj => obj.identifier === "seniors" ) );
 		expect( retrieveRule( assessment.rule.toString() ) ).

--- a/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/exportInclusiveLanguageConfigs.test.js
+++ b/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/exportInclusiveLanguageConfigs.test.js
@@ -100,7 +100,7 @@ describe( "Export of the inclusive language configuration", () => {
 		expect( retrieveRule( assessment.rule.toString() ) ).toEqual( "" );
 
 		assessment = new InclusiveLanguageAssessment( inclusiveLanguageAssessmentsConfigs.find( obj => obj.identifier === "binge" ) );
-		expect( retrieveRule( assessment.rule.toString() ) ).toEqual( "NotFollowedBy: \"drink\", \"drinks\", \"drinking\"" );
+		expect( retrieveRule( assessment.rule.toString() ) ).toEqual( "NotFollowedBy: \"drink\", \"drinks\" \"drinking\", \"eating disorder\", \"and purge\", \"behavior\", \"behaviors\", \"behaviour\", \"behaviours\"" );
 
 		assessment = new InclusiveLanguageAssessment( inclusiveLanguageAssessmentsConfigs.find( obj => obj.identifier === "seniors" ) );
 		expect( retrieveRule( assessment.rule.toString() ) ).

--- a/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/exportInclusiveLanguageConfigs.test.js
+++ b/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/exportInclusiveLanguageConfigs.test.js
@@ -100,7 +100,9 @@ describe( "Export of the inclusive language configuration", () => {
 		expect( retrieveRule( assessment.rule.toString() ) ).toEqual( "" );
 
 		assessment = new InclusiveLanguageAssessment( inclusiveLanguageAssessmentsConfigs.find( obj => obj.identifier === "binge" ) );
-		expect( retrieveRule( assessment.rule.toString() ) ).toEqual( "NotFollowedBy: \"drink\", \"drinks\", \"drinking\", +\"eating disorder\", \"and purge\", \"behavior\", \"behaviors\", \"behaviour\", \"behaviours\"" );
+		expect( retrieveRule( assessment.rule.toString() ) ).toEqual(
+			"NotFollowedBy: \"drink\", \"drinks\", \"drinking\", \"eating disorder\", \"and purge\", " +
+			"\"behavior\", \"behaviors\", \"behaviour\", \"behaviours\"" );
 
 		assessment = new InclusiveLanguageAssessment( inclusiveLanguageAssessmentsConfigs.find( obj => obj.identifier === "seniors" ) );
 		expect( retrieveRule( assessment.rule.toString() ) ).

--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessments.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessments.js
@@ -47,7 +47,7 @@ const medicalCondition = harmfulPotentiallyNonInclusive +
 const potentiallyHarmfulTwoAlternatives = "Avoid using <i>%1$s</i> as it is potentially harmful. " +
 	"Consider using an alternative, such as %2$s when referring to someone's needs, or %3$s when referring to a person.";
 
-const disabilityAssessments =  [
+const disabilityAssessments = [
 	{
 		identifier: "binge",
 		nonInclusivePhrases: [ "binge" ],
@@ -56,8 +56,8 @@ const disabilityAssessments =  [
 		feedbackFormat: "Be careful when using <i>%1$s</i>, unless talking about a symptom of a medical condition. " +
 			"If you are not referencing a symptom, consider other alternatives to describe the trait or behavior, such as %2$s.",
 		rule: ( words, nonInclusivePhrase ) => includesConsecutiveWords( words, nonInclusivePhrase )
-			.filter( isNotFollowedByException( words, nonInclusivePhrase, [ "drink", "drinks", "drinking", +
-				"eating disorder", "and purge", "behavior", "behaviors", "behaviour", "behaviours" ] ) ),
+			.filter( isNotFollowedByException( words, nonInclusivePhrase,
+				[ "drink", "drinks", "drinking", "eating disorder", "and purge", "behavior", "behaviors", "behaviour", "behaviours" ] ) ),
 	},
 	{
 		identifier: "bingeing",
@@ -67,8 +67,8 @@ const disabilityAssessments =  [
 		feedbackFormat: "Be careful when using <i>%1$s</i>, unless talking about a symptom of a medical condition. " +
 			"If you are not referencing a symptom, consider other alternatives to describe the trait or behavior, such as %2$s.",
 		rule: ( words, nonInclusivePhrase ) => includesConsecutiveWords( words, nonInclusivePhrase )
-			.filter( isNotFollowedByException( words, nonInclusivePhrase, [ "and purging", "behavior", +
-				"behaviors", "behaviour", "behaviours"  ] ) ),
+			.filter( isNotFollowedByException( words, nonInclusivePhrase,
+				[ "and purging", "behavior", "behaviors", "behaviour", "behaviours" ] ) ),
 	},
 	{
 		identifier: "binged",
@@ -168,8 +168,8 @@ const disabilityAssessments =  [
 		score: SCORES.NON_INCLUSIVE,
 		feedbackFormat: potentiallyHarmful,
 		rule: ( words, nonInclusivePhrase ) => includesConsecutiveWords( words, nonInclusivePhrase )
-			.filter( isNotFollowedByException( words, nonInclusivePhrase, [ "toilet", "toilets", "parking", "bathroom",
-				"bathrooms", "stall", "stalls" ] ) ),
+			.filter( isNotFollowedByException( words, nonInclusivePhrase,
+				[ "toilet", "toilets", "parking", "bathroom", "bathrooms", "stall", "stalls" ] ) ),
 	},
 	{
 		identifier: "insane",
@@ -518,7 +518,8 @@ const disabilityAssessments =  [
 		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
 		feedbackFormat: medicalCondition,
 		rule: ( words, nonInclusivePhrase ) => includesConsecutiveWords( words, nonInclusivePhrase )
-			.filter( isNotFollowedByException( words, nonInclusivePhrase, [ "personality disorder", "delusion", "delusions", "ideation"  ] ) ),
+			.filter( isNotFollowedByException( words, nonInclusivePhrase,
+				[ "personality disorder", "delusion", "delusions", "ideation" ] ) ),
 	},
 	{
 		identifier: "manic",
@@ -527,7 +528,8 @@ const disabilityAssessments =  [
 		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
 		feedbackFormat: medicalCondition,
 		rule: ( words, nonInclusivePhrase ) => includesConsecutiveWords( words, nonInclusivePhrase )
-			.filter( isNotFollowedByException( words, nonInclusivePhrase, [ "episode", "episodes", "state", "states", "symptoms", "and depressive episodes", "and hypomanic", "or hypomanic"  ] ) ),
+			.filter( isNotFollowedByException( words, nonInclusivePhrase,
+				[ "episode", "episodes", "state", "states", "symptoms", "and depressive episodes", "and hypomanic", "or hypomanic" ] ) ),
 	},
 	{
 		identifier: "hysterical",

--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessments.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessments.js
@@ -56,7 +56,8 @@ const disabilityAssessments =  [
 		feedbackFormat: "Be careful when using <i>%1$s</i>, unless talking about a symptom of a medical condition. " +
 			"If you are not referencing a symptom, consider other alternatives to describe the trait or behavior, such as %2$s.",
 		rule: ( words, nonInclusivePhrase ) => includesConsecutiveWords( words, nonInclusivePhrase )
-			.filter( isNotFollowedByException( words, nonInclusivePhrase, [ "drink", "drinks", "drinking" ] ) ),
+			.filter( isNotFollowedByException( words, nonInclusivePhrase, [ "drink", "drinks", "drinking", +
+				"eating disorder", "and purge", "behavior", "behaviors", "behaviour", "behaviours" ] ) ),
 	},
 	{
 		identifier: "bingeing",
@@ -65,6 +66,9 @@ const disabilityAssessments =  [
 		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
 		feedbackFormat: "Be careful when using <i>%1$s</i>, unless talking about a symptom of a medical condition. " +
 			"If you are not referencing a symptom, consider other alternatives to describe the trait or behavior, such as %2$s.",
+		rule: ( words, nonInclusivePhrase ) => includesConsecutiveWords( words, nonInclusivePhrase )
+			.filter( isNotFollowedByException( words, nonInclusivePhrase, [ "and purging", "behavior", +
+				"behaviors", "behaviour", "behaviours"  ] ) ),
 	},
 	{
 		identifier: "binged",
@@ -73,6 +77,8 @@ const disabilityAssessments =  [
 		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
 		feedbackFormat: "Be careful when using <i>%1$s</i>, unless talking about a symptom of a medical condition. " +
 			"If you are not referencing a symptom, consider other alternatives to describe the trait or behavior, such as %2$s.",
+		rule: ( words, nonInclusivePhrase ) => includesConsecutiveWords( words, nonInclusivePhrase )
+			.filter( isNotFollowedByException( words, nonInclusivePhrase, [ "and purged" ] ) ),
 	},
 	{
 		identifier: "binges",
@@ -81,6 +87,8 @@ const disabilityAssessments =  [
 		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
 		feedbackFormat: "Be careful when using <i>%1$s</i>, unless talking about a symptom of a medical condition. " +
 			"If you are not referencing a symptom, consider other alternatives to describe the trait or behavior, such as %2$s.",
+		rule: ( words, nonInclusivePhrase ) => includesConsecutiveWords( words, nonInclusivePhrase )
+			.filter( isNotFollowedByException( words, nonInclusivePhrase, [ "and purges" ] ) ),
 	},
 	{
 		identifier: "wheelchairBound",
@@ -500,6 +508,8 @@ const disabilityAssessments =  [
 		inclusiveAlternatives: "<i>of two minds, chaotic, confusing</i>",
 		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
 		feedbackFormat: medicalCondition,
+		rule: ( words, nonInclusivePhrase ) => includesConsecutiveWords( words, nonInclusivePhrase )
+			.filter( isNotFollowedByException( words, nonInclusivePhrase, [ "disorder" ] ) ),
 	},
 	{
 		identifier: "paranoid",
@@ -507,6 +517,8 @@ const disabilityAssessments =  [
 		inclusiveAlternatives: "<i>overly suspicious, unreasonable, defensive</i>",
 		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
 		feedbackFormat: medicalCondition,
+		rule: ( words, nonInclusivePhrase ) => includesConsecutiveWords( words, nonInclusivePhrase )
+			.filter( isNotFollowedByException( words, nonInclusivePhrase, [ "personality disorder", "delusion", "delusions", "ideation"  ] ) ),
 	},
 	{
 		identifier: "manic",
@@ -514,6 +526,8 @@ const disabilityAssessments =  [
 		inclusiveAlternatives: "<i>excited, raving, unbalanced, wild</i>",
 		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
 		feedbackFormat: medicalCondition,
+		rule: ( words, nonInclusivePhrase ) => includesConsecutiveWords( words, nonInclusivePhrase )
+			.filter( isNotFollowedByException( words, nonInclusivePhrase, [ "episode", "episodes", "state", "states", "symptoms", "and depressive episodes", "and hypomanic", "or hypomanic"  ] ) ),
 	},
 	{
 		identifier: "hysterical",


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We target words such as "bipolar" when used to describe a personal trait instead of a medical condition (e.g. "They act bipolar in decision-making"). Rules were added to avoid targeting these words in a medical context  (such as "bipolar disorder"), where using them is inclusive. 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves feedback in the inclusive language assessment by excluding false positives for pontentially non-inclusive phrases related to mental health.

## Relevant technical choices:

* Even though the phrase _schizoaffective disorder_ is used instead of _schizophrenic disorder_, the rule "exclude word when followed by disorder" was added for both the word  _bipolar_ and the word _schizophrenic_  since they share the same string.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install Yoast SEO Free
* Open a new post and add the following phrase to the text: `binge eating disorder`.
* Confirm that the inclusive language assessment feedback is not triggered.
* Remove the phrase `binge eating disorder`.
* Add the following phrase to the text: `binge`
* Confirm that the inclusive language analysis returns an **orange** traffic light with the following feedback: `Be careful when using binge, unless talking about a symptom of a medical condition.  If you are not referencing a symptom, consider other alternatives to describe the trait or behavior, such as indulge, satiate, wallow, spree, marathon, consume excessively. Learn more`
* Add the phrase `drink`, `drinks`, `drinking`, `and purge`, `behavior`, `behaviors`, `behaviour`, behaviours after the word `bingeing`
* Confirm that that feedback from the above step disappears.
* Add the phrase `bingeing`
* Confirm that the inclusive language analysis returns a **orange** traffic light with the following feedback: `Be careful when using binge, unless talking about a symptom of a medical condition.  If you are not referencing a symptom, consider other alternatives to describe the trait or behavior, such as indulging, satiating, wallowing, spreeing, marathoning, consuming excessively. Learn more`
* Add the phrase `and purging`, `behaviour`, `behaviors`, `behaviour`, or `behaviours` after the word `bingeing`
* Confirm that that feedback from the above step dissapears.
* Add the phrase `binged`
* Confirm that the inclusive language analysis returns a **orange** traffic light with the following feedback: `Be careful when using binge, unless talking about a symptom of a medical condition.  If you are not referencing a symptom, consider other alternatives to describe the trait or behavior, such as indulged, satiated, wallowed, spreed, marathoned, consumed excessively. Learn more`
* Add the phrase `and purged` after the word `binged`
* Confirm that that feedback from the above step dissapears.
* Add the phrase `binges`
* Confirm that the inclusive language analysis returns a **orange** traffic light with the following feedback: `Be careful when using binge, unless talking about a symptom of a medical condition.  If you are not referencing a symptom, consider other alternatives to describe the trait or behavior, such as indulges, satiates, wallows, sprees, marathons, consumes excessively. Learn more`
* Add the phrase `and purges` after the word `binges`
* Confirm that that feedback from the above step dissapears.
* Add the phrase `bipolar` 
* Confirm that the inclusive language analysis returns a **orange** traffic light with the following feedback: `Avoid using bipolar as it is potentially harmful. Unless you are referencing the specific medical condition, consider using another
alternative to describe the trait or behavior, such as of two minds, chaotic, confusing. Learn more.`
* Add the phrase `disorder` after the word `bipolar`
* Confirm that that feedback from the above step dissapears.
* Add the phrase `paranoid`
* Confirm that the inclusive language analysis returns a **orange** traffic light with the following feedback: `Avoid using paranoid as it is potentially harmful. Unless you are referencing the specific medical condition, consider using another
alternative to describe the trait or behavior, such as of overly suspicious, unreasonable, defensive. Learn more.`
* Add the phrase `delusion`, `delusions`, `personality disorder`, `ideation` after the word `paranoid`.
* Confirm that that feedback from the above step dissapears.
* Add the phrase `manic`
* Confirm that the inclusive language analysis returns a **orange** traffic light with the following feedback: `Avoid using manic as it is potentially harmful. Unless you are referencing the specific medical condition, consider using another
alternative to describe the trait or behavior, such as of excited, raving, unbalanced, wild. Learn more.`
* Add the phrase `episode`, `episodes`, `state`, `states`, `symptoms`, `and depressive episodes`, `and hypomanic`, or`or hypomanic` after `manic`.
* Confirm that that feedback from the above step dissapears.


#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [x] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #https://github.com/orgs/Yoast/projects/51/views/1?pane=issue&itemId=43422944
