### PR TITLE
CS/QA: fix use of duplicate array keys

### DIFF
--- a/tests/Unit/Content_Type_Visibility/Application/Content_Type_Visibility_Watcher_Actions_Test.php
+++ b/tests/Unit/Content_Type_Visibility/Application/Content_Type_Visibility_Watcher_Actions_Test.php
@@ -176,7 +176,7 @@ final class Content_Type_Visibility_Watcher_Actions_Test extends TestCase {
 				'cleaned_taxonomies'          => [ 0 => 'post_tag' ],
 				'clean_times'                 => 1,
 			],
-			'new removed taxonomies' => [
+			'new non public taxonomies' => [
 				'newly_made_none_public'      => [ 'category' ],
 				'new_taxonomies'              => [ 'category' ],
 				'cleaned_taxonomies'          => [],
@@ -235,7 +235,7 @@ final class Content_Type_Visibility_Watcher_Actions_Test extends TestCase {
 				'cleaned_post types'          => [ 0 => 'post' ],
 				'clean_times'                 => 1,
 			],
-			'new removed post types' => [
+			'new non public post types' => [
 				'newly_made_none_public'      => [ 'book' ],
 				'new_post types'              => [ 'book' ],
 				'cleaned_post types'          => [],

--- a/tests/Unit/Integrations/Admin/Admin_Columns_Cache_Integration_Test.php
+++ b/tests/Unit/Integrations/Admin/Admin_Columns_Cache_Integration_Test.php
@@ -123,7 +123,6 @@ final class Admin_Columns_Cache_Integration_Test extends TestCase {
 
 		$results = [
 			(object) [
-				'object_id' => 1,
 				false,
 				false,
 				'object_id' => 2,


### PR DESCRIPTION
## Context

* Code QA/consistency

## Summary

This PR can be summarized in the following changelog entry:

* Code QA/consistency

## Relevant technical choices:

### CS/QA | Content_Type_Visibility_Watcher_Actions_Test: rename duplicate array key in data provider

... which essentially meant that the first data sets using that name were not being run in the tests.

### CS/QA | Admin_Columns_Cache_Integration_Test: fix test expectation

The second instance of the array key encountered would overwrite the value of the first, so removing the first of the two array keys will maintain the existing behaviour.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_ No functional changes.