### PR TITLE
Tests: fix incorrect file and class name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -92,7 +92,7 @@
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_coding_standards"
 		],
 		"check-cs-thresholds": [
-			"@putenv YOASTCS_THRESHOLD_ERRORS=2559",
+			"@putenv YOASTCS_THRESHOLD_ERRORS=2555",
 			"@putenv YOASTCS_THRESHOLD_WARNINGS=267",
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_cs_thresholds"
 		],

--- a/composer.json
+++ b/composer.json
@@ -91,7 +91,7 @@
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_coding_standards"
 		],
 		"check-cs-thresholds": [
-			"@putenv YOASTCS_THRESHOLD_ERRORS=2561",
+			"@putenv YOASTCS_THRESHOLD_ERRORS=2560",
 			"@putenv YOASTCS_THRESHOLD_WARNINGS=267",
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_cs_thresholds"
 		],

--- a/tests/Unit/Inc/Sitemaps/Sitemaps_Router_Test.php
+++ b/tests/Unit/Inc/Sitemaps/Sitemaps_Router_Test.php
@@ -68,8 +68,6 @@ final class Sitemaps_Router_Test extends TestCase {
 			->once()
 			->andReturn( (object) [ 'classes' => $this->create_classes_surface( $this->container ) ] );
 
-		$_SERVER = [];
-
 		$this->instance = new WPSEO_Sitemaps_Router();
 	}
 
@@ -168,7 +166,7 @@ final class Sitemaps_Router_Test extends TestCase {
 	/**
 	 * Data provider for test_redirect_canonical.
 	 *
-	 * @return array
+	 * @return array<array<bool>>
 	 */
 	public static function redirect_canonical_data_provider() {
 		return [
@@ -258,7 +256,7 @@ final class Sitemaps_Router_Test extends TestCase {
 	/**
 	 * Data provider for test_needs_sitemap_index_redirect.
 	 *
-	 * @return array
+	 * @return array<array<bool|string>>
 	 */
 	public static function needs_sitemap_index_redirect_data_provider() {
 		return [
@@ -343,7 +341,7 @@ final class Sitemaps_Router_Test extends TestCase {
 	/**
 	 * Data provider for test_get_base_url.
 	 *
-	 * @return array
+	 * @return array<array<bool|string>>
 	 */
 	public static function get_base_url_data_provider() {
 		return [
@@ -377,7 +375,7 @@ final class Sitemaps_Router_Test extends TestCase {
 
 		Functions\expect( 'home_url' )
 			->with( '/sitemap.xml' )
-			->once()
+			->times( 2 )
 			->andReturn( 'http://example.com/sitemap.xml' );
 
 		$this->redirect_helper = Mockery::mock( Redirect_Helper::class );

--- a/tests/Unit/Inc/Sitemaps/Sitemaps_Router_Test.php
+++ b/tests/Unit/Inc/Sitemaps/Sitemaps_Router_Test.php
@@ -16,7 +16,7 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  *
  * @coversDefaultClass WPSEO_Sitemaps_Router
  */
-final class WPSEO_Sitemaps_Router_Test extends TestCase {
+final class Sitemaps_Router_Test extends TestCase {
 
 	/**
 	 * Mock of the deactivating Yoast SEO conditional.
@@ -57,10 +57,10 @@ final class WPSEO_Sitemaps_Router_Test extends TestCase {
 		$this->deactivating_yoast_conditional = Mockery::mock( Deactivating_Yoast_Seo_Conditional::class );
 		$this->container                      = $this->create_container_with(
 			[
-				Deactivating_Yoast_Seo_Conditional::class => $this->deacrivating_yoast_conditional,
+				Deactivating_Yoast_Seo_Conditional::class => $this->deactivating_yoast_conditional,
 			]
 		);
-		$this->deacrivating_yoast_conditional->expects( 'is_met' )
+		$this->deactivating_yoast_conditional->expects( 'is_met' )
 			->once()
 			->andReturnFalse();
 


### PR DESCRIPTION
## Context

* Code QA/consistency

## Summary

This PR can be summarized in the following changelog entry:

* Code QA/consistency

## Relevant technical choices:

The test class wasn't running due to the incorrect file name (missing `Test`). Now the tests are being run, the tests were failing.

The first issue is fixed via fixing a typo in a property reference (x2).

However, there is a second issue:
```
1) Yoast\WP\SEO\Tests\Unit\Inc\Sitemaps\Sitemaps_Router_Test::test_template_redirect_exit
Mockery\Exception\InvalidCountException: Method home_url(<Any Arguments>) from Mockery_1 should be called
 exactly 1 times but called 2 times.

path/to/wordpress-seo/vendor/mockery/mockery/library/Mockery/CountValidator\Exact.php:38
path/to/wordpress-seo/vendor/mockery/mockery/library/Mockery/Expectation.php:310
path/to/wordpress-seo/vendor/mockery/mockery/library/Mockery/ExpectationDirector.php:119
path/to/wordpress-seo/vendor/mockery/mockery/library/Mockery/Container.php:301
path/to/wordpress-seo/vendor/mockery/mockery/library/Mockery/Container.php:286
path/to/wordpress-seo/vendor/mockery/mockery/library/Mockery/mockery/library/Mockery.php:210
path/to/wordpress-seo/vendor/mockery/mockery/library/Mockery/Adapter\Phpunit\MockeryPHPUnitIntegration.php:74
path/to/wordpress-seo/vendor/mockery/mockery/library/Mockery/Adapter\Phpunit\MockeryPHPUnitIntegration.php:49
path/to/wordpress-seo/vendor/mockery/mockery/library/Mockery/Adapter\Phpunit\MockeryPHPUnitIntegrationAssertPostConditionsForV8.php:29
C:\bin\phars\phpunit-9.6.15.phar:2326
```

Obviously, I can adjust the expectation, but I believe it should be checked that updating the expectation is actually the right course of action.

@vraja-pro Could you please have a look at this ?

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_ No functional changes.