### PR TITLE
Composer/PHPCS: update to YoastCS 3.0.0

### DIFF
--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.4'
+          php-version: 'latest'
           coverage: none
           tools: cs2pr
 

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -8,7 +8,7 @@
 	<!--
 	#############################################################################
 	COMMAND LINE ARGUMENTS
-	https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml
+	https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Annotated-ruleset.xml
 	#############################################################################
 	-->
 
@@ -50,14 +50,28 @@
 				<element value="yoast_seo"/>
 			</property>
 
-			<!-- Set the custom test class whitelist for all sniffs which use it in one go.
-				 Ref: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#custom-unit-test-classes
+			<!-- Set the custom test class list for all sniffs which use it in one go.
+				 Ref: https://github.com/WordPress/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#custom-unit-test-classes
 			-->
-			<property name="custom_test_class_whitelist" type="array">
+			<property name="custom_test_classes" type="array">
 				<element value="Yoast\WP\SEO\Tests\Unit\TestCase"/>
 				<element value="Yoast\WP\SEO\Tests\WP\TestCase"/>
 			</property>
+
+			<property name="psr4_paths" type="array">
+				<element key="Yoast\WP\SEO\Tests\\" value="tests/"/>
+			</property>
 		</properties>
+	</rule>
+
+	<!-- Enforce PSR1 compatible namespaces. -->
+	<rule ref="PSR1.Classes.ClassDeclaration">
+		<!-- YoastCS only applies this rule to test files. Overrule it to also apply to src files. -->
+		<include-pattern>*/config/*\.php$</include-pattern>
+		<include-pattern>*/src/*\.php$</include-pattern>
+
+		<exclude-pattern>*/src/deprecated/*\.php$</exclude-pattern>
+		<exclude-pattern>*/src/config/migrations/*\.php$</exclude-pattern>
 	</rule>
 
 
@@ -84,9 +98,6 @@
 				<element value="wp-seo-main.php"/>
 				<!-- Don't trigger on select view related files. -->
 				<element value="admin/views/tool-bulk-editor.php"/>
-				<!-- Don't trigger on test bootstrap files. -->
-				<element value="tests/Unit/bootstrap.php"/>
-				<element value="tests/WP/bootstrap.php"/>
 			</property>
 
 			<!-- Remove the following prefixes from the names of object structures. -->
@@ -103,15 +114,6 @@
 		<exclude-pattern>/src/config/migrations/*\.php$</exclude-pattern>
 	</rule>
 
-	<rule ref="Yoast.Files.TestDoubles">
-		<properties>
-			<property name="doubles_path" type="array" extend="true">
-				<element value="/tests/Unit/Doubles"/>
-				<element value="/tests/WP/Doubles"/>
-			</property>
-		</properties>
-	</rule>
-
 	<rule ref="Yoast.NamingConventions.ObjectNameDepth">
 		<properties>
 			<property name="max_words" value="5" />
@@ -126,15 +128,7 @@
 			<property name="src_directory" type="array">
 				<element value="config"/>
 				<element value="src"/>
-				<element value="tests/Unit"/>
-				<element value="tests/WP"/>
 				<element value="src/deprecated/src"/>
-			</property>
-
-			<!-- Allow for the tests being in a non-standard directory in YoastSEO Free. -->
-			<property name="prefixes" type="array" extend="true">
-				<element value="Yoast\WP\SEO\Tests\Unit"/>
-				<element value="Yoast\WP\SEO\Tests\WP"/>
 			</property>
 		</properties>
 	</rule>
@@ -144,7 +138,7 @@
 			<!-- We discovered that WP_Filesystem can lead to unexpected behaviour.
 				 See https://github.com/Yoast/wordpress-seo/pull/15713 -->
 			<property name="exclude" type="array" extend="true">
-				<element value="file_system_read"/>
+				<element value="file_system_operations"/>
 			</property>
 		</properties>
 	</rule>
@@ -155,6 +149,15 @@
 		</properties>
 	</rule>
 
+	<!-- Make sure custom capabilities are recognized. -->
+	<rule ref="WordPress.WP.Capabilities">
+		<properties>
+			<property name="custom_capabilities" type="array">
+				<element value="wpseo_manage_network_options"/>
+				<element value="wpseo_manage_options"/>
+			</property>
+		</properties>
+	</rule>
 
 	<!--
 	##########################################################################
@@ -163,14 +166,24 @@
 	#############################################################################
 	-->
 
+	<!-- For named parameter support, the parameters in the overloaded methods *must*
+		 mirror the parameter name as used in Symfony itself.
+		 These cannot be changed until Symfony itself changes the names. -->
+	<rule ref="Universal.NamingConventions.NoReservedKeywordParameterNames.namespaceFound">
+		<exclude-pattern>/config/dependency-injection/custom-loader\.php$</exclude-pattern>
+	</rule>
+	<rule ref="Universal.NamingConventions.NoReservedKeywordParameterNames.resourceFound">
+		<exclude-pattern>/config/dependency-injection/custom-loader\.php$</exclude-pattern>
+	</rule>
+
 	<!-- Exclude the "lib" folder from select naming conventions.
 		 The intention is to extract this to a separate package, so the names are
 		 based on the "future" package. -->
 	<rule ref="Yoast.NamingConventions.NamespaceName">
-		<exclude-pattern>/lib/*</exclude-pattern>
+		<exclude-pattern type="relative">/lib/([a-z-]+/)?[^/]+\.php$</exclude-pattern>
 	</rule>
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedNamespaceFound">
-		<exclude-pattern>/lib/*</exclude-pattern>
+		<exclude-pattern type="relative">/lib/([a-z-]+/)?[^/]+\.php$</exclude-pattern>
 	</rule>
 
 	<!-- Exclude select directories from the object depth naming convention check. -->
@@ -202,6 +215,9 @@
 	<!-- Exclude deprecated code from select sniffs regarding naming conventions.
 		 These classes are still available to prevent BC-breaks and renaming them would
 		 create a BC-break. -->
+	<rule ref="Universal.NamingConventions.NoReservedKeywordParameterNames">
+		<exclude-pattern>/src/deprecated/*</exclude-pattern>
+	</rule>
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
 		<exclude-pattern>/src/deprecated/*</exclude-pattern>
 	</rule>
@@ -222,6 +238,16 @@
 		<exclude-pattern>/tests/*</exclude-pattern>
 	</rule>
 
+	<!-- Valid usage: For setting up/tearing down a test situation, it is better to use the PHP native functions. -->
+	<rule ref="WordPress.WP.AlternativeFunctions.unlink_unlink">
+		<exclude-pattern>/tests/WP/Formatter/Metabox_Formatter_Test\.php$</exclude-pattern>
+	</rule>
+
+	<!-- Valid usage: Mocking the WP native wp_parse_url() function. -->
+	<rule ref="WordPress.WP.AlternativeFunctions.parse_url_parse_url">
+		<exclude-pattern>/tests/Unit/*\.php$</exclude-pattern>
+	</rule>
+
 	<!-- Test code does not go into production, so security is not an issue. -->
 	<rule ref="WordPress.Security">
 		<exclude-pattern>/tests/*</exclude-pattern>
@@ -230,21 +256,6 @@
 	<!-- Changing the cron interval to test things, is fine. -->
 	<rule ref="WordPress.WP.CronInterval">
 		<exclude-pattern>/tests/*</exclude-pattern>
-	</rule>
-
-	<!-- The unit tests are not run within the context of a WP install, so overwritting globals is fine. -->
-	<rule ref="WordPress.WP.GlobalVariablesOverride">
-		<exclude-pattern>/tests/*</exclude-pattern>
-	</rule>
-
-	<!-- Allow for the double/mock classes to override methods just to change the visibility. -->
-	<rule ref="Generic.CodeAnalysis.UselessOverridingMethod">
-		<exclude-pattern>/tests/*/Doubles/*</exclude-pattern>
-	</rule>
-
-	<!-- Test mock/double classes do not have to be prefixed. -->
-	<rule ref="WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound">
-		<exclude-pattern>/tests/*/Doubles/*</exclude-pattern>
 	</rule>
 
 	<!-- For documentation of the double/mock classes, please refer to the _real_ classes. -->
@@ -291,20 +302,6 @@
 
 		<!-- Exclude hooks everywhere for the time being until the prefixes will be fixed. -->
 		<exclude name="WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound"/>
-	</rule>
-
-	<!-- The below issues will be fixed in YoastCS 3.0, after which these excludes can be removed. -->
-	<rule ref="Yoast.Files.FileName.InvalidClassFileName">
-		<exclude-pattern>/tests/*\.php$</exclude-pattern>
-	</rule>
-	<rule ref="Yoast.Files.FileName.InvalidTraitFileName">
-		<exclude-pattern>/tests/Unit/*\.php$</exclude-pattern>
-	</rule>
-	<rule ref="Yoast.NamingConventions.NamespaceName.Invalid">
-		<exclude-pattern>/tests/(Unit|WP)/*_*/*\.php$</exclude-pattern>
-	</rule>
-	<rule ref="Yoast.Commenting.FileComment.Unnecessary">
-		<exclude-pattern>/tests/*/bootstrap\.php$</exclude-pattern>
 	</rule>
 
 </ruleset>

--- a/admin/class-product-upsell-notice.php
+++ b/admin/class-product-upsell-notice.php
@@ -70,7 +70,7 @@ class WPSEO_Product_Upsell_Notice {
 	 * @return void
 	 */
 	public function dismiss_notice_listener() {
-		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Reason: We are validating a nonce here.
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Reason: We are validating a nonce here.
 		if ( ! isset( $_GET['_wpnonce'] ) || ! wp_verify_nonce( $_GET['_wpnonce'], 'dismiss-5star-upsell' ) ) {
 			return;
 		}

--- a/admin/class-yoast-notification-center.php
+++ b/admin/class-yoast-notification-center.php
@@ -534,9 +534,9 @@ class Yoast_Notification_Center {
 	 */
 	public function ajax_get_notifications() {
 		$echo = false;
-		// phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Reason: We are not processing form data.
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Reason: We are not processing form data.
 		if ( isset( $_POST['version'] ) && is_string( $_POST['version'] ) ) {
-			// phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Reason: We are only comparing the variable in a condition.
+			// phpcs:ignore WordPress.Security.NonceVerification.Missing,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Reason: We are only comparing the variable in a condition.
 			$echo = wp_unslash( $_POST['version'] ) === '2';
 		}
 
@@ -703,7 +703,7 @@ class Yoast_Notification_Center {
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized,WordPress.Security.NonceVerification.Missing -- Reason: We are not processing form information and only using this variable in a comparison.
 		$request_method = isset( $_SERVER['REQUEST_METHOD'] ) && is_string( $_SERVER['REQUEST_METHOD'] ) ? strtoupper( wp_unslash( $_SERVER['REQUEST_METHOD'] ) ) : '';
 		// phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Reason: This function does not sanitize variables.
-		// phpcs:disable WordPress.Security.NonceVerification.Recommended, WordPress.Security.NonceVerification.Missing -- Reason: This function does not verify a nonce.
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended,WordPress.Security.NonceVerification.Missing -- Reason: This function does not verify a nonce.
 		if ( $request_method === 'POST' ) {
 			if ( isset( $_POST[ $key ] ) && is_string( $_POST[ $key ] ) ) {
 				return wp_unslash( $_POST[ $key ] );
@@ -712,7 +712,7 @@ class Yoast_Notification_Center {
 		elseif ( isset( $_GET[ $key ] ) && is_string( $_GET[ $key ] ) ) {
 			return wp_unslash( $_GET[ $key ] );
 		}
-		// phpcs:enable WordPress.Security.NonceVerification.Missing, WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		// phpcs:enable WordPress.Security.NonceVerification.Missing,WordPress.Security.NonceVerification.Missing,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		return '';
 	}
 

--- a/admin/class-yoast-plugin-conflict.php
+++ b/admin/class-yoast-plugin-conflict.php
@@ -75,7 +75,7 @@ class Yoast_Plugin_Conflict {
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Reason: We are not processing form information.
 		if ( isset( $_GET['action'] ) && is_string( $_GET['action'] ) ) {
-			// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Reason: We are not processing form information and only comparing the variable in a condition.
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Reason: We are not processing form information and only comparing the variable in a condition.
 			$action = wp_unslash( $_GET['action'] );
 			if ( $action === 'deactivate' ) {
 				$this->remove_deactivated_plugin();

--- a/admin/import/plugins/class-import-aioseo-v4.php
+++ b/admin/import/plugins/class-import-aioseo-v4.php
@@ -107,7 +107,7 @@ class WPSEO_Import_AIOSEO_V4 extends WPSEO_Plugin_Importer {
 		// Now, we'll also loop through the replace_vars array, which holds the mappings between the AiOSEO variables and the Yoast variables.
 		// We'll replace all the AiOSEO variables in the temporary table with their Yoast equivalents.
 		foreach ( $this->replace_vars as $aioseo_variable => $yoast_variable ) {
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Reason: We need this query and this is done at many other places as well, for example class-import-rankmath.
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Reason: We need this query and this is done at many other places as well, for example class-import-rankmath.
 			$wpdb->query(
 				$wpdb->prepare(
 					'UPDATE tmp_meta_table SET meta_value = REPLACE( meta_value, %s, %s )',
@@ -184,7 +184,7 @@ class WPSEO_Import_AIOSEO_V4 extends WPSEO_Plugin_Importer {
 			$aioseo_variable = "#{$aioseo_prefix}-{$unique_custom_field_or_taxonomy}";
 			$yoast_variable  = "%%{$yoast_prefix}_{$unique_custom_field_or_taxonomy}%%";
 
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 			$wpdb->query(
 				$wpdb->prepare(
 					'UPDATE tmp_meta_table SET meta_value = REPLACE( meta_value, %s, %s )',
@@ -195,7 +195,7 @@ class WPSEO_Import_AIOSEO_V4 extends WPSEO_Plugin_Importer {
 		}
 	}
 
-	// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+	// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 
 	/**
 	 * Retrieve all the meta values from the temporary meta table that contain
@@ -216,7 +216,7 @@ class WPSEO_Import_AIOSEO_V4 extends WPSEO_Plugin_Importer {
 		);
 	}
 
-	// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+	// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 
 	/**
 	 * Detects whether there is AIOSEO data to import by looking whether the AIOSEO data have been cleaned up.

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -975,7 +975,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Reason: We are not processing form information.
 		if ( isset( $_GET['post'] ) && is_string( $_GET['post'] ) ) {
-			// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Reason: We are not processing form information, Sanitization happens in the validate_int function.
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Reason: We are not processing form information, Sanitization happens in the validate_int function.
 			$post_id = (int) WPSEO_Utils::validate_int( wp_unslash( $_GET['post'] ) );
 
 			$this->post = get_post( $post_id );

--- a/admin/taxonomy/class-taxonomy-columns.php
+++ b/admin/taxonomy/class-taxonomy-columns.php
@@ -125,7 +125,7 @@ class WPSEO_Taxonomy_Columns {
 	 * @return string|null The current taxonomy or null when it is not set.
 	 */
 	public function get_current_taxonomy() {
-		// phpcs:disable WordPress.Security.NonceVerification.Missing, WordPress.Security.NonceVerification.Recommended -- Reason: We are not processing form information.
+		// phpcs:disable WordPress.Security.NonceVerification.Missing,WordPress.Security.NonceVerification.Recommended -- Reason: We are not processing form information.
 		if ( ! empty( $_SERVER['REQUEST_METHOD'] ) && $_SERVER['REQUEST_METHOD'] === 'POST' ) {
 			if ( isset( $_POST['taxonomy'] ) && is_string( $_POST['taxonomy'] ) ) {
 				return sanitize_text_field( wp_unslash( $_POST['taxonomy'] ) );
@@ -134,7 +134,7 @@ class WPSEO_Taxonomy_Columns {
 		elseif ( isset( $_GET['taxonomy'] ) && is_string( $_GET['taxonomy'] ) ) {
 			return sanitize_text_field( wp_unslash( $_GET['taxonomy'] ) );
 		}
-		// phpcs:enable WordPress.Security.NonceVerification.Missing, WordPress.Security.NonceVerification.Recommended
+		// phpcs:enable WordPress.Security.NonceVerification.Missing,WordPress.Security.NonceVerification.Recommended
 		return null;
 	}
 
@@ -144,7 +144,7 @@ class WPSEO_Taxonomy_Columns {
 	 * @return string|null
 	 */
 	private function get_taxonomy() {
-		// phpcs:disable WordPress.Security.NonceVerification.Missing, WordPress.Security.NonceVerification.Recommended -- Reason: We are not processing form information.
+		// phpcs:disable WordPress.Security.NonceVerification.Missing,WordPress.Security.NonceVerification.Recommended -- Reason: We are not processing form information.
 		if ( wp_doing_ajax() ) {
 			if ( isset( $_POST['taxonomy'] ) && is_string( $_POST['taxonomy'] ) ) {
 				return sanitize_text_field( wp_unslash( $_POST['taxonomy'] ) );
@@ -153,7 +153,7 @@ class WPSEO_Taxonomy_Columns {
 		elseif ( isset( $_GET['taxonomy'] ) && is_string( $_GET['taxonomy'] ) ) {
 			return sanitize_text_field( wp_unslash( $_GET['taxonomy'] ) );
 		}
-		// phpcs:enable WordPress.Security.NonceVerification.Missing, WordPress.Security.NonceVerification.Recommended
+		// phpcs:enable WordPress.Security.NonceVerification.Missing,WordPress.Security.NonceVerification.Recommended
 		return null;
 	}
 

--- a/admin/taxonomy/class-taxonomy.php
+++ b/admin/taxonomy/class-taxonomy.php
@@ -221,7 +221,7 @@ class WPSEO_Taxonomy {
 		foreach ( WPSEO_Taxonomy_Meta::$defaults_per_term as $key => $default ) {
 			// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Reason: Nonce is already checked by WordPress before executing this action.
 			if ( isset( $_POST[ $key ] ) && is_string( $_POST[ $key ] ) ) {
-				// phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Reason: $data is getting sanitized later.
+				// phpcs:ignore WordPress.Security.NonceVerification.Missing,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Reason: $data is getting sanitized later.
 				$data                  = wp_unslash( $_POST[ $key ] );
 				$new_meta_data[ $key ] = ( $key !== 'wpseo_canonical' ) ? WPSEO_Utils::sanitize_text_field( $data ) : WPSEO_Utils::sanitize_url( $data );
 			}
@@ -401,7 +401,7 @@ class WPSEO_Taxonomy {
 	private static function get_tag_id() {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Reason: We are not processing form information.
 		if ( isset( $_GET['tag_ID'] ) && is_string( $_GET['tag_ID'] ) ) {
-			// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Reason: We are not processing form information, We are casting to an integer.
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Reason: We are not processing form information, We are casting to an integer.
 			$tag_id = (int) wp_unslash( $_GET['tag_ID'] );
 			if ( $tag_id > 0 ) {
 				return $tag_id;

--- a/admin/views/tabs/tool/wpseo-export.php
+++ b/admin/views/tabs/tool/wpseo-export.php
@@ -14,7 +14,7 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 /* translators: %1$s expands to Yoast SEO */
 $submit_button_value = sprintf( __( 'Export your %1$s settings', 'wordpress-seo' ), 'Yoast SEO' );
 
-// phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Reason: The nonce will be verified in WPSEO_Export below, We are only strictly comparing with '1'.
+// phpcs:ignore WordPress.Security.NonceVerification.Missing,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Reason: The nonce will be verified in WPSEO_Export below, We are only strictly comparing with '1'.
 if ( isset( $_POST['do_export'] ) && wp_unslash( $_POST['do_export'] ) === '1' ) {
 	$export = new WPSEO_Export();
 	$export->export();

--- a/composer.json
+++ b/composer.json
@@ -91,8 +91,8 @@
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_coding_standards"
 		],
 		"check-cs-thresholds": [
-			"@putenv YOASTCS_THRESHOLD_ERRORS=127",
-			"@putenv YOASTCS_THRESHOLD_WARNINGS=202",
+			"@putenv YOASTCS_THRESHOLD_ERRORS=2713",
+			"@putenv YOASTCS_THRESHOLD_WARNINGS=301",
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_cs_thresholds"
 		],
 		"check-cs": [

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
 		"symfony/dependency-injection": "^3.4",
 		"wordproof/wordpress-sdk": "1.3.5",
 		"yoast/wp-test-utils": "^1.2",
-		"yoast/yoastcs": "^2.3.1"
+		"yoast/yoastcs": "^3.0"
 	},
 	"suggest": {
 		"ext-bcmath": "For more accurate calculations",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "86ce4a3fd495d19959a406e5e10672d5",
+    "content-hash": "28dae8306bc908bcd1e0b4f998e9f17e",
     "packages": [
         {
             "name": "composer/installers",
@@ -200,6 +200,60 @@
                 "source": "https://github.com/antecedent/patchwork/tree/2.1.26"
             },
             "time": "2023-09-18T08:18:37+00:00"
+        },
+        {
+            "name": "automattic/vipwpcs",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/VIP-Coding-Standards.git",
+                "reference": "1b8960ebff9ea3eb482258a906ece4d1ee1e25fd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/VIP-Coding-Standards/zipball/1b8960ebff9ea3eb482258a906ece4d1ee1e25fd",
+                "reference": "1b8960ebff9ea3eb482258a906ece4d1ee1e25fd",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "phpcsstandards/phpcsextra": "^1.1.0",
+                "phpcsstandards/phpcsutils": "^1.0.8",
+                "sirbrillig/phpcs-variable-analysis": "^2.11.17",
+                "squizlabs/php_codesniffer": "^3.7.2",
+                "wp-coding-standards/wpcs": "^3.0"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "phpcompatibility/php-compatibility": "^9",
+                "phpcsstandards/phpcsdevtools": "^1.0",
+                "phpunit/phpunit": "^4 || ^5 || ^6 || ^7"
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/Automattic/VIP-Coding-Standards/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer rules (sniffs) to enforce WordPress VIP minimum coding conventions",
+            "keywords": [
+                "phpcs",
+                "standards",
+                "static analysis",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/Automattic/VIP-Coding-Standards/issues",
+                "source": "https://github.com/Automattic/VIP-Coding-Standards",
+                "wiki": "https://github.com/Automattic/VIP-Coding-Standards/wiki"
+            },
+            "time": "2023-09-05T11:01:05+00:00"
         },
         {
             "name": "brain/monkey",
@@ -1745,6 +1799,219 @@
             "time": "2022-10-24T09:00:36+00:00"
         },
         {
+            "name": "phpcsstandards/phpcsextra",
+            "version": "1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHPCSExtra.git",
+                "reference": "11d387c6642b6e4acaf0bd9bf5203b8cca1ec489"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/11d387c6642b6e4acaf0bd9bf5203b8cca1ec489",
+                "reference": "11d387c6642b6e4acaf0bd9bf5203b8cca1ec489",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "phpcsstandards/phpcsutils": "^1.0.9",
+                "squizlabs/php_codesniffer": "^3.8.0"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "phpcsstandards/phpcsdevcs": "^1.1.6",
+                "phpcsstandards/phpcsdevtools": "^1.2.1",
+                "phpunit/phpunit": "^4.5 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-stable": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHPCSExtra/graphs/contributors"
+                }
+            ],
+            "description": "A collection of sniffs and standards for use with PHP_CodeSniffer.",
+            "keywords": [
+                "PHP_CodeSniffer",
+                "phpcbf",
+                "phpcodesniffer-standard",
+                "phpcs",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/PHPCSExtra/issues",
+                "security": "https://github.com/PHPCSStandards/PHPCSExtra/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHPCSExtra"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2023-12-08T16:49:07+00:00"
+        },
+        {
+            "name": "phpcsstandards/phpcsutils",
+            "version": "1.0.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
+                "reference": "908247bc65010c7b7541a9551e002db12e9dae70"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/908247bc65010c7b7541a9551e002db12e9dae70",
+                "reference": "908247bc65010c7b7541a9551e002db12e9dae70",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0",
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^3.8.0 || 4.0.x-dev@dev"
+            },
+            "require-dev": {
+                "ext-filter": "*",
+                "php-parallel-lint/php-console-highlighter": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "phpcsstandards/phpcsdevcs": "^1.1.6",
+                "yoast/phpunit-polyfills": "^1.1.0 || ^2.0.0"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-stable": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "PHPCSUtils/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHPCSUtils/graphs/contributors"
+                }
+            ],
+            "description": "A suite of utility functions for use with PHP_CodeSniffer",
+            "homepage": "https://phpcsutils.com/",
+            "keywords": [
+                "PHP_CodeSniffer",
+                "phpcbf",
+                "phpcodesniffer-standard",
+                "phpcs",
+                "phpcs3",
+                "standards",
+                "static analysis",
+                "tokens",
+                "utility"
+            ],
+            "support": {
+                "docs": "https://phpcsutils.com/",
+                "issues": "https://github.com/PHPCSStandards/PHPCSUtils/issues",
+                "security": "https://github.com/PHPCSStandards/PHPCSUtils/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHPCSUtils"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2023-12-08T14:50:00+00:00"
+        },
+        {
+            "name": "phpstan/phpdoc-parser",
+            "version": "1.24.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpdoc-parser.git",
+                "reference": "fedf211ff14ec8381c9bf5714e33a7a552dd1acc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/fedf211ff14ec8381c9bf5714e33a7a552dd1acc",
+                "reference": "fedf211ff14ec8381c9bf5714e33a7a552dd1acc",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^2.0",
+                "nikic/php-parser": "^4.15",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^1.5",
+                "phpstan/phpstan-phpunit": "^1.1",
+                "phpstan/phpstan-strict-rules": "^1.0",
+                "phpunit/phpunit": "^9.5",
+                "symfony/process": "^5.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\PhpDocParser\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPDoc parser with support for nullable, intersection and generic types",
+            "support": {
+                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.24.5"
+            },
+            "time": "2023-12-16T09:33:33+00:00"
+        },
+        {
             "name": "phpunit/php-code-coverage",
             "version": "7.0.15",
             "source": {
@@ -3176,17 +3443,140 @@
             "time": "2016-10-03T07:35:21+00:00"
         },
         {
-            "name": "squizlabs/php_codesniffer",
-            "version": "3.7.2",
+            "name": "sirbrillig/phpcs-variable-analysis",
+            "version": "v2.11.17",
             "source": {
                 "type": "git",
-                "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879"
+                "url": "https://github.com/sirbrillig/phpcs-variable-analysis.git",
+                "reference": "3b71162a6bf0cde2bff1752e40a1788d8273d049"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/ed8e00df0a83aa96acf703f8c2979ff33341f879",
-                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879",
+                "url": "https://api.github.com/repos/sirbrillig/phpcs-variable-analysis/zipball/3b71162a6bf0cde2bff1752e40a1788d8273d049",
+                "reference": "3b71162a6bf0cde2bff1752e40a1788d8273d049",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0",
+                "squizlabs/php_codesniffer": "^3.5.6"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || ^1.0",
+                "phpcsstandards/phpcsdevcs": "^1.1",
+                "phpstan/phpstan": "^1.7",
+                "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.5 || ^7.0 || ^8.0 || ^9.0",
+                "sirbrillig/phpcs-import-detection": "^1.1",
+                "vimeo/psalm": "^0.2 || ^0.3 || ^1.1 || ^4.24 || ^5.0@beta"
+            },
+            "type": "phpcodesniffer-standard",
+            "autoload": {
+                "psr-4": {
+                    "VariableAnalysis\\": "VariableAnalysis/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sam Graham",
+                    "email": "php-codesniffer-variableanalysis@illusori.co.uk"
+                },
+                {
+                    "name": "Payton Swick",
+                    "email": "payton@foolord.com"
+                }
+            ],
+            "description": "A PHPCS sniff to detect problems with variables.",
+            "keywords": [
+                "phpcs",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/sirbrillig/phpcs-variable-analysis/issues",
+                "source": "https://github.com/sirbrillig/phpcs-variable-analysis",
+                "wiki": "https://github.com/sirbrillig/phpcs-variable-analysis/wiki"
+            },
+            "time": "2023-08-05T23:46:11+00:00"
+        },
+        {
+            "name": "slevomat/coding-standard",
+            "version": "8.14.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/slevomat/coding-standard.git",
+                "reference": "fea1fd6f137cc84f9cba0ae30d549615dbc6a926"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/fea1fd6f137cc84f9cba0ae30d549615dbc6a926",
+                "reference": "fea1fd6f137cc84f9cba0ae30d549615dbc6a926",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7 || ^1.0",
+                "php": "^7.2 || ^8.0",
+                "phpstan/phpdoc-parser": "^1.23.1",
+                "squizlabs/php_codesniffer": "^3.7.1"
+            },
+            "require-dev": {
+                "phing/phing": "2.17.4",
+                "php-parallel-lint/php-parallel-lint": "1.3.2",
+                "phpstan/phpstan": "1.10.37",
+                "phpstan/phpstan-deprecation-rules": "1.1.4",
+                "phpstan/phpstan-phpunit": "1.3.14",
+                "phpstan/phpstan-strict-rules": "1.5.1",
+                "phpunit/phpunit": "8.5.21|9.6.8|10.3.5"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "8.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "SlevomatCodingStandard\\": "SlevomatCodingStandard/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Slevomat Coding Standard for PHP_CodeSniffer complements Consistence Coding Standard by providing sniffs with additional checks.",
+            "keywords": [
+                "dev",
+                "phpcs"
+            ],
+            "support": {
+                "issues": "https://github.com/slevomat/coding-standard/issues",
+                "source": "https://github.com/slevomat/coding-standard/tree/8.14.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/kukulich",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/slevomat/coding-standard",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-10-08T07:28:08+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
+                "reference": "5805f7a4e4958dbb5e944ef1e6edae0a303765e7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/5805f7a4e4958dbb5e944ef1e6edae0a303765e7",
+                "reference": "5805f7a4e4958dbb5e944ef1e6edae0a303765e7",
                 "shasum": ""
             },
             "require": {
@@ -3196,7 +3586,7 @@
                 "php": ">=5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
             },
             "bin": [
                 "bin/phpcs",
@@ -3215,20 +3605,29 @@
             "authors": [
                 {
                     "name": "Greg Sherwood",
-                    "role": "lead"
+                    "role": "Former lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "Current lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer/graphs/contributors"
                 }
             ],
             "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
-            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
+            "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
             "keywords": [
                 "phpcs",
                 "standards",
                 "static analysis"
             ],
             "support": {
-                "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
-                "source": "https://github.com/squizlabs/PHP_CodeSniffer",
-                "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
+                "issues": "https://github.com/PHPCSStandards/PHP_CodeSniffer/issues",
+                "security": "https://github.com/PHPCSStandards/PHP_CodeSniffer/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
+                "wiki": "https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki"
             },
             "funding": [
                 {
@@ -3244,7 +3643,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2023-02-22T23:07:41+00:00"
+            "time": "2023-12-08T12:32:31+00:00"
         },
         {
             "name": "symfony/config",
@@ -4185,30 +4584,38 @@
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "2.3.0",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
-                "reference": "7da1894633f168fe244afc6de00d141f27517b62"
+                "reference": "b4caf9689f1a0e4a4c632679a44e638c1c67aff1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/7da1894633f168fe244afc6de00d141f27517b62",
-                "reference": "7da1894633f168fe244afc6de00d141f27517b62",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/b4caf9689f1a0e4a4c632679a44e638c1c67aff1",
+                "reference": "b4caf9689f1a0e4a4c632679a44e638c1c67aff1",
                 "shasum": ""
             },
             "require": {
+                "ext-filter": "*",
+                "ext-libxml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlreader": "*",
                 "php": ">=5.4",
-                "squizlabs/php_codesniffer": "^3.3.1"
+                "phpcsstandards/phpcsextra": "^1.1.0",
+                "phpcsstandards/phpcsutils": "^1.0.8",
+                "squizlabs/php_codesniffer": "^3.7.2"
             },
             "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6",
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.2",
                 "phpcompatibility/php-compatibility": "^9.0",
-                "phpcsstandards/phpcsdevtools": "^1.0",
+                "phpcsstandards/phpcsdevtools": "^1.2.0",
                 "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
             },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.6 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
+                "ext-iconv": "For improved results",
+                "ext-mbstring": "For improved results"
             },
             "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
@@ -4225,6 +4632,7 @@
             "keywords": [
                 "phpcs",
                 "standards",
+                "static analysis",
                 "wordpress"
             ],
             "support": {
@@ -4232,7 +4640,13 @@
                 "source": "https://github.com/WordPress/WordPress-Coding-Standards",
                 "wiki": "https://github.com/WordPress/WordPress-Coding-Standards/wiki"
             },
-            "time": "2020-05-13T23:57:56+00:00"
+            "funding": [
+                {
+                    "url": "https://opencollective.com/thewpcc/contribute/wp-php-63406",
+                    "type": "custom"
+                }
+            ],
+            "time": "2023-09-14T07:06:09+00:00"
         },
         {
             "name": "yoast/phpunit-polyfills",
@@ -4365,31 +4779,36 @@
         },
         {
             "name": "yoast/yoastcs",
-            "version": "2.3.1",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/yoastcs.git",
-                "reference": "8ed5af5ce8ef362a88cfe67faf0d9e4503ca7470"
+                "reference": "2ace63e7ea90a1610fb66279c314b321df029fd3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/yoastcs/zipball/8ed5af5ce8ef362a88cfe67faf0d9e4503ca7470",
-                "reference": "8ed5af5ce8ef362a88cfe67faf0d9e4503ca7470",
+                "url": "https://api.github.com/repos/Yoast/yoastcs/zipball/2ace63e7ea90a1610fb66279c314b321df029fd3",
+                "reference": "2ace63e7ea90a1610fb66279c314b321df029fd3",
                 "shasum": ""
             },
             "require": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7 || ^1.0",
-                "php": ">=5.4",
+                "automattic/vipwpcs": "^3.0.0",
+                "ext-tokenizer": "*",
+                "php": ">=7.2",
                 "php-parallel-lint/php-console-highlighter": "^1.0.0",
                 "php-parallel-lint/php-parallel-lint": "^1.3.2",
                 "phpcompatibility/phpcompatibility-wp": "^2.1.4",
-                "squizlabs/php_codesniffer": "^3.7.2",
-                "wp-coding-standards/wpcs": "^2.3.0"
+                "phpcsstandards/phpcsextra": "^1.2.1",
+                "phpcsstandards/phpcsutils": "^1.0.9",
+                "sirbrillig/phpcs-variable-analysis": "^2.11.17",
+                "slevomat/coding-standard": "^8.14.0",
+                "squizlabs/php_codesniffer": "^3.8.0",
+                "wp-coding-standards/wpcs": "^3.0.1"
             },
             "require-dev": {
                 "phpcompatibility/php-compatibility": "^9.3.5",
-                "phpcsstandards/phpcsdevtools": "^1.2.0",
-                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0",
+                "phpcsstandards/phpcsdevtools": "^1.2.1",
+                "phpunit/phpunit": "^8.0 || ^9.0",
                 "roave/security-advisories": "dev-master"
             },
             "type": "phpcodesniffer-standard",
@@ -4415,9 +4834,10 @@
             ],
             "support": {
                 "issues": "https://github.com/Yoast/yoastcs/issues",
+                "security": "https://github.com/Yoast/yoastcs/security/policy",
                 "source": "https://github.com/Yoast/yoastcs"
             },
-            "time": "2023-03-09T10:10:51+00:00"
+            "time": "2023-12-14T15:11:17+00:00"
         }
     ],
     "aliases": [],

--- a/config/dependency-injection/deprecated-classes.php
+++ b/config/dependency-injection/deprecated-classes.php
@@ -8,7 +8,6 @@
  * @phpcs:disable Yoast.Commenting.FileComment.MissingPackageTag
  * @phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
  * @phpcs:disable WordPress.Arrays.CommaAfterArrayItem.NoComma
- * @phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
  * @phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound
  * @phpcs:disable Squiz.Commenting.FunctionComment.Missing
  * @phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped

--- a/config/dependency-injection/deprecated-classes.php
+++ b/config/dependency-injection/deprecated-classes.php
@@ -7,7 +7,6 @@
  * @phpcs:disable Yoast.Files.FileName.InvalidFunctionsFileName
  * @phpcs:disable Yoast.Commenting.FileComment.MissingPackageTag
  * @phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
- * @phpcs:disable WordPress.Arrays.CommaAfterArrayItem.NoComma
  * @phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound
  * @phpcs:disable Squiz.Commenting.FunctionComment.Missing
  * @phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped

--- a/config/dependency-injection/renamed-classes.php
+++ b/config/dependency-injection/renamed-classes.php
@@ -8,7 +8,6 @@
  * @phpcs:disable Yoast.Commenting.FileComment.MissingPackageTag
  * @phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
  * @phpcs:disable WordPress.Arrays.CommaAfterArrayItem.NoComma
- * @phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
  * @phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound
  * @phpcs:disable Squiz.Commenting.FunctionComment.Missing
  * @phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped

--- a/config/dependency-injection/renamed-classes.php
+++ b/config/dependency-injection/renamed-classes.php
@@ -7,7 +7,6 @@
  * @phpcs:disable Yoast.Files.FileName.InvalidFunctionsFileName
  * @phpcs:disable Yoast.Commenting.FileComment.MissingPackageTag
  * @phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
- * @phpcs:disable WordPress.Arrays.CommaAfterArrayItem.NoComma
  * @phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound
  * @phpcs:disable Squiz.Commenting.FunctionComment.Missing
  * @phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped

--- a/inc/class-addon-manager.php
+++ b/inc/class-addon-manager.php
@@ -421,7 +421,7 @@ class WPSEO_Addon_Manager {
 					'<a href="' . esc_url( WPSEO_Shortlinker::get( $addon_link ) ) . '">',
 					'</a>'
 				)
-			    // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Output is escaped above.
+				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Output is escaped above.
 				. $sale_copy
 				. '</strong>';
 		}
@@ -730,7 +730,7 @@ class WPSEO_Addon_Manager {
 		$current_page = null;
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Reason: We are not processing form information.
 		if ( isset( $_GET['page'] ) && is_string( $_GET['page'] ) ) {
-			// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Reason: We are not processing form information, We are only strictly comparing and thus no need to sanitize.
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Reason: We are not processing form information, We are only strictly comparing and thus no need to sanitize.
 			$current_page = wp_unslash( $_GET['page'] );
 		}
 

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -929,7 +929,7 @@ class WPSEO_Utils {
 			$data = apply_filters( 'wpseo_debug_json_data', $data );
 		}
 
-		// phpcs:ignore Yoast.Yoast.AlternativeFunctions.json_encode_wp_json_encodeWithAdditionalParams -- This is the definition of format_json_encode.
+		// phpcs:ignore Yoast.Yoast.JsonEncodeAlternative.FoundWithAdditionalParams -- This is the definition of format_json_encode.
 		return wp_json_encode( $data, $flags );
 	}
 

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -381,7 +381,7 @@ class WPSEO_Utils {
 			return $value;
 		}
 		elseif ( is_float( $value ) ) {
-			// phpcs:ignore WordPress.PHP.StrictComparisons -- Purposeful loose comparison.
+			// phpcs:ignore Universal.Operators.StrictComparisons -- Purposeful loose comparison.
 			if ( (int) $value == $value && ! is_nan( $value ) ) {
 				return (int) $value;
 			}
@@ -510,7 +510,7 @@ class WPSEO_Utils {
 				if ( $bc ) {
 					$result = bcdiv( $number1, $number2, $precision ); // String, or NULL if right_operand is 0.
 				}
-				elseif ( $number2 != 0 ) { // phpcs:ignore WordPress.PHP.StrictComparisons -- Purposeful loose comparison.
+				elseif ( $number2 != 0 ) { // phpcs:ignore Universal.Operators.StrictComparisons -- Purposeful loose comparison.
 					$result = ( $number1 / $number2 );
 				}
 
@@ -525,7 +525,7 @@ class WPSEO_Utils {
 				if ( $bc ) {
 					$result = bcmod( $number1, $number2 ); // String, or NULL if modulus is 0.
 				}
-				elseif ( $number2 != 0 ) { // phpcs:ignore WordPress.PHP.StrictComparisons -- Purposeful loose comparison.
+				elseif ( $number2 != 0 ) { // phpcs:ignore Universal.Operators.StrictComparisons -- Purposeful loose comparison.
 					$result = ( $number1 % $number2 );
 				}
 
@@ -542,7 +542,7 @@ class WPSEO_Utils {
 					$result = bccomp( $number1, $number2, $precision ); // Returns int 0, 1 or -1.
 				}
 				else {
-					// phpcs:ignore WordPress.PHP.StrictComparisons -- Purposeful loose comparison.
+					// phpcs:ignore Universal.Operators.StrictComparisons -- Purposeful loose comparison.
 					$result = ( $number1 == $number2 ) ? 0 : ( ( $number1 > $number2 ) ? 1 : -1 );
 				}
 				break;
@@ -557,7 +557,7 @@ class WPSEO_Utils {
 					}
 				}
 				else {
-					// phpcs:ignore WordPress.PHP.StrictComparisons -- Purposeful loose comparison.
+					// phpcs:ignore Universal.Operators.StrictComparisons -- Purposeful loose comparison.
 					$result = ( intval( $result ) == $result ) ? intval( $result ) : floatval( $result );
 				}
 			}

--- a/inc/sitemaps/class-sitemaps.php
+++ b/inc/sitemaps/class-sitemaps.php
@@ -535,7 +535,7 @@ class WPSEO_Sitemaps {
 					ORDER BY date DESC
 				";
 
-				// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery -- They are prepared on the lines above and a direct query is required.
+				// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery -- They are prepared on the lines above and a direct query is required.
 				foreach ( $wpdb->get_results( $sql ) as $obj ) {
 					$post_type_dates[ $obj->post_type ] = $obj->date;
 				}

--- a/lib/dependency-injection/container-registry.php
+++ b/lib/dependency-injection/container-registry.php
@@ -29,7 +29,7 @@ class Container_Registry {
 		self::$containers[ $name ] = $container;
 	}
 
-    // phpcs:disable Squiz.Commenting.FunctionCommentThrowTag.WrongNumber -- PHPCS doesn't take into account exceptions thrown in called methods.
+	// phpcs:disable Squiz.Commenting.FunctionCommentThrowTag.WrongNumber -- PHPCS doesn't take into account exceptions thrown in called methods.
 
 	/**
 	 * Get an instance from a specific container.
@@ -53,7 +53,7 @@ class Container_Registry {
 		return self::$containers[ $name ]->get( $id, $invalid_behaviour );
 	}
 
-    // phpcs:enable Squiz.Commenting.FunctionCommentThrowTag.WrongNumber
+	// phpcs:enable Squiz.Commenting.FunctionCommentThrowTag.WrongNumber
 
 	/**
 	 * Attempts to find a given service ID in all registered containers.

--- a/lib/orm.php
+++ b/lib/orm.php
@@ -540,7 +540,7 @@ class ORM implements ArrayAccess {
 			if ( ! \is_numeric( $result->{$alias} ) ) {
 				$return_value = $result->{$alias};
 			}
-			// phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison -- Reason: This loose comparison seems intended.
+			// phpcs:ignore Universal.Operators.StrictComparisons -- Reason: This loose comparison seems intentional.
 			elseif ( (int) $result->{$alias} == (float) $result->{$alias} ) {
 				$return_value = (int) $result->{$alias};
 			}

--- a/src/conditionals/third-party/elementor-edit-conditional.php
+++ b/src/conditionals/third-party/elementor-edit-conditional.php
@@ -20,7 +20,7 @@ class Elementor_Edit_Conditional implements Conditional {
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Reason: We are not processing form information.
 		if ( isset( $_GET['action'] ) && \is_string( $_GET['action'] ) ) {
-			// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Reason: We are not processing form information, We are only strictly comparing.
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Reason: We are not processing form information, We are only strictly comparing.
 			$get_action = \wp_unslash( $_GET['action'] );
 			if ( $pagenow === 'post.php' && $get_action === 'elementor' ) {
 				return true;
@@ -29,7 +29,7 @@ class Elementor_Edit_Conditional implements Conditional {
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Reason: We are not processing form information.
 		if ( isset( $_POST['action'] ) && \is_string( $_POST['action'] ) ) {
-			// phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Reason: We are not processing form information, We are only strictly comparing.
+			// phpcs:ignore WordPress.Security.NonceVerification.Missing,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Reason: We are not processing form information, We are only strictly comparing.
 			$post_action = \wp_unslash( $_POST['action'] );
 			return \wp_doing_ajax() && $post_action === 'wpseo_elementor_save';
 		}

--- a/src/helpers/crawl-cleanup-helper.php
+++ b/src/helpers/crawl-cleanup-helper.php
@@ -155,7 +155,7 @@ class Crawl_Cleanup_Helper {
 		}
 
 		// Fix reply to comment links, whoever decided this should be a GET variable?
-        // phpcs:ignore WordPress.Security -- We know this is scary.
+		// phpcs:ignore WordPress.Security -- We know this is scary.
 		if ( isset( $_SERVER['REQUEST_URI'] ) && \preg_match( '`(\?replytocom=[^&]+)`', \sanitize_text_field( $_SERVER['REQUEST_URI'] ), $matches ) ) {
 			$proper_url .= \str_replace( '?replytocom=', '#comment-', $matches[0] );
 		}

--- a/src/helpers/current-page-helper.php
+++ b/src/helpers/current-page-helper.php
@@ -414,7 +414,7 @@ class Current_Page_Helper {
 	public function is_yoast_seo_page() {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Reason: We are not processing form information.
 		if ( isset( $_GET['page'] ) && \is_string( $_GET['page'] ) ) {
-			// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Reason: We are not processing form information, We are only using the variable in the strpos function.
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Reason: We are not processing form information, We are only using the variable in the strpos function.
 			$current_page = \wp_unslash( $_GET['page'] );
 			return \strpos( $current_page, 'wpseo_' ) === 0;
 		}

--- a/src/helpers/pagination-helper.php
+++ b/src/helpers/pagination-helper.php
@@ -196,7 +196,7 @@ class Pagination_Helper {
 		$key_query_loop = $this->get_key_query_loop();
 
 		if ( $key_query_loop ) {
-			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated, WordPress.Security.NonceVerification.Recommended -- Validated in get_key_query_loop().
+			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated,WordPress.Security.NonceVerification.Recommended -- Validated in get_key_query_loop().
 			$page_number = (int) $_GET[ $key_query_loop ];
 			if ( $page_number > 1 ) {
 				return $page_number;

--- a/src/helpers/wpdb-helper.php
+++ b/src/helpers/wpdb-helper.php
@@ -33,7 +33,7 @@ class Wpdb_Helper {
 	 * @return bool Whether the table exists.
 	 */
 	public function table_exists( $table ) {
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Reason: There is no unescaped user input.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Reason: There is no unescaped user input.
 		$table_exists = $this->wpdb->get_var( "SHOW TABLES LIKE '{$table}'" );
 		if ( \is_wp_error( $table_exists ) || \is_null( $table_exists ) ) {
 			return false;

--- a/src/integrations/admin/deactivated-premium-integration.php
+++ b/src/integrations/admin/deactivated-premium-integration.php
@@ -93,7 +93,7 @@ class Deactivated_Premium_Integration implements Integration_Interface {
 				) . '">',
 				'</a>'
 			);
-            // phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped -- Output escaped above.
+			// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped -- Output escaped above.
 			echo new Notice_Presenter(
 				/* translators: 1: Yoast SEO Premium */
 				\sprintf( \__( 'Activate %1$s!', 'wordpress-seo' ), 'Yoast SEO Premium' ),
@@ -103,7 +103,7 @@ class Deactivated_Premium_Integration implements Integration_Interface {
 				true,
 				'yoast-premium-deactivated-notice'
 			);
-            // phpcs:enable
+			// phpcs:enable
 
 			// Enable permanently dismissing the notice.
 			echo "<script>

--- a/src/introductions/application/current-page-trait.php
+++ b/src/introductions/application/current-page-trait.php
@@ -34,7 +34,7 @@ trait Current_Page_Trait {
 	private function get_page() {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Reason: We are not processing form information.
 		if ( isset( $_GET['page'] ) && \is_string( $_GET['page'] ) ) {
-			// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Reason: We are not processing form information, only using it in strict comparison.
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Reason: We are not processing form information, only using it in strict comparison.
 			return \wp_unslash( $_GET['page'] );
 		}
 

--- a/src/repositories/indexable-cleanup-repository.php
+++ b/src/repositories/indexable-cleanup-repository.php
@@ -74,7 +74,7 @@ class Indexable_Cleanup_Repository {
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Reason: There is no unescaped user input.
 		$sql = $wpdb->prepare( "DELETE FROM $indexable_table WHERE object_type = %s AND object_sub_type = %s ORDER BY id LIMIT %d", $object_type, $object_sub_type, $limit );
 
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Reason: Already prepared.
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Reason: Already prepared.
 		return $wpdb->query( $sql );
 	}
 
@@ -110,7 +110,7 @@ class Indexable_Cleanup_Repository {
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Reason: There is no unescaped user input.
 		$sql = $wpdb->prepare( "DELETE FROM $indexable_table WHERE object_type = 'post' AND post_status = %s ORDER BY id LIMIT %d", $post_status, $limit );
 
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Reason: Already prepared.
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Reason: Already prepared.
 		return $wpdb->query( $sql );
 	}
 
@@ -484,14 +484,14 @@ class Indexable_Cleanup_Repository {
 		);
 		// phpcs:enable
 
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Reason: Already prepared.
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Reason: Already prepared.
 		$orphans = $wpdb->get_col( $query );
 
 		if ( empty( $orphans ) ) {
 			return 0;
 		}
 
-		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Reason: Already prepared.
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Reason: Already prepared.
 		return $wpdb->query( "DELETE FROM $indexable_table WHERE object_type = '{$object_type}' AND object_id IN( " . \implode( ',', $orphans ) . ' )' );
 	}
 
@@ -522,14 +522,14 @@ class Indexable_Cleanup_Repository {
 		);
 		// phpcs:enable
 
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Reason: Already prepared.
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Reason: Already prepared.
 		$orphans = $wpdb->get_col( $query );
 
 		if ( empty( $orphans ) ) {
 			return 0;
 		}
 
-		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Reason: Already prepared.
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Reason: Already prepared.
 		return $wpdb->query( "DELETE FROM $indexable_table WHERE object_type = 'user' AND object_id IN( " . \implode( ',', $orphans ) . ' )' );
 	}
 
@@ -546,7 +546,7 @@ class Indexable_Cleanup_Repository {
 		global $wpdb;
 		$indexable_table = Model::get_table_name( 'Indexable' );
 		$source_table    = $wpdb->prefix . $source_table;
-		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Reason: Already prepared.
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Reason: Already prepared.
 		return $wpdb->get_col(
 			"
 			SELECT count(*)
@@ -569,7 +569,7 @@ class Indexable_Cleanup_Repository {
 		global $wpdb;
 		$indexable_table = Model::get_table_name( 'Indexable' );
 		$source_table    = $wpdb->users;
-		//phpcs:disable WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Reason: Already prepared.
+		//phpcs:disable WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Reason: Already prepared.
 		return $wpdb->get_col(
 			"
 			SELECT count(*)
@@ -613,14 +613,14 @@ class Indexable_Cleanup_Repository {
 		);
 		// phpcs:enable
 
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Reason: Already prepared.
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Reason: Already prepared.
 		$orphans = $wpdb->get_col( $query );
 
 		if ( empty( $orphans ) ) {
 			return 0;
 		}
 
-		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Reason: Already prepared.
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Reason: Already prepared.
 		return $wpdb->query( "DELETE FROM $table WHERE {$column} IN( " . \implode( ',', $orphans ) . ' )' );
 	}
 
@@ -639,7 +639,7 @@ class Indexable_Cleanup_Repository {
 		$indexable_table = Model::get_table_name( 'Indexable' );
 
 		// Warning: If this query is changed, make sure to update the query in cleanup_orphaned_from_table in Premium as well.
-		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Reason: Already prepared.
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Reason: Already prepared.
 		return $wpdb->get_col(
 			"
 			SELECT count(*)
@@ -661,7 +661,7 @@ class Indexable_Cleanup_Repository {
 	 * @return int|bool The number of updated rows, false if query to get data fails.
 	 */
 	public function update_indexables_author_to_reassigned( $limit ) {
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Reason: Already prepared.
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Reason: Already prepared.
 		$reassigned_authors_objs = $this->get_reassigned_authors( $limit );
 
 		if ( $reassigned_authors_objs === false ) {
@@ -700,7 +700,7 @@ class Indexable_Cleanup_Repository {
 		);
 		// phpcs:enable
 
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Reason: Already prepared.
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Reason: Already prepared.
 		return $wpdb->get_results( $query, \OBJECT_K );
 	}
 
@@ -741,7 +741,7 @@ class Indexable_Cleanup_Repository {
 			);
 			// phpcs:enable
 
-			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Reason: Already prepared.
+			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Reason: Already prepared.
 			$wpdb->query( $query );
 		}
 

--- a/tests/Unit/Actions/Importing/Abstract_Aioseo_Settings_Importing_Action_Test.php
+++ b/tests/Unit/Actions/Importing/Abstract_Aioseo_Settings_Importing_Action_Test.php
@@ -22,7 +22,7 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  *
  * @coversDefaultClass \Yoast\WP\SEO\Actions\Importing\Aioseo\Abstract_Aioseo_Settings_Importing_Action
  *
- * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded, Yoast.Yoast.AlternativeFunctions.json_encode_json_encode
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
 final class Abstract_Aioseo_Settings_Importing_Action_Test extends TestCase {
 

--- a/tests/Unit/Actions/Importing/Aioseo_Custom_Archive_Settings_Importing_Action_Test.php
+++ b/tests/Unit/Actions/Importing/Aioseo_Custom_Archive_Settings_Importing_Action_Test.php
@@ -24,7 +24,7 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  *
  * @coversDefaultClass \Yoast\WP\SEO\Actions\Importing\Aioseo\Aioseo_Custom_Archive_Settings_Importing_Action
  *
- * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded, Yoast.Yoast.AlternativeFunctions.json_encode_json_encode
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
 final class Aioseo_Custom_Archive_Settings_Importing_Action_Test extends TestCase {
 

--- a/tests/Unit/Actions/Importing/Aioseo_Default_Archive_Settings_Importing_Action_Test.php
+++ b/tests/Unit/Actions/Importing/Aioseo_Default_Archive_Settings_Importing_Action_Test.php
@@ -23,7 +23,7 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  *
  * @coversDefaultClass \Yoast\WP\SEO\Actions\Importing\Aioseo\Aioseo_Default_Archive_Settings_Importing_Action
  *
- * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded, Yoast.Yoast.AlternativeFunctions.json_encode_json_encode
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
 final class Aioseo_Default_Archive_Settings_Importing_Action_Test extends TestCase {
 

--- a/tests/Unit/Actions/Importing/Aioseo_General_Settings_Importing_Action_Test.php
+++ b/tests/Unit/Actions/Importing/Aioseo_General_Settings_Importing_Action_Test.php
@@ -24,7 +24,7 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  *
  * @coversDefaultClass \Yoast\WP\SEO\Actions\Importing\Aioseo\Aioseo_General_Settings_Importing_Action
  *
- * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded, Yoast.Yoast.AlternativeFunctions.json_encode_json_encode
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
 final class Aioseo_General_Settings_Importing_Action_Test extends TestCase {
 

--- a/tests/Unit/Actions/Importing/Aioseo_Posts_Importing_Action_Test.php
+++ b/tests/Unit/Actions/Importing/Aioseo_Posts_Importing_Action_Test.php
@@ -30,8 +30,6 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  * @group importing
  *
  * @coversDefaultClass \Yoast\WP\SEO\Actions\Importing\Aioseo\Aioseo_Posts_Importing_Action
- *
- * @phpcs:disable Yoast.Yoast.AlternativeFunctions.json_encode_json_encode
  */
 final class Aioseo_Posts_Importing_Action_Test extends TestCase {
 

--- a/tests/Unit/Actions/Importing/Aioseo_Posttype_Defaults_Settings_Importing_Action_Test.php
+++ b/tests/Unit/Actions/Importing/Aioseo_Posttype_Defaults_Settings_Importing_Action_Test.php
@@ -23,7 +23,7 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  *
  * @coversDefaultClass \Yoast\WP\SEO\Actions\Importing\Aioseo\Aioseo_Posttype_Defaults_Settings_Importing_Action
  *
- * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded, Yoast.Yoast.AlternativeFunctions.json_encode_json_encode
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
 final class Aioseo_Posttype_Defaults_Settings_Importing_Action_Test extends TestCase {
 

--- a/tests/Unit/Actions/Importing/Aioseo_Taxonomy_Settings_Importing_Action_Test.php
+++ b/tests/Unit/Actions/Importing/Aioseo_Taxonomy_Settings_Importing_Action_Test.php
@@ -23,7 +23,7 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  *
  * @coversDefaultClass \Yoast\WP\SEO\Actions\Importing\Aioseo\Aioseo_Taxonomy_Settings_Importing_Action
  *
- * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded, Yoast.Yoast.AlternativeFunctions.json_encode_json_encode
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
 final class Aioseo_Taxonomy_Settings_Importing_Action_Test extends TestCase {
 

--- a/tests/Unit/Actions/Importing/Aioseo_Validate_Data_Action_Test.php
+++ b/tests/Unit/Actions/Importing/Aioseo_Validate_Data_Action_Test.php
@@ -23,8 +23,6 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  * @group importing
  *
  * @coversDefaultClass \Yoast\WP\SEO\Actions\Importing\Aioseo\Aioseo_Validate_Data_Action
- *
- * @phpcs:disable Yoast.Yoast.AlternativeFunctions.json_encode_json_encode
  */
 final class Aioseo_Validate_Data_Action_Test extends TestCase {
 

--- a/tests/Unit/Admin/Asset_Analysis_Worker_Location_Test.php
+++ b/tests/Unit/Admin/Asset_Analysis_Worker_Location_Test.php
@@ -24,12 +24,12 @@ final class Asset_Analysis_Worker_Location_Test extends TestCase {
 	 */
 	protected function set_up() {
 		parent::set_up();
-		// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound
 		if ( ! \defined( 'WPSEO_FILE' ) ) {
+			// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound
 			\define( 'WPSEO_FILE', $this->get_wpseo_file() );
 		}
-		// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound
 		if ( ! \defined( 'WPSEO_VERSION' ) ) {
+			// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound
 			\define( 'WPSEO_VERSION', '16.6' );
 		}
 	}

--- a/tests/Unit/Admin/Metabox/Metabox_Editor_Test.php
+++ b/tests/Unit/Admin/Metabox/Metabox_Editor_Test.php
@@ -30,12 +30,12 @@ final class Metabox_Editor_Test extends TestCase {
 		parent::set_up();
 		$this->subject = new WPSEO_Metabox_Editor();
 
-		// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound
 		if ( ! \defined( 'WPSEO_FILE' ) ) {
+			// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound
 			\define( 'WPSEO_FILE', $this->get_wpseo_file() );
 		}
-		// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound
 		if ( ! \defined( 'WPSEO_VERSION' ) ) {
+			// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound
 			\define( 'WPSEO_VERSION', '16.6' );
 		}
 	}

--- a/tests/Unit/Builders/Indexable_Post_Builder_Test.php
+++ b/tests/Unit/Builders/Indexable_Post_Builder_Test.php
@@ -330,7 +330,6 @@ final class Indexable_Post_Builder_Test extends TestCase {
 		$this->indexable->orm->expects( 'set' )
 			->with( 'open_graph_image', 'http://basic.wordpress.test/wp-content/uploads/2020/07/WordPress5.jpg' );
 		$this->indexable->orm->expects( 'set' )
-			// phpcs:ignore Yoast.Yoast.AlternativeFunctions.json_encode_json_encodeWithAdditionalParams -- Test code, mocking WP.
 			->with( 'open_graph_image_meta', \json_encode( $image_meta, ( \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES ) ) );
 
 		// We expect the twitter image and its source to be set.

--- a/tests/Unit/Builders/Indexable_Social_Image_Trait_Test.php
+++ b/tests/Unit/Builders/Indexable_Social_Image_Trait_Test.php
@@ -159,7 +159,6 @@ final class Indexable_Social_Image_Trait_Test extends TestCase {
 		$this->indexable->orm->expects( 'set' )
 			->with( 'open_graph_image', 'http://basic.wordpress.test/wp-content/uploads/2020/07/WordPress5.jpg' );
 		$this->indexable->orm->expects( 'set' )
-			// phpcs:ignore Yoast.Yoast.AlternativeFunctions.json_encode_json_encodeWithAdditionalParams -- Test code, mocking WP.
 			->with( 'open_graph_image_meta', \json_encode( $image_meta, ( \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES ) ) );
 
 		// We expect twitter image meta to be set.
@@ -213,7 +212,6 @@ final class Indexable_Social_Image_Trait_Test extends TestCase {
 		$this->indexable->orm->expects( 'set' )
 			->with( 'open_graph_image', 'http://basic.wordpress.test/wp-content/uploads/2020/07/WordPress5.jpg' );
 		$this->indexable->orm->expects( 'set' )
-			// phpcs:ignore Yoast.Yoast.AlternativeFunctions.json_encode_json_encodeWithAdditionalParams -- Test code, mocking WP.
 			->with( 'open_graph_image_meta', \json_encode( $image_meta, ( \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES ) ) );
 
 		$alternative_image = [
@@ -333,7 +331,6 @@ final class Indexable_Social_Image_Trait_Test extends TestCase {
 		$this->indexable->orm->expects( 'set' )
 			->with( 'open_graph_image', 'http://basic.wordpress.test/wp-content/uploads/2020/07/WordPress5.jpg' );
 		$this->indexable->orm->expects( 'set' )
-			// phpcs:ignore Yoast.Yoast.AlternativeFunctions.json_encode_json_encodeWithAdditionalParams -- Test code, mocking WP.
 			->with( 'open_graph_image_meta', \json_encode( $image_meta, ( \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES ) ) );
 
 		$alternative_image = [

--- a/tests/Unit/Builders/Indexable_Term_Builder_Test.php
+++ b/tests/Unit/Builders/Indexable_Term_Builder_Test.php
@@ -359,7 +359,6 @@ final class Indexable_Term_Builder_Test extends TestCase {
 		$indexable_mock->orm->expects( 'set' )
 			->with( 'open_graph_image', 'http://basic.wordpress.test/wp-content/uploads/2020/07/WordPress5.jpg' );
 		$indexable_mock->orm->expects( 'set' )
-			// phpcs:ignore Yoast.Yoast.AlternativeFunctions.json_encode_json_encodeWithAdditionalParams -- Test code, mocking WP.
 			->with( 'open_graph_image_meta', \json_encode( $image_meta, ( \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES ) ) );
 
 		// We expect the twitter image and its source to be set.

--- a/tests/Unit/Helpers/Aioseo_Helper_Test.php
+++ b/tests/Unit/Helpers/Aioseo_Helper_Test.php
@@ -15,8 +15,6 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  * @group helpers
  *
  * @coversDefaultClass \Yoast\WP\SEO\Helpers\Aioseo_Helper
- *
- * @phpcs:disable Yoast.Yoast.AlternativeFunctions.json_encode_json_encode
  */
 final class Aioseo_Helper_Test extends TestCase {
 

--- a/tests/Unit/README.md
+++ b/tests/Unit/README.md
@@ -84,14 +84,13 @@ Now uncomment and update the extension_dir in your php.ini:
 ## Linting
 
 ### Syntax errors
-To check for syntax errors, run `find -L . -path ./vendor -prune -o -path ./node_modules -prune -o -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l`
+To check for syntax errors, run `composer lint`
 
 ### Codestyle
 We use a combination of coding standards to check our code against: WPCS, PHPCompatibility, and [our own YoastCS sniffs](https://github.com/Yoast/yoastcs).
 
 ### Configuration
-1. `composer install`
-2. `composer config-yoastcs`. 
+`composer install`
 
 ### Running the codestyle
 - To check everything: `composer check-cs`

--- a/tests/Unit/Services/Importing/Aioseo_Robots_Provider_Service_Test.php
+++ b/tests/Unit/Services/Importing/Aioseo_Robots_Provider_Service_Test.php
@@ -14,8 +14,6 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  * @group importing
  *
  * @coversDefaultClass \Yoast\WP\SEO\Services\Importing\Aioseo\Aioseo_Robots_Provider_Service
- *
- * @phpcs:disable Yoast.Yoast.AlternativeFunctions.json_encode_json_encode
  */
 final class Aioseo_Robots_Provider_Service_Test extends TestCase {
 

--- a/tests/Unit/Services/Importing/Aioseo_Robots_Transformer_Service_Test.php
+++ b/tests/Unit/Services/Importing/Aioseo_Robots_Transformer_Service_Test.php
@@ -14,8 +14,6 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  * @group importing
  *
  * @coversDefaultClass \Yoast\WP\SEO\Services\Importing\Aioseo\Aioseo_Robots_Transformer_Service
- *
- * @phpcs:disable Yoast.Yoast.AlternativeFunctions.json_encode_json_encode
  */
 final class Aioseo_Robots_Transformer_Service_Test extends TestCase {
 

--- a/tests/Unit/Services/Importing/Aioseo_Social_Images_Provider_Service_Test.php
+++ b/tests/Unit/Services/Importing/Aioseo_Social_Images_Provider_Service_Test.php
@@ -16,7 +16,7 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  *
  * @coversDefaultClass \Yoast\WP\SEO\Services\Importing\Aioseo\Aioseo_Social_Images_Provider_Service
  *
- * @phpcs:disable Yoast.Yoast.AlternativeFunctions.json_encode_json_encode,Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
 final class Aioseo_Social_Images_Provider_Service_Test extends TestCase {
 

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -457,7 +457,7 @@ if ( ! wp_installing() && ( $spl_autoload_exists && $filter_exists ) ) {
 
 			// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Reason: We are not processing form information but only loading the admin init class.
 			if ( isset( $_POST['action'] ) && is_string( $_POST['action'] ) ) {
-				// phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Reason: We are not processing form information but only loading the admin init class, We are strictly comparing only.
+				// phpcs:ignore WordPress.Security.NonceVerification.Missing,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Reason: We are not processing form information but only loading the admin init class, We are strictly comparing only.
 				if ( wp_unslash( $_POST['action'] ) === 'inline-save' ) {
 					add_action( 'plugins_loaded', 'wpseo_admin_init', 15 );
 				}


### PR DESCRIPTION
## Context

* CI/QA update introducing YoastCS 3.0

## Summary

This PR can be summarized in the following changelog entry:

* CI/QA update introducing YoastCS 3.0

## Relevant technical choices:

### Composer/PHPCS: update to YoastCS 3.0.0

YoastCS 3.0.0 has been released and is based on WordPressCS 3.0.0.

This commit makes the necessary updates for that:
* Composer: update the requirements.
* PHPCS ruleset:
    - Update a few sniff/property names for new names in WordPressCS 3.0.
    - Enforce strict PSR-4 for the tests.
    - Add configuration for the new `WordPress.WP.Capabilities` sniff.
    - Remove some configuration which is now handled by YoastCS.
    - Remove a few exclusions and some configuration which is no longer needed.
    - Add a few selective exclusions for specific situations.
* GHA CS workflow: run the CS check on the latest PHP version.
        No need to run on PHP 7.4 any more as the deprecations previously encountered were all fixed.

Refs:
* https://github.com/Yoast/yoastcs/releases/tag/3.0.0
* https://github.com/WordPress/WordPress-Coding-Standards/releases/tag/3.0.0

### PHPCS: update ignore annotations for WPCS 3.0

... to account for renamed sniffs and replaced sniffs.

### PHPCS: update ignore annotations for YoastCS 3.0.0

* The `Yoast.Yoast.AlternativeFunctions` sniff has been renamed to `Yoast.Yoast.JsonEncodeAlternative`.

### PHPCS: remove duplicate ignore annotations
### PHPCS: remove unnecessary ignore annotations

... which aren't ignoring anything.

### PHPCS: remove redundant ignore annotations

The `Yoast.Yoast.AlternativeFunctions` (now `Yoast.Yoast.JsonEncodeAlternative`) sniff is no longer in effect for unit test code as of YoastCS 3.0.0, which means these ignore annotations are now redundant and can be removed.

### PHPCS: improve some ignore annotations

A `disable` without an `enable` disables the rule for the rest of the file, while, by the looks of it, the intention was just to _ignore_ the one line each time.

### PHPCS: fix formatting of some ignore annotations
### Composer/PHPCS: update thresholds 


## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* If the build runs correctly and passes, we're good.