### PR TITLE
Modernize: use nullable types

### DIFF
--- a/admin/class-admin-asset-manager.php
+++ b/admin/class-admin-asset-manager.php
@@ -40,7 +40,7 @@ class WPSEO_Admin_Asset_Manager {
 	 * @param WPSEO_Admin_Asset_Location|null $asset_location The provider of the asset location.
 	 * @param string                          $prefix         The prefix for naming assets.
 	 */
-	public function __construct( WPSEO_Admin_Asset_Location $asset_location = null, $prefix = self::PREFIX ) {
+	public function __construct( ?WPSEO_Admin_Asset_Location $asset_location = null, $prefix = self::PREFIX ) {
 		if ( $asset_location === null ) {
 			$asset_location = self::create_default_location();
 		}

--- a/admin/class-database-proxy.php
+++ b/admin/class-database-proxy.php
@@ -120,7 +120,7 @@ class WPSEO_Database_Proxy {
 	 *
 	 * @return false|int False when the upsert request is invalid, int on number of rows changed.
 	 */
-	public function upsert( array $data, array $where = null, $format = null, $where_format = null ) {
+	public function upsert( array $data, ?array $where = null, $format = null, $where_format = null ) {
 		if ( $where_format !== null ) {
 			_deprecated_argument( __METHOD__, '7.7.0', 'The where_format argument is deprecated' );
 		}

--- a/admin/class-yoast-dashboard-widget.php
+++ b/admin/class-yoast-dashboard-widget.php
@@ -36,7 +36,7 @@ class Yoast_Dashboard_Widget implements WPSEO_WordPress_Integration {
 	 *
 	 * @param WPSEO_Statistics|null $statistics WPSEO_Statistics instance.
 	 */
-	public function __construct( WPSEO_Statistics $statistics = null ) {
+	public function __construct( ?WPSEO_Statistics $statistics = null ) {
 		if ( $statistics === null ) {
 			$statistics = new WPSEO_Statistics();
 		}

--- a/inc/class-wpseo-admin-bar-menu.php
+++ b/inc/class-wpseo-admin-bar-menu.php
@@ -119,11 +119,11 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 	 * @param WPSEO_Shortlinker|null         $shortlinker          The shortlinker.
 	 */
 	public function __construct(
-		WPSEO_Admin_Asset_Manager $asset_manager = null,
-		Indexable_Repository $indexable_repository = null,
-		Score_Icon_Helper $score_icon_helper = null,
-		Product_Helper $product_helper = null,
-		WPSEO_Shortlinker $shortlinker = null
+		?WPSEO_Admin_Asset_Manager $asset_manager = null,
+		?Indexable_Repository $indexable_repository = null,
+		?Score_Icon_Helper $score_icon_helper = null,
+		?Product_Helper $product_helper = null,
+		?WPSEO_Shortlinker $shortlinker = null
 	) {
 		if ( ! $asset_manager ) {
 			$asset_manager = new WPSEO_Admin_Asset_Manager();

--- a/src/integrations/third-party/wordproof.php
+++ b/src/integrations/third-party/wordproof.php
@@ -49,7 +49,7 @@ class Wordproof implements Integration_Interface {
 	 * @param Wordproof_Helper          $wordproof     The WordProof helper instance.
 	 * @param WPSEO_Admin_Asset_Manager $asset_manager The WPSEO admin asset manager instance.
 	 */
-	public function __construct( Wordproof_Helper $wordproof, WPSEO_Admin_Asset_Manager $asset_manager = null ) {
+	public function __construct( Wordproof_Helper $wordproof, ?WPSEO_Admin_Asset_Manager $asset_manager = null ) {
 		if ( ! $asset_manager ) {
 			$asset_manager = new WPSEO_Admin_Asset_Manager();
 		}


### PR DESCRIPTION
## Context

* Code QA/consistency

## Summary

This PR can be summarized in the following changelog entry:

* Code QA/consistency

## Relevant technical choices:

* Use nullable types when the default value of a typed parameter is `null`.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_ No functional changes.