### PR TITLE
Use WHIP to deprecate PHP 7.2 and 7.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
 	"require": {
 		"php": "^7.2.5 || ^8.0",
 		"ext-filter": "*",
-		"composer/installers": "^1.12 || ^2.0"
+		"composer/installers": "^1.12 || ^2.0",
+		"yoast/whip": "^2.0"
 	},
 	"require-dev": {
 		"guzzlehttp/guzzle": "7.8.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7b8dfb1a43e163bbbc70e10be161e5ac",
+    "content-hash": "f8e6cb2f40397e8fe5789f33a49792e9",
     "packages": [
         {
             "name": "composer/installers",
@@ -150,6 +150,58 @@
                 }
             ],
             "time": "2022-08-20T06:45:11+00:00"
+        },
+        {
+            "name": "yoast/whip",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Yoast/whip.git",
+                "reference": "5cfd9c3b433774548ec231fe896d5e85d17ed0d1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Yoast/whip/zipball/5cfd9c3b433774548ec231fe896d5e85d17ed0d1",
+                "reference": "5cfd9c3b433774548ec231fe896d5e85d17ed0d1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
+                "roave/security-advisories": "dev-master",
+                "yoast/yoastcs": "^3.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/Facades/wordpress.php"
+                ],
+                "psr-4": {
+                    "Yoast\\WHIPv2\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Team Yoast",
+                    "email": "support@yoast.com"
+                }
+            ],
+            "description": "A WordPress package to nudge users to upgrade their software versions (starting with PHP)",
+            "homepage": "https://github.com/Yoast/whip",
+            "support": {
+                "issues": "https://github.com/Yoast/whip/issues",
+                "security": "https://yoast.com/security-program/",
+                "source": "https://github.com/Yoast/whip"
+            },
+            "time": "2023-12-27T11:39:30+00:00"
         }
     ],
     "packages-dev": [
@@ -1017,11 +1069,10 @@
                 "shasum": ""
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "@stable",
-                "nikic/php-parser": "@stable",
-                "php": "^8.3",
-                "phpdocumentor/reflection-docblock": "@stable",
-                "phpunit/phpunit": "@stable"
+                "friendsofphp/php-cs-fixer": "v3.46.0",
+                "nikic/php-parser": "v5.0.0",
+                "phpdocumentor/reflection-docblock": "5.3.0",
+                "phpunit/phpunit": "10.5.5"
             },
             "default-branch": true,
             "type": "library",

