### PR TITLE
20853 disable category prefix category archives can be accessed via 2 urls

### DIFF
--- a/inc/class-rewrite.php
+++ b/inc/class-rewrite.php
@@ -88,7 +88,7 @@ class WPSEO_Rewrite {
 	 *
 	 * @param array<string> $query_vars Query vars to check for existence of redirect var.
 	 *
-	 * @return array<string>|void The query vars.
+	 * @return array<string> The query vars.
 	 */
 	public function request( $query_vars ) {
 		if ( ! isset( $query_vars['wpseo_category_redirect'] ) ) {

--- a/inc/class-rewrite.php
+++ b/inc/class-rewrite.php
@@ -96,7 +96,7 @@ class WPSEO_Rewrite {
 		}
 
 		$this->redirect( $query_vars['wpseo_category_redirect'] );
-		return null;
+		return [];
 	}
 
 	/**

--- a/inc/class-rewrite.php
+++ b/inc/class-rewrite.php
@@ -112,7 +112,7 @@ class WPSEO_Rewrite {
 		$permalink_structure = get_option( 'permalink_structure' );
 
 		$blog_prefix = '';
-		if ( is_multisite() && ! is_subdomain_install() && is_main_site() && strpos( $permalink_structure, '/blog/' ) === 0 ) {
+		if ( is_main_site() && strpos( $permalink_structure, '/blog/' ) === 0 ) {
 			$blog_prefix = 'blog/';
 		}
 

--- a/inc/class-rewrite.php
+++ b/inc/class-rewrite.php
@@ -71,9 +71,9 @@ class WPSEO_Rewrite {
 	/**
 	 * Update the query vars with the redirect var when stripcategorybase is active.
 	 *
-	 * @param array $query_vars Main query vars to filter.
+	 * @param array<string> $query_vars Main query vars to filter.
 	 *
-	 * @return array
+	 * @return array<string> The query vars.
 	 */
 	public function query_vars( $query_vars ) {
 		if ( WPSEO_Options::get( 'stripcategorybase' ) === true ) {
@@ -86,9 +86,9 @@ class WPSEO_Rewrite {
 	/**
 	 * Checks whether the redirect needs to be created.
 	 *
-	 * @param array $query_vars Query vars to check for existence of redirect var.
+	 * @param array<string> $query_vars Query vars to check for existence of redirect var.
 	 *
-	 * @return array|void The query vars.
+	 * @return array<string>|void The query vars.
 	 */
 	public function request( $query_vars ) {
 		if ( ! isset( $query_vars['wpseo_category_redirect'] ) ) {
@@ -96,12 +96,13 @@ class WPSEO_Rewrite {
 		}
 
 		$this->redirect( $query_vars['wpseo_category_redirect'] );
+		return null;
 	}
 
 	/**
 	 * This function taken and only slightly adapted from WP No Category Base plugin by Saurabh Gupta.
 	 *
-	 * @return array
+	 * @return array<string> The category rewrite rules.
 	 */
 	public function category_rewrite_rules() {
 		global $wp_rewrite;
@@ -156,12 +157,12 @@ class WPSEO_Rewrite {
 	/**
 	 * Adds required category rewrites rules.
 	 *
-	 * @param array  $rewrites        The current set of rules.
-	 * @param string $category_name   Category nicename.
-	 * @param string $blog_prefix     Multisite blog prefix.
-	 * @param string $pagination_base WP_Query pagination base.
+	 * @param array<string> $rewrites        The current set of rules.
+	 * @param string        $category_name   Category nicename.
+	 * @param string        $blog_prefix     Multisite blog prefix.
+	 * @param string        $pagination_base WP_Query pagination base.
 	 *
-	 * @return array The added set of rules.
+	 * @return array<string> The added set of rules.
 	 */
 	protected function add_category_rewrites( $rewrites, $category_name, $blog_prefix, $pagination_base ) {
 		$rewrite_name = $blog_prefix . '(' . $category_name . ')';


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Fix category redirect when using blog prefix in permalink structure and striping category slug.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where category redirect to base url when using blog prefix in permalink structure and strip category slug.

## Relevant technical choices:

* The blog prefix should be added when it's part of the permalink structure, no matter if it's a multisite or subdirectory.
* There will be one link, `wordpress.test/blog/test-cat` and `wordpress.test/blog/category/test-cat` would be redirected to `wordpress.test/blog/test-cat`. But the difference is that the target link would be `wordpress.test/blog/test-cat` and you can still create a page `wordpress.test/test-cat`.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Make your permalink structure to be custom structure `/blog/%category%/%postname%/`
* Go to `Yoast SEO`->`Settings`->`Categories and Tags`
* Select first `Categories`
* Disable `Show the categories prefix in the slug`
* Go to `Posts`->`Categories`
* Add a category, for example `test-category`
* View the category
* Check the url is like `wordpress.test/blog/test-category`
* try to access `wordpress.test/test-category`
* Check you are getting 404 page.
* Go to `Pages` and create a page with a slug `test-category`
* View the page (`wordpress.test/test-category`) and check you see the page and not the category page.

### Test on multisite
* Create a multisite of subdirectory and add Yoast SEO plugin.
* Add a site and go to it's dashboad.
* Go to `Settings`->`Permalinks`
* Make your permalink structure to be custom structure `/blog/%category%/%postname%/`
* Go to `Yoast SEO`->`Settings`->`Categories and Tags` and select first `Categories`
* Disable `Show the categories prefix in the slug`
* Go to `Posts`->`Categories`
* Add a category, for example `test-category`
* View the category
* Check the url is like `wordpress.test/subdirectory-site-name/blog/test-category`
* try to access `wordpress.test/subdirectory-site-name/test-category`
* Check you are getting 404 page.
* Go to `Pages` and create a page with a slug `test-category`
* View the page (`wordpress.test/subdirectory-site-name/test-category`) and check you see the page and not the category page.
* Repeat for a multisite with subdomain and
* Check the url is like `subdomain-name.wordpress.test/blog/test-category`
* try to access `subdomain-name.wordpress.test/test-category`
* Check you are getting 404 page.
* Go to `Pages` and create a page with a slug `test-category`
* View the page (`subdomain-name.wordpress.test/test-category`) and check you see the page and not the category page.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [x] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/wordpress-seo/issues/20853
