### PR TITLE
CS/QA: modernize function calls to dirname()

### DIFF
--- a/tests/Unit/bootstrap.php
+++ b/tests/Unit/bootstrap.php
@@ -20,7 +20,7 @@ $GLOBALS['wp_version'] = '1.0';
 \define( 'WPSEO_VERSION', '1.0' );
 
 if ( ! \defined( 'WPSEO_PATH' ) ) {
-	\define( 'WPSEO_PATH', \dirname( \dirname( __DIR__ ) ) . '/' );
+	\define( 'WPSEO_PATH', \dirname( __DIR__, 2 ) . '/' );
 }
 
 if ( ! \defined( 'WPSEO_FILE' ) ) {

--- a/tests/WP/bootstrap.php
+++ b/tests/WP/bootstrap.php
@@ -10,7 +10,7 @@ namespace Yoast\WP\SEO\Tests\WP;
 use RuntimeException;
 use Yoast\WPTestUtils\WPIntegration;
 
-require_once \dirname( \dirname( __DIR__ ) ) . '/vendor/yoast/wp-test-utils/src/WPIntegration/bootstrap-functions.php';
+require_once \dirname( __DIR__, 2 ) . '/vendor/yoast/wp-test-utils/src/WPIntegration/bootstrap-functions.php';
 
 
 /* *****[ Ensure a couple of required files are present ]***** */
@@ -21,7 +21,7 @@ require_once \dirname( \dirname( __DIR__ ) ) . '/vendor/yoast/wp-test-utils/src/
  * @throws RuntimeException If the directory or file creation failed.
  */
 $yoast_seo_create_asset_files = static function () {
-	$target_dir = \dirname( \dirname( __DIR__ ) ) . '/src/generated/assets';
+	$target_dir = \dirname( __DIR__, 2 ) . '/src/generated/assets';
 
 	// phpcs:disable WordPress.PHP.NoSilencedErrors.Discouraged -- Silencing warnings when function fails.
 	if ( @\is_dir( $target_dir ) === false ) {
@@ -82,7 +82,7 @@ require_once $_tests_dir . 'includes/functions.php';
 	 * Manually load the plugin being tested.
 	 */
 	static function () {
-		require \dirname( \dirname( __DIR__ ) ) . '/wp-seo.php';
+		require \dirname( __DIR__, 2 ) . '/wp-seo.php';
 	}
 );
 
@@ -101,7 +101,7 @@ require_once $_tests_dir . 'includes/functions.php';
 	 * @return string
 	 */
 	static function ( $url, $path, $plugin ) {
-		$plugin_dir = \dirname( \dirname( __DIR__ ) );
+		$plugin_dir = \dirname( __DIR__, 2 );
 		if ( $plugin === $plugin_dir . '/wp-seo.php' ) {
 			$url = \str_replace( \dirname( $plugin_dir ), '', $url );
 		}


### PR DESCRIPTION
## Context

* Code QA/consistency

## Summary

This PR can be summarized in the following changelog entry:

* Code QA/consistency

## Relevant technical choices:

PHP 7.0 introduced a `$levels` parameter, which means that nested calls to `dirname()` are no longer needed.

Ref: https://www.php.net/manual/en/function.dirname.php


## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_ No functional changes.