--- a/src/integrations/admin/unsupported-php-version-notice.php
+++ b/src/integrations/admin/unsupported-php-version-notice.php
@@ -1,0 +1,167 @@
+<?php
+
+namespace Yoast\WP\SEO\Integrations\Admin;
+
+use WPSEO_Shortlinker;
+use Yoast\WHIPv2\Exceptions\InvalidType;
+use Yoast\WHIPv2\Exceptions\InvalidVersionComparisonString;
+use Yoast\WHIPv2\Interfaces\Message;
+use Yoast\WHIPv2\MessageDismisser;
+use Yoast\WHIPv2\MessageFormatter;
+use Yoast\WHIPv2\Presenters\WPMessagePresenter;
+use Yoast\WHIPv2\RequirementsChecker;
+use Yoast\WHIPv2\VersionRequirement;
+use Yoast\WHIPv2\WPDismissOption;
+use Yoast\WP\SEO\Conditionals\Yoast_Admin_And_Dashboard_Conditional;
+use Yoast\WP\SEO\Integrations\Integration_Interface;
+
+/**
+ * Class Unsupported_PHP_Version_Notice.
+ *
+ * @package Yoast\WP\SEO\Integrations\Admin
+ */
+class Unsupported_PHP_Version_Notice implements Integration_Interface, Message {
+
+	/**
+	 * Returns the conditionals based on which this integration should be active.
+	 *
+	 * @return array<string> The array of conditionals.
+	 */
+	public static function get_conditionals() {
+		return [
+			Yoast_Admin_And_Dashboard_Conditional::class,
+		];
+	}
+
+	/**
+	 * Register hooks.
+	 *
+	 * @return void
+	 */
+	public function register_hooks() {
+		\add_action( 'admin_init', [ $this, 'check_php_version' ] );
+	}
+
+	/**
+	 * Checks the current PHP version.
+	 *
+	 * @return void
+	 */
+	public function check_php_version() {
+		// If the user isn't an admin, don't display anything.
+		if ( ! $this->has_right_capabilities() ) {
+			return;
+		}
+
+		if ( ! $this->on_dashboard_page( $GLOBALS['pagenow'] ) ) {
+			return;
+		}
+
+		// Checks if the user is running at least PHP 7.2.
+		if ( $this->is_supported_php_version_installed() === false ) {
+			$this->show_unsupported_php_message();
+		}
+	}
+
+	/**
+	 * Composes the body of the message to display.
+	 *
+	 * @return string The message to display.
+	 */
+	public function body() {
+		$message   = [];
+		$message[] = MessageFormatter::strongParagraph( \__( 'Upgrade your PHP version', 'wordpress-seo' ) ) . '<br />';
+		$message[] = MessageFormatter::paragraph(
+			\sprintf(
+				/* translators: 1: Yoast SEO, 2: Yoast SEO Premium */
+				\__(
+					'By July 1st, 2024, we’ll update the minimum PHP requirement for %1$s, %2$s and all our add-ons to PHP 7.4. This, to ensure we can keep delivering state of the art features.',
+					'wordpress-seo'
+				),
+				'Yoast SEO',
+				'Yoast SEO Premium'
+			)
+		) . '<br />';
+		$message[] = MessageFormatter::strongParagraph( \__( 'Can’t upgrade yourself? Ask your host!', 'wordpress-seo' ) ) . '<br />';
+		$message[] = MessageFormatter::paragraph(
+			\sprintf(
+			/* translators: 1: Link tag to WordPress Hosts page on Yoast.com; 2: Link closing tag */
+				\__(
+					'Upgrading your PHP version is something your hosting provider can help you out with. If they can’t upgrade your PHP version, we advise you to consider %1$sswitching to a hosting provider%2$s that can provide the security and features a modern host should provide.',
+					'wordpress-seo'
+				),
+				'<a href="' . WPSEO_Shortlinker::get( 'https://yoast.com/wordpress-hosting/' ) . '">',
+				'</a>'
+			)
+		) . '<br />';
+
+		return \implode( \PHP_EOL, $message );
+	}
+
+	/**
+	 * Checks if the current user has the right capabilities.
+	 *
+	 * @return bool True when user has right capabilities.
+	 */
+	protected function has_right_capabilities() {
+		return \current_user_can( 'wpseo_manage_options' );
+	}
+
+	/**
+	 * Whether we are on the admin dashboard page or in the Yoast dashboard page.
+	 *
+	 * We need to have the notice in the main admin otherwise the dismissal mechanism won't work.
+	 *
+	 * @param string $current_page The current page.
+	 *
+	 * @return bool True if current page is the index.php.
+	 */
+	protected function on_dashboard_page( $current_page ) {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Date is not processed or saved.
+		if ( $current_page === 'admin.php' && isset( $_GET['page'] ) && \sanitize_text_field( \wp_unslash( $_GET['page'] ) ) === 'wpseo_dashboard' ) {
+			return true;
+		}
+
+		return ( $current_page === 'index.php' );
+	}
+
+	/**
+	 * Checks if the installed php version is supported.
+	 *
+	 * @codeCoverageIgnore
+	 *
+	 * @return bool True when the php version is support.
+	 */
+	protected function is_supported_php_version_installed() {
+		try {
+			$checker = new RequirementsChecker( [ 'php' => \PHP_VERSION ] );
+
+			$checker->addRequirement( VersionRequirement::fromCompareString( 'php', '>=7.4' ) );
+			$checker->check();
+
+			return $checker->hasMessages() === false;
+		}
+		catch ( InvalidVersionComparisonString $e ) {
+			return true;
+		}
+		catch ( InvalidType $e ) {
+			return true;
+		}
+	}
+
+	/**
+	 * Creates a new message to display regarding the usage of PHP 7.3 (or lower).
+	 *
+	 * @codeCoverageIgnore
+	 *
+	 * @return void
+	 */
+	protected function show_unsupported_php_message() {
+		$presenter = new WPMessagePresenter(
+			$this,
+			new MessageDismisser( \time(), ( \WEEK_IN_SECONDS * 4 ), new WPDismissOption() ),
+			\__( 'Remind me again in 4 weeks.', 'wordpress-seo' )
+		);
+		$presenter->registerHooks();
+	}
+}

