### PR TITLE
Fix the opening of our document panel in WP 6.5

### DIFF
--- a/packages/js/src/initializers/block-editor-integration.js
+++ b/packages/js/src/initializers/block-editor-integration.js
@@ -77,10 +77,31 @@ function registerFormats() {
  * @returns {void}
  */
 function initiallyOpenDocumentSettings() {
-	const openedPanels = select( "core/preferences" ).get( "core/edit-post", "openPanels" );
-	const firstLoad = ! openedPanels.includes( "yoast-seo/document-panel" );
-	if ( firstLoad ) {
-		dispatch( "core/edit-post" ).toggleEditorPanelOpened( "yoast-seo/document-panel" );
+	const PANEL_NAME = "yoast-seo/document-panel";
+
+	/**
+	 * In WP 6.5 the toggleEditorPanelOpened function was added to the core/editor store.
+	 * Using this knowledge to detect which selector we should use to get the opened panels.
+	 *
+	 * We can remove this logic path when WP 6.4 is no longer supported!
+ 	 */
+	const isNewerGutenberg = Boolean( dispatch( "core/editor" )?.toggleEditorPanelOpened );
+
+	if ( ! isNewerGutenberg ) {
+		/**
+		 * Using WP < 6.5 logic.
+		 * @see https://github.com/WordPress/gutenberg/pull/57529
+		 *
+		 * Using `core/edit-post` instead of `core` (select) and `core/editor` (dispatch).
+		 */
+		if ( ! select( "core/preferences" ).get( "core/edit-post", "openPanels" ).includes( PANEL_NAME ) ) {
+			dispatch( "core/edit-post" ).toggleEditorPanelOpened( PANEL_NAME );
+		}
+		return;
+	}
+
+	if ( ! select( "core/preferences" ).get( "core", "openPanels" ).includes( PANEL_NAME ) ) {
+		dispatch( "core/editor" ).toggleEditorPanelOpened( PANEL_NAME );
 	}
 }
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

In WP 6.5:
* the `openPanels` selector moved from `core/edit-post` to `core`
* the `togleEditorPanelOpened` moved from `core/edit-post` to `core/editor`

The first (select) produced an error, making our integration grind to a halt.
The second (dispatch) produced a deprecation warning.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where our block editor integration would no longer work in WP 6.5.

## Relevant technical choices:

* Using the new location of `toggleEditorPanelOpened` to determine what WP version logic to use:
  * I was wondering if it is worth it to go for PHP side passing along the versions (global $wp_version and GUTENBERG_VERSION) -- but that is more complex and the latter is also not working for the Gutenberg `trunk`
  * A problem with this detection is that when using Gutenberg plugin v17.4.1 the Yoast panel does not open. This is due to the selector not being in that version yet, it is scheduled to land in v17.5

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

We need to test with WP 6.4 and WP 6.5 (for now Gutenberg `trunk`)

### Gutenberg trunk
* Add and activate the Gutenberg plugin on `trunk`
  * Clone https://github.com/WordPress/gutenberg
  * Run `composer install` to install PHP deps
  * Use node v20
  * Run `npm install` to install JS deps
  * Run `npm run dev` to build
* Edit a post in the block editor
* Note: before this PR already an error would be in the console and our integration would not load
* Ensure the Settings panel is open:
![image](https://github.com/Yoast/wordpress-seo/assets/35524806/98b564b9-c993-4533-a407-157ca96f79c6)
* Close the Yoast panel:
![image](https://github.com/Yoast/wordpress-seo/assets/35524806/a3f7e381-d8a2-4862-bd6c-641d63f730a2)
* Refresh the page
* Verify the Yoast panel is open again
* Refresh the page again: nothing should change, but verify no errors occurred
* Close the Settings panel
* Refresh the page again and verify no errors occurred

### WP 6.4
* Deactivate Gutenberg `trunk`
* Follow the above steps again, the same should happen

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Our block editor integration

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/wordpress-seo/issues/21021
