### PR TITLE
Prevent failing finish-coveralls workflow

### DIFF
--- a/.github/workflows/finish-coveralls.yml
+++ b/.github/workflows/finish-coveralls.yml
@@ -75,6 +75,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
+      # Wait for the PHP and JS tests to start.
+      - name: Sleep for 30 seconds
+        run: sleep 30s
+        shell: bash
+
       # Wait for the PHP and JS tests to finish.
       # NOTE: The ref value should be different when triggered by pull_request event.
       #       See: https://github.com/lewagon/wait-on-check-action/issues/25.

--- a/.github/workflows/jstest.yml
+++ b/.github/workflows/jstest.yml
@@ -208,6 +208,7 @@ jobs:
         working-directory: packages/${{ matrix.package }}
 
       - name: Upload coverage results to Coveralls
+        if: ${{ steps.checks-run.outputs.should == 'true' }}
         uses: coverallsapp/github-action@v2
         with:
           flag-name: package-${{ matrix.package }}

--- a/.github/workflows/jstest.yml
+++ b/.github/workflows/jstest.yml
@@ -115,6 +115,8 @@ jobs:
 
       - name: Upload coverage results to Coveralls
         uses: coverallsapp/github-action@v2
+        env:
+          COVERALLS_SERVICE_NUMBER: ${{ github.sha }} # Connect all builds together.
         with:
           flag-name: package-${{ matrix.package }}
           parallel: true
@@ -210,6 +212,8 @@ jobs:
       - name: Upload coverage results to Coveralls
         if: ${{ steps.checks-run.outputs.should == 'true' }}
         uses: coverallsapp/github-action@v2
+        env:
+          COVERALLS_SERVICE_NUMBER: ${{ github.sha }} # Connect all builds together.
         with:
           flag-name: package-${{ matrix.package }}
           parallel: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -121,6 +121,8 @@ jobs:
       - name: Upload coverage results to Coveralls
         if: ${{ success() && matrix.coverage == true }}
         uses: coverallsapp/github-action@v2
+        env:
+          COVERALLS_SERVICE_NUMBER: ${{ github.sha }} # Connect all builds together.
         with:
           format: clover
           file: build/logs/clover.xml
@@ -259,6 +261,8 @@ jobs:
       - name: Upload coverage results to Coveralls - single site
         if: ${{ success() && matrix.coverage == true }}
         uses: coverallsapp/github-action@v2
+        env:
+          COVERALLS_SERVICE_NUMBER: ${{ github.sha }} # Connect all builds together.
         with:
           format: clover
           file: build/logs/clover-wp.xml
@@ -268,6 +272,8 @@ jobs:
       - name: Upload coverage results to Coveralls - multisite
         if: ${{ success() && matrix.multisite == true && matrix.coverage == true }}
         uses: coverallsapp/github-action@v2
+        env:
+          COVERALLS_SERVICE_NUMBER: ${{ github.sha }} # Connect all builds together.
         with:
           format: clover
           file: build/logs/clover-wp-ms.xml


### PR DESCRIPTION
## Context
Sometimes the test and jstest workflows are slow to start, causing the finish-coveralls workflow to have checked for running workflows before they have even started, resulting in a failure (like in [this case](https://github.com/Yoast/wordpress-seo/actions/runs/7273265777/job/19816911703)).

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the finish-coveralls CI action would fail when the test actions are slow to start.
* Fixes a bug where the testjs CI action would fail when changes were made any JS pacakge other than yoastseo.
* Fixes a bug where the PHP and JS coverage results would be split into a separate builds on Coveralls on `push` builds.

## Relevant technical choices:

* I sleep for 30 seconds before checking running actions. This should be more than enough time for the jobs to start and not too long that we're idling while the tests have already finished.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

(I've already followed these instructions: [here](https://github.com/Yoast/wordpress-seo/pull/20996) and [here](https://github.com/Yoast/wordpress-seo/pull/20999). The latter includes `push` builds.)
* Create a new PR based from this branch and make a change to any non-yoastseo js file.
* See that all CI jobs succeed and that a Coveralls report is posted on the PR after a couple of minutes. (in my example, the lintLS action fails, but that is expected, since the code I added violates our linting rules.)

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* CI only

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