--- a/src/integrations/admin/unsupported-php-version-notice.php
+++ b/src/integrations/admin/unsupported-php-version-notice.php
@@ -75,7 +75,7 @@ class Unsupported_PHP_Version_Notice implements Integration_Interface, Message {
 			\sprintf(
 				/* translators: 1: Yoast SEO, 2: Yoast SEO Premium */
 				\__(
-					'By July 1st, 2024, we’ll update the minimum PHP requirement for %1$s, %2$s and all our add-ons to PHP 7.4. This, to ensure we can keep delivering state of the art features.',
+					'By November 1st, 2024, we’ll update the minimum PHP requirement for %1$s, %2$s and all our add-ons to PHP 7.4. This, to ensure we can keep delivering state of the art features.',
 					'wordpress-seo'
 				),
 				'Yoast SEO',


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to throw a notice to admins to notify we are dropping compatibility with PHP < 7.4. The date is set to November 1st, 2024.


## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Introduces a notice on the WordPress dashboard and the Yoast SEO dashboard to let users know we are dropping support for PHP < 7.4 starting November 1st, 2024.

## Relevant technical choices:

* We still have the class from the [previous iteration](https://github.com/Yoast/wordpress-seo/pull/19262) as deprecated, so to avoid any conflict/confusion I introduced a new class with a slightly different name

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Run `grunt artifact` to create a zip. This makes it way easier to test on different envs.
* Find a way to have WP running on PHP 7.2 and 7.3.
  * e.g. I was able to have a Local by Flywheel site on PHP 7.3. I'm on Linux, I know other people could not...
  * otherwise there is InstaWP which seems to support PHP back to 5.6
  * Switching the docker env to an older version doesn't seem to work
  * you can also _hack_ the requirement: make sure you are on PHP 7.4, change the line 139 of `src/integrations/admin/unsupported-php-version-notice.php` from 
  ```
  $checker->addRequirement( VersionRequirement::fromCompareString( 'php', '>=7.4' ) );
  ```
  to 
  ```
  $checker->addRequirement( VersionRequirement::fromCompareString( 'php', '>=8.0' ) );
  ```
  (you can do this directly after having uploaded the artifact)
* upload the artifact
* activate Yoast SEO
* see that you get a notice on the WP dashboard and in the Yoast SEO General page:
![Screenshot 2024-04-09 at 10-01-23 Dashboard ‹ oldphp — WordPress](https://github.com/Yoast/wordpress-seo/assets/15989132/2cdec049-7439-4605-8c37-c577ccf136d1)
* Click on "Remind me in 4 weeks"
  * you should be redirected to the WP Dashboard and the notice should be hidden
* inspect the `options` table and set the `whip_dismiss_timestamp` to at least four weeks ago, e.g `1663929217`.
* see that you get the notice again on the WP dashboard and in the Yoast SEO General page.

* Upload the artifact to a 7.4+ env and check that you don't see any notice.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/roadmap/issues/398
