### PR TITLE
Ensures the highlighting functionality in Elementor is only shown for Premium versions >= 21.8

### DIFF
--- a/packages/js/src/elementor/initializers/editor-store.js
+++ b/packages/js/src/elementor/initializers/editor-store.js
@@ -18,7 +18,7 @@ const populateStore = store => {
 	// Initialize the focus keyphrase.
 	store.dispatch( actions.loadFocusKeyword() );
 	// Show marker buttons.
-	store.dispatch( actions.setMarkerStatus( "enabled" ) );
+	store.dispatch( actions.setMarkerStatus( window.wpseoScriptData.metabox.markerStatus ) );
 
 	store.dispatch(
 		actions.setSettings( {

--- a/src/integrations/third-party/elementor.php
+++ b/src/integrations/third-party/elementor.php
@@ -613,7 +613,23 @@ class Elementor implements Integration_Interface {
 			$values['cornerstoneActive'] = false;
 		}
 
+		$values['markerStatus'] = $this->is_highlighting_available() ? 'enabled' : 'hidden';
+
 		return $values;
+	}
+
+	/**
+	 * Checks whether the highlighting functionality is available for Elementor:
+	 * - in Free it's always available (as an upsell).
+	 * - in Premium it's available as long as the version is 21.8-RC0 or above.
+	 *
+	 * @return bool Whether the highlighting functionality is available.
+	 */
+	private function is_highlighting_available() {
+		$is_premium      = \YoastSEO()->helpers->product->is_premium();
+		$premium_version = \YoastSEO()->helpers->product->get_premium_version();
+
+		return ! $is_premium || \version_compare( $premium_version, '21.8-RC0', '>=' );
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to ensure that in Elementor, the highlighting functionality (the eye icon) is only shown for Premium versions >= 21.8. With this PR in place, we have the following situation:
  * Only Free (>= 21.8): upsell for highlighting. 
  * Free + old Premium (< 21.8): **no** highlighting functionality / icon (no upsell)
  * Free + new Premium (>= 21.8): highlighting functionality / icon (no upsell)

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Ensures the highlighting functionality in Elementor is only shown for Premium versions >= 21.8.

## Relevant technical choices:

* I did not add PHP tests because there were no tests for this file, and because the test files have changed folders that would make merging with `trunk` harder. 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### New Free, no Premium
* Install and activate Free, but do *not* install Premium. 
* Create a new post, with the Classic or default editor. 
* Add the sentence "President Kennedy was killed in 1963 in Dallas, Texas by Lee Harvey Oswald."
* Confirm that the _passive voice_ assessment returns a red traffic light, and allows you to highlight the added sentence by clicking the eye icon. 
![Screenshot 2023-12-27 at 10 08 15](https://github.com/Yoast/wordpress-seo/assets/7521233/55b92e91-2a6a-489e-93ff-001c6bdf4a06)
* Open the post with Elementor.
* Confirm that _passive voice_ assessment still returns a red traffic light, but an upsell for the highlighting functionality is shown (the eye icon has a lock). 
![Screenshot 2023-12-27 at 10 04 02](https://github.com/Yoast/wordpress-seo/assets/7521233/d5934393-2d8d-462c-a720-0377994dd0cf)

#### New Free, old Premium
* Install and activate an **old** version of Premium (e.g., 21.7). 
* Open the post again. 
* Confirm that _passive voice_ assessment still returns a red traffic light, but no eye icon is shown. 
![Screenshot 2023-12-27 at 10 06 40](https://github.com/Yoast/wordpress-seo/assets/7521233/a475e44d-cec2-4b95-9eac-c9e4dbd0da45)

#### New Free, new Premium
* Install and activate the **current** version of Premium (i.e., 21.8). 
* Open the post again. 
* Confirm that _passive voice_ assessment still returns a red traffic light, and allows you to highlight the added sentence by clicking the eye icon. 
![Screenshot 2023-12-27 at 10 08 15](https://github.com/Yoast/wordpress-seo/assets/7521233/55b92e91-2a6a-489e-93ff-001c6bdf4a06)

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/plugins-automated-testing/issues/1261
