### PR TITLE
PHP 8.2: prevent dynamic property deprecations

### DIFF
--- a/admin/class-bulk-editor-list-table.php
+++ b/admin/class-bulk-editor-list-table.php
@@ -111,6 +111,15 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 	protected $input_fields = [];
 
 	/**
+	 * The field in the database where meta field is saved.
+	 *
+	 * Should be set in the child class.
+	 *
+	 * @var string
+	 */
+	protected $target_db_field = '';
+
+	/**
 	 * Class constructor.
 	 *
 	 * @param array $args The arguments.

--- a/admin/class-database-proxy.php
+++ b/admin/class-database-proxy.php
@@ -46,6 +46,13 @@ class WPSEO_Database_Proxy {
 	protected $database;
 
 	/**
+	 * Holds the table prefix.
+	 *
+	 * @var string
+	 */
+	protected $table_prefix;
+
+	/**
 	 * Sets the class attributes and registers the table.
 	 *
 	 * @param wpdb   $database           The database object.


### PR DESCRIPTION
## Context

* Code QA/consistency

## Summary

This PR can be summarized in the following changelog entry:

* Improved PHP 8.2 compatibility

## Relevant technical choices:

### PHP 8.2 | WPSEO_Database_Proxy: prevent dynamic property deprecation notice

The `$table_prefix` property was not explicitly declared.

### PHP 8.2 | WPSEO_Bulk_List_Table: prevent dynamic property deprecation notice

The `$target_db_field` property was not explicitly declared, only in the child classes.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_ No functional changes.