### PR TITLE
Makes sure keyphrase occurrences with different types of apostrophes are highlighted in keyphrase distribution assessment

### DIFF
--- a/packages/yoastseo/spec/languageProcessing/helpers/word/markWordsInSentenceSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/helpers/word/markWordsInSentenceSpec.js
@@ -128,7 +128,7 @@ describe( "Adds Yoast marks to specific words in a sentence", function() {
 		);
 
 		sentences = "The fo'c'sle is the upper deck of a sailing ship forward of the foremast.";
-		wordsToMark = [ "fo'c'sle" ];
+		wordsToMark = [ "fo’c’sle" ];
 		expect( markWordsInASentence( sentences, wordsToMark, false ) ).toEqual(
 			[ new Mark( {
 				marked: "The <yoastmark class='yoast-text-mark'>fo'c'sle</yoastmark> is the upper deck of a sailing ship forward of the foremast.",

--- a/packages/yoastseo/spec/languageProcessing/helpers/word/markWordsInSentenceSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/helpers/word/markWordsInSentenceSpec.js
@@ -98,6 +98,26 @@ describe( "Adds Yoast marks to specific words in a sentence", function() {
 					"and a <yoastmark class='yoast-text-mark'>hamster</yoastmark>.",
 			original: "A cat and a turtle and a hamster." } ) ] );
 	} );
+
+	it( "should find a match of words with different types of apostrophe and add Yoast marks for them", () => {
+		let sentences = "The red panda’s coat is mainly red or orange-brown with a black belly and legs.";
+		let wordsToMark = [ "red", "panda's" ];
+		expect( markWordsInASentence( sentences, wordsToMark, false ) ).toEqual(
+			[ new Mark( {
+				marked: "The <yoastmark class='yoast-text-mark'>red panda's</yoastmark> coat is mainly" +
+					" <yoastmark class='yoast-text-mark'>red</yoastmark> or orange-brown with a black belly and legs.",
+				original: "The red panda’s coat is mainly red or orange-brown with a black belly and legs." } ) ]
+		);
+
+		sentences = "The red panda's coat is mainly red or orange-brown with a black belly and legs.";
+		wordsToMark = [ "red", "panda’s" ];
+		expect( markWordsInASentence( sentences, wordsToMark, false ) ).toEqual(
+			[ new Mark( {
+				marked: "The <yoastmark class='yoast-text-mark'>red panda's</yoastmark> coat is mainly" +
+					" <yoastmark class='yoast-text-mark'>red</yoastmark> or orange-brown with a black belly and legs.",
+				original: "The red panda's coat is mainly red or orange-brown with a black belly and legs." } ) ]
+		);
+	} );
 } );
 
 describe( "Adds Yoast marks to specific words in a sentence for languages with custom helper to match words", function() {

--- a/packages/yoastseo/spec/languageProcessing/helpers/word/markWordsInSentenceSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/helpers/word/markWordsInSentenceSpec.js
@@ -104,7 +104,7 @@ describe( "Adds Yoast marks to specific words in a sentence", function() {
 		let wordsToMark = [ "red", "panda's" ];
 		expect( markWordsInASentence( sentences, wordsToMark, false ) ).toEqual(
 			[ new Mark( {
-				marked: "The <yoastmark class='yoast-text-mark'>red panda's</yoastmark> coat is mainly" +
+				marked: "The <yoastmark class='yoast-text-mark'>red panda’s</yoastmark> coat is mainly" +
 					" <yoastmark class='yoast-text-mark'>red</yoastmark> or orange-brown with a black belly and legs.",
 				original: "The red panda’s coat is mainly red or orange-brown with a black belly and legs." } ) ]
 		);
@@ -116,6 +116,15 @@ describe( "Adds Yoast marks to specific words in a sentence", function() {
 				marked: "The <yoastmark class='yoast-text-mark'>red panda's</yoastmark> coat is mainly" +
 					" <yoastmark class='yoast-text-mark'>red</yoastmark> or orange-brown with a black belly and legs.",
 				original: "The red panda's coat is mainly red or orange-brown with a black belly and legs." } ) ]
+		);
+
+		sentences = "« The ‹black-footed› cat has tawny fur that is entirely covered with black spots. »";
+		wordsToMark = [ "black-footed", "cat" ];
+		expect( markWordsInASentence( sentences, wordsToMark, false ) ).toEqual(
+			[ new Mark( {
+				marked: "« The ‹<yoastmark class='yoast-text-mark'>black-footed</yoastmark>› <yoastmark class='yoast-text-mark'>cat</yoastmark> " +
+					"has tawny fur that is entirely covered with black spots. »",
+				original: "« The ‹black-footed› cat has tawny fur that is entirely covered with black spots. »" } ) ]
 		);
 	} );
 } );

