### PR TITLE
CS/QA: upgrade calls to get_terms()

### DIFF
--- a/admin/import/plugins/class-import-wpseo.php
+++ b/admin/import/plugins/class-import-wpseo.php
@@ -193,7 +193,12 @@ class WPSEO_Import_WPSEO extends WPSEO_Plugin_Importer {
 	 * @return void
 	 */
 	private function import_taxonomy_metas() {
-		$terms    = get_terms( get_taxonomies(), [ 'hide_empty' => false ] );
+		$terms    = get_terms(
+			[
+				'taxonomy'   => get_taxonomies(),
+				'hide_empty' => false,
+			]
+		);
 		$tax_meta = get_option( 'wpseo_taxonomy_meta' );
 
 		foreach ( $terms as $term ) {
@@ -291,7 +296,13 @@ class WPSEO_Import_WPSEO extends WPSEO_Plugin_Importer {
 	 * @return void
 	 */
 	private function cleanup_term_meta() {
-		$terms = get_terms( get_taxonomies(), [ 'hide_empty' => false ] );
+		$terms = get_terms(
+			[
+				'taxonomy'   => get_taxonomies(),
+				'hide_empty' => false,
+			]
+		);
+
 		foreach ( $terms as $term ) {
 			$this->delete_taxonomy_metas( $term->taxonomy, $term->term_id );
 		}

--- a/inc/sitemaps/class-taxonomy-sitemap-provider.php
+++ b/inc/sitemaps/class-taxonomy-sitemap-provider.php
@@ -94,10 +94,11 @@ class WPSEO_Taxonomy_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 			$hide_empty_tax = apply_filters( 'wpseo_sitemap_exclude_empty_terms_taxonomy', $hide_empty, $taxonomy_name );
 
 			$term_args      = [
+				'taxonomy'   => $taxonomy_name,
 				'hide_empty' => $hide_empty_tax,
 				'fields'     => 'ids',
 			];
-			$taxonomy_terms = get_terms( $taxonomy_name, $term_args );
+			$taxonomy_terms = get_terms( $term_args );
 
 			if ( count( $taxonomy_terms ) > 0 ) {
 				$all_taxonomies[ $taxonomy_name ] = $taxonomy_terms;


### PR DESCRIPTION
## Context

* Code QA/consistency

## Summary

This PR can be summarized in the following changelog entry:

* Code QA/consistency

## Relevant technical choices:

The function signature of the `get_terms()` function was changed in WP 4.5.0. This updates the function calls to `get_terms()` within this plugin to use the new expected function call format.

Ref: https://developer.wordpress.org/reference/functions/get_terms/

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_ No functional changes.