### PR TITLE
Fix get_head validation callback

### DIFF
--- a/src/routes/indexables-head-route.php
+++ b/src/routes/indexables-head-route.php
@@ -47,7 +47,7 @@ class Indexables_Head_Route implements Route_Interface {
 	/**
 	 * Returns the conditionals based in which this loadable should be active.
 	 *
-	 * @return array
+	 * @return array<string>
 	 */
 	public static function get_conditionals() {
 		return [ Headless_Rest_Endpoints_Enabled_Conditional::class ];

--- a/src/routes/indexables-head-route.php
+++ b/src/routes/indexables-head-route.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\SEO\Routes;
 
 use WP_REST_Request;
 use WP_REST_Response;
+use WPSEO_Utils;
 use Yoast\WP\SEO\Actions\Indexables\Indexable_Head_Action;
 use Yoast\WP\SEO\Conditionals\Headless_Rest_Endpoints_Enabled_Conditional;
 use Yoast\WP\SEO\Main;
@@ -94,7 +95,7 @@ class Indexables_Head_Route implements Route_Interface {
 	 * @return bool Whether or not the url is valid.
 	 */
 	public function is_valid_url( $url ) {
-		$url = \sanitize_url( \utf8_uri_encode( $url ) );
+		$url = WPSEO_Utils::sanitize_url( \utf8_uri_encode( $url ) );
 		if ( \filter_var( $url, \FILTER_VALIDATE_URL ) === false ) {
 			return false;
 		}

--- a/tests/Unit/Routes/Indexables_Head_Route_Test.php
+++ b/tests/Unit/Routes/Indexables_Head_Route_Test.php
@@ -6,6 +6,7 @@ use Brain\Monkey;
 use Mockery;
 use WP_REST_Request;
 use WP_REST_Response;
+use WPSEO_Utils;
 use Yoast\WP\SEO\Actions\Indexables\Indexable_Head_Action;
 use Yoast\WP\SEO\Conditionals\Headless_Rest_Endpoints_Enabled_Conditional;
 use Yoast\WP\SEO\Routes\Indexables_Head_Route;
@@ -29,6 +30,13 @@ final class Indexables_Head_Route_Test extends TestCase {
 	protected $head_action;
 
 	/**
+	 * Represents the utils.
+	 *
+	 * @var Mockery\MockInterface|WPSEO_Utils
+	 */
+	protected $utils;
+
+	/**
 	 * Represents the instance to test.
 	 *
 	 * @var Indexables_Head_Route
@@ -42,6 +50,7 @@ final class Indexables_Head_Route_Test extends TestCase {
 		parent::set_up();
 
 		$this->head_action = Mockery::mock( Indexable_Head_Action::class );
+		$this->utils       = Mockery::mock( WPSEO_Utils::class );
 		$this->instance    = new Indexables_Head_Route( $this->head_action );
 	}
 
@@ -145,6 +154,8 @@ final class Indexables_Head_Route_Test extends TestCase {
 			->with( 'foo bar baz' )
 			->andReturnFirstArg();
 
+		Monkey\Functions\expect( 'wp_parse_url' )->once()->andReturn( false );
+
 		$this->assertFalse( $this->instance->is_valid_url( 'foo bar baz' ) );
 	}
 
@@ -156,10 +167,18 @@ final class Indexables_Head_Route_Test extends TestCase {
 	 * @return void
 	 */
 	public function test_is_valid_url_with_valid_url_given() {
+		$url_parts = [
+			'scheme' => 'https',
+			'host'   => 'example.org',
+		];
 		Monkey\Functions\expect( 'utf8_uri_encode' )
-			->with( 'https://example.org' )
+			->with( implode( '://', $url_parts ) )
 			->andReturnFirstArg();
 
-		$this->assertTrue( $this->instance->is_valid_url( 'https://example.org' ) );
+		Monkey\Functions\expect( 'wp_parse_url' )->once()->andReturn( $url_parts );
+
+		Monkey\Functions\expect( 'esc_url_raw' )->once()->andReturn( implode( '://', $url_parts ) );
+
+		$this->assertTrue( $this->instance->is_valid_url( implode( '://', $url_parts ) ) );
 	}
 }

--- a/tests/Unit/Routes/Indexables_Head_Route_Test.php
+++ b/tests/Unit/Routes/Indexables_Head_Route_Test.php
@@ -45,6 +45,8 @@ final class Indexables_Head_Route_Test extends TestCase {
 
 	/**
 	 * {@inheritDoc}
+	 *
+	 * @return void
 	 */
 	protected function set_up() {
 		parent::set_up();
@@ -172,13 +174,13 @@ final class Indexables_Head_Route_Test extends TestCase {
 			'host'   => 'example.org',
 		];
 		Monkey\Functions\expect( 'utf8_uri_encode' )
-			->with( implode( '://', $url_parts ) )
+			->with( \implode( '://', $url_parts ) )
 			->andReturnFirstArg();
 
 		Monkey\Functions\expect( 'wp_parse_url' )->once()->andReturn( $url_parts );
 
-		Monkey\Functions\expect( 'esc_url_raw' )->once()->andReturn( implode( '://', $url_parts ) );
+		Monkey\Functions\expect( 'esc_url_raw' )->once()->andReturn( \implode( '://', $url_parts ) );
 
-		$this->assertTrue( $this->instance->is_valid_url( implode( '://', $url_parts ) ) );
+		$this->assertTrue( $this->instance->is_valid_url( \implode( '://', $url_parts ) ) );
 	}
 }

--- a/tests/WP/Routes/Indexables_Head_Route_Test.php
+++ b/tests/WP/Routes/Indexables_Head_Route_Test.php
@@ -33,12 +33,12 @@ final class Indexables_Head_Route_Test extends TestCase {
 	 *
 	 * @dataProvider data_provider_get_head
 	 *
-	 * @param string $url    The url.
-	 * @param int    $status The expected status.
+	 * @param string $url             The url.
+	 * @param bool   $valid_head_data Wether the response contains valid data for the page head.
 	 *
 	 * @return void
 	 */
-	public function test_get_head( $url, $status ) {
+	public function test_get_head( $url, $valid_head_data ) {
 		$request = new WP_REST_Request( 'GET', '/yoast/v1/get_head' );
 		$request->set_param( 'url', $url );
 
@@ -51,29 +51,29 @@ final class Indexables_Head_Route_Test extends TestCase {
 		);
 
 		$this->assertEquals(
-			$status,
-			$response->status,
-			'get_head response status'
+			$valid_head_data,
+			\is_object( $response->data ) && \property_exists( $response->data, 'html' ) && \property_exists( $response->data, 'json' ),
+			'get_head valid data'
 		);
 	}
 
 	/**
 	 * Data provider for test_get_head.
 	 *
-	 * @return array<string,int>
+	 * @return array<string,bool>
 	 */
 	public function data_provider_get_head() {
 		yield 'Home URL' => [
-			'url'    => \trailingslashit( \home_url() ),
-			'status' => 200,
+			'url'             => \trailingslashit( \home_url() ),
+			'valid_head_data' => true,
 		];
 		yield 'Multiple words search string' => [
-			'url'    => \add_query_arg( 's', 'xxx yyy', \trailingslashit( \home_url() ) ),
-			'status' => 200,
+			'url'             => \add_query_arg( 's', 'xxx yyy', \trailingslashit( \home_url() ) ),
+			'valid_head_data' => true,
 		];
 		yield 'Invalid URL' => [
-			'url'    => 'This is not a URL',
-			'status' => 400,
+			'url'             => 'This is not a URL',
+			'valid_head_data' => false,
 		];
 	}
 }

--- a/tests/WP/Routes/Indexables_Head_Route_Test.php
+++ b/tests/WP/Routes/Indexables_Head_Route_Test.php
@@ -62,7 +62,7 @@ final class Indexables_Head_Route_Test extends TestCase {
 	 *
 	 * @return array<string,bool>
 	 */
-	public function data_provider_get_head() {
+	public static function data_provider_get_head() {
 		yield 'Home URL' => [
 			'url'             => \trailingslashit( \home_url() ),
 			'valid_head_data' => true,

--- a/tests/WP/Routes/Indexables_Head_Route_Test.php
+++ b/tests/WP/Routes/Indexables_Head_Route_Test.php
@@ -51,8 +51,8 @@ final class Indexables_Head_Route_Test extends TestCase {
 		);
 
 		$this->assertEquals(
-			$response->status,
 			$status,
+			$response->status,
 			'get_head response status'
 		);
 	}
@@ -69,7 +69,7 @@ final class Indexables_Head_Route_Test extends TestCase {
 		];
 		yield 'Multiple words search string' => [
 			'url'    => \add_query_arg( 's', 'hello world', \trailingslashit( \home_url() ) ),
-			'status' => 404,
+			'status' => 200,
 		];
 		yield 'Invalid URL' => [
 			'url'    => 'This is not a URL',

--- a/tests/WP/Routes/Indexables_Head_Route_Test.php
+++ b/tests/WP/Routes/Indexables_Head_Route_Test.php
@@ -68,8 +68,8 @@ final class Indexables_Head_Route_Test extends TestCase {
 			'status' => 200,
 		];
 		yield 'Multiple words search string' => [
-			'url'    => \add_query_arg( 's', 'hello world', \trailingslashit( \home_url() ) ),
-			'status' => 200,
+			'url'    => \add_query_arg( 's', 'xxx yyy', \trailingslashit( \home_url() ) ),
+			'status' => 404,
 		];
 		yield 'Invalid URL' => [
 			'url'    => 'This is not a URL',

--- a/tests/WP/Routes/Indexables_Head_Route_Test.php
+++ b/tests/WP/Routes/Indexables_Head_Route_Test.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\WP\Routes;
+
+use WP_REST_Request;
+use WP_REST_Response;
+use Yoast\WP\SEO\Tests\WP\TestCase;
+
+/**
+ * Integration Test Class for Indexable_Head_Route class.
+ *
+ * @coversDefaultClass Yoast\WP\SEO\Routes\Indexables_Head_Route
+ */
+final class Indexables_Head_Route_Test extends TestCase {
+
+	/**
+	 * Tests the register_routes method.
+	 *
+	 * @covers ::register_routes
+	 *
+	 * @return void
+	 */
+	public function test_has_route() {
+			$routes = \rest_get_server()->get_routes();
+			$this->assertArrayHasKey( '/yoast/v1/get_head', $routes );
+	}
+
+	/**
+	 * Tests the get_head method.
+	 *
+	 * @covers ::get_head
+	 * @covers ::is_valid_url
+	 *
+	 * @dataProvider data_provider_get_head
+	 *
+	 * @param string $url    The url.
+	 * @param int    $status The expected status.
+	 *
+	 * @return void
+	 */
+	public function test_get_head( $url, $status ) {
+		$request = new WP_REST_Request( 'GET', '/yoast/v1/get_head' );
+		$request->set_param( 'url', $url );
+
+		$response = \rest_get_server()->dispatch( $request );
+
+		$this->assertInstanceOf(
+			WP_REST_Response::class,
+			$response,
+			'get_head WP_REST_Response object'
+		);
+
+		$this->assertEquals(
+			$response->status,
+			$status,
+			'get_head response status'
+		);
+	}
+
+	/**
+	 * Data provider for test_get_head.
+	 *
+	 * @return array<string,int>
+	 */
+	public function data_provider_get_head() {
+		yield 'Home URL' => [
+			'url'    => \trailingslashit( \home_url() ),
+			'status' => 200,
+		];
+		yield 'Multiple words search string' => [
+			'url'    => \add_query_arg( 's', 'hello world', \trailingslashit( \home_url() ) ),
+			'status' => 404,
+		];
+		yield 'Invalid URL' => [
+			'url'    => 'This is not a URL',
+			'status' => 400,
+		];
+	}
+}

--- a/tests/WP/Routes/Indexables_Head_Route_Test.php
+++ b/tests/WP/Routes/Indexables_Head_Route_Test.php
@@ -69,7 +69,7 @@ final class Indexables_Head_Route_Test extends TestCase {
 		];
 		yield 'Multiple words search string' => [
 			'url'    => \add_query_arg( 's', 'xxx yyy', \trailingslashit( \home_url() ) ),
-			'status' => 404,
+			'status' => 200,
 		];
 		yield 'Invalid URL' => [
 			'url'    => 'This is not a URL',


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to fix a bug with the `get_head` REST route and  multiple words search strings. 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the `get_head` REST route would return a `rest_invalid_param` if the URL contains a multiple words search string. props to @lucymtc.

## Relevant technical choices:

* N/A

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Without this PR, visit `YOUR_HOME_URL/wp-json/yoast/v1/get_head/?url=YOUR_HOME_URL/?s= test search` (substitute `YOUR_HOME_URL` with your actual home URL)
  * verify you get the following response:
```
{
    "code": "rest_invalid_param",
    "message": "Invalid parameter(s): url",
    "data": {
        "status": 400,
        "params": {
            "url": "Invalid parameter."
        },
        "details": []
    }
}
```
* With this PR verify you get a valid response instead

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.


## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* N/A

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [X] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.
* [X] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/wordpress-seo/issues/21019
