### PR TITLE
Improve copy of plugin ads

### DIFF
--- a/admin/class-premium-upsell-admin-block.php
+++ b/admin/class-premium-upsell-admin-block.php
@@ -53,13 +53,12 @@ class WPSEO_Premium_Upsell_Admin_Block {
 		$url = WPSEO_Shortlinker::get( 'https://yoa.st/17h' );
 
 		$arguments = [
-			'<strong>' . esc_html__( 'Use AI', 'wordpress-seo' ) . '</strong>: ' . esc_html__( 'Quickly create titles & meta descriptions', 'wordpress-seo' ),
-			'<strong>' . esc_html__( 'No more dead links', 'wordpress-seo' ) . '</strong>: ' . esc_html__( 'Easy redirect manager', 'wordpress-seo' ),
-			'<strong>' . esc_html__( 'Superfast internal linking suggestions', 'wordpress-seo' ) . '</strong>',
-			'<strong>' . esc_html__( 'Social media preview', 'wordpress-seo' ) . '</strong>: ' . esc_html__( 'Facebook & Twitter', 'wordpress-seo' ),
-			'<strong>' . esc_html__( 'Multiple keyphrases', 'wordpress-seo' ) . '</strong>: ' . esc_html__( 'Increase your SEO reach', 'wordpress-seo' ),
-			'<strong>' . esc_html__( 'SEO Workouts', 'wordpress-seo' ) . '</strong>: ' . esc_html__( 'Get guided in routine SEO tasks', 'wordpress-seo' ),
-			'<strong>' . esc_html__( '24/7 email support', 'wordpress-seo' ) . '</strong>',
+			'<strong>' . esc_html__( 'AI', 'wordpress-seo' ) . '</strong>: ' . esc_html__( 'Better SEO titles and meta descriptions, faster', 'wordpress-seo' ) . '.',
+			'<strong>' . esc_html__( 'Multiple keywords', 'wordpress-seo' ) . '</strong>: ' . esc_html__( 'Rank higher for more searches', 'wordpress-seo' ) . '.',
+			'<strong>' . esc_html__( 'Super fast', 'wordpress-seo' ) . '</strong>: ' . esc_html__( 'internal linking suggestions', 'wordpress-seo' ) . '.',
+			'<strong>' . esc_html__( 'No more broken links', 'wordpress-seo' ) . '</strong>: ' . esc_html__( 'Automatic redirect manager', 'wordpress-seo' ) . '.',
+			'<strong>' . esc_html__( 'Social preview', 'wordpress-seo' ) . '</strong>: ' . esc_html__( 'Appealing previews people actually want to click on', 'wordpress-seo' ) . '.',
+			'<strong>' . esc_html__( '24/7 support', 'wordpress-seo' ) . '</strong>: ' . esc_html__( 'Also on evenings and weekends', 'wordpress-seo' ) . '.',
 			'<strong>' . esc_html__( 'No ads!', 'wordpress-seo' ) . '</strong>',
 		];
 
@@ -68,7 +67,7 @@ class WPSEO_Premium_Upsell_Admin_Block {
 		$class = $this->get_html_class();
 
 		/* translators: %s expands to Yoast SEO Premium */
-		$button_text = YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-2023-promotion' ) ? \esc_html__( 'Claim your 30% off now!', 'wordpress-seo' ) : sprintf( esc_html__( 'Get %s', 'wordpress-seo' ), 'Yoast SEO Premium' );
+		$button_text = YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-2023-promotion' ) ? \esc_html__( 'Claim your 30% off now!', 'wordpress-seo' ) : sprintf( esc_html__( 'Explore %s now!', 'wordpress-seo' ), 'Yoast SEO Premium' );
 		/* translators: Hidden accessibility text. */
 		$button_text .= '<span class="screen-reader-text">' . esc_html__( '(Opens in a new browser tab)', 'wordpress-seo' ) . '</span>' .
 			'<span aria-hidden="true" class="yoast-button-upsell__caret"></span>';

--- a/admin/class-premium-upsell-admin-block.php
+++ b/admin/class-premium-upsell-admin-block.php
@@ -55,40 +55,40 @@ class WPSEO_Premium_Upsell_Admin_Block {
 		$arguments = [
 			sprintf(
 				/* translators: %1$s expands to a strong opening tag, %2$s expands to a strong closing tag. */
-				esc_html__( '%1$sAI%2$s: Better SEO titles and meta descriptions, faster', 'wordpress-seo' ),
+				esc_html__( '%1$sAI%2$s: Better SEO titles and meta descriptions, faster.', 'wordpress-seo' ),
 				'<strong>',
 				'</strong>'
-			) . '.',
+			),
 			sprintf(
 				/* translators: %1$s expands to a strong opening tag, %2$s expands to a strong closing tag. */
-				esc_html__( '%1$sMultiple keywords%2$s: Rank higher for more searches', 'wordpress-seo' ),
+				esc_html__( '%1$sMultiple keywords%2$s: Rank higher for more searches.', 'wordpress-seo' ),
 				'<strong>',
 				'</strong>'
-			) . '.',
+			),
 			sprintf(
 				/* translators: %1$s expands to a strong opening tag, %2$s expands to a strong closing tag. */
-				esc_html__( '%1$sSuper fast%2$s internal linking suggestions', 'wordpress-seo' ),
+				esc_html__( '%1$sSuper fast%2$s internal linking suggestions.', 'wordpress-seo' ),
 				'<strong>',
 				'</strong>'
-			) . '.',
+			),
 			sprintf(
 				/* translators: %1$s expands to a strong opening tag, %2$s expands to a strong closing tag. */
-				esc_html__( '%1$sNo more broken links%2$s: Automatic redirect manager', 'wordpress-seo' ),
+				esc_html__( '%1$sNo more broken links%2$s: Automatic redirect manager.', 'wordpress-seo' ),
 				'<strong>',
 				'</strong>'
-			) . '.',
+			),
 			sprintf(
 				/* translators: %1$s expands to a strong opening tag, %2$s expands to a strong closing tag. */
-				esc_html__( '%1$sAppealing social previews%2$s people actually want to click on', 'wordpress-seo' ),
+				esc_html__( '%1$sAppealing social previews%2$s people actually want to click on.', 'wordpress-seo' ),
 				'<strong>',
 				'</strong>'
-			) . '.',
+			),
 			sprintf(
 				/* translators: %1$s expands to a strong opening tag, %2$s expands to a strong closing tag. */
-				esc_html__( '%1$s24/7 support%2$s: Also on evenings and weekends', 'wordpress-seo' ),
+				esc_html__( '%1$s24/7 support%2$s: Also on evenings and weekends.', 'wordpress-seo' ),
 				'<strong>',
 				'</strong>'
-			) . '.',
+			),
 			'<strong>' . esc_html__( 'No ads!', 'wordpress-seo' ) . '</strong>',
 		];
 

