### PR TITLE
Docs: various fixes

### DIFF
--- a/admin/watchers/class-slug-change-watcher.php
+++ b/admin/watchers/class-slug-change-watcher.php
@@ -211,7 +211,7 @@ class WPSEO_Slug_Change_Watcher implements WPSEO_WordPress_Integration {
 	/**
 	 * Returns the message around changed URLs.
 	 *
-	 * @param string $first_sentence The first sentence of the notification.
+	 * @param string $first_sentence  The first sentence of the notification.
 	 * @param string $second_sentence The second sentence of the notification.
 	 *
 	 * @return string The full notification.

--- a/config/composer/unit-test-generator.php
+++ b/config/composer/unit-test-generator.php
@@ -15,14 +15,14 @@ class Unit_Test_Generator {
 	/**
 	 * Path to the unit test folder.
 	 *
-	 * @private
+	 * @access private
 	 */
 	public const UNIT_TESTS_FOLDER = 'tests/unit';
 
 	/**
 	 * Path to the unit test folder in Premium.
 	 *
-	 * @private
+	 * @access private
 	 */
 	public const UNIT_TESTS_FOLDER_PREMIUM = 'tests/unit/premium';
 

--- a/inc/options/class-wpseo-option.php
+++ b/inc/options/class-wpseo-option.php
@@ -867,7 +867,7 @@ abstract class WPSEO_Option {
 	/**
 	 * Check whether a given array key conforms to one of the variable array key patterns for this option.
 	 *
-	 * @usedby validate_option() methods for options with variable array keys.
+	 * @used-by validate_option() methods for options with variable array keys.
 	 *
 	 * @param string $key Array key to check.
 	 *

--- a/src/content-type-visibility/application/content-type-visibility-watcher-actions.php
+++ b/src/content-type-visibility/application/content-type-visibility-watcher-actions.php
@@ -38,8 +38,8 @@ class Content_Type_Visibility_Watcher_Actions implements Integration_Interface {
 	/**
 	 * Indexable_Post_Type_Change_Watcher constructor.
 	 *
-	 * @param Options_Helper                                $options             The options helper.
-	 * @param Yoast_Notification_Center                     $notification_center The notification center.
+	 * @param Options_Helper                                $options                            The options helper.
+	 * @param Yoast_Notification_Center                     $notification_center                The notification center.
 	 * @param Content_Type_Visibility_Dismiss_Notifications $content_type_dismiss_notifications The content type dismiss notifications.
 	 */
 	public function __construct(

--- a/src/integrations/blocks/structured-data-blocks.php
+++ b/src/integrations/blocks/structured-data-blocks.php
@@ -178,8 +178,8 @@ class Structured_Data_Blocks implements Integration_Interface {
 	 * For example (in en-US): If 'days' is 1, it returns "1 day". If 'days' is 2, it returns "2 days".
 	 * If a number value is 0, we don't output the string.
 	 *
-	 * @param number $days Number of days.
-	 * @param number $hours Number of hours.
+	 * @param number $days    Number of days.
+	 * @param number $hours   Number of hours.
 	 * @param number $minutes Number of minutes.
 	 * @return array Array of pluralized durations.
 	 */

--- a/src/integrations/settings-integration.php
+++ b/src/integrations/settings-integration.php
@@ -191,18 +191,18 @@ class Settings_Integration implements Integration_Interface {
 	/**
 	 * Constructs Settings_Integration.
 	 *
-	 * @param WPSEO_Admin_Asset_Manager                     $asset_manager       The WPSEO_Admin_Asset_Manager.
-	 * @param WPSEO_Replace_Vars                            $replace_vars        The WPSEO_Replace_Vars.
-	 * @param Schema_Types                                  $schema_types        The Schema_Types.
-	 * @param Current_Page_Helper                           $current_page_helper The Current_Page_Helper.
-	 * @param Post_Type_Helper                              $post_type_helper    The Post_Type_Helper.
-	 * @param Language_Helper                               $language_helper     The Language_Helper.
-	 * @param Taxonomy_Helper                               $taxonomy_helper     The Taxonomy_Helper.
-	 * @param Product_Helper                                $product_helper      The Product_Helper.
-	 * @param Woocommerce_Helper                            $woocommerce_helper  The Woocommerce_Helper.
-	 * @param Article_Helper                                $article_helper      The Article_Helper.
-	 * @param User_Helper                                   $user_helper         The User_Helper.
-	 * @param Options_Helper                                $options             The options helper.
+	 * @param WPSEO_Admin_Asset_Manager                     $asset_manager           The WPSEO_Admin_Asset_Manager.
+	 * @param WPSEO_Replace_Vars                            $replace_vars            The WPSEO_Replace_Vars.
+	 * @param Schema_Types                                  $schema_types            The Schema_Types.
+	 * @param Current_Page_Helper                           $current_page_helper     The Current_Page_Helper.
+	 * @param Post_Type_Helper                              $post_type_helper        The Post_Type_Helper.
+	 * @param Language_Helper                               $language_helper         The Language_Helper.
+	 * @param Taxonomy_Helper                               $taxonomy_helper         The Taxonomy_Helper.
+	 * @param Product_Helper                                $product_helper          The Product_Helper.
+	 * @param Woocommerce_Helper                            $woocommerce_helper      The Woocommerce_Helper.
+	 * @param Article_Helper                                $article_helper          The Article_Helper.
+	 * @param User_Helper                                   $user_helper             The User_Helper.
+	 * @param Options_Helper                                $options                 The options helper.
 	 * @param Content_Type_Visibility_Dismiss_Notifications $content_type_visibility The Content_Type_Visibility_Dismiss_Notifications instance.
 	 */
 	public function __construct(

--- a/src/integrations/third-party/elementor.php
+++ b/src/integrations/third-party/elementor.php
@@ -120,9 +120,9 @@ class Elementor implements Integration_Interface {
 	/**
 	 * Constructor.
 	 *
-	 * @param WPSEO_Admin_Asset_Manager $asset_manager The asset manager.
-	 * @param Options_Helper            $options       The options helper.
-	 * @param Capability_Helper         $capability    The capability helper.
+	 * @param WPSEO_Admin_Asset_Manager $asset_manager     The asset manager.
+	 * @param Options_Helper            $options           The options helper.
+	 * @param Capability_Helper         $capability        The capability helper.
 	 * @param Promotion_Manager         $promotion_manager The promotion manager.
 	 */
 	public function __construct(

--- a/src/integrations/watchers/search-engines-discouraged-watcher.php
+++ b/src/integrations/watchers/search-engines-discouraged-watcher.php
@@ -14,8 +14,6 @@ use Yoast_Notification_Center;
 
 /**
  * Shows a notification for users who have access for robots disabled.
- *
- * @class Search_Engines_Discouraged_Watcher
  */
 class Search_Engines_Discouraged_Watcher implements Integration_Interface {
 

--- a/src/integrations/watchers/woocommerce-beta-editor-watcher.php
+++ b/src/integrations/watchers/woocommerce-beta-editor-watcher.php
@@ -13,8 +13,6 @@ use Yoast_Notification_Center;
 
 /**
  * Shows a notification for users who have Woocommerce product beta editor enabled.
- *
- * @class Woocommerce_Beta_Editor_Watcher
  */
 class Woocommerce_Beta_Editor_Watcher implements Integration_Interface {
 

--- a/src/integrations/watchers/woocommerce-beta-editor-watcher.php
+++ b/src/integrations/watchers/woocommerce-beta-editor-watcher.php
@@ -56,7 +56,7 @@ class Woocommerce_Beta_Editor_Watcher implements Integration_Interface {
 	 *
 	 * @param Yoast_Notification_Center $notification_center The notification center.
 	 * @param Notification_Helper       $notification_helper The notification helper.
-	 * @param Short_Link_Helper         $short_link_helper The short link helper.
+	 * @param Short_Link_Helper         $short_link_helper   The short link helper.
 	 */
 	public function __construct(
 		Yoast_Notification_Center $notification_center,

--- a/src/introductions/domain/invalid-user-id-exception.php
+++ b/src/introductions/domain/invalid-user-id-exception.php
@@ -17,7 +17,7 @@ class Invalid_User_Id_Exception extends InvalidArgumentException {
 	 *
 	 * @param string         $message  [optional] The Exception message to throw.
 	 * @param int            $code     [optional] The Exception code.
-	 * @param null|Throwable $previous [optional] The previous throwable used for the exception chaining.
+	 * @param Throwable|null $previous [optional] The previous throwable used for the exception chaining.
 	 */
 	public function __construct( // phpcs:ignore Generic.CodeAnalysis.UselessOverridingMethod.Found -- Reason: A default message is used.
 		$message = 'Invalid User ID',

--- a/src/promotions/domain/time-interval.php
+++ b/src/promotions/domain/time-interval.php
@@ -29,7 +29,7 @@ class Time_Interval {
 	 * @codeCoverageIgnore
 	 *
 	 * @param int $time_start Interval start time.
-	 * @param int $time_end  Interval end time.
+	 * @param int $time_end   Interval end time.
 	 */
 	public function __construct( int $time_start, int $time_end ) {
 		$this->time_start = $time_start;

--- a/src/repositories/indexable-cleanup-repository.php
+++ b/src/repositories/indexable-cleanup-repository.php
@@ -498,7 +498,7 @@ class Indexable_Cleanup_Repository {
 	/**
 	 * Deletes rows from the indexable table where the source is no longer there.
 	 *
-	 * @param int $limit             The limit we'll apply to the delete query.
+	 * @param int $limit The limit we'll apply to the delete query.
 	 *
 	 * @return int|bool The number of rows that was deleted or false if the query failed.
 	 */

--- a/tests/Unit/Actions/Importing/Abstract_Aioseo_Settings_Importing_Action_Test.php
+++ b/tests/Unit/Actions/Importing/Abstract_Aioseo_Settings_Importing_Action_Test.php
@@ -21,6 +21,7 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  * @group importing
  *
  * @coversDefaultClass \Yoast\WP\SEO\Actions\Importing\Aioseo\Abstract_Aioseo_Settings_Importing_Action
+ *
  * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded, Yoast.Yoast.AlternativeFunctions.json_encode_json_encode
  */
 final class Abstract_Aioseo_Settings_Importing_Action_Test extends TestCase {

--- a/tests/Unit/Actions/Importing/Aioseo_Custom_Archive_Settings_Importing_Action_Test.php
+++ b/tests/Unit/Actions/Importing/Aioseo_Custom_Archive_Settings_Importing_Action_Test.php
@@ -23,6 +23,7 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  * @group importing
  *
  * @coversDefaultClass \Yoast\WP\SEO\Actions\Importing\Aioseo\Aioseo_Custom_Archive_Settings_Importing_Action
+ *
  * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded, Yoast.Yoast.AlternativeFunctions.json_encode_json_encode
  */
 final class Aioseo_Custom_Archive_Settings_Importing_Action_Test extends TestCase {

--- a/tests/Unit/Actions/Importing/Aioseo_Default_Archive_Settings_Importing_Action_Test.php
+++ b/tests/Unit/Actions/Importing/Aioseo_Default_Archive_Settings_Importing_Action_Test.php
@@ -22,6 +22,7 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  * @group importing
  *
  * @coversDefaultClass \Yoast\WP\SEO\Actions\Importing\Aioseo\Aioseo_Default_Archive_Settings_Importing_Action
+ *
  * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded, Yoast.Yoast.AlternativeFunctions.json_encode_json_encode
  */
 final class Aioseo_Default_Archive_Settings_Importing_Action_Test extends TestCase {

--- a/tests/Unit/Actions/Importing/Aioseo_General_Settings_Importing_Action_Test.php
+++ b/tests/Unit/Actions/Importing/Aioseo_General_Settings_Importing_Action_Test.php
@@ -23,6 +23,7 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  * @group importing
  *
  * @coversDefaultClass \Yoast\WP\SEO\Actions\Importing\Aioseo\Aioseo_General_Settings_Importing_Action
+ *
  * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded, Yoast.Yoast.AlternativeFunctions.json_encode_json_encode
  */
 final class Aioseo_General_Settings_Importing_Action_Test extends TestCase {

--- a/tests/Unit/Actions/Importing/Aioseo_Posts_Importing_Action_Test.php
+++ b/tests/Unit/Actions/Importing/Aioseo_Posts_Importing_Action_Test.php
@@ -30,6 +30,7 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  * @group importing
  *
  * @coversDefaultClass \Yoast\WP\SEO\Actions\Importing\Aioseo\Aioseo_Posts_Importing_Action
+ *
  * @phpcs:disable Yoast.Yoast.AlternativeFunctions.json_encode_json_encode
  */
 final class Aioseo_Posts_Importing_Action_Test extends TestCase {

--- a/tests/Unit/Actions/Importing/Aioseo_Posttype_Defaults_Settings_Importing_Action_Test.php
+++ b/tests/Unit/Actions/Importing/Aioseo_Posttype_Defaults_Settings_Importing_Action_Test.php
@@ -22,6 +22,7 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  * @group importing
  *
  * @coversDefaultClass \Yoast\WP\SEO\Actions\Importing\Aioseo\Aioseo_Posttype_Defaults_Settings_Importing_Action
+ *
  * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded, Yoast.Yoast.AlternativeFunctions.json_encode_json_encode
  */
 final class Aioseo_Posttype_Defaults_Settings_Importing_Action_Test extends TestCase {

--- a/tests/Unit/Actions/Importing/Aioseo_Taxonomy_Settings_Importing_Action_Test.php
+++ b/tests/Unit/Actions/Importing/Aioseo_Taxonomy_Settings_Importing_Action_Test.php
@@ -22,6 +22,7 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  * @group importing
  *
  * @coversDefaultClass \Yoast\WP\SEO\Actions\Importing\Aioseo\Aioseo_Taxonomy_Settings_Importing_Action
+ *
  * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded, Yoast.Yoast.AlternativeFunctions.json_encode_json_encode
  */
 final class Aioseo_Taxonomy_Settings_Importing_Action_Test extends TestCase {

--- a/tests/Unit/Actions/Importing/Aioseo_Validate_Data_Action_Test.php
+++ b/tests/Unit/Actions/Importing/Aioseo_Validate_Data_Action_Test.php
@@ -23,6 +23,7 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  * @group importing
  *
  * @coversDefaultClass \Yoast\WP\SEO\Actions\Importing\Aioseo\Aioseo_Validate_Data_Action
+ *
  * @phpcs:disable Yoast.Yoast.AlternativeFunctions.json_encode_json_encode
  */
 final class Aioseo_Validate_Data_Action_Test extends TestCase {

--- a/tests/Unit/Builders/Indexable_Link_Builder/Build_Test.php
+++ b/tests/Unit/Builders/Indexable_Link_Builder/Build_Test.php
@@ -98,12 +98,12 @@ final class Build_Test extends Abstract_Indexable_Link_Builder_TestCase {
 	 *
 	 * @dataProvider build_provider
 	 *
-	 * @param string $content   The content.
-	 * @param string $link_type The link type.
-	 * @param bool   $is_image  Whether the link is an image.
+	 * @param string $content              The content.
+	 * @param string $link_type            The link type.
+	 * @param bool   $is_image             Whether the link is an image.
 	 * @param bool   $ignore_content_scan  Whether content scanning should be ignored.
-	 * @param bool   $should_content_regex  Whether the image id should be extracted with a regex.
-	 * @param bool   $should_doc_scan  Whether the doc document should be used.
+	 * @param bool   $should_content_regex Whether the image id should be extracted with a regex.
+	 * @param bool   $should_doc_scan      Whether the doc document should be used.
 	 */
 	public function test_build( $content, $link_type, $is_image, $ignore_content_scan, $should_content_regex, $should_doc_scan ) {
 		$indexable              = Mockery::mock( Indexable_Mock::class );

--- a/tests/Unit/Content_Type_Visibility/Application/Content_Type_Visibility_Dismiss_Notifications_Test.php
+++ b/tests/Unit/Content_Type_Visibility/Application/Content_Type_Visibility_Dismiss_Notifications_Test.php
@@ -121,12 +121,12 @@ final class Content_Type_Visibility_Dismiss_Notifications_Test extends TestCase 
 	 *
 	 * @dataProvider data_provider_maybe_dismiss_notifications
 	 *
-	 * @param array $new_post_types The new post types.
-	 * @param array $new_taxonomies The new taxonomies.
+	 * @param array $new_post_types              The new post types.
+	 * @param array $new_taxonomies              The new taxonomies.
 	 * @param int   $dismiss_notifications_times The number of times the dismiss_notifications method should be called.
-	 * @param array $new_content_type The new content type.
-	 * @param int   $get_new_post_types_times The number of times the get method should be called.
-	 * @param int   $get_new_taxonomies_times The number of times the get method should be called.
+	 * @param array $new_content_type            The new content type.
+	 * @param int   $get_new_post_types_times    The number of times the get method should be called.
+	 * @param int   $get_new_taxonomies_times    The number of times the get method should be called.
 	 * @return void
 	 */
 	public function test_maybe_dismiss_notifications( $new_post_types, $new_taxonomies, $dismiss_notifications_times, $new_content_type, $get_new_post_types_times, $get_new_taxonomies_times ) {

--- a/tests/Unit/Helpers/Aioseo_Helper_Test.php
+++ b/tests/Unit/Helpers/Aioseo_Helper_Test.php
@@ -15,6 +15,7 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  * @group helpers
  *
  * @coversDefaultClass \Yoast\WP\SEO\Helpers\Aioseo_Helper
+ *
  * @phpcs:disable Yoast.Yoast.AlternativeFunctions.json_encode_json_encode
  */
 final class Aioseo_Helper_Test extends TestCase {

--- a/tests/Unit/Helpers/Pagination_Helper_Test.php
+++ b/tests/Unit/Helpers/Pagination_Helper_Test.php
@@ -146,11 +146,11 @@ final class Pagination_Helper_Test extends TestCase {
 	 *
 	 * @dataProvider data_provider_get_paginated_url_use_permalinks
 	 *
-	 * @param string $url The url to use.
-	 * @param array  $parsed_url The parsed url.
-	 * @param int    $page The page number.
+	 * @param string $url             The url to use.
+	 * @param array  $parsed_url      The parsed url.
+	 * @param int    $page            The page number.
 	 * @param bool   $pagination_base Whether to add the pagination base.
-	 * @param string $expected The expected url.
+	 * @param string $expected        The expected url.
 	 */
 	public function test_get_paginated_url_using_permalink( $url, $parsed_url, $page, $pagination_base, $expected ) {
 		$this->using_permalinks( true );
@@ -198,12 +198,12 @@ final class Pagination_Helper_Test extends TestCase {
 	 *
 	 * @dataProvider data_provider_get_paginated_url_not_using_permalinks
 	 *
-	 * @param string $url The url to use.
-	 * @param int    $page The page number.
-	 * @param string $key The key to use.
+	 * @param string $url                 The url to use.
+	 * @param int    $page                The page number.
+	 * @param string $key                 The key to use.
 	 * @param bool   $add_pagination_base Whether to add the pagination base.
-	 * @param array  $get The get array.
-	 * @param string $expected The expected url.
+	 * @param array  $get                 The get array.
+	 * @param string $expected            The expected url.
 	 */
 	public function test_get_paginated_url_not_using_permalinks( $url, $page, $key, $add_pagination_base, $get, $expected ) {
 		$this->using_permalinks( false );
@@ -244,7 +244,7 @@ final class Pagination_Helper_Test extends TestCase {
 	 * @dataProvider data_provider_get_paginated_url_with_query_loop_param
 	 *
 	 * @param bool   $using_permalinks Whether to use permalinks.
-	 * @param string $expected The expected url.
+	 * @param string $expected         The expected url.
 	 */
 	public function test_get_paginated_url_with_query_loop_param( $using_permalinks, $expected ) {
 		$this->using_permalinks( $using_permalinks );
@@ -313,8 +313,8 @@ final class Pagination_Helper_Test extends TestCase {
 	 * @dataProvider data_provider_get_current_archive_page_number
 	 *
 	 * @param string $query_var_paged The query var paged.
-	 * @param array  $get The get array.
-	 * @param int    $expected The expected page number.
+	 * @param array  $get             The get array.
+	 * @param int    $expected        The expected page number.
 	 */
 	public function test_get_current_archive_page_number( $query_var_paged, $get, $expected ) {
 		$wp_query = Mockery::mock( WP_Query::class );
@@ -365,10 +365,10 @@ final class Pagination_Helper_Test extends TestCase {
 	 *
 	 * @dataProvider data_provider_get_current_post_page_number
 	 *
-	 * @param string $query_var_paged The query var paged.
-	 * @param array  $get The get array.
+	 * @param string $query_var_paged    The query var paged.
+	 * @param array  $get                The get array.
 	 * @param int    $wp_query_get_times The number of times to call get on the wp_query get method.
-	 * @param int    $expected The expected page number.
+	 * @param int    $expected           The expected page number.
 	 */
 	public function test_get_current_post_page_number( $query_var_paged, $get, $wp_query_get_times, $expected ) {
 		$wp_query = Mockery::mock( WP_Query::class );
@@ -421,8 +421,8 @@ final class Pagination_Helper_Test extends TestCase {
 	 * @dataProvider data_provider_get_current_page_number
 	 *
 	 * @param string $query_var_paged The query var paged.
-	 * @param array  $get The get array.
-	 * @param int    $expected The expected page number.
+	 * @param array  $get             The get array.
+	 * @param int    $expected        The expected page number.
 	 */
 	public function test_get_current_page_number( $query_var_paged, $get, $expected ) {
 		Monkey\Functions\expect( 'get_query_var' )
@@ -520,8 +520,8 @@ final class Pagination_Helper_Test extends TestCase {
 	 *
 	 * @covers ::get_key_query_loop
 	 *
-	 * @param string $key   The key to set in the $_GET array.
-	 * @param string $value The value to set in the $_GET array.
+	 * @param string $key     The key to set in the $_GET array.
+	 * @param string $value   The value to set in the $_GET array.
 	 * @param string $expects The expected key query loop.
 	 */
 	public function test_get_key_query_loop( $key, $value, $expects ) {
@@ -582,8 +582,8 @@ final class Pagination_Helper_Test extends TestCase {
 	 *
 	 * @covers ::get_page_number_from_query_loop
 	 *
-	 * @param string $key   The key to set in the $_GET array.
-	 * @param string $value The value to set in the $_GET array.
+	 * @param string $key     The key to set in the $_GET array.
+	 * @param string $value   The value to set in the $_GET array.
 	 * @param string $expects The expected page number.
 	 */
 	public function test_get_page_number_from_query_loop( $key, $value, $expects ) {

--- a/tests/Unit/Inc/Sitemaps/WPSEO_Sitemaps_Router.php
+++ b/tests/Unit/Inc/Sitemaps/WPSEO_Sitemaps_Router.php
@@ -140,8 +140,8 @@ final class WPSEO_Sitemaps_Router_Test extends TestCase {
 	 *
 	 * @param bool $is_sitemap           Whether the sitemap query var is set.
 	 * @param bool $is_yoast_sitemap_xsl Whether the yoast-sitemap-xsl query var is set.
-	 * @param bool $redirect            Whether to redirect.
-	 * @param bool $expected            Whether to redirect.
+	 * @param bool $redirect             Whether to redirect.
+	 * @param bool $expected             Whether to redirect.
 	 */
 	public function test_redirect_canonical( $is_sitemap, $is_yoast_sitemap_xsl, $redirect, $expected ) {
 		Functions\expect( 'get_query_var' )
@@ -217,13 +217,13 @@ final class WPSEO_Sitemaps_Router_Test extends TestCase {
 	 *
 	 * @dataProvider needs_sitemap_index_redirect_data_provider
 	 *
-	 * @param bool   $https        Whether the request is over HTTPS.
-	 * @param string $server_name  The server name.
-	 * @param string $request_uri  The request URI.
-	 * @param bool   $is_404       Whether the request is a 404.
-	 * @param string $http_host    The HTTP host.
-	 * @param string $home_url     The home URL.
-	 * @param bool   $expected     Whether to redirect.
+	 * @param bool   $https       Whether the request is over HTTPS.
+	 * @param string $server_name The server name.
+	 * @param string $request_uri The request URI.
+	 * @param bool   $is_404      Whether the request is a 404.
+	 * @param string $http_host   The HTTP host.
+	 * @param string $home_url    The home URL.
+	 * @param bool   $expected    Whether to redirect.
 	 */
 	public function test_needs_sitemap_index_redirect( $https, $server_name, $request_uri, $is_404, $http_host, $home_url, $expected ) {
 		$_SERVER['HTTPS']       = $https;

--- a/tests/Unit/Inc/Yoast_Dynamic_Rewrites_Test.php
+++ b/tests/Unit/Inc/Yoast_Dynamic_Rewrites_Test.php
@@ -131,7 +131,7 @@ final class Yoast_Dynamic_Rewrites_Test extends TestCase {
 	 * @dataProvider data_provider_sanitize_rewrite_rules_option
 	 *
 	 * @param string|array $rewrite_rules Rewrite rules.
-	 * @param string       $expected Expected result.
+	 * @param string       $expected      Expected result.
 	 */
 	public function test_sanitize_rewrite_rules_option( $rewrite_rules, $expected ) {
 
@@ -164,7 +164,7 @@ final class Yoast_Dynamic_Rewrites_Test extends TestCase {
 	 * @dataProvider data_provider_filter_rewrite_rules_option
 	 *
 	 * @param string|array $rewrite_rules Rewrite rules.
-	 * @param string       $expected Expected result.
+	 * @param string       $expected      Expected result.
 	 */
 	public function test_filter_rewrite_rules_option( $rewrite_rules, $expected ) {
 

--- a/tests/Unit/Integrations/Blocks/Structured_Data_Blocks_Test.php
+++ b/tests/Unit/Integrations/Blocks/Structured_Data_Blocks_Test.php
@@ -152,10 +152,10 @@ final class Structured_Data_Blocks_Test extends TestCase {
 	 * @covers       ::present_duration_text
 	 * @dataProvider how_to_block_provider
 	 *
-	 * @param string $expected The expected content.
+	 * @param string $expected   The expected content.
 	 * @param array  $attributes The block attributes.
-	 * @param string $content The post content.
-	 * @param string $message The error message if the assert fails.
+	 * @param string $content    The post content.
+	 * @param string $message    The error message if the assert fails.
 	 */
 	public function test_present_duration_text( $expected, $attributes, $content, $message ) {
 		$this->assertSame(
@@ -212,10 +212,10 @@ final class Structured_Data_Blocks_Test extends TestCase {
 	 * @covers       ::optimize_how_to_images
 	 * @dataProvider how_to_images_provider
 	 *
-	 * @param string $expected The expected content.
+	 * @param string $expected   The expected content.
 	 * @param array  $attributes The block attributes.
-	 * @param string $content The post content.
-	 * @param string $message The error message if the assert fails.
+	 * @param string $content    The post content.
+	 * @param string $message    The error message if the assert fails.
 	 */
 	public function test_optimize_how_to_images( $expected, $attributes, $content, $message ) {
 		Monkey\Functions\expect( 'register_shutdown_function' )

--- a/tests/Unit/Integrations/Exclude_Attachment_Post_Type_Test.php
+++ b/tests/Unit/Integrations/Exclude_Attachment_Post_Type_Test.php
@@ -12,6 +12,7 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  * @group integrations
  *
  * @coversDefaultClass \Yoast\WP\SEO\Integrations\Exclude_Attachment_Post_Type
+ *
  * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
 final class Exclude_Attachment_Post_Type_Test extends TestCase {

--- a/tests/Unit/Integrations/Exclude_Oembed_Cache_Post_Type_Test.php
+++ b/tests/Unit/Integrations/Exclude_Oembed_Cache_Post_Type_Test.php
@@ -12,6 +12,7 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  * @group integrations
  *
  * @coversDefaultClass \Yoast\WP\SEO\Integrations\Exclude_Oembed_Cache_Post_Type
+ *
  * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
 final class Exclude_Oembed_Cache_Post_Type_Test extends TestCase {

--- a/tests/Unit/Integrations/Front_End_Integration_Test.php
+++ b/tests/Unit/Integrations/Front_End_Integration_Test.php
@@ -729,9 +729,9 @@ final class Front_End_Integration_Test extends TestCase {
 	 *
 	 * @dataProvider data_provider_query_loop_next_prev
 	 *
-	 * @param string $html HTML of the link.
+	 * @param string $html       HTML of the link.
 	 * @param string $block_name Block name.
-	 * @param string $variable Variable name.
+	 * @param string $variable   Variable name.
 	 */
 	public function test_query_loop_links( $html, $block_name, $variable ) {
 

--- a/tests/Unit/Integrations/Settings_Integration_Test.php
+++ b/tests/Unit/Integrations/Settings_Integration_Test.php
@@ -294,9 +294,9 @@ final class Settings_Integration_Test extends TestCase {
 	 *
 	 * @dataProvider data_provider_transform_post_types
 	 *
-	 * @param array $post_types The post types to transform.
+	 * @param array $post_types     The post types to transform.
 	 * @param array $new_post_types The new post types.
-	 * @param array $expected   The expected result.
+	 * @param array $expected       The expected result.
 	 */
 	public function test_transform_post_types( $post_types, $new_post_types, $expected ) {
 
@@ -389,10 +389,10 @@ final class Settings_Integration_Test extends TestCase {
 	 *
 	 * @dataProvider data_provider_transform_taxonomies
 	 *
-	 * @param array $taxonomies The taxonomies to transform.
+	 * @param array $taxonomies      The taxonomies to transform.
 	 * @param array $post_type_names The post type names.
-	 * @param array $new_taxonomies The new taxonomies.
-	 * @param array $expected   The expected result.
+	 * @param array $new_taxonomies  The new taxonomies.
+	 * @param array $expected        The expected result.
 	 */
 	public function test_transform_taxonomies( $taxonomies, $post_type_names, $new_taxonomies, $expected ) {
 

--- a/tests/Unit/Integrations/Support_Integration_Test.php
+++ b/tests/Unit/Integrations/Support_Integration_Test.php
@@ -260,7 +260,7 @@ final class Support_Integration_Test extends TestCase {
 	 * @dataProvider data_provider_enqueu_black_friday_style
 	 *
 	 * @param bool $is_black_friday Whether it is black friday or not.
-	 * @param int  $expected The number of times the action should be called.
+	 * @param int  $expected        The number of times the action should be called.
 	 * @return void
 	 */
 	public function test_enqueue_assets( $is_black_friday, $expected ) {

--- a/tests/Unit/Introductions/Infrastructure/Introductions_Seen_Repository_Test.php
+++ b/tests/Unit/Introductions/Infrastructure/Introductions_Seen_Repository_Test.php
@@ -61,8 +61,8 @@ final class Introductions_Seen_Repository_Test extends TestCase {
 	 *
 	 * @dataProvider provide_get_all_introductions_test_data
 	 *
-	 * @param mixed   $meta     Value `get_meta` returns.
-	 * @param boolean $expected The expected value.
+	 * @param mixed $meta     Value `get_meta` returns.
+	 * @param bool  $expected The expected value.
 	 *
 	 * @throws Invalid_User_Id_Exception Invalid User ID.
 	 */

--- a/tests/Unit/Introductions/Infrastructure/Wistia_Embed_Permission_Repository_Test.php
+++ b/tests/Unit/Introductions/Infrastructure/Wistia_Embed_Permission_Repository_Test.php
@@ -61,8 +61,8 @@ final class Wistia_Embed_Permission_Repository_Test extends TestCase {
 	 *
 	 * @dataProvider provide_get_value_for_user_test_data
 	 *
-	 * @param mixed   $meta     Value `get_meta` returns.
-	 * @param boolean $expected The expected value.
+	 * @param mixed $meta     Value `get_meta` returns.
+	 * @param bool  $expected The expected value.
 	 *
 	 * @throws Exception Invalid User ID.
 	 */

--- a/tests/Unit/Services/Importing/Aioseo_Robots_Provider_Service_Test.php
+++ b/tests/Unit/Services/Importing/Aioseo_Robots_Provider_Service_Test.php
@@ -14,6 +14,7 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  * @group importing
  *
  * @coversDefaultClass \Yoast\WP\SEO\Services\Importing\Aioseo\Aioseo_Robots_Provider_Service
+ *
  * @phpcs:disable Yoast.Yoast.AlternativeFunctions.json_encode_json_encode
  */
 final class Aioseo_Robots_Provider_Service_Test extends TestCase {

--- a/tests/Unit/Services/Importing/Aioseo_Robots_Transformer_Service_Test.php
+++ b/tests/Unit/Services/Importing/Aioseo_Robots_Transformer_Service_Test.php
@@ -14,6 +14,7 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  * @group importing
  *
  * @coversDefaultClass \Yoast\WP\SEO\Services\Importing\Aioseo\Aioseo_Robots_Transformer_Service
+ *
  * @phpcs:disable Yoast.Yoast.AlternativeFunctions.json_encode_json_encode
  */
 final class Aioseo_Robots_Transformer_Service_Test extends TestCase {

--- a/tests/Unit/Services/Importing/Aioseo_Social_Images_Provider_Service_Test.php
+++ b/tests/Unit/Services/Importing/Aioseo_Social_Images_Provider_Service_Test.php
@@ -15,6 +15,7 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  * @group importing
  *
  * @coversDefaultClass \Yoast\WP\SEO\Services\Importing\Aioseo\Aioseo_Social_Images_Provider_Service
+ *
  * @phpcs:disable Yoast.Yoast.AlternativeFunctions.json_encode_json_encode,Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
 final class Aioseo_Social_Images_Provider_Service_Test extends TestCase {

--- a/tests/WP/Content_Type_Visibility/Dismiss_New_Route_Test.php
+++ b/tests/WP/Content_Type_Visibility/Dismiss_New_Route_Test.php
@@ -121,7 +121,7 @@ final class Dismiss_New_Route_Test extends TestCase {
 	 *
 	 * @param array  $new_post_types The new post types.
 	 * @param string $post_type_name The post type name.
-	 * @param string $message The message.
+	 * @param string $message        The message.
 	 */
 	public function test_post_type_dismiss( $new_post_types, $post_type_name, $message ) {
 		$this->content_type_visibility_notifications->new_post_type( $new_post_types );
@@ -172,8 +172,8 @@ final class Dismiss_New_Route_Test extends TestCase {
 	 * @dataProvider data_provider_taxonomy_dismiss
 	 *
 	 * @param array  $new_taxonomies The new post types.
-	 * @param string $taxonomy_name The post type name.
-	 * @param string $message The message.
+	 * @param string $taxonomy_name  The post type name.
+	 * @param string $message        The message.
 	 */
 	public function test_taxonomy_dismiss( $new_taxonomies, $taxonomy_name, $message ) {
 		$this->content_type_visibility_notifications->new_taxonomy( $new_taxonomies );

--- a/tests/WP/Helpers/First_Time_Configuration_Notice_Helper_Test.php
+++ b/tests/WP/Helpers/First_Time_Configuration_Notice_Helper_Test.php
@@ -170,13 +170,13 @@ final class First_Time_Configuration_Notice_Helper_Test extends TestCase {
 	 *
 	 * @dataProvider data_provider_first_time_configuration_not_finished
 	 *
-	 * @param string $user_role The user role.
-	 * @param array  $steps_complete The array of first time configuration steps.
-	 * @param bool   $first_time_install Whether this is a first installation.
-	 * @param bool   $is_initial_indexing Whether the indexing is initial.
+	 * @param string $user_role                       The user role.
+	 * @param array  $steps_complete                  The array of first time configuration steps.
+	 * @param bool   $first_time_install              Whether this is a first installation.
+	 * @param bool   $is_initial_indexing             Whether the indexing is initial.
 	 * @param bool   $is_finished_indexables_indexing Whether indexing has been finished.
-	 * @param bool   $expected The expected result.
-	 * @param string $title First time configuration title.
+	 * @param bool   $expected                        The expected result.
+	 * @param string $title                           First time configuration title.
 	 *
 	 * @return void
 	 */


### PR DESCRIPTION
## Context

* Code QA/consistency

## Summary

This PR can be summarized in the following changelog entry:

* Code QA/consistency

## Relevant technical choices:

* Docs: various minor formatting fixes
* Docs: fix non-existent tag
    The `@private` tag doesn't exist, `@access private` does, though in reality, those constants should probably be made `private` instead.
* Docs: fix incorrect tag name
    Ref: https://docs.phpdoc.org/3.0/guide/references/phpdoc/tags/uses.html#uses-used-by
* Docs: remove non-existent and redundant tag
    The `@class` tag doesn't exist and doesn't have any value with the class declaration statement just below it.
* Docs: use short form type keywords
* Docs: null at last position in type 

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_ No functional changes.