### PR TITLE
Remove plugin icon size override [WP 6.5]

### DIFF
--- a/css/src/metabox.css
+++ b/css/src/metabox.css
@@ -619,10 +619,10 @@ ul.yoast-seo-social-share-buttons a {
   margin-bottom: 10px;
 }
 
-div.interface-pinned-items button.components-button[aria-label="Yoast SEO"] > svg,
-div.interface-pinned-items button.components-button[aria-label="Yoast SEO Premium"] > svg,
-.edit-post-pinned-plugins button.components-button[aria-label="Yoast SEO"] > svg,
-.edit-post-pinned-plugins button.components-button[aria-label="Yoast SEO Premium"] > svg {
+div.interface-pinned-items button.components-button:not(.is-compact)[aria-label="Yoast SEO"] > svg,
+div.interface-pinned-items button.components-button:not(.is-compact)[aria-label="Yoast SEO Premium"] > svg,
+.edit-post-pinned-plugins button.components-button:not(.is-compact)[aria-label="Yoast SEO"] > svg,
+.edit-post-pinned-plugins button.components-button:not(.is-compact)[aria-label="Yoast SEO Premium"] > svg {
 	max-width: 28px;
 	max-height: 28px;
 	width: 28px;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

With Gutenberg 17.3 (PR https://github.com/WordPress/gutenberg/pull/56635) all the button icons are now displayed as "compact", which makes the width 32px (from 36px). Resulting in no space around the icon (horizontally).
This change removes the icon size override when in compact mode. Effectively reverting the icon size back to be 24px. Leaving the same horizontal space as the WP icons.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the Yoast plugin icon in the block editor would not have any horizontal spacing anymore when rendered in "compact" mode.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Edit a post in the block editor
* Verify the Yoast plugin icon in the sidebar looks normal: 
![image](https://github.com/Yoast/wordpress-seo/assets/35524806/bf9ad94c-a3bd-4c82-b5e8-e87b8fc84de2)
  * Button width of 36px and icon width of 28px
* Activate the Gutenberg plugin v17.4.1 (or higher?)
* Edit a post in the block editor
* Verify the Yoast plugin in the sidebar still has horizontal spacing: 
![image](https://github.com/Yoast/wordpress-seo/assets/35524806/ffdaad2c-678c-4249-bbe4-759f07b86495)
  * Button width of 32px and icon width of 24px (same as the WP icon next to it)

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Our Yoast plugin icon in the sidebar of the block editor

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
