### PR TITLE
Update defaults for multiple locations and alert message

### DIFF
--- a/packages/js/src/settings/routes/site-representation.js
+++ b/packages/js/src/settings/routes/site-representation.js
@@ -55,7 +55,7 @@ const SiteRepresentation = () => {
 		),
 		{
 			// eslint-disable-next-line
-			a: <a href={ businessInfoSettingsUrl } className="yst-underline yst-font-medium" />,
+			a: <a href={ businessInfoSettingsUrl } target="_blank" className="yst-underline yst-font-medium" />,
 		}
 	);
 	let alertMessagePhoneEmail = createInterpolateElement(
@@ -68,7 +68,7 @@ const SiteRepresentation = () => {
 		),
 		{
 			// eslint-disable-next-line
-			a: <a href={ businessInfoSettingsUrl } className="yst-underline yst-font-medium" />,
+			a: <a href={ businessInfoSettingsUrl } target="_blank" className="yst-underline yst-font-medium" />,
 		}
 	);
 	if ( businessInfoSettingsUrl.includes( "wpseo_locations" ) ) {

--- a/packages/js/src/settings/routes/site-representation.js
+++ b/packages/js/src/settings/routes/site-representation.js
@@ -45,6 +45,60 @@ const SiteRepresentation = () => {
 	const mastodonPremiumLink = useSelectSettings( "selectLink", [], "https://yoa.st/get-mastodon-integration" );
 	const mastodonUrlLink = useSelectSettings( "selectLink", [], "https://yoa.st/site-representation-mastodon" );
 	const businessInfoSettingsUrl = useSelectSettings( "selectPreference", [], "localSeoPageSettingUrl" );
+	let alertMessageIdentifiers = createInterpolateElement(
+		sprintf(
+			/* translators: %1$s expands for Yoast Local SEO, %2$s and %3$s expands to a link tags. */
+			__( "You have %1$s activated on your site. You can provide your VAT ID and Tax ID in the %2$s‘Business info’ settings%3$s.", "wordpress-seo" ),
+			"Yoast Local SEO",
+			"<a>",
+			"</a>"
+		),
+		{
+			// eslint-disable-next-line
+			a: <a href={ businessInfoSettingsUrl } className="yst-underline yst-font-medium" />,
+		}
+	);
+	let alertMessagePhoneEmail = createInterpolateElement(
+		sprintf(
+			/* translators: %1$s expands for Yoast Local SEO, %2$s and %3$s expands to a link tags. */
+			__( "You have %1$s activated on your site. You can provide your email and phone in the %2$s‘Business info’ settings%3$s.", "wordpress-seo" ),
+			"Yoast Local SEO",
+			"<a>",
+			"</a>"
+		),
+		{
+			// eslint-disable-next-line
+			a: <a href={ businessInfoSettingsUrl } className="yst-underline yst-font-medium" />,
+		}
+	);
+	if ( businessInfoSettingsUrl.includes( "wpseo_locations" ) ) {
+		alertMessageIdentifiers = createInterpolateElement(
+			sprintf(
+				/* translators: %1$s expands for Yoast Local SEO, %2$s and %3$s expands to a link tags. */
+				__( "You have %1$s activated on your site, and you've configured your business for multiple locations. This allows you to provide your VAT ID and Tax ID for %2$seach specific location%3$s.", "wordpress-seo" ),
+				"Yoast Local SEO",
+				"<a>",
+				"</a>"
+			),
+			{
+			// eslint-disable-next-line
+			a: <a href={ businessInfoSettingsUrl } target="_blank" className="yst-underline yst-font-medium" />,
+			}
+		);
+		alertMessagePhoneEmail = createInterpolateElement(
+			sprintf(
+				/* translators: %1$s expands for Yoast Local SEO, %2$s and %3$s expands to a link tags. */
+				__( "You have %1$s activated on your site, and you've configured your business for multiple locations. This allows you to provide your email and phone for %2$seach specific location%3$s.", "wordpress-seo" ),
+				"Yoast Local SEO",
+				"<a>",
+				"</a>"
+			),
+			{
+				// eslint-disable-next-line
+				a: <a href={ businessInfoSettingsUrl } target="_blank" className="yst-underline yst-font-medium" />,
+			}
+		);
+	}
 
 	const handleAddProfile = useCallback( async( arrayHelpers ) => {
 		await arrayHelpers.push( "" );
@@ -296,19 +350,7 @@ const SiteRepresentation = () => {
 
 									{ isLocalSeoActive && isPremium && (
 										<Alert id="alert-local-seo-vat-or-tax-id" variant="info">
-											{ createInterpolateElement(
-												sprintf(
-													/* translators: %1$s expands for Yoast Local SEO, %2$s and %3$s expands to a link tags. */
-													__( "You have %1$s activated on your site. You can provide your VAT ID and Tax ID in the %2$s‘Business info’ settings%3$s.", "wordpress-seo" ),
-													"Yoast Local SEO",
-													"<a>",
-													"</a>"
-												),
-												{
-													// eslint-disable-next-line
-													a: <a href={ businessInfoSettingsUrl } className="yst-underline yst-font-medium" />,
-												}
-											) }
+											{ alertMessagePhoneEmail }
 										</Alert>
 									) }
 									<FormikWithErrorFieldWithDummy
@@ -385,19 +427,7 @@ const SiteRepresentation = () => {
 								>
 									{ isLocalSeoActive && isPremium && (
 										<Alert id="alert-local-seo-vat-or-tax-id" variant="info">
-											{ createInterpolateElement(
-												sprintf(
-													/* translators: %1$s expands for Yoast Local SEO, %2$s and %3$s expands to a link tags. */
-													__( "You have %1$s activated on your site. You can provide your VAT ID and Tax ID in the %2$s‘Business info’ settings%3$s.", "wordpress-seo" ),
-													"Yoast Local SEO",
-													"<a>",
-													"</a>"
-												),
-												{
-													// eslint-disable-next-line
-													a: <a href={ businessInfoSettingsUrl } className="yst-underline yst-font-medium" />,
-												}
-											) }
+											{ alertMessageIdentifiers }
 										</Alert>
 									) }
 									<FormikWithErrorFieldWithDummy

--- a/src/integrations/settings-integration.php
+++ b/src/integrations/settings-integration.php
@@ -462,6 +462,16 @@ class Settings_Integration implements Integration_Interface {
 			$page_on_front = $page_for_posts;
 		}
 
+		$business_settings_url = \get_admin_url( null, 'admin.php?page=wpseo_local' );
+		if ( \defined( 'WPSEO_LOCAL_FILE' ) ) {
+			$local_options      = WPSEO_Options::get_option( 'wpseo_local' );
+			$multiple_locations = $local_options['use_multiple_locations'];
+			$same_organization  = $local_options['multiple_locations_same_organization'];
+			if ( $multiple_locations === 'on' && $same_organization !== 'on' ) {
+				$business_settings_url = \get_admin_url( null, 'edit.php?post_type=wpseo_locations' );
+			}
+		}
+
 		return [
 			'isPremium'                     => $this->product_helper->is_premium(),
 			'isRtl'                         => \is_rtl(),
@@ -479,7 +489,7 @@ class Settings_Integration implements Integration_Interface {
 			'hasWooCommerceShopPage'        => $shop_page_id !== -1,
 			'editWooCommerceShopPageUrl'    => \get_edit_post_link( $shop_page_id, 'js' ),
 			'wooCommerceShopPageSettingUrl' => \get_admin_url( null, 'admin.php?page=wc-settings&tab=products' ),
-			'localSeoPageSettingUrl'        => \get_admin_url( null, 'admin.php?page=wpseo_local' ),
+			'localSeoPageSettingUrl'        => $business_settings_url,
 			'homepageIsLatestPosts'         => $homepage_is_latest_posts,
 			'homepagePageEditUrl'           => \get_edit_post_link( $page_on_front, 'js' ),
 			'homepagePostsEditUrl'          => \get_edit_post_link( $page_for_posts, 'js' ),

--- a/src/integrations/settings-integration.php
+++ b/src/integrations/settings-integration.php
@@ -622,11 +622,46 @@ class Settings_Integration implements Integration_Interface {
 		}
 
 		if ( \defined( 'WPSEO_LOCAL_FILE' ) ) {
-			$local_options                          = WPSEO_Options::get_option( 'wpseo_local' );
-			$defaults['wpseo_titles']['org-vat-id'] = $local_options['location_vat_id'];
-			$defaults['wpseo_titles']['org-tax-id'] = $local_options['location_tax_id'];
-			$defaults['wpseo_titles']['org-email']  = $local_options['location_email'];
-			$defaults['wpseo_titles']['org-phone']  = $local_options['location_phone'];
+			$local_options      = WPSEO_Options::get_option( 'wpseo_local' );
+			$multiple_locations = $local_options['use_multiple_locations'];
+			$same_organization  = $local_options['multiple_locations_same_organization'];
+			$shared_info        = $local_options['multiple_locations_shared_business_info'];
+			if ( $multiple_locations !== 'on' || ( $multiple_locations === 'on' && $same_organization === 'on' && $shared_info === 'on' ) ) {
+				$defaults['wpseo_titles']['org-vat-id'] = $local_options['location_vat_id'];
+				$defaults['wpseo_titles']['org-tax-id'] = $local_options['location_tax_id'];
+				$defaults['wpseo_titles']['org-email']  = $local_options['location_email'];
+				$defaults['wpseo_titles']['org-phone']  = $local_options['location_phone'];
+			}
+
+			if ( $multiple_locations === 'on' && $same_organization === 'on' ) {
+				$primary_location = $local_options['multiple_locations_primary_location'];
+
+				$location_keys = [
+					'org-phone'  => [
+						'is_overridden' => '_wpseo_is_overridden_business_phone',
+						'value'         => '_wpseo_business_phone',
+					],
+					'org-email'  => [
+						'is_overridden' => '_wpseo_is_overridden_business_email',
+						'value'         => '_wpseo_business_email',
+					],
+					'org-tax-id' => [
+						'is_overridden' => '_wpseo_is_overridden_business_tax_id',
+						'value'         => '_wpseo_business_tax_id',
+					],
+					'org-vat-id' => [
+						'is_overridden' => '_wpseo_is_overridden_business_vat_id',
+						'value'         => '_wpseo_business_vat_id',
+					],
+				];
+
+				foreach ( $location_keys as $key => $meta_keys ) {
+					$is_overridden = \get_post_meta( $primary_location, $meta_keys['is_overridden'], true );
+					if ( ( $shared_info === 'on' && $is_overridden && $is_overridden === 'on' ) || $shared_info !== 'on' ) {
+						$defaults['wpseo_titles'][ $key ] = \get_post_meta( $primary_location, $meta_keys['value'], true );
+					}
+				}
+			}
 		}
 
 		return $defaults;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Updates the email, phone, vat and tax ids defaults in case Local SEO is active with multiple locations. Updates the error message and link to Local SEO settings.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

### Alert messages text and link change.
* Activate Yoast SEO premium based on the feature branch `feature/new-organization-schema-fields` and Local SEO based on the branch `restore-email-field-for-location`
* Go to `Yoast SEO`->`Local SEO`
* Set "My business has multiple locations" to yes
* Set "All locations are part of the same business" to no.
* Go to `Yoast SEO`->`Settings`->`Site representation`
* Check the alert message over email and phone is as follows and the link is for Locations page and opens in a new tab:
> You have Yoast Local SEO activated on your site, and you've configured your business for multiple locations. This allows you to provide your phone and email for [each specific location](http://wordpress.test/wp-admin/edit.php?post_type=wpseo_locations).
* Go to `Yoast SEO`->`Settings`->`Site representation`
* Check the alert message over Tax and Vat is as follows and the link is for Locations page and opens in a new tab:
> You have Yoast Local SEO activated on your site, and you've configured your business for multiple locations. This allows you to provide your VAT ID and Tax ID for [each specific location](http://wordpress.test/wp-admin/edit.php?post_type=wpseo_locations).
* Go to `Yoast SEO`->`Local SEO`
* Set "All locations are part of the same business" to yes.
* Check the alert message over email and phone is as follows and the link is for Local SEO settings page:
> You have Yoast Local SEO activated on your site. You can provide your email and phone in the [‘Business info’ settings](http://wordpress.test/wp-admin/admin.php?page=wpseo_local).
* Go to `Yoast SEO`->`Settings`->`Site representation`
* Check the alert message over Tax and Vat is as follows and the link is for Local SEO settings page:
> You have Yoast Local SEO activated on your site. You can provide your VAT ID and Tax ID in the [‘Business info’ settings](http://wordpress.test/wp-admin/admin.php?page=wpseo_local).
* Go to `Yoast SEO`->`Local SEO`
* Set "My business has multiple locations" to yes
* Go to `Yoast SEO`->`Settings`->`Site representation`
* Check the message didn't change in both cases.

### Phone, email, vat and tax ids defaults
 * Go to `Yoast SEO`->`Local SEO`
 * Set "My business has multiple locations" to yes
 * Set "All locations are part of the same business" to yes.
 * Set the primary location.
 * Go to the primary location and change Phone, email, vat and tax ids
* Go to `Yoast SEO`->`Settings`->`Site representation`
* Check the Phone, email, vat and tax ids are taken from the primary location
* Go to `Yoast SEO`->`Local SEO`
* Set "Locations inherit shared business info" to yes
* Change Phone, email, vat and tax ids in the shared info.
* Go to primary location and check Phone, email, vat and tax ids  are not checked on "Override"
* Go to `Yoast SEO`->`Settings`->`Site representation`
* Check the Phone, email, vat and tax ids are taken from the shared business info
* Go to primary location and set Phone, email, vat and tax on "Override", and add the details and save.
* Go to `Yoast SEO`->`Settings`->`Site representation`
* Check the Phone, email, vat and tax ids are taken from the primary location
* Uncheck the override for some fields and check in `Site representation` those fields have data from shared business info.

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
