### PR TITLE
CS/QA: don't use static calls to assertion methods

### DIFF
--- a/tests/Unit/Actions/Indexing/Abstract_Link_Indexing_Action_Test.php
+++ b/tests/Unit/Actions/Indexing/Abstract_Link_Indexing_Action_Test.php
@@ -87,15 +87,15 @@ final class Abstract_Link_Indexing_Action_Test extends TestCase {
 	 * @covers ::__construct
 	 */
 	public function test_construct() {
-		static::assertInstanceOf(
+		$this->assertInstanceOf(
 			Indexable_Link_Builder::class,
 			$this->getPropertyValue( $this->instance, 'link_builder' )
 		);
-		static::assertInstanceOf(
+		$this->assertInstanceOf(
 			Indexable_Repository::class,
 			$this->getPropertyValue( $this->instance, 'repository' )
 		);
-		static::assertInstanceOf(
+		$this->assertInstanceOf(
 			'wpdb',
 			$this->getPropertyValue( $this->instance, 'wpdb' )
 		);
@@ -111,6 +111,6 @@ final class Abstract_Link_Indexing_Action_Test extends TestCase {
 			->with( 5 )
 			->andReturn( 25 );
 
-		static::assertEquals( 25, $this->instance->get_limit() );
+		$this->assertEquals( 25, $this->instance->get_limit() );
 	}
 }

--- a/tests/Unit/Actions/Indexing/Post_Link_Indexing_Action_Test.php
+++ b/tests/Unit/Actions/Indexing/Post_Link_Indexing_Action_Test.php
@@ -90,7 +90,7 @@ final class Post_Link_Indexing_Action_Test extends TestCase {
 	public function test_set_helper() {
 		$this->instance->set_helper( Mockery::mock( Post_Type_Helper::class ) );
 
-		static::assertInstanceOf(
+		$this->assertInstanceOf(
 			Post_Type_Helper::class,
 			$this->getPropertyValue( $this->instance, 'post_type_helper' )
 		);

--- a/tests/Unit/Actions/Indexing/Term_Link_Indexing_Action_Test.php
+++ b/tests/Unit/Actions/Indexing/Term_Link_Indexing_Action_Test.php
@@ -90,7 +90,7 @@ final class Term_Link_Indexing_Action_Test extends TestCase {
 	public function test_set_helper() {
 		$this->instance->set_helper( Mockery::mock( Taxonomy_Helper::class ) );
 
-		static::assertInstanceOf(
+		$this->assertInstanceOf(
 			Taxonomy_Helper::class,
 			$this->getPropertyValue( $this->instance, 'taxonomy_helper' )
 		);

--- a/tests/Unit/Conditionals/WP_Robots_Conditional_Test.php
+++ b/tests/Unit/Conditionals/WP_Robots_Conditional_Test.php
@@ -37,7 +37,7 @@ final class WP_Robots_Conditional_Test extends TestCase {
 	 * @covers ::is_met
 	 */
 	public function test_is_met_without_having_wp_robots_function() {
-		static::assertFalse( $this->instance->is_met() );
+		$this->assertFalse( $this->instance->is_met() );
 	}
 
 	/**
@@ -48,6 +48,6 @@ final class WP_Robots_Conditional_Test extends TestCase {
 	public function test_is_met() {
 		Monkey\Functions\expect( 'wp_robots' )->never();
 
-		static::assertTrue( $this->instance->is_met() );
+		$this->assertTrue( $this->instance->is_met() );
 	}
 }

--- a/tests/Unit/Generators/Schema_Generator_Test.php
+++ b/tests/Unit/Generators/Schema_Generator_Test.php
@@ -554,7 +554,7 @@ final class Schema_Generator_Test extends TestCase {
 			],
 		];
 
-		static::assertEquals( $expected, $this->instance->generate( $this->context ) );
+		$this->assertEquals( $expected, $this->instance->generate( $this->context ) );
 	}
 
 	/**

--- a/tests/Unit/Helpers/Date_Helper_Test.php
+++ b/tests/Unit/Helpers/Date_Helper_Test.php
@@ -42,7 +42,7 @@ final class Date_Helper_Test extends TestCase {
 	 * @param string $expected The expected value.
 	 */
 	public function test_format( $date, $format, $expected ) {
-		static::assertSame( $expected, $this->instance->format( $date, $format ) );
+		$this->assertSame( $expected, $this->instance->format( $date, $format ) );
 	}
 
 	/**
@@ -111,7 +111,7 @@ final class Date_Helper_Test extends TestCase {
 	 * @param string $expected  The expected value.
 	 */
 	public function test_format_timestamp( $timestamp, $format, $expected ) {
-		static::assertSame( $expected, $this->instance->format_timestamp( $timestamp, $format ) );
+		$this->assertSame( $expected, $this->instance->format_timestamp( $timestamp, $format ) );
 	}
 
 	/**
@@ -155,7 +155,7 @@ final class Date_Helper_Test extends TestCase {
 			->with( \DATE_W3C, '1609421820' )
 			->andReturn( '2020-12-31' );
 
-		static::assertSame(
+		$this->assertSame(
 			'2020-12-31',
 			$this->instance->format_translated( '2020-12-31 13:37:00' )
 		);
@@ -171,7 +171,7 @@ final class Date_Helper_Test extends TestCase {
 	 * @param bool  $expected The expected function return value.
 	 */
 	public function test_is_valid_datetime( $input, $expected ) {
-		static::assertSame( $expected, $this->instance->is_valid_datetime( $input ) );
+		$this->assertSame( $expected, $this->instance->is_valid_datetime( $input ) );
 	}
 
 	/**

--- a/tests/Unit/Helpers/Indexing_Helper_Test.php
+++ b/tests/Unit/Helpers/Indexing_Helper_Test.php
@@ -152,27 +152,27 @@ final class Indexing_Helper_Test extends TestCase {
 	 * @covers ::set_indexing_actions
 	 */
 	public function test_set_indexing_actions() {
-		static::assertInstanceOf(
+		$this->assertInstanceOf(
 			Indexable_Post_Indexation_Action::class,
 			$this->getPropertyValue( $this->instance, 'indexing_actions' )[0]
 		);
-		static::assertInstanceOf(
+		$this->assertInstanceOf(
 			Indexable_Term_Indexation_Action::class,
 			$this->getPropertyValue( $this->instance, 'indexing_actions' )[1]
 		);
-		static::assertInstanceOf(
+		$this->assertInstanceOf(
 			Indexable_Post_Type_Archive_Indexation_Action::class,
 			$this->getPropertyValue( $this->instance, 'indexing_actions' )[2]
 		);
-		static::assertInstanceOf(
+		$this->assertInstanceOf(
 			Indexable_General_Indexation_Action::class,
 			$this->getPropertyValue( $this->instance, 'indexing_actions' )[3]
 		);
-		static::assertInstanceOf(
+		$this->assertInstanceOf(
 			Post_Link_Indexing_Action::class,
 			$this->getPropertyValue( $this->instance, 'indexing_actions' )[4]
 		);
-		static::assertInstanceOf(
+		$this->assertInstanceOf(
 			Term_Link_Indexing_Action::class,
 			$this->getPropertyValue( $this->instance, 'indexing_actions' )[5]
 		);
@@ -355,7 +355,7 @@ final class Indexing_Helper_Test extends TestCase {
 			->once()
 			->andReturn( 0 );
 
-		static::assertEquals( 0, $this->instance->get_unindexed_count() );
+		$this->assertEquals( 0, $this->instance->get_unindexed_count() );
 	}
 
 	/**
@@ -398,7 +398,7 @@ final class Indexing_Helper_Test extends TestCase {
 		Monkey\Filters\expectApplied( 'wpseo_indexing_get_unindexed_count' )
 			->andReturn( 20 );
 
-		static::assertEquals( 20, $this->instance->get_filtered_unindexed_count() );
+		$this->assertEquals( 20, $this->instance->get_filtered_unindexed_count() );
 	}
 
 	/**
@@ -428,7 +428,7 @@ final class Indexing_Helper_Test extends TestCase {
 			->once()
 			->andReturn( 10 );
 
-		static::assertEquals( 30, $this->instance->get_limited_filtered_unindexed_count( 25 ) );
+		$this->assertEquals( 30, $this->instance->get_limited_filtered_unindexed_count( 25 ) );
 	}
 
 	/**
@@ -481,7 +481,7 @@ final class Indexing_Helper_Test extends TestCase {
 			->with( 18, 25 )
 			->andReturn( 18 );
 
-		static::assertEquals( 18, $this->instance->get_limited_filtered_unindexed_count( 25 ) );
+		$this->assertEquals( 18, $this->instance->get_limited_filtered_unindexed_count( 25 ) );
 	}
 
 	/**
@@ -511,7 +511,7 @@ final class Indexing_Helper_Test extends TestCase {
 			->once()
 			->andReturn( 10 );
 
-		static::assertEquals( 30, $this->instance->get_limited_filtered_unindexed_count_background( 25 ) );
+		$this->assertEquals( 30, $this->instance->get_limited_filtered_unindexed_count_background( 25 ) );
 	}
 
 	/**
@@ -564,6 +564,6 @@ final class Indexing_Helper_Test extends TestCase {
 			->with( 18, 25 )
 			->andReturn( 18 );
 
-		static::assertEquals( 18, $this->instance->get_limited_filtered_unindexed_count_background( 25 ) );
+		$this->assertEquals( 18, $this->instance->get_limited_filtered_unindexed_count_background( 25 ) );
 	}
 }

--- a/tests/Unit/Helpers/String_Helper_Test.php
+++ b/tests/Unit/Helpers/String_Helper_Test.php
@@ -37,7 +37,7 @@ final class String_Helper_Test extends TestCase {
 	 * @covers ::strip_all_tags
 	 */
 	public function test_strip_all_tags() {
-		static::assertSame( 'This is an anchor', $this->instance->strip_all_tags( 'This is an <a>anchor</a>' ) );
+		$this->assertSame( 'This is an anchor', $this->instance->strip_all_tags( 'This is an <a>anchor</a>' ) );
 	}
 
 	/**
@@ -46,7 +46,7 @@ final class String_Helper_Test extends TestCase {
 	 * @covers ::standardize_whitespace
 	 */
 	public function test_standardize_whitespace() {
-		static::assertSame( 'this is a string', $this->instance->standardize_whitespace( " \nthis\r\ris  a string \t" ) );
+		$this->assertSame( 'this is a string', $this->instance->standardize_whitespace( " \nthis\r\ris  a string \t" ) );
 	}
 
 	/**
@@ -59,6 +59,6 @@ final class String_Helper_Test extends TestCase {
 			->with( 'this is a [shortcode] ' )
 			->andReturn( 'this is a shortcode ' );
 
-		static::assertSame( 'this is a shortcode ', $this->instance->strip_shortcode( 'this is a [shortcode] ' ) );
+		$this->assertSame( 'this is a shortcode ', $this->instance->strip_shortcode( 'this is a [shortcode] ' ) );
 	}
 }

--- a/tests/Unit/Integrations/Academy_Integration_Test.php
+++ b/tests/Unit/Integrations/Academy_Integration_Test.php
@@ -83,7 +83,7 @@ final class Academy_Integration_Test extends TestCase {
 	 * @covers ::__construct
 	 */
 	public function test_construct() {
-		static::assertInstanceOf(
+		$this->assertInstanceOf(
 			Academy_Integration::class,
 			new Academy_Integration(
 				$this->asset_manager,
@@ -100,7 +100,7 @@ final class Academy_Integration_Test extends TestCase {
 	 * @covers ::get_conditionals
 	 */
 	public function test_get_conditionals() {
-		static::assertEquals(
+		$this->assertEquals(
 			[
 				Admin_Conditional::class,
 				User_Can_Manage_Wpseo_Options_Conditional::class,

--- a/tests/Unit/Integrations/Admin/Activation_Cleanup_Integration_Test.php
+++ b/tests/Unit/Integrations/Admin/Activation_Cleanup_Integration_Test.php
@@ -49,7 +49,7 @@ final class Activation_Cleanup_Integration_Test extends TestCase {
 	 * @covers ::get_conditionals
 	 */
 	public function test_get_conditionals() {
-		static::assertEquals(
+		$this->assertEquals(
 			[],
 			Activation_Cleanup_Integration::get_conditionals()
 		);

--- a/tests/Unit/Integrations/Admin/Background_Indexing_Integration_Test.php
+++ b/tests/Unit/Integrations/Admin/Background_Indexing_Integration_Test.php
@@ -168,7 +168,7 @@ final class Background_Indexing_Integration_Test extends TestCase {
 	 * @covers ::get_conditionals
 	 */
 	public function test_get_conditionals() {
-		static::assertEquals(
+		$this->assertEquals(
 			[
 				Migrations_Conditional::class,
 			],
@@ -182,31 +182,31 @@ final class Background_Indexing_Integration_Test extends TestCase {
 	 * @covers ::__construct
 	 */
 	public function test_constructor() {
-		static::assertInstanceOf(
+		$this->assertInstanceOf(
 			Indexable_Post_Indexation_Action::class,
 			$this->getPropertyValue( $this->instance, 'post_indexation' )
 		);
-		static::assertInstanceOf(
+		$this->assertInstanceOf(
 			Indexable_Term_Indexation_Action::class,
 			$this->getPropertyValue( $this->instance, 'term_indexation' )
 		);
-		static::assertInstanceOf(
+		$this->assertInstanceOf(
 			Indexable_Post_Type_Archive_Indexation_Action::class,
 			$this->getPropertyValue( $this->instance, 'post_type_archive_indexation' )
 		);
-		static::assertInstanceOf(
+		$this->assertInstanceOf(
 			Indexable_General_Indexation_Action::class,
 			$this->getPropertyValue( $this->instance, 'general_indexation' )
 		);
-		static::assertInstanceOf(
+		$this->assertInstanceOf(
 			Indexable_Indexing_Complete_Action::class,
 			$this->getPropertyValue( $this->instance, 'complete_indexation_action' )
 		);
-		static::assertInstanceOf(
+		$this->assertInstanceOf(
 			Indexing_Helper::class,
 			$this->getPropertyValue( $this->instance, 'indexing_helper' )
 		);
-		static::assertInstanceOf(
+		$this->assertInstanceOf(
 			Yoast_Admin_And_Dashboard_Conditional::class,
 			$this->getPropertyValue( $this->instance, 'yoast_admin_and_dashboard_conditional' )
 		);

--- a/tests/Unit/Integrations/Admin/Crawl_Settings_Integration_Test.php
+++ b/tests/Unit/Integrations/Admin/Crawl_Settings_Integration_Test.php
@@ -57,7 +57,7 @@ final class Crawl_Settings_Integration_Test extends TestCase {
 	 * @covers ::get_conditionals
 	 */
 	public function test_get_conditionals() {
-		static::assertEquals(
+		$this->assertEquals(
 			[
 				Admin_Conditional::class,
 			],

--- a/tests/Unit/Integrations/Admin/Cron_Integration_Test.php
+++ b/tests/Unit/Integrations/Admin/Cron_Integration_Test.php
@@ -50,7 +50,7 @@ final class Cron_Integration_Test extends TestCase {
 	 * @covers ::get_conditionals
 	 */
 	public function test_get_conditionals() {
-		static::assertEquals(
+		$this->assertEquals(
 			[
 				Admin_Conditional::class,
 			],
@@ -64,7 +64,7 @@ final class Cron_Integration_Test extends TestCase {
 	 * @covers ::__construct
 	 */
 	public function test_constructor() {
-		static::assertInstanceOf(
+		$this->assertInstanceOf(
 			Date_Helper::class,
 			$this->getPropertyValue( $this->instance, 'date_helper' )
 		);

--- a/tests/Unit/Integrations/Admin/Import_Integration_Test.php
+++ b/tests/Unit/Integrations/Admin/Import_Integration_Test.php
@@ -76,15 +76,15 @@ final class Import_Integration_Test extends TestCase {
 	 * @covers ::__construct
 	 */
 	public function test_constructor() {
-		static::assertInstanceOf(
+		$this->assertInstanceOf(
 			WPSEO_Admin_Asset_Manager::class,
 			self::getPropertyValue( $this->instance, 'asset_manager' )
 		);
-		static::assertInstanceOf(
+		$this->assertInstanceOf(
 			Importable_Detector_Service::class,
 			self::getPropertyValue( $this->instance, 'importable_detector' )
 		);
-		static::assertInstanceOf(
+		$this->assertInstanceOf(
 			Importing_Route::class,
 			self::getPropertyValue( $this->instance, 'importing_route' )
 		);

--- a/tests/Unit/Integrations/Admin/Indexing_Notification_Integration_Test.php
+++ b/tests/Unit/Integrations/Admin/Indexing_Notification_Integration_Test.php
@@ -242,7 +242,7 @@ final class Indexing_Notification_Integration_Test extends TestCase {
 	 * @covers ::get_conditionals
 	 */
 	public function test_get_conditionals() {
-		static::assertSame(
+		$this->assertSame(
 			[
 				Admin_Conditional::class,
 				Not_Admin_Ajax_Conditional::class,

--- a/tests/Unit/Integrations/Admin/Indexing_Tool_Integration_Test.php
+++ b/tests/Unit/Integrations/Admin/Indexing_Tool_Integration_Test.php
@@ -127,35 +127,35 @@ final class Indexing_Tool_Integration_Test extends TestCase {
 	 * @covers ::__construct
 	 */
 	public function test_constructor() {
-		static::assertInstanceOf(
+		$this->assertInstanceOf(
 			WPSEO_Admin_Asset_Manager::class,
 			self::getPropertyValue( $this->instance, 'asset_manager' )
 		);
-		static::assertInstanceOf(
+		$this->assertInstanceOf(
 			Indexable_Helper::class,
 			self::getPropertyValue( $this->instance, 'indexable_helper' )
 		);
-		static::assertInstanceOf(
+		$this->assertInstanceOf(
 			Short_Link_Helper::class,
 			self::getPropertyValue( $this->instance, 'short_link_helper' )
 		);
-		static::assertInstanceOf(
+		$this->assertInstanceOf(
 			Indexing_Helper::class,
 			self::getPropertyValue( $this->instance, 'indexing_helper' )
 		);
-		static::assertInstanceOf(
+		$this->assertInstanceOf(
 			WPSEO_Addon_Manager::class,
 			self::getPropertyValue( $this->instance, 'addon_manager' )
 		);
-		static::assertInstanceOf(
+		$this->assertInstanceOf(
 			Product_Helper::class,
 			self::getPropertyValue( $this->instance, 'product_helper' )
 		);
-		static::assertInstanceOf(
+		$this->assertInstanceOf(
 			Importable_Detector_Service::class,
 			self::getPropertyValue( $this->instance, 'importable_detector' )
 		);
-		static::assertInstanceOf(
+		$this->assertInstanceOf(
 			Importing_Route::class,
 			self::getPropertyValue( $this->instance, 'importing_route' )
 		);

--- a/tests/Unit/Integrations/Admin/Installation_Success_Integration_Test.php
+++ b/tests/Unit/Integrations/Admin/Installation_Success_Integration_Test.php
@@ -60,7 +60,7 @@ final class Installation_Success_Integration_Test extends TestCase {
 	 * @covers ::get_conditionals
 	 */
 	public function test_get_conditionals() {
-		static::assertEquals(
+		$this->assertEquals(
 			[
 				Admin_Conditional::class,
 			],
@@ -74,12 +74,12 @@ final class Installation_Success_Integration_Test extends TestCase {
 	 * @covers ::__construct
 	 */
 	public function test_constructor() {
-		static::assertInstanceOf(
+		$this->assertInstanceOf(
 			Options_Helper::class,
 			$this->getPropertyValue( $this->instance, 'options_helper' )
 		);
 
-		static::assertInstanceOf(
+		$this->assertInstanceOf(
 			Product_Helper::class,
 			$this->getPropertyValue( $this->instance, 'product_helper' )
 		);

--- a/tests/Unit/Integrations/Admin/Old_Configuration_Integration_Test.php
+++ b/tests/Unit/Integrations/Admin/Old_Configuration_Integration_Test.php
@@ -39,7 +39,7 @@ final class Old_Configuration_Integration_Test extends TestCase {
 	 * @covers ::get_conditionals
 	 */
 	public function test_get_conditionals() {
-		static::assertEquals(
+		$this->assertEquals(
 			[
 				Admin_Conditional::class,
 			],

--- a/tests/Unit/Integrations/Admin/Redirect_Integration_Test.php
+++ b/tests/Unit/Integrations/Admin/Redirect_Integration_Test.php
@@ -58,7 +58,7 @@ final class Redirect_Integration_Test extends TestCase {
 	 * @covers ::get_conditionals
 	 */
 	public function test_get_conditionals() {
-		static::assertEquals(
+		$this->assertEquals(
 			[
 				Admin_Conditional::class,
 			],

--- a/tests/Unit/Integrations/Admin/Redirects_Page_Integration_Test.php
+++ b/tests/Unit/Integrations/Admin/Redirects_Page_Integration_Test.php
@@ -40,7 +40,7 @@ final class Redirects_Page_Integration_Test extends TestCase {
 	 * @covers ::get_conditionals
 	 */
 	public function test_get_conditionals() {
-		static::assertEquals(
+		$this->assertEquals(
 			[
 				Admin_Conditional::class,
 				Premium_Inactive_Conditional::class,

--- a/tests/Unit/Integrations/Blocks/Structured_Data_Blocks_Test.php
+++ b/tests/Unit/Integrations/Blocks/Structured_Data_Blocks_Test.php
@@ -62,7 +62,7 @@ final class Structured_Data_Blocks_Test extends TestCase {
 	 * @covers ::__construct
 	 */
 	public function test_construct() {
-		static::assertInstanceOf(
+		$this->assertInstanceOf(
 			Structured_Data_Blocks::class,
 			new Structured_Data_Blocks(
 				$this->asset_manager,

--- a/tests/Unit/Integrations/Cleanup_Integration_Test.php
+++ b/tests/Unit/Integrations/Cleanup_Integration_Test.php
@@ -79,7 +79,7 @@ final class Cleanup_Integration_Test extends TestCase {
 	 * @covers ::get_conditionals
 	 */
 	public function test_get_conditionals() {
-		static::assertEquals( [], Cleanup_Integration::get_conditionals() );
+		$this->assertEquals( [], Cleanup_Integration::get_conditionals() );
 	}
 
 	/**

--- a/tests/Unit/Integrations/Estimated_Reading_Time_Test.php
+++ b/tests/Unit/Integrations/Estimated_Reading_Time_Test.php
@@ -50,7 +50,7 @@ final class Estimated_Reading_Time_Test extends TestCase {
 	 * @covers ::get_conditionals
 	 */
 	public function test_get_conditionals() {
-		static::assertEquals(
+		$this->assertEquals(
 			[ Estimated_Reading_Time_Conditional::class ],
 			Estimated_Reading_Time::get_conditionals()
 		);

--- a/tests/Unit/Integrations/Front_End/WP_Robots_Integration_Test.php
+++ b/tests/Unit/Integrations/Front_End/WP_Robots_Integration_Test.php
@@ -49,9 +49,9 @@ final class WP_Robots_Integration_Test extends TestCase {
 	 * @covers ::__construct
 	 */
 	public function test_construct() {
-		static::assertInstanceOf(
+		$this->assertInstanceOf(
 			Meta_Tags_Context_Memoizer::class,
-			static::getPropertyValue( $this->instance, 'context_memoizer' )
+			$this->getPropertyValue( $this->instance, 'context_memoizer' )
 		);
 	}
 
@@ -63,7 +63,7 @@ final class WP_Robots_Integration_Test extends TestCase {
 	public function test_register_hooks() {
 		$this->instance->register_hooks();
 
-		static::assertNotFalse( \has_filter( 'wp_robots', [ $this->instance, 'add_robots' ] ) );
+		$this->assertNotFalse( \has_filter( 'wp_robots', [ $this->instance, 'add_robots' ] ) );
 	}
 
 	/**
@@ -72,7 +72,7 @@ final class WP_Robots_Integration_Test extends TestCase {
 	 * @covers ::get_conditionals
 	 */
 	public function test_get_conditionals() {
-		static::assertEquals(
+		$this->assertEquals(
 			[
 				Front_End_Conditional::class,
 				WP_Robots_Conditional::class,
@@ -102,7 +102,7 @@ final class WP_Robots_Integration_Test extends TestCase {
 			->once()
 			->andReturn( $context );
 
-		static::assertEquals(
+		$this->assertEquals(
 			[
 				'index'  => true,
 				'follow' => true,
@@ -144,7 +144,7 @@ final class WP_Robots_Integration_Test extends TestCase {
 			]
 		);
 
-		static::assertEquals(
+		$this->assertEquals(
 			[
 				'follow'            => true,
 				'index'             => true,
@@ -180,7 +180,7 @@ final class WP_Robots_Integration_Test extends TestCase {
 			->once()
 			->andReturn( $context );
 
-		static::assertEquals(
+		$this->assertEquals(
 			[
 				'follow'            => true,
 				'index'             => true,
@@ -223,7 +223,7 @@ final class WP_Robots_Integration_Test extends TestCase {
 			->once()
 			->andReturn( $context );
 
-		static::assertEquals(
+		$this->assertEquals(
 			[
 				'follow'  => true,
 				'noindex' => true,
@@ -264,7 +264,7 @@ final class WP_Robots_Integration_Test extends TestCase {
 			->once()
 			->andReturn( $context );
 
-		static::assertEquals(
+		$this->assertEquals(
 			[
 				'index'  => true,
 				'follow' => true,
@@ -305,7 +305,7 @@ final class WP_Robots_Integration_Test extends TestCase {
 			->once()
 			->andReturn( $context );
 
-		static::assertEquals(
+		$this->assertEquals(
 			[
 				'index'             => true,
 				'follow'            => true,
@@ -348,7 +348,7 @@ final class WP_Robots_Integration_Test extends TestCase {
 			->once()
 			->andReturn( $context );
 
-		static::assertEquals(
+		$this->assertEquals(
 			[
 				'index'        => true,
 				'nofollow'     => true,

--- a/tests/Unit/Integrations/Front_End_Integration_Test.php
+++ b/tests/Unit/Integrations/Front_End_Integration_Test.php
@@ -603,7 +603,7 @@ final class Front_End_Integration_Test extends TestCase {
 			'Yoast\WP\SEO\Presenters\Robots_Presenter',
 		];
 
-		static::assertEquals( $presenters, $this->instance->filter_robots_presenter( $presenters ) );
+		$this->assertEquals( $presenters, $this->instance->filter_robots_presenter( $presenters ) );
 	}
 
 	/**
@@ -620,7 +620,7 @@ final class Front_End_Integration_Test extends TestCase {
 			'Yoast\WP\SEO\Presenters\Robots_Presenter',
 		];
 
-		static::assertEquals( $presenters, $this->instance->filter_robots_presenter( $presenters ) );
+		$this->assertEquals( $presenters, $this->instance->filter_robots_presenter( $presenters ) );
 	}
 
 	/**
@@ -644,7 +644,7 @@ final class Front_End_Integration_Test extends TestCase {
 			'Yoast\WP\SEO\Presenters\Robots_Presenter',
 		];
 
-		static::assertEquals(
+		$this->assertEquals(
 			[
 				'Yoast\WP\SEO\Presenters\Title_Presenter',
 				'Yoast\WP\SEO\Presenters\Meta_Description_Presenter',
@@ -674,7 +674,7 @@ final class Front_End_Integration_Test extends TestCase {
 			'Yoast\WP\SEO\Presenters\Robots_Presenter',
 		];
 
-		static::assertEquals(
+		$this->assertEquals(
 			[
 				'Yoast\WP\SEO\Presenters\Title_Presenter',
 				'Yoast\WP\SEO\Presenters\Meta_Description_Presenter',

--- a/tests/Unit/Integrations/Settings_Integration_Test.php
+++ b/tests/Unit/Integrations/Settings_Integration_Test.php
@@ -123,7 +123,7 @@ final class Settings_Integration_Test extends TestCase {
 	 * @covers ::get_conditionals
 	 */
 	public function test_get_conditionals() {
-		static::assertEquals(
+		$this->assertEquals(
 			[
 				Settings_Conditional::class,
 			],

--- a/tests/Unit/Integrations/Support_Integration_Test.php
+++ b/tests/Unit/Integrations/Support_Integration_Test.php
@@ -99,7 +99,7 @@ final class Support_Integration_Test extends TestCase {
 	 * @covers ::__construct
 	 */
 	public function test_construct() {
-		static::assertInstanceOf(
+		$this->assertInstanceOf(
 			Support_Integration::class,
 			new Support_Integration(
 				$this->asset_manager,
@@ -116,7 +116,7 @@ final class Support_Integration_Test extends TestCase {
 	 * @covers ::get_conditionals
 	 */
 	public function test_get_conditionals() {
-		static::assertEquals(
+		$this->assertEquals(
 			[
 				Admin_Conditional::class,
 				User_Can_Manage_Wpseo_Options_Conditional::class,

--- a/tests/Unit/Integrations/Third_Party/WooCommerce_Permalinks_Test.php
+++ b/tests/Unit/Integrations/Third_Party/WooCommerce_Permalinks_Test.php
@@ -51,7 +51,7 @@ final class WooCommerce_Permalinks_Test extends TestCase {
 	 * @covers ::get_conditionals
 	 */
 	public function test_get_conditionals() {
-		static::assertEquals(
+		$this->assertEquals(
 			[ WooCommerce_Conditional::class, Migrations_Conditional::class ],
 			Woocommerce_Permalinks::get_conditionals()
 		);
@@ -63,7 +63,7 @@ final class WooCommerce_Permalinks_Test extends TestCase {
 	 * @covers ::__construct
 	 */
 	public function test_constructor() {
-		static::assertInstanceOf(
+		$this->assertInstanceOf(
 			Indexable_Helper::class,
 			$this->getPropertyValue( $this->instance, 'indexable_helper' )
 		);
@@ -77,8 +77,8 @@ final class WooCommerce_Permalinks_Test extends TestCase {
 	public function test_register_hooks() {
 		$this->instance->register_hooks();
 
-		static::assertNotFalse( Monkey\Filters\has( 'wpseo_post_types_reset_permalinks', [ $this->instance, 'filter_product_from_post_types' ] ) );
-		static::assertNotFalse( Monkey\Actions\has( 'update_option_woocommerce_permalinks', [ $this->instance, 'reset_woocommerce_permalinks' ] ) );
+		$this->assertNotFalse( Monkey\Filters\has( 'wpseo_post_types_reset_permalinks', [ $this->instance, 'filter_product_from_post_types' ] ) );
+		$this->assertNotFalse( Monkey\Actions\has( 'update_option_woocommerce_permalinks', [ $this->instance, 'reset_woocommerce_permalinks' ] ) );
 	}
 
 	/**

--- a/tests/Unit/User_Profiles_Additions/User_Interface/User_Profiles_Additions_Ui_Test.php
+++ b/tests/Unit/User_Profiles_Additions/User_Interface/User_Profiles_Additions_Ui_Test.php
@@ -74,7 +74,7 @@ final class User_Profiles_Additions_Ui_Test extends TestCase {
 	 * @covers ::get_conditionals
 	 */
 	public function test_get_conditionals() {
-		static::assertEquals(
+		$this->assertEquals(
 			[ User_Profile_Conditional::class ],
 			User_Profiles_Additions_Ui::get_conditionals()
 		);


### PR DESCRIPTION


## Context

* Code QA/consistency

## Summary

This PR can be summarized in the following changelog entry:

* Code QA/consistency

## Relevant technical choices:

* Everywhere else, `$this->assert*()` is used, so let's use that here too.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_ No functional changes.