### PR TITLE
CS/QA: no "lonely if"

### DIFF
--- a/admin/class-yoast-notification-center.php
+++ b/admin/class-yoast-notification-center.php
@@ -699,10 +699,8 @@ class Yoast_Notification_Center {
 				return wp_unslash( $_POST[ $key ] );
 			}
 		}
-		else {
-			if ( isset( $_GET[ $key ] ) && is_string( $_GET[ $key ] ) ) {
-				return wp_unslash( $_GET[ $key ] );
-			}
+		elseif ( isset( $_GET[ $key ] ) && is_string( $_GET[ $key ] ) ) {
+			return wp_unslash( $_GET[ $key ] );
 		}
 		// phpcs:enable WordPress.Security.NonceVerification.Missing, WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		return '';

--- a/admin/taxonomy/class-taxonomy-columns.php
+++ b/admin/taxonomy/class-taxonomy-columns.php
@@ -131,10 +131,8 @@ class WPSEO_Taxonomy_Columns {
 				return sanitize_text_field( wp_unslash( $_POST['taxonomy'] ) );
 			}
 		}
-		else {
-			if ( isset( $_GET['taxonomy'] ) && is_string( $_GET['taxonomy'] ) ) {
-				return sanitize_text_field( wp_unslash( $_GET['taxonomy'] ) );
-			}
+		elseif ( isset( $_GET['taxonomy'] ) && is_string( $_GET['taxonomy'] ) ) {
+			return sanitize_text_field( wp_unslash( $_GET['taxonomy'] ) );
 		}
 		// phpcs:enable WordPress.Security.NonceVerification.Missing, WordPress.Security.NonceVerification.Recommended
 		return null;
@@ -152,10 +150,8 @@ class WPSEO_Taxonomy_Columns {
 				return sanitize_text_field( wp_unslash( $_POST['taxonomy'] ) );
 			}
 		}
