### PR TITLE
Uses an allowlist for the webworker's dependencies

### DIFF
--- a/packages/js/src/analysis-worker.js
+++ b/packages/js/src/analysis-worker.js
@@ -33,6 +33,7 @@ function loadDependencies( dependencies ) {
 		}
 
 		// Check if we allow this dependency to be loaded.
+		// A dependency is allowed if it's in the `allowedDependencies` list or if it's an internal dependency.
 		if ( ! ( allowedDependencies.includes( dependency ) || dependency.startsWith( "yoast-seo" ) ) ) {
 			continue;
 		}

--- a/packages/js/src/analysis-worker.js
+++ b/packages/js/src/analysis-worker.js
@@ -2,23 +2,23 @@
 self.window = self;
 
 /**
- * These dependencies reference objects and methods that
- * are not available inside a web worker, so we disallow
- * loading them.
+ * This array lists the allowed dependencies.
+ * We use an allowlist because we have no control over the dependencies that are loaded alongside the web worker.
  *
- * We need to do that in this file, since we have no
- * control over the dependencies of WordPress dependencies that we want to load.
+ * - lodash: used for functional programming.
+ * - regenerator-runtime: used for (transpiled) async functions.
+ * - wp-hooks: dependency for wp-i18n.
+ * - wp-i18n: used for translation strings.
+ * - wp-polyfill: polyfills for old browsers.
  *
  * @type {string[]}
  */
-const disallowedDependencies = [
-	/**
-	 * References `Element`, a DOM interface not available in web workers.
-	 *
-	 * Was renamed, hence the two variants.
-	 */
-	"wp-inert-polyfill",
-	"wp-polyfill-inert",
+const allowedDependencies = [
+	"lodash",
+	"regenerator-runtime",
+	"wp-hooks",
+	"wp-i18n",
+	"wp-polyfill",
 ];
 
 /**
@@ -34,7 +34,8 @@ function loadDependencies( dependencies ) {
 			continue;
 		}
 
-		if ( disallowedDependencies.includes( dependency ) ) {
+		// Check if we allow this dependency to be loaded.
+		if ( ! ( allowedDependencies.includes( dependency ) || dependency.startsWith( "yoast-seo" ) ) ) {
 			continue;
 		}
 
@@ -56,7 +57,7 @@ function loadDependencies( dependencies ) {
  */
 function loadTranslations( translations ) {
 	for ( const [ domain, translation ] of translations ) {
-		var localeData = translation.locale_data[ domain ] || translation.locale_data.messages;
+		const localeData = translation.locale_data[ domain ] || translation.locale_data.messages;
 		localeData[ "" ].domain = domain;
 		self.wp.i18n.setLocaleData( localeData, domain );
 	}

--- a/packages/js/src/analysis-worker.js
+++ b/packages/js/src/analysis-worker.js
@@ -9,7 +9,6 @@ self.window = self;
  * - regenerator-runtime: used for (transpiled) async functions.
  * - wp-hooks: dependency for wp-i18n.
  * - wp-i18n: used for translation strings.
- * - wp-polyfill: polyfills for old browsers.
  *
  * @type {string[]}
  */
@@ -18,7 +17,6 @@ const allowedDependencies = [
 	"regenerator-runtime",
 	"wp-hooks",
 	"wp-i18n",
-	"wp-polyfill",
 ];
 
 /**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to prevent conflicting dependencies to be loaded in the analysis web worker. Initially, we solved that by adding additional dependencies to the denylist (see https://github.com/Yoast/wordpress-seo/pull/20915, which is **not** merged to `trunk`). However, such an approach is not fail-safe, as other conflicting dependencies could be added in the future. Therefore, in this PR, we instead introduce an allowlist for the dependencies we load into the web worker.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Uses an allowlist instead of a denylist for the webworker's dependencies.

## Relevant technical choices:

* We are allowlisting the following dependencies: 
  * `lodash`: used for functional programming.
  * `regenerator-runtime`: used for (transpiled) async functions.
  * `wp-hooks`: dependency for `wp-i18n`.
  * `wp-i18n`: used for translation strings.
  * all dependencies starting with `yoast-seo`: internal dependencies.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install and activate Free (containing this PR) and [Elementor 3.18.0](https://github.com/elementor/elementor/releases/tag/3.18.0). Make sure **not** to have activated Premium. 
* Smoke test the content analysis in Elementor: 
  * Confirm there are no "Refused to execute script..." and "Failed to execute importScripts..." console errors (see screenshot in https://github.com/Yoast/wordpress-seo/pull/20915).
  * Confirm that the SEO, readability, and inclusive language analysis all work.
  * Confirm that the Social Appearance preview is loaded.
  * Confirm that the Insights modal is fully loaded and the results make sense.
* Upgrade to the latest version of Elementor and repeat the above steps in **all** editors (Block, Classic, Elementor, and latest Gutenberg).

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [x] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The content analysis as a whole (smoke testing suffices, if there's an error, you will see it on page load in the console).

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/lingo-other-tasks/issues/298
