### PR TITLE
Decrease the waiting time for refreshing the analysis in Elementor

### DIFF
--- a/packages/js/src/watchers/elementorWatcher.js
+++ b/packages/js/src/watchers/elementorWatcher.js
@@ -3,6 +3,7 @@ import { debounce, get } from "lodash";
 import firstImageUrlInContent from "../helpers/firstImageUrlInContent";
 import { registerElementorUIHookAfter, registerElementorUIHookBefore } from "../helpers/elementorHook";
 import { markers, Paper } from "yoastseo";
+import { refreshDelay } from "../analysis/constants";
 
 const editorData = {
 	content: "",
@@ -161,7 +162,7 @@ function resetMarks() {
 	window.YoastSEO.analysis.applyMarks( new Paper( "", {} ), [] );
 }
 
-const debouncedHandleEditorChange = debounce( handleEditorChange, 1500 );
+const debouncedHandleEditorChange = debounce( handleEditorChange, refreshDelay );
 
 /**
  * Observes changes to the whole document through a MutationObserver.
@@ -180,13 +181,13 @@ function observeChanges() {
  */
 export default function initialize() {
 	// This hook will fire 500ms after a widget is edited -- this allows Elementor to set the cursor at the end of the widget.
-	registerElementorUIHookBefore( "panel/editor/open", "yoast-seo-reset-marks-edit", debounce( resetMarks, 500 ) );
+	registerElementorUIHookBefore( "panel/editor/open", "yoast-seo-reset-marks-edit", debounce( resetMarks, refreshDelay ) );
 	// This hook will fire just before the document is saved.
 	registerElementorUIHookBefore( "document/save/save", "yoast-seo-reset-marks-save", resetMarks );
 
 	// This hook will fire when the Elementor preview becomes available.
 	registerElementorUIHookAfter( "editor/documents/attach-preview", "yoast-seo-content-scraper-initial", debouncedHandleEditorChange );
-	registerElementorUIHookAfter( "editor/documents/attach-preview", "yoast-seo-content-scraper", debounce( observeChanges, 500 ) );
+	registerElementorUIHookAfter( "editor/documents/attach-preview", "yoast-seo-content-scraper", debounce( observeChanges, refreshDelay ) );
 
 	// This hook will fire when the contents of the editor are modified.
 	registerElementorUIHookAfter( "document/save/set-is-modified", "yoast-seo-content-scraper-on-modified", debouncedHandleEditorChange );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* When editing in Elementor, it could take a while before the analysis is refreshed after a change is made. This waiting time is at least 1500 miliseconds and also could be longer (I waited for around 3 seconds in my case). As a result, some applicable assessments would not be immediately displayed in the metabox or the highlighting of Keyphrase density would not be immediately applied correctly, until the analysis is refreshed.
* [Context for the discussion on Slack](https://yoast.slack.com/archives/C027BFR5L/p1702464363362229?thread_ts=1702455658.784279&cid=C027BFR5L)

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Decreases the debouncing time for refreshing the analysis in Elementor from `1500` to `500` ms.

## Relevant technical choices:

* The debouncing time is changed from `1500` to `500` ms in line with the time we set in `post-scrapper.js` for other editors.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install and activate Yoast SEO
* Install and activate Yoast SEO Premium
* Install and activate Elementor
* Set the site language to English

#### Test in a new post
* Create a post in Elementor
* Set the focus keyphrase to: word counts
* Add the following text to a text widget (please paste the text without the formatting: using `Shift + CMD + V` for mac):
> Apart from counting words and characters, our online editor can help you to improve word choice and writing style, and, optionally, help you to detect grammar mistakes and plagiarism. To check word count, simply place your cursor into the text box above and start typing. You'll see the number of characters and words increase or decrease as you type, delete, and edit them. You can also copy and paste text from another program over into the online editor above. The Auto-Save feature will make sure you won't lose any changes while editing, even if you leave the site and come back later. Apart from counting words and characters, our online editor can help you to improve word choice and writing style, and, optionally, help you to detect grammar mistakes and plagiarism. To check word count, simply place your cursor into the text box above and start typing. You'll see the number of characters and words increase or decrease as you type, delete, and edit them. You can also copy and paste text from another program over into the online editor above. The Auto-Save feature will make sure you won't lose any changes while editing, even if you leave the site and come back later.

* Go to SEO analysis
* Confirm that in less than 1500 miliseconds (basically it should feel instantaneous) you see the Keyphrase density assessment, with the following feedback:
> [Keyphrase density](https://yoa.st/33v?php_version=8.2&platform=wordpress&platform_version=6.4.2&software=premium&software_version=21.8-RC1&days_active=222&user_language=en_US): The keyphrase was found 4 times. This is great!

* Click on the eye button of the Keyphrase density assessment
* Confirm that the keyphrase occurrences in the text are highlighted correctly
  * Specifically: 4 occurrences of count/counting + 6 occurrences of word/words
* Save the post

#### Test in a existing post
* Open the post that you created in the above scenario in Elementor
* Add another text editor widget to the post
* Add the following text (please paste the text without the formatting: using `Shift + CMD + V` for mac):
> The black-footed cat (Felis nigripes), also called the small-spotted cat, is the smallest wild [cat](https://en.wikipedia.org/wiki/Felis) in Africa, having a head-and-body length of 35–52 cm (14–20 in). Despite its name, only the soles of its feet are black or dark brown. With its bold small spots and stripes on the tawny fur, it is well camouflaged, especially on moonlit nights. It bears black streaks running from the corners of the eyes along the cheeks, and its banded tail has a black tip.

* Confirm that the Keyphrase density assessment still returns the same feedback
* Move the text editor widget that you just added to the top of the post
* In less than 1500 miliseconds, click on the eye button of the Keyphrase density assessment
* Confirm that the focus keyphrase occurrences are highlighted correctly
* You could also try to change the keyphrase to: word
* Confirm that the Keyphrase density assessment immediately returns different feedback: `The keyphrase was found 8 times.` 
* Confirm that all 8 occurrences of the focus keyphrase are highlighted correctly.


#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* No other impacts other than what is covered in the testing instruction

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [x] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