-		else {
-			if ( isset( $_GET['taxonomy'] ) && is_string( $_GET['taxonomy'] ) ) {
-				return sanitize_text_field( wp_unslash( $_GET['taxonomy'] ) );
-			}
+		elseif ( isset( $_GET['taxonomy'] ) && is_string( $_GET['taxonomy'] ) ) {
+			return sanitize_text_field( wp_unslash( $_GET['taxonomy'] ) );
 		}
 		// phpcs:enable WordPress.Security.NonceVerification.Missing, WordPress.Security.NonceVerification.Recommended
 		return null;

--- a/inc/class-wpseo-replace-vars.php
+++ b/inc/class-wpseo-replace-vars.php
@@ -366,21 +366,17 @@ class WPSEO_Replace_Vars {
 			// Returns a string.
 			$replacement = YoastSEO()->helpers->date->format_translated( $this->args->post_date, get_option( 'date_format' ) );
 		}
-		else {
-			if ( get_query_var( 'day' ) && get_query_var( 'day' ) !== '' ) {
-				// Returns a string.
-				$replacement = get_the_date();
-			}
-			else {
-				if ( single_month_title( ' ', false ) && single_month_title( ' ', false ) !== '' ) {
-					// Returns a string.
-					$replacement = single_month_title( ' ', false );
-				}
-				elseif ( get_query_var( 'year' ) !== '' ) {
-					// Returns an integer, let's cast to string.
-					$replacement = (string) get_query_var( 'year' );
-				}
-			}
+		elseif ( get_query_var( 'day' ) && get_query_var( 'day' ) !== '' ) {
+			// Returns a string.
+			$replacement = get_the_date();
+		}
+		elseif ( single_month_title( ' ', false ) && single_month_title( ' ', false ) !== '' ) {
+			// Returns a string.
+			$replacement = single_month_title( ' ', false );
+		}
+		elseif ( get_query_var( 'year' ) !== '' ) {
+			// Returns an integer, let's cast to string.
+			$replacement = (string) get_query_var( 'year' );
 		}
 
 		return $replacement;

--- a/inc/options/class-wpseo-option-titles.php
+++ b/inc/options/class-wpseo-option-titles.php
@@ -845,10 +845,8 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 							if ( ! isset( $post_type_names[ $tax ] ) && isset( $option_value[ $old_prefix . $tax ] ) ) {
 								unset( $option_value[ $old_prefix . $tax ] );
 							}
-							else {
-								if ( isset( $post_type_names[ $tax ] ) && ! isset( $option_value[ $old_prefix . $tax ] ) ) {
-									$option_value[ $old_prefix . $tax ] = $original[ $old_prefix . $tax ];
-								}
+							elseif ( isset( $post_type_names[ $tax ] ) && ! isset( $option_value[ $old_prefix . $tax ] ) ) {
+								$option_value[ $old_prefix . $tax ] = $original[ $old_prefix . $tax ];
 							}
 
 							if ( $old_prefix === 'tax-hideeditbox-' ) {

--- a/lib/migrations/adapter.php
+++ b/lib/migrations/adapter.php
@@ -794,10 +794,8 @@ class Adapter {
 					$column_type_sql .= \sprintf( '(%d)', $precision );
 				}
 			}
-			else {
-				if ( $scale ) {
-					throw new Exception( "Error adding $type column: precision cannot be empty if scale is specified" );
-				}
+			elseif ( $scale ) {
+				throw new Exception( "Error adding $type column: precision cannot be empty if scale is specified" );
 			}
 		}
 		elseif ( $type === 'enum' ) {

--- a/lib/migrations/table.php
+++ b/lib/migrations/table.php
@@ -186,13 +186,11 @@ class Table {
 		if ( \is_array( $this->options ) && \array_key_exists( 'options', $this->options ) ) {
 			$opt_str = $this->options['options'];
 		}
+		elseif ( isset( $this->adapter->db_info['charset'] ) ) {
+			$opt_str = ' DEFAULT CHARSET=' . $this->adapter->db_info['charset'];
+		}
 		else {
-			if ( isset( $this->adapter->db_info['charset'] ) ) {
-				$opt_str = ' DEFAULT CHARSET=' . $this->adapter->db_info['charset'];
-			}
-			else {
-				$opt_str = ' DEFAULT CHARSET=utf8';
-			}
+			$opt_str = ' DEFAULT CHARSET=utf8';
 		}
 		$close_sql        = \sprintf( ') %s;', $opt_str );
 		$create_table_sql = $this->sql;

--- a/lib/orm.php
+++ b/lib/orm.php
@@ -2055,10 +2055,8 @@ class ORM implements \ArrayAccess {
 					}
 				}
 			}
-			else {
-				if ( $id === null ) {
-					throw new \Exception( 'Primary key ID missing from row or is null' );
-				}
+			elseif ( $id === null ) {
+				throw new \Exception( 'Primary key ID missing from row or is null' );
 			}
 		}
 
@@ -2114,10 +2112,8 @@ class ORM implements \ArrayAccess {
 			if ( $expr === false && isset( $this->expr_fields[ $field ] ) ) {
 				unset( $this->expr_fields[ $field ] );
 			}
-			else {
-				if ( $expr === true ) {
-					$this->expr_fields[ $field ] = true;
-				}
+			elseif ( $expr === true ) {
+				$this->expr_fields[ $field ] = true;
 			}
 		}
 

--- a/src/integrations/front-end/crawl-cleanup-basic.php
+++ b/src/integrations/front-end/crawl-cleanup-basic.php
@@ -115,10 +115,8 @@ class Crawl_Cleanup_Basic implements Integration_Interface {
 					unset( $hints[ $key ] );
 				}
 			}
-			else {
-				if ( \strpos( $hint, '//s.w.org' ) !== false ) {
+			elseif ( \strpos( $hint, '//s.w.org' ) !== false ) {
 					unset( $hints[ $key ] );
-				}
 			}
 		}
 


### PR DESCRIPTION
## Context

* Code QA/consistency

## Summary

This PR can be summarized in the following changelog entry:

* Code QA/consistency

## Relevant technical choices:

Reformat code where an `if` statement is the only code within an `else` clause to use `elseif`.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_ No functional changes.