--- a/packages/yoastseo/spec/languageProcessing/helpers/word/markWordsInSentenceSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/helpers/word/markWordsInSentenceSpec.js
@@ -126,6 +126,14 @@ describe( "Adds Yoast marks to specific words in a sentence", function() {
 					"has tawny fur that is entirely covered with black spots. »",
 				original: "« The ‹black-footed› cat has tawny fur that is entirely covered with black spots. »" } ) ]
 		);
+
+		sentences = "The fo'c'sle is the upper deck of a sailing ship forward of the foremast.";
+		wordsToMark = [ "fo'c'sle" ];
+		expect( markWordsInASentence( sentences, wordsToMark, false ) ).toEqual(
+			[ new Mark( {
+				marked: "The <yoastmark class='yoast-text-mark'>fo'c'sle</yoastmark> is the upper deck of a sailing ship forward of the foremast.",
+				original: "The fo'c'sle is the upper deck of a sailing ship forward of the foremast." } ) ]
+		);
 	} );
 } );
 

--- a/packages/yoastseo/src/languageProcessing/helpers/sanitize/quotes.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/sanitize/quotes.js
@@ -1,5 +1,5 @@
 const SINGLE_QUOTES_ARRAY = [ "'", "‘", "’", "‛", "`", "‹", "›" ];
