### PR TITLE
Tests: make dataproviders `static`

### DIFF
--- a/tests/Unit/Actions/Configuration/First_Time_Configuration_Action_Test.php
+++ b/tests/Unit/Actions/Configuration/First_Time_Configuration_Action_Test.php
@@ -116,7 +116,7 @@ final class First_Time_Configuration_Action_Test extends TestCase {
 	 *
 	 * @return array Data for test_set_site_representation function.
 	 */
-	public function site_representation_provider() {
+	public static function site_representation_provider() {
 		$success_company = [
 			'params'                => [
 				'company_or_person' => 'company',
@@ -220,7 +220,7 @@ final class First_Time_Configuration_Action_Test extends TestCase {
 	 *
 	 * @return array Data for test_set_social_profiles function.
 	 */
-	public function social_profiles_provider() {
+	public static function social_profiles_provider() {
 		$success_all = [
 			'set_profiles_results' => [],
 			'get_profiles_results' => [
@@ -307,7 +307,7 @@ final class First_Time_Configuration_Action_Test extends TestCase {
 	 *
 	 * @return array Data for test_set_enable_tracking function.
 	 */
-	public function enable_tracking_provider() {
+	public static function enable_tracking_provider() {
 		$false_to_true = [
 			'params'                => [
 				'tracking' => true,
@@ -413,7 +413,7 @@ final class First_Time_Configuration_Action_Test extends TestCase {
 	 *
 	 * @return array Data for test_check_capability function.
 	 */
-	public function check_capability_provider() {
+	public static function check_capability_provider() {
 		$success = [
 			'user_id'  => 123,
 			'can_edit' => true,
@@ -473,7 +473,7 @@ final class First_Time_Configuration_Action_Test extends TestCase {
 	 *
 	 * @return array Data for save_configuration_state function.
 	 */
-	public function configuration_provider() {
+	public static function configuration_provider() {
 		$success_save = [
 			'params'                => [
 				'finishedSteps'     => [ 'step1 ' ],

--- a/tests/Unit/Actions/Importing/Abstract_Aioseo_Settings_Importing_Action_Test.php
+++ b/tests/Unit/Actions/Importing/Abstract_Aioseo_Settings_Importing_Action_Test.php
@@ -280,7 +280,7 @@ final class Abstract_Aioseo_Settings_Importing_Action_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function provider_import_single_setting() {
+	public static function provider_import_single_setting() {
 		return [
 			[
 				'/separator',
@@ -306,7 +306,7 @@ final class Abstract_Aioseo_Settings_Importing_Action_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function provider_get_total_unindexed() {
+	public static function provider_get_total_unindexed() {
 		return [
 			[ [], true, 0 ],
 			[ [ 0 ], false, 1 ],
@@ -319,7 +319,7 @@ final class Abstract_Aioseo_Settings_Importing_Action_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function provider_get_limited_unindexed() {
+	public static function provider_get_limited_unindexed() {
 		return [
 			[ [], true, 0 ],
 			[ [ 0 ], false, 1 ],
@@ -332,7 +332,7 @@ final class Abstract_Aioseo_Settings_Importing_Action_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function provider_index() {
+	public static function provider_index() {
 		return [
 			[ [], true, [] ],
 			[
@@ -365,7 +365,7 @@ final class Abstract_Aioseo_Settings_Importing_Action_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function provider_get_unimported_chunk() {
+	public static function provider_get_unimported_chunk() {
 		$aioseo_settings = [
 			'post'       => [
 				'title'           => 'title1',

--- a/tests/Unit/Actions/Importing/Aioseo_Cleanup_Action_Test.php
+++ b/tests/Unit/Actions/Importing/Aioseo_Cleanup_Action_Test.php
@@ -206,7 +206,7 @@ final class Aioseo_Cleanup_Action_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function provider_index() {
+	public static function provider_index() {
 		$successful_result = [
 			'metadata_cleanup'   => 10,
 			'indexables_cleanup' => true,
@@ -223,7 +223,7 @@ final class Aioseo_Cleanup_Action_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function provider_get_unindexed() {
+	public static function provider_get_unindexed() {
 		$completed                 = [
 			'aioseo_cleanup' => true,
 		];

--- a/tests/Unit/Actions/Importing/Aioseo_Custom_Archive_Settings_Importing_Action_Test.php
+++ b/tests/Unit/Actions/Importing/Aioseo_Custom_Archive_Settings_Importing_Action_Test.php
@@ -103,7 +103,7 @@ final class Aioseo_Custom_Archive_Settings_Importing_Action_Test extends TestCas
 	 *
 	 * @var array
 	 */
-	protected $full_settings_to_import = [
+	protected static $full_settings_to_import = [
 		'book'  => [
 			'show'            => true,
 			'title'           => 'Book Title',
@@ -127,7 +127,7 @@ final class Aioseo_Custom_Archive_Settings_Importing_Action_Test extends TestCas
 	 *
 	 * @var array
 	 */
-	protected $flattened_settings_to_import = [
+	protected static $flattened_settings_to_import = [
 		'/book/show'                              => true,
 		'/book/title'                             => 'Book Title',
 		'/book/metaDescription'                   => 'Book Desc',
@@ -304,7 +304,7 @@ final class Aioseo_Custom_Archive_Settings_Importing_Action_Test extends TestCas
 	 *
 	 * @return array
 	 */
-	public function provider_isset_settings_tab() {
+	public static function provider_isset_settings_tab() {
 		$aioseo_settings_with_subsetting_set = [
 			'searchAppearance' => [
 				'archives' => 'settings',
@@ -327,7 +327,7 @@ final class Aioseo_Custom_Archive_Settings_Importing_Action_Test extends TestCas
 	 *
 	 * @return array
 	 */
-	public function provider_map() {
+	public static function provider_map() {
 		return [
 			[ '/book/title', 'Book Title', 1, 1, 0 ],
 			[ '/book/metaDescription', 'Book Desc', 1, 1, 0 ],
@@ -344,10 +344,10 @@ final class Aioseo_Custom_Archive_Settings_Importing_Action_Test extends TestCas
 	 *
 	 * @return array
 	 */
-	public function provider_query() {
+	public static function provider_query() {
 		$full_settings = [
 			'searchAppearance' => [
-				'archives'   => $this->full_settings_to_import,
+				'archives'   => self::$full_settings_to_import,
 				'postypes'   => [
 					'post' => [
 						'title'           => 'title1',
@@ -363,10 +363,10 @@ final class Aioseo_Custom_Archive_Settings_Importing_Action_Test extends TestCas
 			],
 		];
 
-		$full_settings_expected = $this->flattened_settings_to_import;
+		$full_settings_expected = self::$flattened_settings_to_import;
 
 		return [
-			[ \json_encode( $full_settings ), $this->full_settings_to_import, $full_settings_expected, 1 ],
+			[ \json_encode( $full_settings ), self::$full_settings_to_import, $full_settings_expected, 1 ],
 		];
 	}
 }

--- a/tests/Unit/Actions/Importing/Aioseo_Default_Archive_Settings_Importing_Action_Test.php
+++ b/tests/Unit/Actions/Importing/Aioseo_Default_Archive_Settings_Importing_Action_Test.php
@@ -95,7 +95,7 @@ final class Aioseo_Default_Archive_Settings_Importing_Action_Test extends TestCa
 	 *
 	 * @var array
 	 */
-	protected $full_settings_to_import = [
+	protected static $full_settings_to_import = [
 		'author' => [
 			'show'            => true,
 			'title'           => 'Author Title',
@@ -127,7 +127,7 @@ final class Aioseo_Default_Archive_Settings_Importing_Action_Test extends TestCa
 	 *
 	 * @var array
 	 */
-	protected $flattened_settings_to_import = [
+	protected static $flattened_settings_to_import = [
 		'/author/show'                             => true,
 		'/author/title'                            => 'Author Title',
 		'/author/metaDescription'                  => 'Author Desc',
@@ -297,7 +297,7 @@ final class Aioseo_Default_Archive_Settings_Importing_Action_Test extends TestCa
 	 *
 	 * @return array
 	 */
-	public function provider_isset_settings_tab() {
+	public static function provider_isset_settings_tab() {
 		$aioseo_settings_with_subsetting_set = [
 			'searchAppearance' => [
 				'archives' => 'settings',
@@ -320,7 +320,7 @@ final class Aioseo_Default_Archive_Settings_Importing_Action_Test extends TestCa
 	 *
 	 * @return array
 	 */
-	public function provider_map() {
+	public static function provider_map() {
 		return [
 			[ '/author/title', 'Author Title', 1, 1, 0 ],
 			[ '/author/metaDescription', 'Author Desc', 1, 1, 0 ],
@@ -338,10 +338,10 @@ final class Aioseo_Default_Archive_Settings_Importing_Action_Test extends TestCa
 	 *
 	 * @return array
 	 */
-	public function provider_query() {
+	public static function provider_query() {
 		$full_settings = [
 			'searchAppearance' => [
-				'archives'   => $this->full_settings_to_import,
+				'archives'   => self::$full_settings_to_import,
 				'postypes'   => [
 					'post' => [
 						'title'           => 'title1',
@@ -357,10 +357,10 @@ final class Aioseo_Default_Archive_Settings_Importing_Action_Test extends TestCa
 			],
 		];
 
-		$full_settings_expected = $this->flattened_settings_to_import;
+		$full_settings_expected = self::$flattened_settings_to_import;
 
 		return [
-			[ \json_encode( $full_settings ), $this->full_settings_to_import, $full_settings_expected, 1 ],
+			[ \json_encode( $full_settings ), self::$full_settings_to_import, $full_settings_expected, 1 ],
 		];
 	}
 }

--- a/tests/Unit/Actions/Importing/Aioseo_General_Settings_Importing_Action_Test.php
+++ b/tests/Unit/Actions/Importing/Aioseo_General_Settings_Importing_Action_Test.php
@@ -103,7 +103,7 @@ final class Aioseo_General_Settings_Importing_Action_Test extends TestCase {
 	 *
 	 * @var array
 	 */
-	protected $full_settings_to_import = [
+	protected static $full_settings_to_import = [
 		'separator'       => '&larr;',
 		'siteTitle'       => 'Site Title',
 		'metaDescription' => 'Site Desc',
@@ -120,7 +120,7 @@ final class Aioseo_General_Settings_Importing_Action_Test extends TestCase {
 	 *
 	 * @var array
 	 */
-	protected $flattened_settings_to_import = [
+	protected static $flattened_settings_to_import = [
 		'/separator'               => '&larr;',
 		'/siteTitle'               => 'Site Title',
 		'/metaDescription'         => 'Site Desc',
@@ -325,7 +325,7 @@ final class Aioseo_General_Settings_Importing_Action_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function provider_isset_settings_tab() {
+	public static function provider_isset_settings_tab() {
 		$aioseo_settings_with_subsetting_set = [
 			'searchAppearance' => [
 				'global' => 'settings',
@@ -348,7 +348,7 @@ final class Aioseo_General_Settings_Importing_Action_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function provider_transform_site_represents() {
+	public static function provider_transform_site_represents() {
 		return [
 			[ 'person', 'person' ],
 			[ 'organization', 'company' ],
@@ -361,7 +361,7 @@ final class Aioseo_General_Settings_Importing_Action_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function provider_transform_separator() {
+	public static function provider_transform_separator() {
 		return [
 			[ '&#45;', 'sc-dash' ],
 			[ '&ndash;', 'sc-ndash' ],
@@ -380,7 +380,7 @@ final class Aioseo_General_Settings_Importing_Action_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function provider_map() {
+	public static function provider_map() {
 		return [
 			[ '/separator', '&larr;', 1, 0, 0, 0 ],
 			[ '/siteTitle', 'Site Title', 1, 1, 0, 0 ],
@@ -398,10 +398,10 @@ final class Aioseo_General_Settings_Importing_Action_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function provider_query() {
+	public static function provider_query() {
 		$full_settings = [
 			'searchAppearance' => [
-				'global'     => $this->full_settings_to_import,
+				'global'     => self::$full_settings_to_import,
 				'postypes'   => [
 					'post' => [
 						'title'           => 'title1',
@@ -417,10 +417,10 @@ final class Aioseo_General_Settings_Importing_Action_Test extends TestCase {
 			],
 		];
 
-		$full_settings_expected = $this->flattened_settings_to_import;
+		$full_settings_expected = self::$flattened_settings_to_import;
 
 		return [
-			[ \json_encode( $full_settings ), $this->full_settings_to_import, $full_settings_expected, 1 ],
+			[ \json_encode( $full_settings ), self::$full_settings_to_import, $full_settings_expected, 1 ],
 		];
 	}
 }

--- a/tests/Unit/Actions/Importing/Aioseo_Posts_Importing_Action_Test.php
+++ b/tests/Unit/Actions/Importing/Aioseo_Posts_Importing_Action_Test.php
@@ -354,7 +354,7 @@ final class Aioseo_Posts_Importing_Action_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function provider_donot_map() {
+	public static function provider_donot_map() {
 		$aioseo_indexable = [
 			'id'      => 123,
 			'post_id' => 234,
@@ -771,7 +771,7 @@ final class Aioseo_Posts_Importing_Action_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function provider_social_image_url_import() {
+	public static function provider_social_image_url_import() {
 		$open_graph_mapping = [
 			'yoast_name'                   => 'open_graph_image',
 			'social_image_import'          => true,

--- a/tests/Unit/Actions/Importing/Aioseo_Posttype_Defaults_Settings_Importing_Action_Test.php
+++ b/tests/Unit/Actions/Importing/Aioseo_Posttype_Defaults_Settings_Importing_Action_Test.php
@@ -95,7 +95,7 @@ final class Aioseo_Posttype_Defaults_Settings_Importing_Action_Test extends Test
 	 *
 	 * @var array
 	 */
-	protected $full_settings_to_import = [
+	protected static $full_settings_to_import = [
 		'post'       => [
 			'show'            => true,
 			'title'           => 'Post Title',
@@ -137,7 +137,7 @@ final class Aioseo_Posttype_Defaults_Settings_Importing_Action_Test extends Test
 	 *
 	 * @var array
 	 */
-	protected $flattened_settings_to_import = [
+	protected static $flattened_settings_to_import = [
 		'/post/show'                              => true,
 		'/post/title'                             => 'Post Title',
 		'/post/metaDescription'                   => 'Post Desc',
@@ -337,7 +337,7 @@ final class Aioseo_Posttype_Defaults_Settings_Importing_Action_Test extends Test
 	 *
 	 * @return array
 	 */
-	public function provider_isset_settings_tab() {
+	public static function provider_isset_settings_tab() {
 		$aioseo_settings_with_subsetting_set = [
 			'searchAppearance' => [
 				'postTypes' => 'settings',
@@ -360,7 +360,7 @@ final class Aioseo_Posttype_Defaults_Settings_Importing_Action_Test extends Test
 	 *
 	 * @return array
 	 */
-	public function provider_import_redirect_attachment() {
+	public static function provider_import_redirect_attachment() {
 		return [
 			[ 'disabled', false ],
 			[ 'attachment', true ],
@@ -373,7 +373,7 @@ final class Aioseo_Posttype_Defaults_Settings_Importing_Action_Test extends Test
 	 *
 	 * @return array
 	 */
-	public function provider_map() {
+	public static function provider_map() {
 		return [
 			[ '/post/title', 'Post Title', 1, 1, 0 ],
 			[ '/post/metaDescription', 'Post Desc', 1, 1, 0 ],
@@ -397,10 +397,10 @@ final class Aioseo_Posttype_Defaults_Settings_Importing_Action_Test extends Test
 	 *
 	 * @return array
 	 */
-	public function provider_query() {
+	public static function provider_query() {
 		$full_settings = [
 			'searchAppearance' => [
-				'postTypes'   => $this->full_settings_to_import,
+				'postTypes'   => self::$full_settings_to_import,
 				'archives'    => [
 					'author' => [
 						'title'           => 'title1',
@@ -410,10 +410,10 @@ final class Aioseo_Posttype_Defaults_Settings_Importing_Action_Test extends Test
 			],
 		];
 
-		$full_settings_expected = $this->flattened_settings_to_import;
+		$full_settings_expected = self::$flattened_settings_to_import;
 
 		return [
-			[ \json_encode( $full_settings ), $this->full_settings_to_import, $full_settings_expected, 1 ],
+			[ \json_encode( $full_settings ), self::$full_settings_to_import, $full_settings_expected, 1 ],
 		];
 	}
 }

--- a/tests/Unit/Actions/Importing/Aioseo_Taxonomy_Settings_Importing_Action_Test.php
+++ b/tests/Unit/Actions/Importing/Aioseo_Taxonomy_Settings_Importing_Action_Test.php
@@ -95,7 +95,7 @@ final class Aioseo_Taxonomy_Settings_Importing_Action_Test extends TestCase {
 	 *
 	 * @var array
 	 */
-	protected $full_settings_to_import = [
+	protected static $full_settings_to_import = [
 		'category'      => [
 			'show'            => true,
 			'title'           => 'Category Title',
@@ -127,7 +127,7 @@ final class Aioseo_Taxonomy_Settings_Importing_Action_Test extends TestCase {
 	 *
 	 * @var array
 	 */
-	protected $flattened_settings_to_import = [
+	protected static $flattened_settings_to_import = [
 		'/category/show'                                  => true,
 		'/category/title'                                 => 'Category Title',
 		'/category/metaDescription'                       => 'Category Desc',
@@ -400,7 +400,7 @@ final class Aioseo_Taxonomy_Settings_Importing_Action_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function provider_isset_settings_tab() {
+	public static function provider_isset_settings_tab() {
 		$aioseo_settings_with_subsetting_set = [
 			'searchAppearance' => [
 				'taxonomies' => 'settings',
@@ -423,7 +423,7 @@ final class Aioseo_Taxonomy_Settings_Importing_Action_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function provider_map() {
+	public static function provider_map() {
 		return [
 			[ '/category/title', 'Category Title', 1, 1, 0 ],
 			[ '/category/metaDescription', 'Category Desc', 1, 1, 0 ],
@@ -443,10 +443,10 @@ final class Aioseo_Taxonomy_Settings_Importing_Action_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function provider_query() {
+	public static function provider_query() {
 		$full_settings = [
 			'searchAppearance' => [
-				'taxonomies'   => $this->full_settings_to_import,
+				'taxonomies'   => self::$full_settings_to_import,
 				'postypes'     => [
 					'post' => [
 						'title'           => 'title1',
@@ -456,10 +456,10 @@ final class Aioseo_Taxonomy_Settings_Importing_Action_Test extends TestCase {
 			],
 		];
 
-		$full_settings_expected = $this->flattened_settings_to_import;
+		$full_settings_expected = self::$flattened_settings_to_import;
 
 		return [
-			[ \json_encode( $full_settings ), $this->full_settings_to_import, $full_settings_expected, 1 ],
+			[ \json_encode( $full_settings ), self::$full_settings_to_import, $full_settings_expected, 1 ],
 		];
 	}
 }

--- a/tests/Unit/Actions/Importing/Aioseo_Validate_Data_Action_Test.php
+++ b/tests/Unit/Actions/Importing/Aioseo_Validate_Data_Action_Test.php
@@ -380,7 +380,7 @@ final class Aioseo_Validate_Data_Action_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function provider_validate_default_robot_settings() {
+	public static function provider_validate_default_robot_settings() {
 		$robot_setting_map_custom_archives_empty    = [];
 		$robot_setting_map_default_archives_all_set = [
 			'option_name' => 'aioseo_options_dynamic',
@@ -505,7 +505,7 @@ final class Aioseo_Validate_Data_Action_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function provider_validate_post_robot_settings() {
+	public static function provider_validate_post_robot_settings() {
 		$aioseo_global_settings_all_set = [
 			'searchAppearance' => [
 				'advanced' => [
@@ -622,7 +622,7 @@ final class Aioseo_Validate_Data_Action_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function provider_validate_aioseo_settings() {
+	public static function provider_validate_aioseo_settings() {
 		$aioseo_settings = [
 			'searchAppearance' => [
 				'archive'    => 'settings',
@@ -689,7 +689,7 @@ final class Aioseo_Validate_Data_Action_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function provider_validate_aioseo_table() {
+	public static function provider_validate_aioseo_table() {
 		return [
 			[ false, [ 'irrelevant' ], [ 'irrelevant' ], 0, false ],
 			[
@@ -729,7 +729,7 @@ final class Aioseo_Validate_Data_Action_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function provider_get_unindexed() {
+	public static function provider_get_unindexed() {
 		$completed                 = [
 			'aioseo_validate_data' => true,
 		];

--- a/tests/Unit/Actions/Importing/Deactivate_Conflicting_Plugins_Action_Test.php
+++ b/tests/Unit/Actions/Importing/Deactivate_Conflicting_Plugins_Action_Test.php
@@ -106,7 +106,7 @@ final class Deactivate_Conflicting_Plugins_Action_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function is_compatible_with_testdata() {
+	public static function is_compatible_with_testdata() {
 		return [
 			[
 				null,
@@ -158,7 +158,7 @@ final class Deactivate_Conflicting_Plugins_Action_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function is_compatible_with_wrong_testdata() {
+	public static function is_compatible_with_wrong_testdata() {
 		return [
 			[
 				null,
@@ -278,7 +278,7 @@ final class Deactivate_Conflicting_Plugins_Action_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function get_limited_data() {
+	public static function get_limited_data() {
 		return [
 			[ 5, 4 ],
 			[ 4, 4 ],

--- a/tests/Unit/Actions/Indexables/Indexable_Head_Action_Test.php
+++ b/tests/Unit/Actions/Indexables/Indexable_Head_Action_Test.php
@@ -225,7 +225,7 @@ final class Indexable_Head_Action_Test extends TestCase {
 	 *
 	 * @return array A mapping of methods and expected inputs.
 	 */
-	public function method_provider() {
+	public static function method_provider() {
 		return [
 			[ 'for_url', 'https://example.org/' ],
 			[ 'for_post', 1 ],

--- a/tests/Unit/Admin/Ajax/Shortcode_Filter_Test.php
+++ b/tests/Unit/Admin/Ajax/Shortcode_Filter_Test.php
@@ -86,7 +86,7 @@ final class Shortcode_Filter_Test extends TestCase {
 	 *
 	 * @return array The test data to use.
 	 */
-	public function provider_do_filter() {
+	public static function provider_do_filter() {
 		return [
 			'Valid shortcodes' => [
 				'post_data'           => [

--- a/tests/Unit/Admin/Capabilities/Capabilities_Utils_Test.php
+++ b/tests/Unit/Admin/Capabilities/Capabilities_Utils_Test.php
@@ -128,7 +128,7 @@ final class Capabilities_Utils_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function get_applicable_roles_provider() {
+	public static function get_applicable_roles_provider() {
 		return [
 			[
 				'role'     => (object) [

--- a/tests/Unit/Admin/Gutenberg_Compatibility_Notification_Test.php
+++ b/tests/Unit/Admin/Gutenberg_Compatibility_Notification_Test.php
@@ -110,7 +110,7 @@ final class Gutenberg_Compatibility_Notification_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function data_provider_manage_notification_remove_notification() {
+	public static function data_provider_manage_notification_remove_notification() {
 		return [
 			'filter is false'  => [
 				'installed'        => true,

--- a/tests/Unit/Admin/Metabox/Metabox_Collapsibles_Sections_Test.php
+++ b/tests/Unit/Admin/Metabox/Metabox_Collapsibles_Sections_Test.php
@@ -67,7 +67,7 @@ final class Metabox_Collapsibles_Sections_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function data_display_content_with_collapsible() {
+	public static function data_display_content_with_collapsible() {
 		return [
 			[ 'Collapsible 1 label' ],
 			[ 'Collapsible 1 content' ],

--- a/tests/Unit/Admin/Metabox/Metabox_Section_Additional_Test.php
+++ b/tests/Unit/Admin/Metabox/Metabox_Section_Additional_Test.php
@@ -48,7 +48,7 @@ final class Metabox_Section_Additional_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function data_display_content() {
+	public static function data_display_content() {
 		return [
 			[ 'Additional Content' ],
 			[ 'id="wpseo-meta-section-additional-tab"' ],
@@ -90,7 +90,7 @@ final class Metabox_Section_Additional_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function data_display_link() {
+	public static function data_display_link() {
 		return [
 			[ 'Additional Tab' ],
 			[ 'id="wpseo-meta-tab-additional-tab"' ],

--- a/tests/Unit/Admin/User_Profile_Test.php
+++ b/tests/Unit/Admin/User_Profile_Test.php
@@ -81,7 +81,7 @@ final class User_Profile_Test extends TestCase {
 	 *
 	 * @return array The data for test_process_user_option_update_with_dataprovider.
 	 */
-	public function process_user_option_update_dataprovider() {
+	public static function process_user_option_update_dataprovider() {
 		$all_set                               = [
 			[
 				'wpseo_author_title' => [

--- a/tests/Unit/Analytics/Application/Missing_Indexables_Collector_Test.php
+++ b/tests/Unit/Analytics/Application/Missing_Indexables_Collector_Test.php
@@ -45,7 +45,7 @@ final class Missing_Indexables_Collector_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function collector_get_data() {
+	public static function collector_get_data() {
 		$indexation_action = new Abstract_Indexing_Action_Double();
 
 		return [

--- a/tests/Unit/Builders/Indexable_Builder/Is_Type_With_No_Id_Test.php
+++ b/tests/Unit/Builders/Indexable_Builder/Is_Type_With_No_Id_Test.php
@@ -45,7 +45,7 @@ final class Is_Type_With_No_Id_Test extends Abstract_Indexable_Builder_TestCase 
 	 *
 	 * @return array The test data.
 	 */
-	public function is_type_with_no_id_provider() {
+	public static function is_type_with_no_id_provider() {
 		return [
 			'Home page type' => [
 				'type'     => 'home-page',

--- a/tests/Unit/Builders/Indexable_Builder/Save_Indexable_Test.php
+++ b/tests/Unit/Builders/Indexable_Builder/Save_Indexable_Test.php
@@ -47,7 +47,7 @@ final class Save_Indexable_Test extends Abstract_Indexable_Builder_TestCase {
 	 *
 	 * @return array The test data.
 	 */
-	public function save_indexable_provider() {
+	public static function save_indexable_provider() {
 		$before = Mockery::mock( Indexable::class );
 		return [
 			'Should index and save' => [

--- a/tests/Unit/Builders/Indexable_Link_Builder/Build_Test.php
+++ b/tests/Unit/Builders/Indexable_Link_Builder/Build_Test.php
@@ -27,7 +27,7 @@ final class Build_Test extends Abstract_Indexable_Link_Builder_TestCase {
 	 *
 	 * @return array The test data.
 	 */
-	public function build_provider() {
+	public static function build_provider() {
 		return [
 			[
 				'
@@ -410,7 +410,7 @@ final class Build_Test extends Abstract_Indexable_Link_Builder_TestCase {
 	 *
 	 * @return Generator
 	 */
-	public function provide_no_content_scan() {
+	public static function provide_no_content_scan() {
 		yield 'No content so no links' => [
 			'input_content' => '',
 			'output_result' => [],

--- a/tests/Unit/Builders/Indexable_Link_Builder/Get_Permalink_Test.php
+++ b/tests/Unit/Builders/Indexable_Link_Builder/Get_Permalink_Test.php
@@ -36,7 +36,7 @@ final class Get_Permalink_Test extends Abstract_Indexable_Link_Builder_TestCase 
 	 *
 	 * @return array
 	 */
-	public function data_provider_get_permalink() {
+	public static function data_provider_get_permalink() {
 		return [
 			'No www with anchor' => [
 				'link'           => 'http://example.com/page#section',

--- a/tests/Unit/Builders/Indexable_Link_Builder/Patch_Seo_Links_Test.php
+++ b/tests/Unit/Builders/Indexable_Link_Builder/Patch_Seo_Links_Test.php
@@ -21,7 +21,7 @@ final class Patch_Seo_Links_Test extends Abstract_Indexable_Link_Builder_TestCas
 	 *
 	 * @return array
 	 */
-	public function patch_seo_links_provider() {
+	public static function patch_seo_links_provider() {
 		$object                                  = (object) [ 'type' => 'not SEO_Links' ];
 		$seo_link                                = new SEO_Links_Mock();
 		$seo_link->target_indexable_id           = null;

--- a/tests/Unit/Builders/Indexable_Link_Builder/Update_Incoming_Links_For_Related_Test.php
+++ b/tests/Unit/Builders/Indexable_Link_Builder/Update_Incoming_Links_For_Related_Test.php
@@ -38,7 +38,7 @@ final class Update_Incoming_Links_For_Related_Test extends Abstract_Indexable_Li
 	 *
 	 * @return array
 	 */
-	public function data_provider_update_incoming_links_for_related_indexables() {
+	public static function data_provider_update_incoming_links_for_related_indexables() {
 		return [
 			'no related indexables' => [
 				'related_indexable_ids'                            => [],

--- a/tests/Unit/Builders/Indexable_Post_Builder_Test.php
+++ b/tests/Unit/Builders/Indexable_Post_Builder_Test.php
@@ -363,7 +363,7 @@ final class Indexable_Post_Builder_Test extends TestCase {
 	 *
 	 * @return array The data to provide.
 	 */
-	public function provider_build() {
+	public static function provider_build() {
 		$postmeta_set_with_missing_data                     = [
 			'_yoast_wpseo_linkdex'                        => [ '100' ],
 			'_yoast_wpseo_is_cornerstone'                 => [ '1' ],

--- a/tests/Unit/Conditionals/Admin/Yoast_Admin_Conditional_Test.php
+++ b/tests/Unit/Conditionals/Admin/Yoast_Admin_Conditional_Test.php
@@ -85,7 +85,7 @@ final class Yoast_Admin_Conditional_Test extends TestCase {
 	 *
 	 * @return array The data.
 	 */
-	public function is_met_data() {
+	public static function is_met_data() {
 		return [
 			'on a Yoast admin page'     => [
 				'is_admin'          => true,

--- a/tests/Unit/Conditionals/Third_Party/Elementor_Edit_Conditional_Test.php
+++ b/tests/Unit/Conditionals/Third_Party/Elementor_Edit_Conditional_Test.php
@@ -70,7 +70,7 @@ final class Elementor_Edit_Conditional_Test extends TestCase {
 	 *
 	 * @return array[] The data for test_is_met.
 	 */
-	public function is_met_dataprovider() {
+	public static function is_met_dataprovider() {
 		$action_in_get          = [
 			'pagenow_new'   => 'post.php',
 			'get_action'    => 'elementor',

--- a/tests/Unit/Config/Indexable_Builder_Versions_Test.php
+++ b/tests/Unit/Config/Indexable_Builder_Versions_Test.php
@@ -92,7 +92,7 @@ final class Indexable_Builder_Versions_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function data_get_latest_version_for_type() {
+	public static function data_get_latest_version_for_type() {
 		$default = Indexable_Builder_Versions::DEFAULT_INDEXABLE_BUILDER_VERSION;
 
 		return [

--- a/tests/Unit/Context/Meta_Tags_Context_Test.php
+++ b/tests/Unit/Context/Meta_Tags_Context_Test.php
@@ -163,7 +163,7 @@ final class Meta_Tags_Context_Test extends TestCase {
 	 *
 	 * @return array Test data to use.
 	 */
-	public function generate_schema_page_type_provider() {
+	public static function generate_schema_page_type_provider() {
 		return [
 			[
 				'indexable' => [
@@ -358,7 +358,7 @@ final class Meta_Tags_Context_Test extends TestCase {
 	 *
 	 * @return array Test data to use.
 	 */
-	public function generate_schema_article_type_provider() {
+	public static function generate_schema_article_type_provider() {
 		return [
 			[
 				'indexable'            => [

--- a/tests/Unit/Generators/Breadcrumbs_Generator_Test.php
+++ b/tests/Unit/Generators/Breadcrumbs_Generator_Test.php
@@ -244,7 +244,7 @@ final class Breadcrumbs_Generator_Test extends TestCase {
 	 *
 	 * @return array The data to use.
 	 */
-	public function generate_provider() {
+	public static function generate_provider() {
 		return [
 			'hide-blog-page' => [
 				'scenario'         => 'hide-blog-page',
@@ -344,7 +344,7 @@ final class Breadcrumbs_Generator_Test extends TestCase {
 	 *
 	 * @return array[] Test data to use.
 	 */
-	public function date_archive_provider() {
+	public static function date_archive_provider() {
 		return [
 			'for_day' => [
 				'scenario'     => 'day',

--- a/tests/Unit/Generators/Open_Graph_Locale_Generator_Test.php
+++ b/tests/Unit/Generators/Open_Graph_Locale_Generator_Test.php
@@ -70,7 +70,7 @@ final class Open_Graph_Locale_Generator_Test extends TestCase {
 	 *
 	 * @return array The data to use for the test.
 	 */
-	public function generate_provider() {
+	public static function generate_provider() {
 		return [
 			[
 				'locale'   => 'ca',

--- a/tests/Unit/Generators/Schema/Article_Test.php
+++ b/tests/Unit/Generators/Schema/Article_Test.php
@@ -320,7 +320,7 @@ final class Article_Test extends TestCase {
 	 *
 	 * @return array The data to use.
 	 */
-	public function provider_for_generate() {
+	public static function provider_for_generate() {
 		return [
 			[
 				'values_to_test' => [

--- a/tests/Unit/Generators/Schema/Organization_Test.php
+++ b/tests/Unit/Generators/Schema/Organization_Test.php
@@ -268,7 +268,7 @@ final class Organization_Test extends TestCase {
 	 *
 	 * @return array The test data to use.
 	 */
-	public function generate_provider() {
+	public static function generate_provider() {
 		return [
 			'Every possible social profile filled' => [
 				'profiles_input'    => [

--- a/tests/Unit/Generators/Schema/WebPage_Test.php
+++ b/tests/Unit/Generators/Schema/WebPage_Test.php
@@ -556,7 +556,7 @@ final class WebPage_Test extends TestCase {
 	 *
 	 * @return array The data to use.
 	 */
-	public function provider_for_generate() {
+	public static function provider_for_generate() {
 		return [
 			[
 				'values_to_test' => [
@@ -645,7 +645,7 @@ final class WebPage_Test extends TestCase {
 	 *
 	 * @return array The data to use.
 	 */
-	public function provider_for_is_needed() {
+	public static function provider_for_is_needed() {
 		return [
 			[
 				'object_type'     => 'user',

--- a/tests/Unit/Helpers/Aioseo_Helper_Test.php
+++ b/tests/Unit/Helpers/Aioseo_Helper_Test.php
@@ -119,7 +119,7 @@ final class Aioseo_Helper_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function provider_get_global_option() {
+	public static function provider_get_global_option() {
 		$retrieved_aioseo_options = [
 			'option1' => 'value1',
 			'option2' => 'value2',
@@ -135,7 +135,7 @@ final class Aioseo_Helper_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function provider_aioseo_exists() {
+	public static function provider_aioseo_exists() {
 		return [
 			[ false, false ],
 			[ true, true ],

--- a/tests/Unit/Helpers/Crawl_Cleanup_Helper_Test.php
+++ b/tests/Unit/Helpers/Crawl_Cleanup_Helper_Test.php
@@ -117,7 +117,7 @@ final class Crawl_Cleanup_Helper_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function should_avoid_redirect_provider() {
+	public static function should_avoid_redirect_provider() {
 		return [
 			[ true, false, null, false, true ],
 			[ false, true, null, false, true ],
@@ -170,7 +170,7 @@ final class Crawl_Cleanup_Helper_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function get_allowed_extravars_provider() {
+	public static function get_allowed_extravars_provider() {
 		return [
 			[ 'variable1,variable2,variable3', [], [ 'variable1', 'variable2', 'variable3' ] ],
 			[ '', [], [] ],
@@ -226,7 +226,7 @@ final class Crawl_Cleanup_Helper_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function front_page_url_provider() {
+	public static function front_page_url_provider() {
 		return [
 			[ true, false, 0, 1, 0, 'http://basic.wordpress.test/' ],
 			[ false, true, 1, 0, 1, 'http://basic.wordpress.test/permalink' ],
@@ -288,7 +288,7 @@ final class Crawl_Cleanup_Helper_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function page_not_found_url_provider() {
+	public static function page_not_found_url_provider() {
 		return [
 			[ true, true, true, '', null, 0, 0, 0, '', '' ],
 			[ false, false, true, '', null, 0, 0, 0, '', '' ],
@@ -355,7 +355,7 @@ final class Crawl_Cleanup_Helper_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function taxonomy_url_provider() {
+	public static function taxonomy_url_provider() {
 		return [
 			[ false, 0, 1, 'http://basic.wordpress.test/products' ],
 			[ true, 1, 0, 'http://basic.wordpress.test/products/feed' ],
@@ -422,7 +422,7 @@ final class Crawl_Cleanup_Helper_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function query_var_page_url_provider() {
+	public static function query_var_page_url_provider() {
 		$proper_url = 'http://basic.wordpress.test';
 		return [
 			[ true, $proper_url, 1, 1, 'http://basic.wordpress.test/page/test/?s=test' ],
@@ -462,7 +462,7 @@ final class Crawl_Cleanup_Helper_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function is_query_var_page_provider() {
+	public static function is_query_var_page_provider() {
 		$proper_url = 'http://basic.wordpress.test';
 		return [
 			[ '', null, null, false ],
@@ -540,7 +540,7 @@ final class Crawl_Cleanup_Helper_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function get_url_type_provider() {
+	public static function get_url_type_provider() {
 		return [
 			[ true, false, false, false, false, false, false, false, 0, 'singular_url' ],
 			[ false, true, false, false, false, false, false, false, 0, 'front_page_url' ],

--- a/tests/Unit/Helpers/Date_Helper_Test.php
+++ b/tests/Unit/Helpers/Date_Helper_Test.php
@@ -54,7 +54,7 @@ final class Date_Helper_Test extends TestCase {
 	 *
 	 * @return array The test data.
 	 */
-	public function format_provider() {
+	public static function format_provider() {
 		return [
 			'Test formatting the date, the default way' => [
 				'date'     => '2020-12-31 13:37:00',
@@ -125,7 +125,7 @@ final class Date_Helper_Test extends TestCase {
 	 *
 	 * @return array The test data.
 	 */
-	public function format_timestamp_provider() {
+	public static function format_timestamp_provider() {
 		return [
 			'Test formatting a date given as timestamp' => [
 				'timestamp' => '1973-11-29 21:33:09',
@@ -189,7 +189,7 @@ final class Date_Helper_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function data_is_valid_datetime() {
+	public static function data_is_valid_datetime() {
 		return [
 			'Valid datetime string' => [
 				'input'    => '2015-02-25T04:44:44+00:00',

--- a/tests/Unit/Helpers/Import_Cursor_Helper_Test.php
+++ b/tests/Unit/Helpers/Import_Cursor_Helper_Test.php
@@ -122,7 +122,7 @@ final class Import_Cursor_Helper_Test extends TestCase {
 	 *
 	 * @return array Data for test_set_cursor_invalid function.
 	 */
-	public function not_set_cursor_values() {
+	public static function not_set_cursor_values() {
 		return [
 			[ 0 ],
 			[ -1 ],
@@ -167,7 +167,7 @@ final class Import_Cursor_Helper_Test extends TestCase {
 	 *
 	 * @return array Data for test_set_cursor function.
 	 */
-	public function set_cursor_values() {
+	public static function set_cursor_values() {
 		return [
 			[ 1338 ],
 			[ 1337.5 ],

--- a/tests/Unit/Helpers/Import_Helper_Test.php
+++ b/tests/Unit/Helpers/Import_Helper_Test.php
@@ -55,7 +55,7 @@ final class Import_Helper_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function provider_flatten_settings() {
+	public static function provider_flatten_settings() {
 
 		$full_custom_archive_settings_to_import      = [
 			'book'  => [

--- a/tests/Unit/Helpers/Indexable_Helper_Test.php
+++ b/tests/Unit/Helpers/Indexable_Helper_Test.php
@@ -137,7 +137,7 @@ final class Indexable_Helper_Test extends TestCase {
 	 *
 	 * @return array The test data.
 	 */
-	public function get_page_type_for_indexable_provider() {
+	public static function get_page_type_for_indexable_provider() {
 		return [
 			[ 'post', 'page', true, false, 'Static_Home_Page' ],
 			[ 'post', 'page', false, true, 'Static_Posts_Page' ],
@@ -197,7 +197,7 @@ final class Indexable_Helper_Test extends TestCase {
 	 *
 	 * @return array[]
 	 */
-	public function should_index_for_production_environment_provider() {
+	public static function should_index_for_production_environment_provider() {
 		return [
 			[ 'production', true ],
 			[ 'staging', false ],
@@ -242,7 +242,7 @@ final class Indexable_Helper_Test extends TestCase {
 	 *
 	 * @return array[]
 	 */
-	public function provider_check_if_default_indexable() {
+	public static function provider_check_if_default_indexable() {
 		$all_default_fields     = [
 			[
 				'field_name'  => 'title',
@@ -306,7 +306,7 @@ final class Indexable_Helper_Test extends TestCase {
 	 *
 	 * @return array[]
 	 */
-	public function provider_check_if_default_field() {
+	public static function provider_check_if_default_field() {
 		return [
 			[ 'title', null, true ],
 			[ 'title', 'not null', false ],

--- a/tests/Unit/Helpers/Language_Helper_Test.php
+++ b/tests/Unit/Helpers/Language_Helper_Test.php
@@ -51,7 +51,7 @@ final class Language_Helper_Test extends TestCase {
 	 *
 	 * @return string[][] The dataset.
 	 */
-	public function supported_language_provider() {
+	public static function supported_language_provider() {
 		return [ [ 'de' ], [ 'en' ], [ 'es' ], [ 'fr' ], [ 'it' ], [ 'nl' ], [ 'ru' ], [ 'id' ], [ 'pt' ], [ 'pl' ], [ 'ar' ], [ 'sv' ], [ 'he' ], [ 'hu' ], [ 'nb' ], [ 'tr' ], [ 'cs' ], [ 'sk' ], [ 'el' ], [ 'ja' ] ];
 	}
 
@@ -75,7 +75,7 @@ final class Language_Helper_Test extends TestCase {
 	 *
 	 * @return string[][] The dataset.
 	 */
-	public function language_with_function_word_support_provider() {
+	public static function language_with_function_word_support_provider() {
 		return [
 			[ 'en' ],
 			[ 'de' ],

--- a/tests/Unit/Helpers/Pagination_Helper_Test.php
+++ b/tests/Unit/Helpers/Pagination_Helper_Test.php
@@ -355,7 +355,7 @@ final class Pagination_Helper_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function data_provider_get_current_post_page_number() {
+	public static function data_provider_get_current_post_page_number() {
 		return [
 			'query_var page number' => [
 				'query_var_paged'    => '2',
@@ -415,7 +415,7 @@ final class Pagination_Helper_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function data_provider_get_current_page_number() {
+	public static function data_provider_get_current_page_number() {
 		return [
 			'Query var paged' => [
 				'query_var_paged' => 100,
@@ -506,7 +506,7 @@ final class Pagination_Helper_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function data_provider_get_key_query_loop() {
+	public static function data_provider_get_key_query_loop() {
 		return [
 			'Key with one digit number' => [
 				'key'     => 'query-1-page',
@@ -565,7 +565,7 @@ final class Pagination_Helper_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function data_provider_test_get_page_number_from_query_loop() {
+	public static function data_provider_test_get_page_number_from_query_loop() {
 		return [
 			'Key with one digit number' => [
 				'key'     => 'query-1-page',

--- a/tests/Unit/Helpers/Post_Type_Helper_Test.php
+++ b/tests/Unit/Helpers/Post_Type_Helper_Test.php
@@ -68,7 +68,7 @@ final class Post_Type_Helper_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function post_type_archive_provider() {
+	public static function post_type_archive_provider() {
 		$book              = new stdClass();
 		$book->name        = 'books';
 		$book->has_archive = true;
@@ -112,7 +112,7 @@ final class Post_Type_Helper_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function post_type_archive_object_provider() {
+	public static function post_type_archive_object_provider() {
 		$book              = new stdClass();
 		$book->name        = 'books';
 		$book->has_archive = true;

--- a/tests/Unit/Helpers/Robots_Txt_Helper_Test.php
+++ b/tests/Unit/Helpers/Robots_Txt_Helper_Test.php
@@ -73,7 +73,7 @@ final class Robots_Txt_Helper_Test extends TestCase {
 	 *
 	 * @return array Data to use for test_add_disallow.
 	 */
-	public function add_disallow_dataprovider() {
+	public static function add_disallow_dataprovider() {
 		$single_disallow_rule                         = [
 			'arguments' => [
 				[ '*', '/admin.php' ],
@@ -160,7 +160,7 @@ final class Robots_Txt_Helper_Test extends TestCase {
 	 *
 	 * @return array Data to use for test_add_allow.
 	 */
-	public function add_allow_dataprovider() {
+	public static function add_allow_dataprovider() {
 		$single_allow_rule                         = [
 			'arguments' => [
 				[ '*', '/admin.php' ],
@@ -247,7 +247,7 @@ final class Robots_Txt_Helper_Test extends TestCase {
 	 *
 	 * @return array Data to use for test_add_sitemap.
 	 */
-	public function add_sitemap_dataprovider() {
+	public static function add_sitemap_dataprovider() {
 		$single_sitemap    = [
 			'sitemaps' => [
 				'http://sitemap.com/sitemap_index.xml',

--- a/tests/Unit/Helpers/Schema/HTML_Helper_Test.php
+++ b/tests/Unit/Helpers/Schema/HTML_Helper_Test.php
@@ -58,7 +58,7 @@ final class HTML_Helper_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function data_sanitize() {
+	public static function data_sanitize() {
 		return [
 			'Empty text string' => [
 				'input'    => '',
@@ -110,7 +110,7 @@ final class HTML_Helper_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function data_smart_strip_tags() {
+	public static function data_smart_strip_tags() {
 		return [
 			'Empty text string' => [
 				'input'    => '',
@@ -183,7 +183,7 @@ text string',
 	 *
 	 * @return array
 	 */
-	public function data_incorrect_input_types() {
+	public static function data_incorrect_input_types() {
 		return [
 			'null' => [
 				'input'    => null,

--- a/tests/Unit/Helpers/Score_Icon_Helper_Test.php
+++ b/tests/Unit/Helpers/Score_Icon_Helper_Test.php
@@ -86,7 +86,7 @@ final class Score_Icon_Helper_Test extends TestCase {
 	 *
 	 * @return array The readability data.
 	 */
-	public function readability_provider() {
+	public static function readability_provider() {
 		return [
 			'not available' => [
 				'score'       => 0,
@@ -141,7 +141,7 @@ final class Score_Icon_Helper_Test extends TestCase {
 	 *
 	 * @return array The inclusive language data.
 	 */
-	public function inclusive_language_provider() {
+	public static function inclusive_language_provider() {
 		return [
 			'not available' => [
 				'score'       => 0,
@@ -200,7 +200,7 @@ final class Score_Icon_Helper_Test extends TestCase {
 	 *
 	 * @return array The SEO data.
 	 */
-	public function seo_provider() {
+	public static function seo_provider() {
 		return [
 			'not available'      => [
 				'is_indexable'   => true,

--- a/tests/Unit/Helpers/Short_Link_Helper_Test.php
+++ b/tests/Unit/Helpers/Short_Link_Helper_Test.php
@@ -116,7 +116,7 @@ final class Short_Link_Helper_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function build_dataprovider() {
+	public static function build_dataprovider() {
 		return [
 			'premium' => [
 				'is_premium'               => true,
@@ -200,7 +200,7 @@ final class Short_Link_Helper_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function get_query_params_dataprovider() {
+	public static function get_query_params_dataprovider() {
 		return [
 			'screen' => [
 				'is_premium'         => true,

--- a/tests/Unit/Helpers/Social_Profiles_Helper_Test.php
+++ b/tests/Unit/Helpers/Social_Profiles_Helper_Test.php
@@ -100,7 +100,7 @@ final class Social_Profiles_Helper_Test extends TestCase {
 	 *
 	 * @return array Data for test_set_person_social_profiles function.
 	 */
-	public function set_person_social_profiles() {
+	public static function set_person_social_profiles() {
 		$success_all = [
 			'social_profiles'             => [
 				'facebook'   => 'https://facebook.com/janedoe',
@@ -260,7 +260,7 @@ final class Social_Profiles_Helper_Test extends TestCase {
 	 *
 	 * @return array Data for test_set_organization_social_profiles function.
 	 */
-	public function set_organization_social_profiles() {
+	public static function set_organization_social_profiles() {
 		$success_all = [
 			'social_profiles'             => [
 				'facebook_site'          => '',

--- a/tests/Unit/Helpers/Url_Helper_Test.php
+++ b/tests/Unit/Helpers/Url_Helper_Test.php
@@ -127,7 +127,7 @@ final class Url_Helper_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function data_get_url_path() {
+	public static function data_get_url_path() {
 		return [
 			'URL is an empty string' => [
 				'url_input' => '',
@@ -206,7 +206,7 @@ final class Url_Helper_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function data_get_url_host() {
+	public static function data_get_url_host() {
 		return [
 			'URL is an empty string' => [
 				'url_input' => '',
@@ -537,7 +537,7 @@ final class Url_Helper_Test extends TestCase {
 	 *
 	 * @return array The test data.
 	 */
-	public function get_link_type_test_data() {
+	public static function get_link_type_test_data() {
 		return [
 			[
 				[
@@ -682,7 +682,7 @@ final class Url_Helper_Test extends TestCase {
 	 *
 	 * @return array The test data.
 	 */
-	public function recreate_current_url_test_data() {
+	public static function recreate_current_url_test_data() {
 		return [
 			'HTTP with request uri' => [
 				'params'   => [

--- a/tests/Unit/Inc/Addon_Manager_Test.php
+++ b/tests/Unit/Inc/Addon_Manager_Test.php
@@ -847,7 +847,7 @@ final class Addon_Manager_Test extends TestCase {
 	 *
 	 * @return array Values for the test.
 	 */
-	public function check_for_updates_provider() {
+	public static function check_for_updates_provider() {
 		return [
 			[
 				'addons'   => [],
@@ -945,7 +945,7 @@ final class Addon_Manager_Test extends TestCase {
 	 *
 	 * @return array Values for the test.
 	 */
-	public function get_plugin_information_provider() {
+	public static function get_plugin_information_provider() {
 		return [
 			[
 				'action'   => 'wrong_action',
@@ -1107,7 +1107,7 @@ final class Addon_Manager_Test extends TestCase {
 	 *
 	 * @return array[] The data for test_get_myyoast_site_information.
 	 */
-	public function get_myyoast_site_information_dataprovider() {
+	public static function get_myyoast_site_information_dataprovider() {
 		$normal_call            = [
 			'pagenow_new'      => 'plugins.php',
 			'page'             => 'wpseo_licences',

--- a/tests/Unit/Inc/Image_Utils_Test.php
+++ b/tests/Unit/Inc/Image_Utils_Test.php
@@ -81,7 +81,7 @@ final class Image_Utils_Test extends TestCase {
 	 *
 	 * @return array Data to execute for each run.
 	 */
-	public function get_first_image_provider() {
+	public static function get_first_image_provider() {
 		return [
 			[
 				'images'   => [ 'https://example.com/media/first_image.jpg', 'https://example.com/media/second_image.jpg' ],

--- a/tests/Unit/Inc/Options/Option_Social_Test.php
+++ b/tests/Unit/Inc/Options/Option_Social_Test.php
@@ -134,7 +134,7 @@ final class Option_Social_Test extends TestCase {
 	 *
 	 * @return array The test data.
 	 */
-	public function validate_option_valid_data_provider() {
+	public static function validate_option_valid_data_provider() {
 		return [
 			[
 				'expected' => [ 'og_default_image_id' => 'value' ],
@@ -196,7 +196,7 @@ final class Option_Social_Test extends TestCase {
 	 *
 	 * @return array The test data.
 	 */
-	public function validate_option_invalid_data_provider() {
+	public static function validate_option_invalid_data_provider() {
 		return [
 			[
 				'expected'  => [ 'facebook_site' => '' ],
@@ -220,7 +220,7 @@ final class Option_Social_Test extends TestCase {
 	 *
 	 * @return array The test data.
 	 */
-	public function validate_option_invalid_array_data_provider() {
+	public static function validate_option_invalid_array_data_provider() {
 		return [
 			[
 				'expected'  => [

--- a/tests/Unit/Inc/Sitemaps/WPSEO_Sitemaps_Router.php
+++ b/tests/Unit/Inc/Sitemaps/WPSEO_Sitemaps_Router.php
@@ -170,7 +170,7 @@ final class WPSEO_Sitemaps_Router_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function redirect_canonical_data_provider() {
+	public static function redirect_canonical_data_provider() {
 		return [
 			'no sitemap' => [
 				'is_sitemap'           => false,
@@ -260,7 +260,7 @@ final class WPSEO_Sitemaps_Router_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function needs_sitemap_index_redirect_data_provider() {
+	public static function needs_sitemap_index_redirect_data_provider() {
 		return [
 			'no https 1' => [
 				'https'       => false,
@@ -345,7 +345,7 @@ final class WPSEO_Sitemaps_Router_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function get_base_url_data_provider() {
+	public static function get_base_url_data_provider() {
 		return [
 			'index permalinks' => [
 				'using_index_permalinks' => true,

--- a/tests/Unit/Initializers/Crawl_Cleanup_Permalinks_Test.php
+++ b/tests/Unit/Initializers/Crawl_Cleanup_Permalinks_Test.php
@@ -142,7 +142,7 @@ final class Crawl_Cleanup_Permalinks_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function register_hooks_provider() {
+	public static function register_hooks_provider() {
 		return [
 			[ null, 'returned_value_campaign_tracking_urls', 'returned_value_clean_permalinks', 0, 0 ],
 			[ null, 'returned_value_campaign_tracking_urls', null, 0, 0 ],
@@ -206,7 +206,7 @@ final class Crawl_Cleanup_Permalinks_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function utm_redirect_provider() {
+	public static function utm_redirect_provider() {
 		return [
 			[ null, null, 0 ],
 			[ 'random_post_slug', null, 0 ],
@@ -279,7 +279,7 @@ final class Crawl_Cleanup_Permalinks_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function clean_permalinks_no_redirect_provider() {
+	public static function clean_permalinks_no_redirect_provider() {
 		return [
 			[ true, 0, null, null, 0 ],
 			[ false, 1, 'http://www.example.com/?unknown=123', [ 'query' => [] ], 0 ],
@@ -358,7 +358,7 @@ final class Crawl_Cleanup_Permalinks_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function clean_permalinks_provider() {
+	public static function clean_permalinks_provider() {
 		$allowed_params = [
 			'query'         => [ 'unknown' => '123' ],
 			'allowed_query' => [ 'utm_medium' => 'allowed' ],
@@ -473,7 +473,7 @@ final class Crawl_Cleanup_Permalinks_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function clean_permalinks_with_page_var_provider() {
+	public static function clean_permalinks_with_page_var_provider() {
 		$allowed_params = [
 			'query'         => [ 'unknown' => '123' ],
 			'allowed_query' => [ 'utm_medium' => 'allowed' ],

--- a/tests/Unit/Initializers/Disable_Core_Sitemaps_Test.php
+++ b/tests/Unit/Initializers/Disable_Core_Sitemaps_Test.php
@@ -138,7 +138,7 @@ final class Disable_Core_Sitemaps_Test extends TestCase {
 	 *
 	 * @return array The test data.
 	 */
-	public function template_redirect_data() {
+	public static function template_redirect_data() {
 		return [
 			[ null, null ],
 			[ '/', null ],

--- a/tests/Unit/Integrations/Academy_Integration_Test.php
+++ b/tests/Unit/Integrations/Academy_Integration_Test.php
@@ -120,7 +120,7 @@ final class Academy_Integration_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function register_hooks_provider() {
+	public static function register_hooks_provider() {
 		return [
 			'Not on academy page' => [
 				'current_page' => 'not academy page',

--- a/tests/Unit/Integrations/Admin/Background_Indexing_Integration_Test.php
+++ b/tests/Unit/Integrations/Admin/Background_Indexing_Integration_Test.php
@@ -761,7 +761,7 @@ final class Background_Indexing_Integration_Test extends TestCase {
 	 *
 	 * @return array The test data.
 	 */
-	public function data_schedule_cron_indexing() {
+	public static function data_schedule_cron_indexing() {
 		return [
 			'Cron job is not scheduled when not on the right pages' => [
 				'admin_dashboard_conditional_result' => false,

--- a/tests/Unit/Integrations/Admin/Crawl_Settings_Integration_Test.php
+++ b/tests/Unit/Integrations/Admin/Crawl_Settings_Integration_Test.php
@@ -120,7 +120,7 @@ final class Crawl_Settings_Integration_Test extends TestCase {
 	 *
 	 * @return array The data for the test: $is_network_admin, $get_response, $expected.
 	 */
-	public function enqueue_assets_provider() {
+	public static function enqueue_assets_provider() {
 		return [
 			[ true, null, 0 ],
 			[ false, null, 0 ],

--- a/tests/Unit/Integrations/Admin/First_Time_Configuration_Notice_Integration_Test.php
+++ b/tests/Unit/Integrations/Admin/First_Time_Configuration_Notice_Integration_Test.php
@@ -118,7 +118,7 @@ final class First_Time_Configuration_Notice_Integration_Test extends TestCase {
 	 *
 	 * @return array The data for the test.
 	 */
-	public function dismiss_first_time_configuration_notice_provider() {
+	public static function dismiss_first_time_configuration_notice_provider() {
 		return [
 			[
 				'check_ajax_referer'                   => true,
@@ -179,7 +179,7 @@ final class First_Time_Configuration_Notice_Integration_Test extends TestCase {
 	 *
 	 * @return array The data for the test.
 	 */
-	public function first_time_configuration_notice_provider() {
+	public static function first_time_configuration_notice_provider() {
 
 		// In case of change in js, make sure to match the tabs and line breaks for this test to pass (avoid 4 spaces as tab).
 		$default_message = '<div id="yoast-first-time-configuration-notice" class="notice notice-yoast yoast is-dismissible"><div class="notice-yoast__container"><div><div class="notice-yoast__header"><span class="yoast-icon"></span><h2 class="notice-yoast__header-heading">First-time SEO configuration</h2></div><p>Get started quickly with the <a href="">Yoast SEO First-time configuration</a> and configure Yoast SEO with the optimal SEO settings for your site!</p></div><img src="images/mirrored_fit_bubble_woman_1_optim.svg" alt="" height="60" width="75"/></div></div><script>

--- a/tests/Unit/Integrations/Admin/Indexing_Notification_Integration_Test.php
+++ b/tests/Unit/Integrations/Admin/Indexing_Notification_Integration_Test.php
@@ -443,7 +443,7 @@ final class Indexing_Notification_Integration_Test extends TestCase {
 	 *
 	 * @return array A mapping of methods and expected inputs.
 	 */
-	public function reason_provider() {
+	public static function reason_provider() {
 		return [
 			[ 'permalink_settings_changed' ],
 			[ 'category_base_changed' ],

--- a/tests/Unit/Integrations/Admin/Redirect_Integration_Test.php
+++ b/tests/Unit/Integrations/Admin/Redirect_Integration_Test.php
@@ -115,7 +115,7 @@ final class Redirect_Integration_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function provider_old_settings_redirect() {
+	public static function provider_old_settings_redirect() {
 		return [
 			[ 'wpseo_titles', 1 ],
 			[ 'NOT_wpseo_titles', 0 ],

--- a/tests/Unit/Integrations/Blocks/Structured_Data_Blocks_Test.php
+++ b/tests/Unit/Integrations/Blocks/Structured_Data_Blocks_Test.php
@@ -80,7 +80,7 @@ final class Structured_Data_Blocks_Test extends TestCase {
 	 *
 	 * @return array[]
 	 */
-	public function how_to_block_provider() {
+	public static function how_to_block_provider() {
 		return [
 			[
 				'<p class="schema-how-to-total-time"><span class="schema-how-to-duration-time-text">The amount of time it will take:&nbsp;</span>2 hours and 20 minutes</p>',
@@ -179,7 +179,7 @@ final class Structured_Data_Blocks_Test extends TestCase {
 	 *
 	 * @return array[]
 	 */
-	public function how_to_images_provider() {
+	public static function how_to_images_provider() {
 		return [
 			[
 				'<p class="schema-how-to-total-time"><span class="schema-how-to-duration-time-text">The amount of time it will take:&nbsp;</span>2 hours and 20 minutes</p>'

--- a/tests/Unit/Integrations/Front_End/Crawl_Cleanup_Rss_Test.php
+++ b/tests/Unit/Integrations/Front_End/Crawl_Cleanup_Rss_Test.php
@@ -119,7 +119,7 @@ final class Crawl_Cleanup_Rss_Test extends TestCase {
 	 *
 	 * @return array[]
 	 */
-	public function maybe_disable_feeds_dataprovider() {
+	public static function maybe_disable_feeds_dataprovider() {
 		return [
 			'singular, feed enabled' => [
 				'types'           => [

--- a/tests/Unit/Integrations/Front_End/Crawl_Cleanup_Searches_Test.php
+++ b/tests/Unit/Integrations/Front_End/Crawl_Cleanup_Searches_Test.php
@@ -274,7 +274,7 @@ final class Crawl_Cleanup_Searches_Test extends TestCase {
 	 *
 	 * @return Generator
 	 */
-	public function provide_query_string_parameters() {
+	public static function provide_query_string_parameters() {
 		yield 'Redirects because there are more then 5 characters' => [
 			'input_query_string'  => 'this_is_longer_then_5',
 			'output_query_string' => 'this_',

--- a/tests/Unit/Integrations/Front_End/Open_Graph_OEmbed_Test.php
+++ b/tests/Unit/Integrations/Front_End/Open_Graph_OEmbed_Test.php
@@ -119,7 +119,7 @@ final class Open_Graph_OEmbed_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function set_oembed_data() {
+	public static function set_oembed_data() {
 		return [
 			'with-no-data-set'            => [
 				'expected'  => [],

--- a/tests/Unit/Integrations/Front_End/Robots_Txt_Integration_Test.php
+++ b/tests/Unit/Integrations/Front_End/Robots_Txt_Integration_Test.php
@@ -276,7 +276,7 @@ final class Robots_Txt_Integration_Test extends TestCase {
 	 *
 	 * @return array The multisite to test.
 	 */
-	public function multisite_provider() {
+	public static function multisite_provider() {
 		return [
 			'Multisite subdomain' => [
 				'multisite' => [
@@ -546,7 +546,7 @@ final class Robots_Txt_Integration_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function data_remove_default_robots() {
+	public static function data_remove_default_robots() {
 		return [
 			'Original input doesn\'t contain default string' => [
 				'input'    => 'User-agent: \*Disallow: /wp-admin/',

--- a/tests/Unit/Integrations/Front_End_Integration_Test.php
+++ b/tests/Unit/Integrations/Front_End_Integration_Test.php
@@ -741,7 +741,7 @@ final class Front_End_Integration_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function data_provider_query_loop_next_prev() {
+	public static function data_provider_query_loop_next_prev() {
 		return [
 			'Next link' => [
 				'html'       => '<a href="/?query-1-page=2">Next</a>',

--- a/tests/Unit/Integrations/Primary_Category_Test.php
+++ b/tests/Unit/Integrations/Primary_Category_Test.php
@@ -88,7 +88,7 @@ final class Primary_Category_Test extends TestCase {
 	 *
 	 * @return array The test data to use.
 	 */
-	public function post_link_category_provider() {
+	public static function post_link_category_provider() {
 		return [
 			[
 				'category_id' => 52,

--- a/tests/Unit/Integrations/Support_Integration_Test.php
+++ b/tests/Unit/Integrations/Support_Integration_Test.php
@@ -136,7 +136,7 @@ final class Support_Integration_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function register_hooks_provider() {
+	public static function register_hooks_provider() {
 		return [
 			'Not on support page' => [
 				'current_page' => 'not support page',
@@ -252,7 +252,7 @@ final class Support_Integration_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function data_provider_enqueu_black_friday_style() {
+	public static function data_provider_enqueu_black_friday_style() {
 		return [
 			'is black friday' => [
 				'is_black_friday' => true,

--- a/tests/Unit/Integrations/Third_Party/WooCommerce_Test.php
+++ b/tests/Unit/Integrations/Third_Party/WooCommerce_Test.php
@@ -375,7 +375,7 @@ final class WooCommerce_Test extends TestCase {
 	 *
 	 * @return array The test data.
 	 */
-	public function meta_value_provider() {
+	public static function meta_value_provider() {
 		return [
 			'has_model_value' => [
 				'expected'       => 'This is a value',

--- a/tests/Unit/Integrations/Watchers/Addon_Update_Watcher_Test.php
+++ b/tests/Unit/Integrations/Watchers/Addon_Update_Watcher_Test.php
@@ -481,7 +481,7 @@ final class Addon_Update_Watcher_Test extends TestCase {
 	 *
 	 * @return string[][] The data.
 	 */
-	public function plugin_provider() {
+	public static function plugin_provider() {
 		return [
 			[ 'wordpress-seo-premium/wp-seo-premium.php' ],
 			[ 'wpseo-video/video-seo.php' ],

--- a/tests/Unit/Integrations/Watchers/Indexable_Attachment_Watcher_Test.php
+++ b/tests/Unit/Integrations/Watchers/Indexable_Attachment_Watcher_Test.php
@@ -102,7 +102,7 @@ final class Indexable_Attachment_Watcher_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function check_option_provider() {
+	public static function check_option_provider() {
 		return [
 			'Old and new values are not arrays' => [
 				'old_value'                => 1,

--- a/tests/Unit/Integrations/Watchers/Indexable_Post_Type_Change_Watcher_Test.php
+++ b/tests/Unit/Integrations/Watchers/Indexable_Post_Type_Change_Watcher_Test.php
@@ -199,7 +199,7 @@ final class Indexable_Post_Type_Change_Watcher_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function provider_check_post_types_public_availability() {
+	public static function provider_check_post_types_public_availability() {
 
 		return [
 			'When it is ajax request' => [

--- a/tests/Unit/Integrations/Watchers/Indexable_Taxonomy_Change_Watcher_Test.php
+++ b/tests/Unit/Integrations/Watchers/Indexable_Taxonomy_Change_Watcher_Test.php
@@ -199,7 +199,7 @@ final class Indexable_Taxonomy_Change_Watcher_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function provider_check_taxonomy_public_availability() {
+	public static function provider_check_taxonomy_public_availability() {
 
 		return [
 			'When it is ajax request' => [

--- a/tests/Unit/Integrations/Watchers/Search_Engines_Discouraged_Watcher_Test.php
+++ b/tests/Unit/Integrations/Watchers/Search_Engines_Discouraged_Watcher_Test.php
@@ -233,7 +233,7 @@ final class Search_Engines_Discouraged_Watcher_Test extends TestCase {
 	 *
 	 * @return array Data for test_maybe_show_search_engines_discouraged_notice.
 	 */
-	public function maybe_show_search_engines_discouraged_notice_dataprovider() {
+	public static function maybe_show_search_engines_discouraged_notice_dataprovider() {
 		$should_show_notice             = [
 			'blog_public_option_value'        => '0',
 			'current_user_can_manage_options' => true,
@@ -377,7 +377,7 @@ final class Search_Engines_Discouraged_Watcher_Test extends TestCase {
 	 *
 	 * @return array data for manage_search_engines_discouraged_notification.
 	 */
-	public function manage_search_engines_discouraged_notification_dataprovider() {
+	public static function manage_search_engines_discouraged_notification_dataprovider() {
 		$should_add_notification        = [
 			'blog_public_option_value'      => '0',
 			'ignore_notice'                 => false,

--- a/tests/Unit/Introductions/Application/Ai_Generate_Titles_And_Descriptions_Introduction_Upsell_Test.php
+++ b/tests/Unit/Introductions/Application/Ai_Generate_Titles_And_Descriptions_Introduction_Upsell_Test.php
@@ -140,7 +140,7 @@ final class Ai_Generate_Titles_And_Descriptions_Introduction_Upsell_Test extends
 	 *
 	 * @return array
 	 */
-	public function should_show_data() {
+	public static function should_show_data() {
 		return [
 			'showing'                                 => [
 				'is_premium'          => false,

--- a/tests/Unit/Introductions/Application/Current_Page_Trait_Test.php
+++ b/tests/Unit/Introductions/Application/Current_Page_Trait_Test.php
@@ -57,7 +57,7 @@ final class Current_Page_Trait_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function is_on_installation_page_get_data() {
+	public static function is_on_installation_page_get_data() {
 		return [
 			'no page'                   => [
 				'page'     => '',

--- a/tests/Unit/Introductions/Application/Introductions_Collector_Test.php
+++ b/tests/Unit/Introductions/Application/Introductions_Collector_Test.php
@@ -58,7 +58,7 @@ final class Introductions_Collector_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function collector_get_data() {
+	public static function collector_get_data() {
 		$introductions = [
 			'test1' => new Introduction_Mock( 'test1', 1, true ),
 			'test2' => new Introduction_Mock( 'test2', 2, true ),
@@ -259,7 +259,7 @@ final class Introductions_Collector_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function collector_is_available_introduction_data() {
+	public static function collector_is_available_introduction_data() {
 		$introductions = [
 			'test1' => new Introduction_Mock( 'test1', 1, true ),
 			'test2' => new Introduction_Mock( 'test2', 2, true ),

--- a/tests/Unit/Introductions/Application/User_Allowed_Trait_Test.php
+++ b/tests/Unit/Introductions/Application/User_Allowed_Trait_Test.php
@@ -62,7 +62,7 @@ final class User_Allowed_Trait_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function is_user_allowed_get_data() {
+	public static function is_user_allowed_get_data() {
 		return [
 			'no capabilities'                                => [
 				'capabilities'     => [],

--- a/tests/Unit/Introductions/Application/Version_Trait_Test.php
+++ b/tests/Unit/Introductions/Application/Version_Trait_Test.php
@@ -54,7 +54,7 @@ final class Version_Trait_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function is_version_between_get_data() {
+	public static function is_version_between_get_data() {
 		return [
 			'minor version'     => [
 				'version'     => '21.0',

--- a/tests/Unit/Introductions/Infrastructure/Introductions_Seen_Repository_Test.php
+++ b/tests/Unit/Introductions/Infrastructure/Introductions_Seen_Repository_Test.php
@@ -87,7 +87,7 @@ final class Introductions_Seen_Repository_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function provide_get_all_introductions_test_data() {
+	public static function provide_get_all_introductions_test_data() {
 		return [
 			'nothing stored'    => [
 				'meta'     => '',
@@ -173,7 +173,7 @@ final class Introductions_Seen_Repository_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function provide_is_introduction_seen_test_data() {
+	public static function provide_is_introduction_seen_test_data() {
 		return [
 			'seen'             => [
 				'introduction_id' => 'foo',
@@ -248,7 +248,7 @@ final class Introductions_Seen_Repository_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function provide_set_introduction_test_data() {
+	public static function provide_set_introduction_test_data() {
 		return [
 			'seen'      => [
 				'introduction_id' => 'foo',

--- a/tests/Unit/Introductions/Infrastructure/Wistia_Embed_Permission_Repository_Test.php
+++ b/tests/Unit/Introductions/Infrastructure/Wistia_Embed_Permission_Repository_Test.php
@@ -87,7 +87,7 @@ final class Wistia_Embed_Permission_Repository_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function provide_get_value_for_user_test_data() {
+	public static function provide_get_value_for_user_test_data() {
 		return [
 			'stored string 1'    => [
 				'meta'     => '1',
@@ -156,7 +156,7 @@ final class Wistia_Embed_Permission_Repository_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function provide_set_value_for_user_test_data() {
+	public static function provide_set_value_for_user_test_data() {
 		return [
 			'true with new entry'          => [
 				'input_value'     => true,

--- a/tests/Unit/Main_Test.php
+++ b/tests/Unit/Main_Test.php
@@ -163,7 +163,7 @@ final class Main_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function data_declared_inaccessible_properties() {
+	public static function data_declared_inaccessible_properties() {
 		return [
 			'container'       => [ 'container' ],
 			'cached_surfaces' => [ 'cached_surfaces' ],
@@ -175,7 +175,7 @@ final class Main_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function data_undeclared_properties() {
+	public static function data_undeclared_properties() {
 		return [
 			'xyz'     => [ 'xyz' ],
 			'unknown' => [ 'unknown' ],

--- a/tests/Unit/Presentations/Indexable_Presentation/Twitter_Image_Test.php
+++ b/tests/Unit/Presentations/Indexable_Presentation/Twitter_Image_Test.php
@@ -90,7 +90,7 @@ final class Twitter_Image_Test extends TestCase {
 	 *
 	 * @return array The data to provide.
 	 */
-	public function twitter_image_provider() {
+	public static function twitter_image_provider() {
 		return [
 			[
 				'image_source'    => 'set-by-user',
@@ -123,7 +123,7 @@ final class Twitter_Image_Test extends TestCase {
 	 *
 	 * @return array The data to provide.
 	 */
-	public function twitter_image_open_graph_fallback_provider() {
+	public static function twitter_image_open_graph_fallback_provider() {
 		return [
 			[
 				'image_source'              => 'featured-image',

--- a/tests/Unit/Presenters/Robots_Txt_Presenter_Test.php
+++ b/tests/Unit/Presenters/Robots_Txt_Presenter_Test.php
@@ -79,7 +79,7 @@ final class Robots_Txt_Presenter_Test extends TestCase {
 	 *
 	 * @return array The data used for test_present.
 	 */
-	public function present_dataprovider() {
+	public static function present_dataprovider() {
 		$no_disallow_allow_directives_registered = [
 			'robots_txt_user_agents' => ( new User_Agent_List() )->get_user_agents(),
 			'sitemaps'               => [

--- a/tests/Unit/Presenters/Score_Icon_Presenter_Test.php
+++ b/tests/Unit/Presenters/Score_Icon_Presenter_Test.php
@@ -62,7 +62,7 @@ final class Score_Icon_Presenter_Test extends TestCase {
 	 *
 	 * @return array The test data.
 	 */
-	public function present_provider() {
+	public static function present_provider() {
 		return [
 			'title and class' => [
 				'title'     => 'title',

--- a/tests/Unit/Repositories/Indexable_Cleanup_Repository_Test.php
+++ b/tests/Unit/Repositories/Indexable_Cleanup_Repository_Test.php
@@ -195,7 +195,7 @@ final class Indexable_Cleanup_Repository_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function data_orphaned_from_table() {
+	public static function data_orphaned_from_table() {
 		return [
 			[ 50, 'Indexable_Hierarchy', 'indexable_id' ],
 			[ 50, 'SEO_Links', 'indexable_id' ],
@@ -606,7 +606,7 @@ final class Indexable_Cleanup_Repository_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function data_clean_indexables_for_object_type_and_source_table() {
+	public static function data_clean_indexables_for_object_type_and_source_table() {
 		return [
 			[ 50, 'posts', 'ID', 'post' ],
 			[ 50, 'terms', 'term_id', 'term' ],

--- a/tests/Unit/Repositories/SEO_Links_Repository_Test.php
+++ b/tests/Unit/Repositories/SEO_Links_Repository_Test.php
@@ -275,7 +275,7 @@ final class SEO_Links_Repository_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function get_incoming_link_counts_for_indexable_ids_provider() {
+	public static function get_incoming_link_counts_for_indexable_ids_provider() {
 		return [
 			'Indexable counts is false' => [
 				'indexable_counts' => false,

--- a/tests/Unit/Routes/First_Time_Configuration_Route_Test.php
+++ b/tests/Unit/Routes/First_Time_Configuration_Route_Test.php
@@ -248,7 +248,7 @@ final class First_Time_Configuration_Route_Test extends TestCase {
 	 *
 	 * @return array Data for can_edit_user function.
 	 */
-	public function can_edit_user_provider() {
+	public static function can_edit_user_provider() {
 		$success = [
 			'can_edit' => (object) [
 				'success' => true,

--- a/tests/Unit/Routes/Importing_Route_Test.php
+++ b/tests/Unit/Routes/Importing_Route_Test.php
@@ -174,7 +174,7 @@ final class Importing_Route_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function all_routes() {
+	public static function all_routes() {
 		return [
 			[
 				'aioseo',

--- a/tests/Unit/Routes/Yoast_Head_REST_Field_Test.php
+++ b/tests/Unit/Routes/Yoast_Head_REST_Field_Test.php
@@ -304,7 +304,7 @@ final class Yoast_Head_REST_Field_Test extends TestCase {
 	 *
 	 * @return array A mapping of methods and expected inputs.
 	 */
-	public function method_provider() {
+	public static function method_provider() {
 		return [
 			[
 				'for_post',

--- a/tests/Unit/Services/Importing/Aioseo_Replacevar_Service_Test.php
+++ b/tests/Unit/Services/Importing/Aioseo_Replacevar_Service_Test.php
@@ -50,7 +50,7 @@ final class Aioseo_Replacevar_Service_Test extends TestCase {
 	 *
 	 * @return array The data to provide.
 	 */
-	public function transform_provider() {
+	public static function transform_provider() {
 		return [
 			[
 				'aioseo_data'         => '#archive_title',

--- a/tests/Unit/Services/Importing/Aioseo_Robots_Provider_Service_Test.php
+++ b/tests/Unit/Services/Importing/Aioseo_Robots_Provider_Service_Test.php
@@ -87,7 +87,7 @@ final class Aioseo_Robots_Provider_Service_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function provider_get_subtype_robot_setting() {
+	public static function provider_get_subtype_robot_setting() {
 		$mapping = [
 			'option_name' => 'aioseo_table',
 			'type'        => 'type',
@@ -134,7 +134,7 @@ final class Aioseo_Robots_Provider_Service_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function provider_get_global_robot_settings() {
+	public static function provider_get_global_robot_settings() {
 		$empty_settings = '';
 
 		$default_global = [

--- a/tests/Unit/Services/Importing/Aioseo_Robots_Transformer_Service_Test.php
+++ b/tests/Unit/Services/Importing/Aioseo_Robots_Transformer_Service_Test.php
@@ -75,7 +75,7 @@ final class Aioseo_Robots_Transformer_Service_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function provider_transform_robot_setting() {
+	public static function provider_transform_robot_setting() {
 		$mapping = [
 			'option_name' => 'aioseo_table',
 			'type'        => 'type',

--- a/tests/Unit/Services/Importing/Aioseo_Social_Images_Provider_Service_Test.php
+++ b/tests/Unit/Services/Importing/Aioseo_Social_Images_Provider_Service_Test.php
@@ -209,7 +209,7 @@ final class Aioseo_Social_Images_Provider_Service_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function provider_get_featured_image() {
+	public static function provider_get_featured_image() {
 		return [
 			[ 234, 234, 1, 'https://example.com/featured-image.png' ],
 			[ false, 'irrelevant', 0, '' ],
@@ -221,7 +221,7 @@ final class Aioseo_Social_Images_Provider_Service_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function provider_get_first_attached_image() {
+	public static function provider_get_first_attached_image() {
 		$no_attachments = [];
 
 		$multiple_attachments = [
@@ -245,7 +245,7 @@ final class Aioseo_Social_Images_Provider_Service_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function provider_get_first_image_in_content() {
+	public static function provider_get_first_image_in_content() {
 		return [
 			[ 'https://example.com/gallery-image.png', 'irrelevant', 0, 'https://example.com/gallery-image.png' ],
 			[ '', 'https://example.com/post-content-image.png', 1, 'https://example.com/post-content-image.png' ],
@@ -257,7 +257,7 @@ final class Aioseo_Social_Images_Provider_Service_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function provider_get_default_custom_social_image() {
+	public static function provider_get_default_custom_social_image() {
 		$image_url      = 'https://example.com/image.png';
 		$empty_settings = [];
 
@@ -333,7 +333,7 @@ final class Aioseo_Social_Images_Provider_Service_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function provider_get_default_social_image_source() {
+	public static function provider_get_default_social_image_source() {
 		$empty_settings = [];
 
 		$fb_default_image            = [

--- a/tests/Unit/Services/Importing/Conflicting_Plugins_Service_Test.php
+++ b/tests/Unit/Services/Importing/Conflicting_Plugins_Service_Test.php
@@ -155,7 +155,7 @@ final class Conflicting_Plugins_Service_Test extends TestCase {
 	 *
 	 * @return array[] Data to use for test_detect_deactivating_conflicting_plugins_plugin_is_int.
 	 */
-	public function detect_deactivating_conflicting_plugins_dataprovider() {
+	public static function detect_deactivating_conflicting_plugins_dataprovider() {
 		$action_is_null       = [
 			'action'   => null,
 			'plugin'   => 'xml-sitemaps/xml-sitemaps.php',

--- a/tests/Unit/Surfaces/Helpers_Surface_Test.php
+++ b/tests/Unit/Surfaces/Helpers_Surface_Test.php
@@ -154,7 +154,7 @@ final class Helpers_Surface_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function provide_classes() {
+	public static function provide_classes() {
 		return [
 			'get helpers from the helpers namespace'        => [
 				'helper_name' => 'test',

--- a/tests/Unit/Surfaces/Meta_Surface_Test.php
+++ b/tests/Unit/Surfaces/Meta_Surface_Test.php
@@ -584,7 +584,7 @@ final class Meta_Surface_Test extends TestCase {
 	 *
 	 * @return array The test parameters.
 	 */
-	public function for_url_provider() {
+	public static function for_url_provider() {
 		return [
 			'Static_Home_Page'   => [ 'post', 'post', 1, 'Static_Home_Page' ],
 			'Static_Posts_Page'  => [ 'post', 'post', 1, 'Static_Posts_Page' ],
@@ -627,7 +627,7 @@ final class Meta_Surface_Test extends TestCase {
 	 *
 	 * @return array The test parameters.
 	 */
-	public function data_for_url_with_unexpected_value() {
+	public static function data_for_url_with_unexpected_value() {
 		return [
 			'malformed_url' => [ 'http:///example.com' ],
 			'invalid_url'   => [ '' ],

--- a/tests/Unit/Surfaces/Open_Graph_Helpers_Surface_Test.php
+++ b/tests/Unit/Surfaces/Open_Graph_Helpers_Surface_Test.php
@@ -154,7 +154,7 @@ final class Open_Graph_Helpers_Surface_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function provide_classes() {
+	public static function provide_classes() {
 		return [
 			'get helpers from the helpers namespace'        => [
 				'helper_name' => 'test',

--- a/tests/Unit/Surfaces/Schema_Helpers_Surface_Test.php
+++ b/tests/Unit/Surfaces/Schema_Helpers_Surface_Test.php
@@ -155,7 +155,7 @@ final class Schema_Helpers_Surface_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function provide_classes() {
+	public static function provide_classes() {
 		return [
 			'get helpers from the helpers namespace'        => [
 				'helper_name' => 'test',

--- a/tests/Unit/Surfaces/Twitter_Helpers_Surface_Test.php
+++ b/tests/Unit/Surfaces/Twitter_Helpers_Surface_Test.php
@@ -155,7 +155,7 @@ final class Twitter_Helpers_Surface_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function provide_classes() {
+	public static function provide_classes() {
 		return [
 			'get helpers from the helpers namespace'        => [
 				'helper_name' => 'test',

--- a/tests/Unit/Surfaces/Values/Meta_Test.php
+++ b/tests/Unit/Surfaces/Values/Meta_Test.php
@@ -130,7 +130,7 @@ final class Meta_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function data_declared_inaccessible_properties() {
+	public static function data_declared_inaccessible_properties() {
 		return [
 			'container'      => [ 'container' ],
 			'context'        => [ 'context' ],
@@ -146,7 +146,7 @@ final class Meta_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function data_undeclared_properties() {
+	public static function data_undeclared_properties() {
 		return [
 			'xyz'     => [ 'xyz' ],
 			'unknown' => [ 'unknown' ],

--- a/tests/WP/Admin/Asset_Manager_Test.php
+++ b/tests/WP/Admin/Asset_Manager_Test.php
@@ -351,7 +351,7 @@ final class Asset_Manager_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function flatten_version_provider() {
+	public static function flatten_version_provider() {
 		return [
 			[ '3.0', '300' ],
 			[ '1.4', '140' ],

--- a/tests/WP/Admin/Meta_Columns_Test.php
+++ b/tests/WP/Admin/Meta_Columns_Test.php
@@ -47,7 +47,7 @@ final class Meta_Columns_Test extends TestCase {
 	 *
 	 * @return array The SEO filters dataprovider.
 	 */
-	public function determine_seo_filters_dataprovider() {
+	public static function determine_seo_filters_dataprovider() {
 		return [
 			[
 				'bad',
@@ -126,7 +126,7 @@ final class Meta_Columns_Test extends TestCase {
 	 *
 	 * @return array The readability filters dataprovider.
 	 */
-	public function determine_readability_filters_dataprovider() {
+	public static function determine_readability_filters_dataprovider() {
 		return [
 			[
 				'bad',
@@ -169,7 +169,7 @@ final class Meta_Columns_Test extends TestCase {
 	 *
 	 * @return array The Readability filters dataprovider.
 	 */
-	public function build_filter_query_dataprovider() {
+	public static function build_filter_query_dataprovider() {
 		return [
 			[
 				[],

--- a/tests/WP/Admin/Metabox/Metabox_Test.php
+++ b/tests/WP/Admin/Metabox/Metabox_Test.php
@@ -225,7 +225,7 @@ final class Metabox_Test extends TestCase {
 	 *
 	 * @return array The data to use.
 	 */
-	public function save_metabox_field_provider() {
+	public static function save_metabox_field_provider() {
 		return [
 			[
 				// Related issue for this case: https://github.com/Yoast/wordpress-seo/issues/14476.

--- a/tests/WP/Admin/Recommended_Replace_Vars_Test.php
+++ b/tests/WP/Admin/Recommended_Replace_Vars_Test.php
@@ -235,7 +235,7 @@ final class Recommended_Replace_Vars_Test extends TestCase {
 	 *
 	 * @return array With the $page_type and $expected variables.
 	 */
-	public function get_recommended_replacevars_provider() {
+	public static function get_recommended_replacevars_provider() {
 		// This is basically a copy of the $recommended_replace_vars in WPSEO_Admin_Recommended_Replace_Vars.
 		return [
 			// Posts.

--- a/tests/WP/Capability/Register_Capabilities_Test.php
+++ b/tests/WP/Capability/Register_Capabilities_Test.php
@@ -84,7 +84,7 @@ final class Register_Capabilities_Test extends TestCase {
 	 *
 	 * @return array The test data.
 	 */
-	public function data_filter_user_has_wpseo_manage_options_cap() {
+	public static function data_filter_user_has_wpseo_manage_options_cap() {
 		return [
 			[ 'wpseo_manager', 'superadmin', true ],
 			[ 'administrator', 'superadmin', false ],

--- a/tests/WP/Frontend/Image_Utils_Test.php
+++ b/tests/WP/Frontend/Image_Utils_Test.php
@@ -158,7 +158,7 @@ final class Image_Utils_Test extends TestCase {
 	 *
 	 * @return array Data.
 	 */
-	public function data_get_usable_dimensions() {
+	public static function data_get_usable_dimensions() {
 		return [
 			[ 200, 200, true ],
 			[ 200, 199, false ],
@@ -198,7 +198,7 @@ final class Image_Utils_Test extends TestCase {
 	 *
 	 * @return array Data.
 	 */
-	public function data_get_absolute_path() {
+	public static function data_get_absolute_path() {
 		$uploads = \wp_get_upload_dir();
 
 		return [
@@ -225,7 +225,7 @@ final class Image_Utils_Test extends TestCase {
 	 *
 	 * @return array The test data.
 	 */
-	public function get_data_provider() {
+	public static function get_data_provider() {
 		$attachment_id = self::factory()->attachment->create();
 		return [
 			[

--- a/tests/WP/Functions_Test.php
+++ b/tests/WP/Functions_Test.php
@@ -94,7 +94,7 @@ final class Functions_Test extends TestCase {
 	 *
 	 * @return Generator
 	 */
-	public function provide_excerpt_replace_var_data() {
+	public static function provide_excerpt_replace_var_data() {
 		yield 'Generates an empty excerpt without any post data' => [
 			'post_data' => null,
 			'locale'    => 'en',

--- a/tests/WP/Inc/Rank_Test.php
+++ b/tests/WP/Inc/Rank_Test.php
@@ -56,7 +56,7 @@ final class Rank_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function provider_get_css_class() {
+	public static function provider_get_css_class() {
 		return [
 			[ WPSEO_Rank::BAD, 'bad' ],
 			[ WPSEO_Rank::OK, 'ok' ],
@@ -88,7 +88,7 @@ final class Rank_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function provider_get_label() {
+	public static function provider_get_label() {
 		return [
 			[ WPSEO_Rank::NO_FOCUS, 'Not available' ],
 			[ WPSEO_Rank::NO_INDEX, 'No index' ],
@@ -120,7 +120,7 @@ final class Rank_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function provider_get_inclusive_language_label() {
+	public static function provider_get_inclusive_language_label() {
 		return [
 			[ WPSEO_Rank::NO_FOCUS, 'Not available' ],
 			[ WPSEO_Rank::NO_INDEX, 'No index' ],
@@ -152,7 +152,7 @@ final class Rank_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function provider_get_drop_down_label() {
+	public static function provider_get_drop_down_label() {
 		return [
 			[ WPSEO_Rank::NO_FOCUS, 'SEO: No Focus Keyphrase' ],
 			[ WPSEO_Rank::BAD, 'SEO: Needs improvement' ],
@@ -184,7 +184,7 @@ final class Rank_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function provider_get_drop_down_readability_labels() {
+	public static function provider_get_drop_down_readability_labels() {
 		return [
 			[ WPSEO_Rank::BAD, 'Readability: Needs improvement' ],
 			[ WPSEO_Rank::OK, 'Readability: OK' ],
@@ -214,7 +214,7 @@ final class Rank_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function provider_get_drop_down_inclusive_language_labels() {
+	public static function provider_get_drop_down_inclusive_language_labels() {
 		return [
 			[ WPSEO_Rank::BAD, 'Inclusive language: Needs improvement' ],
 			[ WPSEO_Rank::OK, 'Inclusive language: Potentially non-inclusive' ],
@@ -244,7 +244,7 @@ final class Rank_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function provider_get_starting_score() {
+	public static function provider_get_starting_score() {
 		return [
 			[ WPSEO_Rank::NO_INDEX, -1 ],
 			[ WPSEO_Rank::NO_FOCUS, 0 ],
@@ -276,7 +276,7 @@ final class Rank_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function provider_get_end_score() {
+	public static function provider_get_end_score() {
 		return [
 			[ WPSEO_Rank::NO_INDEX, -1 ],
 			[ WPSEO_Rank::NO_FOCUS, 0 ],
@@ -308,7 +308,7 @@ final class Rank_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function provider_from_numeric_score() {
+	public static function provider_from_numeric_score() {
 		return [
 			[ 0, WPSEO_Rank::NO_FOCUS ],
 			[ 1, WPSEO_Rank::BAD ],

--- a/tests/WP/Inc/Utils_Test.php
+++ b/tests/WP/Inc/Utils_Test.php
@@ -59,7 +59,7 @@ final class Utils_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function translate_score_provider() {
+	public static function translate_score_provider() {
 		return [
 			[ 0, true, 'na' ],
 			[ 1, true, 'bad' ],
@@ -211,7 +211,7 @@ final class Utils_Test extends TestCase {
 	 *
 	 * @return array The test data.
 	 */
-	public function sanitize_url_provider() {
+	public static function sanitize_url_provider() {
 		return [
 			// Related issue: https://github.com/Yoast/wordpress-seo/issues/17099.
 			'with_at_sign_in_url_path'       => [

--- a/tests/WP/Notifications/Yoast_Notification_Center_Test.php
+++ b/tests/WP/Notifications/Yoast_Notification_Center_Test.php
@@ -963,7 +963,7 @@ final class Yoast_Notification_Center_Test extends TestCase {
 	 *
 	 * @return array The test values.
 	 */
-	public function has_stored_notifications_provider() {
+	public static function has_stored_notifications_provider() {
 		return [
 			[
 				'stored_notifications' => false,

--- a/tests/WP/Repositories/SEO_Links_Repository_Test.php
+++ b/tests/WP/Repositories/SEO_Links_Repository_Test.php
@@ -236,7 +236,7 @@ final class SEO_Links_Repository_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function data_provider_test_update_target_indexable_id() {
+	public static function data_provider_test_update_target_indexable_id() {
 		return [
 			'The update should be succesful, with no change' => [
 				'link_id'             => 113,
@@ -289,7 +289,7 @@ final class SEO_Links_Repository_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function data_provider_test_delete_all_by_post_id() {
+	public static function data_provider_test_delete_all_by_post_id() {
 		return [
 			'The delete should be succesful' => [
 				'post_id'         => 110,
@@ -344,7 +344,7 @@ final class SEO_Links_Repository_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function data_provider_test_delete_all_by_post_id_where_indexable_id_null() {
+	public static function data_provider_test_delete_all_by_post_id_where_indexable_id_null() {
 		return [
 			'The delete should be succesful' => [
 				'post_id'         => 110,
@@ -410,7 +410,7 @@ final class SEO_Links_Repository_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function data_provider_test_delete_all_by_indexable_id() {
+	public static function data_provider_test_delete_all_by_indexable_id() {
 		return [
 			'The delete should be succesful' => [
 				'indexable_id'    => 101,
@@ -464,7 +464,7 @@ final class SEO_Links_Repository_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function data_provider_get_incoming_link_counts_for_post_ids() {
+	public static function data_provider_get_incoming_link_counts_for_post_ids() {
 		return [
 			'One item in post_ids array with result' => [
 				'post_ids'        => [ 154 ],
@@ -532,7 +532,7 @@ final class SEO_Links_Repository_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function data_provider_test_delete_many_by_id() {
+	public static function data_provider_test_delete_many_by_id() {
 		return [
 			'The delete should be succesful' => [
 				'ids'             => [ 222, 113 ],
@@ -588,7 +588,7 @@ final class SEO_Links_Repository_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function data_provider_test_get_incoming_link_counts_for_indexable_ids() {
+	public static function data_provider_test_get_incoming_link_counts_for_indexable_ids() {
 		return [
 			'One target indexable id' => [
 				'indexable_ids'   => [ 355 ],

--- a/tests/WP/Sitemaps/Cache_Data_Test.php
+++ b/tests/WP/Sitemaps/Cache_Data_Test.php
@@ -143,7 +143,7 @@ final class Cache_Data_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function data_set_status_string() {
+	public static function data_set_status_string() {
 		return [
 			'Ok using interface constant' => [
 				'input'    => WPSEO_Sitemap_Cache_Data::OK,

--- a/tests/WP/Sitemaps/Renderer_Test.php
+++ b/tests/WP/Sitemaps/Renderer_Test.php
@@ -126,7 +126,7 @@ final class Renderer_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function data_encode_and_escape() {
+	public static function data_encode_and_escape() {
 		return [
 			'Full URL which will validate with the filter - contains plain &' => [
 				'loc'      => 'http://example.com/page-name?s=keyword&p=2#anchor',

--- a/tests/WP/Sitemaps/Router_Test.php
+++ b/tests/WP/Sitemaps/Router_Test.php
@@ -81,7 +81,7 @@ final class Router_Test extends TestCase {
 	 *
 	 * @return array Test data to use.
 	 */
-	public function data_get_base_url() {
+	public static function data_get_base_url() {
 		return [
 			'Tests the base URL of the sitemap for an http home url' => [
 				'home_url' => 'http://example.org',
@@ -160,7 +160,7 @@ final class Router_Test extends TestCase {
 	 *
 	 * @return array The test data.
 	 */
-	public function data_needs_sitemap_index_redirect() {
+	public static function data_needs_sitemap_index_redirect() {
 		$server_vars_sets = [
 			[
 				'SERVER_NAME' => 'testsite.org',

--- a/tests/WP/Sitemaps/Sitemaps_Test.php
+++ b/tests/WP/Sitemaps/Sitemaps_Test.php
@@ -57,7 +57,7 @@ final class Sitemaps_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function data_post_sitemap() {
+	public static function data_post_sitemap() {
 		return [
 			[ '<?xml' ],
 			[ '<urlset ' ],
@@ -93,7 +93,7 @@ final class Sitemaps_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function data_main_sitemap() {
+	public static function data_main_sitemap() {
 		return [
 			[ '<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">' ],
 			[ '<sitemap>' ],

--- a/tests/WP/Sitemaps/Taxonomy_Sitemap_Provider_Test.php
+++ b/tests/WP/Sitemaps/Taxonomy_Sitemap_Provider_Test.php
@@ -103,7 +103,7 @@ final class Taxonomy_Sitemap_Provider_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function data_provider_is_valis_taxonomy() {
+	public static function data_provider_is_valis_taxonomy() {
 		return [
 			'Pattern Categories' => [
 				'taxonomy' => 'wp_pattern_category',


### PR DESCRIPTION
## Context

*

## Summary

This PR can be summarized in the following changelog entry:

* Tests: use static dataproviders

## Relevant technical choices:

As of PHPUnit 10, data providers are (again) expected to be `static` methods.

This updates the test suite to respect that.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_ If the builds pass, we're good.