### PR TITLE
Docs: remove use of `@api` for hook docs

### DIFF
--- a/admin/capabilities/class-abstract-capability-manager.php
+++ b/admin/capabilities/class-abstract-capability-manager.php
@@ -75,7 +75,7 @@ abstract class WPSEO_Abstract_Capability_Manager implements WPSEO_Capability_Man
 		/**
 		 * Filter: Allow changing roles that a capability is added to.
 		 *
-		 * @api array $roles The default roles to be filtered.
+		 * @param array $roles The default roles to be filtered.
 		 */
 		$filtered = apply_filters( $capability . '_roles', $roles );
 

--- a/admin/class-admin-editor-specific-replace-vars.php
+++ b/admin/class-admin-editor-specific-replace-vars.php
@@ -59,7 +59,7 @@ class WPSEO_Admin_Editor_Specific_Replace_Vars {
 		/**
 		 * Filter: Adds the possibility to add extra editor specific replacement variables.
 		 *
-		 * @api array $replacement_variables Array of editor specific replace vars.
+		 * @param array $replacement_variables Array of editor specific replace vars.
 		 */
 		$replacement_variables = apply_filters(
 			'wpseo_editor_specific_replace_vars',

--- a/admin/class-admin-gutenberg-compatibility-notification.php
+++ b/admin/class-admin-gutenberg-compatibility-notification.php
@@ -58,7 +58,7 @@ class WPSEO_Admin_Gutenberg_Compatibility_Notification implements WPSEO_WordPres
 		 * Filter: 'yoast_display_gutenberg_compat_notification' - Allows developer to disable the Gutenberg compatibility
 		 * notification.
 		 *
-		 * @api bool
+		 * @param bool $display_notification
 		 */
 		$display_notification = apply_filters( 'yoast_display_gutenberg_compat_notification', true );
 

--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -132,7 +132,7 @@ class WPSEO_Admin_Init {
 		 * the WPSEO metaboxes are only registered on the typical pages (lean loading) or always
 		 * registered when in admin.
 		 *
-		 * @api bool Whether to always register the metaboxes or not. Defaults to false.
+		 * @param bool $register_metaboxes Whether to always register the metaboxes or not. Defaults to false.
 		 */
 		if ( apply_filters( 'wpseo_always_register_metaboxes_on_admin', false ) ) {
 			return true;
@@ -353,7 +353,7 @@ class WPSEO_Admin_Init {
 			/**
 			 * Fires after the post time/date setting in the Publish meta box.
 			 *
-			 * @api \WP_Post The current post object.
+			 * @param WP_Post $post The current post object.
 			 */
 			do_action( 'wpseo_publishbox_misc_actions', $post );
 		}

--- a/admin/class-admin-recommended-replace-vars.php
+++ b/admin/class-admin-recommended-replace-vars.php
@@ -149,7 +149,7 @@ class WPSEO_Admin_Recommended_Replace_Vars {
 		/**
 		 * Filter: Adds the possibility to add extra recommended replacement variables.
 		 *
-		 * @api array $additional_replace_vars Empty array to add the replacevars to.
+		 * @param array $additional_replace_vars Empty array to add the replacevars to.
 		 */
 		$recommended_replace_vars = apply_filters( 'wpseo_recommended_replace_vars', $this->recommended_replace_vars );
 

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -157,7 +157,7 @@ class WPSEO_Admin {
 		/**
 		 * Filter: 'wpseo_manage_options_capability' - Allow changing the capability users need to view the settings pages.
 		 *
-		 * @api string unsigned The capability.
+		 * @param string $capability The capability.
 		 */
 		return apply_filters( 'wpseo_manage_options_capability', 'wpseo_manage_options' );
 	}

--- a/admin/class-meta-columns.php
+++ b/admin/class-meta-columns.php
@@ -412,9 +412,8 @@ class WPSEO_Meta_Columns {
 			 *
 			 * @internal
 			 *
-			 * @api array $keyword_filter The current keyword filter.
-			 *
-			 * @param array $keyphrase The keyphrase used in the filter.
+			 * @param array $keyphrase      The keyphrase used in the filter.
+			 * @param array $keyword_filter The current keyword filter.
 			 */
 			$keyphrase_filter = apply_filters(
 				'wpseo_change_keyphrase_filter_in_request',

--- a/admin/class-option-tabs-formatter.php
+++ b/admin/class-option-tabs-formatter.php
@@ -66,10 +66,9 @@ class WPSEO_Option_Tabs_Formatter {
 			 *
 			 * @internal For internal Yoast SEO use only.
 			 *
-			 * @api      string|null The content that should be displayed for this tab. Leave empty for default behaviour.
-			 *
-			 * @param WPSEO_Option_Tabs $option_tabs The registered option tabs.
-			 * @param WPSEO_Option_Tab  $tab         The tab that is being displayed.
+			 * @param string|null       $tab_contents The content that should be displayed for this tab. Leave empty for default behaviour.
+			 * @param WPSEO_Option_Tabs $option_tabs  The registered option tabs.
+			 * @param WPSEO_Option_Tab  $tab          The tab that is being displayed.
 			 */
 			$option_tab_content = apply_filters( 'wpseo_option_tab-' . $tab_filter_name, null, $option_tabs, $tab );
 			if ( ! empty( $option_tab_content ) ) {

--- a/admin/class-primary-term-admin.php
+++ b/admin/class-primary-term-admin.php
@@ -193,8 +193,7 @@ class WPSEO_Primary_Term_Admin implements WPSEO_WordPress_Integration {
 		/**
 		 * Filters which taxonomies for which the user can choose the primary term.
 		 *
-		 * @api array    $taxonomies An array of taxonomy objects that are primary_term enabled.
-		 *
+		 * @param array  $taxonomies     An array of taxonomy objects that are primary_term enabled.
 		 * @param string $post_type      The post type for which to filter the taxonomies.
 		 * @param array  $all_taxonomies All taxonomies for this post types, even ones that don't have primary term
 		 *                               enabled.

--- a/admin/class-yoast-notification-center.php
+++ b/admin/class-yoast-notification-center.php
@@ -606,7 +606,7 @@ class Yoast_Notification_Center {
 		/**
 		 * Filter: 'yoast_notifications_before_storage' - Allows developer to filter notifications before saving them.
 		 *
-		 * @api Yoast_Notification[] $notifications
+		 * @param Yoast_Notification[] $notifications
 		 */
 		$filtered_merged_notifications = apply_filters( 'yoast_notifications_before_storage', $merged_notifications );
 

--- a/admin/filters/class-cornerstone-filter.php
+++ b/admin/filters/class-cornerstone-filter.php
@@ -138,7 +138,7 @@ class WPSEO_Cornerstone_Filter extends WPSEO_Abstract_Post_Filter {
 		/**
 		 * Filter: 'wpseo_cornerstone_post_types' - Filters post types to exclude the cornerstone feature for.
 		 *
-		 * @api array - The accessible post types to filter.
+		 * @param array $post_types The accessible post types to filter.
 		 */
 		$post_types = apply_filters( 'wpseo_cornerstone_post_types', parent::get_post_types() );
 		if ( ! is_array( $post_types ) ) {

--- a/admin/formatter/class-post-metabox-formatter.php
+++ b/admin/formatter/class-post-metabox-formatter.php
@@ -91,9 +91,8 @@ class WPSEO_Post_Metabox_Formatter implements WPSEO_Metabox_Formatter_Interface 
 		/**
 		 * Filter: 'wpseo_post_edit_values' - Allows changing the values Yoast SEO uses inside the post editor.
 		 *
-		 * @api array $values The key-value map Yoast SEO uses inside the post editor.
-		 *
-		 * @param WP_Post $post The post opened in the editor.
+		 * @param array   $values The key-value map Yoast SEO uses inside the post editor.
+		 * @param WP_Post $post   The post opened in the editor.
 		 */
 		return apply_filters( 'wpseo_post_edit_values', $values, $this->post );
 	}

--- a/admin/menu/class-admin-menu.php
+++ b/admin/menu/class-admin-menu.php
@@ -99,7 +99,7 @@ class WPSEO_Admin_Menu extends WPSEO_Base_Menu {
 		/**
 		 * Filter: 'wpseo_submenu_pages' - Collects all submenus that need to be shown.
 		 *
-		 * @api array $submenu_pages List with all submenu pages.
+		 * @param array $submenu_pages List with all submenu pages.
 		 */
 		return (array) apply_filters( 'wpseo_submenu_pages', $submenu_pages );
 	}

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -371,7 +371,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 		/**
 		 * Filter: 'wpseo_content_meta_section_content' - Allow filtering the metabox content before outputting.
 		 *
-		 * @api string $post_content The metabox content string.
+		 * @param string $post_content The metabox content string.
 		 */
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Output should be escaped in the filter.
 		echo apply_filters( 'wpseo_content_meta_section_content', '' );

--- a/admin/taxonomy/class-taxonomy-fields.php
+++ b/admin/taxonomy/class-taxonomy-fields.php
@@ -98,7 +98,7 @@ class WPSEO_Taxonomy_Fields {
 		/**
 		 * Filter: 'wpseo_taxonomy_content_fields' - Adds the possibility to register additional content fields.
 		 *
-		 * @api array - The additional fields.
+		 * @param array $additional_fields The additional fields.
 		 */
 		$additional_fields = apply_filters( 'wpseo_taxonomy_content_fields', [] );
 

--- a/admin/tracking/class-tracking-settings-data.php
+++ b/admin/tracking/class-tracking-settings-data.php
@@ -246,7 +246,7 @@ class WPSEO_Tracking_Settings_Data implements WPSEO_Collection {
 		/**
 		 * Filter: 'wpseo_tracking_settings_include_list' - Allow filtering the settings included in tracking.
 		 *
-		 * @api string $include_list the list with included setting names.
+		 * @param string $include_list The list with included setting names.
 		 */
 		$this->include_list = apply_filters( 'wpseo_tracking_settings_include_list', $this->include_list );
 

--- a/admin/tracking/class-tracking.php
+++ b/admin/tracking/class-tracking.php
@@ -216,7 +216,7 @@ class WPSEO_Tracking implements WPSEO_WordPress_Integration {
 			/**
 			 * Filter: 'wpseo_enable_tracking' - Enables the data tracking of Yoast SEO Premium and add-ons.
 			 *
-			 * @api string $is_enabled The enabled state. Default is false.
+			 * @param string $is_enabled The enabled state. Default is false.
 			 */
 			$tracking = apply_filters( 'wpseo_enable_tracking', false );
 

--- a/admin/views/tool-import-export.php
+++ b/admin/views/tool-import-export.php
@@ -51,7 +51,7 @@ elseif ( isset( $_POST['settings_import'] ) && wp_unslash( $_POST['settings_impo
 /**
  * Allow custom import actions.
  *
- * @api WPSEO_Import_Status $yoast_seo_import Contains info about the handled import.
+ * @param WPSEO_Import_Status $yoast_seo_import Contains info about the handled import.
  */
 $yoast_seo_import = apply_filters( 'wpseo_handle_import', $yoast_seo_import );
 
@@ -65,7 +65,7 @@ if ( $yoast_seo_import ) {
 	/**
 	 * Allow customization of import/export message.
 	 *
-	 * @api  string  $yoast_seo_msg  The message.
+	 * @param string $yoast_seo_msg The message.
 	 */
 	$yoast_seo_msg = apply_filters( 'wpseo_import_message', $yoast_seo_message );
 

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -109,7 +109,7 @@ class WPSEO_Upgrade {
 		/**
 		 * Filter: 'wpseo_run_upgrade' - Runs the upgrade hook which are dependent on Yoast SEO.
 		 *
-		 * @api string - The current version of Yoast SEO
+		 * @param string $version The current version of Yoast SEO
 		 */
 		do_action( 'wpseo_run_upgrade', $version );
 

--- a/inc/class-wpseo-admin-bar-menu.php
+++ b/inc/class-wpseo-admin-bar-menu.php
@@ -753,7 +753,7 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 		/**
 		 * Filter: 'wpseo_use_page_analysis' Determines if the analysis should be enabled.
 		 *
-		 * @api bool Determines if the analysis should be enabled.
+		 * @param bool $enabled Determines if the analysis should be enabled.
 		 */
 		if ( apply_filters( 'wpseo_use_page_analysis', true ) !== true ) {
 			return '';

--- a/inc/class-wpseo-content-images.php
+++ b/inc/class-wpseo-content-images.php
@@ -98,7 +98,7 @@ class WPSEO_Content_Images {
 		/**
 		 * Filter: 'wpseo_pre_analysis_post_content' - Allow filtering the content before analysis.
 		 *
-		 * @api string $post_content The Post content string.
+		 * @param string $post_content The Post content string.
 		 */
 		$content = apply_filters( 'wpseo_pre_analysis_post_content', $post->post_content, $post );
 

--- a/inc/class-wpseo-image-utils.php
+++ b/inc/class-wpseo-image-utils.php
@@ -148,7 +148,7 @@ class WPSEO_Image_Utils {
 		 *
 		 * Elements with keys not listed in the section will be discarded.
 		 *
-		 * @api array {
+		 * @param array $image_data {
 		 *     Array of image data
 		 *
 		 *     @type int    id       Image's ID as an attachment.
@@ -162,7 +162,7 @@ class WPSEO_Image_Utils {
 		 *     @type string url      Image's URL.
 		 *     @type int    filesize The file size in bytes, if already set.
 		 * }
-		 * @api int  Attachment ID.
+		 * @param int   $attachment_id Attachment ID.
 		 */
 		$image = apply_filters( 'wpseo_image_data', $image, $attachment_id );
 
@@ -186,7 +186,7 @@ class WPSEO_Image_Utils {
 		 * Filter: 'wpseo_image_image_weight_limit' - Determines what the maximum weight
 		 * (in bytes) of an image is allowed to be, default is 2 MB.
 		 *
-		 * @api int - The maximum weight (in bytes) of an image.
+		 * @param int $max_bytes The maximum weight (in bytes) of an image.
 		 */
 		$max_size = apply_filters( 'wpseo_image_image_weight_limit', 2097152 );
 
@@ -404,7 +404,7 @@ class WPSEO_Image_Utils {
 		/**
 		 * Filter: 'wpseo_image_sizes' - Determines which image sizes we'll loop through to get an appropriate image.
 		 *
-		 * @api array - The array of image sizes to loop through.
+		 * @param array<string> $sizes The array of image sizes to loop through.
 		 */
 		return apply_filters( 'wpseo_image_sizes', [ 'full', 'large', 'medium_large' ] );
 	}

--- a/inc/class-wpseo-replace-vars.php
+++ b/inc/class-wpseo-replace-vars.php
@@ -167,10 +167,9 @@ class WPSEO_Replace_Vars {
 		/**
 		 * Filter: 'wpseo_replacements' - Allow customization of the replacements before they are applied.
 		 *
-		 * @api     array   $replacements The replacements.
-		 *
-		 * @param array $args The object some of the replacement values might come from,
-		 *                    could be a post, taxonomy or term.
+		 * @param array $replacements The replacements.
+		 * @param array $args         The object some of the replacement values might come from,
+		 *                            could be a post, taxonomy or term.
 		 */
 		$replacements = apply_filters( 'wpseo_replacements', $replacements, $this->args );
 
@@ -190,7 +189,7 @@ class WPSEO_Replace_Vars {
 		 *
 		 * @example <code>add_filter( 'wpseo_replacements_final', '__return_false' );</code>
 		 *
-		 * @api     bool $final
+		 * @param bool $final
 		 */
 		if ( apply_filters( 'wpseo_replacements_final', true ) === true && ( isset( $matches[1] ) && is_array( $matches[1] ) ) ) {
 			// Remove non-replaced variables.
@@ -1587,8 +1586,8 @@ class WPSEO_Replace_Vars {
 		 * Allows filtering of the terms list used to replace %%category%%, %%tag%%
 		 * and %%ct_<custom-tax-name>%% variables.
 		 *
-		 * @api    string    $output    Comma-delimited string containing the terms.
-		 * @api    string    $taxonomy  The taxonomy of the terms.
+		 * @param string $output   Comma-delimited string containing the terms.
+		 * @param string $taxonomy The taxonomy of the terms.
 		 */
 		return apply_filters( 'wpseo_terms', $output, $taxonomy );
 	}

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -43,7 +43,7 @@ class WPSEO_Utils {
 		 * Filter: 'wpseo_allow_system_file_edit' - Allow developers to change whether the editing of
 		 * .htaccess and robots.txt is allowed.
 		 *
-		 * @api bool $allowed Whether file editing is allowed.
+		 * @param bool $allowed Whether file editing is allowed.
 		 */
 		return apply_filters( 'wpseo_allow_system_file_edit', $allowed );
 	}
@@ -920,7 +920,7 @@ class WPSEO_Utils {
 			/**
 			 * Filter the Yoast SEO development mode.
 			 *
-			 * @api array $data Allows filtering of the JSON data for debug purposes.
+			 * @param array $data Allows filtering of the JSON data for debug purposes.
 			 */
 			$data = apply_filters( 'wpseo_debug_json_data', $data );
 		}

--- a/inc/options/class-wpseo-option-titles.php
+++ b/inc/options/class-wpseo-option-titles.php
@@ -211,7 +211,7 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 		/**
 		 * Allow altering the array with separator options.
 		 *
-		 * @api array $separator_options Array with the separator options.
+		 * @param array $separator_options Array with the separator options.
 		 */
 		$filtered_separators = apply_filters( 'wpseo_separator_options', $separators );
 
@@ -640,7 +640,7 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 						 *
 						 * Make sure when you filter this to also filter `wpseo_schema_article_types_labels`.
 						 *
-						 * @api array $schema_article_types The available schema article types.
+						 * @param array $schema_article_types The available schema article types.
 						 */
 						if ( array_key_exists( $dirty[ $key ], apply_filters( 'wpseo_schema_article_types', Schema_Types::ARTICLE_TYPES ) ) ) {
 							$clean[ $key ] = $dirty[ $key ];
@@ -927,7 +927,7 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 			/**
 			 * Allow altering the array with variable array key patterns.
 			 *
-			 * @api  array  $patterns  Array with the variable array key patterns.
+			 * @param array $patterns Array with the variable array key patterns.
 			 */
 			$patterns = apply_filters( 'wpseo_option_titles_variable_array_key_patterns', $patterns );
 
@@ -1018,7 +1018,7 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 		/**
 		 * Allows altering the separator options array.
 		 *
-		 * @api array $separators Array with the separator options.
+		 * @param array $separators Array with the separator options.
 		 */
 		$separator_list = apply_filters( 'wpseo_separator_option_list', $separators );
 

--- a/inc/options/class-wpseo-option-wpseo.php
+++ b/inc/options/class-wpseo-option-wpseo.php
@@ -219,7 +219,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 		/**
 		 * Filter: 'wpseo_enable_tracking' - Enables the data tracking of Yoast SEO Premium.
 		 *
-		 * @api string $is_enabled The enabled state. Default is false.
+		 * @param string $is_enabled The enabled state. Default is false.
 		 */
 		$this->defaults['tracking'] = apply_filters( 'wpseo_enable_tracking', false );
 

--- a/inc/options/class-wpseo-options.php
+++ b/inc/options/class-wpseo-options.php
@@ -200,7 +200,7 @@ class WPSEO_Options {
 		/**
 		 * Filter: wpseo_options - Allow developers to change the option name to include.
 		 *
-		 * @api array The option names to include in get_all and reset().
+		 * @param array $option_names The option names to include in get_all and reset().
 		 */
 		return apply_filters( 'wpseo_options', $option_names );
 	}

--- a/inc/sitemaps/class-post-type-sitemap-provider.php
+++ b/inc/sitemaps/class-post-type-sitemap-provider.php
@@ -313,7 +313,7 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 		/**
 		 * Filter: 'wpseo_exclude_from_sitemap_by_post_ids' - Allow extending and modifying the posts to exclude.
 		 *
-		 * @api array $posts_to_exclude The posts to exclude.
+		 * @param array $posts_to_exclude The posts to exclude.
 		 */
 		$excluded_posts_ids = apply_filters( 'wpseo_exclude_from_sitemap_by_post_ids', $excluded_posts_ids );
 		if ( ! is_array( $excluded_posts_ids ) ) {

--- a/inc/sitemaps/class-sitemap-image-parser.php
+++ b/inc/sitemaps/class-sitemap-image-parser.php
@@ -121,9 +121,8 @@ class WPSEO_Sitemap_Image_Parser {
 		/**
 		 * Filter images to be included for the post in XML sitemap.
 		 *
-		 * @param array  $images Array of image items.
-		 * @param int    $post_id ID of the post.
-		 * @return array $image_list Array of image items.
+		 * @param array $images  Array of image items.
+		 * @param int   $post_id ID of the post.
 		 */
 		$image_list = apply_filters( 'wpseo_sitemap_urlimages', $images, $post->ID );
 		if ( isset( $image_list ) && is_array( $image_list ) ) {
@@ -154,9 +153,8 @@ class WPSEO_Sitemap_Image_Parser {
 		/**
 		 * Filter images to be included for the term in XML sitemap.
 		 *
-		 * @param array  $image_list Array of image items.
-		 * @param int    $term_id ID of the post.
-		 * @return array $image_list Array of image items.
+		 * @param array $image_list Array of image items.
+		 * @param int   $term_id    ID of the post.
 		 */
 		$image_list = apply_filters( 'wpseo_sitemap_urlimages_term', $images, $term->term_id );
 		if ( isset( $image_list ) && is_array( $image_list ) ) {

--- a/inc/sitemaps/class-sitemaps-admin.php
+++ b/inc/sitemaps/class-sitemaps-admin.php
@@ -81,7 +81,7 @@ class WPSEO_Sitemaps_Admin {
 		/**
 		 * Filter: 'wpseo_allow_xml_sitemap_ping' - Check if pinging is not allowed (allowed by default).
 		 *
-		 * @api boolean $allow_ping The boolean that is set to true by default.
+		 * @param bool $allow_ping The boolean that is set to true by default.
 		 */
 		if ( apply_filters( 'wpseo_allow_xml_sitemap_ping', true ) === false ) {
 			return;

--- a/inc/sitemaps/class-sitemaps-renderer.php
+++ b/inc/sitemaps/class-sitemaps-renderer.php
@@ -103,7 +103,7 @@ class WPSEO_Sitemaps_Renderer {
 		/**
 		 * Filters the `urlset` for a sitemap by type.
 		 *
-		 * @api string $urlset The output for the sitemap's `urlset`.
+		 * @param string $urlset The output for the sitemap's `urlset`.
 		 */
 		$xml = apply_filters( "wpseo_sitemap_{$type}_urlset", $urlset );
 
@@ -239,9 +239,8 @@ class WPSEO_Sitemaps_Renderer {
 		/**
 		 * Filters the output for the sitemap URL tag.
 		 *
-		 * @api   string $output The output for the sitemap url tag.
-		 *
-		 * @param array $url The sitemap URL array on which the output is based.
+		 * @param string $output The output for the sitemap url tag.
+		 * @param array  $url    The sitemap URL array on which the output is based.
 		 */
 		return apply_filters( 'wpseo_sitemap_url', $output, $url );
 	}

--- a/inc/sitemaps/class-taxonomy-sitemap-provider.php
+++ b/inc/sitemaps/class-taxonomy-sitemap-provider.php
@@ -229,7 +229,7 @@ class WPSEO_Taxonomy_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 		/**
 		 * Filter: 'wpseo_exclude_from_sitemap_by_term_ids' - Allow excluding terms by ID.
 		 *
-		 * @api array $terms_to_exclude The terms to exclude.
+		 * @param array $terms_to_exclude The terms to exclude.
 		 */
 		$terms_to_exclude = apply_filters( 'wpseo_exclude_from_sitemap_by_term_ids', [] );
 

--- a/lib/orm.php
+++ b/lib/orm.php
@@ -2250,7 +2250,7 @@ class ORM implements ArrayAccess {
 		/**
 		 * Filter: 'wpseo_chunk_bulked_insert_queries' - Allow filtering the chunk size of each bulked INSERT query.
 		 *
-		 * @api int The chunk size of the bulked INSERT queries.
+		 * @param int $chunk_size The chunk size of the bulked INSERT queries.
 		 */
 		$chunk = \apply_filters( 'wpseo_chunk_bulk_insert_queries', 100 );
 		$chunk = ! \is_int( $chunk ) ? 100 : $chunk;

--- a/src/actions/alert-dismissal-action.php
+++ b/src/actions/alert-dismissal-action.php
@@ -196,7 +196,7 @@ class Alert_Dismissal_Action {
 		/**
 		 * Filter: 'wpseo_allowed_dismissable_alerts' - List of allowed dismissable alerts.
 		 *
-		 * @api string[] $allowed_dismissable_alerts Allowed dismissable alerts list.
+		 * @param string[] $allowed_dismissable_alerts Allowed dismissable alerts list.
 		 */
 		$allowed_dismissable_alerts = \apply_filters( 'wpseo_allowed_dismissable_alerts', [] );
 

--- a/src/actions/importing/aioseo/abstract-aioseo-settings-importing-action.php
+++ b/src/actions/importing/aioseo/abstract-aioseo-settings-importing-action.php
@@ -232,7 +232,7 @@ abstract class Abstract_Aioseo_Settings_Importing_Action extends Abstract_Aioseo
 		/**
 		 * Filter 'wpseo_aioseo_<identifier>_import_cursor' - Allow filtering the value of the aioseo settings import cursor.
 		 *
-		 * @api int The value of the aioseo posttype default settings import cursor.
+		 * @param int $import_cursor The value of the aioseo posttype default settings import cursor.
 		 */
 		$cursor = \apply_filters( 'wpseo_aioseo_' . $this->get_type() . '_import_cursor', $cursor );
 
@@ -257,7 +257,7 @@ abstract class Abstract_Aioseo_Settings_Importing_Action extends Abstract_Aioseo
 		/**
 		 * Filter 'wpseo_aioseo_<identifier>_indexation_limit' - Allow filtering the number of settings imported during each importing pass.
 		 *
-		 * @api int The maximum number of posts indexed.
+		 * @param int $max_posts The maximum number of posts indexed.
 		 */
 		$limit = \apply_filters( 'wpseo_aioseo_' . $this->get_type() . '_indexation_limit', 25 );
 

--- a/src/actions/importing/aioseo/aioseo-cleanup-action.php
+++ b/src/actions/importing/aioseo/aioseo-cleanup-action.php
@@ -163,7 +163,7 @@ class Aioseo_Cleanup_Action extends Abstract_Aioseo_Importing_Action {
 		/**
 		 * Filter 'wpseo_aioseo_cleanup_limit' - Allow filtering the number of posts indexed during each indexing pass.
 		 *
-		 * @api int The maximum number of posts cleaned up.
+		 * @param int $max_posts The maximum number of posts cleaned up.
 		 */
 		$limit = \apply_filters( 'wpseo_aioseo_cleanup_limit', 25 );
 

--- a/src/actions/importing/aioseo/aioseo-posts-importing-action.php
+++ b/src/actions/importing/aioseo/aioseo-posts-importing-action.php
@@ -380,7 +380,7 @@ class Aioseo_Posts_Importing_Action extends Abstract_Aioseo_Importing_Action {
 		/**
 		 * Filter 'wpseo_aioseo_post_indexation_limit' - Allow filtering the number of posts indexed during each indexing pass.
 		 *
-		 * @api int The maximum number of posts indexed.
+		 * @param int $max_posts The maximum number of posts indexed.
 		 */
 		$limit = \apply_filters( 'wpseo_aioseo_post_indexation_limit', 25 );
 
@@ -445,7 +445,7 @@ class Aioseo_Posts_Importing_Action extends Abstract_Aioseo_Importing_Action {
 		/**
 		 * Filter 'wpseo_aioseo_post_cursor' - Allow filtering the value of the aioseo post import cursor.
 		 *
-		 * @api int The value of the aioseo post import cursor.
+		 * @param int $import_cursor The value of the aioseo post import cursor.
 		 */
 		$cursor = \apply_filters( 'wpseo_aioseo_post_import_cursor', $cursor );
 

--- a/src/actions/importing/aioseo/aioseo-validate-data-action.php
+++ b/src/actions/importing/aioseo/aioseo-validate-data-action.php
@@ -242,7 +242,7 @@ class Aioseo_Validate_Data_Action extends Abstract_Aioseo_Importing_Action {
 		/**
 		 * Filter 'wpseo_aioseo_cleanup_limit' - Allow filtering the number of validations during each action pass.
 		 *
-		 * @api int The maximum number of validations.
+		 * @param int $limit The maximum number of validations.
 		 */
 		$limit = \apply_filters( 'wpseo_aioseo_validation_limit', 25 );
 

--- a/src/actions/indexing/abstract-link-indexing-action.php
+++ b/src/actions/indexing/abstract-link-indexing-action.php
@@ -98,7 +98,7 @@ abstract class Abstract_Link_Indexing_Action extends Abstract_Indexing_Action {
 		/**
 		 * Filter 'wpseo_link_indexing_limit' - Allow filtering the number of texts indexed during each link indexing pass.
 		 *
-		 * @api int The maximum number of texts indexed.
+		 * @param int $limit The maximum number of texts indexed.
 		 */
 		return \apply_filters( 'wpseo_link_indexing_limit', 5 );
 	}

--- a/src/actions/indexing/indexable-post-indexation-action.php
+++ b/src/actions/indexing/indexable-post-indexation-action.php
@@ -120,7 +120,7 @@ class Indexable_Post_Indexation_Action extends Abstract_Indexing_Action {
 		/**
 		 * Filter 'wpseo_post_indexation_limit' - Allow filtering the amount of posts indexed during each indexing pass.
 		 *
-		 * @api int The maximum number of posts indexed.
+		 * @param int $limit The maximum number of posts indexed.
 		 */
 		$limit = \apply_filters( 'wpseo_post_indexation_limit', 25 );
 

--- a/src/actions/indexing/indexable-post-type-archive-indexation-action.php
+++ b/src/actions/indexing/indexable-post-type-archive-indexation-action.php
@@ -127,7 +127,7 @@ class Indexable_Post_Type_Archive_Indexation_Action implements Indexation_Action
 		/**
 		 * Filter 'wpseo_post_type_archive_indexation_limit' - Allow filtering the number of posts indexed during each indexing pass.
 		 *
-		 * @api int The maximum number of posts indexed.
+		 * @param int $limit The maximum number of posts indexed.
 		 */
 		$limit = \apply_filters( 'wpseo_post_type_archive_indexation_limit', 25 );
 

--- a/src/actions/indexing/indexable-term-indexation-action.php
+++ b/src/actions/indexing/indexable-term-indexation-action.php
@@ -107,7 +107,7 @@ class Indexable_Term_Indexation_Action extends Abstract_Indexing_Action {
 		/**
 		 * Filter 'wpseo_term_indexation_limit' - Allow filtering the number of terms indexed during each indexing pass.
 		 *
-		 * @api int The maximum number of terms indexed.
+		 * @param int $limit The maximum number of terms indexed.
 		 */
 		$limit = \apply_filters( 'wpseo_term_indexation_limit', 25 );
 

--- a/src/analytics/application/missing-indexables-collector.php
+++ b/src/analytics/application/missing-indexables-collector.php
@@ -56,7 +56,9 @@ class Missing_Indexables_Collector implements WPSEO_Collection {
 		 * Filter: Adds the possibility to add additional indexation actions to be included in the count routine.
 		 *
 		 * @internal
-		 * @api Indexation_Action_Interface This filter expects a list of Indexation_Action_Interface instances and expects only Indexation_Action_Interface implementations to be added to the list.
+		 * @param Indexation_Action_Interface $actions This filter expects a list of Indexation_Action_Interface instances
+		 *                                             and expects only Indexation_Action_Interface implementations to be
+		 *                                             added to the list.
 		 */
 		$indexing_actions = (array) \apply_filters( 'wpseo_indexable_collector_add_indexation_actions', $this->indexation_actions );
 

--- a/src/analytics/application/to-be-cleaned-indexables-collector.php
+++ b/src/analytics/application/to-be-cleaned-indexables-collector.php
@@ -75,7 +75,7 @@ class To_Be_Cleaned_Indexables_Collector implements WPSEO_Collection {
 		 * Action: Adds the possibility to add additional to be cleaned objects.
 		 *
 		 * @internal
-		 * @api To_Be_Cleaned_Indexable_Bucket An indexable cleanup bucket. New values are instances of To_Be_Cleaned_Indexable_Count.
+		 * @param To_Be_Cleaned_Indexable_Bucket $bucket An indexable cleanup bucket. New values are instances of To_Be_Cleaned_Indexable_Count.
 		 */
 		\do_action( 'wpseo_add_cleanup_counts_to_indexable_bucket', $to_be_cleaned_indexable_bucket );
 	}

--- a/src/conditionals/should-index-links-conditional.php
+++ b/src/conditionals/should-index-links-conditional.php
@@ -36,7 +36,7 @@ class Should_Index_Links_Conditional implements Conditional {
 		/**
 		 * Filter: 'wpseo_should_index_links' - Allows disabling of Yoast's links indexation.
 		 *
-		 * @api bool To disable the indexation, return false.
+		 * @param bool $enable To disable the indexation, return false.
 		 */
 		return \apply_filters( 'wpseo_should_index_links', $should_index_links );
 	}

--- a/src/config/schema-types.php
+++ b/src/config/schema-types.php
@@ -118,7 +118,7 @@ class Schema_Types {
 		 *
 		 * Make sure when you filter this to also filter `wpseo_schema_article_types`.
 		 *
-		 * @api array $schema_article_types_labels The available schema article types and their labels.
+		 * @param array $schema_article_types_labels The available schema article types and their labels.
 		 */
 		return \apply_filters(
 			'wpseo_schema_article_types_labels',

--- a/src/context/meta-tags-context.php
+++ b/src/context/meta-tags-context.php
@@ -306,7 +306,7 @@ class Meta_Tags_Context extends Abstract_Presentation {
 		/**
 		 * Filter: 'wpseo_schema_company_name' - Allows filtering company name
 		 *
-		 * @api string $company_name.
+		 * @param string $company_name.
 		 */
 		$company_name = \apply_filters( 'wpseo_schema_company_name', $this->options->get( 'company_name' ) );
 
@@ -341,7 +341,7 @@ class Meta_Tags_Context extends Abstract_Presentation {
 		/**
 		 * Filter: 'wpseo_schema_person_logo_id' - Allows filtering person logo id.
 		 *
-		 * @api integer $person_logo_id.
+		 * @param int $person_logo_id.
 		 */
 		return \apply_filters( 'wpseo_schema_person_logo_id', $person_logo_id );
 	}
@@ -362,7 +362,7 @@ class Meta_Tags_Context extends Abstract_Presentation {
 		/**
 		 * Filter: 'wpseo_schema_person_logo_meta' - Allows filtering person logo meta.
 		 *
-		 * @api string $person_logo_meta.
+		 * @param string $person_logo_meta.
 		 */
 		return \apply_filters( 'wpseo_schema_person_logo_meta', $person_logo_meta );
 	}
@@ -382,7 +382,7 @@ class Meta_Tags_Context extends Abstract_Presentation {
 		/**
 		 * Filter: 'wpseo_schema_company_logo_id' - Allows filtering company logo id.
 		 *
-		 * @api integer $company_logo_id.
+		 * @param int $company_logo_id.
 		 */
 		return \apply_filters( 'wpseo_schema_company_logo_id', $company_logo_id );
 	}
@@ -398,7 +398,7 @@ class Meta_Tags_Context extends Abstract_Presentation {
 		/**
 		 * Filter: 'wpseo_schema_company_logo_meta' - Allows filtering company logo meta.
 		 *
-		 * @api string $company_logo_meta.
+		 * @param string $company_logo_meta.
 		 */
 		return \apply_filters( 'wpseo_schema_company_logo_meta', $company_logo_meta );
 	}
@@ -541,7 +541,7 @@ class Meta_Tags_Context extends Abstract_Presentation {
 		/**
 		 * Filter: 'wpseo_schema_webpage_type' - Allow changing the WebPage type.
 		 *
-		 * @api string|array $type The WebPage type.
+		 * @param string|array $type The WebPage type.
 		 */
 		return \apply_filters( 'wpseo_schema_webpage_type', $type );
 	}

--- a/src/deprecated/src/helpers/indexables-page-helper.php
+++ b/src/deprecated/src/helpers/indexables-page-helper.php
@@ -73,7 +73,7 @@ class Indexables_Page_Helper {
 		/**
 		 * Filter 'wpseo_indexables_list_size' - Allow filtering the size of the Indexables lists.
 		 *
-		 * @api int The size of the Indexables lists.
+		 * @param int $list_size The size of the Indexables lists.
 		 */
 		return \apply_filters_deprecated( 'wpseo_indexables_list_size', [ self::LIST_SIZE ], 'Yoast SEO 20.4' );
 	}
@@ -92,7 +92,7 @@ class Indexables_Page_Helper {
 		/**
 		 * Filter 'wpseo_indexables_buffer_size' - Allow filtering the size of the buffer for the Indexables lists, in terms of how many times bigger it is from the lists' size.
 		 *
-		 * @api int The size of the buffer for the Indexables lists, in terms of how many times bigger it is from the lists' size.
+		 * @param int $buffer_size The size of the buffer for the Indexables lists, in terms of how many times bigger it is from the lists' size.
 		 */
 		$times = \apply_filters_deprecated( 'wpseo_indexables_buffer_size', [ self::BUFFER_SIZE ], 'Yoast SEO 20.4' );
 		if ( $times < 3 ) {
@@ -116,7 +116,7 @@ class Indexables_Page_Helper {
 		/**
 		 * Filter 'wpseo_posts_threshold' - Allow filtering the minimum threshold for the amount of posts in the site, in order for Indexable lists to be relevant.
 		 *
-		 * @api int The minimum threshold for the amount of posts in the site, in order for Indexable lists to be relevant.
+		 * @param int $post_threshold The minimum threshold for the amount of posts in the site, in order for Indexable lists to be relevant.
 		 */
 		return \apply_filters_deprecated( 'wpseo_posts_threshold', [ self::POSTS_THRESHOLD ], 'Yoast SEO 20.4' );
 	}
@@ -135,7 +135,7 @@ class Indexables_Page_Helper {
 		/**
 		 * Filter 'wpseo_analyzed_posts_threshold' - Allow filtering the minimum threshold for the amount of analyzed posts in the site, in order for Indexable lists to be relevant.
 		 *
-		 * @api int The minimum threshold for the amount of analyzed posts in the site, in order for Indexable lists to be relevant.
+		 * @param int $analysed_post_threshold The minimum threshold for the amount of analyzed posts in the site, in order for Indexable lists to be relevant.
 		 */
 		return \apply_filters_deprecated( 'wpseo_analyzed_posts_threshold', [ self::ANALYSED_POSTS_THRESHOLD ], 'Yoast SEO 20.4' );
 	}

--- a/src/generators/breadcrumbs-generator.php
+++ b/src/generators/breadcrumbs-generator.php
@@ -212,10 +212,9 @@ class Breadcrumbs_Generator implements Generator_Interface {
 			/**
 			 * Filter: 'wpseo_breadcrumb_single_link_info' - Allow developers to filter the Yoast SEO Breadcrumb link information.
 			 *
-			 * @api array $link_info The breadcrumb link information.
-			 *
-			 * @param int $index The index of the breadcrumb in the list.
-			 * @param array $crumbs The complete list of breadcrumbs.
+			 * @param array $link_info The breadcrumb link information.
+			 * @param int   $index     The index of the breadcrumb in the list.
+			 * @param array $crumbs    The complete list of breadcrumbs.
 			 */
 			return \apply_filters( 'wpseo_breadcrumb_single_link_info', $link_info, $index, $crumbs );
 		};

--- a/src/generators/open-graph-image-generator.php
+++ b/src/generators/open-graph-image-generator.php
@@ -84,7 +84,7 @@ class Open_Graph_Image_Generator implements Generator_Interface {
 			/**
 			 * Filter: wpseo_add_opengraph_images - Allow developers to add images to the Open Graph tags.
 			 *
-			 * @api Yoast\WP\SEO\Values\Open_Graph\Images The current object.
+			 * @param Yoast\WP\SEO\Values\Open_Graph\Images $image_container The current object.
 			 */
 			\apply_filters( 'wpseo_add_opengraph_images', $image_container );
 		} catch ( Error $error ) {
@@ -98,7 +98,7 @@ class Open_Graph_Image_Generator implements Generator_Interface {
 			/**
 			 * Filter: wpseo_add_opengraph_additional_images - Allows to add additional images to the Open Graph tags.
 			 *
-			 * @api Yoast\WP\SEO\Values\Open_Graph\Images The current object.
+			 * @param Yoast\WP\SEO\Values\Open_Graph\Images $image_container The current object.
 			 */
 			\apply_filters( 'wpseo_add_opengraph_additional_images', $image_container );
 		} catch ( Error $error ) {

--- a/src/generators/open-graph-locale-generator.php
+++ b/src/generators/open-graph-locale-generator.php
@@ -22,7 +22,7 @@ class Open_Graph_Locale_Generator implements Generator_Interface {
 		 *
 		 * Note that this filter is different from `wpseo_og_locale`, which is run _after_ the OG specific filtering.
 		 *
-		 * @api string Locale string.
+		 * @param string $locale Locale string.
 		 */
 		$locale = \apply_filters( 'wpseo_locale', \get_locale() );
 

--- a/src/generators/schema-generator.php
+++ b/src/generators/schema-generator.php
@@ -102,7 +102,7 @@ class Schema_Generator implements Generator_Interface {
 			/**
 			 * Filter: 'wpseo_schema_needs_<identifier>' - Allows changing which graph pieces we output.
 			 *
-			 * @api bool $is_needed Whether or not to show a graph piece.
+			 * @param bool $is_needed Whether or not to show a graph piece.
 			 */
 			$is_needed = \apply_filters( 'wpseo_schema_needs_' . $identifier, $piece->is_needed() );
 			if ( ! $is_needed ) {
@@ -141,10 +141,9 @@ class Schema_Generator implements Generator_Interface {
 				 * Filter: 'wpseo_schema_<identifier>' - Allows changing graph piece output.
 				 * This filter can be called with either an identifier or a block type (see `add_schema_blocks_graph_pieces()`).
 				 *
-				 * @api array $graph_piece The graph piece to filter.
-				 *
-				 * @param Meta_Tags_Context $context A value object with context variables.
-				 * @param Abstract_Schema_Piece $graph_piece_generator A value object with context variables.
+				 * @param array                   $graph_piece            The graph piece to filter.
+				 * @param Meta_Tags_Context       $context                A value object with context variables.
+				 * @param Abstract_Schema_Piece   $graph_piece_generator  A value object with context variables.
 				 * @param Abstract_Schema_Piece[] $graph_piece_generators A value object with context variables.
 				 */
 				$graph_piece = \apply_filters( 'wpseo_schema_' . $identifier, $graph_piece, $context, $graph_piece_generator, $graph_piece_generators );
@@ -160,8 +159,7 @@ class Schema_Generator implements Generator_Interface {
 		/**
 		 * Filter: 'wpseo_schema_graph' - Allows changing graph output.
 		 *
-		 * @api array $graph The graph to filter.
-		 *
+		 * @param array             $graph   The graph to filter.
 		 * @param Meta_Tags_Context $context A value object with context variables.
 		 */
 		$graph = \apply_filters( 'wpseo_schema_graph', $graph, $context );
@@ -322,9 +320,8 @@ class Schema_Generator implements Generator_Interface {
 		/**
 		 * Filter: 'wpseo_schema_graph_pieces' - Allows adding pieces to the graph.
 		 *
+		 * @param array             $pieces  The schema pieces.
 		 * @param Meta_Tags_Context $context An object with context variables.
-		 *
-		 * @api array $pieces The schema pieces.
 		 */
 		return \apply_filters( 'wpseo_schema_graph_pieces', $schema_pieces, $context );
 	}
@@ -353,10 +350,9 @@ class Schema_Generator implements Generator_Interface {
 				/**
 				 * Filter: 'wpseo_schema_<type>' - Allows changing graph piece output by @type.
 				 *
-				 * @api array $graph_piece The graph piece to filter.
-				 *
-				 * @param Meta_Tags_Context $context A value object with context variables.
-				 * @param Abstract_Schema_Piece $graph_piece_generator A value object with context variables.
+				 * @param array                   $graph_piece            The graph piece to filter.
+				 * @param Meta_Tags_Context       $context                A value object with context variables.
+				 * @param Abstract_Schema_Piece   $graph_piece_generator  A value object with context variables.
 				 * @param Abstract_Schema_Piece[] $graph_piece_generators A value object with context variables.
 				 */
 				$graph_piece = \apply_filters( 'wpseo_schema_' . $type, $graph_piece, $context, $graph_piece_generator, $graph_piece_generators );

--- a/src/generators/schema/article.php
+++ b/src/generators/schema/article.php
@@ -91,7 +91,7 @@ class Article extends Abstract_Schema_Piece {
 		/**
 		 * Filter: 'wpseo_schema_article_keywords_taxonomy' - Allow changing the taxonomy used to assign keywords to a post type Article data.
 		 *
-		 * @api string $taxonomy The chosen taxonomy.
+		 * @param string $taxonomy The chosen taxonomy.
 		 */
 		$taxonomy = \apply_filters( 'wpseo_schema_article_keywords_taxonomy', 'post_tag' );
 
@@ -109,7 +109,7 @@ class Article extends Abstract_Schema_Piece {
 		/**
 		 * Filter: 'wpseo_schema_article_sections_taxonomy' - Allow changing the taxonomy used to assign keywords to a post type Article data.
 		 *
-		 * @api string $taxonomy The chosen taxonomy.
+		 * @param string $taxonomy The chosen taxonomy.
 		 */
 		$taxonomy = \apply_filters( 'wpseo_schema_article_sections_taxonomy', 'category' );
 
@@ -176,7 +176,7 @@ class Article extends Abstract_Schema_Piece {
 		/**
 		 * Filter: 'wpseo_schema_article_potential_action_target' - Allows filtering of the schema Article potentialAction target.
 		 *
-		 * @api array $targets The URLs for the Article potentialAction target.
+		 * @param array $targets The URLs for the Article potentialAction target.
 		 */
 		$targets = \apply_filters( 'wpseo_schema_article_potential_action_target', [ $this->context->canonical . '#respond' ] );
 

--- a/src/generators/schema/author.php
+++ b/src/generators/schema/author.php
@@ -82,7 +82,7 @@ class Author extends Person {
 		/**
 		 * Filter: 'wpseo_schema_person_user_id' - Allows filtering of user ID used for person output.
 		 *
-		 * @api int|bool $user_id The user ID currently determined.
+		 * @param int|bool $user_id The user ID currently determined.
 		 */
 		$user_id = \apply_filters( 'wpseo_schema_person_user_id', $user_id );
 

--- a/src/generators/schema/organization.php
+++ b/src/generators/schema/organization.php
@@ -73,7 +73,7 @@ class Organization extends Abstract_Schema_Piece {
 		 * Filter: 'wpseo_schema_organization_social_profiles' - Allows filtering social profiles for the
 		 * represented organization.
 		 *
-		 * @api string[] $profiles
+		 * @param string[] $profiles
 		 */
 		$profiles = \apply_filters( 'wpseo_schema_organization_social_profiles', $profiles );
 

--- a/src/generators/schema/person.php
+++ b/src/generators/schema/person.php
@@ -72,7 +72,7 @@ class Person extends Abstract_Schema_Piece {
 		/**
 		 * Filter: 'wpseo_schema_person_user_id' - Allows filtering of user ID used for person output.
 		 *
-		 * @api int|bool $user_id The user ID currently determined.
+		 * @param int|bool $user_id The user ID currently determined.
 		 */
 		$user_id = \apply_filters( 'wpseo_schema_person_user_id', $this->context->site_user_id );
 
@@ -96,10 +96,9 @@ class Person extends Abstract_Schema_Piece {
 		/**
 		 * Filter: 'wpseo_schema_person_social_profiles' - Allows filtering of social profiles per user.
 		 *
-		 * @param int $user_id The current user we're grabbing social profiles for.
-		 *
-		 * @api string[] $social_profiles The array of social profiles to retrieve. Each should be a user meta field
-		 *                                key. As they are retrieved using the WordPress function `get_the_author_meta`.
+		 * @param string[] $social_profiles The array of social profiles to retrieve. Each should be a user meta field
+		 *                                  key. As they are retrieved using the WordPress function `get_the_author_meta`.
+		 * @param int      $user_id         The current user we're grabbing social profiles for.
 		 */
 		$social_profiles = \apply_filters( 'wpseo_schema_person_social_profiles', $this->social_profiles, $user_id );
 

--- a/src/generators/schema/webpage.php
+++ b/src/generators/schema/webpage.php
@@ -138,7 +138,7 @@ class WebPage extends Abstract_Schema_Piece {
 		/**
 		 * Filter: 'wpseo_schema_webpage_potential_action_target' - Allows filtering of the schema WebPage potentialAction target.
 		 *
-		 * @api array $targets The URLs for the WebPage potentialAction target.
+		 * @param array $targets The URLs for the WebPage potentialAction target.
 		 */
 		$targets = \apply_filters( 'wpseo_schema_webpage_potential_action_target', [ $url ] );
 

--- a/src/generators/schema/website.php
+++ b/src/generators/schema/website.php
@@ -71,7 +71,7 @@ class Website extends Abstract_Schema_Piece {
 		/**
 		 * Filter: 'disable_wpseo_json_ld_search' - Allow disabling of the json+ld output.
 		 *
-		 * @api bool $display_search Whether or not to display json+ld search on the frontend.
+		 * @param bool $display_search Whether or not to display json+ld search on the frontend.
 		 */
 		if ( \apply_filters( 'disable_wpseo_json_ld_search', false ) ) {
 			return $data;
@@ -80,7 +80,7 @@ class Website extends Abstract_Schema_Piece {
 		/**
 		 * Filter: 'wpseo_json_ld_search_url' - Allows filtering of the search URL for Yoast SEO.
 		 *
-		 * @api string $search_url The search URL for this site with a `{search_term_string}` variable.
+		 * @param string $search_url The search URL for this site with a `{search_term_string}` variable.
 		 */
 		$search_url = \apply_filters( 'wpseo_json_ld_search_url', $this->context->site_url . '?s={search_term_string}' );
 

--- a/src/helpers/current-page-helper.php
+++ b/src/helpers/current-page-helper.php
@@ -90,7 +90,7 @@ class Current_Page_Helper {
 		/**
 		 * Filter: Allow changing the default page id.
 		 *
-		 * @api int $page_id The default page id.
+		 * @param int $page_id The default page id.
 		 */
 		return \apply_filters( 'wpseo_frontend_page_type_simple_page_id', 0 );
 	}

--- a/src/helpers/open-graph/image-helper.php
+++ b/src/helpers/open-graph/image-helper.php
@@ -55,9 +55,8 @@ class Image_Helper {
 		/**
 		 * Filter: 'wpseo_opengraph_is_valid_image_url' - Allows extra validation for an image url.
 		 *
-		 * @api bool - Current validation result.
-		 *
-		 * @param string $url The image url to validate.
+		 * @param bool   $is_valid Current validation result.
+		 * @param string $url      The image url to validate.
 		 */
 		return (bool) \apply_filters( 'wpseo_opengraph_is_valid_image_url', $is_valid, $image['url'] );
 	}
@@ -80,7 +79,7 @@ class Image_Helper {
 		 * can be used to add an image size that needs to be taken into consideration
 		 * within our own logic.
 		 *
-		 * @api string|false $size Size string.
+		 * @param string|false $size Size string.
 		 */
 		return \apply_filters( 'wpseo_opengraph_image_size', null );
 	}

--- a/src/helpers/options-helper.php
+++ b/src/helpers/options-helper.php
@@ -76,7 +76,7 @@ class Options_Helper {
 		/**
 		 * Filter: 'wpseo_replacements_filter_sep' - Allow customization of the separator character(s).
 		 *
-		 * @api string $replacement The current separator.
+		 * @param string $replacement The current separator.
 		 */
 		return \apply_filters( 'wpseo_replacements_filter_sep', $replacement );
 	}

--- a/src/helpers/pagination-helper.php
+++ b/src/helpers/pagination-helper.php
@@ -49,7 +49,7 @@ class Pagination_Helper {
 		/**
 		 * Filter: 'wpseo_disable_adjacent_rel_links' - Allows disabling of Yoast adjacent links if this is being handled by other code.
 		 *
-		 * @api bool $links_generated Indicates if other code has handled adjacent links.
+		 * @param bool $links_generated Indicates if other code has handled adjacent links.
 		 */
 		return \apply_filters( 'wpseo_disable_adjacent_rel_links', false );
 	}

--- a/src/helpers/post-helper.php
+++ b/src/helpers/post-helper.php
@@ -219,7 +219,7 @@ class Post_Helper {
 		/**
 		 * Filter: 'wpseo_public_post_statuses' - List of public post statuses.
 		 *
-		 * @api array $post_statuses Post status list, defaults to array( 'publish' ).
+		 * @param array $post_statuses Post status list, defaults to array( 'publish' ).
 		 */
 		return \apply_filters( 'wpseo_public_post_statuses', [ 'publish' ] );
 	}

--- a/src/helpers/post-type-helper.php
+++ b/src/helpers/post-type-helper.php
@@ -80,7 +80,7 @@ class Post_Type_Helper {
 		/**
 		 * Filter: 'wpseo_accessible_post_types' - Allow changing the accessible post types.
 		 *
-		 * @api array $post_types The public post types.
+		 * @param array $post_types The public post types.
 		 */
 		$post_types = \apply_filters( 'wpseo_accessible_post_types', $post_types );
 
@@ -103,7 +103,7 @@ class Post_Type_Helper {
 		 * Filter: 'wpseo_indexable_excluded_post_types' - Allows excluding posts of a certain post
 		 * type from being saved to the indexable table.
 		 *
-		 * @api array $excluded_post_types The currently excluded post types that indexables will not be created for.
+		 * @param array $excluded_post_types The currently excluded post types that indexables will not be created for.
 		 */
 		$excluded_post_types = \apply_filters( 'wpseo_indexable_excluded_post_types', [] );
 
@@ -176,7 +176,7 @@ class Post_Type_Helper {
 		 * Filter: 'wpseo_indexable_forced_included_post_types' - Allows force including posts of a certain post
 		 * type to be saved to the indexable table.
 		 *
-		 * @api array $included_post_types The currently included post types that indexables will be created for.
+		 * @param array $included_post_types The currently included post types that indexables will be created for.
 		 */
 		$filtered_included_post_types = \apply_filters( 'wpseo_indexable_forced_included_post_types', $included_post_types );
 

--- a/src/helpers/primary-term-helper.php
+++ b/src/helpers/primary-term-helper.php
@@ -24,8 +24,7 @@ class Primary_Term_Helper {
 		/**
 		 * Filters which taxonomies for which the user can choose the primary term.
 		 *
-		 * @api array    $taxonomies An array of taxonomy objects that are primary_term enabled.
-		 *
+		 * @param array  $taxonomies     An array of taxonomy objects that are primary_term enabled.
 		 * @param string $post_type      The post type for which to filter the taxonomies.
 		 * @param array  $all_taxonomies All taxonomies for this post types, even ones that don't have primary term
 		 *                               enabled.

--- a/src/helpers/schema/language-helper.php
+++ b/src/helpers/schema/language-helper.php
@@ -22,7 +22,7 @@ class Language_Helper {
 		/**
 		 * Filter: 'wpseo_schema_piece_language' - Allow changing the Schema piece language.
 		 *
-		 * @api string $type The Schema piece language.
+		 * @param string $type The Schema piece language.
 		 */
 		$data['inLanguage'] = \apply_filters( 'wpseo_schema_piece_language', \get_bloginfo( 'language' ), $data );
 

--- a/src/helpers/twitter/image-helper.php
+++ b/src/helpers/twitter/image-helper.php
@@ -36,7 +36,7 @@ class Image_Helper {
 		/**
 		 * Filter: 'wpseo_twitter_image_size' - Allow changing the Twitter Card image size.
 		 *
-		 * @api string $featured_img Image size string.
+		 * @param string $featured_img Image size string.
 		 */
 		return (string) \apply_filters( 'wpseo_twitter_image_size', 'full' );
 	}

--- a/src/integrations/admin/background-indexing-integration.php
+++ b/src/integrations/admin/background-indexing-integration.php
@@ -255,7 +255,8 @@ class Background_Indexing_Integration implements Integration_Interface {
 		 * Filter: 'wpseo_unindexed_count_queries_ran' - Informs whether the expensive unindexed count queries have been ran already.
 		 *
 		 * @internal
-		 * @api bool
+		 *
+		 * @param bool $have_queries_ran
 		 */
 		$have_queries_ran = \apply_filters( 'wpseo_unindexed_count_queries_ran', false );
 
@@ -280,7 +281,7 @@ class Background_Indexing_Integration implements Integration_Interface {
 			/**
 			 * Filter: 'wpseo_cron_indexing_limit_size' - Adds the possibility to limit the number of items that are indexed when in cron action.
 			 *
-			 * @api int $limit Maximum number of indexables to be indexed per indexing action.
+			 * @param int $limit Maximum number of indexables to be indexed per indexing action.
 			 */
 			return \apply_filters( 'wpseo_cron_indexing_limit_size', 15 );
 		}
@@ -300,7 +301,7 @@ class Background_Indexing_Integration implements Integration_Interface {
 			/**
 			 * Filter: 'wpseo_cron_link_indexing_limit_size' - Adds the possibility to limit the number of links that are indexed when in cron action.
 			 *
-			 * @api int $limit Maximum number of link indexables to be indexed per link indexing action.
+			 * @param int $limit Maximum number of link indexables to be indexed per link indexing action.
 			 */
 			return \apply_filters( 'wpseo_cron_link_indexing_limit_size', 3 );
 		}
@@ -363,7 +364,7 @@ class Background_Indexing_Integration implements Integration_Interface {
 		/**
 		 * Filter 'wpseo_shutdown_indexation_limit' - Allow filtering the number of objects that can be indexed during shutdown.
 		 *
-		 * @api int The maximum number of objects indexed.
+		 * @param int $limit The maximum number of objects indexed.
 		 */
 		return \apply_filters( 'wpseo_shutdown_indexation_limit', 25 );
 	}

--- a/src/integrations/admin/helpscout-beacon.php
+++ b/src/integrations/admin/helpscout-beacon.php
@@ -183,7 +183,7 @@ class HelpScout_Beacon implements Integration_Interface {
 		/**
 		 * Filter: 'wpseo_helpscout_show_beacon' - Allows overriding whether we show the HelpScout beacon.
 		 *
-		 * @api bool - Whether we show the beacon or not.
+		 * @param bool $show_beacon Whether we show the beacon or not.
 		 */
 		return \apply_filters( 'wpseo_helpscout_show_beacon', $return );
 	}
@@ -446,16 +446,16 @@ class HelpScout_Beacon implements Integration_Interface {
 	 * Allows filtering of the HelpScout settings. Hooked to admin_head to prevent timing issues, not too early, not too late.
 	 */
 	protected function filter_settings() {
-		/**
-		 * Filter: 'wpseo_helpscout_beacon_settings' - Allows overriding the HelpScout beacon settings.
-		 *
-		 * @api string - The HelpScout beacon settings.
-		 */
 		$filterable_helpscout_setting = [
 			'products'  => $this->products,
 			'pages_ids' => $this->pages_ids,
 		];
 
+		/**
+		 * Filter: 'wpseo_helpscout_beacon_settings' - Allows overriding the HelpScout beacon settings.
+		 *
+		 * @param string $beacon_settings The HelpScout beacon settings.
+		 */
 		$helpscout_settings = \apply_filters( 'wpseo_helpscout_beacon_settings', $filterable_helpscout_setting );
 
 		$this->products  = $helpscout_settings['products'];

--- a/src/integrations/blocks/structured-data-blocks.php
+++ b/src/integrations/blocks/structured-data-blocks.php
@@ -147,7 +147,7 @@ class Structured_Data_Blocks implements Integration_Interface {
 		/**
 		 * Filter: 'wpseo_enable_structured_data_blocks' - Allows disabling Yoast's schema blocks entirely.
 		 *
-		 * @api bool If false, our structured data blocks won't show.
+		 * @param bool $enable If false, our structured data blocks won't show.
 		 */
 		if ( ! \apply_filters( 'wpseo_enable_structured_data_blocks', true ) ) {
 			return;

--- a/src/integrations/cleanup-integration.php
+++ b/src/integrations/cleanup-integration.php
@@ -161,7 +161,7 @@ class Cleanup_Integration implements Integration_Interface {
 		/**
 		 * Filter: Adds the possibility to add addition cleanup functions.
 		 *
-		 * @api array Associative array with unique keys. Value should be a cleanup function that receives a limit.
+		 * @param array $additional_tasks Associative array with unique keys. Value should be a cleanup function that receives a limit.
 		 */
 		$additional_tasks = \apply_filters( 'wpseo_cleanup_tasks', [] );
 
@@ -190,7 +190,7 @@ class Cleanup_Integration implements Integration_Interface {
 		/**
 		 * Filter: Adds the possibility to limit the number of items that are deleted from the database on cleanup.
 		 *
-		 * @api int $limit Maximum number of indexables to be cleaned up per query.
+		 * @param int $limit Maximum number of indexables to be cleaned up per query.
 		 */
 		$limit = \apply_filters( 'wpseo_cron_query_limit_size', 1000 );
 

--- a/src/integrations/front-end-integration.php
+++ b/src/integrations/front-end-integration.php
@@ -396,7 +396,7 @@ class Front_End_Integration implements Integration_Interface {
 		/**
 		 * Filter 'wpseo_frontend_presentation' - Allow filtering the presentation used to output our meta values.
 		 *
-		 * @api Indexable_Presention The indexable presentation.
+		 * @param Indexable_Presention $presentation The indexable presentation.
 		 */
 		$presentation = \apply_filters( 'wpseo_frontend_presentation', $context->presentation, $context );
 
@@ -441,10 +441,8 @@ class Front_End_Integration implements Integration_Interface {
 		/**
 		 * Filter 'wpseo_frontend_presenters' - Allow filtering the presenter instances in or out of the request.
 		 *
-		 * @param array             $presenters The presenters.
-		 * @param Meta_Tags_Context $context    The meta tags context for the current page.
-		 *
-		 * @api Abstract_Indexable_Presenter[] List of presenter instances.
+		 * @param Abstract_Indexable_Presenter[] $presenters List of presenter instances.
+		 * @param Meta_Tags_Context              $context    The meta tags context for the current page.
 		 */
 		$presenter_instances = \apply_filters( 'wpseo_frontend_presenters', $presenters, $context );
 

--- a/src/integrations/front-end/redirects.php
+++ b/src/integrations/front-end/redirects.php
@@ -210,10 +210,10 @@ class Redirects implements Integration_Interface {
 		/**
 		 * Allows the developer to change the target redirection URL for attachments.
 		 *
-		 * @api string $attachment_url The attachment URL for the queried object.
-		 * @api object $queried_object The queried object.
-		 *
 		 * @since 7.5.3
+		 *
+		 * @param string $attachment_url The attachment URL for the queried object.
+		 * @param object $queried_object The queried object.
 		 */
 		return \apply_filters(
 			'wpseo_attachment_redirect_url',

--- a/src/integrations/front-end/rss-footer-embed.php
+++ b/src/integrations/front-end/rss-footer-embed.php
@@ -95,9 +95,8 @@ class RSS_Footer_Embed implements Integration_Interface {
 		/**
 		 * Filter: 'wpseo_include_rss_footer' - Allow the RSS footer to be dynamically shown/hidden.
 		 *
-		 * @api boolean $show_embed Indicates if the RSS footer should be shown or not.
-		 *
-		 * @param string $context The context of the RSS content - 'full' or 'excerpt'.
+		 * @param bool   $show_embed Indicates if the RSS footer should be shown or not.
+		 * @param string $context    The context of the RSS content - 'full' or 'excerpt'.
 		 */
 		if ( ! \apply_filters( 'wpseo_include_rss_footer', true, $context ) ) {
 			return false;
@@ -184,9 +183,9 @@ class RSS_Footer_Embed implements Integration_Interface {
 		 * Filter: 'nofollow_rss_links' - Allow the developer to determine whether or not to follow the links in
 		 * the bits Yoast SEO adds to the RSS feed, defaults to false.
 		 *
-		 * @api bool $unsigned Whether or not to follow the links in RSS feed, defaults to true.
-		 *
 		 * @since 1.4.20
+		 *
+		 * @param bool $unsigned Whether or not to follow the links in RSS feed, defaults to true.
 		 */
 		if ( \apply_filters( 'nofollow_rss_links', false ) ) {
 			return '<a rel="nofollow" href="%1$s">%2$s</a>';

--- a/src/introductions/application/introductions-collector.php
+++ b/src/introductions/application/introductions-collector.php
@@ -66,7 +66,9 @@ class Introductions_Collector {
 		 * Filter: Adds the possibility to add additional introductions to be included.
 		 *
 		 * @internal
-		 * @api Introduction_Interface This filter expects a list of Introduction_Interface instances and expects only Introduction_Interface implementations to be added to the list.
+		 *
+		 * @param Introduction_Interface $introductions This filter expects a list of Introduction_Interface instances and
+		 *                                              expects only Introduction_Interface implementations to be added to the list.
 		 */
 		$filtered_introductions = (array) \apply_filters( 'wpseo_introductions', $introductions );
 

--- a/src/loggers/logger.php
+++ b/src/loggers/logger.php
@@ -29,7 +29,7 @@ class Logger implements LoggerInterface {
 		/**
 		 * Gives the possibility to set override the logger interface.
 		 *
-		 * @api \YoastSEO_Vendor\Psr\Log\LoggerInterface $logger Instance of NullLogger.
+		 * @param LoggerInterface $logger Instance of NullLogger.
 		 *
 		 * @return LoggerInterface The logger object.
 		 */

--- a/src/presentations/indexable-post-type-presentation.php
+++ b/src/presentations/indexable-post-type-presentation.php
@@ -268,9 +268,8 @@ class Indexable_Post_Type_Presentation extends Indexable_Presentation {
 			/**
 			 * Filter: 'wpseo_opengraph_show_publish_date' - Allow showing publication date for other post types.
 			 *
+			 * @param bool   $show      Whether or not to show publish date.
 			 * @param string $post_type The current URL's post type.
-			 *
-			 * @api bool Whether or not to show publish date.
 			 */
 			if ( ! \apply_filters( 'wpseo_opengraph_show_publish_date', false, $this->post->get_post_type( $this->source ) ) ) {
 				return '';
@@ -388,7 +387,7 @@ class Indexable_Post_Type_Presentation extends Indexable_Presentation {
 		/**
 		 * Filter: 'wpseo_twitter_creator_account' - Allow changing the Twitter account as output in the Twitter card by Yoast SEO.
 		 *
-		 * @api string $twitter The twitter account name string.
+		 * @param string $twitter The twitter account name string.
 		 */
 		$twitter_creator = \apply_filters( 'wpseo_twitter_creator_account', $twitter_creator );
 

--- a/src/presentations/indexable-presentation.php
+++ b/src/presentations/indexable-presentation.php
@@ -320,8 +320,7 @@ class Indexable_Presentation extends Abstract_Presentation {
 		/**
 		 * Filter: 'wpseo_robots' - Allows filtering of the meta robots output of Yoast SEO.
 		 *
-		 * @api string $robots The meta robots directives to be echoed.
-		 *
+		 * @param string                 $robots       The meta robots directives to be echoed.
 		 * @param Indexable_Presentation $presentation The presentation of an indexable.
 		 */
 		$robots_filtered = \apply_filters( 'wpseo_robots', $robots_string, $this );
@@ -364,8 +363,7 @@ class Indexable_Presentation extends Abstract_Presentation {
 		/**
 		 * Filter: 'wpseo_robots_array' - Allows filtering of the meta robots output array of Yoast SEO.
 		 *
-		 * @api array $robots The meta robots directives to be used.
-		 *
+		 * @param array                  $robots       The meta robots directives to be used.
 		 * @param Indexable_Presentation $presentation The presentation of an indexable.
 		 */
 		return \apply_filters( 'wpseo_robots_array', \array_filter( $robots ), $this );

--- a/src/presenters/breadcrumbs-presenter.php
+++ b/src/presenters/breadcrumbs-presenter.php
@@ -101,9 +101,8 @@ class Breadcrumbs_Presenter extends Abstract_Indexable_Presenter {
 		/**
 		 * Filter: 'wpseo_breadcrumb_output' - Allow changing the HTML output of the Yoast SEO breadcrumbs class.
 		 *
+		 * @param string                 $output       The HTML output.
 		 * @param Indexable_Presentation $presentation The presentation of an indexable.
-		 *
-		 * @api string $output The HTML output.
 		 */
 		return \apply_filters( 'wpseo_breadcrumb_output', $output, $this->presentation );
 	}
@@ -158,9 +157,8 @@ class Breadcrumbs_Presenter extends Abstract_Indexable_Presenter {
 		/**
 		 * Filter: 'wpseo_breadcrumb_single_link' - Allow changing of each link being put out by the Yoast SEO breadcrumbs class.
 		 *
-		 * @param array $link The link array.
-		 *
-		 * @api string $link_output The output string.
+		 * @param string $link_output The output string.
+		 * @param array  $link        The breadcrumb link array.
 		 */
 		return \apply_filters( 'wpseo_breadcrumb_single_link', $link, $breadcrumb );
 	}
@@ -175,7 +173,7 @@ class Breadcrumbs_Presenter extends Abstract_Indexable_Presenter {
 			/**
 			 * Filter: 'wpseo_breadcrumb_output_id' - Allow changing the HTML ID on the Yoast SEO breadcrumbs wrapper element.
 			 *
-			 * @api string $unsigned ID to add to the wrapper element.
+			 * @param string $unsigned ID to add to the wrapper element.
 			 */
 			$this->id = \apply_filters( 'wpseo_breadcrumb_output_id', '' );
 			if ( ! \is_string( $this->id ) ) {
@@ -200,7 +198,7 @@ class Breadcrumbs_Presenter extends Abstract_Indexable_Presenter {
 			/**
 			 * Filter: 'wpseo_breadcrumb_output_class' - Allow changing the HTML class on the Yoast SEO breadcrumbs wrapper element.
 			 *
-			 * @api string $unsigned Class to add to the wrapper element.
+			 * @param string $unsigned Class to add to the wrapper element.
 			 */
 			$this->class = \apply_filters( 'wpseo_breadcrumb_output_class', '' );
 			if ( ! \is_string( $this->class ) ) {

--- a/src/presenters/canonical-presenter.php
+++ b/src/presenters/canonical-presenter.php
@@ -43,8 +43,7 @@ class Canonical_Presenter extends Abstract_Indexable_Tag_Presenter {
 		/**
 		 * Filter: 'wpseo_canonical' - Allow filtering of the canonical URL put out by Yoast SEO.
 		 *
-		 * @api string $canonical The canonical URL.
-		 *
+		 * @param string                 $canonical    The canonical URL.
 		 * @param Indexable_Presentation $presentation The presentation of an indexable.
 		 */
 		return \urldecode( (string) \trim( \apply_filters( 'wpseo_canonical', $this->presentation->canonical, $this->presentation ) ) );

--- a/src/presenters/debug/marker-close-presenter.php
+++ b/src/presenters/debug/marker-close-presenter.php
@@ -18,7 +18,7 @@ final class Marker_Close_Presenter extends Abstract_Indexable_Presenter {
 		/**
 		 * Filter: 'wpseo_debug_markers' - Allow disabling the debug markers.
 		 *
-		 * @api bool $show_markers True when the debug markers should be shown.
+		 * @param bool $show_markers True when the debug markers should be shown.
 		 */
 		if ( ! \apply_filters( 'wpseo_debug_markers', true ) ) {
 			return '';

--- a/src/presenters/debug/marker-open-presenter.php
+++ b/src/presenters/debug/marker-open-presenter.php
@@ -18,7 +18,7 @@ final class Marker_Open_Presenter extends Abstract_Indexable_Presenter {
 		/**
 		 * Filter: 'wpseo_debug_markers' - Allow disabling the debug markers.
 		 *
-		 * @api bool $show_markers True when the debug markers should be shown.
+		 * @param bool $show_markers True when the debug markers should be shown.
 		 */
 		if ( ! \apply_filters( 'wpseo_debug_markers', true ) ) {
 			return '';
@@ -45,7 +45,7 @@ final class Marker_Open_Presenter extends Abstract_Indexable_Presenter {
 		/**
 		 * Filter: 'wpseo_hide_version' - can be used to hide the Yoast SEO version in the debug marker (only available in Yoast SEO Premium).
 		 *
-		 * @api bool
+		 * @param bool $hide_version
 		 */
 		if ( \apply_filters( 'wpseo_hide_version', false ) ) {
 			return '';

--- a/src/presenters/meta-description-presenter.php
+++ b/src/presenters/meta-description-presenter.php
@@ -53,9 +53,8 @@ class Meta_Description_Presenter extends Abstract_Indexable_Tag_Presenter {
 		/**
 		 * Filter: 'wpseo_metadesc' - Allow changing the Yoast SEO meta description sentence.
 		 *
-		 * @api string $meta_description The description sentence.
-		 *
-		 * @param Indexable_Presentation $presentation The presentation of an indexable.
+		 * @param string                 $meta_description The description sentence.
+		 * @param Indexable_Presentation $presentation     The presentation of an indexable.
 		 */
 		$meta_description = \apply_filters( 'wpseo_metadesc', $meta_description, $this->presentation );
 		$meta_description = $this->helpers->string->strip_all_tags( \stripslashes( $meta_description ) );

--- a/src/presenters/open-graph/article-author-presenter.php
+++ b/src/presenters/open-graph/article-author-presenter.php
@@ -33,9 +33,8 @@ class Article_Author_Presenter extends Abstract_Indexable_Tag_Presenter {
 		/**
 		 * Filter: 'wpseo_opengraph_author_facebook' - Allow developers to filter the article author's Facebook URL.
 		 *
-		 * @api bool|string $article_author The article author's Facebook URL, return false to disable.
-		 *
-		 * @param Indexable_Presentation $presentation The presentation of an indexable.
+		 * @param bool|string            $article_author The article author's Facebook URL, return false to disable.
+		 * @param Indexable_Presentation $presentation   The presentation of an indexable.
 		 */
 		return \trim( \apply_filters( 'wpseo_opengraph_author_facebook', $this->presentation->open_graph_article_author, $this->presentation ) );
 	}

--- a/src/presenters/open-graph/article-publisher-presenter.php
+++ b/src/presenters/open-graph/article-publisher-presenter.php
@@ -33,9 +33,8 @@ class Article_Publisher_Presenter extends Abstract_Indexable_Tag_Presenter {
 		/**
 		 * Filter: 'wpseo_og_article_publisher' - Allow developers to filter the article publisher's Facebook URL.
 		 *
-		 * @api bool|string $article_publisher The article publisher's Facebook URL, return false to disable.
-		 *
-		 * @param Indexable_Presentation $presentation The presentation of an indexable.
+		 * @param bool|string            $article_publisher The article publisher's Facebook URL, return false to disable.
+		 * @param Indexable_Presentation $presentation      The presentation of an indexable.
 		 */
 		return \trim( \apply_filters( 'wpseo_og_article_publisher', $this->presentation->open_graph_article_publisher, $this->presentation ) );
 	}

--- a/src/presenters/open-graph/description-presenter.php
+++ b/src/presenters/open-graph/description-presenter.php
@@ -35,8 +35,7 @@ class Description_Presenter extends Abstract_Indexable_Tag_Presenter {
 		/**
 		 * Filter: 'wpseo_opengraph_desc' - Allow changing the Yoast SEO generated Open Graph description.
 		 *
-		 * @api string The description.
-		 *
+		 * @param string                 $description  The description.
 		 * @param Indexable_Presentation $presentation The presentation of an indexable.
 		 */
 		$meta_og_description = \apply_filters( 'wpseo_opengraph_desc', $meta_og_description, $this->presentation );

--- a/src/presenters/open-graph/image-presenter.php
+++ b/src/presenters/open-graph/image-presenter.php
@@ -96,8 +96,7 @@ class Image_Presenter extends Abstract_Indexable_Presenter {
 		/**
 		 * Filter: 'wpseo_opengraph_image' - Allow changing the Open Graph image.
 		 *
-		 * @api string - The URL of the Open Graph image.
-		 *
+		 * @param string                 $image_url    The URL of the Open Graph image.
 		 * @param Indexable_Presentation $presentation The presentation of an indexable.
 		 */
 		$image_url = \trim( \apply_filters( 'wpseo_opengraph_image', $image['url'], $this->presentation ) );

--- a/src/presenters/open-graph/locale-presenter.php
+++ b/src/presenters/open-graph/locale-presenter.php
@@ -33,8 +33,7 @@ final class Locale_Presenter extends Abstract_Indexable_Tag_Presenter {
 		/**
 		 * Filter: 'wpseo_og_locale' - Allow changing the Yoast SEO Open Graph locale.
 		 *
-		 * @api string The locale string
-		 *
+		 * @param string                 $locale       The locale string
 		 * @param Indexable_Presentation $presentation The presentation of an indexable.
 		 */
 		return (string) \trim( \apply_filters( 'wpseo_og_locale', $this->presentation->open_graph_locale, $this->presentation ) );

--- a/src/presenters/open-graph/site-name-presenter.php
+++ b/src/presenters/open-graph/site-name-presenter.php
@@ -33,8 +33,7 @@ class Site_Name_Presenter extends Abstract_Indexable_Tag_Presenter {
 		/**
 		 * Filter: 'wpseo_opengraph_site_name' - Allow changing the Yoast SEO generated Open Graph site name.
 		 *
-		 * @api string $site_name The site_name.
-		 *
+		 * @param string                 $site_name    The site_name.
 		 * @param Indexable_Presentation $presentation The presentation of an indexable.
 		 */
 		return (string) \trim( \apply_filters( 'wpseo_opengraph_site_name', $this->presentation->open_graph_site_name, $this->presentation ) );

--- a/src/presenters/open-graph/title-presenter.php
+++ b/src/presenters/open-graph/title-presenter.php
@@ -35,9 +35,8 @@ class Title_Presenter extends Abstract_Indexable_Tag_Presenter {
 		/**
 		 * Filter: 'wpseo_opengraph_title' - Allow changing the Yoast SEO generated title.
 		 *
+		 * @param string                 $title        The title.
 		 * @param Indexable_Presentation $presentation The presentation of an indexable.
-		 *
-		 * @api string $title The title.
 		 */
 		$title = (string) \trim( \apply_filters( 'wpseo_opengraph_title', $title, $this->presentation ) );
 		return $this->helpers->string->strip_all_tags( $title );

--- a/src/presenters/open-graph/type-presenter.php
+++ b/src/presenters/open-graph/type-presenter.php
@@ -33,8 +33,7 @@ class Type_Presenter extends Abstract_Indexable_Tag_Presenter {
 		/**
 		 * Filter: 'wpseo_opengraph_type' - Allow changing the opengraph type.
 		 *
-		 * @api string $type The type.
-		 *
+		 * @param string                 $type         The type.
 		 * @param Indexable_Presentation $presentation The presentation of an indexable.
 		 */
 		return (string) \apply_filters( 'wpseo_opengraph_type', $this->presentation->open_graph_type, $this->presentation );

--- a/src/presenters/open-graph/url-presenter.php
+++ b/src/presenters/open-graph/url-presenter.php
@@ -40,8 +40,7 @@ class Url_Presenter extends Abstract_Indexable_Tag_Presenter {
 		/**
 		 * Filter: 'wpseo_opengraph_url' - Allow changing the Yoast SEO generated open graph URL.
 		 *
-		 * @api string $url The open graph URL.
-		 *
+		 * @param string                 $url          The open graph URL.
 		 * @param Indexable_Presentation $presentation The presentation of an indexable.
 		 */
 		return \urldecode( (string) \apply_filters( 'wpseo_opengraph_url', $this->presentation->open_graph_url, $this->presentation ) );

--- a/src/presenters/rel-next-presenter.php
+++ b/src/presenters/rel-next-presenter.php
@@ -42,7 +42,7 @@ class Rel_Next_Presenter extends Abstract_Indexable_Tag_Presenter {
 			/**
 			 * Filter: 'wpseo_next_rel_link' - Allow changing link rel output by Yoast SEO.
 			 *
-			 * @api string $unsigned The full `<link` element.
+			 * @param string $unsigned The full `<link` element.
 			 */
 			return \apply_filters( 'wpseo_next_rel_link', $output );
 		}
@@ -63,8 +63,7 @@ class Rel_Next_Presenter extends Abstract_Indexable_Tag_Presenter {
 		/**
 		 * Filter: 'wpseo_adjacent_rel_url' - Allow filtering of the rel next URL put out by Yoast SEO.
 		 *
-		 * @api string $rel_next The rel next URL.
-		 *
+		 * @param string                 $rel_next     The rel next URL.
 		 * @param string                 $rel          Link relationship, prev or next.
 		 * @param Indexable_Presentation $presentation The presentation of an indexable.
 		 */

--- a/src/presenters/rel-prev-presenter.php
+++ b/src/presenters/rel-prev-presenter.php
@@ -42,7 +42,7 @@ class Rel_Prev_Presenter extends Abstract_Indexable_Tag_Presenter {
 			/**
 			 * Filter: 'wpseo_prev_rel_link' - Allow changing link rel output by Yoast SEO.
 			 *
-			 * @api string $unsigned The full `<link` element.
+			 * @param string $unsigned The full `<link` element.
 			 */
 			return \apply_filters( 'wpseo_prev_rel_link', $output );
 		}
@@ -63,9 +63,9 @@ class Rel_Prev_Presenter extends Abstract_Indexable_Tag_Presenter {
 		/**
 		 * Filter: 'wpseo_adjacent_rel_url' - Allow filtering of the rel prev URL put out by Yoast SEO.
 		 *
-		 * @api string $canonical The rel prev URL.
-		 *
+		 * @param string                 $canonical    The rel prev URL.
 		 * @param string                 $rel          Link relationship, prev or next.
+		 * @param Indexable_Presentation $presentation The presentation of an indexable.
 		 */
 		return (string) \trim( \apply_filters( 'wpseo_adjacent_rel_url', $this->presentation->rel_prev, 'prev', $this->presentation ) );
 	}

--- a/src/presenters/schema-presenter.php
+++ b/src/presenters/schema-presenter.php
@@ -29,7 +29,7 @@ class Schema_Presenter extends Abstract_Indexable_Presenter {
 		/**
 		 * Filter: 'wpseo_json_ld_output' - Allows disabling Yoast's schema output entirely.
 		 *
-		 * @api mixed If false or an empty array is returned, disable our output.
+		 * @param mixed $deprecated If false or an empty array is returned, disable our output.
 		 */
 		$return = \apply_filters( 'wpseo_json_ld_output', $deprecated_data, '' );
 		if ( $return === [] || $return === false ) {

--- a/src/presenters/slack/enhanced-data-presenter.php
+++ b/src/presenters/slack/enhanced-data-presenter.php
@@ -58,8 +58,7 @@ class Enhanced_Data_Presenter extends Abstract_Indexable_Presenter {
 		/**
 		 * Filter: 'wpseo_enhanced_slack_data' - Allows filtering of the enhanced data for sharing on Slack.
 		 *
-		 * @api array $data The enhanced Slack sharing data.
-		 *
+		 * @param array                  $data         The enhanced Slack sharing data.
 		 * @param Indexable_Presentation $presentation The presentation of an indexable.
 		 */
 		return \apply_filters( 'wpseo_enhanced_slack_data', $data, $this->presentation );

--- a/src/presenters/title-presenter.php
+++ b/src/presenters/title-presenter.php
@@ -69,8 +69,7 @@ class Title_Presenter extends Abstract_Indexable_Tag_Presenter {
 		/**
 		 * Filter: 'wpseo_title' - Allow changing the Yoast SEO generated title.
 		 *
-		 * @api string $title The title.
-		 *
+		 * @param string                 $title        The title.
 		 * @param Indexable_Presentation $presentation The presentation of an indexable.
 		 */
 		$title = \apply_filters( 'wpseo_title', $title, $this->presentation );

--- a/src/presenters/twitter/description-presenter.php
+++ b/src/presenters/twitter/description-presenter.php
@@ -26,9 +26,8 @@ class Description_Presenter extends Abstract_Indexable_Tag_Presenter {
 		/**
 		 * Filter: 'wpseo_twitter_description' - Allow changing the Twitter description as output in the Twitter card by Yoast SEO.
 		 *
-		 * @api string $twitter_description The description string.
-		 *
-		 * @param Indexable_Presentation $presentation The presentation of an indexable.
+		 * @param string                 $twitter_description The description string.
+		 * @param Indexable_Presentation $presentation        The presentation of an indexable.
 		 */
 		return \apply_filters( 'wpseo_twitter_description', $this->replace_vars( $this->presentation->twitter_description ), $this->presentation );
 	}

--- a/src/presenters/twitter/image-presenter.php
+++ b/src/presenters/twitter/image-presenter.php
@@ -33,9 +33,8 @@ class Image_Presenter extends Abstract_Indexable_Tag_Presenter {
 		/**
 		 * Filter: 'wpseo_twitter_image' - Allow changing the Twitter Card image.
 		 *
-		 * @param Indexable_Presentation $presentation The presentation of an indexable.
-		 *
-		 * @api string $twitter_image Image URL string.
+		 * @param string                 $twitter_image Image URL string.
+		 * @param Indexable_Presentation $presentation  The presentation of an indexable.
 		 */
 		return (string) \apply_filters( 'wpseo_twitter_image', $this->presentation->twitter_image, $this->presentation );
 	}

--- a/src/presenters/twitter/site-presenter.php
+++ b/src/presenters/twitter/site-presenter.php
@@ -26,8 +26,7 @@ class Site_Presenter extends Abstract_Indexable_Tag_Presenter {
 		/**
 		 * Filter: 'wpseo_twitter_site' - Allow changing the Twitter site account as output in the Twitter card by Yoast SEO.
 		 *
-		 * @api string $twitter_site Twitter site account string.
-		 *
+		 * @param string                 $twitter_site Twitter site account string.
 		 * @param Indexable_Presentation $presentation The presentation of an indexable.
 		 */
 		$twitter_site = \apply_filters( 'wpseo_twitter_site', $this->presentation->twitter_site, $this->presentation );

--- a/src/presenters/twitter/title-presenter.php
+++ b/src/presenters/twitter/title-presenter.php
@@ -26,9 +26,8 @@ class Title_Presenter extends Abstract_Indexable_Tag_Presenter {
 		/**
 		 * Filter: 'wpseo_twitter_title' - Allow changing the Twitter title.
 		 *
-		 * @api string $twitter_title The Twitter title.
-		 *
-		 * @param Indexable_Presentation $presentation The presentation of an indexable.
+		 * @param string                 $twitter_title The Twitter title.
+		 * @param Indexable_Presentation $presentation  The presentation of an indexable.
 		 */
 		return \trim( \apply_filters( 'wpseo_twitter_title', $this->replace_vars( $this->presentation->twitter_title ), $this->presentation ) );
 	}

--- a/src/routes/workouts-route.php
+++ b/src/routes/workouts-route.php
@@ -78,7 +78,7 @@ class Workouts_Route implements Route_Interface {
 		/**
 		 * Filter: 'Yoast\WP\SEO\workouts_options' - Allows adding workouts options by the add-ons.
 		 *
-		 * @api array $workouts_option The content of the `workouts_data` option in Free.
+		 * @param array $workouts_option The content of the `workouts_data` option in Free.
 		 */
 		$workouts_option = \apply_filters( 'Yoast\WP\SEO\workouts_options', $workouts_option );
 
@@ -100,7 +100,7 @@ class Workouts_Route implements Route_Interface {
 		/**
 		 * Filter: 'Yoast\WP\SEO\workouts_route_save' - Allows the add-ons to save the options data in their own options.
 		 *
-		 * @api mixed|null $result The result of the previous saving operation.
+		 * @param mixed|null $result The result of the previous saving operation.
 		 *
 		 * @param array $workouts_data The full set of workouts option data to save.
 		 */
@@ -122,7 +122,7 @@ class Workouts_Route implements Route_Interface {
 		/**
 		 * Filter: 'Yoast\WP\SEO\workouts_route_args' - Allows the add-ons add their own arguments to the route registration.
 		 *
-		 * @api array $args_array The array of arguments for the route registration.
+		 * @param array $args_array The array of arguments for the route registration.
 		 */
 		return \apply_filters( 'Yoast\WP\SEO\workouts_route_args', $args_array );
 	}


### PR DESCRIPTION
## Context

* Code QA/consistency

## Summary

This PR can be summarized in the following changelog entry:

* Code QA/consistency

## Relevant technical choices:

Remove use of `@api` for hook docs and improve those docs which were affected to comply with the WP Docs standards.

Refs:
* https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/#4-hooks-actions-and-filters

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_ No functional changes.