-const SINGLE_QUOTES_REGEX = /['‘’‛`‹›]/g;
+const SINGLE_QUOTES_REGEX = new RegExp( "[" + SINGLE_QUOTES_ARRAY.join( "" ) + "]", "g" );
 
 /**
  * Normalizes single quotes to 'regular' quotes.

--- a/packages/yoastseo/src/languageProcessing/helpers/sanitize/quotes.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/sanitize/quotes.js
@@ -1,3 +1,6 @@
+const SINGLE_QUOTES_ARRAY = [ "'", "‘", "’", "‛", "`", "‹", "›" ];
+const SINGLE_QUOTES_REGEX = /['‘’‛`‹›]/g;
+
 /**
  * Normalizes single quotes to 'regular' quotes.
  *
@@ -5,7 +8,7 @@
  * @returns {string} The normalized text.
  */
 function normalizeSingleQuotes( text ) {
-	return text.replace( /[‘’‛`‹›]/g, "'" );
+	return text.replace( SINGLE_QUOTES_REGEX, "'" );
 }
 
 /**
@@ -32,6 +35,8 @@ export {
 	normalizeSingleQuotes as normalizeSingle,
 	normalizeDoubleQuotes as normalizeDouble,
 	normalizeQuotes as normalize,
+	SINGLE_QUOTES_REGEX,
+	SINGLE_QUOTES_ARRAY,
 };
 
 export default {

--- a/packages/yoastseo/src/languageProcessing/helpers/word/markWordsInSentences.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/word/markWordsInSentences.js
@@ -4,7 +4,7 @@ import addMark from "../../../markers/addMarkSingleWord";
 import Mark from "../../../values/Mark";
 import { escapeRegExp } from "lodash-es";
 import getAnchorsFromText from "../link/getAnchorsFromText";
-import { normalizeSingle } from "../sanitize/quotes";
+import { SINGLE_QUOTES_ARRAY, SINGLE_QUOTES_REGEX } from "../sanitize/quotes";
 
 // Regex to deconstruct an anchor into open tag, content and close tag.
 const anchorDeconstructionRegex = /(<a[\s]+[^>]+>)([^]*?)(<\/a>)/;
@@ -77,18 +77,35 @@ const getMarkedAnchors = function( sentence, wordsRegex ) {
  * @returns {string} The sentence with marks.
  */
 export const collectMarkingsInSentence = function( sentence, wordsFoundInSentence, matchWordCustomHelper ) {
-	wordsFoundInSentence = wordsFoundInSentence.map( word => {
-		word = escapeRegExp( word );
-		word = normalizeSingle( word );
-		return word;
+	const allWordsFound = [];
+	wordsFoundInSentence.forEach( word => {
+		// Check if the word in `wordsFoundInSentence` contains a single quote.
+		const matchedSingleQuote = word.match( SINGLE_QUOTES_REGEX );
+		if ( matchedSingleQuote ) {
+			/*
+			 * If yes, make all different combinations of the word with different types of single quotes in the array.
+			 * Later, a regex will be created for all words that were found in the sentence including their variations.
+			 *
+			 * For example:
+			 * `wordsFoundInSentence`: [ "red", "panda’s" ]
+			 * For the word "panda’s", we'll create the following variations:
+			 * "panda's", "panda‘s", "panda’s", "panda‛s", "panda`s", "panda‹s", "panda›s"
+			 * And those variations will be added to `allWordsFound`.
+			 */
+			SINGLE_QUOTES_ARRAY.forEach( singleQuote => {
+				allWordsFound.push( escapeRegExp( word.replace( matchedSingleQuote.toString(), singleQuote ) ) );
+			} );
+		}
+		allWordsFound.push( escapeRegExp( word ) );
 	} );
+
 	// If a language has a custom helper to match words, we disable the word boundary when creating the regex.
-	const wordsRegex = matchWordCustomHelper ? arrayToRegex( wordsFoundInSentence, true ) : arrayToRegex( wordsFoundInSentence );
+	const wordsRegex = matchWordCustomHelper ? arrayToRegex( allWordsFound, true ) : arrayToRegex( allWordsFound );
 
 	// Retrieve the anchors and mark the anchors' text if the words are found in the anchors' text.
 	const { anchors, markedAnchors } = getMarkedAnchors( sentence, wordsRegex );
 
-	let markup = normalizeSingle( sentence ).replace( wordsRegex, function( x ) {
+	let markup = sentence.replace( wordsRegex, function( x ) {
 		return addMark( x );
 	} );
 

--- a/packages/yoastseo/src/languageProcessing/helpers/word/markWordsInSentences.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/word/markWordsInSentences.js
@@ -80,8 +80,8 @@ export const collectMarkingsInSentence = function( sentence, wordsFoundInSentenc
 	const allWordsFound = [];
 	wordsFoundInSentence.forEach( word => {
 		// Check if the word in `wordsFoundInSentence` contains a single quote.
-		const matchedSingleQuote = word.match( SINGLE_QUOTES_REGEX );
-		if ( matchedSingleQuote ) {
+		const matchedSingleQuotes = word.match( SINGLE_QUOTES_REGEX );
+		if ( matchedSingleQuotes ) {
 			/*
 			 * If yes, make all different combinations of the word with different types of single quotes in the array.
 			 * Later, a regex will be created for all words that were found in the sentence including their variations.
@@ -93,10 +93,13 @@ export const collectMarkingsInSentence = function( sentence, wordsFoundInSentenc
 			 * And those variations will be added to `allWordsFound`.
 			 */
 			SINGLE_QUOTES_ARRAY.forEach( singleQuote => {
-				allWordsFound.push( escapeRegExp( word.replace( matchedSingleQuote.toString(), singleQuote ) ) );
+				matchedSingleQuotes.forEach( match => {
+					allWordsFound.push( escapeRegExp( word.replace( match, singleQuote ) ) );
+				} );
 			} );
+		} else {
+			allWordsFound.push( escapeRegExp( word ) );
 		}
-		allWordsFound.push( escapeRegExp( word ) );
 	} );
 
 	// If a language has a custom helper to match words, we disable the word boundary when creating the regex.

--- a/packages/yoastseo/src/languageProcessing/helpers/word/markWordsInSentences.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/word/markWordsInSentences.js
@@ -79,7 +79,7 @@ const getMarkedAnchors = function( sentence, wordsRegex ) {
 export const collectMarkingsInSentence = function( sentence, wordsFoundInSentence, matchWordCustomHelper ) {
 	const allWordsFound = [];
 	wordsFoundInSentence.forEach( word => {
-		// Check if the word in `wordsFoundInSentence` contains a single quote.
+		// Check if the word in `wordsFoundInSentence` contains single quote(s).
 		const matchedSingleQuotes = word.match( SINGLE_QUOTES_REGEX );
 		if ( matchedSingleQuotes ) {
 			/*
@@ -93,8 +93,8 @@ export const collectMarkingsInSentence = function( sentence, wordsFoundInSentenc
 			 * And those variations will be added to `allWordsFound`.
 			 */
 			SINGLE_QUOTES_ARRAY.forEach( singleQuote => {
-				matchedSingleQuotes.forEach( match => {
-					allWordsFound.push( escapeRegExp( word.replace( match, singleQuote ) ) );
+				matchedSingleQuotes.forEach( matchedSingleQuote => {
+					allWordsFound.push( escapeRegExp( word.replace( new RegExp( matchedSingleQuote, "g" ), singleQuote ) ) );
 				} );
 			} );
 		} else {

--- a/packages/yoastseo/src/languageProcessing/helpers/word/markWordsInSentences.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/word/markWordsInSentences.js
@@ -4,6 +4,7 @@ import addMark from "../../../markers/addMarkSingleWord";
 import Mark from "../../../values/Mark";
 import { escapeRegExp } from "lodash-es";
 import getAnchorsFromText from "../link/getAnchorsFromText";
+import { normalizeSingle } from "../sanitize/quotes";
 
 // Regex to deconstruct an anchor into open tag, content and close tag.
 const anchorDeconstructionRegex = /(<a[\s]+[^>]+>)([^]*?)(<\/a>)/;
@@ -76,14 +77,18 @@ const getMarkedAnchors = function( sentence, wordsRegex ) {
  * @returns {string} The sentence with marks.
  */
 export const collectMarkingsInSentence = function( sentence, wordsFoundInSentence, matchWordCustomHelper ) {
-	wordsFoundInSentence = wordsFoundInSentence.map( word => escapeRegExp( word ) );
+	wordsFoundInSentence = wordsFoundInSentence.map( word => {
+		word = escapeRegExp( word );
+		word = normalizeSingle( word );
+		return word;
+	} );
 	// If a language has a custom helper to match words, we disable the word boundary when creating the regex.
 	const wordsRegex = matchWordCustomHelper ? arrayToRegex( wordsFoundInSentence, true ) : arrayToRegex( wordsFoundInSentence );
 
 	// Retrieve the anchors and mark the anchors' text if the words are found in the anchors' text.
 	const { anchors, markedAnchors } = getMarkedAnchors( sentence, wordsRegex );
 
-	let markup = sentence.replace( wordsRegex, function( x ) {
+	let markup = normalizeSingle( sentence ).replace( wordsRegex, function( x ) {
 		return addMark( x );
 	} );
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* In Elementor and other editors (Block and Classic), we want to be able to highlight keyphrase occurrences with different types of apostrophe in the text when _keyphrase distribution_ assessment eye button is activated. For example if the keyphrase is `red panda`, we want to be able to highlight `red panda's` and `red panda’s` occurrences in the text.
* However, that wasn't the case yet. Even though we're able to match `red panda` with both `red panda's` and `red panda’s` occurrences, we're not able to highlight the word that contains non-normalized single quotes such as `panda’s`.
* The problem was (in `packages/yoastseo/src/languageProcessing/helpers/word/markWordsInSentences.js`):
   * Before we're adding the `yoastmark` (the HTML tag that will give the highlighting to the text) to the matched keyphrase occurrences in the sentence/text, we need to find the keyphrase in the sentence (by matching the keyphrase with the sentence)
   * However, the regex that we're using to match the keyphrase and the sentence did not take into account the different styles of single quotes. As a result, we failed to add the `yoastmark` to the word `panda’s`

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [wordpress-seo-premium] Fixes a bug where the highlighting would be applied incorrectly when keyphrase occurrences contained different types of apostrophes than `'` in the _keyphrase distribution_ assessment.
* [shopify-seo] Fixes a bug where the highlighting would be applied incorrectly when keyphrase occurrences contained different types of apostrophes than `'` in the _keyphrase distribution_ assessment.
* [yoastseo] Adds `yoastmark` tags to matched keyphrase with different types of apostrophe. For example, when the keyphrase is "panda" and both "panda's" and "panda’s" are found in the text, `yoastmark` tags would be added to both occurrences.

## Relevant technical choices:

* To fix the problem, if a word (from the keyphrase occurrences) contains a single quote (using the regex ```/['‘’‛`‹›]/g```), different variations of that word with different types of single quotes will be created. 
* Then regex will be created for all words that were found in the sentence including their variations.
* For example:
   * If these are the words that were found in the text: `[ "red", "panda’s" ]`
   * For the word "panda’s", we'll create the following variations: ```"panda's", "panda‘s", "panda’s", "panda‛s", "panda`s", "panda‹s", "panda›s"```
   * And those variations will be added to an array of words where we'll create a regex to match the keyphrase with the sentence.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install and activate Yoast SEO
* Install and activate Yoast SEO Premium
* Install and activate Elementor (Free)
* Set the site language to English

#### Test in Elementor
* Create a post in Elementor
* Set the focus keyphrase to: red panda
* Add the following text to a text editor widget (or just a text editor in Block, Classic and in Shopify):
> The red panda's coat is mainly red or orange-brown with a black belly and legs. The muzzle, cheeks, brows and inner ear margins are mostly white while the bushy tail has red and buff ring patterns and a dark brown tip. The colouration appears to serve as camouflage in habitat with red moss and white lichen-covered trees. The guard hairs are longer and rougher while the dense undercoat is fluffier with shorter hairs. The guard hairs on the back have a circular cross-section and are 47–56 mm (1.9–2.2 in) long. It has moderately long whiskers around the mouth, lower jaw and chin. The hair on the soles of the paws allows the animal to walk in snow.

> The red panda has a relatively small head, though proportionally larger than in similarly sized raccoons, with a reduced snout and triangular ears, and nearly evenly lengthed limbs. It has a head-body length of 51–63.5 cm (20.1–25.0 in) with a 28–48.5 cm (11.0–19.1 in) tail. The Himalayan red panda is recorded to weigh 3.2–9.4 kg (7.1–20.7 lb), while the Chinese red panda weighs 4–15 kg (8.8–33.1 lb) for females and 4.2–13.4 kg (9.3–29.5 lb) for males. It has five curved digits on each foot, each with curved semi-retractile claws that aid in climbing. The pelvis and hindlimbs have flexible joints, adaptations for an arboreal quadrupedal lifestyle. While not prehensile, the tail helps the animal balance while climbing. The red panda is most of the time cute.

> The forepaws possess a "false thumb", which is an extension of a wrist bone, the radial sesamoid found in many carnivorans. This thumb allows the animal to grip onto bamboo stalks and both the digits and wrist bones are highly flexible. The red panda shares this feature with the giant panda, which has a larger sesamoid that is more compressed at the sides. In addition, the red panda's sesamoid has a more sunken tip while the giant panda's curves in the middle. The red panda's skull is wide, and its lower jaw is robust. However, because it eats leaves and stems, which are not as tough, it has smaller chewing muscles than the giant panda. The digestive system of the red panda is only 4.2 times its body length, with a simple stomach, no noticeable divide between the ileum and colon, and no caecum.

* Go to the Keyphrase distribution assessment and click on the eye button
* Confirm that all focus keyphrase occurrences are highlighted including "panda's"
* Change the focus keyphrase to: black-footed cat
* Add the following sentence to the text: « The ‹black-footed› cat has tawny fur that is entirely covered with black spots. »
* Go to the Keyphrase distribution assessment and click on the eye button
* Confirm that "black-footed" and "cat" are highlighted
* Save the post

##### Test in Classic editor
* Install and activate Classic editor
* Open the post that previously created above
* Set the focus keyphrase to: red panda
* Go to the Keyphrase distribution assessment and click on the eye button
* Confirm that all focus keyphrase occurrences are highlighted including "panda's"
* Change the apostrophe in "panda's" from `'` to `’`
* Go to the Keyphrase distribution assessment and click on the eye button
* Confirm that all focus keyphrase occurrences are highlighted including "panda’s"
##### Test in Block editor
* Repeat the test instruction from **Test in Classic editor above**
* Confirm that you get the same result

#### Impact checks
##### Word complexity assessment
* Open the post that previously created above
* Go to Word complexity assessment and confirm that "black-footed" is highlighted
* Add the following phrase to the text: the government's issue
* Go to Word complexity assessment and confirm that "government's" is highlighted

#### Test in Shopify
* Repeat the test instructions under **Test in Elementor**
* Confirm that you get the same result

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [x] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The change also might have an impact on the highlighting of word complexity assessment (in any language). Testing instruction to cover those cases has been added in the above section.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [x] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [x] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/plugins-automated-testing/issues/1249
