### PR TITLE
Revert "Force page type to itempage for products"

### DIFF
--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -943,7 +943,6 @@ class WPSEO_Metabox extends WPSEO_Meta {
 			'blackFridayBlockEditorUrl'  => ( YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-2023-checklist' ) ) ? WPSEO_Shortlinker::get( 'https://yoa.st/black-friday-checklist' ) : '',
 			'isJetpackBoostActive'       => ( $is_block_editor ) ? YoastSEO()->classes->get( Jetpack_Boost_Active_Conditional::class )->is_met() : false,
 			'isJetpackBoostNotPremium'   => ( $is_block_editor ) ? YoastSEO()->classes->get( Jetpack_Boost_Not_Premium_Conditional::class )->is_met() : false,
-			'isWooCommerceSEOActive'     => $woocommerce_seo_active,
 			'isWooCommerceActive'        => $woocommerce_active,
 			'woocommerceUpsell'          => get_post_type( $post_id ) === 'product' && ! $woocommerce_seo_active && $woocommerce_active,
 			'linkParams'                 => WPSEO_Shortlinker::get_query_params(),

--- a/packages/components/src/select/Select.js
+++ b/packages/components/src/select/Select.js
@@ -17,14 +17,12 @@ const selectProps = {
 	options: PropTypes.arrayOf( selectOption ).isRequired,
 	selected: PropTypes.oneOfType( [ PropTypes.arrayOf( PropTypes.string ), PropTypes.string ] ),
 	onChange: PropTypes.func,
-	disabled: PropTypes.bool,
 	...FieldGroupProps,
 };
 const selectDefaultProps = {
 	name: "",
 	selected: [],
 	onChange: () => {},
-	disabled: false,
 	...FieldGroupDefaultProps,
 };
 
@@ -239,7 +237,6 @@ export class Select extends React.Component {
 			id,
 			options,
 			name,
-			disabled,
 			...fieldGroupProps
 		} = this.props;
 
@@ -255,7 +252,6 @@ export class Select extends React.Component {
 					onBlur={ this.onBlurHandler }
 					onInput={ this.onInputHandler }
 					onChange={ noop }
-					disabled={ disabled }
 				>
 					{ options.map( Option ) }
 				</select>

--- a/packages/components/tests/__snapshots__/SelectTest.js.snap
+++ b/packages/components/tests/__snapshots__/SelectTest.js.snap
@@ -14,7 +14,6 @@ exports[`Select should render a select 1`] = `
     </label>
   </div>
   <select
-    disabled={false}
     id="my-awesome-multiselect"
     name="my-selection"
     onBlur={[Function]}

--- a/packages/js/src/components/SchemaTab.js
+++ b/packages/js/src/components/SchemaTab.js
@@ -66,8 +66,7 @@ NewsAlert.propTypes = {
  * @returns {Object[]} A copy of the schema type options.
  */
 const getSchemaTypeOptions = ( schemaTypeOptions, defaultType, postTypeName ) => {
-	const disablePageTypeSelect = get( window, "wpseoScriptData.postType", "" ) === "product" && get( window, "wpseoScriptData.isWooCommerceSEOActive", false );
-	const schemaOption = disablePageTypeSelect ? { name: __( "Item Page", "wordpress-seo" ), value: "ItemPage" } : schemaTypeOptions.find( option => option.value === defaultType );
+	const schemaOption = schemaTypeOptions.find( option => option.value === defaultType );
 	return [
 		{
 			name: sprintf(
@@ -150,7 +149,6 @@ function isNewsArticleType( selectedValue, defaultValue ) {
 	return false;
 }
 
-/* eslint-disable complexity */
 /**
  * Returns the content of the schema tab.
  *
@@ -165,7 +163,6 @@ const Content = ( props ) => {
 	const woocommerceUpsell = get( window, "wpseoScriptData.woocommerceUpsell", "" );
 	const [ focusedArticleType, setFocusedArticleType ] = useState( props.schemaArticleTypeSelected );
 	const woocommerceUpsellText = __( "Want your products stand out in search results with rich results like price, reviews and more?", "wordpress-seo" );
-	const disablePageTypeSelect = get( window, "wpseoScriptData.postType", "" ) === "product" && get( window, "wpseoScriptData.isWooCommerceSEOActive", false );
 
 	const handleOptionChange = useCallback(
 		( _, value ) => {
@@ -195,7 +192,6 @@ const Content = ( props ) => {
 				label={ __( "Page type", "wordpress-seo" ) }
 				onChange={ props.schemaPageTypeChange }
 				selected={ props.schemaPageTypeSelected }
-				disabled={ disablePageTypeSelect }
 			/>
 			{ props.showArticleTypeInput && <Select
 				id={ join( [ "yoast-schema-article-type", props.location ] ) }
@@ -209,18 +205,10 @@ const Content = ( props ) => {
 				location={ props.location }
 				show={ ! props.isNewsEnabled && isNewsArticleType( focusedArticleType, props.defaultArticleType ) }
 			/>
-			{ props.displayFooter && ! disablePageTypeSelect && <p>{ footerWithLink( props.postTypeName ) }</p> }
-			{ disablePageTypeSelect && <p>
-				{ sprintf(
-					/* translators: %1$s expands to Yoast WooCommerce SEO. */
-					__( "You have %1$s activated on your site, automatically setting the Page type for your products to 'Item Page'. As a result, the Page type selection is disabled.", "wordpress-seo" ),
-					"Yoast WooCommerce SEO"
-				) }
-			</p> }
+			{ props.displayFooter && <p>{ footerWithLink( props.postTypeName ) }</p> }
 		</Fragment>
 	);
 };
-/* eslint-enable complexity */
 
 const schemaTypeOptionsPropType = PropTypes.arrayOf( PropTypes.shape( {
 	name: PropTypes.string,

--- a/packages/js/src/settings/routes/templates/post-type.js
+++ b/packages/js/src/settings/routes/templates/post-type.js
@@ -54,13 +54,6 @@ const PostType = ( { name, label, singularLabel, hasArchive, hasSchemaArticleTyp
 	const pageAnalysisPremiumLink = useSelectSettings( "selectLink", [], "https://yoa.st/get-custom-fields" );
 	const schemaLink = useSelectSettings( "selectLink", [], "https://yoa.st/post-type-schema" );
 	const { updatePostTypeReviewStatus } = useDispatchSettings();
-	const isWooCommerceSEOActive = useSelectSettings( "selectPreference", [], "isWooCommerceSEOActive" );
-	const shouldDisablePageTypeSelect = isWooCommerceSEOActive && name === "product";
-	const disabledPageTypeSelectorDescription =  sprintf(
-		/* translators: %1$s expands to Yoast WooCommerce SEO. */
-		__( "You have %1$s activated on your site, automatically setting the Page type for your products to 'Item Page'. As a result, the Page type selection is disabled.", "wordpress-seo" ),
-		"Yoast WooCommerce SEO"
-	);
 
 	useEffect( () => {
 		if ( isNew ) {
@@ -272,10 +265,8 @@ const PostType = ( { name, label, singularLabel, hasArchive, hasSchemaArticleTyp
 							name={ `wpseo_titles.schema-page-type-${ name }` }
 							id={ `input-wpseo_titles-schema-page-type-${ name }` }
 							label={ __( "Page type", "wordpress-seo" ) }
-							options={ shouldDisablePageTypeSelect ? pageTypes.filter( ( { value } ) => value === "ItemPage" ) : pageTypes }
-							className="yst-max-w-5xl"
-							description={ shouldDisablePageTypeSelect ? disabledPageTypeSelectorDescription : "" }
-							disabled={ shouldDisablePageTypeSelect }
+							options={ pageTypes }
+							className="yst-max-w-sm"
 						/>
 						{ hasSchemaArticleType && (
 							<div>

--- a/src/integrations/settings-integration.php
+++ b/src/integrations/settings-integration.php
@@ -11,7 +11,6 @@ use WPSEO_Admin_Editor_Specific_Replace_Vars;
 use WPSEO_Admin_Recommended_Replace_Vars;
 use WPSEO_Option_Titles;
 use WPSEO_Options;
-use WPSEO_Plugin_Availability;
 use WPSEO_Replace_Vars;
 use WPSEO_Shortlinker;
 use WPSEO_Sitemaps_Router;
@@ -454,10 +453,6 @@ class Settings_Integration implements Integration_Interface {
 		$page_on_front            = \get_option( 'page_on_front' );
 		$page_for_posts           = \get_option( 'page_for_posts' );
 
-		$wpseo_plugin_availability_checker = new WPSEO_Plugin_Availability();
-		$woocommerce_seo_file              = 'wpseo-woocommerce/wpseo-woocommerce.php';
-		$woocommerce_seo_active            = $wpseo_plugin_availability_checker->is_active( $woocommerce_seo_file );
-
 		if ( empty( $page_on_front ) ) {
 			$page_on_front = $page_for_posts;
 		}
@@ -471,7 +466,6 @@ class Settings_Integration implements Integration_Interface {
 			'isWooCommerceActive'           => $this->woocommerce_helper->is_active(),
 			'isLocalSeoActive'              => \defined( 'WPSEO_LOCAL_FILE' ),
 			'isNewsSeoActive'               => \defined( 'WPSEO_NEWS_FILE' ),
-			'isWooCommerceSEOActive'        => $woocommerce_seo_active,
 			'promotions'                    => \YoastSEO()->classes->get( Promotion_Manager::class )->get_current_promotions(),
 			'siteUrl'                       => \get_bloginfo( 'url' ),
 			'siteTitle'                     => \get_bloginfo( 'name' ),


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Revert #20956 to look at it more deeply.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Reverts "Force page type to itempage for products".

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

*

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
