### PR TITLE
255 inclusive language tech debt flip the behavior of the isprecededbyexception function

### DIFF
--- a/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/helpers/isPrecededByExceptionSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/helpers/isPrecededByExceptionSpec.js
@@ -5,7 +5,7 @@ xdescribe( "Test isFollowedByException", () => {
 	it( "returns the right value when term is preceded by an exception", () => {
 		const words = "this is a sentence".split( " " );
 		const exceptions = [ "this" ];
-		const callback = isPrecededByException( words, exceptions );
+		const callback = isNotPrecededByException( words, exceptions );
 		const index = 1;
 
 		// eslint-disable-next-line callback-return
@@ -14,7 +14,7 @@ xdescribe( "Test isFollowedByException", () => {
 	it( "returns the right value when term is not preceded by an exception", () => {
 		const words = "that is a cat".split( " " );
 		const exceptions = [ "this" ];
-		const callback = isPrecededByException( words, exceptions );
+		const callback = isNotPrecededByException( words, exceptions );
 		const index = 1;
 
 		// eslint-disable-next-line callback-return
@@ -26,7 +26,7 @@ xdescribe( "Test isNotFollowedByException", () => {
 	it( "returns the right value when term is preceded by an exception", () => {
 		const words = "this is a sentence".split( " " );
 		const exceptions = [ "this" ];
-		const notCallback = isNotPrecededByException( words, exceptions );
+		const notCallback = isPrecededByException( words, exceptions );
 		const index = 1;
 
 		expect( notCallback( index ) ).toEqual( false );
@@ -34,7 +34,7 @@ xdescribe( "Test isNotFollowedByException", () => {
 	it( "returns the right value when term is not preceded by an exception", () => {
 		const words = "that is a cat".split( " " );
 		const exceptions = [ "this" ];
-		const notCallback = isNotPrecededByException( words, exceptions );
+		const notCallback = isPrecededByException( words, exceptions );
 		const index = 1;
 
 		expect( notCallback( index ) ).toEqual( true );

--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/ageAssessments.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/ageAssessments.js
@@ -1,5 +1,5 @@
 import { potentiallyHarmful, potentiallyHarmfulUnless, harmfulNonInclusive } from "./feedbackStrings";
-import { isPrecededByException } from "../helpers/isPrecededByException";
+import { isNotPrecededByException } from "../helpers/isPrecededByException";
 import { isNotFollowedByException } from "../helpers/isFollowedByException";
 import { includesConsecutiveWords } from "../helpers/includesConsecutiveWords";
 import { SCORES } from "./scores";
@@ -70,7 +70,7 @@ const ageAssessments = [
 		feedbackFormat: [ potentiallyHarmfulUnless, specificAgeGroup ].join( " " ),
 		rule: ( words, nonInclusivePhrase ) => {
 			return includesConsecutiveWords( words, nonInclusivePhrase )
-				.filter( isPrecededByException( words, [ "high school", "college", "graduating", "juniors and" ] ) )
+				.filter( isNotPrecededByException( words, [ "high school", "college", "graduating", "juniors and" ] ) )
 				.filter( isNotFollowedByException( words, nonInclusivePhrase, [ "in high school", "in college", "who are graduating" ] ) );
 		},
 	},

--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessments.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessments.js
@@ -112,7 +112,7 @@ const disabilityAssessments = [
 		feedbackFormat: derogatory,
 		rule: ( words, nonInclusivePhrase ) => {
 			return includesConsecutiveWords( words, nonInclusivePhrase )
-				.filter( isPrecededByException( words, [ "mentally" ] ) );
+				.filter( isNotPrecededByException( words, [ "mentally" ] ) );
 		},
 	},
 	{
@@ -346,7 +346,7 @@ const disabilityAssessments = [
 		feedbackFormat: potentiallyHarmful,
 		rule: ( words, nonInclusivePhrase ) => {
 			return includesConsecutiveWords( words, nonInclusivePhrase )
-				.filter( isPrecededByException( words, [ "deaf and" ] ) );
+				.filter( isNotPrecededByException( words, [ "deaf and" ] ) );
 		},
 	},
 	{
@@ -414,7 +414,7 @@ const disabilityAssessments = [
 		// Target only when preceded by a form of "to be", the negation "not", and an optional intensifier (e.g. "is not so crazy about" ).
 		rule: ( words, nonInclusivePhrase ) => {
 			return includesConsecutiveWords( words, nonInclusivePhrase )
-				.filter( isNotPrecededByException( words, formsOfToBeNotWithOptionalIntensifier ) );
+				.filter( isPrecededByException( words, formsOfToBeNotWithOptionalIntensifier ) );
 		},
 	},
 	{
@@ -426,7 +426,7 @@ const disabilityAssessments = [
 		// Target only when preceded by a form of "to be" and an optional intensifier (e.g. "am so crazy about")
 		rule: ( words, nonInclusivePhrase ) => {
 			return includesConsecutiveWords( words, nonInclusivePhrase )
-				.filter( isNotPrecededByException( words, formsOfToBeWithOptionalIntensifier ) );
+				.filter( isPrecededByException( words, formsOfToBeWithOptionalIntensifier ) );
 		},
 	},
 	{
@@ -446,7 +446,7 @@ const disabilityAssessments = [
 		// Target only when preceded by a form of "to go" (e.g. 'going crazy').
 		rule: ( words, nonInclusivePhrase ) => {
 			return includesConsecutiveWords( words, nonInclusivePhrase )
-				.filter( isNotPrecededByException( words, formsOfToGo ) );
+				.filter( isPrecededByException( words, formsOfToGo ) );
 		},
 	},
 	{
@@ -459,7 +459,7 @@ const disabilityAssessments = [
 		// Target only when preceded by a form of 'to drive' and an object pronoun (e.g. 'driving me crazy', 'drove everyone crazy').
 		rule: ( words, nonInclusivePhrase ) => {
 			return includesConsecutiveWords( words, nonInclusivePhrase )
-				.filter( isNotPrecededByException( words, combinationsOfDriveAndObjectPronoun ) );
+				.filter( isPrecededByException( words, combinationsOfDriveAndObjectPronoun ) );
 		},
 	},
 	{
@@ -472,7 +472,7 @@ const disabilityAssessments = [
 		// Don't target when 'crazy' is part of a more specific phrase that we target.
 		rule: ( words, nonInclusivePhrase ) => {
 			return includesConsecutiveWords( words, nonInclusivePhrase )
-				.filter( isPrecededByException( words, shouldNotPrecedeStandaloneCrazy ) )
+				.filter( isNotPrecededByException( words, shouldNotPrecedeStandaloneCrazy ) )
 				.filter( isNotFollowedByException( words, nonInclusivePhrase, shouldNotFollowStandaloneCrazy ) )
 				.filter( isNotFollowedAndPrecededByException( words, nonInclusivePhrase,
 					shouldNotPrecedeStandaloneCrazyWhenFollowedByAbout,
@@ -596,7 +596,7 @@ const disabilityAssessments = [
 		// Only target 'OCD' when preceded by a form of 'to be/to get' followed by an optional intensifier.
 		rule: ( words, inclusivePhrases ) => {
 			return includesConsecutiveWords( words, inclusivePhrases )
-				.filter( isNotPrecededByException( words, formsOfToBeAndToBeNotWithOptionalIntensifier ) );
+				.filter( isPrecededByException( words, formsOfToBeAndToBeNotWithOptionalIntensifier ) );
 		},
 	},
 	{

--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/otherAssessments.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/otherAssessments.js
@@ -6,7 +6,7 @@ import {
 	potentiallyHarmfulUnlessAnimalsObjects,
 } from "./feedbackStrings";
 import { includesConsecutiveWords } from "../helpers/includesConsecutiveWords";
-import { isPrecededByException } from "../helpers/isPrecededByException";
+import { isNotPrecededByException } from "../helpers/isPrecededByException";
 
 const otherAssessments = [
 	{
@@ -28,7 +28,7 @@ const otherAssessments = [
 		feedbackFormat: potentiallyHarmful,
 		rule: ( words, nonInclusivePhrase ) => {
 			return includesConsecutiveWords( words, nonInclusivePhrase )
-				.filter( isPrecededByException( words, [ "mentally", "behaviorally", "behaviourally" ] ) );
+				.filter( isNotPrecededByException( words, [ "mentally", "behaviorally", "behaviourally" ] ) );
 		},
 	},
 	{
@@ -41,7 +41,7 @@ const otherAssessments = [
 		caseSensitive: true,
 		rule: ( words, nonInclusivePhrase ) => {
 			return includesConsecutiveWords( words, nonInclusivePhrase )
-				.filter( isPrecededByException( words, [ "mentally", "behaviorally", "behaviourally" ] ) );
+				.filter( isNotPrecededByException( words, [ "mentally", "behaviorally", "behaviourally" ] ) );
 		},
 	},
 	{

--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/helpers/isFollowedAndPrecededByException.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/helpers/isFollowedAndPrecededByException.js
@@ -1,5 +1,5 @@
 import { isFollowedByException } from "./isFollowedByException";
-import { isNotPrecededByException } from "./isPrecededByException";
+import { isPrecededByException } from "./isPrecededByException";
 
 
 /**
@@ -19,7 +19,7 @@ import { isNotPrecededByException } from "./isPrecededByException";
 export function isFollowedAndPrecededByException( words, nonInclusivePhrase, precedingExceptions, followingExceptions ) {
 	return ( index ) => {
 		return ( isFollowedByException( words, nonInclusivePhrase, followingExceptions )( index ) &&
-			isNotPrecededByException( words, precedingExceptions )( index ) );
+			isPrecededByException( words, precedingExceptions )( index ) );
 	};
 }
 

--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/helpers/isPrecededByException.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/helpers/isPrecededByException.js
@@ -12,7 +12,7 @@ import { includesWordsAtPosition } from "./includesWordsAtPosition";
  */
 export function isPrecededByException( words, exceptions ) {
 	const splitExceptions = exceptions.map( exception => getWords( exception, false ) );
-	return index => ! splitExceptions.some( exception => {
+	return index => splitExceptions.some( exception => {
 		const startIndex = index - exception.length;
 		if ( startIndex >= 0 ) {
 			return includesWordsAtPosition( exception, startIndex, words );


### PR DESCRIPTION
## Context
<!-- 
What do we want to achieve with this PR? Why did we write this code?
-->

* The behavior of the `isPrecededByException` functions returns `false` if the phrase is followed by an exception and `true` when it isn't followed by an exception. The function `isNotPrecededByException` returns otherwise. 
  We want to switch the functions around, so that they return the correct values. 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

*  It corrects the behavior of the `isPrecededByException` and `isNotPrecededByException` functions.
*  [shopify-seo] It corrects the behavior of the `isPrecededByException` and `isNotPrecededByException` functions.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* For developers: Run `yarn test` and make sure all specs pass

**Test the `isPrecededByException` function**
1. Create a post
2. Add a text of at least 300 words
3. Add this sentence: _I am crazy about cats_ 
4. Make sure the inclusive language analysis shows an red traffic light and the feedback says:  _Avoid using to be crazy about as it is potentially harmful. Consider using an alternative, such as to love, to be obsessed with, to be infatuated with. Learn more. _ 
5. Write another sentence using the _crazy about_ phrase again, but in a different context. (e.g. _I have notice something crazy about cats_.) 
6. Make sure a second feedback appears under the inclusive language tab, shows an red traffic light and the feedback says: _Avoid using to be crazy about as it is potentially harmful. Consider using an alternative, such as to love, to be obsessed with, to be infatuated with. Learn more_ 

**Test the `isNotPrecededByException` function**
1. Create a post
2. Add a text of at least 300 words
3. Add this sentence: _A group of seniors_ 
3. Make sure the inclusive language assessment result shows an orange traffic light and the feedback says:  _Be careful when using seniors as it is potentially harmful. Consider using an alternative, such as older people, unless referring to someone who explicitly wants to be referred to with this term. Or, if possible, be specific about the group you are referring to (e.g. people older than 70). Learn more_
4. Add  the phrase _high school_ before the word _seniors_  (e.g. _A group of high school seniors_.) 
5. Make sure the Inclusive language assessment now shows a green traffic light and says: _We haven't detected any potentially non-inclusive phrases. Great work!_


#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [X] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [x] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [X] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [X] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.
* [X] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #[Inclusive language tech debt: Flip the behavior of the isPrecededByException function#255](https://github.com/Yoast/lingo-other-tasks/issues/255)