--- a/admin/class-premium-upsell-admin-block.php
+++ b/admin/class-premium-upsell-admin-block.php
@@ -53,12 +53,42 @@ class WPSEO_Premium_Upsell_Admin_Block {
 		$url = WPSEO_Shortlinker::get( 'https://yoa.st/17h' );
 
 		$arguments = [
-			'<strong>' . esc_html__( 'AI', 'wordpress-seo' ) . '</strong>: ' . esc_html__( 'Better SEO titles and meta descriptions, faster', 'wordpress-seo' ) . '.',
-			'<strong>' . esc_html__( 'Multiple keywords', 'wordpress-seo' ) . '</strong>: ' . esc_html__( 'Rank higher for more searches', 'wordpress-seo' ) . '.',
-			'<strong>' . esc_html__( 'Super fast', 'wordpress-seo' ) . '</strong>: ' . esc_html__( 'internal linking suggestions', 'wordpress-seo' ) . '.',
-			'<strong>' . esc_html__( 'No more broken links', 'wordpress-seo' ) . '</strong>: ' . esc_html__( 'Automatic redirect manager', 'wordpress-seo' ) . '.',
-			'<strong>' . esc_html__( 'Social preview', 'wordpress-seo' ) . '</strong>: ' . esc_html__( 'Appealing previews people actually want to click on', 'wordpress-seo' ) . '.',
-			'<strong>' . esc_html__( '24/7 support', 'wordpress-seo' ) . '</strong>: ' . esc_html__( 'Also on evenings and weekends', 'wordpress-seo' ) . '.',
+			sprintf(
+				/* translators: %1$s expands to a strong opening tag, %2$s expands to a strong closing tag. */
+				esc_html__( '%1$sAI%2$s: Better SEO titles and meta descriptions, faster', 'wordpress-seo' ),
+				'<strong>',
+				'</strong>'
+			) . '.',
+			sprintf(
+				/* translators: %1$s expands to a strong opening tag, %2$s expands to a strong closing tag. */
+				esc_html__( '%1$sMultiple keywords%2$s: Rank higher for more searches', 'wordpress-seo' ),
+				'<strong>',
+				'</strong>'
+			) . '.',
+			sprintf(
+				/* translators: %1$s expands to a strong opening tag, %2$s expands to a strong closing tag. */
+				esc_html__( '%1$sSuper fast%2$s internal linking suggestions', 'wordpress-seo' ),
+				'<strong>',
+				'</strong>'
+			) . '.',
+			sprintf(
+				/* translators: %1$s expands to a strong opening tag, %2$s expands to a strong closing tag. */
+				esc_html__( '%1$sNo more broken links%2$s: Automatic redirect manager', 'wordpress-seo' ),
+				'<strong>',
+				'</strong>'
+			) . '.',
+			sprintf(
+				/* translators: %1$s expands to a strong opening tag, %2$s expands to a strong closing tag. */
+				esc_html__( '%1$sAppealing social previews%2$s people actually want to click on', 'wordpress-seo' ),
+				'<strong>',
+				'</strong>'
+			) . '.',
+			sprintf(
+				/* translators: %1$s expands to a strong opening tag, %2$s expands to a strong closing tag. */
+				esc_html__( '%1$s24/7 support%2$s: Also on evenings and weekends', 'wordpress-seo' ),
+				'<strong>',
+				'</strong>'
+			) . '.',
 			'<strong>' . esc_html__( 'No ads!', 'wordpress-seo' ) . '</strong>',
 		];
 

--- a/admin/views/licenses.php
+++ b/admin/views/licenses.php
@@ -161,28 +161,64 @@ if ( YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-202
 				?>
 				<ul class="yoast-seo-premium-benefits yoast-list--usp">
 					<li class="yoast-seo-premium-benefits__item">
-						<span class="yoast-seo-premium-benefits__title"><?php esc_html_e( 'AI', 'wordpress-seo' ); ?>: </span>
-						<span class="yoast-seo-premium-benefits__description"><?php esc_html_e( 'Better SEO titles and meta descriptions, faster', 'wordpress-seo' ); ?></span>
+						<?php
+						printf(
+							/* translators: %1$s expands to a strong opening tag, %2$s expands to a strong closing tag. */
+							esc_html__( '%1$sAI%2$s: Better SEO titles and meta descriptions, faster', 'wordpress-seo' ),
+							'<strong>',
+							'</strong>'
+						);
+						?>
 					</li>
 					<li class="yoast-seo-premium-benefits__item">
-						<span class="yoast-seo-premium-benefits__title"><?php esc_html_e( 'Multiple keywords', 'wordpress-seo' ); ?>: </span>
-						<span class="yoast-seo-premium-benefits__description"><?php esc_html_e( 'Rank higher for more searches', 'wordpress-seo' ); ?></span>
+						<?php
+						printf(
+							/* translators: %1$s expands to a strong opening tag, %2$s expands to a strong closing tag. */
+							esc_html__( '%1$sMultiple keywords%2$s: Rank higher for more searches', 'wordpress-seo' ),
+							'<strong>',
+							'</strong>'
+						);
+						?>
 					</li>
 					<li class="yoast-seo-premium-benefits__item">
-						<span class="yoast-seo-premium-benefits__title"><?php esc_html_e( 'Super fast', 'wordpress-seo' ); ?></span>
-						<span class="yoast-seo-premium-benefits__description"><?php esc_html_e( 'internal linking suggestions', 'wordpress-seo' ); ?></span>
+						<?php
+						printf(
+							/* translators: %1$s expands to a strong opening tag, %2$s expands to a strong closing tag. */
+							esc_html__( '%1$sSuper fast%2$s internal linking suggestions', 'wordpress-seo' ),
+							'<strong>',
+							'</strong>'
+						);
+						?>
 					</li>
 					<li class="yoast-seo-premium-benefits__item">
-						<span class="yoast-seo-premium-benefits__title"><?php esc_html_e( 'No more broken links', 'wordpress-seo' ); ?>: </span>
-						<span class="yoast-seo-premium-benefits__description"><?php esc_html_e( 'Automatic redirect manager', 'wordpress-seo' ); ?></span>
+						<?php
+						printf(
+							/* translators: %1$s expands to a strong opening tag, %2$s expands to a strong closing tag. */
+							esc_html__( '%1$sNo more broken links%2$s: Automatic redirect manager', 'wordpress-seo' ),
+							'<strong>',
+							'</strong>'
+						);
+						?>
 					</li>
 					<li class="yoast-seo-premium-benefits__item">
-						<span class="yoast-seo-premium-benefits__title"><?php esc_html_e( 'Appealing social previews', 'wordpress-seo' ); ?></span>
-						<span class="yoast-seo-premium-benefits__description"><?php esc_html_e( 'people actually want to click on', 'wordpress-seo' ); ?></span>
+						<?php
+						printf(
+							/* translators: %1$s expands to a strong opening tag, %2$s expands to a strong closing tag. */
+							esc_html__( '%1$sAppealing social previews%2$s people actually want to click on', 'wordpress-seo' ),
+							'<strong>',
+							'</strong>'
+						);
+						?>
 					</li>
 					<li class="yoast-seo-premium-benefits__item">
-						<span class="yoast-seo-premium-benefits__title"><?php esc_html_e( '24/7 support', 'wordpress-seo' ); ?>: </span>
-						<span class="yoast-seo-premium-benefits__description"><?php esc_html_e( 'Also on evenings and weekends', 'wordpress-seo' ); ?></span>
+						<?php
+						printf(
+							/* translators: %1$s expands to a strong opening tag, %2$s expands to a strong closing tag. */
+							esc_html__( '%1$s24/7 support%2$s: Also on evenings and weekends', 'wordpress-seo' ),
+							'<strong>',
+							'</strong>'
+						);
+						?>
 					</li>
 				</ul>
 			<?php endif; ?>

--- a/admin/views/licenses.php
+++ b/admin/views/licenses.php
@@ -31,11 +31,11 @@ $extensions = [
 		'buyUrl'        => WPSEO_Shortlinker::get( 'https://yoa.st/zt' ),
 		'infoUrl'       => WPSEO_Shortlinker::get( 'https://yoa.st/zs' ),
 		'title'         => 'Local SEO',
-		'display_title' => __( 'Maximize your visibility for local searches', 'wordpress-seo' ),
+		'display_title' => __( 'Stand out for local searches', 'wordpress-seo' ),
 		'desc'          => __( 'Rank better locally and in Google Maps, without breaking a sweat!', 'wordpress-seo' ),
 		'image'         => plugins_url( 'images/local_plugin_assistant.svg?v=' . WPSEO_VERSION, WPSEO_FILE ),
 		'benefits'      => [
-			__( 'Attract more local customers to your website and physical store', 'wordpress-seo' ),
+			__( 'Attract more customers to your site and physical store', 'wordpress-seo' ),
 			__( 'Automatically get technical SEO best practices for local businesses', 'wordpress-seo' ),
 			__( 'Easily add maps, address finders, and opening hours to your content', 'wordpress-seo' ),
 			__( 'Optimize your business for multiple locations', 'wordpress-seo' ),
@@ -45,14 +45,14 @@ $extensions = [
 		'buyUrl'        => WPSEO_Shortlinker::get( 'https://yoa.st/zx/' ),
 		'infoUrl'       => WPSEO_Shortlinker::get( 'https://yoa.st/zw/' ),
 		'title'         => 'Video SEO',
-		'display_title' => __( 'Drive more traffic to your videos', 'wordpress-seo' ),
+		'display_title' => __( 'Drive more views to your videos', 'wordpress-seo' ),
 		'desc'          => __( 'Optimize your videos to show them off in search results and get more clicks!', 'wordpress-seo' ),
 		'image'         => plugins_url( 'images/video_plugin_assistant.svg?v=' . WPSEO_VERSION, WPSEO_FILE ),
 		'benefits'      => [
-			__( 'Know that Google discovers your videos', 'wordpress-seo' ),
-			__( 'Load pages faster that include videos', 'wordpress-seo' ),
+			__( 'Automatically get technical SEO best practices for video content', 'wordpress-seo' ),
+			__( 'Make sure your videos load quickly for users', 'wordpress-seo' ),
 			__( 'Make your videos responsive for all screen sizes', 'wordpress-seo' ),
-			__( 'Get XML video sitemaps', 'wordpress-seo' ),
+			__( 'Optimize your video previews & thumbnails', 'wordpress-seo' ),
 		],
 	],
 	WPSEO_Addon_Manager::NEWS_SLUG  => [
@@ -66,7 +66,7 @@ $extensions = [
 			__( 'Optimize your site for Google News', 'wordpress-seo' ),
 			__( 'Ping Google on the publication of a new post', 'wordpress-seo' ),
 			__( 'Add all necessary schema.org markup', 'wordpress-seo' ),
-			__( 'Get XML news sitemaps', 'wordpress-seo' ),
+			__( 'Get XML sitemaps', 'wordpress-seo' ),
 		],
 	],
 ];
@@ -82,11 +82,12 @@ if ( YoastSEO()->helpers->woocommerce->is_active() ) {
 		'desc'          => sprintf( __( 'Seamlessly integrate WooCommerce with %1$s and get extra features!', 'wordpress-seo' ), 'Yoast SEO' ),
 		'image'         => plugins_url( 'images/woo_plugin_assistant.svg?v=' . WPSEO_VERSION, WPSEO_FILE ),
 		'benefits'      => [
-			__( 'Write product pages that rank with the enhanced SEO analysis', 'wordpress-seo' ),
-			__( 'Increase clicks of Google search with rich results', 'wordpress-seo' ),
+			__( 'Write product pages that rank using the SEO analysis', 'wordpress-seo' ),
+			__( 'Increase Google clicks with rich results', 'wordpress-seo' ),
 			__( 'Add global identifiers for variable products', 'wordpress-seo' ),
 			/* translators: %1$s expands to Yoast SEO, %2$s expands to WooCommerce */
 			sprintf( __( 'Seamless integration between %1$s and %2$s', 'wordpress-seo' ), 'Yoast SEO', 'WooCommerce' ),
+			__( 'Turn more visitors into customers!', 'wordpress-seo' ),
 		],
 		'buy_button'    => 'WooCommerce SEO',
 	];
@@ -107,9 +108,9 @@ $extensions['yoast-seo-plugin-subscription'] = [
 	'desc'          => '',
 	'image'         => plugins_url( 'images/plugin_subscription.svg?v=' . WPSEO_VERSION, WPSEO_FILE ),
 	'benefits'      => [
-		__( 'Get all 5 Yoast plugins for WordPress with a big discount', 'wordpress-seo' ),
-		__( 'Reach new customers that live near your business', 'wordpress-seo' ),
-		__( 'Drive more traffic with your videos', 'wordpress-seo' ),
+		__( 'Get all 5 Yoast plugins for WordPress at a big discount', 'wordpress-seo' ),
+		__( 'Reach new customers who live near your business', 'wordpress-seo' ),
+		__( 'Drive more views to your videos', 'wordpress-seo' ),
 		__( 'Rank higher in Google\'s news carousel', 'wordpress-seo' ),
 		__( 'Drive more traffic to your online store', 'wordpress-seo' ),
 
@@ -152,14 +153,7 @@ if ( YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-202
 		<section class="yoast-seo-premium-extension">
 			<?php echo $premium_sale_badge; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Reason: Output is already escaped ?>
 			<h2>
-				<?php
-				printf(
-					/* translators: 1: expands to Yoast SEO Premium */
-					esc_html__( 'Drive more traffic to your site with %1$s', 'wordpress-seo' ),
-					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Reason: The `get_title` value is hardcoded; only passed through the WPSEO_Extensions class.
-					$premium_extension['title']
-				);
-				?>
+				<?php esc_html_e( 'Rank higher in search results', 'wordpress-seo' ); ?>
 				<img alt="" width="100" height="100" src="<?php echo esc_url( $premium_extension['image'] ); ?>"/>
 			</h2>
 			<?php
@@ -167,36 +161,28 @@ if ( YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-202
 				?>
 				<ul class="yoast-seo-premium-benefits yoast-list--usp">
 					<li class="yoast-seo-premium-benefits__item">
-						<span class="yoast-seo-premium-benefits__title"><?php esc_html_e( 'Be more efficient in creating content', 'wordpress-seo' ); ?></span>
-						<span class="yoast-seo-premium-benefits__description"><?php esc_html_e( 'Use AI to create high-quality titles and meta descriptions for posts and pages', 'wordpress-seo' ); ?></span>
+						<span class="yoast-seo-premium-benefits__title"><?php esc_html_e( 'AI', 'wordpress-seo' ); ?>: </span>
+						<span class="yoast-seo-premium-benefits__description"><?php esc_html_e( 'Better SEO titles and meta descriptions, faster', 'wordpress-seo' ); ?></span>
 					</li>
 					<li class="yoast-seo-premium-benefits__item">
-						<span class="yoast-seo-premium-benefits__title"><?php esc_html_e( 'Reach bigger audiences', 'wordpress-seo' ); ?></span>
-						<span class="yoast-seo-premium-benefits__description"><?php esc_html_e( 'Optimize a single post for synonyms and related keyphrases and get extra checks with the Premium SEO analysis', 'wordpress-seo' ); ?></span>
+						<span class="yoast-seo-premium-benefits__title"><?php esc_html_e( 'Multiple keywords', 'wordpress-seo' ); ?>: </span>
+						<span class="yoast-seo-premium-benefits__description"><?php esc_html_e( 'Rank higher for more searches', 'wordpress-seo' ); ?></span>
 					</li>
 					<li class="yoast-seo-premium-benefits__item">
-						<span class="yoast-seo-premium-benefits__title"><?php esc_html_e( 'Save time on doing SEO', 'wordpress-seo' ); ?></span>
-						<span class="yoast-seo-premium-benefits__description"><?php esc_html_e( 'The Yoast SEO workouts guide you through important routine SEO tasks', 'wordpress-seo' ); ?></span>
+						<span class="yoast-seo-premium-benefits__title"><?php esc_html_e( 'Super fast', 'wordpress-seo' ); ?></span>
+						<span class="yoast-seo-premium-benefits__description"><?php esc_html_e( 'internal linking suggestions', 'wordpress-seo' ); ?></span>
 					</li>
 					<li class="yoast-seo-premium-benefits__item">
-						<span class="yoast-seo-premium-benefits__title"><?php esc_html_e( 'Improve your internal linking structure', 'wordpress-seo' ); ?></span>
-						<span class="yoast-seo-premium-benefits__description"><?php esc_html_e( 'Get tools that tell you where and how to improve internal linking', 'wordpress-seo' ); ?></span>
+						<span class="yoast-seo-premium-benefits__title"><?php esc_html_e( 'No more broken links', 'wordpress-seo' ); ?>: </span>
+						<span class="yoast-seo-premium-benefits__description"><?php esc_html_e( 'Automatic redirect manager', 'wordpress-seo' ); ?></span>
 					</li>
 					<li class="yoast-seo-premium-benefits__item">
-						<span class="yoast-seo-premium-benefits__title"><?php esc_html_e( 'Reduce your site\'s carbon footprint', 'wordpress-seo' ); ?></span>
-						<span class="yoast-seo-premium-benefits__description"><?php esc_html_e( 'Save energy by reducing the crawlability of your site without hurting your rankings!', 'wordpress-seo' ); ?></span>
+						<span class="yoast-seo-premium-benefits__title"><?php esc_html_e( 'Appealing social previews', 'wordpress-seo' ); ?></span>
+						<span class="yoast-seo-premium-benefits__description"><?php esc_html_e( 'people actually want to click on', 'wordpress-seo' ); ?></span>
 					</li>
 					<li class="yoast-seo-premium-benefits__item">
-						<span class="yoast-seo-premium-benefits__title"><?php esc_html_e( 'Prevents 404s', 'wordpress-seo' ); ?></span>
-						<span class="yoast-seo-premium-benefits__description"><?php esc_html_e( 'Easily create and manage redirects when you move or delete content', 'wordpress-seo' ); ?></span>
-					</li>
-					<li class="yoast-seo-premium-benefits__item">
-						<span class="yoast-seo-premium-benefits__title"><?php esc_html_e( 'Stand out on social media', 'wordpress-seo' ); ?></span>
-						<span class="yoast-seo-premium-benefits__description"><?php esc_html_e( 'Check what your Facebook or Twitter post will look like before posting them', 'wordpress-seo' ); ?></span>
-					</li>
-					<li class="yoast-seo-premium-benefits__item">
-						<span class="yoast-seo-premium-benefits__title"><?php esc_html_e( 'Premium support', 'wordpress-seo' ); ?></span>
-						<span class="yoast-seo-premium-benefits__description"><?php esc_html_e( 'Gain access to our 24/7 support team', 'wordpress-seo' ); ?></span>
+						<span class="yoast-seo-premium-benefits__title"><?php esc_html_e( '24/7 support', 'wordpress-seo' ); ?>: </span>
+						<span class="yoast-seo-premium-benefits__description"><?php esc_html_e( 'Also on evenings and weekends', 'wordpress-seo' ); ?></span>
 					</li>
 				</ul>
 			<?php endif; ?>
@@ -252,14 +238,7 @@ if ( YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-202
 
 				<a target="_blank"  href="<?php echo esc_url( $premium_extension['infoUrl'] ); ?>" class="yoast-link--more-info">
 					<?php
-					printf(
-						/* translators: Text between 1: and 2: will only be shown to screen readers. 3: expands to the product name. */
-						esc_html__( 'More information %1$sabout %3$s%2$s', 'wordpress-seo' ),
-						'<span class="screen-reader-text">',
-						'</span>',
-						// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Reason: The `get_title` value is hardcoded; only passed through the WPSEO_Extensions class.
-						$premium_extension['title']
-					);
+					esc_html_e( 'Explore now', 'wordpress-seo' );
 					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Reason: $new_tab_message is properly escaped.
 					echo $new_tab_message;
 					?>
@@ -267,7 +246,7 @@ if ( YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-202
 			<?php endif; ?>
 			<?php if ( ! $has_valid_premium_subscription ) { ?>
 				<p>
-					<small class="yoast-money-back-guarantee"><?php esc_html_e( 'With 30-day money-back guarantee. No questions asked.', 'wordpress-seo' ); ?></small>
+					<small class="yoast-money-back-guarantee"><?php esc_html_e( 'With a 30-day money-back guarantee. No questions asked.', 'wordpress-seo' ); ?></small>
 				</p>
 			<?php } ?>
 		</section>
@@ -282,7 +261,7 @@ if ( YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-202
 
 				printf(
 					/* translators: 1: expands to Outrank your competitors even further, 2: expands to Yoast SEO */
-					esc_html__( '%1$s with %2$s extensions', 'wordpress-seo' ),
+					esc_html__( '%1$s with %2$s plugins', 'wordpress-seo' ),
 					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Reason: $yoast_seo_extensions is properly escaped.
 					$yoast_outrank_copy,
 					'Yoast SEO'
@@ -365,14 +344,7 @@ if ( YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-202
 
 							<a target="_blank" class="yoast-link--more-info" href="<?php echo esc_url( $extension['infoUrl'] ); ?>">
 								<?php
-								printf(
-									/* translators: Text between 1: and 2: will only be shown to screen readers. 3: expands to the product name, e.g. "News SEO" or "all the Yoast Plugins" */
-									esc_html__( 'More information %1$sabout %3$s%2$s', 'wordpress-seo' ),
-									'<span class="screen-reader-text">',
-									'</span>',
-									// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Reason: The `get_title` value is hardcoded; only passed through the WPSEO_Extensions class.
-									$extension['title']
-								);
+								esc_html_e( 'Explore now', 'wordpress-seo' );
 								// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Reason: $new_tab_message is properly escaped.
 								echo $new_tab_message;
 								?>

--- a/admin/views/licenses.php
+++ b/admin/views/licenses.php
@@ -164,7 +164,7 @@ if ( YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-202
 						<?php
 						printf(
 							/* translators: %1$s expands to a strong opening tag, %2$s expands to a strong closing tag. */
-							esc_html__( '%1$sAI%2$s: Better SEO titles and meta descriptions, faster', 'wordpress-seo' ),
+							esc_html__( '%1$sAI%2$s: Better SEO titles and meta descriptions, faster.', 'wordpress-seo' ),
 							'<strong>',
 							'</strong>'
 						);
@@ -174,7 +174,7 @@ if ( YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-202
 						<?php
 						printf(
 							/* translators: %1$s expands to a strong opening tag, %2$s expands to a strong closing tag. */
-							esc_html__( '%1$sMultiple keywords%2$s: Rank higher for more searches', 'wordpress-seo' ),
+							esc_html__( '%1$sMultiple keywords%2$s: Rank higher for more searches.', 'wordpress-seo' ),
 							'<strong>',
 							'</strong>'
 						);
@@ -184,7 +184,7 @@ if ( YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-202
 						<?php
 						printf(
 							/* translators: %1$s expands to a strong opening tag, %2$s expands to a strong closing tag. */
-							esc_html__( '%1$sSuper fast%2$s internal linking suggestions', 'wordpress-seo' ),
+							esc_html__( '%1$sSuper fast%2$s internal linking suggestions.', 'wordpress-seo' ),
 							'<strong>',
 							'</strong>'
 						);
@@ -194,7 +194,7 @@ if ( YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-202
 						<?php
 						printf(
 							/* translators: %1$s expands to a strong opening tag, %2$s expands to a strong closing tag. */
-							esc_html__( '%1$sNo more broken links%2$s: Automatic redirect manager', 'wordpress-seo' ),
+							esc_html__( '%1$sNo more broken links%2$s: Automatic redirect manager.', 'wordpress-seo' ),
 							'<strong>',
 							'</strong>'
 						);
@@ -204,7 +204,7 @@ if ( YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-202
 						<?php
 						printf(
 							/* translators: %1$s expands to a strong opening tag, %2$s expands to a strong closing tag. */
-							esc_html__( '%1$sAppealing social previews%2$s people actually want to click on', 'wordpress-seo' ),
+							esc_html__( '%1$sAppealing social previews%2$s people actually want to click on.', 'wordpress-seo' ),
 							'<strong>',
 							'</strong>'
 						);
@@ -214,7 +214,7 @@ if ( YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-202
 						<?php
 						printf(
 							/* translators: %1$s expands to a strong opening tag, %2$s expands to a strong closing tag. */
-							esc_html__( '%1$s24/7 support%2$s: Also on evenings and weekends', 'wordpress-seo' ),
+							esc_html__( '%1$s24/7 support%2$s: Also on evenings and weekends.', 'wordpress-seo' ),
 							'<strong>',
 							'</strong>'
 						);

--- a/css/src/yoast-extensions.css
+++ b/css/src/yoast-extensions.css
@@ -672,6 +672,7 @@ a.promoblock:hover {
   font-size: 1.5rem;
   color: rgb(166 30 105);
   display: flex;
+  justify-content: space-between;
 }
 
 .yoast-seo-premium-extension img {
@@ -713,10 +714,6 @@ a.promoblock:hover {
   font-size: .9rem;
   line-height: 24px;
   font-weight: 400;
-}
-
-.yoast-seo-premium-benefits__description:before {
-  content: "– ";
 }
 
 .yoast-link--license, .yoast-link--more-info {

--- a/css/src/yoast-extensions.css
+++ b/css/src/yoast-extensions.css
@@ -698,7 +698,9 @@ a.promoblock:hover {
 }
 .yoast-seo-premium-benefits__item {
   margin-bottom: 8px;
-  line-height: 1;
+  font-size: .9rem;
+  line-height: 24px;
+  font-weight: 400;
 }
 .yoast-seo-premium-benefits__item span {
   color: rgb(64,64,64);

--- a/packages/js/src/ai-generator/components/modal-content.js
+++ b/packages/js/src/ai-generator/components/modal-content.js
@@ -33,7 +33,7 @@ export const ModalContent = () => {
 		);
 		postModalprops.newToText = sprintf(
 			/* translators: %1$s expands to Yoast SEO Premium and Yoast WooCommerce SEO. */
-			__( "New to %1$s", "wordpress-seo" ),
+			__( "New in %1$s", "wordpress-seo" ),
 			upsellPremiumWooLabel
 		);
 		postModalprops.title = __( "Generate product titles & descriptions with AI!", "wordpress-seo" );

--- a/packages/js/src/components/AnalysisUpsell.js
+++ b/packages/js/src/components/AnalysisUpsell.js
@@ -50,7 +50,7 @@ const AnalysisUpsell = ( props ) => {
 			<TextContainer>
 				{ sprintf(
 					/* translators: %s expands to Yoast SEO Premium */
-					__( "Did you know %s also analyzes the different word forms of your keyphrase, like plurals and past tenses?", "wordpress-seo" ),
+					__( "%s looks at more than just your main keyword. It analyzes different word forms, plurals, and past tenses. This helps your website perform even better in searches!", "wordpress-seo" ),
 					"Yoast SEO Premium"
 				) }
 			</TextContainer>

--- a/packages/js/src/components/UpsellBox.js
+++ b/packages/js/src/components/UpsellBox.js
@@ -95,10 +95,7 @@ class UpsellBox extends Component {
 			<StyledList role="list">
 				{ benefits.map( ( benefit, index ) => {
 					return <li key={ `upsell-benefit-${ index }` }>
-						{ createInterpolateElement(
-							benefit.replace( "<strong>", "{{strong}}" ).replace( "</strong>", "{{/strong}}" ),
-							{ strong: <strong /> }
-						) }
+						{ createInterpolateElement( benefit, { strong: <strong /> } ) }
 					</li>;
 				} ) }
 			</StyledList>

--- a/packages/js/src/components/modals/InternalLinkingSuggestionsUpsell.js
+++ b/packages/js/src/components/modals/InternalLinkingSuggestionsUpsell.js
@@ -4,6 +4,7 @@ import { __, sprintf } from "@wordpress/i18n";
 import { addQueryArgs } from "@wordpress/url";
 import { useRootContext } from "@yoast/externals/contexts";
 import { Badge, useSvgAria, useToggleState } from "@yoast/ui-library";
+import { getPremiumBenefits } from "../../helpers/get-premium-benefits";
 import { MetaboxButton } from "../MetaboxButton";
 import SidebarButton from "../SidebarButton";
 import UpsellBox from "../UpsellBox";
@@ -45,15 +46,11 @@ export const InternalLinkingSuggestionsUpsell = () => {
 								__( "%s automatically suggests to what content you can link with easy drag-and-drop functionality, which is good for your SEO!", "wordpress-seo" ),
 								"Yoast SEO Premium"
 							) }
-							benefitsTitle={ __( "What’s more in Yoast SEO Premium?", "wordpress-seo" ) }
-							benefits={ [
-								__( "Create content faster: Use AI to create titles & meta descriptions", "wordpress-seo" ),
-								__( "Get extra SEO checks with the Premium SEO analysis", "wordpress-seo" ),
-								__( "Get help ranking for multiple keyphrases", "wordpress-seo" ),
-								__( "Avoid dead links on your site", "wordpress-seo" ),
-								__( "Preview how your content looks when shared on social", "wordpress-seo" ),
-								__( "Get guidance & save time on routine SEO tasks", "wordpress-seo" ),
-							] }
+							benefitsTitle={
+								/* translators: %s expands to 'Yoast SEO Premium'. */
+								sprintf( "%s also gives you:", "Yoast SEO Premium" )
+							}
+							benefits={ getPremiumBenefits() }
 							upsellButtonText={
 								sprintf(
 									/* translators: %s expands to 'Yoast SEO Premium'. */

--- a/packages/js/src/components/modals/KeywordSynonyms.js
+++ b/packages/js/src/components/modals/KeywordSynonyms.js
@@ -1,5 +1,6 @@
 import { __, sprintf } from "@wordpress/i18n";
 import PropTypes from "prop-types";
+import { getPremiumBenefits } from "../../helpers/get-premium-benefits";
 import UpsellBox from "../UpsellBox";
 
 /**
@@ -9,44 +10,36 @@ import UpsellBox from "../UpsellBox";
  *
  * @returns {wp.Element} The Keyword Synonyms upsell component.
  */
-const KeywordSynonyms = ( props ) => {
-	const benefits = [
-		__( "Create content faster: Use AI to create titles & meta descriptions", "wordpress-seo" ),
-		__( "Get extra SEO checks with the Premium SEO analysis", "wordpress-seo" ),
-		__( "Avoid dead links on your site", "wordpress-seo" ),
-		__( "Easily improve the structure of your site", "wordpress-seo" ),
-		__( "Preview how your content looks when shared on social", "wordpress-seo" ),
-		__( "Get guidance & save time on routine SEO tasks", "wordpress-seo" ),
-	];
-
-	return (
-		<UpsellBox
-			title={ __( "Write more natural and engaging content", "wordpress-seo" ) }
-			description={ sprintf(
-				/* translators: %s expands to "Yoast SEO Premium" */
-				__( "Synonyms help users understand your copy better. It’s easier to read for both users and Google. In %s, you can add synonyms for your focus keyphrase, and we’ll help you optimize for them.", "wordpress-seo" ),
+const KeywordSynonyms = ( props ) => (
+	<UpsellBox
+		title={ __( "Write more natural and engaging content", "wordpress-seo" ) }
+		description={ sprintf(
+			/* translators: %s expands to "Yoast SEO Premium" */
+			__( "Synonyms help users understand your copy better. It’s easier to read for both users and Google. In %s, you can add synonyms for your focus keyphrase, and we’ll help you optimize for them.", "wordpress-seo" ),
+			"Yoast SEO Premium"
+		) }
+		benefitsTitle={
+			/* translators: %s expands to 'Yoast SEO Premium'. */
+			sprintf( "%s also gives you:", "Yoast SEO Premium" )
+		}
+		benefits={ getPremiumBenefits() }
+		upsellButtonText={
+			sprintf(
+				/* translators: %s expands to 'Yoast SEO Premium'. */
+				__( "Unlock with %s", "wordpress-seo" ),
 				"Yoast SEO Premium"
-			) }
-			benefitsTitle={ __( "What’s more in Yoast SEO Premium?", "wordpress-seo" ) }
-			benefits={ benefits }
-			upsellButtonText={
-				sprintf(
-					/* translators: %s expands to 'Yoast SEO Premium'. */
-					__( "Unlock with %s", "wordpress-seo" ),
-					"Yoast SEO Premium"
-				)
-			}
-			upsellButton={ {
-				href: props.buyLink,
-				className: "yoast-button-upsell",
-				rel: null,
-				"data-ctb-id": "f6a84663-465f-4cb5-8ba5-f7a6d72224b2",
-				"data-action": "load-nfd-ctb",
-			} }
-			upsellButtonLabel={ __( "1 year free support and updates included!", "wordpress-seo" ) }
-		/>
-	);
-};
+			)
+		}
+		upsellButton={ {
+			href: props.buyLink,
+			className: "yoast-button-upsell",
+			rel: null,
+			"data-ctb-id": "f6a84663-465f-4cb5-8ba5-f7a6d72224b2",
+			"data-action": "load-nfd-ctb",
+		} }
+		upsellButtonLabel={ __( "1 year free support and updates included!", "wordpress-seo" ) }
+	/>
+);
 KeywordSynonyms.propTypes = {
 	buyLink: PropTypes.string.isRequired,
 };

--- a/packages/js/src/components/modals/MultipleKeywords.js
+++ b/packages/js/src/components/modals/MultipleKeywords.js
@@ -1,5 +1,6 @@
 import { __, sprintf } from "@wordpress/i18n";
 import PropTypes from "prop-types";
+import { getPremiumBenefits } from "../../helpers/get-premium-benefits";
 import UpsellBox from "../UpsellBox";
 
 /**
@@ -9,40 +10,32 @@ import UpsellBox from "../UpsellBox";
  *
  * @returns {JSX.Element} The Multiple Keywords upsell component.
  */
-const MultipleKeywords = ( props ) => {
-	const benefits = [
-		__( "Create content faster: Use AI to create titles & meta descriptions", "wordpress-seo" ),
-		__( "Get extra SEO checks with the Premium SEO analysis", "wordpress-seo" ),
-		__( "Avoid dead links on your site", "wordpress-seo" ),
-		__( "Easily improve the structure of your site", "wordpress-seo" ),
-		__( "Preview how your content looks when shared on social", "wordpress-seo" ),
-		__( "Get guidance & save time on routine SEO tasks", "wordpress-seo" ),
-	];
-
-	return (
-		<UpsellBox
-			title={ __( "Reach a wider audience", "wordpress-seo" ) }
-			description={ __( "Get help optimizing for up to 5 related keyphrases. This helps you reach a wider audience and get more traffic.", "wordpress-seo" ) }
-			benefitsTitle={ __( "What’s more in Yoast SEO Premium?", "wordpress-seo" ) }
-			benefits={ benefits }
-			upsellButtonText={
-				sprintf(
-					/* translators: %s expands to 'Yoast SEO Premium'. */
-					__( "Unlock with %s", "wordpress-seo" ),
-					"Yoast SEO Premium"
-				)
-			}
-			upsellButton={ {
-				href: props.buyLink,
-				className: "yoast-button-upsell",
-				rel: null,
-				"data-ctb-id": "f6a84663-465f-4cb5-8ba5-f7a6d72224b2",
-				"data-action": "load-nfd-ctb",
-			} }
-			upsellButtonLabel={ __( "1 year free support and updates included!", "wordpress-seo" ) }
-		/>
-	);
-};
+const MultipleKeywords = ( props ) => (
+	<UpsellBox
+		title={ __( "Reach a wider audience", "wordpress-seo" ) }
+		description={ __( "Get help optimizing for up to 5 related keyphrases. This helps you reach a wider audience and get more traffic.", "wordpress-seo" ) }
+		benefitsTitle={
+			/* translators: %s expands to 'Yoast SEO Premium'. */
+			sprintf( "%s also gives you:", "Yoast SEO Premium" )
+		}
+		benefits={ getPremiumBenefits() }
+		upsellButtonText={
+			sprintf(
+				/* translators: %s expands to 'Yoast SEO Premium'. */
+				__( "Unlock with %s", "wordpress-seo" ),
+				"Yoast SEO Premium"
+			)
+		}
+		upsellButton={ {
+			href: props.buyLink,
+			className: "yoast-button-upsell",
+			rel: null,
+			"data-ctb-id": "f6a84663-465f-4cb5-8ba5-f7a6d72224b2",
+			"data-action": "load-nfd-ctb",
+		} }
+		upsellButtonLabel={ __( "1 year free support and updates included!", "wordpress-seo" ) }
+	/>
+);
 MultipleKeywords.propTypes = {
 	buyLink: PropTypes.string.isRequired,
 };

--- a/packages/js/src/components/modals/PremiumSEOAnalysisUpsell.js
+++ b/packages/js/src/components/modals/PremiumSEOAnalysisUpsell.js
@@ -3,6 +3,7 @@ import { __, sprintf } from "@wordpress/i18n";
 import { addQueryArgs } from "@wordpress/url";
 import { useRootContext } from "@yoast/externals/contexts";
 import PropTypes from "prop-types";
+import { getPremiumBenefits } from "../../helpers/get-premium-benefits";
 import UpsellBox from "../UpsellBox";
 
 const upsellDescription = __(
@@ -17,15 +18,6 @@ const upsellDescription = __(
  * @returns {wp.Element} The PremiumSEOAnalysisUpsell component.
  */
 const PremiumSEOAnalysisUpsell = ( props ) => {
-	const benefits = [
-		__( "Create content faster: Use AI to create titles & meta descriptions", "wordpress-seo" ),
-		__( "Get help ranking for multiple keyphrases", "wordpress-seo" ),
-		__( "Avoid dead links on your site", "wordpress-seo" ),
-		__( "Easily improve the structure of your site", "wordpress-seo" ),
-		__( "Preview how your content looks when shared on social", "wordpress-seo" ),
-		__( "Get guidance & save time on routine SEO tasks", "wordpress-seo" ),
-	];
-
 	const { locationContext } = useRootContext();
 	const buyLink = addQueryArgs( wpseoAdminL10n[ props.buyLink ], { context: locationContext } );
 
@@ -33,8 +25,11 @@ const PremiumSEOAnalysisUpsell = ( props ) => {
 		<UpsellBox
 			title={ __( "Get more help with writing content that ranks", "wordpress-seo" ) }
 			description={ props.description }
-			benefitsTitle={ __( "What’s more in Yoast SEO Premium?", "wordpress-seo" ) }
-			benefits={ benefits }
+			benefitsTitle={
+				/* translators: %s expands to 'Yoast SEO Premium'. */
+				sprintf( "%s also gives you:", "Yoast SEO Premium" )
+			}
+			benefits={ getPremiumBenefits() }
 			upsellButtonText={
 				sprintf(
 					/* translators: %s expands to 'Yoast SEO Premium'. */

--- a/packages/js/src/components/modals/SEMrushUpsellAlert.js
+++ b/packages/js/src/components/modals/SEMrushUpsellAlert.js
@@ -19,7 +19,7 @@ const SEMrushUpsellAlert = () => {
 				sprintf(
 					/* translators: %s: Expands to "Yoast SEO". */
 					__(
-						"Would you like to be able to add these related keyphrases to the %s analysis so you can optimize your content even further?",
+						"You’ll reach more people with multiple keyphrases! Want to quickly add these related keyphrases to the %s analyses for even better content optimization?",
 						"wordpress-seo"
 					),
 					"Yoast SEO"
@@ -31,7 +31,7 @@ const SEMrushUpsellAlert = () => {
 				{
 					sprintf(
 						/* translators: %s: Expands to "Yoast SEO Premium". */
-						__( "Check out %s!", "wordpress-seo" ),
+						__( "Explore %s!", "wordpress-seo" ),
 						"Yoast SEO Premium"
 					)
 				}

--- a/packages/js/src/helpers/get-premium-benefits.js
+++ b/packages/js/src/helpers/get-premium-benefits.js
@@ -1,0 +1,13 @@
+import { __ } from "@wordpress/i18n";
+
+/**
+ * @returns {string[]} The premium benefits.
+ */
+export const getPremiumBenefits = () => [
+	`<strong>${ __( "AI", "wordpress-seo" ) }:</strong> ${ __( "Better SEO titles and meta descriptions, faster", "wordpress-seo" ) }`,
+	`<strong>${ __( "Multiple keywords", "wordpress-seo" ) }:</strong> ${ __( "Rank higher for more searches", "wordpress-seo" ) }`,
+	`<strong>${ __( "Super fast", "wordpress-seo" ) }</strong> ${ __( "internal linking suggestions", "wordpress-seo" ) }`,
+	`<strong>${ __( "No more broken links", "wordpress-seo" ) }:</strong> ${ __( "Automatic redirect manager", "wordpress-seo" ) }`,
+	`<strong>${ __( "Appealing social previews", "wordpress-seo" ) }</strong> ${ __( "people actually want to click on", "wordpress-seo" ) }`,
+	`<strong>${ __( "24/7 support", "wordpress-seo" ) }:</strong> ${ __( "Also on evenings and weekends", "wordpress-seo" ) }`,
+];

--- a/packages/js/src/helpers/get-premium-benefits.js
+++ b/packages/js/src/helpers/get-premium-benefits.js
@@ -6,37 +6,37 @@ import { __, sprintf } from "@wordpress/i18n";
 export const getPremiumBenefits = () => [
 	sprintf(
 		/* translators: %1$s expands to a strong opening tag, %2$s expands to a strong closing tag. */
-		__( "%1$sAI%2$s: Better SEO titles and meta descriptions, faster", "wordpress-seo" ),
+		__( "%1$sAI%2$s: Better SEO titles and meta descriptions, faster.", "wordpress-seo" ),
 		"<strong>",
 		"</strong>"
 	),
 	sprintf(
 		/* translators: %1$s expands to a strong opening tag, %2$s expands to a strong closing tag. */
-		__( "%1$sMultiple keywords%2$s: Rank higher for more searches", "wordpress-seo" ),
+		__( "%1$sMultiple keywords%2$s: Rank higher for more searches.", "wordpress-seo" ),
 		"<strong>",
 		"</strong>"
 	),
 	sprintf(
 		/* translators: %1$s expands to a strong opening tag, %2$s expands to a strong closing tag. */
-		__( "%1$sSuper fast%2$s internal linking suggestions", "wordpress-seo" ),
+		__( "%1$sSuper fast%2$s internal linking suggestions.", "wordpress-seo" ),
 		"<strong>",
 		"</strong>"
 	),
 	sprintf(
 		/* translators: %1$s expands to a strong opening tag, %2$s expands to a strong closing tag. */
-		__( "%1$sNo more broken links%2$s: Automatic redirect manager", "wordpress-seo" ),
+		__( "%1$sNo more broken links%2$s: Automatic redirect manager.", "wordpress-seo" ),
 		"<strong>",
 		"</strong>"
 	),
 	sprintf(
 		/* translators: %1$s expands to a strong opening tag, %2$s expands to a strong closing tag. */
-		__( "%1$sAppealing social previews%2$s people actually want to click on", "wordpress-seo" ),
+		__( "%1$sAppealing social previews%2$s people actually want to click on.", "wordpress-seo" ),
 		"<strong>",
 		"</strong>"
 	),
 	sprintf(
 		/* translators: %1$s expands to a strong opening tag, %2$s expands to a strong closing tag. */
-		__( "%1$s24/7 support%2$s: Also on evenings and weekends", "wordpress-seo" ),
+		__( "%1$s24/7 support%2$s: Also on evenings and weekends.", "wordpress-seo" ),
 		"<strong>",
 		"</strong>"
 	),

--- a/packages/js/src/helpers/get-premium-benefits.js
+++ b/packages/js/src/helpers/get-premium-benefits.js
@@ -1,13 +1,43 @@
-import { __ } from "@wordpress/i18n";
+import { __, sprintf } from "@wordpress/i18n";
 
 /**
  * @returns {string[]} The premium benefits.
  */
 export const getPremiumBenefits = () => [
-	`<strong>${ __( "AI", "wordpress-seo" ) }:</strong> ${ __( "Better SEO titles and meta descriptions, faster", "wordpress-seo" ) }`,
-	`<strong>${ __( "Multiple keywords", "wordpress-seo" ) }:</strong> ${ __( "Rank higher for more searches", "wordpress-seo" ) }`,
-	`<strong>${ __( "Super fast", "wordpress-seo" ) }</strong> ${ __( "internal linking suggestions", "wordpress-seo" ) }`,
-	`<strong>${ __( "No more broken links", "wordpress-seo" ) }:</strong> ${ __( "Automatic redirect manager", "wordpress-seo" ) }`,
-	`<strong>${ __( "Appealing social previews", "wordpress-seo" ) }</strong> ${ __( "people actually want to click on", "wordpress-seo" ) }`,
-	`<strong>${ __( "24/7 support", "wordpress-seo" ) }:</strong> ${ __( "Also on evenings and weekends", "wordpress-seo" ) }`,
+	sprintf(
+		/* translators: %1$s expands to a strong opening tag, %2$s expands to a strong closing tag. */
+		__( "%1$sAI%2$s: Better SEO titles and meta descriptions, faster", "wordpress-seo" ),
+		"<strong>",
+		"</strong>"
+	),
+	sprintf(
+		/* translators: %1$s expands to a strong opening tag, %2$s expands to a strong closing tag. */
+		__( "%1$sMultiple keywords%2$s: Rank higher for more searches", "wordpress-seo" ),
+		"<strong>",
+		"</strong>"
+	),
+	sprintf(
+		/* translators: %1$s expands to a strong opening tag, %2$s expands to a strong closing tag. */
+		__( "%1$sSuper fast%2$s internal linking suggestions", "wordpress-seo" ),
+		"<strong>",
+		"</strong>"
+	),
+	sprintf(
+		/* translators: %1$s expands to a strong opening tag, %2$s expands to a strong closing tag. */
+		__( "%1$sNo more broken links%2$s: Automatic redirect manager", "wordpress-seo" ),
+		"<strong>",
+		"</strong>"
+	),
+	sprintf(
+		/* translators: %1$s expands to a strong opening tag, %2$s expands to a strong closing tag. */
+		__( "%1$sAppealing social previews%2$s people actually want to click on", "wordpress-seo" ),
+		"<strong>",
+		"</strong>"
+	),
+	sprintf(
+		/* translators: %1$s expands to a strong opening tag, %2$s expands to a strong closing tag. */
+		__( "%1$s24/7 support%2$s: Also on evenings and weekends", "wordpress-seo" ),
+		"<strong>",
+		"</strong>"
+	),
 ];

--- a/packages/js/src/settings/app.js
+++ b/packages/js/src/settings/app.js
@@ -181,32 +181,41 @@ const PremiumUpsellList = () => {
 				</Title>
 				<ul className="yst-grid yst-grid-cols-1 sm:yst-grid-cols-2 yst-gap-x-6 yst-list-disc yst-pl-[1em] yst-list-outside yst-text-slate-800 yst-mt-6">
 					<li>
-						<span className="yst-font-semibold">{ __( "Use AI", "wordpress-seo" ) }</span>
+						<span className="yst-font-semibold">{ __( "AI", "wordpress-seo" ) }</span>
 						:&nbsp;
-						{ __( "Quickly create titles & meta descriptions", "wordpress-seo" ) }
+						{ __( "Better SEO titles and meta descriptions, faster", "wordpress-seo" ) }
+						.
 					</li>
 					<li>
-						<span className="yst-font-semibold">{ __( "No more dead links", "wordpress-seo" ) }</span>
+						<span className="yst-font-semibold">{ __( "Multiple keywords", "wordpress-seo" ) }</span>
 						:&nbsp;
-						{ __( "Easy redirect manager", "wordpress-seo" ) }
-					</li>
-					<li><span className="yst-font-semibold">{ __( "Superfast internal linking suggestions", "wordpress-seo" ) }</span></li>
-					<li>
-						<span className="yst-font-semibold">{ __( "Social media preview", "wordpress-seo" ) }</span>
-						:&nbsp;
-						{ __( "Facebook & Twitter", "wordpress-seo" ) }
+						{ __( "Rank higher for more searches", "wordpress-seo" ) }
+						.
 					</li>
 					<li>
-						<span className="yst-font-semibold">{ __( "Multiple keyphrases", "wordpress-seo" ) }</span>
+						<span className="yst-font-semibold">{ __( "Super fast", "wordpress-seo" ) }</span>
 						:&nbsp;
-						{ __( "Increase your SEO reach", "wordpress-seo" ) }
+						{ __( "internal linking suggestions", "wordpress-seo" ) }
+						.
 					</li>
 					<li>
-						<span className="yst-font-semibold">{ __( "SEO Workouts", "wordpress-seo" ) }</span>
+						<span className="yst-font-semibold">{ __( "No more broken links", "wordpress-seo" ) }</span>
 						:&nbsp;
-						{ __( "Get guided in routine SEO tasks", "wordpress-seo" ) }
+						{ __( "Automatic redirect manager", "wordpress-seo" ) }
+						.
 					</li>
-					<li><span className="yst-font-semibold">{ __( "24/7 email support", "wordpress-seo" ) }</span></li>
+					<li>
+						<span className="yst-font-semibold">{ __( "Social preview", "wordpress-seo" ) }</span>
+						:&nbsp;
+						{ __( "Appealing previews people actually want to click on", "wordpress-seo" ) }
+						.
+					</li>
+					<li>
+						<span className="yst-font-semibold">{ __( "24/7 support", "wordpress-seo" ) }</span>
+						:&nbsp;
+						{ __( "Also on evenings and weekends", "wordpress-seo" ) }
+						.
+					</li>
 					<li><span className="yst-font-semibold">{ __( "No ads!", "wordpress-seo" ) }</span></li>
 				</ul>
 				<Button
@@ -221,7 +230,7 @@ const PremiumUpsellList = () => {
 				>
 					{ isBlackFriday ? __( "Claim your 30% off now!", "wordpress-seo" ) : sprintf(
 					/* translators: %s expands to "Yoast SEO" Premium */
-						__( "Get %s", "wordpress-seo" ),
+						__( "Explore %s now!", "wordpress-seo" ),
 						"Yoast SEO Premium"
 					) }
 					<ArrowNarrowRightIcon className="yst-w-4 yst-h-4 yst-icon-rtl" />

--- a/packages/js/src/settings/app.js
+++ b/packages/js/src/settings/app.js
@@ -2,7 +2,7 @@
 import { Transition } from "@headlessui/react";
 import { AdjustmentsIcon, ArrowNarrowRightIcon, ColorSwatchIcon, DesktopComputerIcon, NewspaperIcon } from "@heroicons/react/outline";
 import { ChevronDownIcon, ChevronUpIcon } from "@heroicons/react/solid";
-import { useCallback, useMemo } from "@wordpress/element";
+import { createInterpolateElement, useCallback, useMemo } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
 import { Badge, Button, ChildrenLimiter, ErrorBoundary, Paper, Title, useBeforeUnload, useSvgAria } from "@yoast/ui-library";
 import classNames from "classnames";
@@ -10,6 +10,7 @@ import { useFormikContext } from "formik";
 import { map } from "lodash";
 import PropTypes from "prop-types";
 import { Link, Navigate, Route, Routes, useLocation } from "react-router-dom";
+import { getPremiumBenefits } from "../helpers/get-premium-benefits";
 import { ErrorFallback, Notifications, Search, SidebarNavigation, SidebarRecommendations, YoastLogo } from "./components";
 import { useRouterScrollRestore, useSelectSettings } from "./hooks";
 import {
@@ -180,43 +181,11 @@ const PremiumUpsellList = () => {
 					) }
 				</Title>
 				<ul className="yst-grid yst-grid-cols-1 sm:yst-grid-cols-2 yst-gap-x-6 yst-list-disc yst-pl-[1em] yst-list-outside yst-text-slate-800 yst-mt-6">
-					<li>
-						<span className="yst-font-semibold">{ __( "AI", "wordpress-seo" ) }</span>
-						:&nbsp;
-						{ __( "Better SEO titles and meta descriptions, faster", "wordpress-seo" ) }
-						.
-					</li>
-					<li>
-						<span className="yst-font-semibold">{ __( "Multiple keywords", "wordpress-seo" ) }</span>
-						:&nbsp;
-						{ __( "Rank higher for more searches", "wordpress-seo" ) }
-						.
-					</li>
-					<li>
-						<span className="yst-font-semibold">{ __( "Super fast", "wordpress-seo" ) }</span>
-						:&nbsp;
-						{ __( "internal linking suggestions", "wordpress-seo" ) }
-						.
-					</li>
-					<li>
-						<span className="yst-font-semibold">{ __( "No more broken links", "wordpress-seo" ) }</span>
-						:&nbsp;
-						{ __( "Automatic redirect manager", "wordpress-seo" ) }
-						.
-					</li>
-					<li>
-						<span className="yst-font-semibold">{ __( "Social preview", "wordpress-seo" ) }</span>
-						:&nbsp;
-						{ __( "Appealing previews people actually want to click on", "wordpress-seo" ) }
-						.
-					</li>
-					<li>
-						<span className="yst-font-semibold">{ __( "24/7 support", "wordpress-seo" ) }</span>
-						:&nbsp;
-						{ __( "Also on evenings and weekends", "wordpress-seo" ) }
-						.
-					</li>
-					<li><span className="yst-font-semibold">{ __( "No ads!", "wordpress-seo" ) }</span></li>
+					{ getPremiumBenefits().map( ( benefit, index ) => (
+						<li key={ `upsell-benefit-${ index }` }>
+							{ createInterpolateElement( benefit, { strong: <span className="yst-font-semibold" /> } ) }
+						</li>
+					) ) }
 				</ul>
 				<Button
 					as="a"

--- a/packages/js/src/settings/routes/site-features.js
+++ b/packages/js/src/settings/routes/site-features.js
@@ -241,7 +241,7 @@ const SiteFeatures = () => {
 								isPremiumLink="https://yoa.st/get-ai-generator"
 								title={ __( "AI title & description generator", "wordpress-seo" ) }
 							>
-								<p>{ __( "Use the power of Yoast AI to automatically generate compelling titles and descriptions for your posts and pages.", "wordpress-seo" ) }</p>
+								<p>{ __( "Use AI to write SEO titles and meta descriptions for your posts and pages. It speeds up your work and does some of the thinking for you!", "wordpress-seo" ) }</p>
 								<LearnMoreLink id="link-ai-generator" link="https://yoa.st/ai-generator-feature" ariaLabel={ __( "AI title & description generator", "wordpress-seo" ) } />
 							</FeatureCard>
 							<FeatureCard
@@ -293,7 +293,7 @@ const SiteFeatures = () => {
 								isPremiumLink="https://yoa.st/get-link-suggestions"
 								title={ __( "Link suggestions", "wordpress-seo" ) }
 							>
-								<p>{ __( "Get recommendations for relevant posts to link to and set up a great internal linking structure by connecting related content.", "wordpress-seo" ) }</p>
+								<p>{ __( "No need to figure out what to link to. You get linking suggestions for relevant posts and pages to make your website easier to navigate.", "wordpress-seo" ) }</p>
 								<LearnMoreLink id="link-suggestions-link" link={ isPremium ? "https://yoa.st/17g" : "https://yoa.st/4ev" } ariaLabel={ __( "Link suggestions", "wordpress-seo" ) } />
 							</FeatureCard>
 						</div>

--- a/packages/js/src/shared-admin/components/ai-generate-titles-and-descriptions-upsell.js
+++ b/packages/js/src/shared-admin/components/ai-generate-titles-and-descriptions-upsell.js
@@ -55,32 +55,18 @@ export const AiGenerateTitlesAndDescriptionsUpsell = ( {
 				<span className="yst-introduction-modal-uppercase">
 					{ newToText }
 				</span>
-
-				{ ! isProductCopy && <span className="yst-uppercase yst-text-slate-700"> 21.0</span> }
 			</div>
 			<div className="yst-mt-4 yst-mx-1.5 yst-text-center">
 				<h3 className="yst-text-slate-900 yst-text-lg yst-font-medium">
 					{ title }
 				</h3>
 				<div className="yst-mt-2 yst-text-slate-600 yst-text-sm">
-					{ isProductCopy ? createInterpolateElement(
-						sprintf(
-							/* translators: %1$s and %2$s are anchor tag; %3$s is the arrow icon. */
-							__(
-								"Speed up your workflow with generative AI. Get high-quality product title and description suggestions for your search and social appearance. %1$sLearn more%2$s%3$s",
-								"wordpress-seo"
-							),
-							"<a>",
-							"<ArrowNarrowRightIcon />",
-							"</a>"
-						),
-						learnMoreLinkStructure
-					)
-						: createInterpolateElement(
+					{ isProductCopy
+						? createInterpolateElement(
 							sprintf(
-							/* translators: %1$s and %2$s are anchor tag; %3$s is the arrow icon. */
+								/* translators: %1$s and %2$s are anchor tag; %3$s is the arrow icon. */
 								__(
-									"Speed up your workflow with generative AI. Get high-quality title and description suggestions for your search and social appearance. %1$sLearn more%2$s%3$s",
+									"Let AI do some of the thinking for you and help you save time. Get high-quality suggestions for product titles and meta descriptions to make your pages rank high and make you look good on social media. %1$sLearn more%2$s%3$s",
 									"wordpress-seo"
 								),
 								"<a>",
@@ -88,7 +74,21 @@ export const AiGenerateTitlesAndDescriptionsUpsell = ( {
 								"</a>"
 							),
 							learnMoreLinkStructure
-						) }
+						)
+						: createInterpolateElement(
+							sprintf(
+								/* translators: %1$s and %2$s are anchor tag; %3$s is the arrow icon. */
+								__(
+									"Let AI do some of the thinking for you and help you save time. Get high-quality suggestions for titles and meta descriptions to make your pages rank high and make you look good on social media. %1$sLearn more%2$s%3$s",
+									"wordpress-seo"
+								),
+								"<a>",
+								"<ArrowNarrowRightIcon />",
+								"</a>"
+							),
+							learnMoreLinkStructure
+						)
+					}
 				</div>
 			</div>
 			<div className="yst-w-full yst-flex yst-mt-10">
@@ -143,11 +143,11 @@ AiGenerateTitlesAndDescriptionsUpsell.propTypes = {
 	bundleNote: PropTypes.oneOfType( [
 		PropTypes.string,
 		PropTypes.element,
-	  ] ),
+	] ),
 };
 
 AiGenerateTitlesAndDescriptionsUpsell.defaultProps = {
-	title: __( "Generate titles & descriptions with Yoast AI!", "wordpress-seo" ),
+	title: __( "Use AI to write your titles & meta descriptions!", "wordpress-seo" ),
 	upsellLabel: sprintf(
 		/* translators: %1$s expands to Yoast SEO Premium. */
 		__( "Unlock with %1$s", "wordpress-seo" ),
@@ -155,7 +155,7 @@ AiGenerateTitlesAndDescriptionsUpsell.defaultProps = {
 	),
 	newToText: sprintf(
 		/* translators: %1$s expands to Yoast SEO Premium. */
-		__( "New to %1$s", "wordpress-seo" ),
+		__( "New in %1$s", "wordpress-seo" ),
 		"Yoast SEO Premium"
 	),
 	isProductCopy: false,

--- a/packages/js/src/shared-admin/components/premium-upsell-card.js
+++ b/packages/js/src/shared-admin/components/premium-upsell-card.js
@@ -16,7 +16,7 @@ import { ReactComponent as G2Logo } from "./g2-logo-white.svg";
  * @returns {JSX.Element} The premium upsell card.
  */
 export const PremiumUpsellCard = ( { link, linkProps, promotions } ) => {
-	const info = useMemo( () => __( "Use AI to generate titles and meta descriptions, automatically redirect deleted pages, get 24/7 support and much, much more!", "wordpress-seo" ), [] );
+	const info = useMemo( () => __( "Get AI to write SEO titles and meta descriptions faster. Reach a wider audience with multiple keywords. Get automatic internal linking suggestions. And much, much more!", "wordpress-seo" ), [] );
 	const getPremium = createInterpolateElement(
 		sprintf(
 			/* translators: %1$s and %2$s expand to a span wrap to avoid linebreaks. %3$s expands to "Yoast SEO Premium". */

--- a/src/presenters/admin/sidebar-presenter.php
+++ b/src/presenters/admin/sidebar-presenter.php
@@ -60,7 +60,7 @@ class Sidebar_Presenter extends Abstract_Presenter {
 						</h2>
 						<p>
 							<?php
-							echo \esc_html__( 'Use AI to generate titles and meta descriptions, automatically redirect deleted pages, get 24/7 support and much, much more!', 'wordpress-seo' );
+							echo \esc_html__( 'Get AI to write SEO titles and meta descriptions faster. Reach a wider audience with multiple keywords. Get automatic internal linking suggestions. And much, much more!', 'wordpress-seo' );
 							?>
 						</p>
 						<?php if ( YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-2023-promotion' ) ) : ?>


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves the copy of some of our ads.

## Relevant technical choices:

* Moved the benefits list to a helper, to only have to maintain one list - and added strong tags around to be the same as in other lists
* As per CR: The order of things can be different per language. This gives control to the translators.
* Removed the classes inside licenses.php to be able to keep the same translations, this will save on having to double translate.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

Before you start
* Deactivate Premium
* Install & activate WooCommerce (not our plugin)
* have [the doc](https://docs.google.com/document/d/1fm2KBnwnnjo-V5-udCadqZUQHJYywC3n4Mzb7rL_ivI/edit) with the required changes ready for comparison

Premium upsell cards
* PHP version found in Yoast > General
* JS version found in Yoast > Settings (amongst others)
* Verify the copy of the card in the sidebar
![image](https://github.com/Yoast/wordpress-seo/assets/35524806/6f630679-57a8-4477-a5ca-f29ccfc704cb)
* Verify the copy of the card in the footer 
![Screenshot 2023-12-13 at 14-26-33 Site features ‹ Settings - Yoast SEO ‹ development-symlink — WordPress](https://github.com/Yoast/wordpress-seo/assets/15989132/dff37d81-1a2f-4342-9ade-9ac7cb587d12)


Premium page
* Go to Yoast > Premium
* Verify the copy of all the cards

Site features
* Go to Yoast > Settings > Site features
* Verify the copy of AI title & description generator
* Verify the copy of Link suggestions

Premium upsells in the editor
* Edit a post
* Verify the copy of the Premium SEO analysis upsell
* Verify the copy of the Add related keyphrases upsell
* Verify the copy of the Internal linking suggestions upsell
* Verify the copy of the Add synonyms upsell (under SEO analysis)
* Verify the copy of the analysis upsell (under SEO analysis)
![image](https://github.com/Yoast/wordpress-seo/assets/35524806/99d2a0fa-02c3-46bc-b6fa-3af59169e88d)
* Verify the copy of the Semrush upsell
  * Click on "Get related keyphrases" under the focus keyphrase field
  * Connect your site to Semrush
  * Verify the copy in the alert
* Verify the copy of the AI upsell
  * Click on use AI to open the modal
  * This should also be checked editing a product -- where the copy is slightly different -- `product` is added in front:
      * of `titles & descriptions` in the title
      * of `titles and meta descriptions` in the description

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/wordpress-seo-premium/issues/4162