### PR TITLE
Composer: update suggested PHP extensions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
 	},
 	"require": {
 		"php": "^7.2.5 || ^8.0",
+		"ext-filter": "*",
 		"composer/installers": "^1.12 || ^2.0"
 	},
 	"require-dev": {
@@ -37,6 +38,12 @@
 		"wordproof/wordpress-sdk": "1.3.5",
 		"yoast/wp-test-utils": "^1.2",
 		"yoast/yoastcs": "^2.3.1"
+	},
+	"suggest": {
+		"ext-bcmath": "For more accurate calculations",
+		"ext-dom": "Improves image sitemap",
+		"ext-libxml": "Improves image sitemap",
+		"ext-mbstring": "For cyrillic support"
 	},
 	"minimum-stability": "dev",
 	"prefer-stable": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "233a854e8150784cadc57667479a4988",
+    "content-hash": "86ce4a3fd495d19959a406e5e10672d5",
     "packages": [
         {
             "name": "composer/installers",
@@ -965,9 +965,9 @@
             "require-dev": {
                 "friendsofphp/php-cs-fixer": "@stable",
                 "nikic/php-parser": "@stable",
-                "php": "^8.0",
+                "php": "^8.3",
                 "phpdocumentor/reflection-docblock": "@stable",
-                "phpunit/phpunit": "^9.6"
+                "phpunit/phpunit": "@stable"
             },
             "default-branch": true,
             "type": "library",
@@ -3180,12 +3180,12 @@
             "version": "3.7.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
                 "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ed8e00df0a83aa96acf703f8c2979ff33341f879",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/ed8e00df0a83aa96acf703f8c2979ff33341f879",
                 "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879",
                 "shasum": ""
             },
@@ -3230,6 +3230,20 @@
                 "source": "https://github.com/squizlabs/PHP_CodeSniffer",
                 "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
             },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                }
+            ],
             "time": "2023-02-22T23:07:41+00:00"
         },
         {
@@ -4412,7 +4426,8 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.2.5 || ^8.0"
+        "php": "^7.2.5 || ^8.0",
+        "ext-filter": "*"
     },
     "platform-dev": [],
     "platform-overrides": {


### PR DESCRIPTION
## Context

* Be explicit about required PHP extensions

## Summary

This PR can be summarized in the following changelog entry:

* Be explicit about required PHP extensions

## Relevant technical choices:

The Filter extension is used unconditionally within the library. All the other are used conditionally.

Discovered using the ComposerRequireChecker tool and manually verified.

Ref: https://github.com/maglnet/ComposerRequireChecker

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_

